### PR TITLE
Display workflow job for runner in admin panel

### DIFF
--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -685,6 +685,16 @@ RSpec.describe CloverAdmin do
     expect(GithubRunner.select_map([:repository_name, :label, :installation_id])).to eq([["test-repo", "ubicloud", ins.id]] * 2)
   end
 
+  it "shows workflow job for github runner as extra" do
+    workflow_job = {id: 60587328050, name: "ubicloud-standard-2", status: "in_progress"}
+    installation_id = GithubInstallation.create(installation_id: 123, name: "ubicloud", type: "User").id
+    runner = GithubRunner.create(repository_name: "ubicloud/ubicloud", label: "ubicloud-standard-2", installation_id:, workflow_job:)
+    visit "/model/GithubRunner/#{runner.ubid}"
+    expect(page.title).to eq "Ubicloud Admin - GithubRunner #{runner.ubid}"
+    expect(page.all(".workflow-job-table td").map(&:text))
+      .to eq ["id", "60587328050", "name", "ubicloud-standard-2", "status", "in_progress"]
+  end
+
   it "supports suspending Accounts" do
     account = create_account(with_project: false)
     fill_in "UBID or UUID", with: account.ubid

--- a/views/admin/extras/GithubRunner.erb
+++ b/views/admin/extras/GithubRunner.erb
@@ -1,0 +1,7 @@
+<%# locals: (obj: nil) %>
+
+<%== part("components/table",
+  title: "Workflow Job",
+  table_class: "workflow-job-table",
+  data: obj.workflow_job&.map { |k, v| {"Column" => k, "Value" => v} }
+) %>


### PR DESCRIPTION
We added `workflow_job` to `redacted_columns` because it contains a lot of data and was cluttering logs and pry output.

However, since the admin panel relies on `inspect_values` to display object details, this also hides `workflow_job` information there.

We can render it as an extra view in the admin panel. This has an added benefit, presenting the data in a structured table makes it much easier to read compared to raw JSON.

<img width="1912" height="1234" alt="CleanShot 2026-01-16 at 15 51 56@2x" src="https://github.com/user-attachments/assets/5daa26f8-1255-4a08-9a3c-7f663bafcd51" />
