### PR TITLE
Add assoc table links to admin object view

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -274,6 +274,11 @@ class CloverAdmin < Roda
     .each_with_object({}) { |name, h| h[name] = true }
     .freeze
 
+  OBJECT_ASSOC_TABLE_PARAMS = {
+    ["GithubInstallation", :runners] => "installation",
+    ["Project", :vms] => "project"
+  }.freeze
+
   plugin :autoforme do
     # :nocov:
     register_by_name if Config.development?
@@ -380,8 +385,10 @@ class CloverAdmin < Roda
     model GithubRunner do
       order Sequel.desc(:created_at)
       eager_graph [:strand]
+      eager [:installation]
       columns do |type_symbol, request|
         cs = [:repository_name, :label, :strand_label, :created_at]
+        cs.prepend(:installation) if type_symbol == :search_form
         cs.prepend(:ubid) unless type_symbol == :search_form
         cs
       end
@@ -471,8 +478,8 @@ class CloverAdmin < Roda
 
     model Vm do
       order Sequel.desc(:created_at)
-      eager [:location, :vm_host]
-      columns [:name, :display_state, :vm_host, :location, :arch, :boot_image, :family, :vcpus, :created_at]
+      eager [:location, :vm_host, :project]
+      columns [:name, :display_state, :project, :vm_host, :location, :arch, :boot_image, :family, :vcpus, :created_at]
       column_options display_state: {type: "select", options: ["running", "creating", "starting", "rebooting", "deleting"], add_blank: true},
         arch: {type: "select", options: ["x64", "arm64"], add_blank: true},
         family: {type: "select", options: Option::VmFamilies.map(&:name), add_blank: true},

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -114,6 +114,9 @@ code {
     text-align: center;
     padding-top: 0;
     margin-top: 0;
+    & a {
+      font-size: 75%;
+    }
   }
 
   & ul {

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -59,7 +59,12 @@
     %>
 
     <div class="association">
-      <h3><%= assoc %></h3>
+      <h3>
+        <%= assoc %>
+        <% if table_param = OBJECT_ASSOC_TABLE_PARAMS[[@klass.name, assoc]] %>
+          <a href="/autoforme/<%= associated_class %>/search/1?<%= table_param %>=<%= @obj.id %>">(table)</a>
+        <% end %>
+      </h3>
       <ul>
       <% assoc_objs.each do %>
         <li><a href="/model/<%= associated_class %>/<%= it.ubid %>" title="<%= it.ubid %>"><%= it.admin_label %></a></li>


### PR DESCRIPTION
Some associations have too many entries to browse as a bulleted list in the object view. i.e. I want to see all the runner details for a installation, or all the vm details for a project.

Instead of duplicating the data in the object view, we can just link to a pre-filtered search page for the association.

I don't like the if/else logic in the view, but it was the quickest way to get this working. We can refactor later if we want to.

<img width="2172" height="1482" alt="CleanShot 2026-02-18 at 18 27 55@2x" src="https://github.com/user-attachments/assets/cffdd81a-9f7b-4eb9-be96-e76fe27b93c6" />

<img width="2238" height="832" alt="CleanShot 2026-02-18 at 18 28 10@2x" src="https://github.com/user-attachments/assets/92cb55df-21fd-441d-82a2-80d03ee51c01" />
