### PR TITLE
Add missing read replica check in Postgres PATCH endpoint

### DIFF
--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -52,6 +52,10 @@ class Clover
         authorize("Postgres:edit", pg)
         handle_validation_failure("postgres/show") { @page = "resize" }
 
+        if pg.read_replica?
+          raise CloverError.new(400, "InvalidRequest", "Read replicas cannot be modified directly! Please modify the parent database instead.")
+        end
+
         size = typecast_params.nonempty_str("size", pg.target_vm_size)
         target_storage_size_gib = typecast_params.pos_int("storage_size", pg.target_storage_size_gib)
         ha_type = typecast_params.nonempty_str("ha_type", pg.ha_type)

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -308,6 +308,16 @@ RSpec.describe Clover, "postgres" do
         expect(last_response).to have_api_error(400, "Database is not ready for update")
       end
 
+      it "fails to update read replica" do
+        pg.update(parent_id: pg.id)
+
+        patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}", {
+          size: "standard-4"
+        }.to_json
+
+        expect(last_response).to have_api_error(400, "Read replicas cannot be modified directly! Please modify the parent database instead.")
+      end
+
       it "read-replica" do
         VmStorageVolume.create(vm_id: pg.representative_server.vm.id, size_gib: pg.target_storage_size_gib, boot: false, disk_index: 0)
         expect(PostgresTimeline).to receive(:earliest_restore_time).and_return(true)


### PR DESCRIPTION
We don't allow modifying read replicas directly, so we need to add a check in the PATCH endpoint to raise an error if someone tries to do that.