### PR TITLE
Fix nondeterministic Prog::DnsZone::DnsZoneNexus test failure

### DIFF
--- a/spec/prog/dns_zone/dns_zone_nexus_spec.rb
+++ b/spec/prog/dns_zone/dns_zone_nexus_spec.rb
@@ -69,6 +69,7 @@ zone-commit postgres.ubicloud.com
 COMMANDS
 
       expect(sshable).to receive(:_cmd).with("sudo -u knot knotc", stdin: expected_commands.chomp).and_return("OK\nOK\nOK\nOK\nOK")
+      DnsRecord.where(data: "5.6.7.8").update(created_at: Time.now - 60)
       expect { nx.refresh_dns_servers }.to hop("wait")
     end
 


### PR DESCRIPTION
This is ordered by created_at, and the created_at for all entries in the tests is the same. Modify the created_at for one of the records for a deterministic result.