### PR TITLE
Extract shared requestBody for load balancer creation

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -768,43 +768,7 @@ paths:
       operationId: createLocationLoadBalancer
       summary: Create a new load balancer
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                algorithm:
-                  description: Algorithm of the Load Balancer
-                  type: string
-                stack:
-                  description: 'Networking stack of the Load Balancer (ipv4, ipv6, or dual)'
-                  type: string
-                dst_port:
-                  description: Destination port for the Load Balancer
-                  type: integer
-                health_check_endpoint:
-                  description: Health check endpoint URL
-                  type: string
-                health_check_protocol:
-                  description: Health check endpoint protocol
-                  type: string
-                private_subnet_id:
-                  description: ID of Private Subnet
-                  type: string
-                src_port:
-                  description: Source port for the Load Balancer
-                  type: integer
-                cert_enabled:
-                  description: Whether SSL certificates are enabled for the Load Balancer
-                  type: boolean
-              additionalProperties: false
-              required:
-                - algorithm
-                - dst_port
-                - health_check_protocol
-                - private_subnet_id
-                - src_port
+        $ref: '#/components/requestBodies/LoadBalancer'
       responses:
         '200':
           $ref: '#/components/responses/LoadBalancer'
@@ -3086,6 +3050,45 @@ components:
         - name
         - node_count
         - node_size
+  requestBodies:
+    LoadBalancer:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              algorithm:
+                description: Algorithm of the Load Balancer
+                type: string
+              stack:
+                description: 'Networking stack of the Load Balancer (ipv4, ipv6, or dual)'
+                type: string
+              dst_port:
+                description: Destination port for the Load Balancer
+                type: integer
+              health_check_endpoint:
+                description: Health check endpoint URL
+                type: string
+              health_check_protocol:
+                description: Health check endpoint protocol
+                type: string
+              private_subnet_id:
+                description: ID of Private Subnet
+                type: string
+              src_port:
+                description: Source port for the Load Balancer
+                type: integer
+              cert_enabled:
+                description: Whether SSL certificates are enabled for the Load Balancer
+                type: boolean
+            additionalProperties: false
+            required:
+              - algorithm
+              - dst_port
+              - health_check_protocol
+              - private_subnet_id
+              - src_port
   responses:
     Delete:
       description: An empty response after successful resource delete


### PR DESCRIPTION
The createLocationLoadBalancer endpoint had an inline requestBody definition. Extract it to components/requestBodies/LoadBalancer for reuse across load balancer endpoints.

Based on https://github.com/ubicloud/ubicloud/pull/3533