### PR TITLE
Update postgres images to 20260120.1.0

### DIFF
--- a/migrate/20260120_update_pg_amis.rb
+++ b/migrate/20260120_update_pg_amis.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  ami_ids = [
+    ["us-west-2", "x64", "ami-0bd7deb9a303d5e17", "ami-0f8904e4361eb8be7"],
+    ["us-east-1", "x64", "ami-02334466469aeb012", "ami-0baca50c6f0398ccb"],
+    ["us-east-2", "x64", "ami-0fced2d13417707a1", "ami-0199d6df117801fc7"],
+    ["eu-west-1", "x64", "ami-0b8df9173cf9368f1", "ami-04e410455af2701a7"],
+    ["ap-southeast-2", "x64", "ami-0d9582aab33848069", "ami-058daa4601bf9bb85"],
+    ["us-west-2", "arm64", "ami-03326139e14cbe464", "ami-0208e2e5828df2c98"],
+    ["us-east-1", "arm64", "ami-0da75f483363335bf", "ami-0ec032eb86708362d"],
+    ["us-east-2", "arm64", "ami-055149f57145208d4", "ami-065754213f20865f4"],
+    ["eu-west-1", "arm64", "ami-081e08cd10ca655c6", "ami-0381f44b045b93d25"],
+    ["ap-southeast-2", "arm64", "ami-0960a5538edec5d98", "ami-03380543da666e424"]
+  ]
+
+  up do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: old_ami)
+        .update(aws_ami_id: new_ami)
+    end
+  end
+
+  down do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: new_ami)
+        .update(aws_ami_id: old_ami)
+    end
+  end
+end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -99,7 +99,7 @@ class Prog::DownloadBootImage < Prog::Base
     ["github-ubuntu-2204", "arm64", "20251208.1.0"] => "4586386b5244ab727cfccfb058d1d9ac7f97875bfc5de47baa5c06ef50a274fd",
     ["github-gpu-ubuntu-2204", "x64", "20251017.1.0"] => "a27a6a5f169093cc7ecb761833e256a22b0bf42ef914542cf013490db0ab8ba5",
     ["github-gpu-ubuntu-2204", "x64", "20251208.1.0"] => "644fa94ead16baefc3f8efda27199ad60312201b042d9eb5d545c53455733f00",
-    ["postgres-ubuntu-2204", "x64", "20251218.1.0"] => "90ceab88e8c4b9965fff41b56e12a5c0f28f54fa26ada2a1c51abd185268aebb",
+    ["postgres-ubuntu-2204", "x64", "20260120.1.0"] => "23aa107096b0d50088bf0b834ed56a1111abe25cda9a24d4dd2f816c4280063a",
     ["postgres16-ubuntu-2204", "x64", "20250425.1.1"] => "f59622da276d646ed2a1c03de546b0a7ec3fd48aeb27c0bfe2b8b8be98c062d2",
     ["postgres17-ubuntu-2204", "x64", "20250425.1.1"] => "ccb4bcd8197c2e230be3f485dd33f24a51041a4dc0408257e42b3fe9f1c0bfb3",
     ["postgres-paradedb-ubuntu-2204", "x64", "20260107.1.0"] => "b60e173766eaf0b3928e69c8037d60943df4fc0314930ad9cd429405bf91b520",


### PR DESCRIPTION
## Summary
- Updates boot image SHA256 hashes in `prog/download_boot_image.rb`
- Adds migration to update AWS AMI IDs in `pg_aws_ami` table

## Image Version
`20260120.1.0`

## Changes
- x64 SHA256: `23aa107096b0d50088bf0b834ed56a1111abe25cda9a24d4dd2f816c4280063a`
- arm64 SHA256: `0bac5863da3ab5e20ba48a94578727e13af713a4e1e18d82c1729038e5697a50`

🤖 Generated by [postgres-vm-images](https://github.com/ubicloud/postgres-vm-images) workflow