### PR TITLE
Demock postgres_resource_spec

### DIFF
--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -7,8 +7,52 @@ RSpec.describe Prog::Test::PostgresResource do
 
   let(:test_project) { Project.create(name: "test-project") }
   let(:service_project) { Project.create(name: "service-project") }
-  let(:working_representative_server) { instance_double(PostgresServer, run_query: "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1") }
-  let(:faulty_representative_server) { instance_double(PostgresServer, run_query: "") }
+  let(:location_id) { Location::HETZNER_FSN1_ID }
+
+  let(:private_subnet) {
+    PrivateSubnet.create(
+      name: "pg-subnet", project_id: test_project.id, location_id:,
+      net4: "172.0.0.0/26", net6: "fdfa:b5aa:14a3:4a3d::/64"
+    )
+  }
+
+  let(:timeline) { PostgresTimeline.create(location_id:) }
+
+  let(:postgres_resource) {
+    pr = PostgresResource.create(
+      name: "pg-test",
+      superuser_password: "dummy-password",
+      ha_type: "none",
+      target_version: "17",
+      location_id:,
+      project_id: test_project.id,
+      user_config: {},
+      pgbouncer_user_config: {},
+      target_vm_size: "standard-2",
+      target_storage_size_gib: 64
+    )
+    Strand.create_with_id(pr, prog: "Postgres::PostgresResourceNexus", label: "wait")
+    pr
+  }
+
+  def create_postgres_server
+    vm = Prog::Vm::Nexus.assemble_with_sshable(
+      test_project.id, name: "pg-vm-#{SecureRandom.hex(4)}", private_subnet_id: private_subnet.id,
+      location_id:, unix_user: "ubi"
+    ).subject
+    server = PostgresServer.create(
+      timeline:, resource_id: postgres_resource.id, vm_id: vm.id,
+      representative_at: Time.now, synchronization_status: "ready", timeline_access: "push", version: "17"
+    )
+    Strand.create_with_id(server, prog: "Postgres::PostgresServerNexus", label: "wait")
+    server
+  end
+
+  def setup_postgres_resource(with_server: true)
+    postgres_resource
+    create_postgres_server if with_server
+    refresh_frame(pgr_test, new_values: {"postgres_resource_id" => postgres_resource.id})
+  end
 
   before do
     allow(Config).to receive(:postgres_service_project_id).and_return(service_project.id)
@@ -24,83 +68,89 @@ RSpec.describe Prog::Test::PostgresResource do
 
   describe "#start" do
     it "creates resource on metal and hops to wait_postgres_resource" do
-      expect(pgr_test).to receive(:frame).and_return({"provider" => "metal", "postgres_test_project_id" => test_project.id}).at_least(:once)
       expect { pgr_test.start }.to hop("wait_postgres_resource")
     end
 
     it "creates resource on aws and hops to wait_postgres_resource" do
       expect(Config).to receive(:e2e_aws_access_key).and_return("access_key")
       expect(Config).to receive(:e2e_aws_secret_key).and_return("secret_key")
-      expect(pgr_test).to receive(:frame).and_return({"provider" => "aws", "postgres_test_project_id" => test_project.id}).at_least(:once)
-      expect { pgr_test.start }.to hop("wait_postgres_resource")
+      aws_strand = described_class.assemble(provider: "aws")
+      aws_pgr_test = described_class.new(aws_strand)
+      expect { aws_pgr_test.start }.to hop("wait_postgres_resource")
       location = Location[provider: "aws", project_id: nil, name: "us-west-2"]
       expect(LocationCredential[location.id].access_key).to eq("access_key")
     end
   end
 
   describe "#wait_postgres_resource" do
-    it "hops to test_basic_connectivity if the postgres resource is ready" do
-      expect(pgr_test).to receive(:postgres_resource).exactly(2).and_return(instance_double(Prog::Postgres::PostgresResourceNexus, strand: instance_double(Strand, label: "wait"), representative_server: instance_double(PostgresServer, run_query: "1")))
+    before { setup_postgres_resource }
+
+    let(:sshable) { pgr_test.representative_server.vm.sshable }
+
+    it "hops to test_postgres if the postgres resource is ready" do
+      expect(sshable).to receive(:_cmd).and_return("1\n")
       expect { pgr_test.wait_postgres_resource }.to hop("test_postgres")
     end
 
     it "naps for 10 seconds if the postgres resource is not ready" do
-      expect(pgr_test).to receive(:postgres_resource).exactly(2).and_return(instance_double(Prog::Postgres::PostgresResourceNexus, strand: instance_double(Strand, label: "wait"), representative_server: instance_double(PostgresServer, run_query: "")))
+      expect(sshable).to receive(:_cmd).and_return("\n")
       expect { pgr_test.wait_postgres_resource }.to nap(10)
     end
   end
 
   describe "#test_postgres" do
+    before { setup_postgres_resource }
+
+    let(:sshable) { pgr_test.representative_server.vm.sshable }
+
     it "fails if the basic connectivity test fails" do
-      expect(pgr_test).to receive(:representative_server).and_return(faulty_representative_server)
+      expect(sshable).to receive(:_cmd).and_return("\n")
       expect { pgr_test.test_postgres }.to hop("destroy_postgres")
     end
 
-    it "hops to test_table_create if the basic connectivity test passes" do
-      expect(pgr_test).to receive(:representative_server).and_return(working_representative_server)
+    it "hops to destroy_postgres if the basic connectivity test passes" do
+      expect(sshable).to receive(:_cmd).and_return("DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1\n")
       expect { pgr_test.test_postgres }.to hop("destroy_postgres")
     end
   end
 
   describe "#destroy_postgres" do
-    it "increments the destroy count and hops to destroy" do
-      postgres_resource = instance_double(Prog::Postgres::PostgresResourceNexus, incr_destroy: nil)
-      expect(PostgresResource).to receive(:[]).and_return(postgres_resource)
-      expect(postgres_resource).to receive(:incr_destroy)
-      expect(pgr_test).to receive(:frame).and_return({})
+    before { setup_postgres_resource(with_server: false) }
+
+    it "increments the destroy count and hops to wait_resources_destroyed" do
       expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
+      expect(Semaphore.where(strand_id: postgres_resource.id, name: "destroy").count).to eq(1)
     end
   end
 
   describe "#wait_resources_destroyed" do
     it "naps if the postgres resource isn't deleted yet" do
-      expect(pgr_test).to receive(:postgres_resource).and_return(instance_double(PostgresResource))
+      setup_postgres_resource(with_server: false)
       expect { pgr_test.wait_resources_destroyed }.to nap(5)
     end
 
     it "naps if the private subnet isn't deleted yet" do
-      expect(pgr_test).to receive(:postgres_resource).and_return(nil)
-      expect(PrivateSubnet).to receive(:[]).and_return(instance_double(PrivateSubnet))
+      project_id = pgr_test.strand.stack.first["postgres_test_project_id"]
+      PrivateSubnet.create(name: "subnet", project_id:, location_id:, net4: "10.0.0.0/26", net6: "fd00::/64")
       expect { pgr_test.wait_resources_destroyed }.to nap(5)
     end
 
     it "hops to destroy if the postgres resource destroyed" do
-      expect(pgr_test).to receive(:postgres_resource).and_return(nil)
       expect { pgr_test.wait_resources_destroyed }.to hop("destroy")
     end
   end
 
   describe "#destroy" do
-    it "increments the destroy count and exits if no failure happened" do
-      expect(Project).to receive(:[]).exactly(2).and_return(instance_double(Project, id: "1234", destroy: nil))
-      expect(pgr_test).to receive(:frame).exactly(3).and_return({"project_created" => false})
+    it "exits successfully if no failure happened" do
       expect { pgr_test.destroy }.to exit({"msg" => "Postgres tests are finished!"})
     end
 
-    it "increments the destroy count and hops to failed if a failure happened" do
-      expect(Project).to receive(:[]).exactly(2).and_return(instance_double(Project, id: "1234", destroy: nil))
-      expect(pgr_test).to receive(:frame).exactly(3).and_return({"fail_message" => "Test failed", "project_created" => true})
-      expect { pgr_test.destroy }.to hop("failed")
+    it "hops to failed if a failure happened" do
+      pgr_test.strand.stack.first["fail_message"] = "Test failed"
+      pgr_test.strand.modified!(:stack)
+      pgr_test.strand.save_changes
+      fresh_pgr_test = described_class.new(pgr_test.strand)
+      expect { fresh_pgr_test.destroy }.to hop("failed")
     end
   end
 
@@ -110,11 +160,11 @@ RSpec.describe Prog::Test::PostgresResource do
     end
   end
 
-  describe ".representative_server" do
+  describe "#representative_server" do
+    before { setup_postgres_resource }
+
     it "returns the representative server" do
-      postgres_resource = instance_double(Prog::Postgres::PostgresResourceNexus, representative_server: working_representative_server)
-      expect(pgr_test).to receive(:postgres_resource).and_return(postgres_resource)
-      expect(pgr_test.representative_server).to eq(working_representative_server)
+      expect(pgr_test.representative_server).to eq(postgres_resource.representative_server)
     end
   end
 end


### PR DESCRIPTION
Instance doubles for PostgresResource and PostgresServer disconnected these tests from real database behavior. Schema or association changes would go undetected since mocks don't validate against actual models.

Replace all Sequel model mocks with real persisted instances:
- PostgresResource with associated Strand via postgres_resource let
- PostgresServer via create_postgres_server() helper with real Vm
- Real semaphore operations (incr_destroy) instead of yield stubs
- Proper FK chain: Project → PrivateSubnet → Vm → PostgresServer

The setup_postgres_resource() helper encapsulates the repeated fixture pattern, and create_postgres_server() handles the 10+ line setup for each server instance.