### PR TITLE
Do not cc the support email for invoice failures

### DIFF
--- a/model/invoice.rb
+++ b/model/invoice.rb
@@ -181,7 +181,6 @@ class Invoice < Sequel::Model
     receivers = [data.billing_email]
     receivers += project.accounts.select { Authorization.has_permission?(project, it, "Project:billing", project) }.map(&:email)
     Util.send_email(receivers.uniq, "Urgent: Action Required to Prevent Service Disruption",
-      cc: Config.mail_from,
       greeting: "Dear #{data.billing_name},",
       body: ["We hope this message finds you well.",
         "We've noticed that your credit card on file has been declined with the following errors:",


### PR DESCRIPTION
Previously, cc’ing the support email was helpful for visibility when customers created support tickets about failed invoice payments.

However, now that we have an admin panel, anyone can easily check invoice statuses there.

We can remove the support email from cc on invoice failures, as it no longer adds value and mostly creates noise.