### PR TITLE
Increase Inference Router Replica Page severity to error

### DIFF
--- a/prog/ai/inference_router_replica_nexus.rb
+++ b/prog/ai/inference_router_replica_nexus.rb
@@ -224,7 +224,7 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
     Prog::PageNexus.assemble(
       format(page_details[:message], inference_router_replica.ubid.to_s[0..7], inference_router.name),
       [page_details[:tag], inference_router_replica.ubid],
-      inference_router_replica.ubid, severity: "warning", extra_data:
+      inference_router_replica.ubid, extra_data:
     )
   end
 


### PR DESCRIPTION
By removing the explicit `severity: "warning"` setting when creating a page, we know create inference router replica pages in "error" mode, when inference router itself, or one of the models is unavailable.

severity=error mode triggers notification process in PagerDuty, which is important as we have more customers rely on our inference router in critical workloads.