### PR TITLE
Wait for 5% drop to decrement auto scale semaphores

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -249,12 +249,12 @@ class PostgresResource < Sequel::Model
       return
     end
 
-    # Clear semaphores only when usage drops at least 3% below threshold to avoid spurious emails
+    # Clear semaphores only when usage drops at least 5% below threshold to avoid spurious emails
     [90, 85, 80].each {
-      send("decr_storage_auto_scale_action_performed_#{it}") if disk_usage_percent <= it - 3
+      send("decr_storage_auto_scale_action_performed_#{it}") if disk_usage_percent <= it - 5
     }
 
-    if disk_usage_percent <= 77
+    if disk_usage_percent <= 75
       Page.from_tag_parts("PGStorageAutoScaleMaxSize", id)&.incr_resolve
       Page.from_tag_parts("PGStorageAutoScaleQuotaInsufficient", id)&.incr_resolve
       Page.from_tag_parts("PGStorageAutoScaleCanceled", id)&.incr_resolve


### PR DESCRIPTION
It seems 3% oscilation is not uncommon as I'd expect. For now, I'm increasing the hysteresis to 5% to avoid spurious emails. If this is not sufficient, we can decide to not decrement the semaphores at all.