### PR TITLE
Set cloudinit disk to readonly

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -577,7 +577,11 @@ EOS
     r "mcopy -oi #{vp.q_cloudinit_img} -s #{vp.q_user_data} ::"
     r "mcopy -oi #{vp.q_cloudinit_img} -s #{vp.q_meta_data} ::"
     r "mcopy -oi #{vp.q_cloudinit_img} -s #{vp.q_network_config} ::"
-    FileUtils.chown @vm_name, @vm_name, vp.cloudinit_img
+
+    # Ensure the VM can't modify read-only mode bits by retaining
+    # owner as root.
+    FileUtils.chmod 0o440, vp.cloudinit_img
+    FileUtils.chown "root", @vm_name, vp.cloudinit_img
   end
 
   def generate_swap_config(swap_size_bytes)

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe VmSetup do
         %w[
           --api-socket path=/tmp/ch.sock \
           --kernel /opt/fw/CLOUDHV-202311.fd \
-          --disk path=/vm/test/cloudinit.img \
+          --disk path=/vm/test/cloudinit.img,readonly=on \
           --console off --serial file=/vm/test/serial.log \
           --cpus boot=2,topology=1:1:1:2 \
           --memory size=2G,hugepages=on,hugepage_size=1G \


### PR DESCRIPTION
There's no good reason for a guest or even a compromised cloud-hypervisor or other service to be able to modify this file.