### PR TITLE
Update postgres images to 20260127.1.0

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -185,7 +185,7 @@ module Config
   override :github_gpu_ubuntu_2204_version, "20251208.1.0", string
   override :github_ubuntu_2204_aws_ami_version, "ami-0db39f24fb80dd3d2", string
   override :github_ubuntu_2404_aws_ami_version, "ami-0daff749acdc980cd", string
-  override :postgres_ubuntu_2204_version, "20260123.1.0", string
+  override :postgres_ubuntu_2204_version, "20260127.1.0", string
   override :postgres16_ubuntu_2204_version, "20250425.1.1", string
   override :postgres17_ubuntu_2204_version, "20250425.1.1", string
   override :postgres_paradedb_ubuntu_2204_version, "20260107.1.0", string

--- a/migrate/20260127_update_pg_amis.rb
+++ b/migrate/20260127_update_pg_amis.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  ami_ids = [
+    ["us-west-2", "x64", "ami-084600c250269044d", "ami-0648b09582126019c"],
+    ["us-east-1", "x64", "ami-096c2c2c73d94b700", "ami-00721d2bcb72bc798"],
+    ["us-east-2", "x64", "ami-0841a3a2703abcd47", "ami-02194ea0f45d9ad90"],
+    ["eu-west-1", "x64", "ami-0e38c2ad60fe310ed", "ami-08f3f94032b404ac8"],
+    ["ap-southeast-2", "x64", "ami-0e914bbc89f0cccb2", "ami-0143ebba55241a7bb"],
+    ["us-west-2", "arm64", "ami-0ae0f4a1fb36ba703", "ami-0a2efc7ae2dad69c8"],
+    ["us-east-1", "arm64", "ami-000d705e37bdd8de1", "ami-0da22fbdd571c9bac"],
+    ["us-east-2", "arm64", "ami-09ee60ae7acd69303", "ami-0d42e3872e22a6a73"],
+    ["eu-west-1", "arm64", "ami-020ee721c0b6f0eb3", "ami-0cf26a35275aaf530"],
+    ["ap-southeast-2", "arm64", "ami-0e0cad9a4ec9bd737", "ami-082aaa8eb267e01b3"]
+  ]
+
+  up do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: old_ami)
+        .update(aws_ami_id: new_ami)
+    end
+  end
+
+  down do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: new_ami)
+        .update(aws_ami_id: old_ami)
+    end
+  end
+end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -99,7 +99,7 @@ class Prog::DownloadBootImage < Prog::Base
     ["github-ubuntu-2204", "arm64", "20251208.1.0"] => "4586386b5244ab727cfccfb058d1d9ac7f97875bfc5de47baa5c06ef50a274fd",
     ["github-gpu-ubuntu-2204", "x64", "20251017.1.0"] => "a27a6a5f169093cc7ecb761833e256a22b0bf42ef914542cf013490db0ab8ba5",
     ["github-gpu-ubuntu-2204", "x64", "20251208.1.0"] => "644fa94ead16baefc3f8efda27199ad60312201b042d9eb5d545c53455733f00",
-    ["postgres-ubuntu-2204", "x64", "20260123.1.0"] => "63975380d55f88ea542453b4cd7b094190d3dc3792a01a0a46399b1bc639e523",
+    ["postgres-ubuntu-2204", "x64", "20260127.1.0"] => "66b4b91b4e3c21da9c3c6fbaf3e1c1261414af4b73b38e476865b7f71bf357d5",
     ["postgres16-ubuntu-2204", "x64", "20250425.1.1"] => "f59622da276d646ed2a1c03de546b0a7ec3fd48aeb27c0bfe2b8b8be98c062d2",
     ["postgres17-ubuntu-2204", "x64", "20250425.1.1"] => "ccb4bcd8197c2e230be3f485dd33f24a51041a4dc0408257e42b3fe9f1c0bfb3",
     ["postgres-paradedb-ubuntu-2204", "x64", "20260107.1.0"] => "b60e173766eaf0b3928e69c8037d60943df4fc0314930ad9cd429405bf91b520",


### PR DESCRIPTION
## Summary
- Updates image version in `config.rb`
- Updates boot image SHA256 hashes in `prog/download_boot_image.rb`
- Adds migration to update AWS AMI IDs in `pg_aws_ami` table

## Image Version
`20260127.1.0`

## Changes
- x64 SHA256: `66b4b91b4e3c21da9c3c6fbaf3e1c1261414af4b73b38e476865b7f71bf357d5`
- arm64 SHA256: `aff80ebad3ff184ae86794dda1fec1342c1c2bf718a4c5cfb8762047b84e814a`

🤖 Generated by [postgres-vm-images](https://github.com/ubicloud/postgres-vm-images) workflow