### PR TITLE
Add basic testing of all models on admin site

### DIFF
--- a/spec/routes/web/admin/model/access_control_entry_spec.rb
+++ b/spec/routes/web/admin/model/access_control_entry_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "AccessControlEntry" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_access_control_entry
+    admin_account_setup_and_login
+  end
+
+  it "displays the AccessControlEntry instance page correctly" do
+    click_link "AccessControlEntry"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - AccessControlEntry"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - AccessControlEntry #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/account_spec.rb
+++ b/spec/routes/web/admin/model/account_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Account" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_account
+    admin_account_setup_and_login
+  end
+
+  it "displays the Account instance page correctly" do
+    @instance.update(name: "Test-Admin-Account")
+    click_link "Account"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Account - Browse"
+
+    click_link @instance.name
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Account #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/action_tag_spec.rb
+++ b/spec/routes/web/admin/model/action_tag_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "ActionTag" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_action_tag
+    admin_account_setup_and_login
+  end
+
+  it "displays the ActionTag instance page correctly" do
+    click_link "ActionTag"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - ActionTag"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - ActionTag #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/action_type_spec.rb
+++ b/spec/routes/web/admin/model/action_type_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "ActionType" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_action_type
+    admin_account_setup_and_login
+  end
+
+  it "displays the ActionType instance page correctly" do
+    click_link "ActionType"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - ActionType"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - ActionType #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/address_spec.rb
+++ b/spec/routes/web/admin/model/address_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Address" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_address
+    admin_account_setup_and_login
+  end
+
+  it "displays the Address instance page correctly" do
+    click_link "Address"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Address"
+
+    click_link @instance.admin_label.to_s
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Address #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/api_key_spec.rb
+++ b/spec/routes/web/admin/model/api_key_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "ApiKey" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_api_key
+    admin_account_setup_and_login
+  end
+
+  it "displays the ApiKey instance page correctly" do
+    click_link "ApiKey"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - ApiKey"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - ApiKey #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/assigned_host_address_spec.rb
+++ b/spec/routes/web/admin/model/assigned_host_address_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "AssignedHostAddress" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_assigned_host_address
+    admin_account_setup_and_login
+  end
+
+  it "displays the AssignedHostAddress instance page correctly" do
+    click_link "AssignedHostAddress"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - AssignedHostAddress"
+
+    click_link @instance.admin_label.to_s
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - AssignedHostAddress #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/assigned_vm_address_spec.rb
+++ b/spec/routes/web/admin/model/assigned_vm_address_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "AssignedVmAddress" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_assigned_vm_address
+    admin_account_setup_and_login
+  end
+
+  it "displays the AssignedVmAddress instance page correctly" do
+    click_link "AssignedVmAddress"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - AssignedVmAddress"
+
+    click_link @instance.admin_label.to_s
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - AssignedVmAddress #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/aws_instance_spec.rb
+++ b/spec/routes/web/admin/model/aws_instance_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "AwsInstance" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_aws_instance
+    admin_account_setup_and_login
+  end
+
+  it "displays the AwsInstance instance page correctly" do
+    click_link "AwsInstance"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - AwsInstance"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - AwsInstance #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/billing_info_spec.rb
+++ b/spec/routes/web/admin/model/billing_info_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "BillingInfo" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_billing_info
+    admin_account_setup_and_login
+  end
+
+  it "displays the BillingInfo instance page correctly" do
+    click_link "BillingInfo"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - BillingInfo - Browse"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - BillingInfo #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/billing_record_spec.rb
+++ b/spec/routes/web/admin/model/billing_record_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "BillingRecord" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_billing_record
+    admin_account_setup_and_login
+  end
+
+  it "displays the BillingRecord instance page correctly" do
+    click_link "BillingRecord"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - BillingRecord"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - BillingRecord #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/boot_image_spec.rb
+++ b/spec/routes/web/admin/model/boot_image_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "BootImage" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_boot_image
+    admin_account_setup_and_login
+  end
+
+  it "displays the BootImage instance page correctly" do
+    click_link "BootImage"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - BootImage"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - BootImage #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/cert_spec.rb
+++ b/spec/routes/web/admin/model/cert_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Cert" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_cert
+    admin_account_setup_and_login
+  end
+
+  it "displays the Cert instance page correctly" do
+    click_link "Cert"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Cert"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Cert #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/connected_subnet_spec.rb
+++ b/spec/routes/web/admin/model/connected_subnet_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "ConnectedSubnet" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_connected_subnet
+    admin_account_setup_and_login
+  end
+
+  it "displays the ConnectedSubnet instance page correctly" do
+    click_link "ConnectedSubnet"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - ConnectedSubnet"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - ConnectedSubnet #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/discount_code_spec.rb
+++ b/spec/routes/web/admin/model/discount_code_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "DiscountCode" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_discount_code
+    admin_account_setup_and_login
+  end
+
+  it "displays the DiscountCode instance page correctly" do
+    click_link "DiscountCode"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - DiscountCode"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - DiscountCode #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/dns_record_spec.rb
+++ b/spec/routes/web/admin/model/dns_record_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "DnsRecord" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_dns_record
+    admin_account_setup_and_login
+  end
+
+  it "displays the DnsRecord instance page correctly" do
+    click_link "DnsRecord"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - DnsRecord"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - DnsRecord #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/dns_server_spec.rb
+++ b/spec/routes/web/admin/model/dns_server_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "DnsServer" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_dns_server
+    admin_account_setup_and_login
+  end
+
+  it "displays the DnsServer instance page correctly" do
+    click_link "DnsServer"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - DnsServer"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - DnsServer #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/dns_zone_spec.rb
+++ b/spec/routes/web/admin/model/dns_zone_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "DnsZone" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_dns_zone
+    admin_account_setup_and_login
+  end
+
+  it "displays the DnsZone instance page correctly" do
+    click_link "DnsZone"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - DnsZone"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - DnsZone #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/firewall_rule_spec.rb
+++ b/spec/routes/web/admin/model/firewall_rule_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "FirewallRule" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_firewall_rule
+    admin_account_setup_and_login
+  end
+
+  it "displays the FirewallRule instance page correctly" do
+    click_link "FirewallRule"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - FirewallRule"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - FirewallRule #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/firewall_spec.rb
+++ b/spec/routes/web/admin/model/firewall_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Firewall" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_firewall
+    admin_account_setup_and_login
+  end
+
+  it "displays the Firewall instance page correctly" do
+    click_link "Firewall"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Firewall - Browse"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Firewall #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/github_cache_entry_spec.rb
+++ b/spec/routes/web/admin/model/github_cache_entry_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "GithubCacheEntry" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_github_cache_entry
+    admin_account_setup_and_login
+  end
+
+  it "displays the GithubCacheEntry instance page correctly" do
+    click_link "GithubCacheEntry"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GithubCacheEntry"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GithubCacheEntry #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/github_custom_label_spec.rb
+++ b/spec/routes/web/admin/model/github_custom_label_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "GithubCustomLabel" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_github_custom_label
+    admin_account_setup_and_login
+  end
+
+  it "displays the GithubCustomLabel instance page correctly" do
+    click_link "GithubCustomLabel"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GithubCustomLabel"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GithubCustomLabel #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/github_installation_spec.rb
+++ b/spec/routes/web/admin/model/github_installation_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "GithubInstallation" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_github_installation
+    admin_account_setup_and_login
+  end
+
+  it "displays the GithubInstallation instance page correctly" do
+    click_link "GithubInstallation"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GithubInstallation - Browse"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GithubInstallation #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/github_repository_spec.rb
+++ b/spec/routes/web/admin/model/github_repository_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "GithubRepository" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_github_repository
+    admin_account_setup_and_login
+  end
+
+  it "displays the GithubRepository instance page correctly" do
+    click_link "GithubRepository"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GithubRepository"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GithubRepository #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/github_runner_spec.rb
+++ b/spec/routes/web/admin/model/github_runner_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "GithubRunner" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_github_runner
+    admin_account_setup_and_login
+  end
+
+  it "displays the GithubRunner instance page correctly" do
+    click_link "GithubRunner"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GithubRunner - Browse"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GithubRunner #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/globally_blocked_dnsname_spec.rb
+++ b/spec/routes/web/admin/model/globally_blocked_dnsname_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "GloballyBlockedDnsname" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_globally_blocked_dnsname
+    admin_account_setup_and_login
+  end
+
+  it "displays the GloballyBlockedDnsname instance page correctly" do
+    click_link "GloballyBlockedDnsname"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GloballyBlockedDnsname"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GloballyBlockedDnsname #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/gpu_partition_spec.rb
+++ b/spec/routes/web/admin/model/gpu_partition_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "GpuPartition" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_gpu_partition
+    admin_account_setup_and_login
+  end
+
+  it "displays the GpuPartition instance page correctly" do
+    click_link "GpuPartition"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GpuPartition"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - GpuPartition #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/inference_endpoint_replica_spec.rb
+++ b/spec/routes/web/admin/model/inference_endpoint_replica_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "InferenceEndpointReplica" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_inference_endpoint_replica
+    admin_account_setup_and_login
+  end
+
+  it "displays the InferenceEndpointReplica instance page correctly" do
+    click_link "InferenceEndpointReplica"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - InferenceEndpointReplica"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - InferenceEndpointReplica #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/inference_endpoint_spec.rb
+++ b/spec/routes/web/admin/model/inference_endpoint_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "InferenceEndpoint" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_inference_endpoint
+    admin_account_setup_and_login
+  end
+
+  it "displays the InferenceEndpoint instance page correctly" do
+    click_link "InferenceEndpoint"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - InferenceEndpoint"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - InferenceEndpoint #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/inference_router_model_spec.rb
+++ b/spec/routes/web/admin/model/inference_router_model_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "InferenceRouterModel" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_inference_router_model
+    admin_account_setup_and_login
+  end
+
+  it "displays the InferenceRouterModel instance page correctly" do
+    click_link "InferenceRouterModel"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - InferenceRouterModel"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - InferenceRouterModel #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/inference_router_replica_spec.rb
+++ b/spec/routes/web/admin/model/inference_router_replica_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "InferenceRouterReplica" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_inference_router_replica
+    admin_account_setup_and_login
+  end
+
+  it "displays the InferenceRouterReplica instance page correctly" do
+    click_link "InferenceRouterReplica"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - InferenceRouterReplica"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - InferenceRouterReplica #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/inference_router_spec.rb
+++ b/spec/routes/web/admin/model/inference_router_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "InferenceRouter" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_inference_router
+    admin_account_setup_and_login
+  end
+
+  it "displays the InferenceRouter instance page correctly" do
+    click_link "InferenceRouter"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - InferenceRouter"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - InferenceRouter #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/inference_router_target_spec.rb
+++ b/spec/routes/web/admin/model/inference_router_target_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "InferenceRouterTarget" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_inference_router_target
+    admin_account_setup_and_login
+  end
+
+  it "displays the InferenceRouterTarget instance page correctly" do
+    click_link "InferenceRouterTarget"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - InferenceRouterTarget"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - InferenceRouterTarget #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/invoice_spec.rb
+++ b/spec/routes/web/admin/model/invoice_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Invoice" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_invoice
+    admin_account_setup_and_login
+  end
+
+  it "displays the Invoice instance page correctly" do
+    click_link "Invoice"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Invoice - Browse"
+
+    expect(Aws::S3::Client).to receive(:new).and_return(Aws::S3::Client.new(stub_responses: true))
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Invoice #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/ipsec_tunnel_spec.rb
+++ b/spec/routes/web/admin/model/ipsec_tunnel_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "IpsecTunnel" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_ipsec_tunnel
+    admin_account_setup_and_login
+  end
+
+  it "displays the IpsecTunnel instance page correctly" do
+    click_link "IpsecTunnel"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - IpsecTunnel"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - IpsecTunnel #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/admin/model/kubernetes_cluster_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "KubernetesCluster" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_kubernetes_cluster
+    admin_account_setup_and_login
+  end
+
+  it "displays the KubernetesCluster instance page correctly" do
+    click_link "KubernetesCluster"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - KubernetesCluster"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - KubernetesCluster #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/kubernetes_node_spec.rb
+++ b/spec/routes/web/admin/model/kubernetes_node_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "KubernetesNode" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_kubernetes_node
+    admin_account_setup_and_login
+  end
+
+  it "displays the KubernetesNode instance page correctly" do
+    click_link "KubernetesNode"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - KubernetesNode"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - KubernetesNode #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/kubernetes_nodepool_spec.rb
+++ b/spec/routes/web/admin/model/kubernetes_nodepool_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "KubernetesNodepool" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_kubernetes_nodepool
+    admin_account_setup_and_login
+  end
+
+  it "displays the KubernetesNodepool instance page correctly" do
+    click_link "KubernetesNodepool"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - KubernetesNodepool"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - KubernetesNodepool #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/load_balancer_port_spec.rb
+++ b/spec/routes/web/admin/model/load_balancer_port_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "LoadBalancerPort" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_load_balancer_port
+    admin_account_setup_and_login
+  end
+
+  it "displays the LoadBalancerPort instance page correctly" do
+    click_link "LoadBalancerPort"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - LoadBalancerPort"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - LoadBalancerPort #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/load_balancer_spec.rb
+++ b/spec/routes/web/admin/model/load_balancer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "LoadBalancer" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_load_balancer
+    admin_account_setup_and_login
+  end
+
+  it "displays the LoadBalancer instance page correctly" do
+    click_link "LoadBalancer"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - LoadBalancer"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - LoadBalancer #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/load_balancer_vm_port_spec.rb
+++ b/spec/routes/web/admin/model/load_balancer_vm_port_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "LoadBalancerVmPort" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_load_balancer_vm_port
+    admin_account_setup_and_login
+  end
+
+  it "displays the LoadBalancerVmPort instance page correctly" do
+    click_link "LoadBalancerVmPort"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - LoadBalancerVmPort"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - LoadBalancerVmPort #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/load_balancer_vm_spec.rb
+++ b/spec/routes/web/admin/model/load_balancer_vm_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "LoadBalancerVm" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_load_balancer_vm
+    admin_account_setup_and_login
+  end
+
+  it "displays the LoadBalancerVm instance page correctly" do
+    click_link "LoadBalancerVm"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - LoadBalancerVm"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - LoadBalancerVm #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/location_aws_az_spec.rb
+++ b/spec/routes/web/admin/model/location_aws_az_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "LocationAwsAz" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_location_aws_az
+    admin_account_setup_and_login
+  end
+
+  it "displays the LocationAwsAz instance page correctly" do
+    click_link "LocationAwsAz"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - LocationAwsAz"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - LocationAwsAz #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/location_credential_spec.rb
+++ b/spec/routes/web/admin/model/location_credential_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "LocationCredential" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_location_credential
+    admin_account_setup_and_login
+  end
+
+  it "displays the LocationCredential instance page correctly" do
+    click_link "LocationCredential"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - LocationCredential"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - LocationCredential #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/location_spec.rb
+++ b/spec/routes/web/admin/model/location_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Location" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_location
+    admin_account_setup_and_login
+  end
+
+  it "displays the Location instance page correctly" do
+    click_link "Location"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Location"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Location #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/minio_cluster_spec.rb
+++ b/spec/routes/web/admin/model/minio_cluster_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "MinioCluster" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_minio_cluster
+    admin_account_setup_and_login
+  end
+
+  it "displays the MinioCluster instance page correctly" do
+    click_link "MinioCluster"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - MinioCluster"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - MinioCluster #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/minio_pool_spec.rb
+++ b/spec/routes/web/admin/model/minio_pool_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "MinioPool" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_minio_pool
+    admin_account_setup_and_login
+  end
+
+  it "displays the MinioPool instance page correctly" do
+    click_link "MinioPool"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - MinioPool"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - MinioPool #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/minio_server_spec.rb
+++ b/spec/routes/web/admin/model/minio_server_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "MinioServer" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_minio_server
+    admin_account_setup_and_login
+  end
+
+  it "displays the MinioServer instance page correctly" do
+    click_link "MinioServer"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - MinioServer"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - MinioServer #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/nic_aws_resource_spec.rb
+++ b/spec/routes/web/admin/model/nic_aws_resource_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "NicAwsResource" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_nic_aws_resource
+    admin_account_setup_and_login
+  end
+
+  it "displays the NicAwsResource instance page correctly" do
+    click_link "NicAwsResource"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - NicAwsResource"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - NicAwsResource #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/nic_spec.rb
+++ b/spec/routes/web/admin/model/nic_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Nic" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_nic
+    admin_account_setup_and_login
+  end
+
+  it "displays the Nic instance page correctly" do
+    click_link "Nic"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Nic"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Nic #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/object_tag_spec.rb
+++ b/spec/routes/web/admin/model/object_tag_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "ObjectTag" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_object_tag
+    admin_account_setup_and_login
+  end
+
+  it "displays the ObjectTag instance page correctly" do
+    click_link "ObjectTag"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - ObjectTag"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - ObjectTag #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/oidc_provider_spec.rb
+++ b/spec/routes/web/admin/model/oidc_provider_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "OidcProvider" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_oidc_provider
+    admin_account_setup_and_login
+  end
+
+  it "displays the OidcProvider instance page correctly" do
+    click_link "OidcProvider"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - OidcProvider"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - OidcProvider #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/page_spec.rb
+++ b/spec/routes/web/admin/model/page_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Page" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_page
+    admin_account_setup_and_login
+  end
+
+  it "displays the Page instance page correctly" do
+    click_link "Page"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Page"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Page #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/payment_method_spec.rb
+++ b/spec/routes/web/admin/model/payment_method_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "PaymentMethod" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_payment_method
+    admin_account_setup_and_login
+  end
+
+  it "displays the PaymentMethod instance page correctly" do
+    click_link "PaymentMethod"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PaymentMethod - Browse"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PaymentMethod #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/pci_device_spec.rb
+++ b/spec/routes/web/admin/model/pci_device_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "PciDevice" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_pci_device
+    admin_account_setup_and_login
+  end
+
+  it "displays the PciDevice instance page correctly" do
+    click_link "PciDevice"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PciDevice"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PciDevice #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/pg_aws_ami_spec.rb
+++ b/spec/routes/web/admin/model/pg_aws_ami_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "PgAwsAmi" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_pg_aws_ami
+    admin_account_setup_and_login
+  end
+
+  it "displays the PgAwsAmi instance page correctly" do
+    click_link "PgAwsAmi"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PgAwsAmi"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PgAwsAmi #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/postgres_metric_destination_spec.rb
+++ b/spec/routes/web/admin/model/postgres_metric_destination_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "PostgresMetricDestination" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_postgres_metric_destination
+    admin_account_setup_and_login
+  end
+
+  it "displays the PostgresMetricDestination instance page correctly" do
+    click_link "PostgresMetricDestination"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PostgresMetricDestination"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PostgresMetricDestination #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/postgres_resource_spec.rb
+++ b/spec/routes/web/admin/model/postgres_resource_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "PostgresResource" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_postgres_resource
+    admin_account_setup_and_login
+  end
+
+  it "displays the PostgresResource instance page correctly" do
+    click_link "PostgresResource"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PostgresResource"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PostgresResource #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/postgres_server_spec.rb
+++ b/spec/routes/web/admin/model/postgres_server_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "PostgresServer" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_postgres_server
+    admin_account_setup_and_login
+  end
+
+  it "displays the PostgresServer instance page correctly" do
+    click_link "PostgresServer"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PostgresServer"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PostgresServer #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/postgres_timeline_spec.rb
+++ b/spec/routes/web/admin/model/postgres_timeline_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "PostgresTimeline" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_postgres_timeline
+    admin_account_setup_and_login
+  end
+
+  it "displays the PostgresTimeline instance page correctly" do
+    click_link "PostgresTimeline"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PostgresTimeline"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PostgresTimeline #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/private_subnet_aws_resource_spec.rb
+++ b/spec/routes/web/admin/model/private_subnet_aws_resource_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "PrivateSubnetAwsResource" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_private_subnet_aws_resource
+    admin_account_setup_and_login
+  end
+
+  it "displays the PrivateSubnetAwsResource instance page correctly" do
+    click_link "PrivateSubnetAwsResource"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PrivateSubnetAwsResource"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PrivateSubnetAwsResource #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/private_subnet_spec.rb
+++ b/spec/routes/web/admin/model/private_subnet_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "PrivateSubnet" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_private_subnet
+    admin_account_setup_and_login
+  end
+
+  it "displays the PrivateSubnet instance page correctly" do
+    click_link "PrivateSubnet"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PrivateSubnet"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - PrivateSubnet #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/project_discount_code_spec.rb
+++ b/spec/routes/web/admin/model/project_discount_code_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "ProjectDiscountCode" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_project_discount_code
+    admin_account_setup_and_login
+  end
+
+  it "displays the ProjectDiscountCode instance page correctly" do
+    click_link "ProjectDiscountCode"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - ProjectDiscountCode"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - ProjectDiscountCode #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/project_spec.rb
+++ b/spec/routes/web/admin/model/project_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Project" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_project
+    admin_account_setup_and_login
+  end
+
+  it "displays the Project instance page correctly" do
+    click_link "Project"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Project - Browse"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Project #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/semaphore_spec.rb
+++ b/spec/routes/web/admin/model/semaphore_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Semaphore" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_semaphore
+    admin_account_setup_and_login
+  end
+
+  it "displays the Semaphore instance page correctly" do
+    click_link "Semaphore"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Semaphore"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Semaphore #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/spdk_installation_spec.rb
+++ b/spec/routes/web/admin/model/spdk_installation_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "SpdkInstallation" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_spdk_installation
+    admin_account_setup_and_login
+  end
+
+  it "displays the SpdkInstallation instance page correctly" do
+    click_link "SpdkInstallation"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - SpdkInstallation"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - SpdkInstallation #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/spec_helper.rb
+++ b/spec/routes/web/admin/model/spec_helper.rb
@@ -1,0 +1,566 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+module AdminModelSpecHelper
+  def create_access_control_entry
+    project = Project.create(name: "test-project")
+    subject_tag = SubjectTag.create(project_id: project.id, name: "Admin")
+    AccessControlEntry.create(project_id: project.id, subject_id: subject_tag.id)
+  end
+
+  def create_action_tag
+    project = Project.create(name: "test-project")
+    ActionTag.create(project_id: project.id, name: "test-action")
+  end
+
+  def create_action_type
+    ActionType.first
+  end
+
+  def create_address
+    host = Prog::Vm::HostNexus.assemble("1.2.3.4").subject
+    Address.create(cidr: "10.0.0.0/24", routed_to_host_id: host.id)
+  end
+
+  def create_api_key
+    account = create_account
+    project = account.projects.first
+    ApiKey.create(owner_id: account.id, owner_table: "accounts", key: "test-key-value", used_for: "api", project_id: project.id)
+  end
+
+  def create_assigned_host_address
+    host = Prog::Vm::HostNexus.assemble("1.2.3.4").subject
+    addr = Address.create(cidr: "10.0.0.0/24", routed_to_host_id: host.id)
+    AssignedHostAddress.create(ip: "10.0.0.1/32", address_id: addr.id, host_id: host.id)
+  end
+
+  def create_assigned_vm_address
+    project = Project.create(name: "test-project")
+    vm = Prog::Vm::Nexus.assemble("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGWmPgJE test@example.com", project.id, name: "test-vm").subject
+    host = vm.vm_host || Prog::Vm::HostNexus.assemble("1.2.3.4").subject
+    addr = Address.create(cidr: "10.0.0.0/24", routed_to_host_id: host.id)
+    AssignedVmAddress.create(ip: "10.0.0.1/32", address_id: addr.id, dst_vm_id: vm.id)
+  end
+
+  def create_aws_instance
+    AwsInstance.create(instance_id: "i-1234567890")
+  end
+
+  def create_billing_info
+    BillingInfo.create(stripe_id: "cus_test123")
+  end
+
+  def create_billing_record
+    project = Project.create(name: "test-project")
+    vm = Prog::Vm::Nexus.assemble("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGWmPgJE test@example.com", project.id, name: "test-vm").subject
+    BillingRecord.create(
+      project_id: project.id,
+      resource_id: vm.id,
+      resource_name: vm.name,
+      span: Sequel::Postgres::PGRange.new(Time.now - 3600, nil),
+      billing_rate_id: BillingRate.from_resource_properties("VmVCpu", vm.family, vm.location.name)["id"],
+      amount: vm.vcpus
+    )
+  end
+
+  def create_boot_image
+    host = Prog::Vm::HostNexus.assemble("1.2.3.4").subject
+    BootImage.create(name: "ubuntu-jammy", version: "20240101", vm_host_id: host.id, size_gib: 10)
+  end
+
+  def create_cert
+    project = Project.create(name: "test-project")
+    zone = DnsZone.create(project_id: project.id, name: "test.com")
+    Cert.create(hostname: "test.example.com", dns_zone_id: zone.id, cert: "cert-data")
+  end
+
+  def create_connected_subnet
+    project = Project.create(name: "test-project")
+    ps1 = PrivateSubnet.create(name: "test-ps1", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.0.0/26", net6: "fdfa::/64")
+    ps2 = PrivateSubnet.create(name: "test-ps2", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.1.0/26", net6: "fdfb::/64")
+    # Ensure subnet_id_1 < subnet_id_2 for the check constraint
+    subnet_ids = [ps1.id, ps2.id].sort
+    ConnectedSubnet.create(subnet_id_1: subnet_ids[0], subnet_id_2: subnet_ids[1])
+  end
+
+  def create_discount_code
+    DiscountCode.create(code: "TEST123", credit_amount: 10, expires_at: Time.now + 86400)
+  end
+
+  def create_dns_record
+    project = Project.create(name: "test-project")
+    zone = DnsZone.create(project_id: project.id, name: "test.com")
+    DnsRecord.create(dns_zone_id: zone.id, name: "www", type: "A", ttl: 300, data: "1.2.3.4")
+  end
+
+  def create_dns_server
+    DnsServer.create(name: "test-dns-server")
+  end
+
+  def create_dns_zone
+    project = Project.create(name: "test-project")
+    DnsZone.create(project_id: project.id, name: "test.com")
+  end
+
+  def create_firewall
+    project = Project.create(name: "test-project")
+    Firewall.create(name: "test-firewall", project_id: project.id, location_id: Location::HETZNER_FSN1_ID)
+  end
+
+  def create_firewall_rule
+    project = Project.create(name: "test-project")
+    firewall = Firewall.create(name: "test-firewall", project_id: project.id, location_id: Location::HETZNER_FSN1_ID)
+    FirewallRule.create(firewall_id: firewall.id, cidr: "0.0.0.0/0", port_range: Sequel.pg_range(80..80))
+  end
+
+  def create_github_cache_entry
+    installation = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User")
+    repo = GithubRepository.create(installation_id: installation.id, name: "test-repo")
+    runner = GithubRunner.create(installation_id: installation.id, repository_name: "test-repo", label: "ubicloud")
+    GithubCacheEntry.create(repository_id: repo.id, key: "test-key", version: "v1", scope: "test", created_by: runner.id)
+  end
+
+  def create_github_custom_label
+    installation = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User")
+    GithubCustomLabel.create(installation_id: installation.id, name: "custom-label", alias_for: "ubicloud-standard-2")
+  end
+
+  def create_github_installation
+    GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User")
+  end
+
+  def create_github_repository
+    installation = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User")
+    GithubRepository.create(installation_id: installation.id, name: "test-repo")
+  end
+
+  def create_github_runner
+    installation = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User")
+    GithubRunner.create(installation_id: installation.id, repository_name: "test-repo", label: "ubicloud")
+  end
+
+  def create_globally_blocked_dnsname
+    GloballyBlockedDnsname.create(dns_name: "blocked.example.com")
+  end
+
+  def create_gpu_partition
+    host = Prog::Vm::HostNexus.assemble("1.2.3.4", family: "gpu-standard").subject
+    GpuPartition.create(vm_host_id: host.id, partition_id: 0, gpu_count: 1)
+  end
+
+  def create_inference_endpoint
+    project = Project.create(name: "test-project")
+    ps = PrivateSubnet.create(name: "test-ps", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.0.0/26", net6: "fdfa::/64")
+    lb = LoadBalancer.create(name: "test-lb", project_id: project.id, private_subnet_id: ps.id, health_check_endpoint: "/health")
+    InferenceEndpoint.create(
+      project_id: project.id,
+      location_id: Location::HETZNER_FSN1_ID,
+      name: "test-endpoint",
+      model_name: "test-model",
+      private_subnet_id: ps.id,
+      load_balancer_id: lb.id,
+      boot_image: "ai-ubuntu-jammy",
+      vm_size: "gpu-standard-2",
+      storage_volumes: [{size_gib: 100}].to_json,
+      engine: "vllm",
+      engine_params: "{}",
+      replica_count: 1
+    )
+  end
+
+  def create_inference_endpoint_replica
+    endpoint = create_inference_endpoint
+    vm = Prog::Vm::Nexus.assemble_with_sshable(endpoint.project_id, name: "replica-vm", private_subnet_id: endpoint.private_subnet_id).subject
+    InferenceEndpointReplica.create(inference_endpoint_id: endpoint.id, vm_id: vm.id)
+  end
+
+  def create_inference_router
+    project = Project.create(name: "test-project")
+    ps = PrivateSubnet.create(name: "test-ps", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.0.0/26", net6: "fdfa::/64")
+    lb = LoadBalancer.create(name: "test-lb", project_id: project.id, private_subnet_id: ps.id, health_check_endpoint: "/health")
+    InferenceRouter.create(
+      project_id: project.id,
+      location_id: Location::HETZNER_FSN1_ID,
+      name: "test-router",
+      private_subnet_id: ps.id,
+      load_balancer_id: lb.id,
+      vm_size: "standard-2",
+      replica_count: 1
+    )
+  end
+
+  def create_inference_router_model
+    InferenceRouterModel.create(
+      model_name: "test/model-#{SecureRandom.hex(4)}",
+      prompt_billing_resource: "prompt",
+      completion_billing_resource: "completion",
+      project_inflight_limit: 10,
+      project_prompt_tps_limit: 100,
+      project_completion_tps_limit: 100
+    )
+  end
+
+  def create_inference_router_replica
+    router = create_inference_router
+    vm = Prog::Vm::Nexus.assemble_with_sshable(router.project_id, name: "router-replica-vm", private_subnet_id: router.private_subnet_id).subject
+    InferenceRouterReplica.create(inference_router_id: router.id, vm_id: vm.id)
+  end
+
+  def create_inference_router_target
+    router = create_inference_router
+    router_model = create_inference_router_model
+    InferenceRouterTarget.create(
+      name: "test-inference-router",
+      host: "127.0.0.1",
+      api_key: "a",
+      inflight_limit: 1,
+      priority: 1,
+      inference_router_id: router.id,
+      inference_router_model_id: router_model.id
+    )
+  end
+
+  def create_invoice
+    project = Project.create(name: "test-project")
+    Invoice.create(
+      project_id: project.id,
+      invoice_number: "test-invoice-#{SecureRandom.hex(4)}",
+      content: {billing_info: {country: "US"}, cost: 10, subtotal: 10},
+      begin_time: Time.now - 86400,
+      end_time: Time.now
+    )
+  end
+
+  def create_ipsec_tunnel
+    project = Project.create(name: "test-project")
+    ps1 = PrivateSubnet.create(name: "test-ps1", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.0.0/26", net6: "fdfa::/64")
+    ps2 = PrivateSubnet.create(name: "test-ps2", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.1.0/26", net6: "fdfb::/64")
+    vm1 = Prog::Vm::Nexus.assemble("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGWmPgJE test@example.com", project.id, name: "vm1", private_subnet_id: ps1.id).subject
+    vm2 = Prog::Vm::Nexus.assemble("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGWmPgJE test@example.com", project.id, name: "vm2", private_subnet_id: ps2.id).subject
+    nic1 = Nic.create(private_subnet_id: ps1.id, vm_id: vm1.id, name: "default", private_ipv4: "10.0.0.2", private_ipv6: "fdfa::2", mac: "00:00:00:00:00:02", state: "active")
+    nic2 = Nic.create(private_subnet_id: ps2.id, vm_id: vm2.id, name: "default", private_ipv4: "10.0.1.2", private_ipv6: "fdfb::2", mac: "00:00:00:00:00:03", state: "active")
+    IpsecTunnel.create(src_nic_id: nic1.id, dst_nic_id: nic2.id)
+  end
+
+  def create_kubernetes_cluster
+    project = Project.create(name: "test-project")
+    ps = PrivateSubnet.create(name: "test-ps", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.0.0/26", net6: "fdfa::/64")
+    KubernetesCluster.create(
+      project_id: project.id,
+      name: "test-cluster",
+      private_subnet_id: ps.id,
+      location_id: Location::HETZNER_FSN1_ID,
+      cp_node_count: 3,
+      version: Option.kubernetes_versions.first,
+      target_node_size: "standard-2"
+    )
+  end
+
+  def create_kubernetes_node
+    cluster = create_kubernetes_cluster
+    vm = Prog::Vm::Nexus.assemble_with_sshable(cluster.project_id, name: "k8s-node-vm", private_subnet_id: cluster.private_subnet_id).subject
+    KubernetesNode.create(kubernetes_cluster_id: cluster.id, vm_id: vm.id)
+  end
+
+  def create_kubernetes_nodepool
+    cluster = create_kubernetes_cluster
+    KubernetesNodepool.create(kubernetes_cluster_id: cluster.id, name: "test-pool", target_node_size: "standard-2", node_count: 1)
+  end
+
+  def create_load_balancer
+    project = Project.create(name: "test-project")
+    ps = PrivateSubnet.create(name: "test-ps", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.0.0/26", net6: "fdfa::/64")
+    LoadBalancer.create(name: "test-lb", project_id: project.id, private_subnet_id: ps.id, health_check_endpoint: "/health")
+  end
+
+  def create_load_balancer_port
+    lb = create_load_balancer
+    LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 80, dst_port: 8080)
+  end
+
+  def create_load_balancer_vm
+    lb = create_load_balancer
+    vm = Prog::Vm::Nexus.assemble_with_sshable(lb.project_id, name: "lb-vm", private_subnet_id: lb.private_subnet_id).subject
+    LoadBalancerVm.create(load_balancer_id: lb.id, vm_id: vm.id)
+  end
+
+  def create_load_balancer_vm_port
+    lbvm = create_load_balancer_vm
+    lb_port = LoadBalancerPort.create(load_balancer_id: lbvm.load_balancer_id, src_port: 80, dst_port: 8080)
+    LoadBalancerVmPort.create(load_balancer_vm_id: lbvm.id, load_balancer_port_id: lb_port.id, stack: "ipv4")
+  end
+
+  def create_location
+    Location.create(name: "test-loc", display_name: "Test Location", ui_name: "Test", visible: true, provider: "hetzner")
+  end
+
+  def create_location_aws_az
+    location = Location.create(name: "us-east-1", display_name: "AWS US East 1", ui_name: "AWS US East", visible: true, provider: "aws", project_id: nil)
+    LocationAwsAz.create(location_id: location.id, az: "us-east-1a", zone_id: "use1-az1")
+  end
+
+  def create_location_credential
+    location = Location.create(name: "test-loc-cred", display_name: "Test Location", ui_name: "Test", visible: true, provider: "aws")
+    LocationCredential.create(access_key: "test-key", secret_key: "test-secret") { it.id = location.id }
+  end
+
+  def create_minio_cluster
+    project = Project.create(name: "test-project")
+    ps = PrivateSubnet.create(name: "test-ps", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.0.0/26", net6: "fdfa::/64")
+    MinioCluster.create(
+      name: "test-cluster",
+      project_id: project.id,
+      location_id: Location::HETZNER_FSN1_ID,
+      private_subnet_id: ps.id,
+      admin_user: "admin",
+      admin_password: "test-password"
+    )
+  end
+
+  def create_minio_pool
+    cluster = create_minio_cluster
+    MinioPool.create(cluster_id: cluster.id, server_count: 1, drive_count: 1, storage_size_gib: 100, vm_size: "standard-2", start_index: 0)
+  end
+
+  def create_minio_server
+    pool = create_minio_pool
+    vm = Prog::Vm::Nexus.assemble_with_sshable(pool.cluster.project_id, name: "minio-vm", private_subnet_id: pool.cluster.private_subnet_id).subject
+    MinioServer.create(minio_pool_id: pool.id, vm_id: vm.id, index: 0)
+  end
+
+  def create_nic
+    project = Project.create(name: "test-project")
+    ps = PrivateSubnet.create(name: "test-ps", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.0.0/26", net6: "fdfa::/64")
+    vm = Prog::Vm::Nexus.assemble("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGWmPgJE test@example.com", project.id, name: "test-vm", private_subnet_id: ps.id).subject
+    Nic.create(private_subnet_id: ps.id, vm_id: vm.id, name: "default", private_ipv4: "10.0.0.2", private_ipv6: "fdfa::2", mac: "00:00:00:00:00:02", state: "active")
+  end
+
+  def create_nic_aws_resource
+    nic = create_nic
+    NicAwsResource.create_with_id(nic, network_interface_id: "eni-12345")
+  end
+
+  def create_object_tag
+    project = Project.create(name: "test-project")
+    ObjectTag.create(project_id: project.id, name: "test-object-tag")
+  end
+
+  def create_oidc_provider
+    OidcProvider.create(
+      display_name: "Test Provider",
+      url: "https://test.example.com",
+      client_id: "test-client-id",
+      client_secret: "test-client-secret",
+      authorization_endpoint: "/oauth/authorize",
+      token_endpoint: "/oauth/token",
+      userinfo_endpoint: "/oauth/userinfo",
+      jwks_uri: "https://test.example.com/.well-known/jwks.json"
+    )
+  end
+
+  def create_page
+    Page.create(summary: "Test page", tag: "test-tag", details: {})
+  end
+
+  def create_payment_method
+    billing_info = BillingInfo.create(stripe_id: "cus_test123")
+    PaymentMethod.create(billing_info_id: billing_info.id, stripe_id: "pm_test456")
+  end
+
+  def create_pci_device
+    host = Prog::Vm::HostNexus.assemble("1.2.3.4").subject
+    PciDevice.create(vm_host_id: host.id, slot: "0000:01:00.0", device_class: "0x0302", vendor: "0x10de", device: "0x2230", iommu_group: 1, numa_node: 0)
+  end
+
+  def create_pg_aws_ami
+    PgAwsAmi.create(aws_ami_id: "ami-#{SecureRandom.hex(4)}", aws_location_name: "us-east-#{SecureRandom.hex(2)}", pg_version: "16", arch: "x64")
+  end
+
+  def create_postgres_metric_destination
+    project = Project.create(name: "test-project")
+    ps = PrivateSubnet.create(name: "test-ps", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.0.0/26", net6: "fdfa::/64")
+    vm = Prog::Vm::Nexus.assemble_with_sshable(project.id, name: "vm-metrics", private_subnet_id: ps.id).subject
+    vmr = VictoriaMetricsResource.create(
+      project_id: project.id,
+      location_id: Location::HETZNER_FSN1_ID,
+      private_subnet_id: ps.id,
+      name: "test-vmr",
+      admin_user: "admin",
+      admin_password: "test-password",
+      target_vm_size: "standard-2",
+      target_storage_size_gib: 100
+    )
+    VictoriaMetricsServer.create(victoria_metrics_resource_id: vmr.id, vm_id: vm.id)
+    pg = PostgresResource.create(
+      project_id: project.id,
+      location_id: Location::HETZNER_FSN1_ID,
+      name: "test-pg",
+      superuser_password: "test-pass",
+      ha_type: "none",
+      target_vm_size: "standard-2",
+      target_storage_size_gib: 100,
+      target_version: "16"
+    )
+    PostgresMetricDestination.create_with_id(pg, url: "https://metrics.example.com", username: "test", password: "test-pass", postgres_resource_id: pg.id)
+  end
+
+  def create_postgres_resource
+    project = Project.create(name: "test-project")
+    PostgresResource.create(
+      project_id: project.id,
+      location_id: Location::HETZNER_FSN1_ID,
+      name: "test-pg",
+      superuser_password: "test-pass",
+      ha_type: "none",
+      target_vm_size: "standard-2",
+      target_storage_size_gib: 100,
+      target_version: "16"
+    )
+  end
+
+  def create_postgres_server
+    pg = create_postgres_resource
+    timeline = PostgresTimeline.create(location_id: pg.location_id, access_key: "test-key", secret_key: "test-secret")
+    vm = Prog::Vm::Nexus.assemble_with_sshable(pg.project_id, name: "pg-vm", location_id: pg.location_id, unix_user: "ubi").subject
+    VmStorageVolume.create(vm_id: vm.id, boot: false, size_gib: 64, disk_index: 1)
+    PostgresServer.create(timeline_id: timeline.id, resource_id: pg.id, vm_id: vm.id, version: "18")
+  end
+
+  def create_postgres_timeline
+    PostgresTimeline.create(location_id: Location::HETZNER_FSN1_ID, access_key: "test-key", secret_key: "test-secret")
+  end
+
+  def create_private_subnet
+    project = Project.create(name: "test-project")
+    PrivateSubnet.create(name: "test-ps", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.0.0/26", net6: "fdfa::/64")
+  end
+
+  def create_private_subnet_aws_resource
+    ps = create_private_subnet
+    PrivateSubnetAwsResource.create_with_id(ps, vpc_id: "vpc-12345")
+  end
+
+  def create_project
+    Project.create(name: "test-project")
+  end
+
+  def create_project_discount_code
+    project = Project.create(name: "test-project")
+    code = DiscountCode.create(code: "TEST123", credit_amount: 10, expires_at: Time.now + 86400)
+    ProjectDiscountCode.create(project_id: project.id, discount_code_id: code.id)
+  end
+
+  def create_semaphore
+    strand = Strand.create(prog: "Test", label: "test")
+    Semaphore.create(strand_id: strand.id, name: "test-semaphore")
+  end
+
+  def create_spdk_installation
+    host = Prog::Vm::HostNexus.assemble("1.2.3.4").subject
+    SpdkInstallation.create(vm_host_id: host.id, version: "24.01", allocation_weight: 100)
+  end
+
+  def create_ssh_public_key
+    project = Project.create(name: "test-project")
+    SshPublicKey.create(project_id: project.id, name: "test-key", public_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGFakeKeyData test@example.com")
+  end
+
+  def create_sshable
+    host = Prog::Vm::HostNexus.assemble("1.2.3.4").subject
+    host.sshable
+  end
+
+  def create_storage_device
+    host = Prog::Vm::HostNexus.assemble("1.2.3.4").subject
+    StorageDevice.create(vm_host_id: host.id, name: "nvme0n1", total_storage_gib: 1000, available_storage_gib: 1000)
+  end
+
+  def create_storage_key_encryption_key
+    StorageKeyEncryptionKey.create(algorithm: "aes-256-gcm", key: "a" * 64, init_vector: "b" * 24, auth_data: "test")
+  end
+
+  def create_strand
+    Strand.create(prog: "Test", label: "test")
+  end
+
+  def create_subject_tag
+    project = Project.create(name: "test-project")
+    SubjectTag.create(project_id: project.id, name: "test-subject-tag")
+  end
+
+  def create_usage_alert
+    account = create_account
+    project = account.projects.first
+    UsageAlert.create(project_id: project.id, user_id: account.id, name: "test-alert", limit: 100)
+  end
+
+  def create_vhost_block_backend
+    host = Prog::Vm::HostNexus.assemble("1.2.3.4").subject
+    VhostBlockBackend.create(vm_host_id: host.id, version: "24.01", allocation_weight: 100)
+  end
+
+  def create_victoria_metrics_resource
+    project = Project.create(name: "test-project")
+    ps = PrivateSubnet.create(name: "test-ps", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.0.0.0/26", net6: "fdfa::/64")
+    VictoriaMetricsResource.create(
+      project_id: project.id,
+      location_id: Location::HETZNER_FSN1_ID,
+      private_subnet_id: ps.id,
+      name: "test-vmr",
+      admin_user: "admin",
+      admin_password: "test-password",
+      target_vm_size: "standard-2",
+      target_storage_size_gib: 100
+    )
+  end
+
+  def create_victoria_metrics_server
+    vmr = create_victoria_metrics_resource
+    vm = Prog::Vm::Nexus.assemble_with_sshable(vmr.project_id, name: "vm-metrics", private_subnet_id: vmr.private_subnet_id).subject
+    VictoriaMetricsServer.create(victoria_metrics_resource_id: vmr.id, vm_id: vm.id)
+  end
+
+  def create_vm
+    project = Project.create(name: "test-project")
+    Prog::Vm::Nexus.assemble("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGWmPgJE test@example.com", project.id, name: "test-vm").subject
+  end
+
+  def create_vm_host
+    Prog::Vm::HostNexus.assemble("1.2.3.4").subject
+  end
+
+  def create_vm_host_slice
+    host = Prog::Vm::HostNexus.assemble("1.2.3.4").subject
+    VmHostSlice.create(
+      vm_host_id: host.id,
+      name: "testslice",
+      cores: 2,
+      total_memory_gib: 4,
+      used_memory_gib: 0,
+      total_cpu_percent: 200,
+      used_cpu_percent: 0,
+      family: "standard"
+    )
+  end
+
+  def create_vm_init_script
+    vm = create_vm
+    VmInitScript.create_with_id(vm, init_script: "echo 'test'")
+  end
+
+  def create_vm_pool
+    VmPool.create(
+      size: 3,
+      vm_size: "standard-2",
+      boot_image: "ubuntu-jammy",
+      location_id: Location::HETZNER_FSN1_ID,
+      storage_size_gib: 86
+    )
+  end
+
+  def create_vm_storage_volume
+    vm = create_vm
+    VmStorageVolume.create(vm_id: vm.id, boot: false, size_gib: 10, disk_index: 1)
+  end
+end

--- a/spec/routes/web/admin/model/ssh_public_key_spec.rb
+++ b/spec/routes/web/admin/model/ssh_public_key_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "SshPublicKey" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_ssh_public_key
+    admin_account_setup_and_login
+  end
+
+  it "displays the SshPublicKey instance page correctly" do
+    click_link "SshPublicKey"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - SshPublicKey"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - SshPublicKey #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/sshable_spec.rb
+++ b/spec/routes/web/admin/model/sshable_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Sshable" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_sshable
+    admin_account_setup_and_login
+  end
+
+  it "displays the Sshable instance page correctly" do
+    click_link "Sshable"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Sshable"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Sshable #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/storage_device_spec.rb
+++ b/spec/routes/web/admin/model/storage_device_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "StorageDevice" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_storage_device
+    admin_account_setup_and_login
+  end
+
+  it "displays the StorageDevice instance page correctly" do
+    click_link "StorageDevice"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - StorageDevice"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - StorageDevice #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/storage_key_encryption_key_spec.rb
+++ b/spec/routes/web/admin/model/storage_key_encryption_key_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "StorageKeyEncryptionKey" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_storage_key_encryption_key
+    admin_account_setup_and_login
+  end
+
+  it "displays the StorageKeyEncryptionKey instance page correctly" do
+    click_link "StorageKeyEncryptionKey"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - StorageKeyEncryptionKey"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - StorageKeyEncryptionKey #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/strand_spec.rb
+++ b/spec/routes/web/admin/model/strand_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Strand" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_strand
+    admin_account_setup_and_login
+  end
+
+  it "displays the Strand instance page correctly" do
+    click_link "Strand"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Strand - Browse"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Strand #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/subject_tag_spec.rb
+++ b/spec/routes/web/admin/model/subject_tag_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "SubjectTag" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_subject_tag
+    admin_account_setup_and_login
+  end
+
+  it "displays the SubjectTag instance page correctly" do
+    click_link "SubjectTag"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - SubjectTag"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - SubjectTag #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/usage_alert_spec.rb
+++ b/spec/routes/web/admin/model/usage_alert_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "UsageAlert" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_usage_alert
+    admin_account_setup_and_login
+  end
+
+  it "displays the UsageAlert instance page correctly" do
+    click_link "UsageAlert"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - UsageAlert"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - UsageAlert #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/vhost_block_backend_spec.rb
+++ b/spec/routes/web/admin/model/vhost_block_backend_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "VhostBlockBackend" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_vhost_block_backend
+    admin_account_setup_and_login
+  end
+
+  it "displays the VhostBlockBackend instance page correctly" do
+    click_link "VhostBlockBackend"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VhostBlockBackend"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VhostBlockBackend #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/victoria_metrics_resource_spec.rb
+++ b/spec/routes/web/admin/model/victoria_metrics_resource_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "VictoriaMetricsResource" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_victoria_metrics_resource
+    admin_account_setup_and_login
+  end
+
+  it "displays the VictoriaMetricsResource instance page correctly" do
+    click_link "VictoriaMetricsResource"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VictoriaMetricsResource"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VictoriaMetricsResource #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/victoria_metrics_server_spec.rb
+++ b/spec/routes/web/admin/model/victoria_metrics_server_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "VictoriaMetricsServer" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_victoria_metrics_server
+    admin_account_setup_and_login
+  end
+
+  it "displays the VictoriaMetricsServer instance page correctly" do
+    click_link "VictoriaMetricsServer"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VictoriaMetricsServer"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VictoriaMetricsServer #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/vm_host_slice_spec.rb
+++ b/spec/routes/web/admin/model/vm_host_slice_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "VmHostSlice" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_vm_host_slice
+    admin_account_setup_and_login
+  end
+
+  it "displays the VmHostSlice instance page correctly" do
+    click_link "VmHostSlice"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VmHostSlice"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VmHostSlice #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/vm_host_spec.rb
+++ b/spec/routes/web/admin/model/vm_host_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "VmHost" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_vm_host
+    admin_account_setup_and_login
+  end
+
+  it "displays the VmHost instance page correctly" do
+    click_link "VmHost"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VmHost - Browse"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/vm_init_script_spec.rb
+++ b/spec/routes/web/admin/model/vm_init_script_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "VmInitScript" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_vm_init_script
+    admin_account_setup_and_login
+  end
+
+  it "displays the VmInitScript instance page correctly" do
+    click_link "VmInitScript"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VmInitScript"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VmInitScript #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/vm_pool_spec.rb
+++ b/spec/routes/web/admin/model/vm_pool_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "VmPool" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_vm_pool
+    admin_account_setup_and_login
+  end
+
+  it "displays the VmPool instance page correctly" do
+    click_link "VmPool"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VmPool"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VmPool #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/vm_spec.rb
+++ b/spec/routes/web/admin/model/vm_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "Vm" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_vm
+    admin_account_setup_and_login
+  end
+
+  it "displays the Vm instance page correctly" do
+    click_link "Vm"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Vm - Browse"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - Vm #{@instance.ubid}"
+  end
+end

--- a/spec/routes/web/admin/model/vm_storage_volume_spec.rb
+++ b/spec/routes/web/admin/model/vm_storage_volume_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe CloverAdmin, "VmStorageVolume" do
+  include AdminModelSpecHelper
+
+  before do
+    @instance = create_vm_storage_volume
+    admin_account_setup_and_login
+  end
+
+  it "displays the VmStorageVolume instance page correctly" do
+    click_link "VmStorageVolume"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VmStorageVolume"
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - VmStorageVolume #{@instance.ubid}"
+  end
+end


### PR DESCRIPTION
I used Claude to generate a separate spec file for each model on the admin site. It did most of the work, and I handled the cleanup.

This will allow us to catch breakage for model pages on the admin site before deploying the changes. No existing model pages need to be fixed, but I tested that this would have caught cases that resulted in previous production exceptions.