### PR TITLE
Update postgres images to 20260218.1.0

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -189,7 +189,7 @@ module Config
   override :github_gpu_ubuntu_2204_version, "20260202.1.0", string
   override :github_ubuntu_2204_aws_ami_version, "ami-02609928906c79843", string
   override :github_ubuntu_2404_aws_ami_version, "ami-04046eda554773409", string
-  override :postgres_ubuntu_2204_version, "20260213.1.0", string
+  override :postgres_ubuntu_2204_version, "20260218.1.0", string
   override :postgres16_ubuntu_2204_version, "20250425.1.1", string
   override :postgres17_ubuntu_2204_version, "20250425.1.1", string
   override :postgres_paradedb_ubuntu_2204_version, "20260107.1.0", string

--- a/migrate/20260218_update_pg_amis.rb
+++ b/migrate/20260218_update_pg_amis.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  ami_ids = [
+    ["us-west-2", "x64", "ami-0ec7057ec5fad7e47", "ami-0921aa8d0d9e87eb9"],
+    ["us-east-1", "x64", "ami-046ea18f748f0b14a", "ami-0964c462716607d90"],
+    ["us-east-2", "x64", "ami-01d90da2797cd161c", "ami-052a6ec9973ee9196"],
+    ["eu-west-1", "x64", "ami-06b8099588ba2fbbf", "ami-0370e12352f15902e"],
+    ["ap-southeast-2", "x64", "ami-02863dc84159f6ff5", "ami-0714b0e80026f0700"],
+    ["us-west-2", "arm64", "ami-0d34af69c6e816e93", "ami-029d46a417cbbb2d3"],
+    ["us-east-1", "arm64", "ami-075dd67ffd7ea12a1", "ami-09b9c68e0e535256b"],
+    ["us-east-2", "arm64", "ami-057b0bf5bf0af62d4", "ami-0b5225540951bd764"],
+    ["eu-west-1", "arm64", "ami-0b62a8210720b7e39", "ami-060cb6bfd8643a124"],
+    ["ap-southeast-2", "arm64", "ami-079943061900fc0e1", "ami-0dbc06390bc9509f9"]
+  ]
+
+  up do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: old_ami)
+        .update(aws_ami_id: new_ami)
+    end
+  end
+
+  down do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: new_ami)
+        .update(aws_ami_id: old_ami)
+    end
+  end
+end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -99,7 +99,7 @@ class Prog::DownloadBootImage < Prog::Base
     ["github-ubuntu-2204", "arm64", "20260202.1.0"] => "6e46d65bca5dadb66f26bbe2fa9f5f450406f54e0816087edc68935bc95b745e",
     ["github-gpu-ubuntu-2204", "x64", "20251208.1.0"] => "644fa94ead16baefc3f8efda27199ad60312201b042d9eb5d545c53455733f00",
     ["github-gpu-ubuntu-2204", "x64", "20260202.1.0"] => "047f5603e27e888dc275333ba205032d5a46869e78e3fb4abc9eda15026867da",
-    ["postgres-ubuntu-2204", "x64", "20260213.1.0"] => "bed2782470b0fb8cda8194bc229eae7c31eed583260b351b1e3450eb7a2808e8",
+    ["postgres-ubuntu-2204", "x64", "20260218.1.0"] => "59cd53e09800cc7ee34d3536d4fe28c3fbe08c775772a59c5eed92f3a5d6c355",
     ["postgres16-ubuntu-2204", "x64", "20250425.1.1"] => "f59622da276d646ed2a1c03de546b0a7ec3fd48aeb27c0bfe2b8b8be98c062d2",
     ["postgres17-ubuntu-2204", "x64", "20250425.1.1"] => "ccb4bcd8197c2e230be3f485dd33f24a51041a4dc0408257e42b3fe9f1c0bfb3",
     ["postgres-paradedb-ubuntu-2204", "x64", "20260107.1.0"] => "b60e173766eaf0b3928e69c8037d60943df4fc0314930ad9cd429405bf91b520",


### PR DESCRIPTION
## Summary
- Updates image version in `config.rb`
- Updates boot image SHA256 hashes in `prog/download_boot_image.rb`
- Adds migration to update AWS AMI IDs in `pg_aws_ami` table

## Image Version
`20260218.1.0`

## Changes
- x64 SHA256: `59cd53e09800cc7ee34d3536d4fe28c3fbe08c775772a59c5eed92f3a5d6c355`
- arm64 SHA256: `ba1d8b1d8bdf77f018928925a39ef0546a2ea20ef431839b2ab1be4e20490836`

🤖 Generated by [postgres-vm-images](https://github.com/ubicloud/postgres-vm-images) workflow