### PR TITLE
Allow HA to work without dns_zone configured in development

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -96,16 +96,18 @@ class PostgresResource < Sequel::Model
   end
 
   def replication_connection_string(application_name:)
+    return nil unless dns_zone || representative_server
+
     query_parameters = {
       sslrootcert: "/etc/ssl/certs/ca.crt",
       sslcert: "/etc/ssl/certs/server.crt",
       sslkey: "/etc/ssl/certs/server.key",
-      sslmode: "verify-full",
+      sslmode: dns_zone ? "verify-full" : "require",
       dbname: "postgres",
       application_name:
     }.map { |k, v| "#{k}=#{v}" }.join("&")
 
-    URI::Generic.build2(scheme: "postgres", userinfo: "ubi_replication", host: identity, query: query_parameters).to_s
+    URI::Generic.build2(scheme: "postgres", userinfo: "ubi_replication", host: dns_zone ? identity : representative_server.vm.ip4_string, query: query_parameters).to_s
   end
 
   def version

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -58,9 +58,24 @@ RSpec.describe PostgresResource do
     expect(postgres_resource.connection_string).to be_nil
   end
 
+  it "returns replication connection string as nil if there is no server" do
+    # No server created, no dns_zone
+    expect(postgres_resource.replication_connection_string(application_name: "pgubidstandby")).to be_nil
+  end
+
   it "returns replication_connection_string" do
+    expect(postgres_resource).to receive(:dns_zone).and_return(instance_double(DnsZone)).at_least(:once)
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
     expect(s).to include("ubi_replication@#{postgres_resource.ubid}.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/server.crt")
+  end
+
+  it "returns replication_connection_string with ip when no dns_zone exists" do
+    vm = create_hosted_vm(project, private_subnet, "pg-vm")
+    PostgresServer.create(timeline:, resource_id: postgres_resource.id, vm_id: vm.id, representative_at: Time.now, synchronization_status: "ready", timeline_access: "push", version: "17")
+    AssignedVmAddress.create(dst_vm_id: vm.id, ip: "1.2.3.4/32")
+    expect(postgres_resource.dns_zone).to be_nil
+    s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
+    expect(s).to include("ubi_replication@1.2.3.4", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/server.crt")
   end
 
   describe "#provision_new_standby" do


### PR DESCRIPTION
mTLS with sslmode=require is fine; verification impossible connecting via IP