### PR TITLE
Fix pg_hba.conf rule order for standby cert auth

### DIFF
--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -77,9 +77,6 @@ local   replication     all                                     peer
 host    replication     all             127.0.0.1/32            scram-sha-256
 host    replication     all             ::1/128                 scram-sha-256
 
-# Allow connections from private subnet with SCRAM authentication
-#{private_subnets}
-
 # Allow replication connection using special replication user for
 # HA standbys
 hostssl replication     ubi_replication all                     cert map=standby2replication
@@ -90,6 +87,9 @@ hostssl replication     postgres        all                     scram-sha-256
 
 # Allow certificate authentication for specific users
 #{cert_auth_users}
+
+# Allow connections from private subnet with SCRAM authentication
+#{private_subnets}
 
 # Allow connections from public internet with md5 authentication
 # Note that if the password is encrypted as scram-sha-256, PostgreSQL


### PR DESCRIPTION
Standby servers connecting to the primary via the ubi_replication role were failing with "password not supplied" errors in environments with private DNS configuration. This occurred because pg_hba.conf processes rules sequentially, using the first match.

The private subnet rules (requiring SCRAM-SHA-256 password auth) were positioned before the HA standby rules (using certificate auth). When standbys connected from within the private subnet, they matched the password-based rule first, even though they were presenting certificates rather than passwords.

Reorder the rules to place certificate-based HA standby authentication before general private subnet password authentication. This ensures standbys can authenticate using their certificates regardless of whether they connect via IP (local) or hostname (DNS-enabled environments). This is backwards compatible