### PR TITLE
Create pages for unavailable VMs and slices regardless of host status

### DIFF
--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -796,10 +796,6 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect { nx.wait }.to hop("unavailable")
 
       vm.incr_checkup
-      expect(nx).to receive(:available?).and_raise Sshable::SshError.new("ssh failed", "", "", nil, nil)
-      expect { nx.wait }.to hop("unavailable")
-
-      vm.incr_checkup
       expect(nx).to receive(:available?).and_return(true)
       expect { nx.wait }.to nap(6 * 60 * 60)
     end
@@ -1090,6 +1086,11 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(sshable).to receive(:_cmd).and_return("active\nactive\n")
       expect(vm).to receive(:inhost_name).and_return("vmxxxx").at_least(:once)
       expect(nx.available?).to be true
+    end
+
+    it "fails when SSH fails" do
+      expect(sshable).to receive(:_cmd).and_raise(Sshable::SshError.new("ssh failed", "", "", nil, nil))
+      expect(nx.available?).to be false
     end
   end
 end

--- a/spec/prog/vm/vm_host_slice_nexus_spec.rb
+++ b/spec/prog/vm/vm_host_slice_nexus_spec.rb
@@ -126,12 +126,6 @@ RSpec.describe Prog::Vm::VmHostSliceNexus do
       expect { nx.wait }.to hop("unavailable")
     end
 
-    it "hops to unavailable when SSH fails during checkup" do
-      nx.incr_checkup
-      expect(sshable).to receive(:start_fresh_session).and_raise(Sshable::SshError.new("ssh failed", "", "", nil, nil))
-      expect { nx.wait }.to hop("unavailable")
-    end
-
     it "naps when checkup finds slice available" do
       nx.incr_checkup
       stub_available(available: true)
@@ -194,6 +188,11 @@ RSpec.describe Prog::Vm::VmHostSliceNexus do
 
     it "fails on the incorrect partition status" do
       expect(session).to receive(:_exec!).with("cat /sys/fs/cgroup/standard.slice/cpuset.cpus.partition").and_return("isolated\n").once
+      expect(nx.available?).to be false
+    end
+
+    it "fails when SSH fails during" do
+      expect(session).to receive(:_exec!).with("cat /sys/fs/cgroup/standard.slice/cpuset.cpus.partition").and_raise(Sshable::SshError.new("ssh failed", "", "", nil, nil))
       expect(nx.available?).to be false
     end
   end


### PR DESCRIPTION
In the current VM monitoring design, SSH errors during availability checks were silently handled by hopping to unavailable without creating a page, assuming the host being down would be handled separately by HostNexus. This assumption was flawed.

This assumption originates from the initial VM monitoring design (e8edbe60c4), but VMs can have SSH issues while the host is healthy, and vice versa.

VMs and slices should be monitored independently, and pages should be created whenever a resource is unavailable, regardless of the state of underlying resources. This aligns with our prior discussions and ensures consistent behavior across resources similar to PostgresServer.

While this may introduce some additional alerts, pages are already grouped by VM host in the admin UI, which should be help to handle noise.

This change updates both VM Nexus and VM host slice logic, as the slice logic duplicated the same assumption.