### PR TITLE
Catch common connection errors

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -15,8 +15,13 @@ class Sshable < Sequel::Model
   SSH_CONNECTION_ERRORS = [
     Net::SSH::Disconnect,
     Net::SSH::ConnectionTimeout,
+    Net::OpenTimeout,
     Errno::ECONNRESET,
     Errno::ECONNREFUSED,
+    Errno::ETIMEDOUT,
+    Errno::EHOSTUNREACH,
+    SocketError,
+    EOFError,
     IOError
   ].freeze
 


### PR DESCRIPTION
Recently, we had a case where connection attempt to a server was raising `Errno::EHOSTUNREACH` error while we are trying to fence it. This error implies that the server is already unreachable, so we don't need to wait for fencing and proceed with the failover immediately. However, since we did not catch this error, the fencing operation was retried multiple times and the failover was delayed until operator intervention.