### PR TITLE
Fix misleading error message in validate_kubernetes_name

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -292,7 +292,7 @@ module Validation
   end
 
   def self.validate_kubernetes_name(name)
-    fail ValidationFailed.new({name: "Kubernetes cluster name must only contain lowercase letters, numbers, spaces, and hyphens and have max length 40."}) unless name&.match(ALLOWED_KUBERNETES_NAME_PATTERN)
+    fail ValidationFailed.new({name: "Kubernetes cluster name must only contain lowercase letters, numbers, and hyphens and have max length 40."}) unless name&.match(ALLOWED_KUBERNETES_NAME_PATTERN)
   end
 
   def self.validate_kubernetes_cp_node_count(count)

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe Clover, "Kubernetes" do
         fill_in "name", with: "new-name%"
         click_button "Rename"
         expect(page).to have_flash_error("Validation failed for following fields: name")
-        expect(page).to have_content("Kubernetes cluster name must only contain lowercase letters, numbers, spaces, and hyphens and have max length 40.")
+        expect(page).to have_content("Kubernetes cluster name must only contain lowercase letters, numbers, and hyphens and have max length 40.")
         expect(kc.reload.name).to eq old_name
 
         fill_in "name", with: "new-name"


### PR DESCRIPTION
The error message incorrectly stated that spaces are allowed in Kubernetes cluster names. The ALLOWED_KUBERNETES_NAME_PATTERN regex only permits lowercase letters, numbers, and hyphens (max 40 chars), and KubernetesCluster doesn't provide a custom route regex, so it falls back on the default ALLOWED_NAME_PATTERN which also forbids spaces. Update the message to match the actual validation behavior.