### PR TITLE
Use Postgres MinIO server for storing etcd backups

### DIFF
--- a/model/kubernetes/kubernetes_etcd_backup.rb
+++ b/model/kubernetes/kubernetes_etcd_backup.rb
@@ -36,7 +36,7 @@ class KubernetesEtcdBackup < Sequel::Model
 
   def blob_storage
     return @blob_storage if defined?(@blob_storage)
-    @blob_storage = MinioCluster[project_id: Config.minio_service_project_id, location_id: location.id]
+    @blob_storage = MinioCluster[project_id: Config.postgres_service_project_id, location_id: location.id]
   end
 
   def blob_storage_policy

--- a/spec/model/kubernetes/kubernetes_etcd_backup_spec.rb
+++ b/spec/model/kubernetes/kubernetes_etcd_backup_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe KubernetesEtcdBackup do
   }
 
   before do
-    allow(Config).to receive(:minio_service_project_id).and_return(project.id)
+    allow(Config).to receive(:postgres_service_project_id).and_return(project.id)
   end
 
   describe "#blob_storage" do


### PR DESCRIPTION
    In production, MinIO servers are hosted within the Postgres project
    rather than the MinIO service project. This update redirects etcd
    backups to the correct project.