### PR TITLE
Add admin page to find archived records

### DIFF
--- a/model/archived_record.rb
+++ b/model/archived_record.rb
@@ -5,6 +5,14 @@ require_relative "../model"
 class ArchivedRecord < Sequel::Model
   no_primary_key
 
+  def self.find_by_id(id, model_name:, days: 15)
+    DB[:archived_record]
+      .where(model_name:)
+      .where(Sequel[:archived_at] > Sequel::CURRENT_TIMESTAMP - Sequel.cast("#{days} days", :interval))
+      .where(Sequel.pg_jsonb_op(:model_values).get_text("id") => id)
+      .first
+  end
+
   def self.vms_by_ips(ips)
     ip_values = Sequel.pg_jsonb_op(Sequel[:ip][:model_values])
     vm_values = Sequel.pg_jsonb_op(Sequel[:vm][:model_values])

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -153,7 +153,7 @@ code {
   }
 }
 
-#action-form {
+.form-vertical {
   display: flex;
   flex-direction: column;
   align-items: start;

--- a/spec/model/archived_record_spec.rb
+++ b/spec/model/archived_record_spec.rb
@@ -30,4 +30,13 @@ RSpec.describe ArchivedRecord do
   it "fails to create in the distant future" do
     expect { described_class.create(archived_at: Time.now + 60 * 60 * 24 * 365 * 10, model_name: "Vm", model_values: {"state" => "creating"}) }.to raise_error(Sequel::ConstraintViolation)
   end
+
+  it "finds archived record by id" do
+    (vm = create_vm).destroy
+    record = described_class.find_by_id(vm.id, model_name: "Vm")
+    expect(record).not_to be_nil
+    expect(record[:model_values]["id"]).to eq(vm.id)
+    expect(record[:model_values]["name"]).to eq(vm.name)
+    expect(record[:archived_at]).to be_within(5).of(Time.now)
+  end
 end

--- a/views/admin/archived_record_by_id.erb
+++ b/views/admin/archived_record_by_id.erb
@@ -1,0 +1,23 @@
+<% @page_title = "Find Archived Record by ID" %>
+
+<p>
+  This page allows you to find archived records by UBID or UUID. Useful for investigating deleted resources.
+</p>
+
+<% form(id: "archived_record_form", class: "form-vertical") do |f| %>
+  <%== f.input("text", key: "id", label: "ID", placeholder: "Enter UBID or UUID", value: @id) %>
+  <%== f.input("select", key: "model_name", label: "Model Name", add_blank: "From ID", options: @classes.map(&:name), value: @model_name) %>
+  <%== f.input("number", key: "days", label: "Days", placeholder: "1-60", value: @days, min: 1, max: 60) %>
+  Higher day values will increase query duration significantly. Use the smallest value possible.
+  <%== f.button("Find Archived Record") %>
+<% end %>
+
+<% if @id %>
+  <% if @record
+    data = {model_name: @record[:model_name], archived_at: @record[:archived_at]}
+      .merge!(@record[:model_values])
+      .map { |k, v| {"Key" => k, "Value" => v} }
+    end %>
+
+  <%== part("components/table", title: "Archived Record", table_class: "archived-record-table", data:) %>
+<% end %>

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -52,6 +52,7 @@
 
   <h2>Custom Tools</h2>
   <ul>
+    <li><a href="/archived-record-by-id">Find Archived Record by ID</a></li>
     <li><a href="/vm-by-ipv4">Find VM by IPv4 Address</a></li>
   </ul>
 

--- a/views/admin/object_action.erb
+++ b/views/admin/object_action.erb
@@ -1,6 +1,6 @@
 <% @page_title = "#{@klass.name} #{@obj.ubid}" %>
 
-<% form(method: :post, id: "action-form") do |f| %>
+<% form(method: :post, id: "action-form", class: "form-vertical") do |f| %>
   <% @params.each do |name, value| %>
     <%
       type = "text"


### PR DESCRIPTION
I often find myself querying the database to find archived records.

This is especially painful when working with short-lived resources such as GitHub runners. Being able to look up archived records in the admin panel using an ID from logs would be extremely helpful and save a lot of time.

ArchivedRecord table has index on `archived_at` and `model_name` columns, so it's important to filter by those columns in any query on this table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2522" height="1616" alt="CleanShot 2026-01-14 at 17 09 14@2x" src="https://github.com/user-attachments/assets/92e31b79-2391-4d90-ba0f-b6daf7bd0441" />

