### PR TITLE
Handle lsn_monitor being nil in PostgresServer#failover_target

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -191,7 +191,7 @@ class PostgresServer < Sequel::Model
     return nil if target.nil?
 
     if resource.ha_type == PostgresResource::HaType::ASYNC
-      return nil if lsn_monitor.last_known_lsn.nil?
+      return nil if lsn_monitor&.last_known_lsn.nil?
       return nil if lsn_diff(lsn_monitor.last_known_lsn, target[:lsn]) > 80 * 1024 * 1024 # 80 MB or ~5 WAL files
     end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -231,6 +231,11 @@ RSpec.describe PostgresServer do
       expect(postgres_server.failover_target).to be_nil
     end
 
+    it "returns nil if no lsn_monitor for async replication" do
+      resource.update(ha_type: PostgresResource::HaType::ASYNC)
+      expect(postgres_server.failover_target).to be_nil
+    end
+
     it "returns nil if lsn difference is too hign for async replication" do
       expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::ASYNC)
       expect(postgres_server).to receive(:lsn_monitor).and_return(instance_double(PostgresLsnMonitor, last_known_lsn: "2/0")).twice


### PR DESCRIPTION
Ran into this locally where lsn monitor wasn't being created because monitor wasn't running