### PR TITLE
Fix tune2fs failing on RAID setups

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -117,11 +117,6 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
     storage_device_paths = postgres_server.storage_device_paths
     case vm.sshable.d_check("format_disk")
     when "Succeeded"
-      # ext4 defaults to reserving 5% of disk for root, on 1TiB this is 50GiB. Cap this to 50GiB
-      reserved_blocks_per_gb = 13107 # ~5% of 262144 (number of 4KiB blocks per GB)
-      reserve_blocks = [postgres_server.storage_size_gib * reserved_blocks_per_gb, 13107200].min
-      vm.sshable.cmd("sudo tune2fs :path -r :reserve_blocks", path: storage_device_paths.first, reserve_blocks:)
-
       device_path = if storage_device_paths.count > 1
         vm.sshable.cmd("sudo mdadm --detail --scan | sudo tee -a /etc/mdadm/mdadm.conf")
         vm.sshable.cmd("sudo update-initramfs -u")
@@ -129,6 +124,11 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
       else
         storage_device_paths.first
       end
+
+      # ext4 defaults to reserving 5% of disk for root, on 1TiB this is 50GiB. Cap this to 50GiB
+      reserved_blocks_per_gb = 13107 # ~5% of 262144 (number of 4KiB blocks per GB)
+      reserve_blocks = [postgres_server.storage_size_gib * reserved_blocks_per_gb, 13107200].min
+      vm.sshable.cmd("sudo tune2fs :path -r :reserve_blocks", path: device_path, reserve_blocks:)
 
       vm.sshable.cmd("sudo mkdir -p /dat")
       vm.sshable.cmd("sudo common/bin/add_to_fstab :device_path /dat ext4 defaults 0 0", device_path:)

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -354,10 +354,10 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "mounts data disk correctly when there are multiple storage volumes" do
       expect(server).to receive(:storage_size_gib).and_return(128)
       expect(server).to receive(:storage_device_paths).and_return(["/dev/nvme1n1", "/dev/nvme2n1"])
-      expect(sshable).to receive(:_cmd).with("sudo tune2fs /dev/nvme1n1 -r 1677696").and_return("Succeeded")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check format_disk").and_return("Succeeded")
       expect(sshable).to receive(:_cmd).with("sudo mdadm --detail --scan | sudo tee -a /etc/mdadm/mdadm.conf")
       expect(sshable).to receive(:_cmd).with("sudo update-initramfs -u")
+      expect(sshable).to receive(:_cmd).with("sudo tune2fs /dev/md0 -r 1677696").and_return("Succeeded")
       expect(sshable).to receive(:_cmd).with("sudo mkdir -p /dat")
       expect(sshable).to receive(:_cmd).with("sudo common/bin/add_to_fstab /dev/md0 /dat ext4 defaults 0 0")
       expect(sshable).to receive(:_cmd).with("sudo mount /dev/md0 /dat")


### PR DESCRIPTION
Changes in 6f28eb50f110e16cdb9b63735fc3268f92e161aa led to tune2fs failing for RAID setups (for multi-disk AWS instances)