### PR TITLE
Use different mail list for disk auto scale mails

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -162,6 +162,7 @@ module Config
   optional :postgres_monitor_database_root_certs, string
   optional :postgres_paradedb_notification_email, string
   optional :postgres_lantern_notification_email, string
+  optional :postgres_notification_email, string
   override :aws_postgres_iam_access, false, bool
 
   # Logging

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -392,7 +392,7 @@ class PostgresResource < Sequel::Model
     Util.send_email(
       accounts_with_access.map(&:email).uniq,
       "PostgreSQL Storage Warning: #{name} at #{usage_percent}% capacity",
-      cc: Config.mail_from,
+      bcc: Config.postgres_notification_email,
       greeting: "Hello,",
       body:,
       button_title: "View Database",
@@ -432,7 +432,7 @@ class PostgresResource < Sequel::Model
     Util.send_email(
       accounts_with_access.map(&:email).uniq,
       "PostgreSQL Auto-Scaling: #{name}",
-      cc: Config.mail_from,
+      bcc: Config.postgres_notification_email,
       greeting: "Hello,",
       body:,
       button_title: "View Database",
@@ -454,7 +454,7 @@ class PostgresResource < Sequel::Model
     Util.send_email(
       accounts_with_access.map(&:email).uniq,
       "PostgreSQL Auto-Scaling Canceled: #{name}",
-      cc: Config.mail_from,
+      bcc: Config.postgres_notification_email,
       greeting: "Hello,",
       body:,
       button_title: "View Database",


### PR DESCRIPTION
The goal is reducing the noise on the generic support mail alias.