### PR TITLE
Retry SSH related failures in VmHostSlice Healthchecks

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -46,7 +46,7 @@ else
     Vm.exclude(vm_host_id: nil).exclude(unix_user: "runneradmin").eager(:vm_host, :sshable, :vm_storage_volumes),
     MinioServer,
     GithubRunner.exclude(ready_at: nil),
-    VmHostSlice,
+    VmHostSlice.eager(:vm_host),
     LoadBalancerVmPort,
     KubernetesCluster,
     VictoriaMetricsServer

--- a/model/vm_host_slice.rb
+++ b/model/vm_host_slice.rb
@@ -63,7 +63,10 @@ class VmHostSlice < Sequel::Model
   def check_pulse(session:, previous_pulse:)
     reading = begin
       up?(session[:ssh_session]) ? "up" : "down"
-    rescue
+    rescue IOError, Errno::ECONNRESET
+      raise
+    rescue => e
+      Clog.emit("Exception in VmHostSlice #{ubid}", Util.exception_to_hash(e))
       "down"
     end
     pulse = aggregate_readings(previous_pulse:, reading:)


### PR DESCRIPTION
By raising an exception when SSH errors occur, the monitor will attempt to re-establish the connection and retry the check.