### PR TITLE
Check for PostgresServer#run_query insecurity

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -605,16 +605,16 @@ namespace :linter do
     end
   end
 
-  desc "Check for potentially unsafe overrides of cmd/exec!"
+  desc "Check for potentially unsafe overrides of methods"
   task :cmd_exec do
     failure = false
     Dir.glob("spec/**/*.rb").each do |file|
       number = 0
       File.foreach(file) do |line|
         number += 1
-        if /\(:(cmd|exec!|kubectl|rootish_ssh)/.match?(line)
+        if /\(:(cmd|exec!|kubectl|rootish_ssh|run_query)/.match?(line)
           failure = true
-          warn "Potentially insecure :cmd/:exec! override: #{file}:#{number}: #{line}"
+          warn "Potentially insecure method override: #{file}:#{number}: #{line}"
         end
       end
     end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -376,10 +376,10 @@ CONFIG
       # database to do the encryption.
       conn.encrypt_password(postgres_server.resource.superuser_password, "postgres", "scram-sha-256")
     end
-    commands = <<SQL
+    commands = DB[<<SQL, encrypted_password:]
 BEGIN;
 SET LOCAL log_statement = 'none';
-ALTER ROLE postgres WITH PASSWORD #{DB.literal(encrypted_password)};
+ALTER ROLE postgres WITH PASSWORD :encrypted_password;
 COMMIT;
 SQL
     postgres_server.run_query(commands)
@@ -421,7 +421,7 @@ SQL
   end
 
   label def wait_synchronization
-    query = "SELECT sync_state FROM pg_stat_replication WHERE application_name = '#{postgres_server.ubid}'"
+    query = DB["SELECT sync_state FROM pg_stat_replication WHERE application_name = :ubid", ubid: postgres_server.ubid]
     sync_state = postgres_server.resource.representative_server.run_query(query).chomp
     hop_wait if ["quorum", "sync"].include?(sync_state)
 

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -159,10 +159,10 @@ class Prog::Test::HaPostgresResource < Prog::Test::Base
   end
 
   def test_queries_sql
-    File.read("./prog/test/testdata/order_analytics_queries.sql")
+    File.read("./prog/test/testdata/order_analytics_queries.sql").freeze
   end
 
   def read_queries_sql
-    File.read("./prog/test/testdata/order_analytics_read_queries.sql")
+    File.read("./prog/test/testdata/order_analytics_read_queries.sql").freeze
   end
 end

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -103,6 +103,6 @@ class Prog::Test::PostgresResource < Prog::Test::Base
   end
 
   def test_queries_sql
-    File.read("./prog/test/testdata/order_analytics_queries.sql")
+    File.read("./prog/test/testdata/order_analytics_queries.sql").freeze
   end
 end

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -213,8 +213,8 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
   describe "#trigger_pg_current_xact_id_on_parent" do
     it "triggers pg_current_xact_id and pops" do
-      representative_server = instance_double(PostgresServer)
-      expect(representative_server).to receive(:run_query).with("SELECT pg_current_xact_id()")
+      representative_server = PostgresServer.new
+      expect(representative_server).to receive(:_run_query).with("SELECT pg_current_xact_id()")
       expect(postgres_resource).to receive(:parent).and_return(instance_double(PostgresResource, representative_server:))
 
       expect { nx.trigger_pg_current_xact_id_on_parent }.to exit({"msg" => "triggered pg_current_xact_id"})

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -86,14 +86,14 @@ RSpec.describe Prog::Test::HaPostgresResource do
     end
 
     it "fails if the postgres test fails" do
-      allow(pgr_test.representative_server).to receive(:run_query).and_return("")
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("")
       expect { pgr_test.test_postgres }.to hop("destroy_postgres")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run test queries")
     end
 
     it "hops to trigger_failover if the postgres test passes" do
-      allow(pgr_test.representative_server).to receive(:run_query).and_return("DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1")
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1")
       expect { pgr_test.test_postgres }.to hop("trigger_failover")
     end
   end
@@ -142,14 +142,14 @@ RSpec.describe Prog::Test::HaPostgresResource do
     end
 
     it "fails if the postgres test fails" do
-      allow(pgr_test.representative_server).to receive(:run_query).and_return("")
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("")
       expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run read queries after failover")
     end
 
     it "logs that no primary was found after failover" do
       refresh_frame(pgr_test, new_values: {"primary_ubid" => pgr_test.postgres_resource.representative_server.ubid})
-      allow(pgr_test.representative_server).to receive(:run_query).and_return("")
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("")
       expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run read queries after failover")
       expect(Clog).to receive(:emit).with(/Postgres servers after failover: .*/).once.ordered
@@ -160,13 +160,13 @@ RSpec.describe Prog::Test::HaPostgresResource do
     end
 
     it "hops to destroy_postgres if the standby does not exit read-only mode" do
-      allow(pgr_test.representative_server).to receive(:run_query).and_return("4159.90\n415.99\n4.1", "")
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "")
       expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run write queries after failover")
     end
 
     it "hops to destroy_postgres if the postgres test succeeds" do
-      allow(pgr_test.representative_server).to receive(:run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1")
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1")
       expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
       expect(frame_value(pgr_test, "fail_message")).to be_nil
     end


### PR DESCRIPTION
This changes PostgresServer#run_query to work similarly to Sshable#cmd, and fail if passed a non-frozen string. To handle cases currently using interpolation, instead of the :placeholder usage, allow passing a Sequel::Dataset, and take the SQL from that (without parameterization, since the full SQL is needed). The Sequel::Dataset can use :placeholders, so this allows for very similar code as used for shell command placeholder escaping.

Have run_query call _run_query, and have the specs override that.

Check that run_query itself is never mocked in the specs.

While non of the interpolated strings appear to be vulnerable, this replaces an insecure pattern with a secure pattern, which should be preferable.