### PR TITLE
Spread out retries when facing AWS instance restrictions

### DIFF
--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -423,7 +423,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
     if (retry_count = frame["retry_count"] || 0) >= 5
       Clog.emit("resetting excluding azs to retry", {retry_different_az_failed: {vm:, error: e.class.name, message: e.message, retry_count:}})
       update_stack({"exclude_availability_zones" => nil, "retry_count" => 0})
-      nap 60
+      nap 5 * 60
     end
 
     Clog.emit("retrying in different az", {retry_different_az: {vm:, error: e.class.name, message: e.message, retry_count: retry_count + 1}})

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -480,7 +480,7 @@ usermod -L ubuntu
       it "clear exclude_availability_zones after 5 retry attempts" do
         refresh_frame(nx, new_values: {"retry_count" => 5})
         expect(Clog).not_to receive(:emit).with("retrying in different az", instance_of(Hash))
-        expect { nx.create_instance }.to nap(60)
+        expect { nx.create_instance }.to nap(300)
         expect(st.stack.last["exclude_availability_zones"]).to be_nil
       end
 
@@ -536,7 +536,7 @@ usermod -L ubuntu
       it "clear exclude_availability_zones after 5 retry attempts" do
         refresh_frame(nx, new_values: {"retry_count" => 5})
         expect(Clog).not_to receive(:emit).with("retrying in different az", instance_of(Hash))
-        expect { nx.create_instance }.to nap(60)
+        expect { nx.create_instance }.to nap(300)
         expect(st.stack.last["exclude_availability_zones"]).to be_nil
       end
 


### PR DESCRIPTION
Retrying quickly leads to multiple create/delete EIP calls, especially when AWS does not have capacity leading to abuse warning from AWS. This spaces the retries to 5 minutes post excluded_azs reset