### PR TITLE
Fix double nested exception logs

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -24,7 +24,7 @@ Util.safe_write_to_file(postgres_monitor_db_ca_bundle_filename, Config.postgres_
 begin
   POSTGRES_MONITOR_DB = Sequel.connect(Config.postgres_monitor_database_url, max_connections: Config.db_pool_monitor, pool_timeout: Config.database_timeout, driver_options:) if Config.postgres_monitor_database_url
 rescue Sequel::DatabaseConnectionError => ex
-  Clog.emit("Failed to connect to Postgres Monitor database") { {database_connection_failed: {exception: Util.exception_to_hash(ex)}} }
+  Clog.emit("Failed to connect to Postgres Monitor database") { {database_connection_failed: Util.exception_to_hash(ex)} }
 end
 
 # Load Sequel Database/Global extensions here

--- a/lib/monitor_runner.rb
+++ b/lib/monitor_runner.rb
@@ -145,7 +145,7 @@ class MonitorRunner
     shutdown! unless @shutdown
     nil
   rescue => ex
-    Clog.emit("Pulse checking or resource scanning has failed.") { {pulse_checking_or_resource_scanning_failure: {exception: Util.exception_to_hash(ex)}} }
+    Clog.emit("Pulse checking or resource scanning has failed.") { {pulse_checking_or_resource_scanning_failure: Util.exception_to_hash(ex)} }
     ThreadPrinter.run
     Kernel.exit! 2
   end

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -435,6 +435,6 @@ class Prog::Vm::Aws::Nexus < Prog::Base
     Aws::IAM::Errors::InvalidRoleName,
     Aws::IAM::Errors::NoSuchEntity,
     Aws::IAM::Errors::EntityAlreadyExists => e
-    Clog.emit("ID not found or already exists for aws instance") { {ignored_aws_instance_failure: {exception: Util.exception_to_hash(e, backtrace: nil)}} }
+    Clog.emit("ID not found or already exists for aws instance") { {ignored_aws_instance_failure: Util.exception_to_hash(e, backtrace: nil)} }
   end
 end

--- a/prog/vnet/aws/nic_nexus.rb
+++ b/prog/vnet/aws/nic_nexus.rb
@@ -165,7 +165,7 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
     rescue Aws::EC2::Errors::DependencyViolation => e
       raise e if private_subnet.nics.count == 1
 
-      Clog.emit("dependency violation for aws nic") { {ignored_aws_nic_failure: {exception: Util.exception_to_hash(e, backtrace: nil)}} }
+      Clog.emit("dependency violation for aws nic") { {ignored_aws_nic_failure: Util.exception_to_hash(e, backtrace: nil)} }
     end
 
     hop_destroy_entities
@@ -210,6 +210,6 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
     Aws::EC2::Errors::InvalidAllocationIDNotFound,
     Aws::EC2::Errors::InvalidAddressIDNotFound,
     Aws::EC2::Errors::InvalidSubnetIDNotFound => e
-    Clog.emit("ID not found for aws nic") { {ignored_aws_nic_failure: {exception: Util.exception_to_hash(e, backtrace: nil)}} }
+    Clog.emit("ID not found for aws nic") { {ignored_aws_nic_failure: Util.exception_to_hash(e, backtrace: nil)} }
   end
 end

--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -172,7 +172,7 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
     Aws::EC2::Errors::InvalidNetworkInterfaceIDNotFound,
     Aws::EC2::Errors::InvalidInternetGatewayIDNotFound,
     Aws::EC2::Errors::InvalidVpcIDNotFound => e
-    Clog.emit("ID not found for aws vpc") { {ignored_aws_vpc_failure: {exception: Util.exception_to_hash(e, backtrace: nil)}} }
+    Clog.emit("ID not found for aws vpc") { {ignored_aws_vpc_failure: Util.exception_to_hash(e, backtrace: nil)} }
   end
 
   def location


### PR DESCRIPTION
`Util.exception_to_hash` already returns a hash with an exception key, so wrapping it again with another exception key is unnecessary and results in double nesting.

When rebasing #4465, I missed some changes in #4446. This includes the changes in #4446 that were not already merged as part of #4465.