### PR TITLE
Fix 2 N+1 query issues in Vm serializer detailed view

### DIFF
--- a/serializers/vm.rb
+++ b/serializers/vm.rb
@@ -17,7 +17,7 @@ class Serializers::Vm < Serializers::Base
 
     if options[:detailed]
       base.merge!(
-        firewalls: Serializers::Firewall.serialize(vm.firewalls, {include_path: true}),
+        firewalls: Serializers::Firewall.serialize(vm.firewalls(eager: [:location, :firewall_rules]), {include_path: true}),
         private_ipv4: vm.private_ipv4,
         private_ipv6: vm.private_ipv6,
         subnet: vm.nics.first.private_subnet.name,


### PR DESCRIPTION
In detailed view, the VM serialier includes firewall information, which results in N+1 queries to get the location and firewall rules for each firewall. Eager load those to fix the issue.