### PR TITLE
SPDK Migration improvements

### DIFF
--- a/prog/storage/migrate_spdk_vm_to_ubiblk.rb
+++ b/prog/storage/migrate_spdk_vm_to_ubiblk.rb
@@ -119,7 +119,7 @@ class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
   end
 
   label def create_ubiblk_systemd_unit
-    vm.vm_host.sshable.cmd("sudo chown :inhost_name::inhost_name :root_dir_path/disk.raw && sudo chmod 600 :root_dir_path/disk.raw && sudo rm -f :kek_file_path", inhost_name:, root_dir_path:, kek_file_path:)
+    vm.vm_host.sshable.cmd("sudo chown :inhost_name::inhost_name :root_dir_path/disk.raw && sudo chmod 600 :root_dir_path/disk.raw", inhost_name:, root_dir_path:)
     vm.vm_host.sshable.cmd("sudo host/bin/spdk-migration-helper create-vhost-backend-service-file", stdin: migration_script_params)
     hop_start_ubiblk_systemd_unit
   end

--- a/spec/prog/storage/migrate_spdk_vm_to_ubiblk_spec.rb
+++ b/spec/prog/storage/migrate_spdk_vm_to_ubiblk_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Prog::Storage::MigrateSpdkVmToUbiblk do
 
   describe "#create_ubiblk_systemd_unit" do
     it "creates the systemd unit and hops to the next label" do
-      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo chown #{vm.inhost_name}:#{vm.inhost_name} /var/storage/#{vm.inhost_name}/0/disk.raw && sudo chmod 600 /var/storage/#{vm.inhost_name}/0/disk.raw && sudo rm -f /var/storage/#{vm.inhost_name}/0/kek.pipe")
+      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo chown #{vm.inhost_name}:#{vm.inhost_name} /var/storage/#{vm.inhost_name}/0/disk.raw && sudo chmod 600 /var/storage/#{vm.inhost_name}/0/disk.raw")
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo host/bin/spdk-migration-helper create-vhost-backend-service-file", stdin: prog.migration_script_params)
       expect { prog.create_ubiblk_systemd_unit }.to hop("start_ubiblk_systemd_unit")
     end


### PR DESCRIPTION
Update Vm's systemd unit after migration

The Vm's systemd unit had After and Require fields which relied on the
SPDK systemd unit and that needs to be changed to its storage systemd
unit.

Do not delete kek fifo file in SPDK migration prog

By deleting this file and calling write_kek_pipe afterwards, we are
writing to a regular file instead of a fifo file, meaning the kek would
be still readable after the vm reads the kek file and boots.

By removing the rm command, after booting the vm, the kek file still
exists but if you try to read it, the cat command will wait for stdin
on the file, meaning the contents are already consumed and there will
be no need for removals.