### PR TITLE
Demock spec/prog/vm/aws/nexus_spec.rb

### DIFF
--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -1,35 +1,59 @@
 # frozen_string_literal: true
 
+require "aws-sdk-ec2"
+require "aws-sdk-iam"
+
 RSpec.describe Prog::Vm::Aws::Nexus do
   subject(:nx) {
-    described_class.new(vm.strand).tap {
-      it.instance_variable_set(:@vm, vm)
-      it.instance_variable_set(:@aws_instance, aws_instance)
-    }
+    described_class.new(st)
   }
 
   let(:st) {
     vm.strand
   }
 
+  let(:project) { Project.create(name: "test-prj") }
+
+  let(:location) {
+    Location.create(name: "us-west-2", provider: "aws", project_id: project.id,
+      display_name: "aws-us-west-2", ui_name: "AWS US East 1", visible: true)
+  }
+
+  let(:location_credential) {
+    LocationCredential.create_with_id(location, access_key: "test-access-key", secret_key: "test-secret-key")
+  }
+
+  let(:storage_volumes) {
+    [{encrypted: true, size_gib: 30}, {encrypted: true, size_gib: 3800}]
+  }
+
+  let(:vm_params) {
+    {location_id: location.id, unix_user: "test-user-aws", boot_image: "ami-030c060f85668b37d",
+     name: "testvm", size: "m6gd.large", arch: "arm64", storage_volumes:}
+  }
+
   let(:vm) {
-    prj = Project.create(name: "test-prj")
-    loc = Location.create(name: "us-west-2", provider: "aws", project_id: prj.id, display_name: "aws-us-west-2", ui_name: "AWS US East 1", visible: true)
-    LocationCredential.create_with_id(loc, access_key: "test-access-key", secret_key: "test-secret-key")
-    storage_volumes = [
-      {encrypted: true, size_gib: 30},
-      {encrypted: true, size_gib: 3800}
-    ]
-    Prog::Vm::Nexus.assemble("dummy-public key", prj.id, location_id: loc.id, unix_user: "test-user-aws", boot_image: "ami-030c060f85668b37d", name: "testvm", size: "m6gd.large", arch: "arm64", storage_volumes:).subject
+    location_credential  # force creation
+    Prog::Vm::Nexus.assemble_with_sshable(project.id, **vm_params).subject
+  }
+
+  let(:vm_without_sshable) {
+    location_credential
+    Prog::Vm::Nexus.assemble("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI", project.id, **vm_params).subject
   }
 
   let(:aws_instance) { AwsInstance.create_with_id(vm, instance_id: "i-0123456789abcdefg") }
+
+  let(:nic_aws_resource) {
+    NicAwsResource.create_with_id(vm.nics.first, network_interface_id: "eni-0123456789abcdefg")
+  }
 
   let(:client) { Aws::EC2::Client.new(stub_responses: true) }
 
   let(:iam_client) { Aws::IAM::Client.new(stub_responses: true) }
 
   let(:user_data) {
+    public_key = vm.sshable.keys.first.public_key.shellescape
     <<~USER_DATA
 #!/bin/bash
 custom_user="#{vm.unix_user}"
@@ -43,20 +67,17 @@ if [ ! -d /home/$custom_user ]; then
   chmod 700 /home/$custom_user/.ssh
   chmod 600 /home/$custom_user/.ssh/authorized_keys
 fi
-echo dummy-public-key > /home/$custom_user/.ssh/authorized_keys
+echo #{public_key} > /home/$custom_user/.ssh/authorized_keys
 usermod -L ubuntu
     USER_DATA
   }
 
   before do
-    allow(nx).to receive_messages(vm:, aws_instance:)
     allow(Aws::EC2::Client).to receive(:new).with(credentials: anything, region: "us-west-2").and_return(client)
     allow(Aws::IAM::Client).to receive(:new).with(credentials: anything, region: "us-west-2").and_return(iam_client)
   end
 
   describe ".assemble" do
-    let(:project) { Project.create(name: "test-prj") }
-
     it "creates correct number of storage volumes for storage optimized instance types" do
       loc = Location.create(name: "us-west-2", provider: "aws", project_id: project.id, display_name: "us-west-2", ui_name: "us-west-2", visible: true)
       storage_volumes = [
@@ -97,18 +118,22 @@ usermod -L ubuntu
   end
 
   describe "#before_destroy" do
-    it "stops billing records" do
+    it "finalizes active billing records" do
       br = BillingRecord.create(
-        project_id: vm.project.id,
+        project_id: project.id,
         resource_id: vm.id,
         resource_name: vm.name,
         billing_rate_id: BillingRate.from_resource_properties("VmVCpu", vm.family, vm.location.name)["id"],
         amount: vm.vcpus
       )
 
-      expect(vm).to receive(:active_billing_records).and_return([br])
-      expect(br).to receive(:finalize)
-      nx.before_destroy
+      expect { nx.before_destroy }
+        .to change { br.reload.span.unbounded_end? }.from(true).to(false)
+    end
+
+    it "completes without billing records" do
+      expect(vm.active_billing_records).to be_empty
+      expect { nx.before_destroy }.not_to change { vm.reload.active_billing_records.count }
     end
   end
 
@@ -120,9 +145,7 @@ usermod -L ubuntu
 
     it "creates a role for instance" do
       vm.nics.first.strand.update(label: "wait")
-      iam_client.stub_responses(:create_role, {})
-      allow(nx).to receive(:iam_client).and_return(iam_client)
-      iam_client.stub_responses(:create_role, {})
+      iam_client.stub_responses(:create_role, {role: {role_name: vm.name, path: "/", role_id: "ROLE123", arn: "arn:aws:iam::123456789012:role/#{vm.name}", create_date: Time.now}})
       expect(iam_client).to receive(:create_role).with({
         role_name: vm.name,
         assume_role_policy_document: {
@@ -135,14 +158,13 @@ usermod -L ubuntu
             }
           ]
         }.to_json
-      })
+      }).and_call_original
 
       expect { nx.start }.to hop("create_role_policy")
     end
 
     it "hops to create_role_policy if role already exists" do
       vm.nics.first.strand.update(label: "wait")
-      allow(nx).to receive(:iam_client).and_return(iam_client)
       expect(iam_client).to receive(:create_role).with({role_name: vm.name, assume_role_policy_document: {
         Version: "2012-10-17",
         Statement: [
@@ -193,13 +215,12 @@ usermod -L ubuntu
             }
           ]
         }.to_json
-      })
+      }).and_call_original
 
       expect { nx.create_role_policy }.to hop("attach_role_policy")
     end
 
     it "hops to attach_role_policy if policy already exists" do
-      allow(nx).to receive(:iam_client).and_return(iam_client)
       expect(iam_client).to receive(:create_policy).and_raise(Aws::IAM::Errors::EntityAlreadyExists.new(nil, "EntityAlreadyExists"))
       expect { nx.create_role_policy }.to hop("attach_role_policy")
     end
@@ -207,20 +228,19 @@ usermod -L ubuntu
 
   describe "#attach_role_policy" do
     it "attaches role policy" do
-      allow(nx).to receive(:iam_client).and_return(iam_client)
       iam_client.stub_responses(:attach_role_policy, {})
       iam_client.stub_responses(:list_policies, policies: [{policy_name: "#{vm.name}-cw-agent-policy", arn: "arn:aws:iam::aws:policy/#{vm.name}-cw-agent-policy"}])
       expect(iam_client).to receive(:attach_role_policy).with({
         role_name: vm.name,
         policy_arn: "arn:aws:iam::aws:policy/#{vm.name}-cw-agent-policy"
-      })
+      }).and_call_original
 
       expect { nx.attach_role_policy }.to hop("create_instance_profile")
     end
 
     it "hops to create_instance_profile if policy already exists" do
-      allow(nx).to receive(:iam_client).and_return(iam_client)
       iam_client.stub_responses(:list_policies, policies: [{policy_name: "#{vm.name}-cw-agent-policy", arn: "arn:aws:iam::aws:policy/#{vm.name}-cw-agent-policy"}])
+      expect(iam_client).to receive(:list_policies).with(scope: "Local", marker: nil, max_items: 100).and_call_original
       expect(iam_client).to receive(:attach_role_policy).and_raise(Aws::IAM::Errors::EntityAlreadyExists.new(nil, "EntityAlreadyExists"))
       expect { nx.attach_role_policy }.to hop("create_instance_profile")
     end
@@ -228,17 +248,15 @@ usermod -L ubuntu
 
   describe "#create_instance_profile" do
     it "creates an instance profile" do
-      allow(nx).to receive(:iam_client).and_return(iam_client)
-      iam_client.stub_responses(:create_instance_profile, {})
+      iam_client.stub_responses(:create_instance_profile, instance_profile: {instance_profile_name: "#{vm.name}-instance-profile", instance_profile_id: "test-id", path: "/", roles: [], arn: "arn:aws:iam::123456789012:instance-profile/#{vm.name}-instance-profile", create_date: Time.now})
       expect(iam_client).to receive(:create_instance_profile).with({
         instance_profile_name: "#{vm.name}-instance-profile"
-      })
+      }).and_call_original
 
       expect { nx.create_instance_profile }.to hop("add_role_to_instance_profile")
     end
 
     it "hops to add_role_to_instance_profile if instance profile already exists" do
-      allow(nx).to receive(:iam_client).and_return(iam_client)
       expect(iam_client).to receive(:create_instance_profile).and_raise(Aws::IAM::Errors::EntityAlreadyExists.new(nil, "EntityAlreadyExists"))
       expect { nx.create_instance_profile }.to hop("add_role_to_instance_profile")
     end
@@ -246,18 +264,16 @@ usermod -L ubuntu
 
   describe "#add_role_to_instance_profile" do
     it "adds role to instance profile" do
-      allow(nx).to receive(:iam_client).and_return(iam_client)
       iam_client.stub_responses(:add_role_to_instance_profile, {})
       expect(iam_client).to receive(:add_role_to_instance_profile).with({
         instance_profile_name: "#{vm.name}-instance-profile",
         role_name: vm.name
-      })
+      }).and_call_original
 
       expect { nx.add_role_to_instance_profile }.to hop("wait_instance_profile_created")
     end
 
     it "hops to wait_instance_profile_created if role is already added to instance profile" do
-      allow(nx).to receive(:iam_client).and_return(iam_client)
       expect(iam_client).to receive(:add_role_to_instance_profile).and_raise(Aws::IAM::Errors::EntityAlreadyExists.new(nil, "LimitExceeded"))
       expect { nx.add_role_to_instance_profile }.to hop("wait_instance_profile_created")
     end
@@ -265,28 +281,28 @@ usermod -L ubuntu
 
   describe "#wait_instance_profile_created" do
     it "waits for instance profile to be created" do
-      expect(nx).to receive(:iam_client).and_return(iam_client)
+      iam_client.stub_responses(:get_instance_profile, instance_profile: {instance_profile_name: "#{vm.name}-instance-profile", instance_profile_id: "#{vm.name}-instance-profile-id", path: "/", roles: [], arn: "arn:aws:iam::#{vm.project_id}:instance-profile/#{vm.name}-instance-profile", create_date: Time.now})
+      expect(iam_client).to receive(:get_instance_profile).with({
+        instance_profile_name: "#{vm.name}-instance-profile"
+      }).and_call_original
 
-      iam_client.stub_responses(:get_instance_profile, instance_profile: {instance_profile_name: "#{vm.name}-instance-profile", instance_profile_id: "#{vm.name}-instance-profile-id", path: "/", roles: [], arn: "arn:aws:iam::#{vm.project.id}:instance-profile/#{vm.name}-instance-profile", create_date: Time.now})
       expect { nx.wait_instance_profile_created }.to hop("create_instance")
     end
 
     it "naps if instance profile is not created" do
-      expect(nx).to receive(:iam_client).and_return(iam_client)
       expect(iam_client).to receive(:get_instance_profile).and_raise(Aws::IAM::Errors::NoSuchEntity.new(nil, "NoSuchEntity"))
-
       expect { nx.wait_instance_profile_created }.to nap(1)
     end
   end
 
   describe "#create_instance" do
+    before do
+      nic_aws_resource
+      client.stub_responses(:describe_subnets, subnets: [{availability_zone_id: "use1-az1"}])
+    end
+
     it "creates an instance" do
       client.stub_responses(:run_instances, instances: [{instance_id: "i-0123456789abcdefg", network_interfaces: [{subnet_id: "subnet-12345678"}], public_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com"}])
-      client.stub_responses(:describe_subnets, subnets: [{availability_zone_id: "use1-az1"}])
-      expect(vm).to receive(:vcpus).and_return(2)
-      expect(vm).to receive(:sshable).and_return(create_mock_sshable(keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
-
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
       expect(client).to receive(:run_instances).with({
         image_id: "ami-030c060f85668b37d",
         instance_type: "m6gd.large",
@@ -316,166 +332,142 @@ usermod -L ubuntu
         },
         min_count: 1,
         max_count: 1,
-        user_data: Base64.encode64(user_data),
         tag_specifications: Util.aws_tag_specifications("instance", vm.name),
-        iam_instance_profile: {
-          name: "#{vm.name}-instance-profile"
-        },
+        iam_instance_profile: {name: "#{vm.name}-instance-profile"},
         client_token: vm.id,
-        instance_market_options: nil
+        instance_market_options: nil,
+        user_data: Base64.encode64(user_data)
       }).and_call_original
-      expect(AwsInstance).to receive(:create_with_id).with(vm, instance_id: "i-0123456789abcdefg", az_id: "use1-az1", iam_role: "testvm", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
       expect { nx.create_instance }.to hop("wait_instance_created")
+      expect(vm.aws_instance).to have_attributes(instance_id: "i-0123456789abcdefg", az_id: "use1-az1", iam_role: "testvm", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
     end
 
     it "skips instance profile creation for runner instances" do
       client.stub_responses(:run_instances, instances: [{instance_id: "i-0123456789abcdefg", network_interfaces: [{subnet_id: "subnet-12345678"}], public_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com"}])
-      client.stub_responses(:describe_subnets, subnets: [{availability_zone_id: "use1-az1"}])
       vm.update(unix_user: "runneradmin")
-      expect(vm).to receive(:sshable).and_return(create_mock_sshable(keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
       expect(client).to receive(:run_instances).with(hash_not_including(:iam_instance_profile)).and_call_original
-      expect(AwsInstance).to receive(:create_with_id).with(vm, instance_id: "i-0123456789abcdefg", az_id: "use1-az1", iam_role: "testvm", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
       expect { nx.create_instance }.to hop("wait_instance_created")
+      expect(vm.aws_instance).to have_attributes(instance_id: "i-0123456789abcdefg", az_id: "use1-az1", iam_role: "testvm", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
     end
 
     it "naps until instance profile not propagated yet" do
       client.stub_responses(:run_instances, Aws::EC2::Errors::InvalidParameterValue.new(nil, "Invalid IAM Instance Profile name"))
-      client.stub_responses(:describe_subnets, subnets: [{availability_zone_id: "use1-az1"}])
-      expect(vm).to receive(:sshable).and_return(create_mock_sshable(keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
-      expect { nx.create_instance }.to nap(1)
+      expect { nx.create_instance }
+        .to nap(1)
+        .and change(client, :api_requests)
+        .to(include(a_hash_including(operation_name: :run_instances)))
     end
 
     it "raises exception if it's not for invalid instance profile" do
       client.stub_responses(:run_instances, Aws::EC2::Errors::InvalidParameterValue.new(nil, "Invalid instance name"))
-      client.stub_responses(:describe_subnets, subnets: [{availability_zone_id: "use1-az1"}])
-      expect(vm).to receive(:sshable).and_return(create_mock_sshable(keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
       expect { nx.create_instance }.to raise_error(Aws::EC2::Errors::InvalidParameterValue)
     end
 
     it "sets transparent cache host for runners" do
       client.stub_responses(:run_instances, instances: [{instance_id: "i-0123456789abcdefg", network_interfaces: [{subnet_id: "subnet-12345678"}], public_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com"}])
-      client.stub_responses(:describe_subnets, subnets: [{availability_zone_id: "use1-az1"}])
-      expect(vm).to receive(:private_ipv4).and_return("1.2.3.4")
       vm.update(unix_user: "runneradmin")
-      expect(vm).to receive(:sshable).and_return(create_mock_sshable(keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
-      new_data = user_data + "echo \"1.2.3.4 ubicloudhostplaceholder.blob.core.windows.net\" >> /etc/hosts"
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
-      expect(client).to receive(:run_instances).with(hash_including(user_data: Base64.encode64(new_data))).and_call_original
-      expect(AwsInstance).to receive(:create_with_id).with(vm, instance_id: "i-0123456789abcdefg", az_id: "use1-az1", iam_role: "testvm", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
+      expected_user_data = user_data + "echo \"#{vm.private_ipv4} ubicloudhostplaceholder.blob.core.windows.net\" >> /etc/hosts"
+      expect(client).to receive(:run_instances).with(hash_including(
+        user_data: Base64.encode64(expected_user_data)
+      )).and_call_original
       expect { nx.create_instance }.to hop("wait_instance_created")
+      expect(vm.aws_instance).to have_attributes(instance_id: "i-0123456789abcdefg", az_id: "use1-az1", iam_role: "testvm", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
     end
 
     it "uses spot instances for runners when enabled" do
       expect(Config).to receive(:github_runner_aws_spot_instance_enabled).and_return(true)
       client.stub_responses(:run_instances, instances: [{instance_id: "i-0123456789abcdefg", network_interfaces: [{subnet_id: "subnet-12345678"}], public_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com"}])
-      client.stub_responses(:describe_subnets, subnets: [{availability_zone_id: "use1-az1"}])
-      expect(vm).to receive(:private_ipv4).and_return("1.2.3.4")
       vm.update(unix_user: "runneradmin")
-      expect(vm).to receive(:sshable).and_return(create_mock_sshable(keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
-      new_data = user_data + "echo \"1.2.3.4 ubicloudhostplaceholder.blob.core.windows.net\" >> /etc/hosts"
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
       expect(client).to receive(:run_instances).with(hash_including(
-        user_data: Base64.encode64(new_data),
         instance_market_options: {market_type: "spot", spot_options: {instance_interruption_behavior: "terminate", spot_instance_type: "one-time"}}
       )).and_call_original
-      expect(AwsInstance).to receive(:create_with_id).with(vm, instance_id: "i-0123456789abcdefg", az_id: "use1-az1", iam_role: "testvm", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
       expect { nx.create_instance }.to hop("wait_instance_created")
+      expect(vm.aws_instance).to have_attributes(instance_id: "i-0123456789abcdefg", az_id: "use1-az1", iam_role: "testvm", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
     end
 
     it "sets max price for spot instances if provided" do
       expect(Config).to receive(:github_runner_aws_spot_instance_enabled).and_return(true)
       expect(Config).to receive(:github_runner_aws_spot_instance_max_price_per_vcpu).and_return(0.001).at_least(:once)
-
       client.stub_responses(:run_instances, instances: [{instance_id: "i-0123456789abcdefg", network_interfaces: [{subnet_id: "subnet-12345678"}], public_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com"}])
-      client.stub_responses(:describe_subnets, subnets: [{availability_zone_id: "use1-az1"}])
-      expect(vm).to receive(:private_ipv4).and_return("1.2.3.4")
       vm.update(unix_user: "runneradmin")
-      expect(vm).to receive(:sshable).and_return(create_mock_sshable(keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
-      new_data = user_data + "echo \"1.2.3.4 ubicloudhostplaceholder.blob.core.windows.net\" >> /etc/hosts"
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
       expect(client).to receive(:run_instances).with(hash_including(
-        user_data: Base64.encode64(new_data),
         instance_market_options: {market_type: "spot", spot_options: {instance_interruption_behavior: "terminate", spot_instance_type: "one-time", max_price: "0.12"}}
       )).and_call_original
-      expect(AwsInstance).to receive(:create_with_id).with(vm, instance_id: "i-0123456789abcdefg", az_id: "use1-az1", iam_role: "testvm", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
       expect { nx.create_instance }.to hop("wait_instance_created")
+      expect(vm.aws_instance).to have_attributes(instance_id: "i-0123456789abcdefg", az_id: "use1-az1", iam_role: "testvm", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
     end
 
     describe "when insufficient capacity error" do
+      def set_alternative_families(families)
+        refresh_frame(nx, new_values: {"alternative_families" => families})
+      end
+
       before do
         client.stub_responses(:run_instances, Aws::EC2::Errors::InsufficientInstanceCapacity.new(nil, "Insufficient capacity for instance type"))
         vm.update(unix_user: "runneradmin")
         installation = GithubInstallation.create(name: "ubicloud", type: "Organization", installation_id: 123, project_id: vm.project_id)
         GithubRunner.create(label: "ubicloud-standard-2", repository_name: "ubicloud/test", installation_id: installation.id, vm_id: vm.id)
-        expect(vm).to receive(:sshable).and_return(create_mock_sshable(keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
-        expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
         expect(Clog).to receive(:emit).with("insufficient instance capacity", instance_of(Hash)).and_call_original
       end
 
-      it "recreates runner when alternative_families is not set" do
-        expect(nx).to receive(:frame).and_return({}).at_least(:once)
-        expect(Prog::Github::GithubRunnerNexus).to receive(:assemble).and_call_original
-        expect { nx.create_instance }.to nap(0)
+      it "recreates runner when alternative_families is nil" do
+        set_alternative_families(nil)
+        expect { nx.create_instance }.to nap(0).and change(GithubRunner, :count).by(1)
       end
 
       it "recreates runner when alternative_families is empty" do
-        expect(nx).to receive(:frame).and_return({"alternative_families" => []}).at_least(:once)
-        expect(Prog::Github::GithubRunnerNexus).to receive(:assemble).and_call_original
-        expect { nx.create_instance }.to nap(0)
+        set_alternative_families([])
+        expect { nx.create_instance }.to nap(0).and change(GithubRunner, :count).by(1)
       end
 
       it "creates runner with the first alternative when current_family is the initial family" do
-        expect(nx).to receive(:frame).and_return({"alternative_families" => ["m7i", "m6a"]}).at_least(:once)
+        set_alternative_families(["m7i", "m6a"])
         expect { nx.create_instance }.to nap(0)
-        expect(vm.family).to eq("m7i")
+          .and not_change(GithubRunner, :count)
+          .and change { vm.reload.family }.from("m6gd").to("m7i")
       end
 
       it "creates runner with the next alternative when current_family is the first family" do
         vm.update(family: "m7i")
-        expect(nx).to receive(:frame).and_return({"alternative_families" => ["m7i", "m6a"]}).at_least(:once)
+        set_alternative_families(["m7i", "m6a"])
         expect { nx.create_instance }.to nap(0)
-        expect(vm.family).to eq("m6a")
+          .and not_change(GithubRunner, :count)
+          .and change { vm.reload.family }.from("m7i").to("m6a")
       end
 
       it "recreates runner when current_family is the last family" do
         vm.update(family: "m6a")
-        expect(nx).to receive(:frame).and_return({"alternative_families" => ["m7i", "m6a"]}).at_least(:once)
-        expect(Prog::Github::GithubRunnerNexus).to receive(:assemble).and_call_original
-        expect { nx.create_instance }.to nap(0)
+        set_alternative_families(["m7i", "m6a"])
+        expect { nx.create_instance }.to nap(0).and change(GithubRunner, :count).by(1)
       end
     end
 
     it "fails if not runner when encountering insufficient capacity error" do
       client.stub_responses(:run_instances, Aws::EC2::Errors::InsufficientInstanceCapacity.new(nil, "Insufficient capacity for instance type"))
-      expect(vm).to receive(:sshable).and_return(create_mock_sshable(keys: [instance_double(SshKey, public_key: "dummy-public-key")]))
-      expect(vm.nics.first).to receive(:nic_aws_resource).and_return(instance_double(NicAwsResource, network_interface_id: "eni-0123456789abcdefg"))
       expect { nx.create_instance }.to raise_error(Aws::EC2::Errors::InsufficientInstanceCapacity)
     end
 
     describe "when unsupported instance type error" do
       let(:nic) { vm.nics.first }
+      let(:nic_nx) { Prog::Vnet::Aws::NicNexus.new(nic.strand) }
 
       before do
         client.stub_responses(:run_instances, Aws::EC2::Errors::Unsupported.new(nil, "Instance type not supported in availability zone"))
-        expect(vm).to receive(:sshable).and_return(create_mock_sshable(keys: [instance_double(SshKey, public_key: "dummy-public-key")])).at_least(:once)
-        nic.strand.stack.push({"exclude_availability_zones" => []})
-        NicAwsResource.create_with_id(nic, network_interface_id: "eni-0123456789abcdefg", subnet_az: "a")
+        refresh_frame(nic_nx, new_frame: {"exclude_availability_zones" => []})
+        nic.nic_aws_resource.update(subnet_az: "a")
       end
 
       it "retries by excluding the failed AZ on first failure" do
         expect(Clog).to receive(:emit).with("unsupported instance type", instance_of(Hash)).and_call_original
         expect { nx.create_instance }.to hop("wait_old_nic_deleted")
+          .and change { nic.reload.destroy_set? }.from(false).to(true)
         expect(st.stack.last["exclude_availability_zones"]).to eq(["a"])
         expect(st.stack.last["retry_count"]).to eq(1)
-        expect(nic.reload.destroy_set?).to be true
       end
 
       it "increments retry count on subsequent failures" do
         refresh_frame(nx, new_values: {"retry_count" => 2})
-        nic.strand.stack.first["exclude_availability_zones"] = ["b", "c"]
+        refresh_frame(nic_nx, new_values: {"exclude_availability_zones" => ["b", "c"]})
         expect(Clog).to receive(:emit).with("unsupported instance type", instance_of(Hash)).and_call_original
         expect(nx).to receive(:update_stack).with({
           "exclude_availability_zones" => ["b", "c", "a"],
@@ -485,7 +477,7 @@ usermod -L ubuntu
       end
 
       it "avoids duplicate AZs in exclusion list" do
-        nic.strand.stack.first["exclude_availability_zones"] = ["a", "b"]
+        refresh_frame(nic_nx, new_values: {"exclude_availability_zones" => ["a", "b"]})
         expect { nx.create_instance }.to hop("wait_old_nic_deleted")
         expect(st.stack.last["exclude_availability_zones"]).to eq(["a", "b"])
       end
@@ -513,30 +505,61 @@ usermod -L ubuntu
 
   describe "#wait_instance_created" do
     before do
+      aws_instance
       client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "running"}, network_interfaces: [{association: {public_ip: "1.2.3.4"}, ipv_6_addresses: [{ipv_6_address: "2a01:4f8:173:1ed3:aa7c::/79"}]}]}]}])
     end
 
     it "updates the vm" do
-      time = Time.now
-      expect(Time).to receive(:now).and_return(time).at_least(:once)
-      expect(client).to receive(:describe_instances).with({filters: [{name: "instance-id", values: ["i-0123456789abcdefg"]}, {name: "tag:Ubicloud", values: ["true"]}]}).and_call_original
-      expect(vm).to receive(:update).with(cores: 1, allocated_at: time, ephemeral_net6: "2a01:4f8:173:1ed3:aa7c::/79")
+      now = Time.now.floor
+      expect(Time).to receive(:now).at_least(:once).and_return(now)
       expect { nx.wait_instance_created }.to hop("wait_sshable")
+      vm.reload
+      expect(vm.cores).to eq(1)
+      expect(vm.ephemeral_net6.to_s).to eq("2a01:4f8:173:1ed3:aa7c::/79")
+      expect(vm.allocated_at).to eq(now)
     end
 
-    it "updates the vm with the instance id and updates ip according to the sshable" do
-      time = Time.now
-      expect(Time).to receive(:now).and_return(time).at_least(:once)
-      sshable = Sshable.new
-      expect(vm).to receive(:sshable).and_return(sshable)
-      expect(sshable).to receive(:update).with(host: "1.2.3.4")
-      expect(vm).to receive(:update).with(cores: 1, allocated_at: time, ephemeral_net6: "2a01:4f8:173:1ed3:aa7c::/79")
+    it "updates the sshable host" do
       expect { nx.wait_instance_created }.to hop("wait_sshable")
+        .and change { vm.sshable.reload.host }.to("1.2.3.4")
     end
 
     it "naps if the instance is not running" do
       client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "pending"}}]}])
-      expect { nx.wait_instance_created }.to nap(1)
+      expect { nx.wait_instance_created }
+        .to nap(1)
+        .and change(client, :api_requests)
+        .to(include(a_hash_including(
+          operation_name: :describe_instances,
+          params: a_hash_including(filters: [
+            {name: "instance-id", values: ["i-0123456789abcdefg"]},
+            {name: "tag:Ubicloud", values: ["true"]}
+          ])
+        )))
+    end
+  end
+
+  describe "#wait_instance_created", "without sshable" do
+    let(:vm) { vm_without_sshable }
+    let(:aws_instance) { AwsInstance.create_with_id(vm, instance_id: "i-0123456789abcdefg") }
+
+    before do
+      aws_instance
+      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "running"}, network_interfaces: [{association: {public_ip: "1.2.3.4"}, ipv_6_addresses: [{ipv_6_address: "2a01:4f8:173:1ed3:aa7c::/79"}]}]}]}])
+    end
+
+    it "handles vm without sshable" do
+      expect { nx.wait_instance_created }
+        .to hop("wait_sshable")
+        .and change(client, :api_requests)
+        .to(include(a_hash_including(
+          operation_name: :describe_instances,
+          params: a_hash_including(filters: [
+            {name: "instance-id", values: ["i-0123456789abcdefg"]},
+            {name: "tag:Ubicloud", values: ["true"]}
+          ])
+        )))
+        .and change { vm.reload.cores }.to(1)
     end
   end
 
@@ -545,13 +568,11 @@ usermod -L ubuntu
     let(:private_subnet_id) { old_nic.private_subnet_id }
 
     before do
-      st.stack.first["private_subnet_id"] = private_subnet_id
-      st.stack.first["exclude_availability_zones"] = ["a", "b"]
-      nx.instance_variable_set(:@frame, nil) # Clear cached frame
+      refresh_frame(nx, new_values: {"private_subnet_id" => private_subnet_id, "exclude_availability_zones" => ["a", "b"]})
     end
 
     it "naps if old NIC still exists" do
-      expect(vm.nic).not_to be_nil
+      expect(vm.nic).to exist
       expect { nx.wait_old_nic_deleted }.to nap(1)
     end
 
@@ -587,15 +608,15 @@ usermod -L ubuntu
     end
 
     it "naps if not sshable" do
-      expect(vm).to receive(:ip4).and_return(NetAddr::IPv4.parse("10.0.0.1"))
+      AssignedVmAddress.create(dst_vm_id: vm.id, ip: "10.0.0.1/32")
       vm.incr_update_firewall_rules
       expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1).and_raise Errno::ECONNREFUSED
       expect { nx.wait_sshable }.to nap(1)
     end
 
     it "hops to create_billing_record if sshable" do
+      AssignedVmAddress.create(dst_vm_id: vm.id, ip: "10.0.0.1/32")
       vm.incr_update_firewall_rules
-      expect(vm).to receive(:ip4).and_return(NetAddr::IPv4.parse("10.0.0.1"))
       expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1)
       expect { nx.wait_sshable }.to hop("create_billing_record")
     end
@@ -611,6 +632,7 @@ usermod -L ubuntu
     let(:now) { Time.now }
 
     before do
+      aws_instance
       expect(Time).to receive(:now).and_return(now).at_least(:once)
       vm.update(allocated_at: now - 100)
       expect(Clog).to receive(:emit).with("vm provisioned", instance_of(Array)).and_call_original
@@ -619,15 +641,15 @@ usermod -L ubuntu
     it "not create billing records when the project is not billable" do
       vm.project.update(billable: false)
       expect { nx.create_billing_record }.to hop("wait")
-      expect(BillingRecord.count).to eq(0)
+      expect(BillingRecord.all).to be_empty
     end
 
     it "creates billing records for only vm" do
       expect { nx.create_billing_record }.to hop("wait")
         .and change(BillingRecord, :count).from(0).to(1)
+        .and change { vm.reload.display_state }.from("creating").to("running")
       expect(vm.active_billing_records.first.billing_rate["resource_type"]).to eq("VmVCpu")
-      expect(vm.display_state).to eq("running")
-      expect(vm.provisioned_at).to eq(now)
+      expect(vm.provisioned_at).to be_within(1).of(now)
     end
   end
 
@@ -637,18 +659,17 @@ usermod -L ubuntu
     end
 
     it "hops to update_firewall_rules when needed" do
-      expect(nx).to receive(:when_update_firewall_rules_set?).and_yield
+      nx.incr_update_firewall_rules
       expect { nx.wait }.to hop("update_firewall_rules")
     end
   end
 
   describe "#update_firewall_rules" do
     it "hops to wait_firewall_rules" do
-      vm.incr_update_firewall_rules
-      expect(vm).to receive(:location).and_return(instance_double(Location, aws?: true))
+      nx.incr_update_firewall_rules
       expect(nx).to receive(:push).with(Prog::Vnet::Aws::UpdateFirewallRules, {}, :update_firewall_rules)
-      expect(nx).to receive(:decr_update_firewall_rules).and_call_original
       nx.update_firewall_rules
+      expect(Semaphore.where(strand_id: st.id, name: "update_firewall_rules").all).to be_empty
     end
 
     it "hops to wait if firewall rules are applied" do
@@ -659,32 +680,37 @@ usermod -L ubuntu
 
   describe "#prevent_destroy" do
     it "registers a deadline and naps while preventing" do
-      expect(nx).to receive(:register_deadline)
+      now = Time.now
+      expect(Time).to receive(:now).at_least(:once).and_return(now)
       expect { nx.prevent_destroy }.to nap(30)
+      expect(nx.strand.stack.first["deadline_target"]).to eq("destroy")
+      expect(nx.strand.stack.first["deadline_at"]).to eq(now + 24 * 60 * 60)
     end
   end
 
   describe "#destroy" do
     it "prevents destroy if the semaphore set" do
-      expect(nx).to receive(:when_prevent_destroy_set?).and_yield
+      nx.incr_prevent_destroy
       expect(Clog).to receive(:emit).with("Destroy prevented by the semaphore").and_call_original
       expect { nx.destroy }.to hop("prevent_destroy")
-    end
-
-    it "deletes the instance" do
-      expect(aws_instance).to receive(:destroy)
-      expect(client).to receive(:terminate_instances).with({instance_ids: ["i-0123456789abcdefg"]})
-      expect { nx.destroy }.to hop("cleanup_roles")
-    end
-
-    it "pops directly if there is no aws_instance" do
-      expect(nx).to receive(:aws_instance).and_return(nil)
-      expect { nx.destroy }.to hop("cleanup_roles")
     end
 
     it "exits directly if it's a runner" do
       vm.update(unix_user: "runneradmin")
       expect { nx.destroy }.to exit({"msg" => "vm destroyed"})
+    end
+
+    it "hops to cleanup_roles if there is no aws_instance" do
+      expect { nx.destroy }.to hop("cleanup_roles")
+    end
+  end
+
+  describe "#destroy", "with aws_instance" do
+    it "deletes the instance" do
+      aws_instance
+      expect(client).to receive(:terminate_instances).with({instance_ids: ["i-0123456789abcdefg"]})
+      expect { nx.destroy }.to hop("cleanup_roles")
+      expect(aws_instance).not_to exist
     end
   end
 
@@ -735,6 +761,10 @@ usermod -L ubuntu
 
       policy = nx.cloudwatch_policy
       expect(policy).to be_nil
+      expect(iam_client.api_requests).to include(
+        a_hash_including(operation_name: :list_policies, params: a_hash_including(scope: "Local", max_items: 100, marker: nil)),
+        a_hash_including(operation_name: :list_policies, params: a_hash_including(scope: "Local", max_items: 100, marker: "next-page-marker"))
+      )
     end
   end
 
@@ -750,10 +780,19 @@ usermod -L ubuntu
         {policy_name: "policy-name", policy_arn: "policy-arn"}
       ]})
       iam_client.stub_responses(:list_attached_role_policies, policies)
-      expect(iam_client).to receive(:detach_role_policy).with({policy_arn: "arn:aws:iam::aws:policy/testvm-cw-agent-policy", role_name: "testvm"})
-      expect(iam_client).to receive(:detach_role_policy).with({role_name: vm.name, policy_arn: "policy-arn"})
+      iam_client.stub_responses(:detach_role_policy, {})
+      expect(iam_client).to receive(:detach_role_policy).with({policy_arn: "arn:aws:iam::aws:policy/testvm-cw-agent-policy", role_name: "testvm"}).and_call_original
+      expect(iam_client).to receive(:detach_role_policy).with({role_name: vm.name, policy_arn: "policy-arn"}).and_call_original
 
-      expect { nx.cleanup_roles }.to exit({"msg" => "vm destroyed"})
+      expect { nx.cleanup_roles }
+        .to exit({"msg" => "vm destroyed"})
+        .and change(iam_client, :api_requests)
+        .to(include(
+          a_hash_including(operation_name: :remove_role_from_instance_profile, params: {instance_profile_name: "testvm-instance-profile", role_name: "testvm"}),
+          a_hash_including(operation_name: :delete_instance_profile, params: {instance_profile_name: "testvm-instance-profile"}),
+          a_hash_including(operation_name: :delete_policy, params: {policy_arn: "arn:aws:iam::aws:policy/testvm-cw-agent-policy"}),
+          a_hash_including(operation_name: :delete_role, params: {role_name: "testvm"})
+        ))
     end
 
     it "skips policy cleanup if the cloudwatch policy doesn't exist" do
@@ -761,7 +800,14 @@ usermod -L ubuntu
       iam_client.stub_responses(:remove_role_from_instance_profile, {})
       iam_client.stub_responses(:delete_instance_profile, {})
       iam_client.stub_responses(:delete_role, {})
-      expect { nx.cleanup_roles }.to exit({"msg" => "vm destroyed"})
+      expect { nx.cleanup_roles }
+        .to exit({"msg" => "vm destroyed"})
+        .and change(iam_client, :api_requests)
+        .to(include(
+          a_hash_including(operation_name: :remove_role_from_instance_profile, params: {instance_profile_name: "testvm-instance-profile", role_name: "testvm"}),
+          a_hash_including(operation_name: :delete_instance_profile, params: {instance_profile_name: "testvm-instance-profile"}),
+          a_hash_including(operation_name: :delete_role, params: {role_name: "testvm"})
+        ))
     end
   end
 end


### PR DESCRIPTION
Replace instance_double and attribute mocking with real database fixtures.

- Remove instance_double(GithubRunner) and instance_double(GithubInstallation)
- Create real GithubInstallation and GithubRunner records
- Replace mocked attribute readers with model.update() calls
- Use Sequel exists? checks instead of nil comparisons
- Scope aws_instance fixture to describe blocks that need it
- Flatten context wrapper that no longer served a purpose
- Use have_attributes matcher for aws_instance verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)