### PR TITLE
Persist firewall rules on Kubernetes nodes across reboots

### DIFF
--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -83,27 +83,36 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
   label def bootstrap_rhizome
     nap 5 unless vm.strand.label == "wait"
 
-    vm.sshable.cmd("sudo iptables-nft -t nat -A POSTROUTING -s :private_ipv4 -o ens3 -j MASQUERADE", private_ipv4: vm.nics.first.private_ipv4)
-    vm.sshable.cmd("sudo nft --file -", stdin: <<TEMPLATE)
-table ip6 pod_access;
-delete table ip6 pod_access;
-table ip6 pod_access {
-  chain ingress_egress_control {
-    type filter hook forward priority filter; policy drop;
-    # allow access to the vm itself in order to not break the normal functionality of Clover and SSH
-    ip6 daddr #{vm.ip6} ct state established,related,new counter accept
-    ip6 saddr #{vm.ip6} ct state established,related,new counter accept
+    nft_rules = <<~NFT
+      #!/usr/sbin/nft -f
+      flush ruleset
 
-    # not allow new connections from internet but allow new connections from inside
-    ip6 daddr #{vm.ephemeral_net6} ct state established,related counter accept
-    ip6 saddr #{vm.ephemeral_net6} ct state established,related,new counter accept
+      table ip nat {
+        chain postrouting {
+          type nat hook postrouting priority 100;
+          ip saddr #{vm.nics.first.private_ipv4} oifname "ens3" masquerade
+        }
+      }
 
-    # used for internal private ipv6 communication between pods
-    ip6 saddr #{kubernetes_cluster.private_subnet.net6} ct state established,related,new counter accept
-    ip6 daddr #{kubernetes_cluster.private_subnet.net6} ct state established,related,new counter accept
-  }
-}
-TEMPLATE
+      table ip6 pod_access {
+        chain ingress_egress_control {
+          type filter hook forward priority filter; policy drop;
+          # allow access to the vm itself in order to not break the normal functionality of Clover and SSH
+          ip6 daddr #{vm.ip6} ct state established,related,new counter accept
+          ip6 saddr #{vm.ip6} ct state established,related,new counter accept
+
+          # not allow new connections from internet but allow new connections from inside
+          ip6 daddr #{vm.ephemeral_net6} ct state established,related counter accept
+          ip6 saddr #{vm.ephemeral_net6} ct state established,related,new counter accept
+
+          # used for internal private ipv6 communication between pods
+          ip6 saddr #{kubernetes_cluster.private_subnet.net6} ct state established,related,new counter accept
+          ip6 daddr #{kubernetes_cluster.private_subnet.net6} ct state established,related,new counter accept
+        }
+      }
+    NFT
+    vm.sshable.cmd("sudo tee /etc/nftables.conf > /dev/null", stdin: nft_rules)
+    vm.sshable.cmd("sudo systemctl enable --now nftables")
     vm.sshable.cmd "sudo systemctl enable --now kubelet"
 
     bud Prog::BootstrapRhizome, {"target_folder" => "kubernetes", "subject_id" => vm.id, "user" => "ubi"}

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
 
   let(:node) {
     nic = Prog::Vnet::NicNexus.assemble(subnet.id, ipv4_addr: "172.19.145.64/26", ipv6_addr: "fd40:1a0a:8d48:182a::/79").subject
-    vm = Prog::Vm::Nexus.assemble("pub key", Config.kubernetes_service_project_id, name: "test-vm", private_subnet_id: subnet.id, nic_id: nic.id).subject
+    vm = Prog::Vm::Nexus.assemble_with_sshable(Config.kubernetes_service_project_id, name: "test-vm", private_subnet_id: subnet.id, nic_id: nic.id).subject
     vm.update(ephemeral_net6: "2001:db8:85a3:73f2:1c4a::/79", created_at: Time.now - 1)
     KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kubernetes_cluster.id)
   }
@@ -141,35 +141,26 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     end
 
     it "enables kubelet and buds a bootstrap rhizome process" do
-      sshable = Sshable.new
-      st = instance_double(Strand, label: "wait")
-      expect(prog.node.vm).to receive(:strand).and_return(st)
-      expect(prog.vm).to receive(:sshable).and_return(sshable).thrice
-      expect(sshable).to receive(:_cmd).with("sudo iptables-nft -t nat -A POSTROUTING -s 172.19.145.64/26 -o ens3 -j MASQUERADE")
+      prog.node.vm.strand.update(label: "wait")
+      sshable = prog.vm.sshable
       expect(sshable).to receive(:_cmd).with(
-        "sudo nft --file -",
-        stdin: <<~TEMPLATE
-table ip6 pod_access;
-delete table ip6 pod_access;
-table ip6 pod_access {
-  chain ingress_egress_control {
-    type filter hook forward priority filter; policy drop;
-    # allow access to the vm itself in order to not break the normal functionality of Clover and SSH
-    ip6 daddr 2001:db8:85a3:73f2:1c4a::2 ct state established,related,new counter accept
-    ip6 saddr 2001:db8:85a3:73f2:1c4a::2 ct state established,related,new counter accept
-
-    # not allow new connections from internet but allow new connections from inside
-    ip6 daddr 2001:db8:85a3:73f2:1c4a::/79 ct state established,related counter accept
-    ip6 saddr 2001:db8:85a3:73f2:1c4a::/79 ct state established,related,new counter accept
-
-    # used for internal private ipv6 communication between pods
-    ip6 saddr fd40:1a0a:8d48:182a::/64 ct state established,related,new counter accept
-    ip6 daddr fd40:1a0a:8d48:182a::/64 ct state established,related,new counter accept
-  }
-}
-        TEMPLATE
-      )
-      expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now kubelet")
+        "sudo tee /etc/nftables.conf > /dev/null",
+        stdin: satisfy { |s|
+          s.include?("#!/usr/sbin/nft -f") &&
+          s.include?("flush ruleset") &&
+          s.include?("table ip nat") &&
+          s.include?("ip saddr 172.19.145.64/26 oifname \"ens3\" masquerade") &&
+          s.include?("table ip6 pod_access") &&
+          s.include?("ip6 daddr 2001:db8:85a3:73f2:1c4a::2 ct state established,related,new counter accept") &&
+          s.include?("ip6 saddr 2001:db8:85a3:73f2:1c4a::2 ct state established,related,new counter accept") &&
+          s.include?("ip6 daddr 2001:db8:85a3:73f2:1c4a::/79 ct state established,related counter accept") &&
+          s.include?("ip6 saddr 2001:db8:85a3:73f2:1c4a::/79 ct state established,related,new counter accept") &&
+          s.include?("ip6 saddr fd40:1a0a:8d48:182a::/64 ct state established,related,new counter accept") &&
+          s.include?("ip6 daddr fd40:1a0a:8d48:182a::/64 ct state established,related,new counter accept")
+        }
+      ).ordered
+      expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now nftables").ordered
+      expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now kubelet").ordered
 
       expect(prog).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "kubernetes", "subject_id" => prog.node.vm.id, "user" => "ubi"})
       expect { prog.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")


### PR DESCRIPTION
Replaces the previous approach of applying iptables and nft rules at runtime with writing a complete nftables ruleset to /etc/nftables.conf and enabling the nftables systemd service. This ensures NAT masquerading and IPv6 pod access control rules survive node reboots.

The ruleset includes a flush to start clean, an ip nat table for POSTROUTING masquerade, and an ip6 pod_access table for ingress and egress filtering.