### PR TITLE
Add restarting as possible display state for postgres resource

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -52,6 +52,7 @@ class PostgresResource < Sequel::Model
     return "restoring_backup" if server_strand_label == "initialize_database_from_backup"
     return "replaying_wal" if ["wait_catch_up", "wait_synchronization"].include?(server_strand_label)
     return "finalizing_restore" if server_strand_label == "wait_recovery_completion"
+    return "restarting" if server_strand_label == "restart"
     return "running" if ["wait", "refresh_certificates", "refresh_dns_record"].include?(strand.label) && !initial_provisioning_set?
 
     "creating"

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -367,6 +367,11 @@ RSpec.describe PostgresResource do
       expect(postgres_resource.display_state).to eq("finalizing_restore")
     end
 
+    it "returns 'restarting' when representative server's strand label is 'restart'" do
+      create_representative_server(strand_label: "restart")
+      expect(postgres_resource.display_state).to eq("restarting")
+    end
+
     it "returns 'running' when strand label is 'wait' and has no children" do
       # The strand already has label "wait" from subject, no children by default
       expect(postgres_resource.display_state).to eq("running")


### PR DESCRIPTION
Set when representative server's strand label is `restart`