### PR TITLE
Add deleting display state to private subnet

### DIFF
--- a/helpers/private_subnet.rb
+++ b/helpers/private_subnet.rb
@@ -37,7 +37,7 @@ class Clover
 
     if api?
       dataset = dataset.where(location: @location) if @location
-      paginated_result(dataset.eager(:location, firewalls: [:location, :firewall_rules], nics: [:private_subnet, :vm]), Serializers::PrivateSubnet)
+      paginated_result(dataset.eager(:location, :semaphores, firewalls: [:location, :firewall_rules], nics: [:private_subnet, :vm]), Serializers::PrivateSubnet)
     else
       @pss = dataset.eager(:location).all
       view "networking/private_subnet/index"

--- a/helpers/web.rb
+++ b/helpers/web.rb
@@ -8,7 +8,8 @@ class Clover < Roda
   ).freeze
 
   PS_STATE_LABEL_COLOR = Hash.new("bg-yellow-100 text-yellow-80").merge!(
-    "available" => "bg-green-100 text-green-800"
+    "available" => "bg-green-100 text-green-800",
+    "deleting" => "bg-red-100 text-red-800"
   ).freeze
 
   KUBERNETES_STATE_LABEL_COLOR = Hash.new("bg-slate-100 text-slate-800").merge!(

--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -77,6 +77,7 @@ class PrivateSubnet < Sequel::Model
   end
 
   def display_state
+    return "deleting" if destroying_set? || destroy_set?
     (state == "waiting") ? "available" : state
   end
 

--- a/serializers/firewall.rb
+++ b/serializers/firewall.rb
@@ -15,7 +15,7 @@ class Serializers::Firewall < Serializers::Base
     end
 
     if options[:detailed]
-      base[:private_subnets] = Serializers::PrivateSubnet.serialize(firewall.private_subnets(eager: [:location, nics: :vm, firewalls: [:location, :firewall_rules]]))
+      base[:private_subnets] = Serializers::PrivateSubnet.serialize(firewall.private_subnets(eager: [:location, :semaphores, nics: :vm, firewalls: [:location, :firewall_rules]]))
     end
 
     base


### PR DESCRIPTION
When we trigger the destroy action for a private subnet, it still appears as “available” until the very end of the process.

Adding a “deleting” state would make it clear that the resource is in the process of being destroyed.

Since this is the first semaphore dependent display state for private subnets, we need to load it eagerly.