### PR TITLE
Decrease day limits in archived record search page

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -580,7 +580,7 @@ class CloverAdmin < Roda
         fail CloverError.new(400, "InvalidRequest", "Invalid UBID or UUID provided")
       end
       @model_name = typecast_params.nonempty_str("model_name") || UBID.class_for_ubid(@id.to_s)&.name
-      @days = (typecast_params.pos_int("days") || 15).clamp(1, 60)
+      @days = (typecast_params.pos_int("days") || 5).clamp(1, 15)
       @classes = available_classes
       @record = if @id
         fail CloverError.new(400, "InvalidRequest", "Could not determine model name from ID") unless @model_name

--- a/model/archived_record.rb
+++ b/model/archived_record.rb
@@ -5,7 +5,7 @@ require_relative "../model"
 class ArchivedRecord < Sequel::Model
   no_primary_key
 
-  def self.find_by_id(id, model_name:, days: 15)
+  def self.find_by_id(id, model_name:, days: 5)
     DB[:archived_record]
       .where(model_name:)
       .where(Sequel[:archived_at] > Sequel::CURRENT_TIMESTAMP - Sequel.cast("#{days} days", :interval))

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -929,7 +929,7 @@ RSpec.describe CloverAdmin do
       within("#archived_record_form") do
         fill_in "id", with: vm.ubid
         select "Vm", from: "model_name"
-        fill_in "days", with: "30"
+        fill_in "days", with: "10"
         click_button "Find Archived Record"
       end
       expect(page).to have_content("archived-vm")
@@ -937,7 +937,7 @@ RSpec.describe CloverAdmin do
       within("#archived_record_form") do
         fill_in "id", with: vm.id
         select "Vm", from: "model_name"
-        fill_in "days", with: "30"
+        fill_in "days", with: "10"
         click_button "Find Archived Record"
       end
       expect(page).to have_content("archived-vm")
@@ -982,21 +982,21 @@ RSpec.describe CloverAdmin do
 
       visit "/archived-record-by-id"
 
-      # Test max limit (60)
+      # Test max limit (15)
       within("#archived_record_form") do
         fill_in "id", with: vm.ubid
-        fill_in "days", with: "100"
+        fill_in "days", with: "30"
         click_button "Find Archived Record"
       end
-      expect(page.find_field("days").value).to eq "60"
+      expect(page.find_field("days").value).to eq "15"
 
-      # Test default (15) when no value provided
+      # Test default (5) when no value provided
       within("#archived_record_form") do
         fill_in "id", with: vm.ubid
         fill_in "days", with: nil
         click_button "Find Archived Record"
       end
-      expect(page.find_field("days").value).to eq "15"
+      expect(page.find_field("days").value).to eq "5"
     end
   end
 end

--- a/views/admin/archived_record_by_id.erb
+++ b/views/admin/archived_record_by_id.erb
@@ -7,7 +7,7 @@
 <% form(id: "archived_record_form", class: "form-vertical") do |f| %>
   <%== f.input("text", key: "id", label: "ID", placeholder: "Enter UBID or UUID", value: @id) %>
   <%== f.input("select", key: "model_name", label: "Model Name", add_blank: "From ID", options: @classes.map(&:name), value: @model_name) %>
-  <%== f.input("number", key: "days", label: "Days", placeholder: "1-60", value: @days, min: 1, max: 60) %>
+  <%== f.input("number", key: "days", label: "Days", placeholder: "1-15", value: @days, min: 1, max: 15) %>
   Higher day values will increase query duration significantly. Use the smallest value possible.
   <%== f.button("Find Archived Record") %>
 <% end %>


### PR DESCRIPTION
The page can fetch archived records from the last 15 days in ~4 seconds.

When the number of days is increased, query time grows much faster than linearly. As a result, the request can exceed Heroku’s 30-second router timeout, causing a timeout error on the UI while the query continues running in the background.