### PR TITLE
Fix one_to_one associations that should be many_to_one

### DIFF
--- a/model/ai/inference_endpoint_replica.rb
+++ b/model/ai/inference_endpoint_replica.rb
@@ -4,7 +4,7 @@ require_relative "../../model"
 
 class InferenceEndpointReplica < Sequel::Model
   one_to_one :strand, key: :id, read_only: true
-  one_to_one :vm, key: :id, primary_key: :vm_id, read_only: true
+  many_to_one :vm, read_only: true
   many_to_one :inference_endpoint, read_only: true, is_used: true
   one_through_one :load_balancer_vm_port, left_key: :vm_id, left_primary_key: :vm_id, right_key: :id, right_primary_key: :load_balancer_vm_id, join_table: :load_balancers_vms, read_only: true
 

--- a/model/ai/inference_router_replica.rb
+++ b/model/ai/inference_router_replica.rb
@@ -4,7 +4,7 @@ require_relative "../../model"
 
 class InferenceRouterReplica < Sequel::Model
   one_to_one :strand, key: :id, read_only: true
-  one_to_one :vm, key: :id, primary_key: :vm_id, read_only: true
+  many_to_one :vm, read_only: true
   many_to_one :inference_router, read_only: true, is_used: true
   one_through_one :load_balancer_vm_port, left_key: :vm_id, left_primary_key: :vm_id, right_key: :id, right_primary_key: :load_balancer_vm_id, join_table: :load_balancers_vms, read_only: true
 

--- a/model/github/github_runner.rb
+++ b/model/github/github_runner.rb
@@ -7,7 +7,7 @@ class GithubRunner < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :installation, class: :GithubInstallation
   many_to_one :repository, class: :GithubRepository, read_only: true
-  one_to_one :vm, key: :id, primary_key: :vm_id, read_only: true
+  many_to_one :vm, read_only: true
   one_through_one :project, join_table: :github_installation, left_key: :id, left_primary_key: :installation_id, read_only: true
 
   plugin ResourceMethods, redacted_columns: :workflow_job

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -8,7 +8,7 @@ class PostgresServer < Sequel::Model
   one_to_one :strand, key: :id, read_only: true
   many_to_one :resource, class: :PostgresResource
   many_to_one :timeline, class: :PostgresTimeline
-  one_to_one :vm, key: :id, primary_key: :vm_id, read_only: true
+  many_to_one :vm, read_only: true
   one_to_one :lsn_monitor, class: :PostgresLsnMonitor, read_only: true, is_used: true
 
   plugin :association_dependencies, lsn_monitor: :destroy


### PR DESCRIPTION
In Sequel, one_to_one is only used if there is foreign key in the associated table that references a key in the current table. If the foreign key is in the current table referencing the associated table, then many_to_one should be used, even if the underlying relationship is one-to-one due to database constraints.

The many_to_one/one_to_one distinction mostly doesn't matter for read-only associations, but it should be fixed anyway. It also results in simpler code, since you don't need to override the key/primary_key options when using the correct association type.