### PR TITLE
Do not set up nftables twice when preparing a VM host

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -214,7 +214,7 @@ class VmHost < Sequel::Model
       end
     end
 
-    Strand.create(prog: "SetupNftables", label: "start", stack: [{subject_id: id}])
+    Strand.create(prog: "SetupNftables", label: "start", stack: [{subject_id: id}]) unless allocation_state == "unprepared"
   end
 
   # Operational Functions


### PR DESCRIPTION
We currently call `create_addresses` during host assembly, which starts the `SetupNftables` prog. We also bud the same prog at the `prep` label of the VM host nexus.

The first invocation cannot connect to the VM host until rhizome is bootstrapped, which leads to unnecessary exceptions.

No need to setup nftables twice.