### PR TITLE
Remove LocationCredential project association

### DIFF
--- a/model/location_credential.rb
+++ b/model/location_credential.rb
@@ -6,7 +6,6 @@ require "aws-sdk-iam"
 
 class LocationCredential < Sequel::Model
   plugin ResourceMethods, encrypted_columns: [:access_key, :secret_key]
-  many_to_one :project
   many_to_one :location, key: :id
 
   def credentials


### PR DESCRIPTION
This association was broken, as the location_credential table does not have a project_id column. This resulted in a production exception:

NoMethodError - undefined method 'project_id' for an instance of LocationCredential