### PR TITLE
[destroying #8] Pop extra stack frames in before_run during destruction

### DIFF
--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -41,16 +41,6 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      if !destroying_set?
-        hop_destroy
-      elsif strand.stack.count > 1
-        pop "operation is cancelled due to the destruction of the inference endpoint replica"
-      end
-    end
-  end
-
   label def start
     nap 5 unless vm.strand.label == "wait"
 

--- a/prog/ai/inference_router_replica_nexus.rb
+++ b/prog/ai/inference_router_replica_nexus.rb
@@ -50,16 +50,6 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      if !destroying_set?
-        hop_destroy
-      elsif strand.stack.count > 1
-        pop "operation is cancelled due to the destruction of the inference router replica"
-      end
-    end
-  end
-
   label def start
     nap 5 unless vm.strand.label == "wait"
 

--- a/prog/ai/inference_router_target_nexus.rb
+++ b/prog/ai/inference_router_target_nexus.rb
@@ -33,16 +33,6 @@ class Prog::Ai::InferenceRouterTargetNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      if !destroying_set?
-        hop_destroy
-      elsif strand.stack.count > 1
-        pop "operation is cancelled due to the destruction of the inference router target"
-      end
-    end
-  end
-
   label def start
     hop_setup if inference_router_target.type == "runpod"
     hop_wait

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -40,16 +40,6 @@ class Prog::Minio::MinioServerNexus < Prog::Base
     end
   end
 
-  def before_run
-    when_destroy_set? do
-      if !destroying_set?
-        hop_destroy
-      elsif strand.stack.count > 1
-        pop "operation is cancelled due to the destruction of the minio server"
-      end
-    end
-  end
-
   def cluster
     @cluster ||= minio_server.cluster
   end

--- a/prog/vnet/cert_server.rb
+++ b/prog/vnet/cert_server.rb
@@ -8,10 +8,7 @@ class Prog::Vnet::CertServer < Prog::Base
   end
 
   label def before_run
-    when_destroy_set? do
-      pop "early exit due to destroy semaphore"
-    end
-
+    super
     pop "vm is destroyed" unless vm
   end
 

--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -12,10 +12,7 @@ class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
   end
 
   def before_run
-    when_destroy_set? do
-      pop "early exit due to destroy semaphore"
-    end
-
+    super
     pop "VM is destroyed" unless vm
   end
 

--- a/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_endpoint_replica_nexus_spec.rb
@@ -82,27 +82,6 @@ RSpec.describe Prog::Ai::InferenceEndpointReplicaNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      nx.incr_destroy
-      expect { nx.before_run }.to hop("destroy")
-        .and change { Semaphore[strand_id: st.id, name: "destroying"] }.from(nil).to(be_a(Semaphore))
-    end
-
-    it "does not hop to destroy if already destroying" do
-      nx.incr_destroy
-      nx.incr_destroying
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "pops additional operations from stack" do
-      nx.incr_destroy
-      nx.incr_destroying
-      expect(nx.strand.stack).to receive(:count).and_return(2)
-      expect { nx.before_run }.to exit({"msg" => "operation is cancelled due to the destruction of the inference endpoint replica"})
-    end
-  end
-
   describe "#start" do
     it "naps if vm not ready" do
       vm.strand.update(label: "prep")

--- a/spec/prog/ai/inference_router_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_router_replica_nexus_spec.rb
@@ -83,27 +83,6 @@ RSpec.describe Prog::Ai::InferenceRouterReplicaNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy when needed" do
-      nx.incr_destroy
-      expect { nx.before_run }.to hop("destroy")
-        .and change { Semaphore[strand_id: st.id, name: "destroying"] }.from(nil).to(be_a(Semaphore))
-    end
-
-    it "does not hop to destroy if already destroying" do
-      nx.incr_destroy
-      nx.incr_destroying
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "pops additional operations from stack" do
-      nx.incr_destroy
-      nx.incr_destroying
-      expect(nx.strand.stack).to receive(:count).and_return(2)
-      expect { nx.before_run }.to exit({"msg" => "operation is cancelled due to the destruction of the inference router replica"})
-    end
-  end
-
   describe "#start" do
     it "naps if vm not ready" do
       vm.strand.update(label: "prep")

--- a/spec/prog/ai/inference_router_target_nexus_spec.rb
+++ b/spec/prog/ai/inference_router_target_nexus_spec.rb
@@ -78,31 +78,6 @@ RSpec.describe Prog::Ai::InferenceRouterTargetNexus do
     end
   end
 
-  describe "#before_run" do
-    context "when destroy is set" do
-      before { nexus.incr_destroy }
-
-      it "hops to destroy if not already destroying" do
-        nexus.strand.update(label: "active")
-        expect { nexus.before_run }.to hop("destroy")
-      end
-
-      it "does not hop if already destroying" do
-        nexus.incr_destroying
-        expect { nexus.before_run }.not_to hop("destroy")
-      end
-
-      it "pops stack and hops to back-link if there are operations on the stack" do
-        new_frame = {"subject_id" => nexus.inference_router_target.id, "link" => [nexus.strand.prog, "destroy"]}
-        nexus.strand.update(stack: [new_frame] + nexus.strand.stack)
-        nexus.incr_destroying
-        reloaded_nexus = described_class.new(nexus.strand.reload)
-        reloaded_nexus.incr_destroy
-        expect { reloaded_nexus.before_run }.to hop("destroy")
-      end
-    end
-  end
-
   describe "#start" do
     it "hops to wait for manual target" do
       target_strand.subject.update(type: "manual")

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -473,5 +473,13 @@ RSpec.describe Prog::Base do
         st.unsynchronized_run
       }.to raise_error(RuntimeError, "BUG: destroying semaphore not set on destroy label")
     end
+
+    it "pops additional operations from stack" do
+      Semaphore.incr(st.id, :destroy)
+      Semaphore.incr(st.id, :destroying)
+      st.update(stack: [{"link" => ["Test", "napper"]}, {}])
+      expect { st.unsynchronized_run }
+        .to change { st.reload.retval }.from(nil).to({"msg" => "operation is cancelled due to explicitly requested destruction"})
+    end
   end
 end

--- a/spec/prog/minio/minio_server_nexus_spec.rb
+++ b/spec/prog/minio/minio_server_nexus_spec.rb
@@ -384,30 +384,6 @@ RSpec.describe Prog::Minio::MinioServerNexus do
     end
   end
 
-  describe "#before_run" do
-    it "hops to destroy if strand is not destroy" do
-      nx.incr_destroy
-      expect { nx.before_run }.to hop("destroy")
-    end
-
-    it "does not hop to destroy if already destroying" do
-      nx.incr_destroy
-      nx.incr_destroying
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if destroy is not set" do
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "pops additional operations from stack" do
-      nx.incr_destroy
-      nx.incr_destroying
-      expect(nx.strand.stack).to receive(:count).and_return(2)
-      expect { nx.before_run }.to exit({"msg" => "operation is cancelled due to the destruction of the minio server"})
-    end
-  end
-
   describe "#available?" do
     before do
       allow(nx.minio_server).to receive(:cert).and_return("cert")

--- a/spec/prog/vnet/cert_server_spec.rb
+++ b/spec/prog/vnet/cert_server_spec.rb
@@ -39,8 +39,7 @@ RSpec.describe Prog::Vnet::CertServer do
 
     it "pops if destroy semaphore is set" do
       nx.incr_destroy
-
-      expect { nx.before_run }.to exit({"msg" => "early exit due to destroy semaphore"})
+      expect { nx.before_run }.to exit({"msg" => "exiting early due to destroy semaphore"})
     end
 
     it "if vm exists, does nothing" do

--- a/spec/prog/vnet/update_load_balancer_node_spec.rb
+++ b/spec/prog/vnet/update_load_balancer_node_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Prog::Vnet::UpdateLoadBalancerNode do
 
     it "pops if destroy semaphore is set" do
       nx.incr_destroy
-      expect { nx.before_run }.to exit({"msg" => "early exit due to destroy semaphore"})
+      expect { nx.before_run }.to exit({"msg" => "exiting early due to destroy semaphore"})
     end
 
     it "doesn't do anything if the VM is not destroyed" do


### PR DESCRIPTION
When a strand has multiple frames in its stack and is destroyed, the top frame destroys the associated entities and pops. The next frame then continues to work but fails because the entities are already destroyed. This is fixed by first popping all frames but the last one, then switching to the destroy label to handle cleanup.

Several progs (InferenceEndpointReplicaNexus, InferenceRouterReplicaNexus, InferenceRouterTargetNexus, MinioServerNexus) had custom before_run implementations to handle this case. We added these because we hit the issue before, but any prog that pushes other progs could encounter it. Moving this logic into the base before_run handles it universally.