### PR TITLE
Avoid use of Sequel.asc

### DIFF
--- a/prog/dns_zone/dns_zone_nexus.rb
+++ b/prog/dns_zone/dns_zone_nexus.rb
@@ -26,7 +26,7 @@ class Prog::DnsZone::DnsZoneNexus < Prog::Base
       records_to_rectify = dns_zone.records_dataset
         .left_join(:seen_dns_records_by_dns_servers, dns_record_id: :id, dns_server_id: dns_server.id)
         .where(Sequel[:seen_dns_records_by_dns_servers][:dns_record_id] => nil)
-        .order(Sequel.asc(:created_at)).all
+        .order(:created_at).all
 
       next if records_to_rectify.empty?
 

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -491,7 +491,7 @@ module Scheduling::Allocator
       # select the cpuset for the new slice
       cpus = VmHostCpu
         .where(vm_host_id:, spdk: false, vm_host_slice_id: nil)
-        .order_by(Sequel.asc(:cpu_number))
+        .order_by(:cpu_number)
         .limit(n)
         .map(&:cpu_number)
 


### PR DESCRIPTION
This is unnecessary, as ASC is the default and doesn't need to be specified explicitly.