### PR TITLE
Add more data to the payment method's Stripe data

### DIFF
--- a/model/payment_method.rb
+++ b/model/payment_method.rb
@@ -14,7 +14,7 @@ class PaymentMethod < Sequel::Model
 
   def stripe_data
     if (Stripe.api_key = Config.stripe_secret_key)
-      @stripe_data ||= Stripe::PaymentMethod.retrieve(stripe_id)["card"].to_h.transform_keys!(&:to_s).slice(*%w[last4 brand exp_month exp_year])
+      @stripe_data ||= Stripe::PaymentMethod.retrieve(stripe_id)["card"].to_h.transform_keys!(&:to_s).slice(*%w[last4 brand exp_month exp_year country funding wallet checks])
     end
   end
 

--- a/spec/model/payment_method_spec.rb
+++ b/spec/model/payment_method_spec.rb
@@ -7,8 +7,11 @@ RSpec.describe PaymentMethod do
 
   it "return Stripe Data if Stripe enabled" do
     allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
-    expect(Stripe::PaymentMethod).to receive(:retrieve).with("pm_1234567890").and_return(Stripe::StripeObject.construct_from("id" => "pm_1234567890", "card" => Stripe::StripeObject.construct_from("brand" => "Visa", "last4" => "1234", "exp_month" => 12, "exp_year" => 2023)))
-    expect(payment_method.stripe_data).to eq({"brand" => "Visa", "last4" => "1234", "exp_month" => 12, "exp_year" => 2023})
+    response = Stripe::StripeObject.construct_from(id: "pm_1234567890", card: {brand: "Visa", last4: "1234", exp_month: 12, exp_year: 2023, country: "NL", funding: "debit", wallet: {type: "apple_pay"}, checks: {address_line1_check: "pass", cvc_check: "pass"}})
+    expect(Stripe::PaymentMethod).to receive(:retrieve).with("pm_1234567890").and_return(response)
+    expect(payment_method.stripe_data["brand"]).to eq("Visa")
+    expect(payment_method.stripe_data["funding"]).to eq("debit")
+    expect(payment_method.stripe_data["wallet"]["type"]).to eq("apple_pay")
   end
 
   it "not return Stripe Data if Stripe not enabled" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe CloverAdmin do
     expect(Config).to receive(:stripe_secret_key).and_return("secret_key")
     billing_info = BillingInfo.create(stripe_id: "cus_test123")
     payment_method = PaymentMethod.create(billing_info_id: billing_info.id, stripe_id: "pm_1234567890")
-    expect(Stripe::PaymentMethod).to receive(:retrieve).with("pm_1234567890").and_return(Stripe::StripeObject.construct_from("id" => "pm_1234567890", "card" => Stripe::StripeObject.construct_from("brand" => "Visa", "last4" => "1234", "exp_month" => 12, "exp_year" => 2023)))
+    expect(Stripe::PaymentMethod).to receive(:retrieve).with("pm_1234567890").and_return(Stripe::StripeObject.construct_from(id: "pm_1234567890", card: {brand: "Visa", last4: "1234", exp_month: 12, exp_year: 2023, country: "NL", funding: "debit", wallet: {type: "apple_pay"}, checks: {address_line1_check: "pass", cvc_check: "pass"}}))
     visit "/model/PaymentMethod/#{payment_method.ubid}"
     expect(page.title).to eq "Ubicloud Admin - PaymentMethod #{payment_method.ubid}"
     expect(page).to have_content "Stripe Data"


### PR DESCRIPTION
This exposes additional payment method details in the admin panel and reduces the need to check the Stripe Console.