### PR TITLE
Update postgres-standard images to 20260119.1.0

### DIFF
--- a/migrate/20260119_update_pg_standard_amis.rb
+++ b/migrate/20260119_update_pg_standard_amis.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    [
+      ["us-west-2", "x64", "16", "ami-07216deeaa235e092", "ami-0f8904e4361eb8be7"],
+      ["us-west-2", "x64", "17", "ami-07216deeaa235e092", "ami-0f8904e4361eb8be7"],
+      ["us-west-2", "x64", "18", "ami-07216deeaa235e092", "ami-0f8904e4361eb8be7"],
+      ["us-east-1", "x64", "16", "ami-05453c5f8b6ee1699", "ami-0baca50c6f0398ccb"],
+      ["us-east-1", "x64", "17", "ami-05453c5f8b6ee1699", "ami-0baca50c6f0398ccb"],
+      ["us-east-1", "x64", "18", "ami-05453c5f8b6ee1699", "ami-0baca50c6f0398ccb"],
+      ["us-east-2", "x64", "16", "ami-063af4d9afb2e908d", "ami-0199d6df117801fc7"],
+      ["us-east-2", "x64", "17", "ami-063af4d9afb2e908d", "ami-0199d6df117801fc7"],
+      ["us-east-2", "x64", "18", "ami-063af4d9afb2e908d", "ami-0199d6df117801fc7"],
+      ["eu-west-1", "x64", "16", "ami-085cb9014043e3870", "ami-04e410455af2701a7"],
+      ["eu-west-1", "x64", "17", "ami-085cb9014043e3870", "ami-04e410455af2701a7"],
+      ["eu-west-1", "x64", "18", "ami-085cb9014043e3870", "ami-04e410455af2701a7"],
+      ["ap-southeast-2", "x64", "16", "ami-039be95901d14f3f8", "ami-058daa4601bf9bb85"],
+      ["ap-southeast-2", "x64", "17", "ami-039be95901d14f3f8", "ami-058daa4601bf9bb85"],
+      ["ap-southeast-2", "x64", "18", "ami-039be95901d14f3f8", "ami-058daa4601bf9bb85"],
+      ["us-west-2", "arm64", "16", "ami-0bf8cd4daba873da2", "ami-0208e2e5828df2c98"],
+      ["us-west-2", "arm64", "17", "ami-0bf8cd4daba873da2", "ami-0208e2e5828df2c98"],
+      ["us-west-2", "arm64", "18", "ami-0bf8cd4daba873da2", "ami-0208e2e5828df2c98"],
+      ["us-east-1", "arm64", "16", "ami-002e22a4b4ca21f8f", "ami-0ec032eb86708362d"],
+      ["us-east-1", "arm64", "17", "ami-002e22a4b4ca21f8f", "ami-0ec032eb86708362d"],
+      ["us-east-1", "arm64", "18", "ami-002e22a4b4ca21f8f", "ami-0ec032eb86708362d"],
+      ["us-east-2", "arm64", "16", "ami-00f56035200b834c1", "ami-065754213f20865f4"],
+      ["us-east-2", "arm64", "17", "ami-00f56035200b834c1", "ami-065754213f20865f4"],
+      ["us-east-2", "arm64", "18", "ami-00f56035200b834c1", "ami-065754213f20865f4"],
+      ["eu-west-1", "arm64", "16", "ami-0e91b71121c80ed56", "ami-0381f44b045b93d25"],
+      ["eu-west-1", "arm64", "17", "ami-0e91b71121c80ed56", "ami-0381f44b045b93d25"],
+      ["eu-west-1", "arm64", "18", "ami-0e91b71121c80ed56", "ami-0381f44b045b93d25"],
+      ["ap-southeast-2", "arm64", "16", "ami-0706e441141f7caa2", "ami-03380543da666e424"],
+      ["ap-southeast-2", "arm64", "17", "ami-0706e441141f7caa2", "ami-03380543da666e424"],
+      ["ap-southeast-2", "arm64", "18", "ami-0706e441141f7caa2", "ami-03380543da666e424"]
+    ].each do |location_name, arch, pg_version, new_ami, _old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch: arch, pg_version: pg_version)
+        .update(aws_ami_id: new_ami)
+    end
+  end
+
+  down do
+    [
+      ["us-west-2", "x64", "16", "ami-07216deeaa235e092", "ami-0f8904e4361eb8be7"],
+      ["us-west-2", "x64", "17", "ami-07216deeaa235e092", "ami-0f8904e4361eb8be7"],
+      ["us-west-2", "x64", "18", "ami-07216deeaa235e092", "ami-0f8904e4361eb8be7"],
+      ["us-east-1", "x64", "16", "ami-05453c5f8b6ee1699", "ami-0baca50c6f0398ccb"],
+      ["us-east-1", "x64", "17", "ami-05453c5f8b6ee1699", "ami-0baca50c6f0398ccb"],
+      ["us-east-1", "x64", "18", "ami-05453c5f8b6ee1699", "ami-0baca50c6f0398ccb"],
+      ["us-east-2", "x64", "16", "ami-063af4d9afb2e908d", "ami-0199d6df117801fc7"],
+      ["us-east-2", "x64", "17", "ami-063af4d9afb2e908d", "ami-0199d6df117801fc7"],
+      ["us-east-2", "x64", "18", "ami-063af4d9afb2e908d", "ami-0199d6df117801fc7"],
+      ["eu-west-1", "x64", "16", "ami-085cb9014043e3870", "ami-04e410455af2701a7"],
+      ["eu-west-1", "x64", "17", "ami-085cb9014043e3870", "ami-04e410455af2701a7"],
+      ["eu-west-1", "x64", "18", "ami-085cb9014043e3870", "ami-04e410455af2701a7"],
+      ["ap-southeast-2", "x64", "16", "ami-039be95901d14f3f8", "ami-058daa4601bf9bb85"],
+      ["ap-southeast-2", "x64", "17", "ami-039be95901d14f3f8", "ami-058daa4601bf9bb85"],
+      ["ap-southeast-2", "x64", "18", "ami-039be95901d14f3f8", "ami-058daa4601bf9bb85"],
+      ["us-west-2", "arm64", "16", "ami-0bf8cd4daba873da2", "ami-0208e2e5828df2c98"],
+      ["us-west-2", "arm64", "17", "ami-0bf8cd4daba873da2", "ami-0208e2e5828df2c98"],
+      ["us-west-2", "arm64", "18", "ami-0bf8cd4daba873da2", "ami-0208e2e5828df2c98"],
+      ["us-east-1", "arm64", "16", "ami-002e22a4b4ca21f8f", "ami-0ec032eb86708362d"],
+      ["us-east-1", "arm64", "17", "ami-002e22a4b4ca21f8f", "ami-0ec032eb86708362d"],
+      ["us-east-1", "arm64", "18", "ami-002e22a4b4ca21f8f", "ami-0ec032eb86708362d"],
+      ["us-east-2", "arm64", "16", "ami-00f56035200b834c1", "ami-065754213f20865f4"],
+      ["us-east-2", "arm64", "17", "ami-00f56035200b834c1", "ami-065754213f20865f4"],
+      ["us-east-2", "arm64", "18", "ami-00f56035200b834c1", "ami-065754213f20865f4"],
+      ["eu-west-1", "arm64", "16", "ami-0e91b71121c80ed56", "ami-0381f44b045b93d25"],
+      ["eu-west-1", "arm64", "17", "ami-0e91b71121c80ed56", "ami-0381f44b045b93d25"],
+      ["eu-west-1", "arm64", "18", "ami-0e91b71121c80ed56", "ami-0381f44b045b93d25"],
+      ["ap-southeast-2", "arm64", "16", "ami-0706e441141f7caa2", "ami-03380543da666e424"],
+      ["ap-southeast-2", "arm64", "17", "ami-0706e441141f7caa2", "ami-03380543da666e424"],
+      ["ap-southeast-2", "arm64", "18", "ami-0706e441141f7caa2", "ami-03380543da666e424"]
+    ].each do |location_name, arch, pg_version, _new_ami, old_ami|
+      next if old_ami.to_s.empty?
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch: arch, pg_version: pg_version)
+        .update(aws_ami_id: old_ami)
+    end
+  end
+end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -99,7 +99,7 @@ class Prog::DownloadBootImage < Prog::Base
     ["github-ubuntu-2204", "arm64", "20251208.1.0"] => "4586386b5244ab727cfccfb058d1d9ac7f97875bfc5de47baa5c06ef50a274fd",
     ["github-gpu-ubuntu-2204", "x64", "20251017.1.0"] => "a27a6a5f169093cc7ecb761833e256a22b0bf42ef914542cf013490db0ab8ba5",
     ["github-gpu-ubuntu-2204", "x64", "20251208.1.0"] => "644fa94ead16baefc3f8efda27199ad60312201b042d9eb5d545c53455733f00",
-    ["postgres-ubuntu-2204", "x64", "20251218.1.0"] => "90ceab88e8c4b9965fff41b56e12a5c0f28f54fa26ada2a1c51abd185268aebb",
+    ["postgres-ubuntu-2204", "x64", "20260119.1.0"] => "da0fdd8132a1278e52cddca20f6564350accffc97245efe8a8e3c7d584ce3b7a",
     ["postgres16-ubuntu-2204", "x64", "20250425.1.1"] => "f59622da276d646ed2a1c03de546b0a7ec3fd48aeb27c0bfe2b8b8be98c062d2",
     ["postgres17-ubuntu-2204", "x64", "20250425.1.1"] => "ccb4bcd8197c2e230be3f485dd33f24a51041a4dc0408257e42b3fe9f1c0bfb3",
     ["postgres-paradedb-ubuntu-2204", "x64", "20260107.1.0"] => "b60e173766eaf0b3928e69c8037d60943df4fc0314930ad9cd429405bf91b520",


### PR DESCRIPTION
## Summary
- Updates boot image SHA256 hashes in `prog/download_boot_image.rb`
- Adds migration to insert AWS AMI IDs in `pg_aws_ami` table

## Image Version
`20260119.1.0`

## Changes
- x64 SHA256: `da0fdd8132a1278e52cddca20f6564350accffc97245efe8a8e3c7d584ce3b7a`
- arm64 SHA256: `653144e6b8f45a86c9b2e83d52720f00e17f965fea77327cdd02a9c26243b978`

🤖 Generated by [postgres-vm-images](https://github.com/ubicloud/postgres-vm-images) workflow