### PR TITLE
Make ubiblk the default storage backend for new hosts

### DIFF
--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -66,9 +66,7 @@ class Prog::Test::HetznerServer < Prog::Test::Base
       frame["hostname"],
       provider_name: HostProvider::HETZNER_PROVIDER_NAME,
       server_identifier: frame["server_id"],
-      default_boot_images: frame["default_boot_images"],
-      spdk_version: nil,
-      vhost_block_backend_version: Config.vhost_block_backend_version
+      default_boot_images: frame["default_boot_images"]
     ).subject
     update_stack({"vm_host_id" => vm_host.id})
 

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -3,7 +3,7 @@
 class Prog::Vm::HostNexus < Prog::Base
   subject_is :sshable, :vm_host
 
-  def self.assemble(sshable_hostname, location_id: Location::HETZNER_FSN1_ID, family: "standard", net6: nil, ndp_needed: false, provider_name: nil, server_identifier: nil, spdk_version: Config.spdk_version, vhost_block_backend_version: nil, default_boot_images: [])
+  def self.assemble(sshable_hostname, location_id: Location::HETZNER_FSN1_ID, family: "standard", net6: nil, ndp_needed: false, provider_name: nil, server_identifier: nil, spdk_version: nil, vhost_block_backend_version: Config.vhost_block_backend_version, default_boot_images: [])
     DB.transaction do
       unless Location[location_id]
         raise "No existing Location"


### PR DESCRIPTION
Ubiblk has been tested in production and has been stable. This change makes it the default storage backend for new hosts.