### PR TITLE
Fix resize operation for databases with init_script

### DIFF
--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -60,7 +60,7 @@ class Clover
         target_storage_size_gib = typecast_params.pos_int("storage_size", pg.target_storage_size_gib)
         ha_type = typecast_params.nonempty_str("ha_type", pg.ha_type)
         tags = typecast_params.array(:Hash, "tags", pg.tags)
-        init_script = typecast_params.nonempty_str("init_script", pg.init_script)
+        init_script = typecast_params.nonempty_str("init_script") || pg.init_script&.init_script
 
         postgres_params = {
           "flavor" => pg.flavor,

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -55,7 +55,7 @@
   end
 
   if @project.get_ff_postgres_init_script
-    form_elements << {name: "init_script", type: "textarea", label: "Initialization Script", required: "", placeholder: "Enter script to run on database creation"}
+    form_elements << {name: "init_script", type: "textarea", label: "Initialization Script", placeholder: "Enter script to run on database creation"}
   end
 
   action = "#{@project.path}/postgres"


### PR DESCRIPTION
We missed one additional indirection of init_script. Because of that in the update call in below, we pass PostgresInitScript object instead of string, which causes the error.