### PR TITLE
Update postgres images to 20260123.1.0

### DIFF
--- a/migrate/20260123_update_pg_amis.rb
+++ b/migrate/20260123_update_pg_amis.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  ami_ids = [
+    ["us-west-2", "x64", "ami-06117c26f617d438b", "ami-042161c17b1718547"],
+    ["us-east-1", "x64", "ami-0a9e2c6f27818523d", "ami-0137b56243210a883"],
+    ["us-east-2", "x64", "ami-0a86960ab2d36682c", "ami-0e0b1d0e3e926d066"],
+    ["eu-west-1", "x64", "ami-000848dcac93911f7", "ami-0a9ecb1f734e3267e"],
+    ["ap-southeast-2", "x64", "ami-04da6741347527e45", "ami-063f4af4439eca1b3"],
+    ["us-west-2", "arm64", "ami-0861cfc0d5537096a", "ami-0bcf0974e0dfd19b7"],
+    ["us-east-1", "arm64", "ami-031b7115fc97475d5", "ami-03f25039f0bd61216"],
+    ["us-east-2", "arm64", "ami-0c582465ed19d71a6", "ami-0298f1dccfb07c6ec"],
+    ["eu-west-1", "arm64", "ami-03da373d18bee8049", "ami-06d8da668cf964b22"],
+    ["ap-southeast-2", "arm64", "ami-0c10129e535424e17", "ami-04179a820c1bd4c82"]
+  ]
+
+  up do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: old_ami)
+        .update(aws_ami_id: new_ami)
+    end
+  end
+
+  down do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: new_ami)
+        .update(aws_ami_id: old_ami)
+    end
+  end
+end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -99,7 +99,7 @@ class Prog::DownloadBootImage < Prog::Base
     ["github-ubuntu-2204", "arm64", "20251208.1.0"] => "4586386b5244ab727cfccfb058d1d9ac7f97875bfc5de47baa5c06ef50a274fd",
     ["github-gpu-ubuntu-2204", "x64", "20251017.1.0"] => "a27a6a5f169093cc7ecb761833e256a22b0bf42ef914542cf013490db0ab8ba5",
     ["github-gpu-ubuntu-2204", "x64", "20251208.1.0"] => "644fa94ead16baefc3f8efda27199ad60312201b042d9eb5d545c53455733f00",
-    ["postgres-ubuntu-2204", "x64", "20260120.1.0"] => "2ef1e1a696fd4ea5d8ba2932d885d41c69ddff9226d4af9a8f8846db2094cc5e",
+    ["postgres-ubuntu-2204", "x64", "20260123.1.0"] => "d2e0da61bd74b38419c544732b8dfb9482fdba74a0f5abaa1259c6cdda758225",
     ["postgres16-ubuntu-2204", "x64", "20250425.1.1"] => "f59622da276d646ed2a1c03de546b0a7ec3fd48aeb27c0bfe2b8b8be98c062d2",
     ["postgres17-ubuntu-2204", "x64", "20250425.1.1"] => "ccb4bcd8197c2e230be3f485dd33f24a51041a4dc0408257e42b3fe9f1c0bfb3",
     ["postgres-paradedb-ubuntu-2204", "x64", "20260107.1.0"] => "b60e173766eaf0b3928e69c8037d60943df4fc0314930ad9cd429405bf91b520",


### PR DESCRIPTION
## Summary
- Updates boot image SHA256 hashes in `prog/download_boot_image.rb`
- Adds migration to update AWS AMI IDs in `pg_aws_ami` table

## Image Version
`20260123.1.0`

## Changes
- x64 SHA256: `d2e0da61bd74b38419c544732b8dfb9482fdba74a0f5abaa1259c6cdda758225`
- arm64 SHA256: `148377248d5b1f4591cb994327e156c1924961804a1929357d9e7c87f89c3828`

🤖 Generated by [postgres-vm-images](https://github.com/ubicloud/postgres-vm-images) workflow