### PR TITLE
sketch: determining expected vs unexpected vs guest-initiated shutdown

### DIFF
--- a/cli-commands/vm/post/start.rb
+++ b/cli-commands/vm/post/start.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+UbiCli.on("vm").run_on("start") do
+  desc "Start a virtual machine"
+
+  banner "ubi vm (location/vm-name | vm-id) start"
+
+  run do
+    id = sdk_object.start.id
+    response("Scheduled start of VM with id #{id}")
+  end
+end

--- a/cli-commands/vm/post/stop.rb
+++ b/cli-commands/vm/post/stop.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+UbiCli.on("vm").run_on("stop") do
+  desc "Stop a virtual machine"
+
+  banner "ubi vm (location/vm-name | vm-id) stop"
+
+  run do
+    id = sdk_object.stop.id
+    response(<<END)
+Scheduled stop of VM with id #{id}.
+Note that stopped VMs still accrue billing charges. To stop billing charges,
+destroy the VM.
+END
+  end
+end

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -125,6 +125,8 @@ class Clover < Roda
     restore
     restrict
     set_maintenance_window
+    start
+    stop
     unrestrict
     update
     update_billing

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -121,6 +121,7 @@ class Vm < Sequel::Model
     return "deleting" if destroying_set? || destroy_set?
     return "restarting" if restart_set? || label == "restart"
     return "stopped" if stop_set? || label == "stopped"
+    return "unavailable" if label == "unavailable"
 
     if waiting_for_capacity_set?
       return "no capacity available" if Time.now - created_at > 15 * 60

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -131,6 +131,18 @@ class Vm < Sequel::Model
     super
   end
 
+  def can_restart?
+    display_state == "running"
+  end
+
+  def can_stop?
+    %w[running restarting unavailable rebooting].include?(display_state)
+  end
+
+  def can_start?
+    %w[unavailable stopped].include?(display_state)
+  end
+
   # cloud-hypervisor takes topology information in this format:
   #
   # topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -40,7 +40,7 @@ class Vm < Sequel::Model
   plugin ResourceMethods, redacted_columns: :public_key
   plugin ProviderDispatcher, __FILE__
   plugin SemaphoreMethods, :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules,
-    :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started, :restart, :stop, :migrate_to_separate_progs
+    :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started, :restart, :start, :stop, :migrate_to_separate_progs
   include HealthMonitorMethods
 
   include ObjectTag::Cleanup

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1825,6 +1825,36 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Virtual Machine
+  '/project/{project_id}/location/{location}/vm/{vm_reference}/start':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/vm_reference'
+    post:
+      operationId: startVM
+      summary: Start a VM
+      responses:
+        '200':
+          $ref: '#/components/responses/Vm'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Virtual Machine
+  '/project/{project_id}/location/{location}/vm/{vm_reference}/stop':
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/vm_reference'
+    post:
+      operationId: stopVm
+      summary: Stop a VM
+      responses:
+        '200':
+          $ref: '#/components/responses/Vm'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Virtual Machine
   '/project/{project_id}/object-info/{object_id}':
     parameters:
       - $ref: '#/components/parameters/project_id'

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -262,7 +262,6 @@ class Prog::Vm::Metal::Nexus < Prog::Base
 
     when_checkup_set? do
       unless available?
-        register_deadline("wait", 2 * 60)
         hop_unavailable
       end
       decr_checkup

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -310,6 +310,11 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       hop_start_after_host_reboot
     end
 
+    when_restart_set? do
+      register_deadline("wait", 5 * 60)
+      hop_restart
+    end
+
     if available?
       decr_checkup
       hop_wait

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -295,9 +295,9 @@ class Prog::Vm::Metal::Nexus < Prog::Base
 
   label def stopped
     when_stop_set? do
+      decr_stop
       host.sshable.cmd("sudo systemctl stop :vm_name", vm_name:)
     end
-    decr_stop
 
     nap 60 * 60
   end

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -55,6 +55,10 @@ class Clover
       r.post %w[restart start stop] do |action|
         authorize("Vm:edit", vm)
 
+        if vm.aws?
+          raise CloverError.new(400, "InvalidRequest", "The #{action} action is not supported for VMs running on AWS")
+        end
+
         DB.transaction do
           vm.public_send(:"incr_#{action}")
           audit_log(vm, action)

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -52,18 +52,18 @@ class Clover
 
       r.show_object(vm, actions: %w[overview networking settings], perm: "Vm:view", template: "vm/show")
 
-      r.post "restart" do
+      r.post %w[restart start stop] do |action|
         authorize("Vm:edit", vm)
 
         DB.transaction do
-          vm.incr_restart
-          audit_log(vm, "restart")
+          vm.public_send(:"incr_#{action}")
+          audit_log(vm, action)
         end
 
         if api?
           Serializers::Vm.serialize(vm, {detailed: true})
         else
-          flash["notice"] = "'#{vm.name}' will be restarted in a few seconds"
+          flash["notice"] = "Scheduled #{action} of #{vm.name}"
           r.redirect vm, "/settings"
         end
       end

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -67,7 +67,11 @@ class Clover
         if api?
           Serializers::Vm.serialize(vm, {detailed: true})
         else
-          flash["notice"] = "Scheduled #{action} of #{vm.name}"
+          notice = "Scheduled #{action} of #{vm.name}"
+          if action == "stop"
+            notice << ". Note that stopped VMs still accrue billing charges. To stop billing charges, delete the VM."
+          end
+          flash["notice"] = notice
           r.redirect vm, "/settings"
         end
       end

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -54,9 +54,14 @@ class Clover
 
       r.post %w[restart start stop] do |action|
         authorize("Vm:edit", vm)
+        handle_validation_failure("vm/show") { @page = "settings" }
 
         if vm.aws?
           raise CloverError.new(400, "InvalidRequest", "The #{action} action is not supported for VMs running on AWS")
+        end
+
+        unless vm.send(:"can_#{action}?")
+          raise CloverError.new(400, "InvalidRequest", "The #{action} action is not supported in the VM's current state")
         end
 
         DB.transaction do

--- a/sdk/ruby/lib/ubicloud/model/vm.rb
+++ b/sdk/ruby/lib/ubicloud/model/vm.rb
@@ -23,5 +23,17 @@ module Ubicloud
     def restart
       merge_into_values(adapter.post(_path("/restart")))
     end
+
+    # Schedule a start of the virtual machine. Returns self.
+    def start
+      merge_into_values(adapter.post(_path("/start")))
+    end
+
+    # Schedule a stop of the virtual machine. Returns self.
+    # Note that stopped virtual machines still accrue billing charges.
+    # To avoid billing charges, destroy the virtual machine.
+    def stop
+      merge_into_values(adapter.post(_path("/stop")))
+    end
   end
 end

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe Vm do
       expect(vm.display_state).to eq("stopped")
     end
 
+    it "returns unavailable if strand is at unavailable label" do
+      vm.strand.update(label: "unavailable")
+      expect(vm.display_state).to eq("unavailable")
+    end
+
     it "returns waiting for capacity if semaphore increased" do
       vm.incr_waiting_for_capacity
       expect(vm.display_state).to eq("waiting for capacity")

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -807,7 +807,6 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     it "hops to unavailable based on the vm's available status" do
       vm.incr_checkup
       expect(nx).to receive(:available?).and_return(false)
-      expect(nx).to receive(:register_deadline).with("wait", 2 * 60)
       expect { nx.wait }.to hop("unavailable")
 
       vm.incr_checkup

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -871,6 +871,14 @@ RSpec.describe Prog::Vm::Metal::Nexus do
         .and change { vm.reload.checkup_set? }.from(false).to(true)
     end
 
+    it "hops to restart when needed" do
+      vm.incr_restart
+      expect { nx.unavailable }.to hop("restart")
+      frame = st.stack[0]
+      expect(frame["deadline_target"]).to eq "wait"
+      expect(frame["deadline_at"]).to be_within(10).of(Time.now + 300)
+    end
+
     it "naps if vm is still unavailable" do
       expect(nx).to receive(:available?).and_return(false)
       expect { nx.unavailable }.to nap(30)

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -850,12 +850,37 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     end
   end
 
+  describe "#start_after_stop" do
+    it "hops to wait after starting the vm" do
+      vm.incr_start
+      expect(sshable).to receive(:_cmd).with("sudo systemctl start #{vm.inhost_name}")
+      expect { nx.start_after_stop }.to hop("wait")
+        .and change { vm.reload.start_set? }.from(true).to(false)
+    end
+  end
+
   describe "#stopped" do
     it "naps after stopping the vm" do
       vm.incr_stop
       expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{vm.inhost_name}")
-      expect { nx.stopped }.to nap(60 * 60)
+      expect { nx.stopped }.to nap(0)
         .and change { vm.reload.stop_set? }.from(true).to(false)
+    end
+
+    it "hops to restart when needed" do
+      vm.incr_restart
+      expect { nx.stopped }.to hop("restart")
+      frame = st.stack[0]
+      expect(frame["deadline_target"]).to eq "wait"
+      expect(frame["deadline_at"]).to be_within(10).of(Time.now + 300)
+    end
+
+    it "hops to start when needed" do
+      vm.incr_start
+      expect { nx.stopped }.to hop("start_after_stop")
+      frame = st.stack[0]
+      expect(frame["deadline_target"]).to eq "wait"
+      expect(frame["deadline_at"]).to be_within(10).of(Time.now + 300)
     end
 
     it "does not stop if already stopped" do
@@ -871,12 +896,24 @@ RSpec.describe Prog::Vm::Metal::Nexus do
         .and change { vm.reload.checkup_set? }.from(false).to(true)
     end
 
-    it "hops to restart when needed" do
+    it "restarts the VM when needed" do
       vm.incr_restart
-      expect { nx.unavailable }.to hop("restart")
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm restart #{vm.inhost_name}")
+      expect { nx.unavailable }.to nap(0)
+        .and change { vm.reload.restart_set? }.from(true).to(false)
+    end
+
+    it "hops to start when needed" do
+      vm.incr_start
+      expect { nx.unavailable }.to hop("start_after_stop")
       frame = st.stack[0]
       expect(frame["deadline_target"]).to eq "wait"
       expect(frame["deadline_at"]).to be_within(10).of(Time.now + 300)
+    end
+
+    it "hops to stopped when needed" do
+      vm.incr_stop
+      expect { nx.unavailable }.to hop("stopped")
     end
 
     it "naps if vm is still unavailable" do

--- a/spec/routes/api/cli/golden-files/help -r vm.txt
+++ b/spec/routes/api/cli/golden-files/help -r vm.txt
@@ -16,6 +16,8 @@ Post Commands:
     sftp       Copy files to or from virtual machine using `sftp`
     show       Show details for a virtual machine
     ssh        Connect to a virtual machine using `ssh`
+    start      Start a virtual machine
+    stop       Stop a virtual machine
 
 Post Options:
     -4, --ip4                        use IPv4 address
@@ -118,5 +120,17 @@ Connect to a virtual machine using `ssh`
 
 Usage:
     ubi vm (location/vm-name | vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+
+
+Start a virtual machine
+
+Usage:
+    ubi vm (location/vm-name | vm-id) start
+
+
+Stop a virtual machine
+
+Usage:
+    ubi vm (location/vm-name | vm-id) stop
 
 

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -1000,6 +1000,8 @@ Post Commands:
     sftp       Copy files to or from virtual machine using `sftp`
     show       Show details for a virtual machine
     ssh        Connect to a virtual machine using `ssh`
+    start      Start a virtual machine
+    stop       Stop a virtual machine
 
 Post Options:
     -4, --ip4                        use IPv4 address
@@ -1102,5 +1104,17 @@ Connect to a virtual machine using `ssh`
 
 Usage:
     ubi vm (location/vm-name | vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+
+
+Start a virtual machine
+
+Usage:
+    ubi vm (location/vm-name | vm-id) start
+
+
+Stop a virtual machine
+
+Usage:
+    ubi vm (location/vm-name | vm-id) stop
 
 

--- a/spec/routes/api/cli/golden-files/help -ru vm.txt
+++ b/spec/routes/api/cli/golden-files/help -ru vm.txt
@@ -9,3 +9,5 @@ ubi vm (location/vm-name | vm-id) [options] scp [scp-options] (local-path :remot
 ubi vm (location/vm-name | vm-id) [options] sftp [sftp-options]
 ubi vm (location/vm-name | vm-id) show [options]
 ubi vm (location/vm-name | vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+ubi vm (location/vm-name | vm-id) start
+ubi vm (location/vm-name | vm-id) stop

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -112,3 +112,5 @@ ubi vm (location/vm-name | vm-id) [options] scp [scp-options] (local-path :remot
 ubi vm (location/vm-name | vm-id) [options] sftp [sftp-options]
 ubi vm (location/vm-name | vm-id) show [options]
 ubi vm (location/vm-name | vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]
+ubi vm (location/vm-name | vm-id) start
+ubi vm (location/vm-name | vm-id) stop

--- a/spec/routes/api/cli/golden-files/help vm.txt
+++ b/spec/routes/api/cli/golden-files/help vm.txt
@@ -16,6 +16,8 @@ Post Commands:
     sftp       Copy files to or from virtual machine using `sftp`
     show       Show details for a virtual machine
     ssh        Connect to a virtual machine using `ssh`
+    start      Start a virtual machine
+    stop       Stop a virtual machine
 
 Post Options:
     -4, --ip4                        use IPv4 address

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm -X sftp.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm -X sftp.txt
@@ -18,6 +18,8 @@ Post Commands:
     sftp       Copy files to or from virtual machine using `sftp`
     show       Show details for a virtual machine
     ssh        Connect to a virtual machine using `ssh`
+    start      Start a virtual machine
+    stop       Stop a virtual machine
 
 Post Options:
     -4, --ip4                        use IPv4 address

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f id,name,state,location,size,unix-user,storage-size-gib.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f id,name,state,location,size,unix-user,storage-size-gib.txt
@@ -1,6 +1,6 @@
 id: vmdzyppz6j166jh5e9t2dwrfas
 name: test-vm
-state: creating
+state: running
 location: eu-central-h1
 size: standard-2
 unix-user: ubi

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show.txt
@@ -1,6 +1,6 @@
 id: vmdzyppz6j166jh5e9t2dwrfas
 name: test-vm
-state: creating
+state: running
 location: eu-central-h1
 size: standard-2
 unix-user: ubi

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_vmdzyppz6j166jh5e9t2dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_vmdzyppz6j166jh5e9t2dwrfas show.txt
@@ -1,6 +1,6 @@
 id: vmdzyppz6j166jh5e9t2dwrfas
 name: test-vm
-state: creating
+state: running
 location: eu-central-h1
 size: standard-2
 unix-user: ubi

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfa show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfa show.txt
@@ -18,6 +18,8 @@ Post Commands:
     sftp       Copy files to or from virtual machine using `sftp`
     show       Show details for a virtual machine
     ssh        Connect to a virtual machine using `ssh`
+    start      Start a virtual machine
+    stop       Stop a virtual machine
 
 Post Options:
     -4, --ip4                        use IPv4 address

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t0dwrfas show.txt
@@ -18,6 +18,8 @@ Post Commands:
     sftp       Copy files to or from virtual machine using `sftp`
     show       Show details for a virtual machine
     ssh        Connect to a virtual machine using `ssh`
+    start      Start a virtual machine
+    stop       Stop a virtual machine
 
 Post Options:
     -4, --ip4                        use IPv4 address

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfas show.txt
@@ -1,6 +1,6 @@
 id: vmdzyppz6j166jh5e9t2dwrfas
 name: test-vm
-state: creating
+state: running
 location: eu-central-h1
 size: standard-2
 unix-user: ubi

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfasa show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfasa show.txt
@@ -18,6 +18,8 @@ Post Commands:
     sftp       Copy files to or from virtual machine using `sftp`
     show       Show details for a virtual machine
     ssh        Connect to a virtual machine using `ssh`
+    start      Start a virtual machine
+    stop       Stop a virtual machine
 
 Post Options:
     -4, --ip4                        use IPv4 address

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Clover, "cli" do
     SshPublicKey.create_with_id("32092997-2a00-8f33-8129-4c0f18e5153c", project_id: @project.id, name: "spk", public_key: "a a")
     cli(%w[vm eu-central-h1/test-vm create] << "ssh-rsa a")
     @vm = Vm.first
+    @vm.update(display_state: "running")
     add_ipv4_to_vm(@vm, "128.0.0.1")
     @vm.nics.first.update(private_ipv4: "10.67.141.133/32", private_ipv6: "fda0:d79a:93e7:d4fd:1c2::0/80")
     @ps = PrivateSubnet.first

--- a/spec/routes/api/cli/vm/restart_spec.rb
+++ b/spec/routes/api/cli/vm/restart_spec.rb
@@ -9,9 +9,16 @@ RSpec.describe Clover, "cli vm restart" do
   end
 
   it "restarts vm" do
+    @vm.update(display_state: "running")
     expect do
       expect(cli(%w[vm eu-central-h1/test-vm restart])).to eq("Scheduled restart of VM with id #{@vm.ubid}\n")
     end.to change { Semaphore.where(strand_id: @vm.id, name: "restart").count }.from(0).to(1)
+  end
+
+  it "raises error if VM is not in the correct state" do
+    expect do
+      expect(cli(%w[vm eu-central-h1/test-vm restart], status: 400)).to eq "! Unexpected response status: 400\nDetails: The restart action is not supported in the VM's current state\n"
+    end.to not_change { Semaphore.where(strand_id: @vm.id, name: "restart").count }
   end
 
   it "raises error if running on AWS" do

--- a/spec/routes/api/cli/vm/restart_spec.rb
+++ b/spec/routes/api/cli/vm/restart_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Clover, "cli vm restart" do
   end
 
   it "restarts vm" do
-    expect(Semaphore.where(strand_id: @vm.id, name: "restart")).to be_empty
-    expect(cli(%w[vm eu-central-h1/test-vm restart])).to eq "Scheduled restart of VM with id #{@vm.ubid}\n"
-    expect(Semaphore.where(strand_id: @vm.id, name: "restart")).not_to be_empty
+    expect do
+      expect(cli(%w[vm eu-central-h1/test-vm restart])).to eq("Scheduled restart of VM with id #{@vm.ubid}\n")
+    end.to change { Semaphore.where(strand_id: @vm.id, name: "restart").count }.from(0).to(1)
   end
 end

--- a/spec/routes/api/cli/vm/restart_spec.rb
+++ b/spec/routes/api/cli/vm/restart_spec.rb
@@ -13,4 +13,11 @@ RSpec.describe Clover, "cli vm restart" do
       expect(cli(%w[vm eu-central-h1/test-vm restart])).to eq("Scheduled restart of VM with id #{@vm.ubid}\n")
     end.to change { Semaphore.where(strand_id: @vm.id, name: "restart").count }.from(0).to(1)
   end
+
+  it "raises error if running on AWS" do
+    @vm.update(location: Location[name: "us-east-1"])
+    expect do
+      expect(cli(%w[vm us-east-1/test-vm restart], status: 400)).to eq "! Unexpected response status: 400\nDetails: The restart action is not supported for VMs running on AWS\n"
+    end.to not_change { Semaphore.where(strand_id: @vm.id, name: "restart").count }
+  end
 end

--- a/spec/routes/api/cli/vm/start_spec.rb
+++ b/spec/routes/api/cli/vm/start_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli vm start" do
+  before do
+    cli(%w[vm eu-central-h1/test-vm create] << "a a")
+    @vm = Vm.first
+  end
+
+  it "restarts vm" do
+    expect do
+      expect(cli(%w[vm eu-central-h1/test-vm start])).to eq("Scheduled start of VM with id #{@vm.ubid}\n")
+    end.to change { Semaphore.where(strand_id: @vm.id, name: "start").count }.from(0).to(1)
+  end
+end

--- a/spec/routes/api/cli/vm/start_spec.rb
+++ b/spec/routes/api/cli/vm/start_spec.rb
@@ -13,4 +13,11 @@ RSpec.describe Clover, "cli vm start" do
       expect(cli(%w[vm eu-central-h1/test-vm start])).to eq("Scheduled start of VM with id #{@vm.ubid}\n")
     end.to change { Semaphore.where(strand_id: @vm.id, name: "start").count }.from(0).to(1)
   end
+
+  it "raises error if running on AWS" do
+    @vm.update(location: Location[name: "us-east-1"])
+    expect do
+      expect(cli(%w[vm us-east-1/test-vm start], status: 400)).to eq "! Unexpected response status: 400\nDetails: The start action is not supported for VMs running on AWS\n"
+    end.to not_change { Semaphore.where(strand_id: @vm.id, name: "start").count }
+  end
 end

--- a/spec/routes/api/cli/vm/start_spec.rb
+++ b/spec/routes/api/cli/vm/start_spec.rb
@@ -9,9 +9,16 @@ RSpec.describe Clover, "cli vm start" do
   end
 
   it "restarts vm" do
+    @vm.strand.update(label: "stopped")
     expect do
       expect(cli(%w[vm eu-central-h1/test-vm start])).to eq("Scheduled start of VM with id #{@vm.ubid}\n")
     end.to change { Semaphore.where(strand_id: @vm.id, name: "start").count }.from(0).to(1)
+  end
+
+  it "raises error if VM is not in the correct state" do
+    expect do
+      expect(cli(%w[vm eu-central-h1/test-vm start], status: 400)).to eq "! Unexpected response status: 400\nDetails: The start action is not supported in the VM's current state\n"
+    end.to not_change { Semaphore.where(strand_id: @vm.id, name: "start").count }
   end
 
   it "raises error if running on AWS" do

--- a/spec/routes/api/cli/vm/stop_spec.rb
+++ b/spec/routes/api/cli/vm/stop_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Clover, "cli vm stop" do
   end
 
   it "stops vm" do
+    @vm.update(display_state: "running")
     expect do
       expect(cli(%w[vm eu-central-h1/test-vm stop])).to eq(<<END)
 Scheduled stop of VM with id #{@vm.ubid}.
@@ -16,6 +17,12 @@ Note that stopped VMs still accrue billing charges. To stop billing charges,
 destroy the VM.
 END
     end.to change { Semaphore.where(strand_id: @vm.id, name: "stop").count }.from(0).to(1)
+  end
+
+  it "raises error if VM is not in the correct state" do
+    expect do
+      expect(cli(%w[vm eu-central-h1/test-vm stop], status: 400)).to eq "! Unexpected response status: 400\nDetails: The stop action is not supported in the VM's current state\n"
+    end.to not_change { Semaphore.where(strand_id: @vm.id, name: "stop").count }
   end
 
   it "raises error if running on AWS" do

--- a/spec/routes/api/cli/vm/stop_spec.rb
+++ b/spec/routes/api/cli/vm/stop_spec.rb
@@ -17,4 +17,11 @@ destroy the VM.
 END
     end.to change { Semaphore.where(strand_id: @vm.id, name: "stop").count }.from(0).to(1)
   end
+
+  it "raises error if running on AWS" do
+    @vm.update(location: Location[name: "us-east-1"])
+    expect do
+      expect(cli(%w[vm us-east-1/test-vm stop], status: 400)).to eq "! Unexpected response status: 400\nDetails: The stop action is not supported for VMs running on AWS\n"
+    end.to not_change { Semaphore.where(strand_id: @vm.id, name: "stop").count }
+  end
 end

--- a/spec/routes/api/cli/vm/stop_spec.rb
+++ b/spec/routes/api/cli/vm/stop_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli vm stop" do
+  before do
+    cli(%w[vm eu-central-h1/test-vm create] << "a a")
+    @vm = Vm.first
+  end
+
+  it "stops vm" do
+    expect do
+      expect(cli(%w[vm eu-central-h1/test-vm stop])).to eq(<<END)
+Scheduled stop of VM with id #{@vm.ubid}.
+Note that stopped VMs still accrue billing charges. To stop billing charges,
+destroy the VM.
+END
+    end.to change { Semaphore.where(strand_id: @vm.id, name: "stop").count }.from(0).to(1)
+  end
+end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -881,6 +881,19 @@ RSpec.describe CloverAdmin do
     expect(created_at_cell).to have_content(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/)
   end
 
+  it "shows unavailable VMs" do
+    project = Project.create(name: "test")
+    vm = create_vm(project_id: project.id, name: "active-vm")
+    Strand.create_with_id(vm, prog: "Vm::Metal::Nexus", label: "unavailable")
+
+    visit "/"
+    click_link "Show Unavailable VMs"
+    click_link vm.ubid
+    expect(page.title).to eq "Ubicloud Admin - Strand #{vm.ubid}"
+    click_link "Subject"
+    expect(page.title).to eq "Ubicloud Admin - Vm #{vm.ubid}"
+  end
+
   it "finds both active and archived VMs by IPv4" do
     host = create_vm_host
     project = Project.create(name: "test")

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -832,6 +832,19 @@ RSpec.describe Clover, "vm" do
           end
         end
 
+        it "cannot #{action} AWS VM" do
+          vm.update(location: Location[name: "us-east-1"])
+          if action == "start"
+            vm.strand.update(label: "stopped")
+          else
+            vm.update(display_state: "running")
+          end
+
+          visit "#{project.path}#{vm.path}"
+          within("#vm-submenu") { click_link "Settings" }
+          expect(page).to have_no_content action.capitalize
+        end
+
         it "cannot #{action} vm not in state supporting it" do
           visit "#{project.path}#{vm.path}"
           within("#vm-submenu") { click_link "Settings" }

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -813,6 +813,12 @@ RSpec.describe Clover, "vm" do
     %w[restart start stop].each do |action|
       describe action do
         it "can #{action} vm" do
+          if action == "start"
+            vm.strand.update(label: "stopped")
+          else
+            vm.update(display_state: "running")
+          end
+
           visit "#{project.path}#{vm.path}"
           within("#vm-submenu") { click_link "Settings" }
           click_button action.capitalize
@@ -826,13 +832,19 @@ RSpec.describe Clover, "vm" do
           end
         end
 
+        it "cannot #{action} vm not in state supporting it" do
+          visit "#{project.path}#{vm.path}"
+          within("#vm-submenu") { click_link "Settings" }
+          expect(page).to have_no_content action.capitalize
+        end
+
         it "can not #{action} virtual machine without edit permissions" do
           AccessControlEntry.create(project_id: project_wo_permissions.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Vm:view"])
 
           visit "#{project_wo_permissions.path}#{vm_wo_permission.path}/settings"
           expect(page.title).to eq "Ubicloud - dummy-vm-2"
 
-          expect(page).to have_no_content "Restart"
+          expect(page).to have_no_content action.capitalize
         end
       end
     end

--- a/test_vm_exit_reason.rb
+++ b/test_vm_exit_reason.rb
@@ -1,0 +1,282 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# test_vm_exit_reason.rb — Reproduce VM exit reason detection on any
+# Ubuntu machine with KVM, systemd, curl, and Ruby.
+#
+# Usage:
+#   sudo ruby test_vm_exit_reason.rb
+#
+# What it does:
+#   1. Downloads cloud-hypervisor v50 static binary + ch-remote + firmware
+#   2. Downloads an Ubuntu cloud image and converts to raw
+#   3. Installs a systemd unit matching Ubicloud production layout
+#      (Type=simple, ExecStop=ch-remote shutdown-vmm, -v flag)
+#   4. Runs three tests:
+#      A) Guest ACPI shutdown (via CH API power-button)
+#      B) SIGTERM (direct kill -TERM on CH pid)
+#      C) SIGKILL (kill -9)
+#   5. For each test, reports systemd Result and journal grep output
+#
+# Prerequisites:
+#   - Ubuntu with KVM (/dev/kvm must exist)
+#   - systemd, curl, qemu-utils (for qemu-img)
+#   - Root (for systemd unit management and KVM access)
+#   - ~3 GB disk space for the cloud image
+#
+# This script is disposable. It cleans up after itself.
+
+require "fileutils"
+require "json"
+require "open3"
+
+WORKDIR = "/tmp/ch-exit-reason-test"
+UNIT_NAME = "ch-exit-test"
+CH_VERSION = "v50.0"
+CH_URL = "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/#{CH_VERSION}/cloud-hypervisor-static"
+CH_REMOTE_URL = "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/#{CH_VERSION}/ch-remote-static"
+FW_URL = "https://github.com/cloud-hypervisor/rust-hypervisor-firmware/releases/download/0.4.2/hypervisor-fw"
+IMAGE_URL = "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-disk-kvm.img"
+
+def run(cmd, allow_failure: false)
+  stdout, stderr, status = Open3.capture3(cmd)
+  unless status.success? || allow_failure
+    $stderr.puts "FAILED: #{cmd}"
+    $stderr.puts stderr
+    exit 1
+  end
+  stdout.strip
+end
+
+def log(msg)
+  puts "\n#{"=" * 60}\n#{msg}\n#{"=" * 60}"
+end
+
+def download(url, dest)
+  return if File.exist?(dest)
+  puts "  Downloading #{File.basename(dest)}..."
+  run("curl -sL -o #{dest} '#{url}'")
+end
+
+def wait_for_exit(timeout: 60)
+  (timeout / 2).times do
+    sleep 2
+    return true if run("systemctl is-active #{UNIT_NAME}", allow_failure: true) != "active"
+  end
+  false
+end
+
+def wait_for_boot(timeout: 30)
+  timeout.times do
+    sleep 1
+    state = run("curl -s --unix-socket #{WORKDIR}/ch-short.sock " \
+                "http://localhost/api/v1/vm.info 2>/dev/null", allow_failure: true)
+    return true if state.include?('"Running"')
+  end
+  false
+end
+
+def systemd_result
+  run("systemctl show -p Result -p InvocationID --value #{UNIT_NAME}")
+    .split("\n")
+    .then { |lines| {result: lines[0], invocation_id: lines[1]} }
+end
+
+def journal_grep(invocation_id)
+  out = run(
+    "journalctl _SYSTEMD_INVOCATION_ID=#{invocation_id} -o cat -n 50 --no-pager " \
+    "| grep -m1 -oF " \
+    "-e 'ACPI Shutdown signalled' " \
+    "-e 'vCPU thread panicked' " \
+    "-e 'VCPU generated error' " \
+    "-e 'thread panicked'",
+    allow_failure: true
+  )
+  out.empty? ? "(no match)" : out
+end
+
+def journal_tail(invocation_id, n: 5)
+  run("journalctl _SYSTEMD_INVOCATION_ID=#{invocation_id} -o cat --no-pager | tail -#{n}",
+    allow_failure: true)
+end
+
+def systemd_messages(n: 5)
+  run("journalctl -u #{UNIT_NAME} --no-pager | grep 'systemd\\[1\\]' | tail -#{n}",
+    allow_failure: true)
+end
+
+def start_vm
+  run("systemctl reset-failed #{UNIT_NAME}", allow_failure: true)
+  run("rm -f #{WORKDIR}/ch.sock #{WORKDIR}/ch-short.sock")
+  run("systemctl start #{UNIT_NAME}")
+  # The API socket path is long; symlink it for curl compatibility.
+  run("ln -sf #{WORKDIR}/ch.sock #{WORKDIR}/ch-short.sock")
+  unless wait_for_boot
+    abort "VM failed to boot. Check: journalctl -u #{UNIT_NAME} --no-pager | tail -30"
+  end
+  puts "  VM is running."
+end
+
+def report(label, info)
+  puts <<~REPORT
+
+    --- #{label} ---
+    systemd Result:  #{info[:result]}
+    InvocationID:    #{info[:invocation_id]}
+    Journal grep:    #{info[:grep]}
+    systemd message: #{info[:systemd_msg]}
+    CH tail:
+    #{info[:ch_tail].gsub(/^/, "      ")}
+  REPORT
+end
+
+def run_test(label)
+  start_vm
+  # Let the guest OS finish booting (cloud-init, acpid, etc.)
+  puts "  Waiting 20s for guest to settle..."
+  sleep 20
+
+  yield
+
+  unless wait_for_exit
+    puts "  WARNING: VM did not exit within timeout"
+  end
+  sleep 1
+
+  info = systemd_result
+  info[:grep] = journal_grep(info[:invocation_id])
+  info[:ch_tail] = journal_tail(info[:invocation_id])
+  info[:systemd_msg] = systemd_messages(n: 3)
+  report(label, info)
+  info
+end
+
+# ── Preflight ──────────────────────────────────────────────
+
+abort "Must run as root (need systemd and KVM access)" unless Process.uid == 0
+abort "/dev/kvm not found — KVM required" unless File.exist?("/dev/kvm")
+
+unless system("which qemu-img > /dev/null 2>&1")
+  puts "Installing qemu-utils..."
+  run("apt-get install -y qemu-utils")
+end
+
+# ── Setup ──────────────────────────────────────────────────
+
+log "Setting up in #{WORKDIR}"
+FileUtils.mkdir_p(WORKDIR)
+
+download(CH_URL, "#{WORKDIR}/cloud-hypervisor")
+FileUtils.chmod(0o755, "#{WORKDIR}/cloud-hypervisor")
+
+download(CH_REMOTE_URL, "#{WORKDIR}/ch-remote")
+FileUtils.chmod(0o755, "#{WORKDIR}/ch-remote")
+
+download(FW_URL, "#{WORKDIR}/hypervisor-fw")
+
+download(IMAGE_URL, "#{WORKDIR}/guest.qcow2")
+
+unless File.exist?("#{WORKDIR}/guest.raw")
+  puts "  Converting qcow2 → raw..."
+  run("qemu-img convert -f qcow2 -O raw #{WORKDIR}/guest.qcow2 #{WORKDIR}/guest.raw")
+end
+
+puts "  CH version: #{run("#{WORKDIR}/cloud-hypervisor --version")}"
+
+# ── Install systemd unit (matches production layout) ──────
+
+# Production uses:
+#   ExecStart=<ch-bin> -v --api-socket path=<sock> --kernel <fw> ...
+#   ExecStop=<ch-remote> --api-socket <sock> shutdown-vmm
+#   --serial file=<log>  (serial to file, not tty)
+#
+# The -v flag is critical: without it, CH does not log INFO-level
+# messages (including "ACPI Shutdown signalled") to journald.
+
+unit = <<~UNIT
+  [Unit]
+  Description=CH exit reason test VM
+
+  [Service]
+  Type=simple
+  ExecStartPre=/usr/bin/rm -f #{WORKDIR}/ch.sock
+  ExecStart=#{WORKDIR}/cloud-hypervisor -v \\
+    --api-socket path=#{WORKDIR}/ch.sock \\
+    --firmware #{WORKDIR}/hypervisor-fw \\
+    --cpus boot=1 \\
+    --memory size=512M \\
+    --disk path=#{WORKDIR}/guest.raw \\
+    --net tap=,mac=12:34:56:78:90:ab \\
+    --serial file=#{WORKDIR}/serial.log \\
+    --console off
+  ExecStop=#{WORKDIR}/ch-remote --api-socket #{WORKDIR}/ch.sock shutdown-vmm
+UNIT
+
+File.write("/etc/systemd/system/#{UNIT_NAME}.service", unit)
+run("systemctl daemon-reload")
+puts "  Installed #{UNIT_NAME}.service"
+
+# ── Tests ─────────────────────────────────────────────────
+
+results = []
+
+log "Test A: Guest ACPI shutdown (power button via CH API)"
+results << run_test("ACPI Shutdown") do
+  puts "  Sending ACPI power button..."
+  run("curl -s --unix-socket #{WORKDIR}/ch-short.sock " \
+      "-X PUT http://localhost/api/v1/vm.power-button",
+    allow_failure: true)
+end
+
+log "Test B: SIGTERM (kill -TERM on CH process)"
+results << run_test("SIGTERM") do
+  pid = run("systemctl show -p MainPID --value #{UNIT_NAME}")
+  puts "  Sending SIGTERM to PID #{pid}..."
+  Process.kill("TERM", pid.to_i)
+end
+
+log "Test C: SIGKILL (kill -9 on CH process)"
+results << run_test("SIGKILL") do
+  pid = run("systemctl show -p MainPID --value #{UNIT_NAME}")
+  puts "  Sending SIGKILL to PID #{pid}..."
+  Process.kill("KILL", pid.to_i)
+end
+
+# ── Summary ───────────────────────────────────────────────
+
+log "Summary"
+
+puts <<~TABLE
+  | Test             | systemd Result | Journal grep match         |
+  |------------------|----------------|----------------------------|
+TABLE
+
+labels = ["ACPI Shutdown", "SIGTERM", "SIGKILL"]
+results.each_with_index do |r, i|
+  printf("  | %-16s | %-14s | %-26s |\n", labels[i], r[:result], r[:grep])
+end
+
+puts <<~ANALYSIS
+
+  Interpretation:
+  - "exit-code" means CH exited on its own AND ExecStop (ch-remote)
+    failed because the socket was already gone. This is the AMBIGUOUS
+    case — need journal grep to distinguish guest ACPI shutdown from
+    SIGTERM or other clean exits.
+  - "signal" means the process was forcibly killed (SIGKILL, OOM).
+    Unambiguous — always page-worthy.
+  - "success" would mean ExecStop (ch-remote shutdown-vmm) ran
+    successfully — i.e. an operator intentionally stopped the VM.
+    (Not tested here because systemctl stop runs ExecStop itself.)
+ANALYSIS
+
+# ── Cleanup ───────────────────────────────────────────────
+
+log "Cleanup"
+run("systemctl stop #{UNIT_NAME}", allow_failure: true)
+run("systemctl reset-failed #{UNIT_NAME}", allow_failure: true)
+run("rm -f /etc/systemd/system/#{UNIT_NAME}.service")
+run("systemctl daemon-reload")
+run("rm -f #{WORKDIR}/ch-short.sock")
+puts "  Unit removed. Image/binaries left in #{WORKDIR} for re-runs."
+puts "  To fully clean up: rm -rf #{WORKDIR}"

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -54,6 +54,7 @@
   <ul>
     <li><a href="/archived-record-by-id">Find Archived Record by ID</a></li>
     <li><a href="/vm-by-ipv4">Find VM by IPv4 Address</a></li>
+    <li><a href="/autoforme/Strand/search/1?prog=Vm%3A%3AMetal%3A%3ANexus&amp;label=unavailable">Show Unavailable VMs</a></li>
   </ul>
 
   <% if @info_pages.any? %>

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -15,6 +15,9 @@
 
   <% if strand || @obj.is_a?(Strand) %>
     <% strand ||= @obj %>
+    <% if @obj.is_a?(Strand) && strand.subject != strand %>
+      <a href="/model/<%= strand.subject.class %>/<%= strand.subject.ubid %>">Subject</a> |
+    <% end %>
     <%== form({action: "/model/Strand/#{strand.ubid}/schedule", method: :post}, button: "Schedule Strand to Run Now") %>
   <% end %>
 </div>

--- a/views/vm/settings.erb
+++ b/views/vm/settings.erb
@@ -16,7 +16,7 @@
   </div>
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <!-- Restart Card -->
-    <% if edit_perm %>
+    <% if edit_perm && !@vm.aws? %>
       <% if @vm.can_restart? %>
         <div class="px-4 py-5 sm:p-6">
           <% form(action: "#{path(@vm)}/restart", method: :post) do %>

--- a/views/vm/settings.erb
+++ b/views/vm/settings.erb
@@ -17,65 +17,31 @@
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <!-- Restart Card -->
     <% if edit_perm && !@vm.aws? %>
-      <% if @vm.can_restart? %>
-        <div class="px-4 py-5 sm:p-6">
-          <% form(action: "#{path(@vm)}/restart", method: :post) do %>
-            <div class="sm:flex sm:items-center sm:justify-between">
-              <div>
-                <h3 class="text-base font-semibold leading-6 text-gray-900">Restart virtual machine</h3>
-                <div class="mt-2 text-sm text-gray-500">
-                  <p>This action will restart the virtual machine, causing it to be temporarily offline.</p>
+      <% [
+          ["restart", "This action will restart the virtual machine, causing it to be temporarily offline."],
+          ["start", "This action will start the virtual machine if it is currently stopped."],
+          ["stop", "This action will stop the virtual machine, causing it to be offline until it is started. Note that stopped VMs still accrue billing charges. To stop billing charges, delete the VM."]
+        ].each do |action, message| %>
+        <% if @vm.send(:"can_#{action}?") %>
+          <div class="px-4 py-5 sm:p-6">
+            <% form(action: "#{path(@vm)}/#{action}", method: :post) do %>
+              <div class="sm:flex sm:items-center sm:justify-between">
+                <div>
+                  <h3 class="text-base font-semibold leading-6 text-gray-900"><%= action.capitalize %>
+                    virtual machine</h3>
+                  <div class="mt-2 text-sm text-gray-500">
+                    <p><%= message %></p>
+                  </div>
+                </div>
+                <div id="vm-<%= action %>-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+                  <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                    <%== part("components/form/submit_button", text: action.capitalize, extra_class: "#{action}-btn") %>
+                  </div>
                 </div>
               </div>
-              <div id="vm-restart-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-                <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
-                  <%== part("components/form/submit_button", text: "Restart", extra_class: "restart-btn") %>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-
-      <% if @vm.can_start? %>
-        <div class="px-4 py-5 sm:p-6">
-          <% form(action: "#{path(@vm)}/start", method: :post) do %>
-            <div class="sm:flex sm:items-center sm:justify-between">
-              <div>
-                <h3 class="text-base font-semibold leading-6 text-gray-900">Start virtual machine</h3>
-                <div class="mt-2 text-sm text-gray-500">
-                  <p>This action will start the virtual machine if it is currently stopped.</p>
-                </div>
-              </div>
-              <div id="vm-restart-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-                <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
-                  <%== part("components/form/submit_button", text: "Start", extra_class: "start-btn") %>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-
-      <% if @vm.can_stop? %>
-        <div class="px-4 py-5 sm:p-6">
-          <% form(action: "#{path(@vm)}/stop", method: :post) do %>
-            <div class="sm:flex sm:items-center sm:justify-between">
-              <div>
-                <h3 class="text-base font-semibold leading-6 text-gray-900">Stop virtual machine</h3>
-                <div class="mt-2 text-sm text-gray-500">
-                  <p>This action will stop the virtual machine, causing it to be offline until it is started. Note that
-                    stopped VMs still accrue billing charges. To stop billing charges, delete the VM.</p>
-                </div>
-              </div>
-              <div id="vm-restart-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-                <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
-                  <%== part("components/form/submit_button", text: "Stop", extra_class: "stop-btn") %>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        </div>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
     <!-- Delete Card -->

--- a/views/vm/settings.erb
+++ b/views/vm/settings.erb
@@ -34,6 +34,43 @@
           </div>
         <% end %>
       </div>
+
+      <div class="px-4 py-5 sm:p-6">
+        <% form(action: "#{path(@vm)}/start", method: :post) do %>
+          <div class="sm:flex sm:items-center sm:justify-between">
+            <div>
+              <h3 class="text-base font-semibold leading-6 text-gray-900">Start virtual machine</h3>
+              <div class="mt-2 text-sm text-gray-500">
+                <p>This action will start the virtual machine if it is currently stopped.</p>
+              </div>
+            </div>
+            <div id="vm-restart-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+              <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                <%== part("components/form/submit_button", text: "Start", extra_class: "start-btn") %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="px-4 py-5 sm:p-6">
+        <% form(action: "#{path(@vm)}/stop", method: :post) do %>
+          <div class="sm:flex sm:items-center sm:justify-between">
+            <div>
+              <h3 class="text-base font-semibold leading-6 text-gray-900">Stop virtual machine</h3>
+              <div class="mt-2 text-sm text-gray-500">
+                <p>This action will stop the virtual machine, causing it to be offline until it is started. Note that
+                  stopped VMs still accrue billing charges. To stop billing charges, delete the VM.</p>
+              </div>
+            </div>
+            <div id="vm-restart-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+              <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                <%== part("components/form/submit_button", text: "Stop", extra_class: "stop-btn") %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
     <% end %>
     <!-- Delete Card -->
     <% if has_permission?("Vm:delete", @vm) %>

--- a/views/vm/settings.erb
+++ b/views/vm/settings.erb
@@ -17,60 +17,66 @@
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <!-- Restart Card -->
     <% if edit_perm %>
-      <div class="px-4 py-5 sm:p-6">
-        <% form(action: "#{path(@vm)}/restart", method: :post) do %>
-          <div class="sm:flex sm:items-center sm:justify-between">
-            <div>
-              <h3 class="text-base font-semibold leading-6 text-gray-900">Restart virtual machine</h3>
-              <div class="mt-2 text-sm text-gray-500">
-                <p>This action will restart the virtual machine, causing it to be temporarily offline.</p>
+      <% if @vm.can_restart? %>
+        <div class="px-4 py-5 sm:p-6">
+          <% form(action: "#{path(@vm)}/restart", method: :post) do %>
+            <div class="sm:flex sm:items-center sm:justify-between">
+              <div>
+                <h3 class="text-base font-semibold leading-6 text-gray-900">Restart virtual machine</h3>
+                <div class="mt-2 text-sm text-gray-500">
+                  <p>This action will restart the virtual machine, causing it to be temporarily offline.</p>
+                </div>
+              </div>
+              <div id="vm-restart-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+                <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                  <%== part("components/form/submit_button", text: "Restart", extra_class: "restart-btn") %>
+                </div>
               </div>
             </div>
-            <div id="vm-restart-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-              <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
-                <%== part("components/form/submit_button", text: "Restart", extra_class: "restart-btn") %>
-              </div>
-            </div>
-          </div>
-        <% end %>
-      </div>
+          <% end %>
+        </div>
+      <% end %>
 
-      <div class="px-4 py-5 sm:p-6">
-        <% form(action: "#{path(@vm)}/start", method: :post) do %>
-          <div class="sm:flex sm:items-center sm:justify-between">
-            <div>
-              <h3 class="text-base font-semibold leading-6 text-gray-900">Start virtual machine</h3>
-              <div class="mt-2 text-sm text-gray-500">
-                <p>This action will start the virtual machine if it is currently stopped.</p>
+      <% if @vm.can_start? %>
+        <div class="px-4 py-5 sm:p-6">
+          <% form(action: "#{path(@vm)}/start", method: :post) do %>
+            <div class="sm:flex sm:items-center sm:justify-between">
+              <div>
+                <h3 class="text-base font-semibold leading-6 text-gray-900">Start virtual machine</h3>
+                <div class="mt-2 text-sm text-gray-500">
+                  <p>This action will start the virtual machine if it is currently stopped.</p>
+                </div>
+              </div>
+              <div id="vm-restart-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+                <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                  <%== part("components/form/submit_button", text: "Start", extra_class: "start-btn") %>
+                </div>
               </div>
             </div>
-            <div id="vm-restart-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-              <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
-                <%== part("components/form/submit_button", text: "Start", extra_class: "start-btn") %>
-              </div>
-            </div>
-          </div>
-        <% end %>
-      </div>
+          <% end %>
+        </div>
+      <% end %>
 
-      <div class="px-4 py-5 sm:p-6">
-        <% form(action: "#{path(@vm)}/stop", method: :post) do %>
-          <div class="sm:flex sm:items-center sm:justify-between">
-            <div>
-              <h3 class="text-base font-semibold leading-6 text-gray-900">Stop virtual machine</h3>
-              <div class="mt-2 text-sm text-gray-500">
-                <p>This action will stop the virtual machine, causing it to be offline until it is started. Note that
-                  stopped VMs still accrue billing charges. To stop billing charges, delete the VM.</p>
+      <% if @vm.can_stop? %>
+        <div class="px-4 py-5 sm:p-6">
+          <% form(action: "#{path(@vm)}/stop", method: :post) do %>
+            <div class="sm:flex sm:items-center sm:justify-between">
+              <div>
+                <h3 class="text-base font-semibold leading-6 text-gray-900">Stop virtual machine</h3>
+                <div class="mt-2 text-sm text-gray-500">
+                  <p>This action will stop the virtual machine, causing it to be offline until it is started. Note that
+                    stopped VMs still accrue billing charges. To stop billing charges, delete the VM.</p>
+                </div>
+              </div>
+              <div id="vm-restart-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+                <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
+                  <%== part("components/form/submit_button", text: "Stop", extra_class: "stop-btn") %>
+                </div>
               </div>
             </div>
-            <div id="vm-restart-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
-              <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
-                <%== part("components/form/submit_button", text: "Stop", extra_class: "stop-btn") %>
-              </div>
-            </div>
-          </div>
-        <% end %>
-      </div>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
     <!-- Delete Card -->
     <% if has_permission?("Vm:delete", @vm) %>

--- a/vm_exit_reason.rb
+++ b/vm_exit_reason.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+# Sketch: VM exit reason detection for Metal::Nexus
+#
+# This module provides vm_exit_reason and a replacement unavailable
+# label that uses it. Intended to be integrated into
+# Prog::Vm::Metal::Nexus.
+#
+# ## Experimental results (2026-01-30)
+#
+# Tested on Ubuntu 24.04 with cloud-hypervisor v50, using a
+# persistent systemd unit with ExecStop=ch-remote shutdown-vmm
+# (matching production). Key finding: when the CH main process
+# exits on its own, systemd runs ExecStop, which fails because
+# the API socket is already gone. This makes Result="exit-code"
+# the common case for all self-exits, not Result="success".
+#
+#   | Cause              | systemd Result | Journal grep match         |
+#   |--------------------|----------------|----------------------------|
+#   | Guest ACPI shutdown| exit-code      | "ACPI Shutdown signalled"  |
+#   | SIGTERM (direct)   | exit-code      | (no match)                 |
+#   | SIGKILL / OOM      | signal         | (no CH log output)         |
+#   | systemctl stop     | success        | (ExecStop ran cleanly)     |
+#
+# The original sketch assumed Result="success" was the ambiguous
+# case needing journal disambiguation. In practice, "exit-code"
+# is the ambiguous one. "signal" is unambiguous (forcible kill).
+# "success" means ExecStop worked (orderly operator-initiated
+# shutdown via ch-remote).
+#
+# To reproduce these results, see companion script:
+#   test_vm_exit_reason.rb
+
+module VmExitReason
+  # Unambiguous systemd Result values that need no journal check.
+  # These indicate the process was forcibly terminated (not a
+  # clean exit), so we always page.
+  FORCIBLE_RESULTS = %w[signal core-dump oom-kill timeout].freeze
+
+  # Queries systemd and (for the ambiguous exit-code case) CH's
+  # own journald output to classify why the VM unit stopped.
+  #
+  # systemd's Result property reflects how the unit ended:
+  #
+  #   "success"    — ExecStop ran and succeeded. In production
+  #                  this means ch-remote shutdown-vmm worked,
+  #                  i.e. an operator or automation stopped the
+  #                  VM intentionally.
+  #
+  #   "exit-code"  — The main process exited on its own (any
+  #                  exit code) AND ExecStop failed (because the
+  #                  CH socket was already gone). This is the
+  #                  ambiguous case: could be guest ACPI shutdown,
+  #                  SIGTERM caught by CH, or any other clean exit.
+  #
+  #   "signal"     — Process killed by signal (SIGKILL, OOM, etc.)
+  #   "core-dump"  — Process dumped core.
+  #   "oom-kill"   — Killed by OOM.
+  #   "timeout"    — ExecStop timed out.
+  #
+  # For "exit-code" we check CH's journal output to disambiguate.
+  # Cloud-hypervisor logs a distinctive line before each exit path.
+  # The grep uses -m1 (first match) and -F (fixed strings). The
+  # match strings come from CH source (stable across shipped
+  # versions). To find them:
+  #
+  #   grep -n 'exit_evt.write' vmm/src/**/*.rs devices/src/**/*.rs
+  #
+  # and check the log line before each call site. As of v50:
+  #
+  #   "ACPI Shutdown signalled"  — devices/src/acpi.rs  (guest S5)
+  #   "vCPU thread panicked"     — vmm/src/cpu.rs       (catch_unwind)
+  #   "VCPU generated error"     — vmm/src/cpu.rs       (hypervisor err)
+  #   "thread panicked"          — vmm/src/lib.rs et al (any thread)
+  #
+  def vm_exit_reason
+    result, invocation_id = host.sshable.cmd(
+      "systemctl show -p Result -p InvocationID --value :vm_name", vm_name:
+    ).strip.split("\n")
+
+    # Orderly shutdown via ch-remote (operator/automation).
+    return {result:, reason: "operator-stop"} if result == "success"
+
+    # Forcible kill — no CH logs to check, always page-worthy.
+    return {result:, reason: result} if FORCIBLE_RESULTS.include?(result)
+
+    # "exit-code" (or any other unexpected value): CH exited on
+    # its own. Check journal to find out why.
+    reason = begin
+      host.sshable.cmd(
+        "journalctl _SYSTEMD_INVOCATION_ID=:invocation_id " \
+        "-o cat -n 50 --no-pager " \
+        "| grep -m1 -oF " \
+        "-e 'ACPI Shutdown signalled' " \
+        "-e 'vCPU thread panicked' " \
+        "-e 'VCPU generated error' " \
+        "-e 'thread panicked'",
+        vm_name:, invocation_id:
+      ).strip
+    rescue Sshable::SshError
+      # grep exit code 1 (no match) raises SshError.
+      nil
+    end
+
+    {result:, reason: reason || "clean-exit-unknown-cause"}
+  end
+
+  # Replacement for the unavailable label in Prog::Vm::Metal::Nexus.
+  # Uses vm_exit_reason to decide whether to page or accept the stop.
+  #
+  # label def unavailable
+  #   when_start_after_host_reboot_set? do
+  #     incr_checkup
+  #     hop_start_after_host_reboot
+  #   end
+  #
+  #   begin
+  #     if available?
+  #       decr_checkup
+  #       Page.from_tag_parts("VmExit", vm.ubid)&.incr_resolve
+  #       hop_wait
+  #     else
+  #       exit_info = vm_exit_reason
+  #
+  #       case exit_info[:reason]
+  #       when "ACPI Shutdown signalled"
+  #         # Guest initiated shutdown (customer action). Log it,
+  #         # don't page, stop polling.
+  #         Clog.emit("VM stopped by guest ACPI shutdown",
+  #           {vm_exit: {vm: vm.ubid, **exit_info}})
+  #         decr_checkup
+  #         # Transition to stopped so the strand doesn't keep
+  #         # polling. The customer can use the "start" action to
+  #         # bring the VM back up.
+  #         incr_stop
+  #         hop_stopped
+  #       when "operator-stop"
+  #         # ExecStop succeeded — someone ran systemctl stop or
+  #         # ch-remote shutdown-vmm. This is intentional; don't
+  #         # page.
+  #         Clog.emit("VM stopped by operator",
+  #           {vm_exit: {vm: vm.ubid, **exit_info}})
+  #         decr_checkup
+  #         incr_stop
+  #         hop_stopped
+  #       else
+  #         # Unexpected exit: signal, crash, unknown cause.
+  #         # Page with the reason in the summary.
+  #         Prog::PageNexus.assemble(
+  #           "#{vm.ubid} stopped unexpectedly (#{exit_info[:reason]})",
+  #           ["VmExit", vm.ubid], vm.ubid,
+  #           extra_data: {vm_host: host.ubid, **exit_info}
+  #         )
+  #       end
+  #     end
+  #   rescue Sshable::SshError
+  #     # Host unreachable — will be handled by HostNexus.
+  #   end
+  #
+  #   nap 30
+  # end
+end


### PR DESCRIPTION
This is not intended to be merged, but I know of no better way to collate comments on something like this than a PR.

The general idea here is to tell apart when a guest vm exits on its own accord, versus abnormal situations worthy of paging us.

Included are two files: a shell-script-like test file, `test_vm_exit_reason.rb`, that models systemd status outputs and so on, which is used as a context-primer to build the implementation sketch file, `vm_exit_reason.rb`. the latter was not tested in integration, but it's not quite a one-shot either, I did several rounds of correcting design (for example: invocation_id was not something claude found, I thought out the unnecessary pathology of omitting it).

I also had it do significant source diving and offered several meaningful corrections in deriving the `vm_exit_reason.rb` sketch you see within. So it was a bit of an effort, but hopefully better than "yeah I guess we should grep some strings huh?" 