### PR TITLE
Fix nondeterministic dns zone modifiction in Prog::DnsZone::DnsZoneNexus

### DIFF
--- a/prog/dns_zone/dns_zone_nexus.rb
+++ b/prog/dns_zone/dns_zone_nexus.rb
@@ -26,7 +26,7 @@ class Prog::DnsZone::DnsZoneNexus < Prog::Base
       records_to_rectify = dns_zone.records_dataset
         .left_join(:seen_dns_records_by_dns_servers, dns_record_id: :id, dns_server_id: dns_server.id)
         .where(Sequel[:seen_dns_records_by_dns_servers][:dns_record_id] => nil)
-        .order(:created_at).all
+        .order(:created_at, Sequel.desc(:tombstoned)).all
 
       next if records_to_rectify.empty?
 

--- a/spec/prog/dns_zone/dns_zone_nexus_spec.rb
+++ b/spec/prog/dns_zone/dns_zone_nexus_spec.rb
@@ -74,7 +74,7 @@ COMMANDS
     end
 
     it "ignores unimportant errors" do
-      expect(sshable).to receive(:_cmd).and_return("no active transaction\nOK\nsuch record already exists in zone\nno such record in zone found\nOK")
+      expect(sshable).to receive(:_cmd).and_return("no active transaction\nOK\nno such record in zone found\nsuch record already exists in zone\nOK\n")
       expect { nx.refresh_dns_servers }.to hop("wait")
     end
 


### PR DESCRIPTION
For records with the same created_at, remove any tombstoned records before adding new records. Otherwise, we can add a record and then remove it.

Progs that both delete_record and insert_record in the same label (same transaction) use delete_record first, so the intent is to update the data for the record, not delete the record.