### PR TITLE
Expand linter:cmd_exec to handle instance_double uses

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -612,7 +612,8 @@ namespace :linter do
       number = 0
       File.foreach(file) do |line|
         number += 1
-        if /\(:(cmd|exec!|kubectl|rootish_ssh|run_query)/.match?(line)
+        cmds = Regexp.union(%w[cmd exec! kubectl rootish_ssh run_query])
+        if /\(:#{cmds}|instance_double\(.*#{cmds}: /.match?(line)
           failure = true
           warn "Potentially insecure method override: #{file}:#{number}: #{line}"
         end


### PR DESCRIPTION
This will only catch single line uses, but that's still valuable.