### PR TITLE
Unify VM healthcheck systemd unit checks

### DIFF
--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -448,7 +448,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
   end
 
   def available?
-    host.sshable.cmd("systemctl is-active :vm_name :vm_name-dnsmasq", vm_name:).split("\n").all?("active")
+    host.sshable.cmd("systemctl is-active :shelljoin_units", shelljoin_units: vm.healthcheck_systemd_units).split("\n").all?("active")
   rescue
     false
   end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -1097,8 +1097,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
 
   describe "#available?" do
     it "returns the available status" do
-      expect(sshable).to receive(:_cmd).and_return("active\nactive\n")
-      expect(vm).to receive(:inhost_name).and_return("vmxxxx").at_least(:once)
+      expect(sshable).to receive(:_cmd).with("systemctl is-active #{vm.inhost_name} #{vm.inhost_name}-dnsmasq").and_return("active\nactive\n")
       expect(nx.available?).to be true
     end
 


### PR DESCRIPTION
The `available?` method in Prog::Vm::Metal::Nexus and `check_pulse` in the Vm model were checking different sets of systemd units. The former only checked the VM service and dnsmasq, while the latter also included storage volume vhost backend services.

Extract a new `healthcheck_systemd_units` method in the Vm model that returns the complete list of units to check, and use it in both places. This ensures consistent health checking behavior across the codebase.