### PR TITLE
Run metal and AWS E2E tests in parallel

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,12 +22,33 @@ on:
     - cron:  '0 */2 * * *'
 
 jobs:
-  run-ci:
+  setup:
     if: vars.RUN_E2E == 'true'
+    runs-on: ubuntu-slim
+    outputs:
+      providers: ${{ steps.set-providers.outputs.providers }}
+    steps:
+      - name: Set provider matrix
+        id: set-providers
+        run: |
+          providers="metal,aws"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.providers }}" ]]; then
+            providers="${{ inputs.providers }}"
+          fi
+          # Convert comma-separated list to JSON array
+          echo "providers=$(echo "$providers" | jq -Rc 'split(",")')" >> $GITHUB_OUTPUT
+
+  e2e:
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: ${{ fromJson(needs.setup.outputs.providers) }}
+    name: E2E - ${{ matrix.provider }}
     runs-on: ubicloud-standard-4
-    environment: E2E-CI
+    environment: E2E-${{ matrix.provider }}
     timeout-minutes: 85
-    concurrency: e2e_environment
+    concurrency: E2E-${{ matrix.provider }}
 
     steps:
     - name: Check out code
@@ -65,16 +86,12 @@ jobs:
 
     - name: Add e2e script to Procfile
       run: |
-        providers="metal,aws"
-        if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.providers }}" ]]; then
-          providers="${{ inputs.providers }}"
-        fi
         test_cases="$(yq -r '[.[] | select(.name != "postgres_upgrade") | .name] | join(",")' config/e2e_test_cases.yml)"
         if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.test_cases }}" ]]; then
           test_cases="${{ inputs.test_cases }}"
         fi
-        echo "Running e2e providers:$providers test cases:$test_cases"
-        echo "e2e: bin/e2e --providers=$providers --test-cases=$test_cases" >> Procfile
+        echo "Running e2e ${{ matrix.provider }} test cases:$test_cases"
+        echo "e2e: bin/e2e --provider=${{ matrix.provider }} --test-cases=$test_cases" >> Procfile
 
     - name: Run tests
       env:
@@ -136,7 +153,7 @@ jobs:
       run: grep -h -v -E "sleep_duration_sec|monitor.1" foreman.log
 
     - name: Extract image download time
-      if: always()
+      if: always() && matrix.provider == 'metal'
       id: extract_download
       run: |
         download_time="$(grep "VmHost.wait_download_boot_images" foreman.log | cut -d'|' -f2 | tail -1)"
@@ -182,7 +199,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v6
       with:
-        name: e2e-${{ github.run_id }}-logs
+        name: e2e-${{ matrix.provider }}-${{ github.run_id }}-logs
         path: foreman.log
 
     - name: Dump PostgreSQL database
@@ -227,7 +244,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v6
       with:
-        name: e2e-${{ github.run_id }}-db-dump
+        name: e2e-${{ matrix.provider }}-${{ github.run_id }}-db-dump
         path: clover_test_dump.sql
 
     - name: Send notification if failed
@@ -244,9 +261,9 @@ jobs:
                 - title: "Event"
                   short: true
                   value: "${{ github.event_name }}"
-                - title: "Reference"
+                - title: "Provider"
                   short: true
-                  value: "<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.ref_name }}>"
+                  value: "${{ matrix.provider }}"
                 - title: "Action"
                   short: true
                   value: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
@@ -258,7 +275,7 @@ jobs:
                   value: "${{ steps.extract_last.outputs.LAST_LINE }}"
 
     - name: Cleanup AWS resources
-      if: always()
+      if: always() && matrix.provider == 'aws'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.E2E_AWS_ACCESS_KEY }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.E2E_AWS_SECRET_KEY }}

--- a/bin/e2e
+++ b/bin/e2e
@@ -9,12 +9,7 @@ require "optparse"
 
 def main(options)
   test_cases = YAML.load_file("config/e2e_test_cases.yml").to_h { [it["name"], it] }
-
-  ["metal", "aws"].each do |provider|
-    next unless options[:providers].include?(provider)
-    puts "Starting #{provider} tests"
-    send("test_#{provider}", options, test_cases)
-  end
+  send("test_#{options[:provider]}", options, test_cases)
 end
 
 def test_metal(options, test_cases)
@@ -126,7 +121,7 @@ end
 options = {test_cases: ["vm"]}
 OptionParser.new do |opts|
   opts.on("--vm-host-id VM_HOST_ID", "Use existing vm host") { |v| options[:vm_host_id] = (v.length == 26) ? UBID.to_uuid(v) : v }
-  opts.on("--providers PROVIDERS", Array, "List of providers to run separated by comma") { |v| options[:providers] = v }
+  opts.on("--provider PROVIDER", String, "Provider to run tests on (metal, aws)") { |v| options[:provider] = v }
   opts.on("--test-cases TEST_CASES", Array, "List of test cases to run separated by comma") { |v| options[:test_cases] = v }
 end.parse!
 

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Prog::Test::GithubRunner do
     it "triggers test runs" do
       allow(ENV).to receive(:[]).and_call_original
       expect(ENV).to receive(:[]).with("GITHUB_RUN_ID").and_return("12345")
-      expect(client).to receive(:post).with("repos/tahcloud/github-e2e-tests/actions/workflows/test_2204.yml/dispatches", {ref: "main", inputs: {triggered_by: "12345"}}).and_return({workflow_run_id: 123456789})
+      expect(client).to receive(:post).with("repos/tahcloud/github-e2e-tests-metal/actions/workflows/test_2204.yml/dispatches", {ref: "main", inputs: {triggered_by: "12345"}}).and_return({workflow_run_id: 123456789})
       expect(gr_test).to receive(:sleep).with(30)
       expect { gr_test.trigger_test_runs }.to hop("check_test_runs")
     end
@@ -76,55 +76,55 @@ RSpec.describe Prog::Test::GithubRunner do
     it "can not triggers test runs" do
       allow(ENV).to receive(:[]).and_call_original
       expect(ENV).to receive(:[]).with("GITHUB_RUN_ID").and_return("12345")
-      expect(client).to receive(:post).with("repos/tahcloud/github-e2e-tests/actions/workflows/test_2204.yml/dispatches", {ref: "main", inputs: {triggered_by: "12345"}}).and_return(false)
+      expect(client).to receive(:post).with("repos/tahcloud/github-e2e-tests-metal/actions/workflows/test_2204.yml/dispatches", {ref: "main", inputs: {triggered_by: "12345"}}).and_return(false)
       expect { gr_test.trigger_test_runs }.to hop("clean_resources")
     end
   end
 
   describe "#check_test_runs" do
     it "check test runs completed" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "success", created_at: Time.now + 10}]})
+      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "success", created_at: Time.now + 10}]})
       expect { gr_test.check_test_runs }.to hop("clean_resources")
     end
 
     it "check test runs completed for alien runners" do
       expect(gr_test).to receive(:frame).and_return(gr_test.frame.merge({"github_runner_aws_location_id" => "c4cf8b4c-70ec-8820-b311-13284f205306"})).at_least(:once)
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "success", created_at: Time.now + 10}]})
+      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "success", created_at: Time.now + 10}]})
       expect { gr_test.check_test_runs }.to hop("clean_resources")
     end
 
     it "check test runs in progress with nil" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: nil, created_at: Time.now + 10}]})
+      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: nil, created_at: Time.now + 10}]})
       expect { gr_test.check_test_runs }.to nap(15)
     end
 
     it "check test runs in progress state" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "in_progress", created_at: Time.now + 10}]})
+      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "in_progress", created_at: Time.now + 10}]})
       expect { gr_test.check_test_runs }.to nap(15)
     end
 
     it "check test runs failed" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "failure", created_at: Time.now + 10}]})
+      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "failure", created_at: Time.now + 10}]})
       expect { gr_test.check_test_runs }.to hop("clean_resources")
     end
 
     it "check test runs created before" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "failure", created_at: Time.now - 2 * 60 * 60}]})
+      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "failure", created_at: Time.now - 2 * 60 * 60}]})
       expect { gr_test.check_test_runs }.to hop("clean_resources")
     end
   end
 
   describe "#clean_resources" do
     it "waits runners to finish their jobs" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
-      expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests", 10)
+      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
+      expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests-metal", 10)
       GithubRunner.create(repository_name: "test-repo", label: "ubicloud")
       expect { gr_test.clean_resources }.to nap(15)
     end
 
     it "waits vm pools to be destroyed" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
-      expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests", 10)
+      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
+      expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests-metal", 10)
       pool = Prog::Vm::VmPool.assemble(size: 1, vm_size: "standard-2", location_id: Location::HETZNER_FSN1_ID, boot_image: "github-ubuntu-2204", storage_size_gib: 86, storage_encrypted: true,
         storage_skip_sync: false, arch: "x64").subject
       expect(VmPool).to receive(:[]).and_return(pool)
@@ -132,8 +132,8 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "waits repositories to be destroyed" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
-      expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests", 10)
+      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
+      expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests-metal", 10)
       installation = GithubInstallation.create(installation_id: 123, name: "test-user", type: "User")
       repo = Prog::Github::GithubRepositoryNexus.assemble(installation, "ubicloud/ubicloud", "master").subject
       expect { gr_test.clean_resources }.to nap(15)
@@ -141,8 +141,8 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources and hop finish" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
-      expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests", 10)
+      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
+      expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests-metal", 10)
       expect(GithubRunner).to receive(:any?).and_return(false)
       expect(VmPool).to receive(:[]).with(anything).and_return(instance_double(VmPool, vms: [], incr_destroy: nil))
       expect(Project).to receive(:[]).with(anything).and_return(instance_double(Project, destroy: nil)).at_least(:once)
@@ -150,17 +150,18 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources and hop failed" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
-      expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests", 10)
+      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
+      expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests-metal", 10)
       expect(GithubRunner).to receive(:any?).and_return(false)
       expect(VmPool).to receive(:[]).with(anything).and_return(instance_double(VmPool, vms: [instance_double(Vm)], incr_destroy: nil))
       expect(Project).to receive(:[]).with(anything).and_return(nil).at_least(:once)
-      expect(gr_test).to receive(:frame).and_return({"fail_message" => "Failed test", "test_cases" => gr_test.frame["test_cases"]}).at_least(:once)
+      refresh_frame(gr_test, new_values: {"fail_message" => "Failed test"})
+      # expect(gr_test).to receive(:frame).and_return({"fail_message" => "Failed test", "test_cases" => gr_test.frame["test_cases"]}).at_least(:once)
       expect { gr_test.clean_resources }.to hop("failed")
     end
 
     it "cleans resources already cancelled" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
+      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
       expect(client).to receive(:cancel_workflow_run).and_raise(StandardError)
       expect(GithubRunner).to receive(:any?).and_return(true)
       expect { gr_test.clean_resources }.to nap(15)


### PR DESCRIPTION
As we introduce new tests, the overall E2E runtime keeps increasing. To mitigate this, we can run the metal and aws E2E tests in parallel.

The biggest challenge here is runner tests. Since they share the same GitHub App, it’s not possible to run them in parallel within the same repository.

To solve this, I created two separate GitHub Apps (e2e-test-app-metal, e2e-test-app-aws) and two repositories (tahcloud/github-e2e-tests-metal, tahcloud/github-e2e-tests-aws) so the tests can run in parallel.

I added configurations for these into two separate environments in this repository (E2E-metal, E2E-aws). Each job uses its own environment to access the correct secrets.

The changes in the runner test prog are a bit ugly. I have another branch to simplify it.

Previously, when we ran the tests serially, if the metal tests failed, the AWS tests wouldn’t even start. Now, even if the metal tests are broken, we can still see the AWS results.

Since most of the time is spent on the metal tests, they take ~56m, while the AWS tests take ~8m. This doesn’t significantly affect the overall runtime, but it gives us ~48m of free time to add more tests for the AWS provider.