### PR TITLE
Do not create new AAAA DNS records for older PG resources

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -127,6 +127,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     pop "triggered pg_current_xact_id"
   end
 
+  AAAA_CUTOFF = Time.utc(2026, 1, 13, 20)
   label def refresh_dns_record
     decr_refresh_dns_record
 
@@ -140,7 +141,10 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         dns_zone.insert_record(record_name:, type: "CNAME", ttl: 10, data: vm.aws_instance.ipv4_dns_name + ".")
       else
         dns_zone.insert_record(record_name:, type: "A", ttl: 10, data: vm.ip4_string)
-        dns_zone.insert_record(record_name:, type: "AAAA", ttl: 10, data: vm.ip6_string)
+        if postgres_resource.created_at >= AAAA_CUTOFF ||
+            !dns_zone.records_dataset.where(type: "AAAA", name: record_name + ".").empty?
+          dns_zone.insert_record(record_name:, type: "AAAA", ttl: 10, data: vm.ip6_string)
+        end
         record_name = "private.#{record_name}"
         dns_zone.insert_record(record_name:, type: "A", ttl: 10, data: vm.private_ipv4_string)
         dns_zone.insert_record(record_name:, type: "AAAA", ttl: 10, data: vm.private_ipv6_string)


### PR DESCRIPTION
This can cause access issues if the firewall rules allow IPv4 but not IPv6.

Update a AAAA record if it already exists, as the customer may be relying on it.