### PR TITLE
Include created_at field in postgres list API

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -2728,6 +2728,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PostgresTag'
+        created_at:
+          description: Creation timestamp of the Postgres database
+          type: string
+          format: date-time
       additionalProperties: false
       required:
         - flavor
@@ -2743,6 +2747,7 @@ components:
         - maintenance_window_start_at
         - read_replica
         - tags
+        - created_at
     PostgresDatabaseMetrics:
       type: object
       properties:

--- a/serializers/postgres.rb
+++ b/serializers/postgres.rb
@@ -19,7 +19,8 @@ class Serializers::Postgres < Serializers::Base
       maintenance_window_start_at: pg.maintenance_window_start_at,
       read_replica: !!pg.read_replica?,
       parent: pg.parent&.path,
-      tags: pg.tags || []
+      tags: pg.tags || [],
+      created_at: pg.created_at.iso8601
     }
 
     if options[:detailed]

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -97,7 +97,10 @@ RSpec.describe Clover, "postgres" do
         }.to_json
 
         expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body)["name"]).to eq("test-postgres-no-ha")
+        response = JSON.parse(last_response.body)
+        expect(response["name"]).to eq("test-postgres-no-ha")
+        expect(response).to have_key("created_at")
+        expect(response["created_at"]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[Z+-]/)
 
         post "/project/#{project.ubid}/location/eu-central-h1/postgres/test-postgres-async", {
           size: "standard-2",

--- a/spec/serializers/postgres_spec.rb
+++ b/spec/serializers/postgres_spec.rb
@@ -96,4 +96,11 @@ RSpec.describe Serializers::Postgres do
     expect(data).not_to have_key(:earliest_restore_time)
     expect(data).not_to have_key(:latest_restore_time)
   end
+
+  it "includes created_at in detailed serialization" do
+    create_representative_server(primary: true)
+    data = described_class.serialize(pg)
+    expect(data).to have_key(:created_at)
+    expect(data[:created_at]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[Z+-]/)
+  end
 end


### PR DESCRIPTION
Useful for general observability,
and allows a view with a list of databases sorted by creation time.