### PR TITLE
Update postgres-standard images to test

### DIFF
--- a/migrate/20260119_update_pg_standard_amis.rb
+++ b/migrate/20260119_update_pg_standard_amis.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  ami_ids = [
+    ["us-west-2", "x64", "ami-test-x64-uswest2", "ami-0f8904e4361eb8be7"],
+    ["us-east-1", "x64", "ami-test-x64-useast1", "ami-0baca50c6f0398ccb"],
+    ["us-west-2", "arm64", "ami-test-arm64-uswest2", "ami-0208e2e5828df2c98"],
+    ["us-east-1", "arm64", "ami-test-arm64-useast1", "ami-0ec032eb86708362d"]
+  ]
+
+  up do
+    ami_ids.each do |location_name, arch, new_ami, _old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch: arch)
+        .update(aws_ami_id: new_ami)
+    end
+  end
+
+  down do
+    ami_ids.each do |location_name, arch, _new_ami, old_ami|
+      next if old_ami.to_s.empty?
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch: arch)
+        .update(aws_ami_id: old_ami)
+    end
+  end
+end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -99,7 +99,7 @@ class Prog::DownloadBootImage < Prog::Base
     ["github-ubuntu-2204", "arm64", "20251208.1.0"] => "4586386b5244ab727cfccfb058d1d9ac7f97875bfc5de47baa5c06ef50a274fd",
     ["github-gpu-ubuntu-2204", "x64", "20251017.1.0"] => "a27a6a5f169093cc7ecb761833e256a22b0bf42ef914542cf013490db0ab8ba5",
     ["github-gpu-ubuntu-2204", "x64", "20251208.1.0"] => "644fa94ead16baefc3f8efda27199ad60312201b042d9eb5d545c53455733f00",
-    ["postgres-ubuntu-2204", "x64", "20251218.1.0"] => "90ceab88e8c4b9965fff41b56e12a5c0f28f54fa26ada2a1c51abd185268aebb",
+    ["postgres-ubuntu-2204", "x64", "test"] => "dummy_x64_sha256_for_testing_0123456789abcdef",
     ["postgres16-ubuntu-2204", "x64", "20250425.1.1"] => "f59622da276d646ed2a1c03de546b0a7ec3fd48aeb27c0bfe2b8b8be98c062d2",
     ["postgres17-ubuntu-2204", "x64", "20250425.1.1"] => "ccb4bcd8197c2e230be3f485dd33f24a51041a4dc0408257e42b3fe9f1c0bfb3",
     ["postgres-paradedb-ubuntu-2204", "x64", "20260107.1.0"] => "b60e173766eaf0b3928e69c8037d60943df4fc0314930ad9cd429405bf91b520",


### PR DESCRIPTION
## Summary
- Updates boot image SHA256 hashes in `prog/download_boot_image.rb`
- Adds migration to insert AWS AMI IDs in `pg_aws_ami` table

## Image Version
`test`

## Changes
- x64 SHA256: `dummy_x64_sha256_for_testing_0123456789abcdef`
- arm64 SHA256: `dummy_arm64_sha256_for_testing_fedcba9876543210`

🤖 Generated by [postgres-vm-images](https://github.com/ubicloud/postgres-vm-images) workflow