### PR TITLE
Remove support for passing blocks to Clog.emit

### DIFF
--- a/lib/clog.rb
+++ b/lib/clog.rb
@@ -6,7 +6,12 @@ require "sequel/model"
 class Clog
   MUTEX = Mutex.new
 
-  def self.emit(message, metadata = block_given? ? yield : {})
+  def self.emit(message, metadata = {})
+    # :nocov:
+    # Cannot use spec passing block to cover this, or Ruby produces a warning
+    raise "Clog.emit no longer takes a block" if block_given?
+    # :nocov:
+
     out = case metadata
     when Hash
       metadata

--- a/spec/lib/clog_spec.rb
+++ b/spec/lib/clog_spec.rb
@@ -16,11 +16,6 @@ RSpec.describe Clog do
     end.join
   end
 
-  it "allows passing metadata in block block" do
-    expect($stdout).to receive(:write).with('{"foo":1,"message":"hello","time":"' + now.to_s + '"}' + "\n")
-    described_class.emit("hello") { {foo: 1} }
-  end
-
   it "doesn't include a thread name if it is not set" do
     expect($stdout).to receive(:write).with('{"message":"hello","time":"' + now.to_s + '"}' + "\n")
     described_class.emit "hello"


### PR DESCRIPTION
To avoid the chance someone passes a block that is silently ignored, raise for this case (without this, Ruby would warn, but tests would still pass).