### PR TITLE
Strip newlines from exception message in E2E summary

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -183,7 +183,7 @@ jobs:
         echo "## Exceptions" >> $GITHUB_STEP_SUMMARY
         echo '| Time | Thread | Class | Message | First Backtrace Line |' >> $GITHUB_STEP_SUMMARY
         echo '|---|---|---|---|---|' >> $GITHUB_STEP_SUMMARY
-        grep 'respirate.*"exception"' foreman.log | cut -d'|' -f2 | jq -r '[.time, .thread, .exception.class, .exception.message, (.exception.backtrace[0] // "" | gsub("\n"; " "))] | "| " + join(" | ") + " |"' >> $GITHUB_STEP_SUMMARY
+        grep 'respirate.*"exception"' foreman.log | cut -d'|' -f2 | jq -r '[.time, .thread, .exception.class, (.exception.message | gsub("\n"; " ")), (.exception.backtrace[0] // "" | gsub("\n"; " "))] | "| " + join(" | ") + " |"' >> $GITHUB_STEP_SUMMARY
 
     - name: Upload logs
       if: always()


### PR DESCRIPTION
The exception extraction step was only applying gsub("\n"; " ") to the backtrace line, but exception messages from Postgres errors also contain embedded newlines (e.g., between ERROR and DETAIL sections). These newlines broke the markdown table layout in the GitHub Actions summary.

**Before**
<img width="4452" height="636" alt="CleanShot 2026-01-16 at 19 38 43@2x" src="https://github.com/user-attachments/assets/59df27d5-ff4a-41e4-853f-ab70ec01108a" />

**After**
<img width="4482" height="754" alt="CleanShot 2026-01-17 at 01 00 03@2x" src="https://github.com/user-attachments/assets/3b216af3-c065-4f2b-bb32-f60c7594408f" />
