### PR TITLE
Split out AI playground CSP header

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -173,7 +173,7 @@ class Clover < Roda
     csp.form_action :self, "https://checkout.stripe.com", "https://github.com/login/oauth/authorize", "https://accounts.google.com/o/oauth2/auth"
     csp.script_src :self, "https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js", "https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js", "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js", "https://challenges.cloudflare.com/turnstile/v0/api.js", "https://cdn.jsdelivr.net/npm/marked@15.0.5/marked.min.js", "https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js"
     csp.frame_src :self, "https://challenges.cloudflare.com"
-    csp.connect_src :self, "https://*.ubicloud.com"
+    csp.connect_src :self
     csp.base_uri :none
     csp.frame_ancestors :none
   end

--- a/routes/project/inference_playground.rb
+++ b/routes/project/inference_playground.rb
@@ -3,6 +3,8 @@
 class Clover
   hash_branch(:project_prefix, "inference-playground") do |r|
     r.get web? do
+      content_security_policy.add_connect_src "https://*.#{Config.inference_dns_zone}"
+
       DB.ignore_duplicate_queries do
         @inference_models = [inference_router_model_ds.eager(inference_router: {load_balancer: :private_subnet}), inference_endpoint_ds.eager(:location, load_balancer: :private_subnet)].flat_map do |ds|
           ds.where(Sequel.pg_jsonb_op(:tags).get_text("capability") => "Text Generation").all


### PR DESCRIPTION
Previous hard coded *.ubicloud.com string was undesirable,
this is only needed by AI playground, so scope header to that route