### PR TITLE
Refactor storage auto scaling methods for easier extension

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -288,7 +288,7 @@ class PostgresResource < Sequel::Model
     }
 
     if disk_usage_percent < 90
-      send_storage_auto_scale_warning_email(disk_usage_percent, next_option, extra_email_content)
+      send_storage_auto_scale_warning_notification(disk_usage_percent, next_option, extra_email_content)
     else
       if next_option
         target_vm_size = next_option["size"]
@@ -300,7 +300,7 @@ class PostgresResource < Sequel::Model
         end
       end
 
-      send_storage_auto_scale_started_email(disk_usage_percent, next_option, extra_email_content)
+      send_storage_auto_scale_started_notification(disk_usage_percent, next_option, extra_email_content)
     end
   end
 
@@ -355,13 +355,13 @@ class PostgresResource < Sequel::Model
 
       Prog::PageNexus.assemble("#{ubid} storage auto-scale canceled by user", ["PGStorageAutoScaleCanceled", id], ubid, severity: "warning")
 
-      send_storage_auto_scale_canceled_email
+      send_storage_auto_scale_canceled_notification
 
       true
     end
   end
 
-  def send_storage_auto_scale_warning_email(usage_percent, next_option, extra_content)
+  def send_storage_auto_scale_warning_notification(usage_percent, next_option, extra_content)
     body = [
       "Your PostgreSQL database '#{name}' (#{ubid}) has reached #{usage_percent}% disk usage.",
       "You are currently using #{storage_size_gib * usage_percent / 100} of #{storage_size_gib} GB of storage."
@@ -398,7 +398,7 @@ class PostgresResource < Sequel::Model
     )
   end
 
-  def send_storage_auto_scale_started_email(usage_percent, next_option, extra_content)
+  def send_storage_auto_scale_started_notification(usage_percent, next_option, extra_content)
     body = [
       "Your PostgreSQL database '#{name}' (#{ubid}) has reached #{usage_percent}% disk usage.",
       "You are currently using #{storage_size_gib * usage_percent / 100} of #{storage_size_gib} GB of storage."
@@ -438,7 +438,7 @@ class PostgresResource < Sequel::Model
     )
   end
 
-  def send_storage_auto_scale_canceled_email
+  def send_storage_auto_scale_canceled_notification
     body = [
       "Auto-scaling for your PostgreSQL database '#{name}' (#{ubid}) has been canceled as requested.",
       "Automatic scale-up will not be re-triggered until disk usage drops below 80% and rises again.",

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -927,7 +927,7 @@ RSpec.describe PostgresResource do
 
     it "includes vm upgrade info when target size differs" do
       next_option = {"size" => "standard-4", "storage_size" => 256}
-      postgres_resource.send_storage_auto_scale_warning_email(85, next_option, nil)
+      postgres_resource.send_storage_auto_scale_warning_notification(85, next_option, nil)
 
       expect(Util).to have_received(:send_email) do |_recipients, _subject, **kwargs|
         expect(kwargs[:body].join("\n")).to include("instance will also be upgraded")
@@ -943,7 +943,7 @@ RSpec.describe PostgresResource do
       )
 
       next_option = {"size" => "standard-2", "storage_size" => 128}
-      postgres_resource.send_storage_auto_scale_warning_email(85, next_option, nil)
+      postgres_resource.send_storage_auto_scale_warning_notification(85, next_option, nil)
 
       expect(Util).to have_received(:send_email) do |_recipients, _subject, **kwargs|
         expect(kwargs[:body].join("\n")).to include("read replica(s)")
@@ -966,7 +966,7 @@ RSpec.describe PostgresResource do
 
     it "includes vm upgrade info when target size differs" do
       next_option = {"size" => "standard-4", "storage_size" => 256}
-      postgres_resource.send_storage_auto_scale_started_email(92, next_option, nil)
+      postgres_resource.send_storage_auto_scale_started_notification(92, next_option, nil)
 
       expect(Util).to have_received(:send_email) do |_recipients, _subject, **kwargs|
         expect(kwargs[:body].join("\n")).to include("instance is being upgraded")
@@ -974,7 +974,7 @@ RSpec.describe PostgresResource do
     end
 
     it "includes quota_insufficient info" do
-      postgres_resource.send_storage_auto_scale_started_email(92, nil, :quota_insufficient)
+      postgres_resource.send_storage_auto_scale_started_notification(92, nil, :quota_insufficient)
 
       expect(Util).to have_received(:send_email) do |_recipients, _subject, **kwargs|
         expect(kwargs[:body].join("\n")).to include("sufficient quota")
@@ -1000,7 +1000,7 @@ RSpec.describe PostgresResource do
     }
 
     it "sends email with canceled info including current storage and instance size" do
-      postgres_resource.send_storage_auto_scale_canceled_email
+      postgres_resource.send_storage_auto_scale_canceled_notification
 
       expect(Util).to have_received(:send_email).with(
         ["user@example.com"],


### PR DESCRIPTION
Extract the following private methods:

* handle_storage_auto_scale_action(disk_usage_percent)
* cancel_storage_auto_scale_action(disk_usage_percent)
* perform_storage_auto_scale_action(disk_usage_percent)

These allow extension at different level. To keep the 77/80/85/90 percentage handling, you can override {cancel,perform}_storage_auto_scale_action with custom behavior. To use custom percentages, you can override handle_storage_auto_scale_action.