### PR TITLE
Revert "Use template1 database for control plane queries"

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -249,7 +249,7 @@ class PostgresServer < Sequel::Model
 
   def check_pulse(session:, previous_pulse:)
     reading = begin
-      session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, user: "postgres", database: "template1", connect_timeout: 4, keep_reference: false)
+      session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, user: "postgres", connect_timeout: 4, keep_reference: false)
       last_known_lsn = session[:db_connection].get(Sequel.function(lsn_function_name).as(:lsn))
       "up"
     rescue
@@ -307,7 +307,7 @@ class PostgresServer < Sequel::Model
   end
 
   private def _run_query(query)
-    vm.sshable.cmd("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d template1 -t --csv -v 'ON_ERROR_STOP=1'", stdin: query).chomp
+    vm.sshable.cmd("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: query).chomp
   end
 
   def export_metrics(session:, tsdb_client:)

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -513,7 +513,7 @@ RSpec.describe PostgresServer do
   end
 
   it "runs query on vm" do
-    expect(postgres_server.vm.sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d template1 -t --csv -v 'ON_ERROR_STOP=1'", stdin: "SELECT 1").and_return("1\n")
+    expect(postgres_server.vm.sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: "SELECT 1").and_return("1\n")
     expect(postgres_server.run_query("SELECT 1")).to eq("1")
   end
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
       fresh_nx = described_class.new(st)
       parent_sshable = fresh_nx.postgres_resource.parent.representative_server.vm.sshable
-      expect(parent_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d template1 -t --csv -v 'ON_ERROR_STOP=1'", hash_including(:stdin)).and_return("1234")
+      expect(parent_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", hash_including(:stdin)).and_return("1234")
 
       expect { fresh_nx.trigger_pg_current_xact_id_on_parent }.to exit({"msg" => "triggered pg_current_xact_id"})
     end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -744,7 +744,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "updates password and buds restart during the initial provisioning" do
       nx.incr_initial_provisioning
       expect(sshable).to receive(:_cmd).with(
-        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d template1 -t --csv -v 'ON_ERROR_STOP=1'",
+        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'",
         hash_including(stdin: password_update_sql_matcher)
       ).and_return("")
       expect(nx).to receive(:push).with(Prog::Postgres::Restart)
@@ -754,7 +754,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "updates password and hops to run_post_installation_script during initial provisioning if restart is already executed" do
       nx.incr_initial_provisioning
       expect(sshable).to receive(:_cmd).with(
-        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d template1 -t --csv -v 'ON_ERROR_STOP=1'",
+        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'",
         hash_including(stdin: password_update_sql_matcher)
       ).and_return("")
       nx.strand.update(retval: Sequel.pg_jsonb_wrap({"msg" => "postgres server is restarted"}))
@@ -767,7 +767,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
         /sudo apt-get install.*pg-analytics.*pg-search/m
       ).and_return("")
       expect(sshable).to receive(:_cmd).with(
-        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d template1 -t --csv -v 'ON_ERROR_STOP=1'",
+        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'",
         hash_including(stdin: password_update_sql_matcher)
       ).and_return("")
       nx.strand.update(retval: Sequel.pg_jsonb_wrap({"msg" => "postgres server is restarted"}))
@@ -777,7 +777,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "updates password and hops to wait at times other than the initial provisioning" do
       expect(sshable).to receive(:_cmd).with(
-        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d template1 -t --csv -v 'ON_ERROR_STOP=1'",
+        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'",
         hash_including(stdin: password_update_sql_matcher)
       ).and_return("")
       expect { nx.update_superuser_password }.to hop("wait")
@@ -788,7 +788,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "creates extensions for non-standard flavor and hops wait" do
       postgres_server.resource.update(flavor: PostgresResource::Flavor::PARADEDB)
       expect(sshable).to receive(:_cmd).with(
-        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d template1 -t --csv -v 'ON_ERROR_STOP=1'",
+        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'",
         hash_including(stdin: /CREATE EXTENSION IF NOT EXISTS pg_cron/)
       ).and_return("")
       expect { nx.run_post_installation_script }.to hop("wait")
@@ -841,13 +841,13 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "hops to wait if sync replication is established" do
-      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d template1 -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("quorum", "sync")
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("quorum", "sync")
       expect { standby_nx.wait_synchronization }.to hop("wait")
       expect { standby_nx.wait_synchronization }.to hop("wait")
     end
 
     it "naps if sync replication is not established" do
-      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d template1 -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("", "async")
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("", "async")
       expect { standby_nx.wait_synchronization }.to nap(30)
       expect { standby_nx.wait_synchronization }.to nap(30)
     end


### PR DESCRIPTION
This reverts commit 3d6ce22650b993c78a3d1a5b2767dfb9437ea234.

It turns out having a persistent connection to the template1 database causes issues while creating a new database out of it. I'll think of another solution for users dropping the postgres database.