### PR TITLE
Tighten file permissions for SPDK migration

### DIFF
--- a/prog/storage/migrate_spdk_vm_to_ubiblk.rb
+++ b/prog/storage/migrate_spdk_vm_to_ubiblk.rb
@@ -68,7 +68,7 @@ class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
 
   label def generate_vhost_backend_conf
     vm.vm_host.sshable.cmd("sudo host/bin/convert-encrypted-dek-to-vhost-backend-conf --encrypted-dek-file :root_dir_path/data_encryption_key.json --kek-file /dev/stdin --vhost-conf-output-file :vhost_conf_path --vm-name :inhost_name --device :device", inhost_name:, root_dir_path:, vhost_conf_path:, device: storage_device_name, stdin: vm.storage_secrets.to_json)
-    vm.vm_host.sshable.cmd("sudo chown :inhost_name::inhost_name :vhost_conf_path", inhost_name:, vhost_conf_path:)
+    vm.vm_host.sshable.cmd("sudo chown :inhost_name::inhost_name :vhost_conf_path && sudo chmod 600 :vhost_conf_path", inhost_name:, vhost_conf_path:)
     hop_ready_migration
   end
 
@@ -119,7 +119,7 @@ class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
   end
 
   label def create_ubiblk_systemd_unit
-    vm.vm_host.sshable.cmd("sudo chown :inhost_name::inhost_name :root_dir_path/disk.raw", inhost_name:, root_dir_path:)
+    vm.vm_host.sshable.cmd("sudo chown :inhost_name::inhost_name :root_dir_path/disk.raw && sudo chmod 600 :root_dir_path/disk.raw && sudo rm -f :kek_file_path", inhost_name:, root_dir_path:, kek_file_path:)
     vm.vm_host.sshable.cmd("sudo host/bin/spdk-migration-helper create-vhost-backend-service-file", stdin: migration_script_params)
     hop_start_ubiblk_systemd_unit
   end

--- a/spec/prog/storage/migrate_spdk_vm_to_ubiblk_spec.rb
+++ b/spec/prog/storage/migrate_spdk_vm_to_ubiblk_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Prog::Storage::MigrateSpdkVmToUbiblk do
   describe "#generate_vhost_backend_conf" do
     it "generates the vhost backend conf" do
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo host/bin/convert-encrypted-dek-to-vhost-backend-conf --encrypted-dek-file /var/storage/#{vm.inhost_name}/0/data_encryption_key.json --kek-file /dev/stdin --vhost-conf-output-file /var/storage/#{vm.inhost_name}/0/vhost-backend.conf --vm-name #{vm.inhost_name} --device DEFAULT", stdin: vm.storage_secrets.to_json)
-      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo chown #{vm.inhost_name}:#{vm.inhost_name} /var/storage/#{vm.inhost_name}/0/vhost-backend.conf")
+      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo chown #{vm.inhost_name}:#{vm.inhost_name} /var/storage/#{vm.inhost_name}/0/vhost-backend.conf && sudo chmod 600 /var/storage/#{vm.inhost_name}/0/vhost-backend.conf")
       expect { prog.generate_vhost_backend_conf }.to hop("ready_migration")
     end
   end
@@ -195,7 +195,7 @@ RSpec.describe Prog::Storage::MigrateSpdkVmToUbiblk do
 
   describe "#create_ubiblk_systemd_unit" do
     it "creates the systemd unit and hops to the next label" do
-      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo chown #{vm.inhost_name}:#{vm.inhost_name} /var/storage/#{vm.inhost_name}/0/disk.raw")
+      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo chown #{vm.inhost_name}:#{vm.inhost_name} /var/storage/#{vm.inhost_name}/0/disk.raw && sudo chmod 600 /var/storage/#{vm.inhost_name}/0/disk.raw && sudo rm -f /var/storage/#{vm.inhost_name}/0/kek.pipe")
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo host/bin/spdk-migration-helper create-vhost-backend-service-file", stdin: prog.migration_script_params)
       expect { prog.create_ubiblk_systemd_unit }.to hop("start_ubiblk_systemd_unit")
     end


### PR DESCRIPTION
Previously, several files were globally readable. While data remained secure because DEKs (Data Encryption Keys) were encrypted by KEKs (Key Encryption Keys), this change implements stricter access controls to align with security best practices.