### PR TITLE
Remove custom before_run for pushed progs

### DIFF
--- a/prog/vnet/aws/update_firewall_rules.rb
+++ b/prog/vnet/aws/update_firewall_rules.rb
@@ -3,10 +3,6 @@
 class Prog::Vnet::Aws::UpdateFirewallRules < Prog::Base
   subject_is :vm
 
-  def before_run
-    pop "firewall rule is added" if vm.destroy_set?
-  end
-
   label def update_firewall_rules
     rules = vm.firewall_rules
     rules.select(&:port_range).map! do |rule|

--- a/prog/vnet/metal/update_firewall_rules.rb
+++ b/prog/vnet/metal/update_firewall_rules.rb
@@ -5,10 +5,6 @@ class Prog::Vnet::Metal::UpdateFirewallRules < Prog::Base
 
   FirewallRuleObj = Struct.new(:cidr, :port_range)
 
-  def before_run
-    pop "firewall rule is added" if vm.destroy_set?
-  end
-
   label def update_firewall_rules
     rules = vm.firewall_rules
     allowed_ingress_ip4_port_set, allowed_ingress_ip4_lb_dest_set = consolidate_rules(rules.select { !it.ip6? && it.port_range })

--- a/prog/vnet/rekey_nic_tunnel.rb
+++ b/prog/vnet/rekey_nic_tunnel.rb
@@ -3,12 +3,6 @@
 class Prog::Vnet::RekeyNicTunnel < Prog::Base
   subject_is :nic
 
-  def before_run
-    if nic.destroy_set?
-      pop "nic.destroy semaphore is set"
-    end
-  end
-
   label def setup_inbound
     nic.dst_ipsec_tunnels.each do |tunnel|
       args = tunnel.src_nic.rekey_payload

--- a/spec/prog/vnet/aws/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/aws/update_firewall_rules_spec.rb
@@ -17,20 +17,6 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
     instance_double(Vm, project: instance_double(Project, get_ff_ipv6_disabled: false), private_subnets: [ps], vm_host: vmh, inhost_name: "x", nics: [nic], ephemeral_net6:, load_balancer: nil, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.0/32").network, location: location.id)
   }
 
-  describe "#before_run" do
-    it "pops if vm is to be destroyed" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:destroy_set?).and_return(true)
-      expect { nx.before_run }.to exit({"msg" => "firewall rule is added"})
-    end
-
-    it "does not pop if vm is not to be destroyed" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:destroy_set?).and_return(false)
-      expect { nx.before_run }.not_to exit
-    end
-  end
-
   describe "update_firewall_rules" do
     let(:ec2_client) { instance_double(Aws::EC2::Client) }
 

--- a/spec/prog/vnet/metal/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/metal/update_firewall_rules_spec.rb
@@ -62,17 +62,6 @@ RSpec.describe Prog::Vnet::Metal::UpdateFirewallRules do
     @st = Strand.create_with_id(vm, prog: "Vnet::Metal::UpdateFirewallRules", label: "update_firewall_rules")
   end
 
-  describe "#before_run" do
-    it "pops if vm is to be destroyed" do
-      vm.incr_destroy
-      expect { nx.before_run }.to exit({"msg" => "firewall rule is added"})
-    end
-
-    it "does not pop if vm is not to be destroyed" do
-      expect { nx.before_run }.not_to exit
-    end
-  end
-
   describe "update_firewall_rules" do
     def create_firewall_rules
       firewall.replace_firewall_rules([

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -37,18 +37,6 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
     nx.instance_variable_set(:@nic, tunnel.src_nic)
   end
 
-  describe "#before_run" do
-    it "pops when destroy is set" do
-      Strand.create_with_id(tunnel.src_nic, prog: "Vnet:NicNexus", label: "wait_vm")
-      tunnel.src_nic.incr_destroy
-      expect { nx.before_run }.to exit({"msg" => "nic.destroy semaphore is set"})
-    end
-
-    it "doesn't do anything if destroy is not set" do
-      expect { nx.before_run }.not_to exit({"msg" => "nic.destroy semaphore is set"})
-    end
-  end
-
   describe "#setup_inbound" do
     before do
       allow(tunnel.src_nic).to receive(:dst_ipsec_tunnels).and_return([tunnel])


### PR DESCRIPTION
Vnet::RekeyNicTunnel is pushed from the nic nexus, and Vnet::UpdateFirewallRules is pushed from the vm nexus. Both check for destroy semaphores on their subject, and since they are pushed from nexuses, they share the same ID as the resource.

We already handle this case in 26b6a4a5f5. When the destroy is incremented and there are multiple stacks, it indicates a pushed prog, and we pop stacks until the base. This logic should already cover these pushed stacks, so custom before_run is redundant.