### PR TITLE
Strip host from cache proxy log lines before tallying

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -484,7 +484,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     end
 
     if (cache_proxy_log = vm.sshable.cmd("sudo cat /var/log/cacheproxy.log", log: false))
-      cache_proxy_log_line_counts = cache_proxy_log.lines.each(&:strip!).reject(&:empty?).tally
+      cache_proxy_log_line_counts = cache_proxy_log.lines.each(&:strip!).each { it.gsub!(/ host: \S+/, "") }.reject(&:empty?).tally
       Clog.emit("Cache proxy log line counts", {cache_proxy_log_line_counts:})
     end
   rescue *Sshable::SSH_CONNECTION_ERRORS, Sshable::SshError


### PR DESCRIPTION
Each runner VM has a unique IP address, which creates a unique log key for every request in the cache proxy logs. This explosion of unique keys causes issues with our log provider. By stripping the host suffix (e.g., " host: 172_27_211_181:51123") before tallying, we consolidate logs by request type rather than by source, significantly reducing cardinality.