### PR TITLE
Refactor Nic locking for subnets while rekeying

### DIFF
--- a/model/metal/private_subnet.rb
+++ b/model/metal/private_subnet.rb
@@ -40,5 +40,18 @@ class PrivateSubnet < Sequel::Model
             .select(Sequel.case({subnet_id_1: :subnet_id_2}, :subnet_id_1, Sequel[:subnet][:id])),
           cycle: {columns: :id})
     end
+
+    def connected_leader_id
+      DB[:subnet]
+        .with_recursive(:subnet,
+          this.select(:id),
+          DB[:connected_subnet]
+            .join(:subnet, {id: [:subnet_id_1, :subnet_id_2]})
+            .select(Sequel.case({subnet_id_1: :subnet_id_2}, :subnet_id_1, Sequel[:subnet][:id])),
+          cycle: {columns: :id})
+        .exclude(:is_cycle)
+        .order(:id)
+        .get(:id)
+    end
   end
 end

--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -3,6 +3,10 @@
 class Prog::Vnet::Metal::SubnetNexus < Prog::Base
   subject_is :private_subnet
 
+  def before_run
+    super unless destroy_set? && !get_locked_nics_dataset.empty?
+  end
+
   def connected_leader
     @connected_leader ||= PrivateSubnet[private_subnet.connected_leader_id]
   end

--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -17,8 +17,13 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
 
   label def wait
     when_refresh_keys_set? do
-      private_subnet.update(state: "refreshing_keys")
       decr_refresh_keys
+      unless connected_leader?
+        connected_leader.incr_refresh_keys
+        nap 0
+      end
+
+      private_subnet.update(state: "refreshing_keys")
       hop_refresh_keys
     end
 

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -363,6 +363,50 @@ RSpec.describe PrivateSubnet do
       expect(ps1.all_nics.map(&:id)).to eq [ps1_nic.id]
     end
 
+    it ".connected_leader_id returns self for standalone subnet" do
+      expect(ps1.connected_leader_id).to eq ps1.id
+    end
+
+    it ".connected_leader_id returns smallest id among connected subnets" do
+      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
+      ps1.connect_subnet(ps2)
+
+      leader_id = [ps1.id, ps2.id].min
+      expect(ps1.connected_leader_id).to eq leader_id
+      expect(ps2.connected_leader_id).to eq leader_id
+    end
+
+    it ".connected_leader_id traverses transitive connections" do
+      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
+      ps3 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps3", location_id: Location::HETZNER_FSN1_ID).subject
+
+      ps1.connect_subnet(ps2)
+      ps2.connect_subnet(ps3)
+
+      leader_id = [ps1.id, ps2.id, ps3.id].min
+      expect(ps1.connected_leader_id).to eq leader_id
+      expect(ps2.connected_leader_id).to eq leader_id
+      expect(ps3.connected_leader_id).to eq leader_id
+    end
+
+    it ".connected_leader_id updates after mesh split" do
+      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
+      ps3 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps3", location_id: Location::HETZNER_FSN1_ID).subject
+
+      ps1.connect_subnet(ps2)
+      ps2.connect_subnet(ps3)
+
+      leader_before = [ps1.id, ps2.id, ps3.id].min
+      expect(ps1.connected_leader_id).to eq leader_before
+
+      ps2.disconnect_subnet(ps3)
+
+      # ps1-ps2 mesh has leader min(ps1, ps2)
+      expect(ps1.connected_leader_id).to eq [ps1.id, ps2.id].min
+      # ps3 is standalone, its own leader
+      expect(ps3.connected_leader_id).to eq ps3.id
+    end
+
     it "disconnect_subnet does not destroy in subnet tunnels" do
       ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
       ps1_nic = Prog::Vnet::NicNexus.assemble(ps1.id, name: "test-ps1-nic1").subject

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -89,6 +89,13 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       expect(vm.reload.update_firewall_rules_set?).to be true
     end
 
+    it "does not check periodic rekey when not the connected leader" do
+      ps.update(last_rekey_at: Time.now - 60 * 60 * 24 - 1)
+      expect(nx).to receive(:connected_leader?).and_return(false)
+      expect { nx.wait }.to nap(10 * 60)
+      expect(Semaphore.where(strand_id: ps.id, name: "refresh_keys").count).to eq(0)
+    end
+
     it "naps if nothing to do" do
       expect { nx.wait }.to nap(10 * 60)
     end
@@ -101,6 +108,13 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
     let(:nx) {
       described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "refresh_keys", id: ps.id))
     }
+
+    it "hops to wait if not the connected leader" do
+      expect(nx).to receive(:connected_leader?).and_return(false)
+      expect(Clog).to receive(:emit)
+      expect { nx.refresh_keys }.to hop("wait")
+      expect(Semaphore.where(strand_id: nx.private_subnet.id, name: "refresh_keys").count).to eq(1)
+    end
 
     it "refreshes keys and hops to wait_refresh_keys" do
       expect(nic.start_rekey_set?).to be false
@@ -126,6 +140,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
 
     it "naps if advisory lock cannot be acquired" do
       nic.update(state: "active")
+      expect(nx).to receive(:connected_leader?).and_return(true)
       expect(nx).to receive(:try_advisory_lock).and_return(false)
       expect { nx.refresh_keys }.to nap(10)
     end
@@ -205,6 +220,24 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       expect(nic.encryption_key).to be_nil
       expect(nic.rekey_payload).to be_nil
       expect(nic.lock_set?).to be false
+    end
+
+    it "updates last_rekey_at on all connected subnets" do
+      Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait", id: ps2.id)
+      ps.connect_subnet(ps2)
+      nic2 = Prog::Vnet::NicNexus.assemble(ps2.id, name: "b").subject.update(rekey_payload: {})
+
+      nx_with_both = described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait_old_state_drop", id: ps.id))
+      nx_with_both.update_stack_locked_nics([nic.id, nic2.id])
+
+      nic.strand.update(label: "wait")
+      nic2.strand.update(label: "wait")
+      ps.update(last_rekey_at: Time.now - 100)
+      ps2.update(last_rekey_at: Time.now - 100)
+
+      expect { nx_with_both.wait_old_state_drop }.to hop("wait")
+      expect(ps.reload.last_rekey_at > Time.now - 10).to be true
+      expect(ps2.reload.last_rekey_at > Time.now - 10).to be true
     end
   end
 

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -123,6 +123,12 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       nic.update(state: "active")
       expect { nx.refresh_keys }.to nap(10)
     end
+
+    it "naps if advisory lock cannot be acquired" do
+      nic.update(state: "active")
+      expect(nx).to receive(:try_advisory_lock).and_return(false)
+      expect { nx.refresh_keys }.to nap(10)
+    end
   end
 
   describe "#wait_inbound_setup" do


### PR DESCRIPTION
## Add advisory lock to prevent concurrent NIC rekeying
Multiple subnet strands in a connected mesh can enter refresh_keys
simultaneously. The incr_lock semaphores set on NICs during this
label are not visible to other strands until the transaction commits
at the end of the label, so the existing lock_set? guard does not
prevent the race.

Acquire pg_try_advisory_xact_lock at the top of refresh_keys. The
lock is transaction-scoped and released automatically when the label
finishes. By that point the NIC lock semaphores have been committed,
so subsequent strands will see them and nap via the existing check.

## Add connected_leader_id to PrivateSubnet
In a mesh of transitively connected subnets, the subnet with the
smallest ID is the "connected leader." This will be used to ensure
that only one subnet coordinates rekeying for the entire mesh,
rather than every subnet independently attempting to rekey the same
set of NICs.

The method reuses the same recursive CTE pattern as
find_all_connected_nics. A standalone subnet with no connections is
its own leader.

## Use connected leader to coordinate rekeying across subnets
Every subnet in a connected mesh independently triggers rekeying for
all NICs in the mesh every 24 hours. With N subnets, this means the
same work is attempted N times.

Only the connected leader now checks the 24-hour periodic timer.
Non-leader subnets skip the check entirely. The advisory lock key is
also updated to use the leader's ID, so all subnets in a mesh
contend on the same lock regardless of which one enters refresh_keys.

wait_old_state_drop now updates last_rekey_at on every subnet whose
NICs were rekeyed, not just the coordinator. This prevents a new
leader from immediately re-triggering after a topology change.

## Forward refresh_keys semaphore to the connected leader
When a non-leader subnet receives a refresh_keys semaphore (e.g.
from connect_subnet or disconnect_subnet), it now consumes it and
forwards a new one to the connected leader instead of entering
refresh_keys itself. This completes the picture: a single subnet
is responsible for rekeying the entire mesh, regardless of which
subnet originally received the trigger.

## Defer subnet destroy while NIC rekey is in progress
If a subnet is destroyed mid-rekey, the locked NICs from other
subnets would never get cleaned up, permanently blocking future
rekeying. Skip the destroy hop in before_run while locked NICs
still exist, allowing the rekey to complete first.