### PR TITLE
Do not have load balancer prog check DNS records every 5 seconds

### DIFF
--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -71,27 +71,7 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
       hop_rewrite_dns_records
     end
 
-    if need_to_rewrite_dns_records?
-      load_balancer.incr_rewrite_dns_records
-    end
-
-    nap 5
-  end
-
-  def need_to_rewrite_dns_records?
-    return false unless load_balancer.dns_zone
-
-    load_balancer.vms_to_dns.each do |vm|
-      if load_balancer.ipv4_enabled? && vm.ip4_string
-        return true unless load_balancer.dns_zone.records_dataset.find { it.name == load_balancer.hostname + "." && it.type == "A" && it.data == vm.ip4_string }
-      end
-
-      if load_balancer.ipv6_enabled?
-        return true unless load_balancer.dns_zone.records_dataset.find { it.name == load_balancer.hostname + "." && it.type == "AAAA" && it.data == vm.ip6_string }
-      end
-    end
-
-    false
+    nap 86400
   end
 
   label def create_new_cert

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
   end
 
   describe "#wait" do
-    it "naps for 5 seconds if nothing to do" do
+    it "naps for 1 day if nothing to do" do
       expect(nx.load_balancer).to receive(:need_certificates?).and_return(false)
-      expect { nx.wait }.to nap(5)
+      expect { nx.wait }.to nap(86400)
     end
 
     it "hops to update vm load balancers" do
@@ -75,13 +75,6 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
     it "creates new cert if needed" do
       expect(nx.load_balancer).to receive(:need_certificates?).and_return(true)
       expect { nx.wait }.to hop("create_new_cert")
-    end
-
-    it "increments rewrite_dns_records if needed" do
-      expect(nx).to receive(:need_to_rewrite_dns_records?).and_return(true)
-      expect(nx.load_balancer).to receive(:need_certificates?).and_return(false)
-      expect(nx.load_balancer).to receive(:incr_rewrite_dns_records)
-      expect { nx.wait }.to nap(5)
     end
   end
 
@@ -351,42 +344,6 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       expect(dns_zone).not_to receive(:insert_record).with(record_name: st.subject.hostname, type: "AAAA", data: "fd10:9b0b:6b4b:8fb0::2", ttl: 10)
       expect(dns_zone).not_to receive(:insert_record).with(record_name: "private.#{st.subject.hostname}", type: "AAAA", data: "fd10:9b0b:6b4b:8fb2::2", ttl: 10)
       expect { nx.rewrite_dns_records }.to hop("wait")
-    end
-  end
-
-  describe ".need_to_rewrite_dns_records?" do
-    it "returns true if dns record is missing for ipv4" do
-      vms = [instance_double(Vm, ip4_string: "192.168.1.0")]
-      expect(nx.load_balancer).to receive(:vms_to_dns).and_return(vms)
-      expect(nx.load_balancer).to receive(:dns_zone).and_return(dns_zone).at_least(:once)
-      expect(nx.need_to_rewrite_dns_records?).to be true
-    end
-
-    it "returns true if dns record is missing for ipv6" do
-      vms = [instance_double(Vm, ip4_string: nil, ip6_string: "fd10:9b0b:6b4b:8fb0::2")]
-      expect(nx.load_balancer).to receive(:vms_to_dns).and_return(vms)
-      expect(nx.load_balancer).to receive(:dns_zone).and_return(dns_zone).at_least(:once)
-      expect(nx.need_to_rewrite_dns_records?).to be true
-    end
-
-    it "returns false if dns record is present for ipv4 and lb is not ipv6 enabled" do
-      vms = [instance_double(Vm, ip4: "192.168.1.0", ip4_string: "192.168.1.0", ip6: nil, ip6_string: nil)]
-      expect(nx.load_balancer).to receive(:vms_to_dns).and_return(vms)
-      expect(nx.load_balancer).to receive(:dns_zone).and_return(dns_zone).at_least(:once)
-      expect(nx.load_balancer).to receive(:ipv6_enabled?).and_return(false)
-      dr = DnsRecord.create(dns_zone_id: dns_zone.id, name: nx.load_balancer.hostname + ".", type: "A", ttl: 10, data: "192.168.1.0")
-      expect(dns_zone).to receive(:records_dataset).and_return(DnsRecord.where(id: dr.id))
-      expect(nx.need_to_rewrite_dns_records?).to be false
-    end
-
-    it "returns false if dns record is present for ipv6 and lb is not ipv4 enabled" do
-      vms = [instance_double(Vm, ip4: nil, ip6_string: "fd10:9b0b:6b4b:8fb0::2")]
-      expect(nx.load_balancer).to receive(:vms_to_dns).and_return(vms)
-      expect(nx.load_balancer).to receive(:dns_zone).and_return(dns_zone).at_least(:once)
-      expect(nx.load_balancer).to receive(:ipv4_enabled?).and_return(false)
-      dr = DnsRecord.create(dns_zone_id: dns_zone.id, name: nx.load_balancer.hostname + ".", type: "AAAA", ttl: 10, data: "fd10:9b0b:6b4b:8fb0::2")
-      expect(dns_zone).to receive(:records_dataset).and_return(DnsRecord.where(id: dr.id))
-      expect(nx.need_to_rewrite_dns_records?).to be false
     end
   end
 end


### PR DESCRIPTION
Expect that if load balancers have a need to update DNS records,
the rewrite_dns_records semaphore will be set on them. Previously,
they checked every 5 seconds because a VM could be added that
didn't yet have a public IP address. Fix that by waiting until the
VM has the expected public IP addresses before updating DNS and
transitioning back to wait, so there is no reason check DNS anymore.
LoadBalancer#{add,evacuate}_vm both set the rewrite_dns_records
semaphore. If there are other situations that would require updating
the DNS records, those should set rewrite_dns_records as well.

The `need_to_rewrite_dns_records?` method was added in #2220.