### PR TITLE
Skip checks for existence of representative_server

### DIFF
--- a/model/postgres/metal/postgres_resource.rb
+++ b/model/postgres/metal/postgres_resource.rb
@@ -15,7 +15,7 @@ class PostgresResource < Sequel::Model
       # If the server is in leaseweb, we don't have multiple DCs, that's
       # why we return an empty list of data centers.
       return ServerExclusionFilters.new(exclude_host_ids: [], exclude_data_centers: [], exclude_availability_zones: [], availability_zone: nil) if Config.allow_unspread_servers
-      return ServerExclusionFilters.new(exclude_host_ids: Array(representative_server&.vm&.vm_host_id), exclude_data_centers: [], exclude_availability_zones: [], availability_zone: nil) if location.provider == HostProvider::LEASEWEB_PROVIDER_NAME
+      return ServerExclusionFilters.new(exclude_host_ids: Array(representative_server.vm.vm_host_id), exclude_data_centers: [], exclude_availability_zones: [], availability_zone: nil) if location.provider == HostProvider::LEASEWEB_PROVIDER_NAME
 
       exclude_data_centers = VmHost
         .where(data_center: VmHost

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -39,17 +39,21 @@ class PostgresResource < Sequel::Model
   end
 
   def vm_size
-    representative_server&.vm&.display_size&.gsub("burstable", "hobby") || target_vm_size
+    representative_server.vm.display_size.gsub("burstable", "hobby")
   end
 
   def storage_size_gib
-    representative_server&.storage_size_gib || target_storage_size_gib
+    representative_server.storage_size_gib
+  end
+
+  def version
+    representative_server.version
   end
 
   def display_state
     return "deleting" if destroying_set? || destroy_set? || strand.nil?
 
-    server_strand_label = representative_server&.strand&.label
+    server_strand_label = representative_server.strand.label
     return "unavailable" if server_strand_label == "unavailable"
     return "restoring_backup" if server_strand_label == "initialize_database_from_backup"
     return "replaying_wal" if ["wait_catch_up", "wait_synchronization"].include?(server_strand_label)
@@ -73,7 +77,7 @@ class PostgresResource < Sequel::Model
     !location.aws? &&
       created_at < AAAA_CUTOFF &&
       dns_zone &&
-      representative_server&.vm&.ip6_string &&
+      representative_server.vm.ip6_string &&
       dns_zone
         .records_dataset
         .where(type: "AAAA", name: hostname + ".")
@@ -86,7 +90,7 @@ class PostgresResource < Sequel::Model
 
       "#{name}.#{ubid}.#{hostname_suffix}"
     else
-      representative_server&.vm&.ip4_string
+      representative_server.vm.ip4_string
     end
   end
 
@@ -95,12 +99,10 @@ class PostgresResource < Sequel::Model
   end
 
   def connection_string
-    return nil unless (hn = hostname)
-
     URI::Generic.build2(
       scheme: "postgres",
       userinfo: "postgres:#{URI.encode_uri_component(superuser_password)}",
-      host: hn,
+      host: hostname,
       port: 5432,
       path: "/postgres",
       query: "channel_binding=require"
@@ -108,8 +110,6 @@ class PostgresResource < Sequel::Model
   end
 
   def replication_connection_string(application_name:)
-    return nil unless dns_zone || representative_server
-
     query_parameters = {
       sslrootcert: "/etc/ssl/certs/ca.crt",
       sslcert: "/etc/ssl/certs/server.crt",
@@ -120,10 +120,6 @@ class PostgresResource < Sequel::Model
     }.map { |k, v| "#{k}=#{v}" }.join("&")
 
     URI::Generic.build2(scheme: "postgres", userinfo: "ubi_replication", host: dns_zone ? identity : representative_server.vm.ip4_string, query: query_parameters).to_s
-  end
-
-  def version
-    representative_server&.version || target_version
   end
 
   def provision_new_standby
@@ -240,8 +236,6 @@ class PostgresResource < Sequel::Model
   end
 
   def handle_storage_auto_scale
-    return unless representative_server
-
     begin
       disk_usage_percent = representative_server.vm.sshable.cmd("df --output=pcent /dat | tail -n 1").strip.delete("%").to_i
     rescue

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -98,8 +98,8 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
   end
 
   label def recycle_representative_server
-    if (rs = postgres_resource.representative_server) && !postgres_resource.ongoing_failover?
-      hop_prune_servers unless rs.needs_recycling?
+    unless postgres_resource.ongoing_failover?
+      hop_prune_servers unless postgres_resource.representative_server.needs_recycling?
       hop_prune_servers if postgres_resource.storage_auto_scale_canceled_set?
       hop_provision_servers unless postgres_resource.has_enough_ready_servers?
 
@@ -108,7 +108,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
       postgres_resource.incr_storage_auto_scale_not_cancellable
 
       register_deadline(nil, 10 * 60)
-      rs.trigger_failover(mode: "planned")
+      postgres_resource.representative_server.trigger_failover(mode: "planned")
     end
 
     nap 60

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -74,7 +74,7 @@ class Clover
 
         validate_postgres_input(pg.name, postgres_params)
 
-        if pg.representative_server.nil? || target_storage_size_gib < pg.representative_server.storage_size_gib
+        if target_storage_size_gib < pg.representative_server.storage_size_gib
           begin
             current_disk_usage = pg.representative_server.vm.sshable.cmd("df --output=used /dev/vdb | tail -n 1").strip.to_i / (1024 * 1024)
           rescue
@@ -403,10 +403,6 @@ class Clover
       r.post "recycle" do
         authorize("Postgres:edit", pg)
 
-        if pg.representative_server.nil?
-          raise CloverError.new(400, "InvalidRequest", "No representative server available to recycle")
-        end
-
         DB.transaction do
           pg.representative_server.incr_recycle
           audit_log(pg, "recycle")
@@ -593,7 +589,7 @@ class Clover
           {
             pg_config: pg.user_config,
             pgbouncer_config: pg.pgbouncer_user_config,
-            default_pg_config: pg.representative_server&.configure_hash&.[](:configs)
+            default_pg_config: pg.representative_server.configure_hash[:configs]
           }
         end
 

--- a/serializers/postgres.rb
+++ b/serializers/postgres.rb
@@ -29,13 +29,13 @@ class Serializers::Postgres < Serializers::Base
         username: "postgres",
         password: pg.superuser_password,
         hostname: pg.hostname,
-        primary: pg.representative_server&.primary?,
+        primary: pg.representative_server.primary?,
         firewall_rules: Serializers::PostgresFirewallRule.serialize(pg.pg_firewall_rules),
         metric_destinations: pg.metric_destinations.map { {id: it.ubid, username: it.username, url: it.url} },
         read_replicas: Serializers::Postgres.serialize(pg.read_replicas, {include_path: true})
       )
 
-      if pg.timeline && pg.representative_server&.primary?
+      if pg.timeline && pg.representative_server.primary?
         begin
           base[:earliest_restore_time] = pg.timeline.earliest_restore_time&.utc&.iso8601
         rescue => ex

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -567,6 +567,8 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
   end
 
   describe "#wait" do
+    before { postgres_server }
+
     it "hops to update_billing_records when update_billing_records is set" do
       nx.incr_update_billing_records
       expect { nx.wait }.to hop("update_billing_records")

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -523,13 +523,6 @@ RSpec.describe Clover, "postgres" do
         expect(last_response).to have_api_error(400, "Validation failed for following fields: pg_config.wal_level")
       end
 
-      it "recycle fails without representative_server" do
-        pg.representative_server.update(is_representative: false)
-        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/recycle"
-
-        expect(last_response.status).to eq(400)
-      end
-
       it "reset password" do
         post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password", {
           password: "DummyPassword123"
@@ -919,19 +912,6 @@ RSpec.describe Clover, "postgres" do
         expect(response_body["pg_config"]).to eq({"max_connections" => "100"})
         expect(response_body["pgbouncer_config"]).to eq({"max_client_conn" => "100"})
         expect(response_body["default_pg_config"]).to include("shared_buffers", "work_mem", "max_connections", "effective_cache_size")
-      end
-
-      it "read skips default_pg_config when resource has no representative_server" do
-        pg.representative_server.update(is_representative: false)
-        pg.update(user_config: {"max_connections" => "100"}, pgbouncer_user_config: {"max_client_conn" => "100"})
-
-        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/config"
-
-        expect(last_response.status).to eq(200)
-        response_body = JSON.parse(last_response.body)
-        expect(response_body["pg_config"]).to eq({"max_connections" => "100"})
-        expect(response_body["pgbouncer_config"]).to eq({"max_client_conn" => "100"})
-        expect(response_body["default_pg_config"]).to be_nil
       end
 
       it "full update" do

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -664,15 +664,6 @@ RSpec.describe Clover, "postgres" do
           expect(page).to have_no_content "Add AAAA Record"
         end
 
-        it "does not show button if there is no representative server" do
-          pg.update(created_at: PostgresResource::AAAA_CUTOFF - 86400)
-          pg.representative_server.update(is_representative: false)
-
-          visit "#{project.path}#{pg.path}/settings"
-          expect(page).to have_no_content "Add IPv6 (AAAA) DNS record"
-          expect(page).to have_no_content "Add AAAA Record"
-        end
-
         it "handles race condition when AAAA is added between page load and button click" do
           pg.update(created_at: PostgresResource::AAAA_CUTOFF - 86400)
 

--- a/spec/serializers/postgres_spec.rb
+++ b/spec/serializers/postgres_spec.rb
@@ -75,28 +75,6 @@ RSpec.describe Serializers::Postgres do
     expect(data).not_to have_key(:latest_restore_time)
   end
 
-  it "can serialize when there is no server" do
-    data = described_class.serialize(pg, {detailed: true})
-    expect(data.fetch(:primary)).to be_nil
-    expect(data).not_to have_key(:earliest_restore_time)
-    expect(data).not_to have_key(:latest_restore_time)
-  end
-
-  it "can serialize when timeline exists but representative server is nil" do
-    vm = create_hosted_vm(project, private_subnet, "pg-vm-nonrep")
-    PostgresServer.create(
-      timeline:, resource_id: pg.id, vm_id: vm.id,
-      is_representative: false,
-      synchronization_status: "ready",
-      timeline_access: "push",
-      version: "17"
-    )
-    data = described_class.serialize(pg, {detailed: true})
-    expect(data.fetch(:primary)).to be_nil
-    expect(data).not_to have_key(:earliest_restore_time)
-    expect(data).not_to have_key(:latest_restore_time)
-  end
-
   it "includes created_at in detailed serialization" do
     create_representative_server(primary: true)
     data = described_class.serialize(pg)


### PR DESCRIPTION
We guarantee that the representative server exists so we don't need these checks or branchs anymore.