### PR TITLE
Use qualified names in psql commands to avoid namespace injection

### DIFF
--- a/rhizome/postgres/bin/lockout
+++ b/rhizome/postgres/bin/lockout
@@ -42,6 +42,6 @@ r "pg_ctlcluster #{v} main reload"
 
 # Terminate all existing connections except our own
 puts "Terminating all existing connections except for the current session and ubi_replication user..."
-r "sudo -u postgres psql -c \"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE usename != 'ubi_replication' AND pid <> pg_backend_pid();\""
+r "sudo -u postgres psql -c \"SELECT pg_catalog.pg_terminate_backend(pid) FROM pg_catalog.pg_stat_activity WHERE usename != 'ubi_replication' AND pid <> pg_catalog.pg_backend_pid();\""
 
 puts "PostgreSQL is now in lockout mode - only UNIX socket connections and ubi_replication are allowed."

--- a/rhizome/postgres/lib/postgres_upgrade.rb
+++ b/rhizome/postgres/lib/postgres_upgrade.rb
@@ -24,7 +24,7 @@ class PostgresUpgrade
   end
 
   def promote(version)
-    if r("sudo -u postgres psql -t -c 'SELECT pg_is_in_recovery();' 2>/dev/null || echo 't'").strip == "f"
+    if r("sudo -u postgres psql -t -c 'SELECT pg_catalog.pg_is_in_recovery();' 2>/dev/null || echo 't'").strip == "f"
       @logger.info("Server is already promoted (not in recovery mode)")
       return
     end
@@ -79,13 +79,13 @@ class PostgresUpgrade
   end
 
   def run_post_upgrade_extension_update
-    databases = r("sudo -u postgres psql -t -c 'SELECT datname FROM pg_database WHERE datistemplate = false;'").split("\n").map(&:strip)
+    databases = r("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").split("\n").map(&:strip)
 
     scripts = EXTENSION_UPGRADE_SCRIPTS[@version]
     scripts.each do |extension, script|
       @logger.info("Running post upgrade extension update for #{extension}")
       databases.each do |database|
-        installed = r("sudo -u postgres psql -d #{database.shellescape} -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_extension WHERE extname = '#{extension.gsub("'", "''")}'").strip
+        installed = r("sudo -u postgres psql -d #{database.shellescape} -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = '#{extension.gsub("'", "''")}'").strip
         if installed == "1"
           @logger.info("Running post upgrade extension update for #{extension} on database #{database}")
           r("sudo -u postgres psql -d #{database.shellescape} -v 'ON_ERROR_STOP=1'", stdin: script)

--- a/rhizome/postgres/spec/postgres_upgrade_spec.rb
+++ b/rhizome/postgres/spec/postgres_upgrade_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe PostgresUpgrade do
 
   describe "#promote" do
     it "promotes server if in recovery mode" do
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT pg_is_in_recovery();' 2>/dev/null || echo 't'").and_return("t\n")
+      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT pg_catalog.pg_is_in_recovery();' 2>/dev/null || echo 't'").and_return("t\n")
       expect(postgres_upgrade).to receive(:r).with("sudo pg_ctlcluster promote 16 main", expect: [0, 1])
       postgres_upgrade.promote(16)
     end
 
     it "skips promotion if server is already promoted" do
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT pg_is_in_recovery();' 2>/dev/null || echo 't'").and_return("f\n")
+      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT pg_catalog.pg_is_in_recovery();' 2>/dev/null || echo 't'").and_return("f\n")
       expect(postgres_upgrade).not_to receive(:r).with("sudo pg_ctlcluster promote 16 main", expect: [0, 1])
       expect(logger).to receive(:info).with("Server is already promoted (not in recovery mode)")
       postgres_upgrade.promote(16)
@@ -128,9 +128,9 @@ RSpec.describe PostgresUpgrade do
 
   describe "#run_post_upgrade_extension_update" do
     it "updates extensions on databases where they are installed" do
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_database WHERE datistemplate = false;'").and_return("postgres\nmydb\n")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_extension WHERE extname = 'postgis'").and_return("1")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d mydb -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_extension WHERE extname = 'postgis'").and_return("")
+      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").and_return("postgres\nmydb\n")
+      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("1")
+      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d mydb -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("")
       expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1'", stdin: "SELECT postgis_extensions_upgrade();")
       expect(logger).to receive(:info).with("Running post upgrade extension update for postgis")
       expect(logger).to receive(:info).with("Running post upgrade extension update for postgis on database postgres")
@@ -139,8 +139,8 @@ RSpec.describe PostgresUpgrade do
     end
 
     it "skips databases where extension is not installed" do
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_database WHERE datistemplate = false;'").and_return("postgres\n")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_extension WHERE extname = 'postgis'").and_return("")
+      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").and_return("postgres\n")
+      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("")
       expect(postgres_upgrade).not_to receive(:r).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1'", stdin: anything)
       expect(logger).to receive(:info).with("Running post upgrade extension update for postgis")
 
@@ -153,9 +153,9 @@ RSpec.describe PostgresUpgrade do
           "ext'sname" => "ALTER EXTENSION \"ext'sname\" UPDATE;"
         }
       })
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_database WHERE datistemplate = false;'").and_return("mydb$(pwd)\n")
+      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").and_return("mydb$(pwd)\n")
       expect(logger).to receive(:info).with("Running post upgrade extension update for ext'sname")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d mydb\\$\\(pwd\\) -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_extension WHERE extname = 'ext''sname'").and_return("1")
+      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d mydb\\$\\(pwd\\) -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'ext''sname'").and_return("1")
       expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d mydb\\$\\(pwd\\) -v 'ON_ERROR_STOP=1'", stdin: "ALTER EXTENSION \"ext'sname\" UPDATE;")
       expect(logger).to receive(:info).with("Running post upgrade extension update for ext'sname on database mydb$(pwd)")
 


### PR DESCRIPTION
User creating `postgres.pg_is_in_recovery` would cause things to go awry