### PR TITLE
Rescue all SSH connection errors in VmHostSliceNexus wait state

### DIFF
--- a/prog/vm/vm_host_slice_nexus.rb
+++ b/prog/vm/vm_host_slice_nexus.rb
@@ -51,7 +51,7 @@ class Prog::Vm::VmHostSliceNexus < Prog::Base
     when_checkup_set? do
       hop_unavailable if !available?
       decr_checkup
-    rescue Sshable::SshError
+    rescue *Sshable::SSH_CONNECTION_ERRORS, Sshable::SshError
       # Host is likely to be down, which will be handled by HostNexus. We still
       # go to the unavailable state for keeping track of the state.
       hop_unavailable


### PR DESCRIPTION
The wait state was only rescuing Sshable::SshError, missing other connection errors like Net::SSH::ConnectionTimeout. This caused unhandled exceptions instead of gracefully hopping to unavailable.

The fix uses SSH_CONNECTION_ERRORS, consistent with the unavailable state handler in the same file and other progs.