### PR TITLE
Create low severity page for GitHub config issues

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -397,6 +397,11 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       Prog::PageNexus.assemble("Repository level self-hosted runners are disabled on #{installation_ubid}", ["GithubSelfHostRunnersDisabled", installation_ubid], installation_ubid, severity: "warning")
       github_runner.incr_destroy
       nap 0
+    elsif e.message.include?("your IP address is not permitted to access this resource")
+      installation_ubid = github_runner.installation.ubid
+      Prog::PageNexus.assemble("The organization has an IP allow list enabled on #{installation_ubid}", ["GithubIPAllowlistEnabled", installation_ubid], installation_ubid, severity: "warning")
+      github_runner.incr_destroy
+      nap 0
     end
     raise
   end

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -687,6 +687,13 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(client).to receive(:post).and_raise(Octokit::Error.new({body: "Unexpected error"}))
       expect { nx.register_runner }.to raise_error Octokit::Error
     end
+
+    it "destroys the runner if generate request fails due to IP allowlist enabled error" do
+      expect(client).to receive(:post).and_raise(Octokit::Error.new({body: "your IP address is not permitted to access this resource"}))
+      expect { nx.register_runner }.to nap(0)
+        .and change { Page.active.count }.by(1)
+      expect(runner.destroy_set?).to be(true)
+    end
   end
 
   describe "#wait" do


### PR DESCRIPTION
- **Create low severity page when self-hosted runner disabled for a repository**
  

- **Create low severity page when IP allowlist enabled for an organization**
  