### PR TITLE
Demock and refine spec/prog/vnet/aws/update_firewall_rules_spec.rb

### DIFF
--- a/spec/prog/vnet/aws/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/aws/update_firewall_rules_spec.rb
@@ -5,63 +5,66 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
     described_class.new(st)
   }
 
-  let(:st) { Strand.new }
-  let(:ps) {
-    instance_double(PrivateSubnet)
+  let(:project) { Project.create(name: "test-project") }
+  let(:location) {
+    Location.create(name: "us-west-2", provider: "aws", display_name: "aws-us-west-2", ui_name: "AWS US East 1", visible: true, project_id: project.id)
   }
+  let(:location_credential) {
+    LocationCredential.create_with_id(location, access_key: "test-access-key", secret_key: "test-secret-key")
+  }
+  let(:private_subnet) {
+    Prog::Vnet::SubnetNexus.assemble(project.id, name: "test-ps", location_id: location.id).subject
+  }
+  let(:private_subnet_aws_resource) {
+    PrivateSubnetAwsResource.create_with_id(private_subnet, security_group_id: "sg-1234567890")
+  }
+  let(:firewall) { private_subnet.firewalls.first }
   let(:vm) {
-    vmh = instance_double(VmHost, sshable: Sshable.new)
-    nic = instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.0/32"), private_ipv6: NetAddr::IPv6Net.parse("fd00::1/128"), ubid_to_tap_name: "tap0")
-    ephemeral_net6 = NetAddr::IPv6Net.parse("fd00::1/79")
-    location = Location.create(name: "us-west-2", provider: "aws", display_name: "aws-us-west-2", ui_name: "AWS US East 1", visible: true)
-    instance_double(Vm, project: instance_double(Project, get_ff_ipv6_disabled: false), private_subnets: [ps], vm_host: vmh, inhost_name: "x", nics: [nic], ephemeral_net6:, load_balancer: nil, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.0/32").network, location: location.id)
+    location_credential
+    private_subnet_aws_resource
+    Prog::Vm::Nexus.assemble_with_sshable(project.id, location_id: location.id, private_subnet_id: private_subnet.id, name: "test-vm").subject
   }
+  let(:st) { vm.strand }
+  let(:ec2_client) { Aws::EC2::Client.new(stub_responses: true) }
+
+  before do
+    vm
+    allow(Aws::EC2::Client).to receive(:new).with(credentials: anything, region: "us-west-2").and_return(ec2_client)
+  end
+
+  def create_firewall_rules
+    # Clear default rules created by SubnetNexus.assemble
+    firewall.firewall_rules.each(&:destroy)
+    FirewallRule.create(firewall_id: firewall.id, cidr: "0.0.0.0/0", port_range: Sequel.pg_range(80..10000), protocol: "tcp")
+    FirewallRule.create(firewall_id: firewall.id, cidr: "1.1.1.1/32", port_range: Sequel.pg_range(22..23), protocol: "tcp")
+    FirewallRule.create(firewall_id: firewall.id, cidr: "fd00::1/128", port_range: Sequel.pg_range(80..10000), protocol: "tcp")
+  end
 
   describe "#before_run" do
     it "pops if vm is to be destroyed" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:destroy_set?).and_return(true)
+      vm.incr_destroy
       expect { nx.before_run }.to exit({"msg" => "firewall rule is added"})
     end
 
     it "does not pop if vm is not to be destroyed" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:destroy_set?).and_return(false)
       expect { nx.before_run }.not_to exit
     end
   end
 
   describe "update_firewall_rules" do
-    let(:ec2_client) { instance_double(Aws::EC2::Client) }
-
-    before do
-      lcred = instance_double(LocationCredential, client: ec2_client)
-      loc = instance_double(Location, provider: "aws", location_credential: lcred)
-      allow(nx).to receive(:vm).and_return(vm)
-      allow(vm).to receive(:location).and_return(loc)
-    end
-
-    it "hops to remove_aws_firewall_rules if there are no fw rules to add" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:firewall_rules).and_return([])
+    it "hops to remove_aws_old_rules if there are no fw rules to add" do
       expect { nx.update_firewall_rules }.to hop("remove_aws_old_rules")
     end
 
-    it "hops to remove_aws_firewall_rules after adding new rules" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:firewall_rules).and_return([
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(80..10000), protocol: "tcp")
-      ])
-      expect(vm.private_subnets.first).to receive(:private_subnet_aws_resource).and_return(instance_double(PrivateSubnetAwsResource, security_group_id: "sg-1234567890")).at_least(:once)
+    it "hops to remove_aws_old_rules after adding new rules" do
+      create_firewall_rules
       expect(ec2_client).to receive(:authorize_security_group_ingress).with({
         group_id: "sg-1234567890",
         ip_permissions: [
           {
             ip_protocol: "tcp",
             from_port: 80,
-            to_port: 9999,
+            to_port: 10000,
             ip_ranges: [{cidr_ip: "0.0.0.0/0"}]
           }
         ]
@@ -72,7 +75,7 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
           {
             ip_protocol: "tcp",
             from_port: 22,
-            to_port: 22,
+            to_port: 23,
             ip_ranges: [{cidr_ip: "1.1.1.1/32"}]
           }
         ]
@@ -83,7 +86,7 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
           {
             ip_protocol: "tcp",
             from_port: 80,
-            to_port: 9999,
+            to_port: 10000,
             ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]
           }
         ]
@@ -93,20 +96,14 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
     end
 
     it "continues and hops to remove_aws_old_rules if there is a duplicate rule" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:firewall_rules).and_return([
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(80..10000), protocol: "tcp")
-      ])
-      expect(vm.private_subnets.first).to receive(:private_subnet_aws_resource).and_return(instance_double(PrivateSubnetAwsResource, security_group_id: "sg-1234567890")).at_least(:once)
+      create_firewall_rules
       expect(ec2_client).to receive(:authorize_security_group_ingress).with({
         group_id: "sg-1234567890",
         ip_permissions: [
           {
             ip_protocol: "tcp",
             from_port: 80,
-            to_port: 9999,
+            to_port: 10000,
             ip_ranges: [{cidr_ip: "0.0.0.0/0"}]
           }
         ]
@@ -117,7 +114,7 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
           {
             ip_protocol: "tcp",
             from_port: 22,
-            to_port: 22,
+            to_port: 23,
             ip_ranges: [{cidr_ip: "1.1.1.1/32"}]
           }
         ]
@@ -128,7 +125,7 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
           {
             ip_protocol: "tcp",
             from_port: 80,
-            to_port: 9999,
+            to_port: 10000,
             ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]
           }
         ]
@@ -139,23 +136,8 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
   end
 
   describe "#remove_aws_old_rules" do
-    let(:ec2_client) { Aws::EC2::Client.new(stub_responses: true) }
-
-    before do
-      lcred = instance_double(LocationCredential, client: ec2_client)
-      loc = instance_double(Location, provider: "aws", location_credential: lcred)
-      allow(nx).to receive(:vm).and_return(vm)
-      allow(vm).to receive(:location).and_return(loc)
-    end
-
     it "removes old rules" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:firewall_rules).and_return([
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(80..10000), protocol: "tcp")
-      ])
-      expect(vm.private_subnets.first).to receive(:private_subnet_aws_resource).and_return(instance_double(PrivateSubnetAwsResource, security_group_id: "sg-1234567890")).at_least(:once)
+      create_firewall_rules
       ec2_client.stub_responses(:describe_security_groups, security_groups: [ip_permissions: [
         {
           ip_protocol: "tcp",
@@ -181,14 +163,14 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
         {
           ip_protocol: "tcp",
           from_port: 80,
-          to_port: 9999,
+          to_port: 10000,
           ip_ranges: [],
           ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]
         },
         {
           ip_protocol: "tcp",
           from_port: 80,
-          to_port: 9999,
+          to_port: 10000,
           ip_ranges: [{cidr_ip: "0.0.0.0/0"}],
           ipv_6_ranges: []
         }
@@ -202,30 +184,27 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
     end
 
     it "doesn't make a call if there are no old rules" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:firewall_rules).and_return([
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(80..10000), protocol: "tcp")
-      ])
-      expect(vm.private_subnets.first).to receive(:private_subnet_aws_resource).and_return(instance_double(PrivateSubnetAwsResource, security_group_id: "sg-1234567890")).at_least(:once)
+      create_firewall_rules
       ec2_client.stub_responses(:describe_security_groups, security_groups: [ip_permissions: [
         {
           ip_protocol: "tcp",
           from_port: 80,
-          to_port: 9999,
+          to_port: 10000,
           ip_ranges: [{cidr_ip: "0.0.0.0/0"}],
           ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]
         },
         {
           ip_protocol: "tcp",
           from_port: 80,
-          to_port: 9999,
+          to_port: 10000,
           ip_ranges: [{cidr_ip: "0.0.0.0/0"}],
           ipv_6_ranges: []
         }
       ]])
       expect(ec2_client).not_to receive(:revoke_security_group_ingress)
+      expect(ec2_client).to receive(:describe_security_groups)
+        .with({group_ids: ["sg-1234567890"]})
+        .and_call_original
 
       expect { nx.remove_aws_old_rules }.to exit({"msg" => "firewall rule is added"})
     end


### PR DESCRIPTION
Replace instance_double/receive mocks with real AWS stub_responses. Apply refinements from overnight run:
- verify-aws-calls (1 commit)
- resource-methods-idiom (1 commit)
- remove-default-params (1 commit)

All 7 tests passing.

Source: spike-demock branch commits clover-84p8y, clover-p1gy6, clover-z9yry, clover-e6nr, clover-1lao, clover-c10x, clover-ibk