### PR TITLE
Update permissions of the old SPDK VM storage directory

### DIFF
--- a/prog/storage/migrate_spdk_vm_to_ubiblk.rb
+++ b/prog/storage/migrate_spdk_vm_to_ubiblk.rb
@@ -70,7 +70,7 @@ class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
     vm.vm_host.sshable.cmd("sudo rm :root_dir_path/vhost.sock", root_dir_path:)
 
     vm.vm_host.sshable.cmd("sudo mkfifo :kek_file_path", kek_file_path:)
-    vm.vm_host.sshable.cmd("sudo chown :inhost_name::inhost_name :kek_file_path", inhost_name:, kek_file_path:)
+    vm.vm_host.sshable.cmd("sudo chown -R :inhost_name::inhost_name :root_vm_storage_path", inhost_name:, root_vm_storage_path:)
 
     hop_download_migration_binaries
   end
@@ -168,8 +168,12 @@ class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
     }.to_json
   end
 
+  def root_vm_storage_path
+    "/var/storage/#{vm.inhost_name}"
+  end
+
   def root_dir_path
-    "/var/storage/#{vm.inhost_name}/0"
+    "#{root_vm_storage_path}/0"
   end
 
   def kek_file_path

--- a/spec/prog/storage/migrate_spdk_vm_to_ubiblk_spec.rb
+++ b/spec/prog/storage/migrate_spdk_vm_to_ubiblk_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Prog::Storage::MigrateSpdkVmToUbiblk do
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo mv /var/storage/#{vm.inhost_name}/0/disk.raw /var/storage/#{vm.inhost_name}/0/disk.raw.bk")
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo rm /var/storage/#{vm.inhost_name}/0/vhost.sock")
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo mkfifo /var/storage/#{vm.inhost_name}/0/kek.pipe")
-      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo chown #{vm.inhost_name}:#{vm.inhost_name} /var/storage/#{vm.inhost_name}/0/kek.pipe")
+      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo chown -R #{vm.inhost_name}:#{vm.inhost_name} /var/storage/#{vm.inhost_name}")
       expect { prog.ready_migration }.to hop("download_migration_binaries")
     end
   end


### PR DESCRIPTION
In older SPDK VMs, the directory hosting the disk was owned by root, which caused issues during migration