### PR TITLE
Update openssl from 3.3.2 to 4.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
     openapi_parser (2.3.0)
-    openssl (3.3.2)
+    openssl (4.0.0)
     openssl-signature_algorithm (1.3.0)
       openssl (> 2.0)
     optparse (0.8.0)

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -26,7 +26,7 @@ module Util
 
   def self.parse_key(key_data)
     OpenSSL::PKey::EC.new(key_data)
-  rescue OpenSSL::PKey::ECError, OpenSSL::PKey::DSAError
+  rescue OpenSSL::PKey::PKeyError
     OpenSSL::PKey::RSA.new(key_data)
   end
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       location_id: Location::HETZNER_FSN1_ID,
       location: Location[Location::HETZNER_FSN1_ID],
       root_cert_1: "root cert 1",
-      root_cert_key_1: nil,
+      root_cert_key_1: "root cert key 1",
       root_cert_2: "root cert 2",
-      root_cert_key_2: nil,
+      root_cert_key_2: "root cert key 2",
       server_cert: "server cert",
       server_cert_key: nil,
       parent: nil,
@@ -317,6 +317,8 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(OpenSSL::X509::Certificate).to receive(:new).with("root cert 1").twice.and_return(instance_double(OpenSSL::X509::Certificate, not_after: Time.now + 60 * 60 * 24 * 360))
       expect(OpenSSL::X509::Certificate).to receive(:new).with("root cert 2").and_return(root_cert_2)
       expect(OpenSSL::X509::Certificate).to receive(:new).with("server cert").and_return(instance_double(OpenSSL::X509::Certificate, not_after: Time.now + 60 * 60 * 24 * 29))
+      expect(OpenSSL::PKey::EC).to receive(:new).with("root cert key 1").and_return(nil)
+      expect(OpenSSL::PKey::EC).to receive(:new).with("root cert key 2").and_return(nil)
 
       expect(Util).to receive(:create_certificate).with(hash_including(issuer_cert: root_cert_2)).and_return([instance_double(OpenSSL::X509::Certificate, to_pem: "server cert")])
       expect(postgres_resource.servers).to all(receive(:incr_refresh_certificates))


### PR DESCRIPTION
First rubocop fails with the following error:

    lib/util.rb:29:3: W: Lint/ShadowedException: Do not shadow rescued Exceptions.
      rescue OpenSSL::PKey::ECError, OpenSSL::PKey::DSAError ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

It's starting to complain about because errors are unified under OpenSSL::PKey::PKeyError at https://github.com/ruby/openssl/pull/929

So no need to rescue specific errors anymore, we can just rescue the parent error.

Secondly, postgres_resource_nexus_spec test fails with the following error:

    1) Prog::Postgres::PostgresResourceNexus#refresh_certificates rotates server certificate using root_cert_2 if root_cert_1 is close to expiration
       Failure/Error: expect { nx.refresh_certificates }.to hop("wait")

       ArgumentError:
         OpenSSL::PKey::EC.new cannot be called without arguments; pkeys are immutable with OpenSSL 3.0
       # ./prog/postgres/postgres_resource_nexus.rb:305:in 'OpenSSL::PKey::EC#initialize'
       # ./prog/postgres/postgres_resource_nexus.rb:305:in 'Class#new'
       # ./prog/postgres/postgres_resource_nexus.rb:305:in 'Prog::Postgres::PostgresResourceNexus#create_certificate'
       # ./prog/postgres/postgres_resource_nexus.rb:187:in 'Prog::Postgres::PostgresResourceNexus#refresh_certificates'
       # ./spec/prog/postgres/postgres_resource_nexus_spec.rb:324:in 'block (4 levels) in <top (required)>'
       # ./spec/spec_helper.rb:173:in 'block (3 levels) in <top (required)>'
       # ./spec/prog/postgres/postgres_resource_nexus_spec.rb:324:in 'block (3 levels) in <top (required)>'
       # ./spec/spec_helper.rb:62:in 'block (3 levels) in <top (required)>'
       # ./spec/spec_helper.rb:61:in 'block (2 levels) in <top (required)>'

It doesn't allow to pass nil to OpenSSL::PKey::EC.new anymore.