### PR TITLE
Remove method argument from resource creation form

### DIFF
--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -1,4 +1,4 @@
-<%# locals: (action:, form_elements:, option_tree:, option_parents:, method: "POST", pre_selected_values: {}, mode: "create") %>
+<%# locals: (action:, form_elements:, option_tree:, option_parents:, pre_selected_values: {}, mode: "create") %>
 <% nonce = SecureRandom.hex(32)
 content_security_policy.add_script_src [:nonce, nonce] %>
 
@@ -10,7 +10,7 @@ let option_dirty = <%== allow_unescaped(JSON.generate(form_elements.map { it[:na
 
 <div>
   <div class="grid gap-6">
-    <% form(action:, method:, id: "creation-form", class: method) do %>
+    <% form(action:, method: "POST", id: "creation-form") do %>
       <% container_class = (mode == "create") ? "overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white" : "" %>
       <div class="<%= container_class %>">
         <div class="px-4 py-5 sm:p-6">


### PR DESCRIPTION
This is no longer used, the resource creation form always uses POST.

This drops the class attribute, which was only previously used by javascript, and is no longer used as of a3991dbf4df2c408a06eb58c748076b8a13aa52a.