### PR TITLE
Fix Clog related flaky test in vpc_nexus_spec.rb

### DIFF
--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -178,7 +178,10 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
   end
 
   describe "#destroy" do
-    before { client.stub_responses(:describe_subnets, subnets: [{state: "available"}]) }
+    before {
+      allow(Clog).to receive(:emit).and_call_original
+      client.stub_responses(:describe_subnets, subnets: [{state: "available"}])
+    }
 
     it "extends deadline if a vm prevents destroy" do
       vm = create_hosted_vm(ps.project, ps, "vm1")


### PR DESCRIPTION
Since subnet creation may generate an extra log regarding a disallowed subnet selection, checking the Clog emit caused a flaky test. We're adding an allow statement for such a case.