### PR TITLE
Retry on SSH failures during VM health checks

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -237,7 +237,10 @@ class Vm < Sequel::Model
       end
 
       session[:ssh_session].exec!("systemctl is-active :shelljoin_units", shelljoin_units: units).split("\n").all?("active") ? "up" : "down"
-    rescue
+    rescue IOError, Errno::ECONNRESET
+      raise
+    rescue => e
+      Clog.emit("Exception in Vm #{ubid}", Util.exception_to_hash(e))
       "down"
     end
     pulse = aggregate_readings(previous_pulse:, reading:)

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -254,6 +254,13 @@ RSpec.describe Vm do
         expect(session[:ssh_session]).to receive(:_exec!).with(expected_cmd).and_return("active\nactive\nactive\n")
         expect(pulse_vm.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
       end
+
+      [IOError.new("closed stream"), Errno::ECONNRESET.new("recvfrom(2)")].each do |ex|
+        it "reraises the exception for exception class: #{ex.class}" do
+          expect(session[:ssh_session]).to receive(:_exec!).and_raise(ex)
+          expect { pulse_vm.check_pulse(session:, previous_pulse: "notnil") }.to raise_error(ex)
+        end
+      end
     end
 
     context "when vm is sshable" do


### PR DESCRIPTION
By raising an exception when SSH errors occur, the monitor will attempt to re-establish the connection and retry the check.