### PR TITLE
Update postgres images to 20260213.1.0

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -187,7 +187,7 @@ module Config
   override :github_gpu_ubuntu_2204_version, "20260202.1.0", string
   override :github_ubuntu_2204_aws_ami_version, "ami-02609928906c79843", string
   override :github_ubuntu_2404_aws_ami_version, "ami-04046eda554773409", string
-  override :postgres_ubuntu_2204_version, "20260205.1.0", string
+  override :postgres_ubuntu_2204_version, "20260213.1.0", string
   override :postgres16_ubuntu_2204_version, "20250425.1.1", string
   override :postgres17_ubuntu_2204_version, "20250425.1.1", string
   override :postgres_paradedb_ubuntu_2204_version, "20260107.1.0", string

--- a/migrate/20260213_update_pg_amis.rb
+++ b/migrate/20260213_update_pg_amis.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  ami_ids = [
+    ["us-west-2", "x64", "ami-0643653705d03da11", "ami-0765f71bf0d92f856"],
+    ["us-east-1", "x64", "ami-08bb3d01832f5608c", "ami-039c50c95d706deb0"],
+    ["us-east-2", "x64", "ami-0030ffca00ab62a0a", "ami-0b86bac7ad7028632"],
+    ["eu-west-1", "x64", "ami-033b508730f8fdca5", "ami-0c034d13972955c2b"],
+    ["ap-southeast-2", "x64", "ami-0f785e228cd0fb5d5", "ami-074aa9b0216fe4acd"],
+    ["us-west-2", "arm64", "ami-08ae3eeeaaa6f1b20", "ami-078463c0b09ced281"],
+    ["us-east-1", "arm64", "ami-0df2b08ca8033f290", "ami-0030fa71a6726182f"],
+    ["us-east-2", "arm64", "ami-0b5c6e9c9f85af1d7", "ami-05ad7f9eba8976570"],
+    ["eu-west-1", "arm64", "ami-02f17dc06f680fedd", "ami-06a64b8a346c3c940"],
+    ["ap-southeast-2", "arm64", "ami-004359cc3bf27e877", "ami-03065a55a4d88f9a3"]
+  ]
+
+  up do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: old_ami)
+        .update(aws_ami_id: new_ami)
+    end
+  end
+
+  down do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: new_ami)
+        .update(aws_ami_id: old_ami)
+    end
+  end
+end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -99,7 +99,7 @@ class Prog::DownloadBootImage < Prog::Base
     ["github-ubuntu-2204", "arm64", "20260202.1.0"] => "6e46d65bca5dadb66f26bbe2fa9f5f450406f54e0816087edc68935bc95b745e",
     ["github-gpu-ubuntu-2204", "x64", "20251208.1.0"] => "644fa94ead16baefc3f8efda27199ad60312201b042d9eb5d545c53455733f00",
     ["github-gpu-ubuntu-2204", "x64", "20260202.1.0"] => "047f5603e27e888dc275333ba205032d5a46869e78e3fb4abc9eda15026867da",
-    ["postgres-ubuntu-2204", "x64", "20260205.1.0"] => "cdda7b1b6b72150d9c252a59085cbda43408ac11d44c2494c96d396c89723d2e",
+    ["postgres-ubuntu-2204", "x64", "20260213.1.0"] => "c8ed19473fd481fe205af16950e2fb9747a58454b7e5d09b35a54ac59e5fbf32",
     ["postgres16-ubuntu-2204", "x64", "20250425.1.1"] => "f59622da276d646ed2a1c03de546b0a7ec3fd48aeb27c0bfe2b8b8be98c062d2",
     ["postgres17-ubuntu-2204", "x64", "20250425.1.1"] => "ccb4bcd8197c2e230be3f485dd33f24a51041a4dc0408257e42b3fe9f1c0bfb3",
     ["postgres-paradedb-ubuntu-2204", "x64", "20260107.1.0"] => "b60e173766eaf0b3928e69c8037d60943df4fc0314930ad9cd429405bf91b520",


### PR DESCRIPTION
## Summary
- Updates image version in `config.rb`
- Updates boot image SHA256 hashes in `prog/download_boot_image.rb`
- Adds migration to update AWS AMI IDs in `pg_aws_ami` table

## Image Version
`20260213.1.0`

## Changes
- x64 SHA256: `c8ed19473fd481fe205af16950e2fb9747a58454b7e5d09b35a54ac59e5fbf32`
- arm64 SHA256: `d5ffd05ba803ae6c94235e50edfbec88b0f69e6831c2aed6abd17f99345027fb`

🤖 Generated by [postgres-vm-images](https://github.com/ubicloud/postgres-vm-images) workflow