### PR TITLE
Increase the length of PG init script

### DIFF
--- a/model/postgres/postgres_init_script.rb
+++ b/model/postgres/postgres_init_script.rb
@@ -7,7 +7,7 @@ class PostgresInitScript < Sequel::Model
 
   def validate
     super
-    validates_max_length(2000, :init_script)
+    validates_max_length(3000, :init_script)
   end
 end
 


### PR DESCRIPTION
Long script length is not very desirable, but we need to increase this temporarily to unblock users. 