### PR TITLE
Remove the use of :no_association_method association option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -352,7 +352,10 @@ task :unused_associations_check do
 
   options_data = Sequel::Model.unused_association_options
   options_data.reject!(&keep)
-  options_data.each { |_, _, opts| opts.delete(:no_dataset_method) }
+  options_data.each do |_, _, opts|
+    opts.delete(:no_dataset_method)
+    opts.delete(:no_association_method)
+  end
   options_data.reject! { |_, _, opts| opts.empty? }
   if options_data.empty?
     puts "No Associations Need Option Changes."

--- a/model/ai/inference_router_model.rb
+++ b/model/ai/inference_router_model.rb
@@ -3,7 +3,7 @@
 require_relative "../../model"
 
 class InferenceRouterModel < Sequel::Model
-  one_to_many :inference_router_targets, read_only: true, no_association_method: true
+  one_to_many :inference_router_targets, read_only: true
   one_through_one :inference_router, join_table: :inference_router_target, read_only: true
 
   plugin ResourceMethods

--- a/model/ai/inference_router_target.rb
+++ b/model/ai/inference_router_target.rb
@@ -4,7 +4,7 @@ require_relative "../../model"
 
 class InferenceRouterTarget < Sequel::Model
   one_to_one :strand, key: :id, read_only: true
-  many_to_one :inference_router, read_only: true, no_association_method: true
+  many_to_one :inference_router, read_only: true
   many_to_one :inference_router_model, read_only: true
 
   plugin ResourceMethods, encrypted_columns: :api_key

--- a/model/cert.rb
+++ b/model/cert.rb
@@ -3,7 +3,7 @@
 require_relative "../model"
 
 class Cert < Sequel::Model
-  one_to_one :load_balancer_cert, read_only: true, no_association_method: true
+  one_to_one :load_balancer_cert, read_only: true
   one_to_one :strand, key: :id
 
   plugin :association_dependencies, load_balancer_cert: :destroy

--- a/model/github/github_installation.rb
+++ b/model/github/github_installation.rb
@@ -6,8 +6,8 @@ class GithubInstallation < Sequel::Model
   many_to_one :project
   one_to_many :runners, key: :installation_id, class: :GithubRunner, remover: nil, clearer: nil, is_used: true
   one_to_many :repositories, key: :installation_id, class: :GithubRepository, read_only: true, is_used: true
-  one_to_many :custom_labels, class: :GithubCustomLabel, key: :installation_id, read_only: true, no_association_method: true
-  many_to_many :cache_entries, join_table: :github_repository, right_key: :id, right_primary_key: :repository_id, left_key: :installation_id, class: :GithubCacheEntry, read_only: true, is_used: true
+  one_to_many :custom_labels, class: :GithubCustomLabel, key: :installation_id, read_only: true
+  many_to_many :cache_entries, join_table: :github_repository, right_key: :id, right_primary_key: :repository_id, left_key: :installation_id, class: :GithubCacheEntry, read_only: true
 
   plugin ResourceMethods
   dataset_module Pagination

--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -10,7 +10,7 @@ class LoadBalancer < Sequel::Model
   one_to_many :load_balancer_vms, read_only: true
   one_to_many :ports, class: :LoadBalancerPort, remover: nil, clearer: nil
   many_to_many :certs, remover: nil, clearer: nil
-  one_to_many :load_balancer_certs, read_only: true, no_association_method: true
+  one_to_many :load_balancer_certs, read_only: true
   many_to_one :custom_hostname_dns_zone, class: :DnsZone, read_only: true
   many_to_many :vm_ports, join_table: :load_balancer_port, right_key: :id, right_primary_key: :load_balancer_port_id, class: :LoadBalancerVmPort, read_only: true
   many_to_many :active_vm_ports, join_table: :load_balancer_port, right_key: :id, right_primary_key: :load_balancer_port_id, class: :LoadBalancerVmPort, read_only: true, conditions: {state: "up"}

--- a/model/oidc_provider.rb
+++ b/model/oidc_provider.rb
@@ -4,7 +4,7 @@ require_relative "../model"
 require "excon"
 
 class OidcProvider < Sequel::Model
-  one_to_many :locked_domains, no_association_method: true, remover: nil, clearer: nil
+  one_to_many :locked_domains, remover: nil, clearer: nil
 
   def self.name_for_ubid(ubid)
     OidcProvider[UBID.to_uuid(ubid)]&.display_name

--- a/model/postgres/postgres_metric_destination.rb
+++ b/model/postgres/postgres_metric_destination.rb
@@ -3,7 +3,7 @@
 require_relative "../../model"
 
 class PostgresMetricDestination < Sequel::Model
-  many_to_one :postgres_resource, no_association_method: true
+  many_to_one :postgres_resource
 
   plugin ResourceMethods, encrypted_columns: :password
 end

--- a/model/project.rb
+++ b/model/project.rb
@@ -28,8 +28,8 @@ class Project < Sequel::Model
   RESOURCE_ASSOCIATION_DATASET_METHODS = RESOURCE_ASSOCIATIONS.map { :"#{it}_dataset" }
 
   one_to_many :invoices, order: Sequel.desc(:created_at), read_only: true
-  one_to_many :quotas, class: :ProjectQuota, no_association_method: true, remover: nil, clearer: nil
-  one_to_many :invitations, class: :ProjectInvitation, no_association_method: true, remover: nil, clearer: nil
+  one_to_many :quotas, class: :ProjectQuota, remover: nil, clearer: nil
+  one_to_many :invitations, class: :ProjectInvitation, remover: nil, clearer: nil
   one_to_many :api_keys, key: :owner_id, conditions: {owner_table: "project"}, read_only: true
   one_to_many :locations, read_only: true
   many_to_many :payment_methods, join_table: :billing_info, left_primary_key: :billing_info_id, left_key: :id, right_key: :id, right_primary_key: :billing_info_id, read_only: true


### PR DESCRIPTION
The admin site expects that if an association exists, the association method exists. It's currently undertested, but it's likely all models that were using :no_association_method have broken admin pages (at least GitHubInstallation did).

Change the unused_associations_check rake task to not recommend the use of this option, as it currently doesn't recommend the use of :no_dataset_method.