### PR TITLE
Handle UBID.parse errors in admin archived record search

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -575,7 +575,11 @@ class CloverAdmin < Roda
       @id = if (uuid = typecast_params.uuid("id"))
         UBID.from_uuidish(uuid)
       elsif (ubid = typecast_params.ubid("id"))
-        UBID.parse(ubid)
+        begin
+          UBID.parse(ubid)
+        rescue UBIDParseError
+          fail CloverError.new(400, "InvalidRequest", "Invalid UBID provided")
+        end
       elsif typecast_params.nonempty_str("id")
         fail CloverError.new(400, "InvalidRequest", "Invalid UBID or UUID provided")
       end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -943,13 +943,22 @@ RSpec.describe CloverAdmin do
       expect(page).to have_content("archived-vm")
     end
 
-    it "fails for invalid UBID" do
+    it "fails for invalid UBID format" do
       visit "/archived-record-by-id"
 
       within("#archived_record_form") do
         fill_in "id", with: "invalid-ubid"
       end
       expect { click_button "Find Archived Record" }.to raise_error CloverError, "Invalid UBID or UUID provided"
+    end
+
+    it "fails for invalid UBID with valid basic format" do
+      visit "/archived-record-by-id"
+
+      within("#archived_record_form") do
+        fill_in "id", with: "xx345678901234567890123456"
+      end
+      expect { click_button "Find Archived Record" }.to raise_error CloverError, "Invalid UBID provided"
     end
 
     it "fails when can't determine model" do


### PR DESCRIPTION
Avoids a production exception.