### PR TITLE
Return 400 instead of 500 for invalid Kubernetes version

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -304,6 +304,10 @@ module Validation
     fail ValidationFailed.new({worker_node_count: "Kubernetes worker node count must be greater than 0."}) if count <= 0
   end
 
+  def self.validate_kubernetes_version(version)
+    fail ValidationFailed.new({version: "Kubernetes version \"#{version}\" is not supported. Available versions: #{Option.kubernetes_versions.join(", ")}"}) unless Option.kubernetes_versions.include?(version)
+  end
+
   def self.validate_victoria_metrics_username(username)
     msg = "VictoriaMetrics user must only contain lowercase letters, numbers, hyphens and underscore and cannot start with a number or hyphen. It also has a max length of 32 and a min length of 3."
     fail ValidationFailed.new({username: msg}) unless username&.match(ALLOWED_VICTORIA_METRICS_USERNAME_PATTERN)

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -9,10 +9,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
         fail "No existing project"
       end
 
-      unless Option.kubernetes_versions.include?(version)
-        fail "Invalid Kubernetes Version"
-      end
-
+      Validation.validate_kubernetes_version(version)
       Validation.validate_kubernetes_name(name)
       Validation.validate_kubernetes_cp_node_count(cp_node_count)
 

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -453,6 +453,20 @@ RSpec.describe Validation do
     end
   end
 
+  describe "#validate_kubernetes_version" do
+    it "valid versions" do
+      Option.kubernetes_versions.each do |version|
+        expect(described_class.validate_kubernetes_version(version)).to be_nil
+      end
+    end
+
+    it "invalid versions" do
+      ["v1.30", "v1.25", "invalid", "1.34"].each do |version|
+        expect { described_class.validate_kubernetes_version(version) }.to raise_error described_class::ValidationFailed
+      end
+    end
+  end
+
   describe "#validate_private_location_name" do
     it "validates aws region names" do
       expect { described_class.validate_provider_location_name("aws", "us-west-2") }.not_to raise_error

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
       expect {
         described_class.assemble(version: "v1.30", project_id: customer_project.id, name: "k8stest", location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3, private_subnet_id: subnet.id)
-      }.to raise_error RuntimeError, "Invalid Kubernetes Version"
+      }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: version"
 
       expect {
         described_class.assemble(name: "Uppercase", project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3, private_subnet_id: subnet.id)

--- a/spec/routes/api/project/location/kubernetes_cluster_spec.rb
+++ b/spec/routes/api/project/location/kubernetes_cluster_spec.rb
@@ -74,6 +74,21 @@ RSpec.describe Clover, "kubernetes-cluster" do
         expect(JSON.parse(last_response.body)["version"]).to eq("v1.33")
         expect(KubernetesCluster[name: "test-cluster"]).not_to be_nil
       end
+
+      it "returns 400 for invalid kubernetes version" do
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/kubernetes-cluster/test-cluster", {
+          version: "v1.30",
+          worker_size: "standard-2",
+          worker_nodes: 2,
+          cp_nodes: 1
+        }.to_json
+
+        expect(last_response.status).to eq(400)
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: version")
+        parsed_body = JSON.parse(last_response.body)
+        expect(parsed_body["error"]["details"]["version"]).to include("Kubernetes version \"v1.30\" is not supported")
+        expect(parsed_body["error"]["details"]["version"]).to include("Available versions:")
+      end
     end
 
     describe "show" do


### PR DESCRIPTION
This commit adds proper validation for Kubernetes version parameter that makes the endpoint return a 400 Bad Request with helpful error message instead of throwing a 500.