### PR TITLE
Add more data to the VmHostSlice deadline pages

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -181,6 +181,9 @@ SQL
             {vm_host: sbj.vm_host&.ubid, data_center: sbj.vm_host&.data_center, boot_image: sbj.boot_image, location: sbj.location.display_name, arch: sbj.arch, vcpus: sbj.vcpus, ipv4: sbj.ip4_string}
           when VmHost
             {data_center: sbj.data_center, location: sbj.location.display_name, arch: sbj.arch, ipv4: sbj.sshable.host, total_cores: sbj.total_cores, allocation_state: sbj.allocation_state, os_version: sbj.os_version, vm_count: sbj.vms_dataset.count}
+          when VmHostSlice
+            vm_host = sbj.vm_host
+            {vm_host: vm_host.ubid, data_center: vm_host.data_center, location: vm_host.location.display_name, arch: vm_host.arch}
           when GithubRunner
             {label: sbj.label, installation: sbj.installation.ubid, vm: sbj.vm&.ubid, vm_host: sbj.vm&.vm_host&.ubid, data_center: sbj.vm&.vm_host&.data_center}
           else

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -410,6 +410,16 @@ RSpec.describe Prog::Base do
       expect(page.details["vm_count"]).to eq(1)
     end
 
+    it "can create a page with extra data from a vm host slice" do
+      slice = VmHostSlice.create(vm_host_id: create_vm_host.id, name: "standard", family: "standard", cores: 1, total_cpu_percent: 200, used_cpu_percent: 200, total_memory_gib: 8, used_memory_gib: 8)
+      st = Strand.create_with_id(slice, prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
+      st.unsynchronized_run
+      page = Page.active.first
+      expect(page).not_to be_nil
+      expect(page.details["vm_host"]).to eq(slice.vm_host.ubid)
+      expect(page.details["location"]).to eq(slice.vm_host.location.display_name)
+    end
+
     it "can create a page with extra data from a github runner" do
       installation = GithubInstallation.create(installation_id: 123, name: "test-user", type: "User", project: Project.create(name: "test-project"))
       runner = GithubRunner.create(label: "ubicloud-standard-2", repository_name: "my-repo", installation:)


### PR DESCRIPTION
We have already added more data for some other models, and it has been helpful for identifying the VM host from pager notifications.

I didn't check for VM host non-existence because the column is non-nullable and has a foreign key constraint.