### PR TITLE
Cap ext4 root reservation to 50GiB

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -115,9 +115,14 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   end
 
   label def mount_data_disk
+    storage_device_paths = postgres_server.storage_device_paths
     case vm.sshable.d_check("format_disk")
     when "Succeeded"
-      storage_device_paths = postgres_server.storage_device_paths
+      # ext4 defaults to reserving 5% of disk for root, on 1TiB this is 50GiB. Cap this to 50GiB
+      reserved_blocks_per_gb = 13107 # ~5% of 262144 (number of 4KiB blocks per GB)
+      reserve_blocks = [postgres_server.storage_size_gib * reserved_blocks_per_gb, 13107200].min
+      vm.sshable.cmd("sudo tune2fs :path -r :reserve_blocks", path: storage_device_paths.first, reserve_blocks:)
+
       device_path = if storage_device_paths.count > 1
         vm.sshable.cmd("sudo mdadm --detail --scan | sudo tee -a /etc/mdadm/mdadm.conf")
         vm.sshable.cmd("sudo update-initramfs -u")
@@ -132,7 +137,6 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
 
       hop_configure_walg_credentials
     when "Failed", "NotStarted"
-      storage_device_paths = postgres_server.storage_device_paths
       if storage_device_paths.count == 1
         vm.sshable.d_run("format_disk", "sudo", "mkfs", "--type", "ext4", storage_device_paths.first)
       else

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -343,6 +343,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "mounts data disk if format disk is succeeded and hops to configure_walg_credentials" do
       expect(server).to receive(:storage_device_paths).and_return(["/dev/vdb"])
+      expect(sshable).to receive(:_cmd).with("sudo tune2fs /dev/vdb -r 838848").and_return("Succeeded")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check format_disk").and_return("Succeeded")
       expect(sshable).to receive(:_cmd).with("sudo mkdir -p /dat")
       expect(sshable).to receive(:_cmd).with("sudo common/bin/add_to_fstab /dev/vdb /dat ext4 defaults 0 0")
@@ -351,8 +352,10 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "mounts data disk correctly when there are multiple storage volumes" do
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check format_disk").and_return("Succeeded")
+      expect(server).to receive(:storage_size_gib).and_return(128)
       expect(server).to receive(:storage_device_paths).and_return(["/dev/nvme1n1", "/dev/nvme2n1"])
+      expect(sshable).to receive(:_cmd).with("sudo tune2fs /dev/nvme1n1 -r 1677696").and_return("Succeeded")
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check format_disk").and_return("Succeeded")
       expect(sshable).to receive(:_cmd).with("sudo mdadm --detail --scan | sudo tee -a /etc/mdadm/mdadm.conf")
       expect(sshable).to receive(:_cmd).with("sudo update-initramfs -u")
       expect(sshable).to receive(:_cmd).with("sudo mkdir -p /dat")


### PR DESCRIPTION
Reserving more than 50GiB needlessly restricts customer disk usage