### PR TITLE
Disable RSpec/ExpectChange cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,9 @@ Layout/EmptyLinesAroundMethodBody:
 Lint/UnderscorePrefixedVariableName:
   Enabled: false
 
+RSpec/ExpectChange:
+  Enabled: false
+
 RSpec/AnyInstance:
   Enabled: false
 


### PR DESCRIPTION
It recommends changing:

```
change { nx.stop_set? }.from(false).to(true)
```

to:

```
change(nx, :stop_set?)
```

which loses the direction of the change.