### PR TITLE
Consolidate Node.js setup into setup-clover action

### DIFF
--- a/.github/actions/setup-clover/action.yml
+++ b/.github/actions/setup-clover/action.yml
@@ -1,5 +1,12 @@
 name: 'Setup Clover'
 
+inputs:
+  setup-node:
+    description: 'Set up Node.js and install npm dependencies'
+    required: false
+    type: boolean
+    default: false
+
 runs:
   using: "composite"
   steps:
@@ -45,3 +52,15 @@ runs:
         createuser -U postgres clover
         createuser -U postgres clover_password
         bundle exec rake setup_database\[test,true\]
+
+    - name: Set up Node.js
+      if: ${{ inputs.setup-node == 'true' }}
+      uses: actions/setup-node@v6
+      with:
+        node-version-file: "package.json"
+        cache: "npm"
+
+    - name: Install node packages
+      if: ${{ inputs.setup-node == 'true' }}
+      shell: bash
+      run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,8 @@ jobs:
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v6
       with:
-         node-version-file: "package.json"
-
-    - name: Install node packages
-      run: npm ci
+        setup-node: true
 
     - name: Run erb-formatter
       run: bundle exec rake linter:erb_formatter

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -25,14 +25,8 @@ jobs:
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v6
       with:
-         node-version-file: "package.json"
-
-    - name: Install node packages
-      run: npm ci
+        setup-node: true
 
     - name: Run unused associations check
       run: bundle exec rake unused_associations_check

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,15 +35,8 @@ jobs:
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v6
       with:
-        node-version-file: "package.json"
-        cache: "npm"
-
-    - name: Install node packages
-      run: npm ci
+        setup-node: true
 
     - name: Build assets
       run: npm run prod


### PR DESCRIPTION
The Node.js setup steps were duplicated across ci.yml, daily-ci.yml, and e2e.yml workflows. This moves the setup into the shared setup-clover action with an optional `setup-node` input (default: false)/