### PR TITLE
Enable wal-g verify on backup-push

### DIFF
--- a/rhizome/postgres/bin/take-backup
+++ b/rhizome/postgres/bin/take-backup
@@ -9,4 +9,4 @@ end
 
 v = ARGV[0]
 
-r "sudo -u postgres wal-g backup-push /dat/#{v}/data --config /etc/postgresql/wal-g.env"
+r "sudo -u postgres wal-g backup-push /dat/#{v}/data --config /etc/postgresql/wal-g.env --verify"


### PR DESCRIPTION
wal-g can check Postgres data checksums during backup-push and log corrupted block numbers to the sentinel JSON, so added --verify to take-backup for that. That information can be used down the line to inform integrity of large backups.