### PR TITLE
Add VM host and runner context to cache proxy error logs

### DIFF
--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -811,8 +811,8 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
         TOKEN=$(curl -m 10 -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         curl -m 10 -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
       COMMAND
-      expect(vm.sshable).to receive(:_cmd).with("sudo cat /var/log/cacheproxy.log", log: false).and_return("Received request - method: GET urlPath: foo\nReceived request - method: GET urlPath: foo\nGetCacheEntry  request failed with status code: 204\n")
-      expect(Clog).not_to receive(:emit).with("Cache proxy error", Hash)
+      expect(vm.sshable).to receive(:_cmd).with("sudo cat /var/log/cacheproxy.log", log: false).and_return("Received request - method: GET urlPath: foo\nReserveCache request failed with status code: 409\n")
+      expect(Clog).to receive(:emit).with("Cache proxy error", {cache_proxy_error: {count: 1, message: "ReserveCache request failed with status code: 409", label: "ubicloud-standard-4", repository_name: "test-repo", conclusion: nil, vm_host_ubid: nil, data_center: nil}})
 
       nx.collect_final_telemetry
     end
@@ -826,7 +826,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
         curl -m 10 -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
       COMMAND
       expect(vm.sshable).to receive(:_cmd).with("sudo cat /var/log/cacheproxy.log", log: false).and_return("Received request - method: GET urlPath: foo\nReserveCache request failed with status code: 409\n")
-      expect(Clog).to receive(:emit).with("Cache proxy error", {cache_proxy_error: {count: 1, message: "ReserveCache request failed with status code: 409"}})
+      expect(Clog).to receive(:emit).with("Cache proxy error", {cache_proxy_error: {count: 1, message: "ReserveCache request failed with status code: 409", label: "ubicloud-standard-4", repository_name: "test-repo", conclusion: "failure", vm_host_ubid: vm.vm_host.ubid, data_center: "FSN1-DC8"}})
 
       nx.collect_final_telemetry
     end
@@ -841,7 +841,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       COMMAND
       expect(vm.sshable).to receive(:_cmd).with("sudo cat /var/log/cacheproxy.log", log: false).and_return("Received request - method: GET urlPath: foo\nReserveCache request failed with status code: 409\n")
 
-      expect(Clog).to receive(:emit).with("Cache proxy error", {cache_proxy_error: {count: 1, message: "ReserveCache request failed with status code: 409"}})
+      expect(Clog).to receive(:emit).with("Cache proxy error", {cache_proxy_error: {count: 1, message: "ReserveCache request failed with status code: 409", label: "ubicloud-standard-4", repository_name: "test-repo", conclusion: nil, vm_host_ubid: vm.vm_host.ubid, data_center: "FSN1-DC8"}})
 
       nx.collect_final_telemetry
     end
@@ -867,9 +867,9 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
       LOG
 
-      expect(Clog).to receive(:emit).with("Cache proxy error", {cache_proxy_error: {count: 2, message: "ReserveCache request failed with status code: 409"}})
-      expect(Clog).to receive(:emit).with("Cache proxy error", {cache_proxy_error: {count: 1, message: "Error copying response: readfrom tcp 10_163_176_47:51123->10_163_176_47:46162: context canceled"}})
-      expect(Clog).to receive(:emit).with("Cache proxy error", {cache_proxy_error: {count: 1, message: "PUT request failed with status code: 500"}})
+      expect(Clog).to receive(:emit).with("Cache proxy error", {cache_proxy_error: {count: 2, message: "ReserveCache request failed with status code: 409", label: "ubicloud-standard-4", repository_name: "test-repo", conclusion: "success", vm_host_ubid: vm.vm_host.ubid, data_center: "FSN1-DC8"}})
+      expect(Clog).to receive(:emit).with("Cache proxy error", {cache_proxy_error: {count: 1, message: "Error copying response: readfrom tcp 10_163_176_47:51123->10_163_176_47:46162: context canceled", label: "ubicloud-standard-4", repository_name: "test-repo", conclusion: "success", vm_host_ubid: vm.vm_host.ubid, data_center: "FSN1-DC8"}})
+      expect(Clog).to receive(:emit).with("Cache proxy error", {cache_proxy_error: {count: 1, message: "PUT request failed with status code: 500", label: "ubicloud-standard-4", repository_name: "test-repo", conclusion: "success", vm_host_ubid: vm.vm_host.ubid, data_center: "FSN1-DC8"}})
 
       nx.collect_final_telemetry
     end


### PR DESCRIPTION
These additional properties help correlate cache proxy errors with specific VM hosts or datacenters, making it easier to identify infrastructure-related issues.