### PR TITLE
Prefer physical_slot_ready standbys for failover, but allow fallback

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -198,9 +198,9 @@ class PostgresServer < Sequel::Model
   def failover_target
     target = resource.servers
       .reject { it.representative_at }
-      .select { it.strand.label == "wait" && !it.needs_recycling? && (read_replica? || it.physical_slot_ready) }
+      .select { it.strand.label == "wait" && !it.needs_recycling? && it.synchronization_status == "ready" }
       .map { {server: it, lsn: it.current_lsn} }
-      .max_by { lsn2int(it[:lsn]) }
+      .max_by { [it[:server].physical_slot_ready ? 1 : 0, lsn2int(it[:lsn])] } # prefers physical slot ready servers
 
     return nil if target.nil?
 


### PR DESCRIPTION
Previously, failover_target required standbys to have physical_slot_ready
set to true. This caused issues when a primary had no standbys initially
and a fresh standby was later added. In this scenario:

- The standby catches up using WAL files from the archive (Minio)
- The standby's synchronization_status becomes "ready"
- But physical_slot_ready remains false because the primary needs to
  configure the slot, and if the primary fails before doing so, the
  slot is never created
- Failover was impossible because no standby met the physical_slot_ready
  requirement

Now failover_target:
- Requires synchronization_status == "ready" (standby has caught up)
- Prefers standbys with physical_slot_ready (properly configured streaming)
- Falls back to standbys without physical_slot_ready if none available
- Still picks the standby with highest LSN within each preference tier

This ensures failover works when standbys caught up via archive while
still preferring the well-configured replication path in normal operations.