### PR TITLE
QEMU VM improvements

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -854,7 +854,7 @@ DNSMASQ_SERVICE
 
     cpu_parts = [
       qemu_smp(cpu_topology, max_vcpus),
-      "-cpu host",
+      qemu_cpu,
       "-enable-kvm",
       "-machine accel=kvm,type=q35"
     ]
@@ -908,5 +908,13 @@ DNSMASQ_SERVICE
     end
 
     "-smp cpus=#{max_vcpus},maxcpus=#{max_vcpus},threads=#{t},cores=#{c},dies=#{d},sockets=#{p}"
+  end
+
+  def qemu_cpu
+    (cpu_vendor == "AuthenticAMD") ? "-cpu host,topoext=on" : "-cpu host"
+  end
+
+  def cpu_vendor
+    r("/usr/bin/lscpu | grep -m1 \"Vendor ID\" | cut -d: -f2").strip
   end
 end


### PR DESCRIPTION
- **Remove `no-reboot` for QEMU VMs**
  We added `no-reboot` to QEMU VMs with the intention to mimic cloud
  hypervisor's behavior. But behavior in case of shutdown/reboot from
  inside the vm are closer to cloud hypervisor without `no-reboot`.
  

- **Expect `-vga none` in QEMU systemd unit test**
  Extend the VM setup test for QEMU systemd unit creation to verify
  that `-vga none` is included in the generated command line.
  

- **QEMU: enable topoext for AMD hosts**
  Detect CPU vendor at runtime using lscpu and adjust the QEMU -cpu
  argument accordingly.
  
  On AuthenticAMD hosts, enable `topoext=on`:
  -cpu host,topoext=on
  
  On other vendors (e.g. Intel), keep:
  -cpu host
  
  This ensures proper CPU topology exposure on AMD systems, while
  maintaining existing behavior for non-AMD hosts.
  