### PR TITLE
Fix missing DNS records when adding ports to load balancer

### DIFF
--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -67,6 +67,7 @@ class LoadBalancer < Sequel::Model
         add_port_with_stack(port, lb_vm.id)
       end
       incr_update_load_balancer
+      incr_rewrite_dns_records
     end
   end
 
@@ -80,6 +81,7 @@ class LoadBalancer < Sequel::Model
       vm_ports_dataset.where(load_balancer_port_id: port.id).destroy
       ports_dataset.where(id: port.id).destroy
       incr_update_load_balancer
+      incr_rewrite_dns_records
     end
   end
 

--- a/spec/model/load_balancer_spec.rb
+++ b/spec/model/load_balancer_spec.rb
@@ -51,21 +51,23 @@ RSpec.describe LoadBalancer do
       lb.add_cert(cert)
     end
 
-    it "adds the new port and increments update_load_balancer" do
+    it "adds the new port and increments update_load_balancer and rewrite_dns_records" do
       expect {
         lb.add_port(443, 8443)
       }.to change { lb.reload.vm_ports.count }.from(2).to(4)
         .and change { lb.ports.count }.from(1).to(2)
         .and change { Semaphore.where(strand_id: lb.id, name: "update_load_balancer").count }.from(0).to(1)
+        .and change { Semaphore.where(strand_id: lb.id, name: "rewrite_dns_records").count }.from(1).to(2)
     end
 
-    it "adds the new port and increments update_load_balancer for ipv6 load balancer" do
+    it "adds the new port and increments update_load_balancer and rewrite_dns_records for ipv6 load balancer" do
       lb.update(stack: "ipv6")
       expect {
         lb.add_port(443, 8443)
       }.to change { lb.reload.vm_ports.count }.from(2).to(3)
         .and change { lb.ports.count }.from(1).to(2)
         .and change { Semaphore.where(strand_id: lb.id, name: "update_load_balancer").count }.from(0).to(1)
+        .and change { Semaphore.where(strand_id: lb.id, name: "rewrite_dns_records").count }.from(1).to(2)
 
       expect(lb.vm_ports.count { |vm_port| vm_port.stack == "ipv4" }).to eq(1)
       expect(lb.vm_ports.count { |vm_port| vm_port.stack == "ipv6" }).to eq(2)
@@ -81,7 +83,7 @@ RSpec.describe LoadBalancer do
       lb.add_cert(cert)
     end
 
-    it "removes the new port and increments update_load_balancer" do
+    it "removes the new port and increments update_load_balancer and rewrite_dns_records" do
       lb.add_port(443, 8443)
       lb.reload
 
@@ -90,6 +92,7 @@ RSpec.describe LoadBalancer do
       }.to change { lb.reload.ports.count }.from(2).to(1)
         .and change { lb.vm_ports.count }.from(4).to(2)
         .and change { Semaphore.where(strand_id: lb.id, name: "update_load_balancer").count }.from(1).to(2)
+        .and change { Semaphore.where(strand_id: lb.id, name: "rewrite_dns_records").count }.from(2).to(3)
     end
   end
 


### PR DESCRIPTION
LoadBalancer#add_port and #remove_port were the only mutation methods
that did not call incr_rewrite_dns_records. This caused a race
condition during Kubernetes LoadBalancer service creation:
sync_kubernetes_services calls add_vm (which sets rewrite_dns_records)
before add_port, but since the services LB starts with zero ports,
add_vm creates zero LoadBalancerVmPort entries. If the LB nexus strand
processes rewrite_dns_records before add_port runs, vms_to_dns returns
empty (the join through load_balancer_vm_port finds nothing), so DNS
records are deleted and never recreated — add_port only set
update_load_balancer, not rewrite_dns_records.

Adding incr_rewrite_dns_records to both add_port and remove_port
ensures DNS records are rewritten after port changes, matching the
behavior of add_vm, remove_vm, evacuate_vm, and remove_vm_port.