### PR TITLE
Install ParadeDB packages before creating extensions

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -159,6 +159,10 @@ class PostgresServer < Sequel::Model
     resource.read_replica?
   end
 
+  def paradedb_and_primary?
+    primary? && resource.flavor == PostgresResource::Flavor::PARADEDB
+  end
+
   def storage_size_gib
     vm.vm_storage_volumes.reject(&:boot).sum(&:size_gib)
   end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -788,6 +788,9 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "updates password and hops to run_post_installation_script during initial provisioning for non-standard flavors if restart is already executed" do
       nx.incr_initial_provisioning
       expect(sshable).to receive(:_cmd).with(
+        /sudo apt-get install.*pg-analytics.*pg-search/m
+      ).and_return("")
+      expect(sshable).to receive(:_cmd).with(
         "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'",
         hash_including(stdin: password_update_sql_matcher)
       ).and_return("")
@@ -808,9 +811,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   describe "#run_post_installation_script" do
     it "creates extensions for non-standard flavor and hops wait" do
       postgres_server.resource.update(flavor: PostgresResource::Flavor::PARADEDB)
-      expect(sshable).to receive(:_cmd).with(
-        /sudo apt-get install.*pg-analytics.*pg-search/m
-      ).and_return("")
       expect(sshable).to receive(:_cmd).with(
         "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'",
         hash_including(stdin: /CREATE EXTENSION IF NOT EXISTS pg_cron/)


### PR DESCRIPTION
The ParadeDB packages must be installed before running restart, otherwise PostgreSQL cannot find the files and fails to start. This moves the apt-get install commands from run_post_installation_script to update_superuser_password, which runs earlier in the provisioning flow.

Also adds a paradedb_and_primary? helper method to consolidate the flavor and role checks.