### PR TITLE
Search project and installation associations by UBID

### DIFF
--- a/spec/routes/web/admin/model/postgres_resource_spec.rb
+++ b/spec/routes/web/admin/model/postgres_resource_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CloverAdmin, "PostgresResource" do
   it "displays the PostgresResource instance page correctly" do
     click_link "PostgresResource"
     expect(page.status_code).to eq 200
-    expect(page.title).to eq "Ubicloud Admin - PostgresResource"
+    expect(page.title).to eq "Ubicloud Admin - PostgresResource - Browse"
 
     click_link @instance.admin_label
     expect(page.status_code).to eq 200

--- a/spec/routes/web/admin/model/postgres_server_spec.rb
+++ b/spec/routes/web/admin/model/postgres_server_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CloverAdmin, "PostgresServer" do
   it "displays the PostgresServer instance page correctly" do
     click_link "PostgresServer"
     expect(page.status_code).to eq 200
-    expect(page.title).to eq "Ubicloud Admin - PostgresServer"
+    expect(page.title).to eq "Ubicloud Admin - PostgresServer - Browse"
 
     click_link @instance.admin_label
     expect(page.status_code).to eq 200


### PR DESCRIPTION
### Search association by UUID in addition to UBID in the admin panel

autoforme uses a select input to search associations, which becomes
problematic when there are many resources (e.g., 1,000+ projects). I
replaced the select input with a text input and added search by UBID
already.

It would be useful to also support searching by UUID and extract this
logic so it can be reused across multiple resources.

### Search project and installation associations by UBID


Since we have hundreds of projects and installations in production,
loading the search page with a very large select input is slow. I
replaced the select input with a text input and enabled searching by
UBID.
