### PR TITLE
Add DNS AAAA records for non-AWS PostgreSQL databases

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -126,19 +126,17 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     if (dns_zone = postgres_resource.dns_zone)
       aws = postgres_resource.location.aws?
       vm = representative_server.vm
-      type, data = aws ? ["CNAME", vm.aws_instance.ipv4_dns_name + "."] : ["A", vm.ip4_string]
-
       record_name = postgres_resource.hostname
       dns_zone.delete_record(record_name:)
-      dns_zone.insert_record(record_name:, type:, ttl: 10, data:)
 
-      unless aws
-        dns_zone.insert_record(
-          record_name: "private-#{record_name}",
-          type: "A",
-          ttl: 10,
-          data: vm.private_ipv4_string
-        )
+      if aws
+        dns_zone.insert_record(record_name:, type: "CNAME", ttl: 10, data: vm.aws_instance.ipv4_dns_name + ".")
+      else
+        dns_zone.insert_record(record_name:, type: "A", ttl: 10, data: vm.ip4_string)
+        dns_zone.insert_record(record_name:, type: "AAAA", ttl: 10, data: vm.ip6_string)
+        record_name = "private-#{record_name}"
+        dns_zone.insert_record(record_name:, type: "A", ttl: 10, data: vm.private_ipv4_string)
+        dns_zone.insert_record(record_name:, type: "AAAA", ttl: 10, data: vm.private_ipv6_string)
       end
     end
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -214,11 +214,15 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     it "creates dns records and hops" do
       expect(postgres_resource.representative_server.vm).to receive(:ip4_string).and_return("1.1.1.1")
       expect(postgres_resource.representative_server.vm).to receive(:private_ipv4_string).and_return("1.1.1.2")
+      expect(postgres_resource.representative_server.vm).to receive(:ip6_string).and_return("::1")
+      expect(postgres_resource.representative_server.vm).to receive(:private_ipv6_string).and_return("::2")
       expect(postgres_resource).to receive(:hostname).and_return("pg-name.postgres.ubicloud.com.")
       dns_zone = instance_double(DnsZone)
       expect(dns_zone).to receive(:delete_record).with(record_name: "pg-name.postgres.ubicloud.com.")
       expect(dns_zone).to receive(:insert_record).with(record_name: "pg-name.postgres.ubicloud.com.", type: "A", ttl: 10, data: "1.1.1.1")
+      expect(dns_zone).to receive(:insert_record).with(record_name: "pg-name.postgres.ubicloud.com.", type: "AAAA", ttl: 10, data: "::1")
       expect(dns_zone).to receive(:insert_record).with(record_name: "private-pg-name.postgres.ubicloud.com.", type: "A", ttl: 10, data: "1.1.1.2")
+      expect(dns_zone).to receive(:insert_record).with(record_name: "private-pg-name.postgres.ubicloud.com.", type: "AAAA", ttl: 10, data: "::2")
       expect(postgres_resource).to receive(:dns_zone).and_return(dns_zone).at_least(:once)
       expect(nx).to receive(:when_initial_provisioning_set?).and_yield
       expect { nx.refresh_dns_record }.to hop("initialize_certificates")


### PR DESCRIPTION
This was already approved in #4364, but it got merged into #4363, then lost in a rebase.