### PR TITLE
Consistently require spec_helper in the specs

### DIFF
--- a/spec/lib/option_spec.rb
+++ b/spec/lib/option_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "rspec"
-require_relative "../../lib/option"
+require_relative "../spec_helper"
 
 RSpec.describe Option do
   describe "#VmSize options" do

--- a/spec/lib/util_spec.rb
+++ b/spec/lib/util_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "rspec"
-require_relative "../../lib/util"
+require_relative "../spec_helper"
 
 RSpec.describe Util do
   describe "#rootish_ssh" do

--- a/spec/model/storage_device_spec.rb
+++ b/spec/model/storage_device_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/system_parser"
-require "rspec"
+require_relative "spec_helper"
 
 RSpec.describe StorageDevice do
   describe "#migrate_device_name_to_device_id" do


### PR DESCRIPTION
These are the only specs that required rspec and the related files directly.