### PR TITLE
Add usage summary to GitHub runner dashboard

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -14,6 +14,8 @@ Octokit.configure do |c|
 end
 
 module Github
+  MINUTE_BILLING_RATE_IDS = BillingRate.from_resource_type("GitHubRunnerMinutes").map { it["id"] }.freeze
+
   def self.oauth_client
     Octokit::Client.new(client_id: Config.github_app_client_id, client_secret: Config.github_app_client_secret)
   end

--- a/model/billing_record.rb
+++ b/model/billing_record.rb
@@ -44,6 +44,14 @@ class BillingRecord < Sequel::Model
   def billing_rate
     @billing_rate ||= BillingRate.from_id(billing_rate_id)
   end
+
+  def self.total_amount_by_rate(project_id:, billing_rate_id:, begin_time:, end_time:)
+    where(project_id:, billing_rate_id:)
+      .where(Sequel.pg_range(:span).overlaps(begin_time...end_time))
+      .select_group(:billing_rate_id)
+      .select_append { sum(:amount).as(:total_amount) }
+      .to_hash(:billing_rate_id, :total_amount)
+  end
 end
 
 # Table: billing_record

--- a/model/project.rb
+++ b/model/project.rb
@@ -186,6 +186,11 @@ class Project < Sequel::Model
     ps || Prog::Vnet::SubnetNexus.assemble(id, name:, location_id:).subject
   end
 
+  def total_github_amount(begin_time, end_time)
+    BillingRecord.total_amount_by_rate(project_id: id, billing_rate_id: Github::MINUTE_BILLING_RATE_IDS, begin_time:, end_time:)
+      .sum { |billing_rate_id, total_amount| (total_amount * BillingRate.from_id(billing_rate_id)["unit_price"]) }
+  end
+
   def self.feature_flag(*flags, into: self)
     flags.map!(&:to_s).each do |flag|
       into.module_eval do

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -76,6 +76,15 @@ class Clover
             .reverse(Sequel[:github_runner][:created_at])
             .all
 
+          @requested_vcpus = @runners.sum { Github.runner_labels[it.label]["vcpus"] }
+          @allocated_vcpus = @runners.sum { it.vm&.allocated_at ? it.vm.vcpus : 0 }
+          date = Date.today
+          today_begin = date.to_time
+          today_end = (date + 1).to_time
+          last_30_day = (date - 29).to_time
+          @today_usage = @project.total_github_amount(today_begin, today_end)
+          @last_30_usage = @project.total_github_amount(last_30_day, today_end)
+
           view "github/runner"
         end
 

--- a/views/github/runner.erb
+++ b/views/github/runner.erb
@@ -4,6 +4,23 @@
 
 <%== render("github/tabbar") %>
 
+<dl id="current-usages" class="mb-5 grid grid-cols-1 gap-3 md:grid-cols-2 lg:gap-5 lg:grid-cols-4">
+  <% [
+    ["Allocated vCPU", @allocated_vcpus, "vCPU"],
+    ["Requested vCPU", @requested_vcpus, "vCPU"],
+    ["Today", money(@today_usage)],
+    ["Last 30 Days", money(@last_30_usage)]
+  ].each do |title, value, subtitle| %>
+    <div class="overflow-hidden rounded-lg bg-white p-3 shadow sm:p-4">
+      <dt class="text-base/6 font-medium text-gray-500"><%= title %></dt>
+      <dl class="mt-1 flex items-baseline gap-x-2 font-mono">
+        <span class="text-3xl font-semibold tracking-tight text-gray-900"><%= value %></span>
+        <span class="text-sm text-gray-500"><%= subtitle %></span>
+      </dl>
+    </div>
+  <% end %>
+</dl>
+
 <% if @installation.project.reputation == "limited" && !@installation.project.quota_available?("GithubRunnerVCpu", 0) %>
   <div class="mb-3 -mt-2 rounded-md bg-red-50 p-4 flex items-center gap-3">
     <%== part("components/icon", name: "hero-squares-plus", classes: "h-5 w-5 text-red-400") %>


### PR DESCRIPTION
  Users currently lack clear visibility into their runner usage and
  associated costs.
  
  This change adds a summary section to the GitHub runner dashboard that
  shows allocated vCPUs, requested vCPUs, today's cost, and the cost over
  the last 30 days.
  
  When customers have hundreds of runners, it's easy to lose track of how
  many vCPUs are allocated versus requested. Some customers already run
  over 1,000 vCPUs concurrently, but this effectively unlimited
  concurrency isn't visible or communicated anywhere today.
  
  It advertises our ability to support very high concurrency and scale
  beyond typical limits.
  
  While historical data would also be valuable, this is a good first step
  toward improving visibility.
  
<img width="3022" height="1298" alt="CleanShot 2026-02-06 at 23 23 56@2x" src="https://github.com/user-attachments/assets/c51b8938-d1e0-494e-b59e-3a9fcee7641e" />

