### PR TITLE
Avoid inconsistency in e.g. usage in CLI

### DIFF
--- a/cli-commands/pg/post/create.rb
+++ b/cli-commands/pg/post/create.rb
@@ -9,7 +9,7 @@ UbiCli.on("pg").run_on("create") do
     on("-s", "--size=size", Option::POSTGRES_SIZE_OPTIONS.keys, "server size")
     on("-S", "--storage-size=size", Option::POSTGRES_STORAGE_SIZE_OPTIONS.map(&:to_s), "storage size GB")
     on("-v", "--version=version", Option::POSTGRES_VERSION_OPTIONS[PostgresResource::Flavor::STANDARD], "PostgreSQL version")
-    on("-c", "--pg-config=config", "postgres config (e.g key1=value1,key2=value2)")
+    on("-c", "--pg-config=config", "postgres config (e.g. key1=value1,key2=value2)")
     on("-u", "--pgbouncer-config=config", "pgbouncer config (e.g. key1=value1,key2=value2)")
     on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
     on("-R", "--restrict-by-default", "restrict access by default (add firewall rules to allow access)")

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -594,7 +594,7 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
-    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -c, --pg-config=config           postgres config (e.g. key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s bad -S 64.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s bad -S 64.txt
@@ -11,7 +11,7 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
-    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -c, --pg-config=config           postgres config (e.g. key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -f bad.txt
@@ -11,7 +11,7 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
-    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -c, --pg-config=config           postgres config (e.g. key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -h bad.txt
@@ -11,7 +11,7 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
-    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -c, --pg-config=config           postgres config (e.g. key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -t bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -t bad.txt
@@ -11,7 +11,7 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
-    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -c, --pg-config=config           postgres config (e.g. key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S 64 -v bad.txt
@@ -11,7 +11,7 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
-    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -c, --pg-config=config           postgres config (e.g. key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S bad.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create -s standard-2 -S bad.txt
@@ -11,7 +11,7 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
-    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -c, --pg-config=config           postgres config (e.g. key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test2-pg create invalid.txt
@@ -11,7 +11,7 @@ Options:
     -s, --size=size                  server size
     -S, --storage-size=size          storage size GB
     -v, --version=version            PostgreSQL version
-    -c, --pg-config=config           postgres config (e.g key1=value1,key2=value2)
+    -c, --pg-config=config           postgres config (e.g. key1=value1,key2=value2)
     -u, --pgbouncer-config=config    pgbouncer config (e.g. key1=value1,key2=value2)
     -t, --tags=tags                  tags (e.g. key1=value1,key2=value2)
     -R, --restrict-by-default        restrict access by default (add firewall rules to allow access)


### PR DESCRIPTION
Always use "e.g." instead of mixing "e.g." and "e.g".