### PR TITLE
Stop metrics export when fenced

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -582,6 +582,7 @@ SQL
     postgres_server.run_query("CHECKPOINT; CHECKPOINT; CHECKPOINT;")
     postgres_server.vm.sshable.cmd("sudo postgres/bin/lockout :version", version:)
     postgres_server.vm.sshable.cmd("sudo pg_ctlcluster :version main stop -m smart", version:)
+    postgres_server.vm.sshable.cmd("sudo systemctl stop postgres-metrics.timer")
 
     hop_wait_in_fence
   end
@@ -683,6 +684,7 @@ SQL
 
     vm.sshable.cmd("sudo postgres/bin/restart :version", version:)
     vm.sshable.cmd("sudo systemctl restart pgbouncer@*.service")
+    vm.sshable.cmd("sudo systemctl restart postgres-metrics.timer")
     pop "postgres server is restarted"
   end
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1071,6 +1071,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(server).to receive(:_run_query).with("CHECKPOINT; CHECKPOINT; CHECKPOINT;")
       expect(sshable).to receive(:_cmd).with("sudo postgres/bin/lockout 16")
       expect(sshable).to receive(:_cmd).with("sudo pg_ctlcluster 16 main stop -m smart")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop postgres-metrics.timer")
       expect { nx.fence }.to hop("wait_in_fence")
     end
   end
@@ -1274,6 +1275,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "sets deadline, restarts and exits" do
       expect(sshable).to receive(:_cmd).with("sudo postgres/bin/restart 16")
       expect(sshable).to receive(:_cmd).with("sudo systemctl restart pgbouncer@*.service")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl restart postgres-metrics.timer")
       expect { nx.restart }.to exit({"msg" => "postgres server is restarted"})
       expect(nx.strand.stack.first["deadline_target"]).to eq("wait")
       expect(nx.strand.stack.first["deadline_at"]).to be_within(5).of(Time.now + 10 * 60)


### PR DESCRIPTION
Previously a fenced primary continued exporting metrics with label role=primary. This created duplicate time series and incorrect metrics like disk usage on the overview page.