### PR TITLE
Update postgres-standard images to 20260119.2.0

### DIFF
--- a/migrate/20260119_update_pg_standard_amis.rb
+++ b/migrate/20260119_update_pg_standard_amis.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    [
+      ["us-west-2", "x64", "16", "ami-04beb3af9a2b61e45"],
+      ["us-west-2", "x64", "17", "ami-04beb3af9a2b61e45"],
+      ["us-west-2", "x64", "18", "ami-04beb3af9a2b61e45"],
+      ["us-east-1", "x64", "16", "ami-03798ede61a18caf4"],
+      ["us-east-1", "x64", "17", "ami-03798ede61a18caf4"],
+      ["us-east-1", "x64", "18", "ami-03798ede61a18caf4"],
+      ["us-east-2", "x64", "16", "ami-0b950ae8f8702193b"],
+      ["us-east-2", "x64", "17", "ami-0b950ae8f8702193b"],
+      ["us-east-2", "x64", "18", "ami-0b950ae8f8702193b"],
+      ["eu-west-1", "x64", "16", "ami-0ff8fb7ca533c6ba9"],
+      ["eu-west-1", "x64", "17", "ami-0ff8fb7ca533c6ba9"],
+      ["eu-west-1", "x64", "18", "ami-0ff8fb7ca533c6ba9"],
+      ["ap-southeast-2", "x64", "16", "ami-0c7928bf9bf4b614f"],
+      ["ap-southeast-2", "x64", "17", "ami-0c7928bf9bf4b614f"],
+      ["ap-southeast-2", "x64", "18", "ami-0c7928bf9bf4b614f"],
+      ["us-west-2", "arm64", "16", "ami-09c4d69087c6918c4"],
+      ["us-west-2", "arm64", "17", "ami-09c4d69087c6918c4"],
+      ["us-west-2", "arm64", "18", "ami-09c4d69087c6918c4"],
+      ["us-east-1", "arm64", "16", "ami-03131ee20d19b210f"],
+      ["us-east-1", "arm64", "17", "ami-03131ee20d19b210f"],
+      ["us-east-1", "arm64", "18", "ami-03131ee20d19b210f"],
+      ["us-east-2", "arm64", "16", "ami-02b0eb1d49c732cef"],
+      ["us-east-2", "arm64", "17", "ami-02b0eb1d49c732cef"],
+      ["us-east-2", "arm64", "18", "ami-02b0eb1d49c732cef"],
+      ["eu-west-1", "arm64", "16", "ami-0ed3b1a85fb1c4faa"],
+      ["eu-west-1", "arm64", "17", "ami-0ed3b1a85fb1c4faa"],
+      ["eu-west-1", "arm64", "18", "ami-0ed3b1a85fb1c4faa"],
+      ["ap-southeast-2", "arm64", "16", "ami-0703b5bda30c77151"],
+      ["ap-southeast-2", "arm64", "17", "ami-0703b5bda30c77151"],
+      ["ap-southeast-2", "arm64", "18", "ami-0703b5bda30c77151"]
+    ].each do |location_name, arch, pg_version, ami_id|
+      from(:pg_aws_ami).insert(
+        id: Sequel.lit("gen_random_ubid_uuid(474)"),
+        aws_location_name: location_name,
+        arch: arch,
+        pg_version: pg_version,
+        aws_ami_id: ami_id
+      )
+    end
+  end
+
+  down do
+    raise Sequel::Error, "Manual rollback required"
+  end
+end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -99,7 +99,7 @@ class Prog::DownloadBootImage < Prog::Base
     ["github-ubuntu-2204", "arm64", "20251208.1.0"] => "4586386b5244ab727cfccfb058d1d9ac7f97875bfc5de47baa5c06ef50a274fd",
     ["github-gpu-ubuntu-2204", "x64", "20251017.1.0"] => "a27a6a5f169093cc7ecb761833e256a22b0bf42ef914542cf013490db0ab8ba5",
     ["github-gpu-ubuntu-2204", "x64", "20251208.1.0"] => "644fa94ead16baefc3f8efda27199ad60312201b042d9eb5d545c53455733f00",
-    ["postgres-ubuntu-2204", "x64", "20251218.1.0"] => "90ceab88e8c4b9965fff41b56e12a5c0f28f54fa26ada2a1c51abd185268aebb",
+    ["postgres-ubuntu-2204", "x64", "20260119.2.0"] => "f8b09da34eaac0ddebdd6a841dab0669de6b2de4520bb1fa42d6207b9657bc04",
     ["postgres16-ubuntu-2204", "x64", "20250425.1.1"] => "f59622da276d646ed2a1c03de546b0a7ec3fd48aeb27c0bfe2b8b8be98c062d2",
     ["postgres17-ubuntu-2204", "x64", "20250425.1.1"] => "ccb4bcd8197c2e230be3f485dd33f24a51041a4dc0408257e42b3fe9f1c0bfb3",
     ["postgres-paradedb-ubuntu-2204", "x64", "20260107.1.0"] => "b60e173766eaf0b3928e69c8037d60943df4fc0314930ad9cd429405bf91b520",


### PR DESCRIPTION
## Summary
- Updates boot image SHA256 hashes in `prog/download_boot_image.rb`
- Adds migration to insert AWS AMI IDs in `pg_aws_ami` table

## Image Version
`20260119.2.0`

## Changes
- x64 SHA256: `f8b09da34eaac0ddebdd6a841dab0669de6b2de4520bb1fa42d6207b9657bc04`
- arm64 SHA256: `b8c2a4730a8fcd8aa07f6202cb8db3b26e5f5424ff02a7d52ca30e1ee47660ae`

🤖 Generated by [postgres-vm-images](https://github.com/ubicloud/postgres-vm-images) workflow