### PR TITLE
Include association method for GithubInstallation#cache_entries

### DIFF
--- a/model/github/github_installation.rb
+++ b/model/github/github_installation.rb
@@ -7,7 +7,7 @@ class GithubInstallation < Sequel::Model
   one_to_many :runners, key: :installation_id, class: :GithubRunner, remover: nil, clearer: nil, is_used: true
   one_to_many :repositories, key: :installation_id, class: :GithubRepository, read_only: true, is_used: true
   one_to_many :custom_labels, class: :GithubCustomLabel, key: :installation_id, read_only: true, no_association_method: true
-  many_to_many :cache_entries, join_table: :github_repository, right_key: :id, right_primary_key: :repository_id, left_key: :installation_id, class: :GithubCacheEntry, read_only: true, no_association_method: true
+  many_to_many :cache_entries, join_table: :github_repository, right_key: :id, right_primary_key: :repository_id, left_key: :installation_id, class: :GithubCacheEntry, read_only: true, is_used: true
 
   plugin ResourceMethods
   dataset_module Pagination


### PR DESCRIPTION
This isn't used anywhere in the specs, but it is used in the admin site.