### PR TITLE
Exclude GithubRunner Vms from Vm Healthchecks

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -43,7 +43,7 @@ else
   monitor_models = [
     VmHost,
     PostgresServer,
-    Vm.exclude(vm_host_id: nil).eager(:vm_host, :sshable, :vm_storage_volumes),
+    Vm.exclude(vm_host_id: nil).exclude(unix_user: "runneradmin").eager(:vm_host, :sshable, :vm_storage_volumes),
     MinioServer,
     GithubRunner.exclude(ready_at: nil),
     VmHostSlice,


### PR DESCRIPTION
After introducing the new healthcheck for vms and including all non-aws vms, a high number of healthchecks were added. For now we are excluding the github runner vms to reduce the load.