### PR TITLE
Nap instead of failing if AWS instance reservations are empty

### DIFF
--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -537,6 +537,11 @@ usermod -L ubuntu
           ])
         )))
     end
+
+    it "naps if the reservations response is empty" do
+      client.stub_responses(:describe_instances, reservations: [])
+      expect { nx.wait_instance_created }.to nap(1)
+    end
   end
 
   describe "#wait_instance_created", "without sshable" do


### PR DESCRIPTION
I saw intermittent `Vm::Aws::Nexus.wait_instance_created` failures in production with `NoMethodError: undefined method 'instances' for nil`.

These errors resolve themselves over time and indicate that the AWS API can return an empty reservations list during initial requests.

Instead of raising an exception in this case, we should nap until reservations are available.