### PR TITLE
Fix invoice ID lookup

### DIFF
--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -169,7 +169,7 @@ class Clover
       end
 
       r.on "invoice", ["current", :ubid_uuid] do |id|
-        next unless (invoice = (id == "current") ? @project.current_invoice : @project.invoices_dataset.with_pk(:id))
+        next unless (invoice = (id == "current") ? @project.current_invoice : @project.invoices_dataset.with_pk(id))
 
         r.get true do
           if invoice.status == "current"


### PR DESCRIPTION
We are passing the `:id` symbol instead of the `id` variable. Since project invoices are ordered by creation date, this caused the query to always return the most recent invoice, regardless of the ID provided.

As a result, customers saw the same invoice when clicking on any invoice in the console.