### PR TITLE
Remove storage volume `skip_sync`.

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -144,7 +144,7 @@ module Validation
 
   def self.validate_storage_volumes(storage_volumes, boot_disk_index)
     allowed_keys = [
-      :encrypted, :size_gib, :boot, :skip_sync, :read_only, :image,
+      :encrypted, :size_gib, :boot, :read_only, :image,
       :max_read_mbytes_per_sec, :max_write_mbytes_per_sec,
       :vring_workers
     ]

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -319,7 +319,6 @@ class Vm < Sequel::Model
         "spdk_version" => s.spdk_version,
         "vhost_block_backend_version" => s.vhost_block_backend_version,
         "use_bdev_ubi" => s.use_bdev_ubi,
-        "skip_sync" => s.skip_sync,
         "storage_device" => s.storage_device.name,
         "read_only" => s.size_gib == 0,
         "max_read_mbytes_per_sec" => s.max_read_mbytes_per_sec,

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -45,7 +45,6 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
         location_id: Location::GITHUB_RUNNERS_ID,
         storage_size_gib: label_data["storage_size_gib"],
         storage_encrypted: true,
-        storage_skip_sync: true,
         arch: label_data["arch"]
       ).first
     end
@@ -84,7 +83,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       size:,
       location_id:,
       boot_image:,
-      storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: true, skip_sync: true}],
+      storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: true}],
       enable_ip4: true,
       arch: label_data["arch"],
       swap_size_bytes: 4294963200, # ~4096MB, the same value with GitHub hosted runners

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -58,8 +58,7 @@ class Prog::Test::GithubRunner < Prog::Test::Base
       location_id: Location::GITHUB_RUNNERS_ID,
       storage_size_gib: label_data["storage_size_gib"],
       arch: label_data["arch"],
-      storage_encrypted: true,
-      storage_skip_sync: true
+      storage_encrypted: true
     ).subject
     update_stack({"vm_pool_id" => pool.id})
 

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -32,9 +32,9 @@ class Prog::Test::VmGroup < Prog::Test::Base
     encrypted = frame.fetch("storage_encrypted", true)
     boot_images = frame.fetch("boot_images")
     storage_options = [
-      [{encrypted:, skip_sync: true}, {encrypted:, size_gib: 5}],
-      [{encrypted:, skip_sync: false, max_read_mbytes_per_sec: 200, max_write_mbytes_per_sec: 150}],
-      [{encrypted:, skip_sync: false}]
+      [{encrypted:}, {encrypted:, size_gib: 5}],
+      [{encrypted:, max_read_mbytes_per_sec: 200, max_write_mbytes_per_sec: 150}],
+      [{encrypted:}]
     ]
     vm_count = [boot_images.size, storage_options.size, size_options.size].max
     vms = Array.new(vm_count) do |index|

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -33,7 +33,6 @@ class Prog::Vm::Nexus < Prog::Base
     # allow missing fields to make testing during development more convenient.
     storage_volumes.each_with_index do |volume, disk_index|
       volume[:size_gib] ||= vm_size.storage_size_options.first
-      volume[:skip_sync] ||= false
       volume[:max_read_mbytes_per_sec] ||= vm_size.io_limits.max_read_mbytes_per_sec
       volume[:max_write_mbytes_per_sec] ||= vm_size.io_limits.max_write_mbytes_per_sec
       volume[:vring_workers] ||= vm_size.vring_workers
@@ -43,7 +42,6 @@ class Prog::Vm::Nexus < Prog::Base
       if volume[:read_only]
         volume[:size_gib] = 0
         volume[:encrypted] = false
-        volume[:skip_sync] = true
         volume[:boot] = false
       end
     end

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -6,7 +6,7 @@ class Prog::Vm::VmPool < Prog::Base
   subject_is :vm_pool
 
   def self.assemble(size:, vm_size:, boot_image:, location_id:, storage_size_gib:,
-    storage_encrypted:, storage_skip_sync:, arch:)
+    storage_encrypted:, arch:)
     DB.transaction do
       vm_pool = VmPool.create(
         size:,
@@ -15,7 +15,6 @@ class Prog::Vm::VmPool < Prog::Base
         location_id:,
         storage_size_gib:,
         storage_encrypted:,
-        storage_skip_sync:,
         arch:
       )
       Strand.create_with_id(vm_pool, prog: "Vm::VmPool", label: "create_new_vm")
@@ -25,8 +24,7 @@ class Prog::Vm::VmPool < Prog::Base
   label def create_new_vm
     storage_params = {
       size_gib: vm_pool.storage_size_gib,
-      encrypted: vm_pool.storage_encrypted,
-      skip_sync: vm_pool.storage_skip_sync
+      encrypted: vm_pool.storage_encrypted
     }
     ps = Prog::Vnet::SubnetNexus.assemble(
       Config.vm_pool_project_id,

--- a/rhizome/host/bin/convert-encrypted-dek-to-vhost-backend-conf
+++ b/rhizome/host/bin/convert-encrypted-dek-to-vhost-backend-conf
@@ -97,7 +97,6 @@ def generate_vhost_conf(plain_keys, kek_data, vm_name, device)
     "copy_on_read" => false,
     "poll_queue_timeout_us" => 1000,
     "device_id" => "#{vm_name}_0",
-    "skip_sync" => false,
     "write_through" => write_through
   }
   key1 = [plain_keys["key"]].pack("H*")

--- a/rhizome/host/lib/spdk_rpc.rb
+++ b/rhizome/host/lib/spdk_rpc.rb
@@ -41,7 +41,6 @@ class SpdkRpc
   end
 
   def bdev_ubi_create(name, base_bdev_name, image_path,
-    skip_sync = false,
     stripe_size_kb = 1024,
     copy_on_read = false,
     directio = true)
@@ -50,7 +49,7 @@ class SpdkRpc
       base_bdev: base_bdev_name,
       image_path: image_path,
       stripe_size_kb: stripe_size_kb,
-      no_sync: skip_sync,
+      no_sync: false,
       copy_on_read: copy_on_read,
       directio: directio
     }

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -27,7 +27,6 @@ class StorageVolume
     @encrypted = params["encrypted"]
     @disk_size_gib = params["size_gib"]
     @use_bdev_ubi = params["use_bdev_ubi"] || false
-    @skip_sync = params["skip_sync"] || false
     @image_path = BootImage.new(params["image"], params["image_version"]).image_path if params["image"]
     @device = params["storage_device"] || DEFAULT_STORAGE_DEVICE
     @spdk_version = params["spdk_version"]
@@ -251,7 +250,6 @@ class StorageVolume
       "copy_on_read" => @copy_on_read,
       "poll_queue_timeout_us" => 1000,
       "device_id" => @device_id,
-      "skip_sync" => @skip_sync,
       "write_through" => write_through_device?,
       "rpc_socket_path" => sp.rpc_socket_path
     }
@@ -534,7 +532,7 @@ class StorageVolume
     end
 
     if @use_bdev_ubi
-      rpc_client.bdev_ubi_create(@device_id, non_ubi_bdev, @image_path, @skip_sync)
+      rpc_client.bdev_ubi_create(@device_id, non_ubi_bdev, @image_path)
     end
   end
 

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -707,7 +707,6 @@ module Scheduling::Allocator
           size_gib: volume["size_gib"],
           use_bdev_ubi:,
           boot_image_id: image_id,
-          skip_sync: volume["skip_sync"],
           disk_index:,
           key_encryption_key_1_id: key_encryption_key&.id,
           spdk_installation_id:,

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -328,12 +328,12 @@ RSpec.describe Vm do
       VmStorageVolume.create(
         vm_id: vm.id, disk_index: 0, size_gib: 1, boot: true,
         boot_image_id: boot_image.id, key_encryption_key_1_id: kek.id,
-        spdk_installation_id: spdk_installation.id, use_bdev_ubi: false, skip_sync: false,
+        spdk_installation_id: spdk_installation.id, use_bdev_ubi: false,
         storage_device_id: storage_device.id
       )
       VmStorageVolume.create(
         vm_id: vm.id, disk_index: 1, size_gib: 100, boot: false,
-        spdk_installation_id: spdk_installation.id, use_bdev_ubi: true, skip_sync: true,
+        spdk_installation_id: spdk_installation.id, use_bdev_ubi: true,
         storage_device_id: storage_device.id, max_read_mbytes_per_sec: 200,
         max_write_mbytes_per_sec: 300, vhost_block_backend_id: vbb.id, vring_workers: 4
       )
@@ -353,7 +353,7 @@ RSpec.describe Vm do
       expect(vm.storage_volumes).to eq([
         {"boot" => true, "image" => "boot_image", "image_version" => "1", "size_gib" => 1,
          "device_id" => expected_device_id_0, "disk_index" => 0, "encrypted" => true,
-         "spdk_version" => "spdk1", "use_bdev_ubi" => false, "skip_sync" => false,
+         "spdk_version" => "spdk1", "use_bdev_ubi" => false,
          "storage_device" => "default", "read_only" => false,
          "max_read_mbytes_per_sec" => nil,
          "max_write_mbytes_per_sec" => nil,
@@ -361,7 +361,7 @@ RSpec.describe Vm do
          "copy_on_read" => false, "slice_name" => "system.slice"},
         {"boot" => false, "image" => nil, "image_version" => nil, "size_gib" => 100,
          "device_id" => expected_device_id_1, "disk_index" => 1, "encrypted" => false,
-         "spdk_version" => "spdk1", "use_bdev_ubi" => true, "skip_sync" => true,
+         "spdk_version" => "spdk1", "use_bdev_ubi" => true,
          "storage_device" => "default", "read_only" => false,
          "max_read_mbytes_per_sec" => 200,
          "max_write_mbytes_per_sec" => 300,

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -76,14 +76,14 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     end
 
     it "uses the existing vm if pool can pick one" do
-      pool = VmPool.create(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
+      pool = VmPool.create(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64")
       vm = create_vm(pool_id: pool.id, display_state: "running")
       picked_vm = nx.pick_vm
       expect(vm.id).to eq(picked_vm.id)
     end
 
     it "uses the premium vm pool if the installation prefers premium runners" do
-      pool = VmPool.create(size: 2, vm_size: "premium-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
+      pool = VmPool.create(size: 2, vm_size: "premium-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64")
       vm = create_vm(pool_id: pool.id, display_state: "running", family: "premium")
       expect(installation).to receive(:premium_runner_enabled?).and_return(true)
       picked_vm = nx.pick_vm
@@ -92,7 +92,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     end
 
     it "uses the premium vm pool if a free premium upgrade is enabled" do
-      pool = VmPool.create(size: 2, vm_size: "premium-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
+      pool = VmPool.create(size: 2, vm_size: "premium-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64")
       vm = create_vm(pool_id: pool.id, display_state: "running", family: "premium")
       expect(installation).to receive(:premium_runner_enabled?).and_return(false)
       expect(installation).to receive(:free_runner_upgrade?).and_return(true)
@@ -102,7 +102,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     end
 
     it "skips pool if feature flag is enabled even when the pool has a vm" do
-      pool = VmPool.create(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64", storage_skip_sync: true)
+      pool = VmPool.create(size: 2, vm_size: "standard-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64")
       vm = create_vm(pool_id: pool.id, display_state: "running")
       project.set_ff_skip_runner_pool(true)
       expect(Prog::Vm::Nexus).to receive(:assemble_with_sshable).and_call_original

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Prog::Test::GithubRunner do
       expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
       expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests-metal", 10)
       pool = Prog::Vm::VmPool.assemble(size: 1, vm_size: "standard-2", location_id: Location::HETZNER_FSN1_ID, boot_image: "github-ubuntu-2204", storage_size_gib: 86, storage_encrypted: true,
-        storage_skip_sync: false, arch: "x64").subject
+        arch: "x64").subject
       expect(VmPool).to receive(:[]).and_return(pool)
       expect { gr_test.clean_resources }.to nap(15)
     end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -220,8 +220,8 @@ RSpec.describe Prog::Vm::Metal::Nexus do
         bi = BootImage.create(name: "my-image", version: "20230303", size_gib: 15, vm_host_id: vm_host.id)
         dev1 = StorageDevice.create(name: "nvme0", total_storage_gib: 1000, available_storage_gib: 500)
         dev2 = StorageDevice.create(name: "DEFAULT", total_storage_gib: 1000, available_storage_gib: 500)
-        VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, skip_sync: false, spdk_installation_id: si.id, storage_device_id: dev1.id, key_encryption_key_1_id: kek.id)
-        VmStorageVolume.create(vm_id: vm.id, boot: false, size_gib: 15, disk_index: 1, use_bdev_ubi: true, skip_sync: true, spdk_installation_id: si.id, storage_device_id: dev2.id, boot_image_id: bi.id)
+        VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, spdk_installation_id: si.id, storage_device_id: dev1.id, key_encryption_key_1_id: kek.id)
+        VmStorageVolume.create(vm_id: vm.id, boot: false, size_gib: 15, disk_index: 1, use_bdev_ubi: true, spdk_installation_id: si.id, storage_device_id: dev2.id, boot_image_id: bi.id)
 
         st.stack = [frame_update]
         vm.ephemeral_net6 = "fe80::/64"
@@ -282,7 +282,6 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     let(:storage_volumes) {
       [{
         "use_bdev_ubi" => false,
-        "skip_sync" => true,
         "size_gib" => 11,
         "boot" => true
       }]
@@ -707,7 +706,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     it "creates billing records when storage volumes are present" do
       2.times {
         dev = StorageDevice.create(name: "disk_#{it}", total_storage_gib: it * 1000, available_storage_gib: it * 500)
-        VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: it, use_bdev_ubi: false, skip_sync: false, storage_device_id: dev.id)
+        VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: it, use_bdev_ubi: false, storage_device_id: dev.id)
       }
 
       expect { nx.create_billing_record }.to hop("prep")
@@ -936,7 +935,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
 
     it "updates storage devices" do
       dev = StorageDevice.create(name: "DEFAULT", total_storage_gib: 1000, available_storage_gib: 500)
-      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, skip_sync: false, storage_device_id: dev.id)
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, storage_device_id: dev.id)
 
       expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10)
       expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq")
@@ -1082,7 +1081,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     it "can start a vm after reboot" do
       kek = StorageKeyEncryptionKey.create(algorithm: "aes-256-gcm", key: "key", init_vector: "iv", auth_data: "somedata")
       dev = StorageDevice.create(name: "nvme0", total_storage_gib: 1000, available_storage_gib: 500)
-      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, skip_sync: false, storage_device_id: dev.id, key_encryption_key_1_id: kek.id)
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, storage_device_id: dev.id, key_encryption_key_1_id: kek.id)
 
       expect(sshable).to receive(:_cmd).with(
         /sudo host\/bin\/setup-vm recreate-unpersisted #{nx.vm_name}/,

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Prog::Vm::VmPool do
   let(:st) {
     pool = VmPool.create(
       size: 0, vm_size: "standard-2", boot_image: "img", location_id: Location::HETZNER_FSN1_ID,
-      storage_size_gib: 86, storage_encrypted: true, storage_skip_sync: true,
+      storage_size_gib: 86, storage_encrypted: true,
       arch: "x64"
     )
     Strand.create_with_id(pool, prog: "Vm::VmPool", label: "start")
@@ -23,7 +23,7 @@ RSpec.describe Prog::Vm::VmPool do
       st = described_class.assemble(
         size: 3, vm_size: "standard-2", boot_image: "img", location_id: Location::HETZNER_FSN1_ID,
         storage_size_gib: 86, storage_encrypted: true,
-        storage_skip_sync: false, arch: "x64"
+        arch: "x64"
       )
       pool = st.subject
       expect(pool).not_to be_nil
@@ -33,7 +33,6 @@ RSpec.describe Prog::Vm::VmPool do
       expect(pool.location_id).to eq(Location::HETZNER_FSN1_ID)
       expect(pool.storage_size_gib).to eq(86)
       expect(pool.storage_encrypted).to be(true)
-      expect(pool.storage_skip_sync).to be(false)
       expect(st.label).to eq("create_new_vm")
     end
   end

--- a/spec/routes/api/cli/pg/create-read-replica_spec.rb
+++ b/spec/routes/api/cli/pg/create-read-replica_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Clover, "cli pg create-read-replica" do
     pg = PostgresResource.first(name: "test-pg")
     server = pg.representative_server
     server.vm.update(family: "standard", vcpus: 2, memory_gib: 8, arch: "x64")
-    VmStorageVolume.create(vm_id: server.vm_id, size_gib: 64, boot: false, use_bdev_ubi: false, skip_sync: false, disk_index: 1)
+    VmStorageVolume.create(vm_id: server.vm_id, size_gib: 64, boot: false, use_bdev_ubi: false, disk_index: 1)
     pg.timeline.update(cached_earliest_backup_at: Time.now)
 
     body = cli(%w[pg eu-central-h1/test-pg create-read-replica -c max_connections=99 -u max_client_conn=99 -t foo=bar,baz=quux test-pg-rr])

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -49,12 +49,10 @@ RSpec.describe Al do
     let(:storage_volumes) {
       [{
         "use_bdev_ubi" => false,
-        "skip_sync" => true,
         "size_gib" => 11,
         "boot" => true
       }, {
         "use_bdev_ubi" => true,
-        "skip_sync" => false,
         "size_gib" => 22,
         "boot" => false
       }]
@@ -109,8 +107,8 @@ RSpec.describe Al do
     let(:req) {
       Al::Request.new(
         "2464de61-7501-8374-9ab0-416caebe31da", 4, 8, 33,
-        [[1, {"use_bdev_ubi" => true, "skip_sync" => false, "size_gib" => 22, "boot" => false}],
-          [0, {"use_bdev_ubi" => false, "skip_sync" => true, "size_gib" => 11, "boot" => true}]],
+        [[1, {"use_bdev_ubi" => true, "size_gib" => 22, "boot" => false}],
+          [0, {"use_bdev_ubi" => false, "size_gib" => 11, "boot" => true}]],
         "ubuntu-jammy", false, 0, nil, true, 0.65, "x64", ["accepting"], [], [], [], [], [],
         "standard", 400, true, false, false, []
       )
@@ -421,8 +419,8 @@ RSpec.describe Al do
     let(:req) {
       Al::Request.new(
         "2464de61-7501-8374-9ab0-416caebe31da", 4, 16, 33,
-        [[1, {"use_bdev_ubi" => true, "skip_sync" => false, "size_gib" => 22, "boot" => false}],
-          [0, {"use_bdev_ubi" => false, "skip_sync" => true, "size_gib" => 11, "boot" => true}]],
+        [[1, {"use_bdev_ubi" => true, "size_gib" => 22, "boot" => false}],
+          [0, {"use_bdev_ubi" => false, "size_gib" => 11, "boot" => true}]],
         "ubuntu-jammy", false, 0, nil, true, 0.65, "x64", ["accepting"], [], [], [], [], [],
         "standard", 400
       )
@@ -587,8 +585,8 @@ RSpec.describe Al do
     let(:req) {
       Al::Request.new(
         "2464de61-7501-8374-9ab0-416caebe31da", 4, 8, 33,
-        [[1, {"use_bdev_ubi" => true, "skip_sync" => false, "size_gib" => 22, "boot" => false}],
-          [0, {"use_bdev_ubi" => false, "skip_sync" => true, "size_gib" => 11, "boot" => true}]],
+        [[1, {"use_bdev_ubi" => true, "size_gib" => 22, "boot" => false}],
+          [0, {"use_bdev_ubi" => false, "size_gib" => 11, "boot" => true}]],
         "ubuntu-jammy", false, 0.65, "x64", ["accepting"], [], [], [], [],
         "standard", 200
       )
@@ -653,7 +651,7 @@ RSpec.describe Al do
 
   describe "update" do
     let(:vol) {
-      [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => false, "boot" => false}]
+      [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => false, "boot" => false}]
     }
 
     before do
@@ -671,8 +669,8 @@ RSpec.describe Al do
       used_cores = vmh.used_cores
       used_hugepages_1g = vmh.used_hugepages_1g
       available_storage = vmh.storage_devices.sum { it.available_storage_gib }
-      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
-        {"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])
+      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false},
+        {"size_gib" => 95, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}])
       vmh.reload
       expect(vm.vm_storage_volumes.detect { it.disk_index == 0 }.size_gib).to eq(85)
       expect(vm.vm_storage_volumes.detect { it.disk_index == 1 }.size_gib).to eq(95)
@@ -691,8 +689,8 @@ RSpec.describe Al do
       used_cores = vmh.used_cores
       used_hugepages_1g = vmh.used_hugepages_1g
       available_storage = vmh.storage_devices.sum { it.available_storage_gib }
-      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
-        {"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}], gpu_count: 1)
+      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false},
+        {"size_gib" => 95, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}], gpu_count: 1)
       vmh.reload
       expect(vm.vm_storage_volumes.detect { it.disk_index == 0 }.size_gib).to eq(85)
       expect(vm.vm_storage_volumes.detect { it.disk_index == 1 }.size_gib).to eq(95)
@@ -712,8 +710,8 @@ RSpec.describe Al do
       PciDevice.create(vm_host_id: vmh.id, slot: "03:00.0", device_class: "0302", vendor: "vd", device: "27b0", numa_node: 1, iommu_group: 3)
       PciDevice.create(vm_host_id: vmh.id, slot: "04:00.0", device_class: "0302", vendor: "vd", device: "27b0", numa_node: 2, iommu_group: 4)
       PciDevice.create(vm_host_id: vmh.id, slot: "05:00.0", device_class: "0302", vendor: "vd", device: "27b0", numa_node: nil, iommu_group: 5)
-      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
-        {"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}], gpu_count: 2)
+      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false},
+        {"size_gib" => 95, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}], gpu_count: 2)
       vmh.reload
       expect(vm.pci_devices.map(&:iommu_group)).to contain_exactly(2, 3)
     end
@@ -726,8 +724,8 @@ RSpec.describe Al do
       PciDevice.create(vm_host_id: vmh.id, slot: "03:00.0", device_class: "0302", vendor: "vd", device: "27b0", numa_node: 1, iommu_group: 3)
       PciDevice.create(vm_host_id: vmh.id, slot: "04:00.0", device_class: "0302", vendor: "vd", device: "27b0", numa_node: 2, iommu_group: 4)
       PciDevice.create(vm_host_id: vmh.id, slot: "05:00.0", device_class: "0302", vendor: "vd", device: "27b0", numa_node: nil, iommu_group: 5)
-      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
-        {"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}], gpu_count: 5)
+      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false},
+        {"size_gib" => 95, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}], gpu_count: 5)
       vmh.reload
       expect(vm.pci_devices.map(&:iommu_group)).to contain_exactly(1, 2, 3, 4, 5)
     end
@@ -740,8 +738,8 @@ RSpec.describe Al do
       PciDevice.create(vm_host_id: vmh.id, slot: "03:00.0", device_class: "0302", vendor: "vd", device: "27b0", numa_node: 0, iommu_group: 3)
       PciDevice.create(vm_host_id: vmh.id, slot: "04:00.0", device_class: "0302", vendor: "vd", device: "27b0", numa_node: 1, iommu_group: 4)
       PciDevice.create(vm_host_id: vmh.id, slot: "05:00.0", device_class: "0302", vendor: "vd", device: "27b0", numa_node: 1, iommu_group: 5)
-      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
-        {"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}], gpu_count: 2)
+      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false},
+        {"size_gib" => 95, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}], gpu_count: 2)
       vmh.reload
       expect(vm.pci_devices.map(&:iommu_group)).to contain_exactly(1, 3)
     end
@@ -767,7 +765,7 @@ RSpec.describe Al do
         DB[:gpu_partitions_pci_devices].insert(gpu_partition_id: gp.id, pci_device_id: pci.id)
       end
 
-      described_class.allocate(vm, [{"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}], gpu_count: 4)
+      described_class.allocate(vm, [{"size_gib" => 95, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}], gpu_count: 4)
       vmh.reload
       expect(vm.pci_devices.map(&:iommu_group)).to contain_exactly(1, 2, 3, 4)
       expect(vm.gpu_partition.id).to eq(gp.id)
@@ -796,7 +794,7 @@ RSpec.describe Al do
         DB[:gpu_partitions_pci_devices].insert(gpu_partition_id: gp_4.id, pci_device_id: pci.id)
       end
 
-      vol = [{"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}]
+      vol = [{"size_gib" => 95, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}]
 
       expect {
         described_class.allocate(vm, vol, gpu_count: 2)
@@ -853,7 +851,7 @@ RSpec.describe Al do
     it "fails concurrent allocations if storage constraints are violated" do
       vm1 = create_vm
       vm2 = create_vm
-      vol = [{"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}]
+      vol = [{"size_gib" => 95, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}]
       al1 = Al::Allocation.best_allocation(create_req(vm, vol))
       al2 = Al::Allocation.best_allocation(create_req(vm, vol))
       al1.update(vm1)
@@ -893,7 +891,7 @@ RSpec.describe Al do
     it "creates volume with rate limits" do
       vm = create_vm
       vol = [{
-        "size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => false,
+        "size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => false,
         "boot" => false, "max_read_mbytes_per_sec" => 200,
         "max_write_mbytes_per_sec" => 300, "rate_limit_bytes_write" => 400
       }]
@@ -925,7 +923,7 @@ RSpec.describe Al do
 
     it "creates volume with encryption key if storage is encrypted" do
       vm = create_vm
-      described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])
+      described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}])
       expect(StorageKeyEncryptionKey.count).to eq(1)
       expect(vm.vm_storage_volumes.first.key_encryption_key_1_id).not_to be_nil
       expect(vm.storage_secrets.count).to eq(1)
@@ -935,7 +933,7 @@ RSpec.describe Al do
       vmh = VmHost.first
       vhost_backend = VhostBlockBackend.create(vm_host_id: vmh.id, version: "v0.1-5", allocation_weight: 100)
       vm = create_vm
-      described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false, "vring_workers" => 3}])
+      described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false, "vring_workers" => 3}])
       volume = vm.vm_storage_volumes.first
       expect(volume.vhost_block_backend_id).to eq(vhost_backend.id)
       expect(volume.spdk_installation_id).to be_nil
@@ -946,7 +944,7 @@ RSpec.describe Al do
       vmh = VmHost.first
       VhostBlockBackend.create(vm_host_id: vmh.id, version: "v0.1-5", allocation_weight: 0)
       vm = create_vm
-      described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false, "vring_workers" => 3}])
+      described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false, "vring_workers" => 3}])
       volume = vm.vm_storage_volumes.first
       expect(volume.vhost_block_backend_id).to be_nil
       expect(volume.spdk_installation_id).to eq(vmh.spdk_installations.first.id)
@@ -960,7 +958,7 @@ RSpec.describe Al do
       BootImage.create(vm_host_id: vmh.id, name: "ubuntu-jammy", version: nil, activated_at: Time.now, size_gib: 3)
       BootImage.create(vm_host_id: vmh.id, name: "ubuntu-jammy", version: "20240404", activated_at: nil, size_gib: 3)
       vm = create_vm
-      described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => true}])
+      described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => true, "boot" => true}])
       expect(vm.vm_storage_volumes.first.boot_image_id).to eq(bi.id)
     end
 
@@ -969,7 +967,7 @@ RSpec.describe Al do
       BootImage.where(vm_host_id: vmh.id).update(activated_at: nil)
       vm = create_vm
       expect {
-        described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => true}])
+        described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => true, "boot" => true}])
       }.to raise_error(RuntimeError, /no space left on any eligible host/)
     end
 
@@ -980,7 +978,7 @@ RSpec.describe Al do
       mi = BootImage.create(vm_host_id: vmh.id, name: "ai-model-test-model", version: "20240406", activated_at: Time.now, size_gib: 3)
       BootImage.create(vm_host_id: vmh.id, name: "ai-model-test-model", version: "20240404", activated_at: Time.now, size_gib: 3)
       vm = create_vm
-      described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => true}, {"size_gib" => 0, "read_only" => true, "image" => "ai-model-test-model", "boot" => false, "skip_sync" => true, "encrypted" => false, "use_bdev_ubi" => false}])
+      described_class.allocate(vm, [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => true, "boot" => true}, {"size_gib" => 0, "read_only" => true, "image" => "ai-model-test-model", "boot" => false, "encrypted" => false, "use_bdev_ubi" => false}])
       expect(vm.vm_storage_volumes.first.boot_image_id).to eq(bi.id)
       expect(vm.vm_storage_volumes.last.boot_image_id).to eq(mi.id)
     end
@@ -1021,8 +1019,8 @@ RSpec.describe Al do
       used_memory = vmh.used_hugepages_1g
 
       vm = create_vm_from_size("standard-gpu-6", "x64")
-      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
-        {"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}], gpu_count: 1, gpu_device: "27b0")
+      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false},
+        {"size_gib" => 95, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}], gpu_count: 1, gpu_device: "27b0")
       vmh.reload
       vm.reload
 
@@ -1048,8 +1046,8 @@ RSpec.describe Al do
       used_memory = vmh.used_hugepages_1g
 
       vm = create_vm_from_size("standard-2", "arm64")
-      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
-        {"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])
+      described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false},
+        {"size_gib" => 95, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}])
       vmh.reload
       vm.reload
 
@@ -1069,15 +1067,15 @@ RSpec.describe Al do
 
       vm = create_vm
       expect {
-        described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
-          {"size_gib" => 95, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])
+        described_class.allocate(vm, [{"size_gib" => 85, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false},
+          {"size_gib" => 95, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}])
       }.to raise_error(RuntimeError, /no space left on any eligible host/)
     end
   end
 
   describe "project and host selection with slices" do
     let(:vol) {
-      [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => false, "boot" => false}]
+      [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => false, "boot" => false}]
     }
 
     before do
@@ -1145,7 +1143,7 @@ RSpec.describe Al do
 
   describe "slice selection" do
     let(:vol) {
-      [{"size_gib" => 5, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => false, "boot" => false}]
+      [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => false, "boot" => false}]
     }
 
     before do
@@ -1427,8 +1425,8 @@ RSpec.describe Al do
 
       # Create a standard VM in a slice
       vm = create_vm_from_size("standard-2", "arm64")
-      described_class.allocate(vm, [{"size_gib" => 40, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
-        {"size_gib" => 40, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])
+      described_class.allocate(vm, [{"size_gib" => 40, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false},
+        {"size_gib" => 40, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}])
       vmh.reload
       vm.reload
 
@@ -1449,8 +1447,8 @@ RSpec.describe Al do
 
       # Create a burstable VM in a slice
       vm_b1 = create_vm_from_size("burstable-1", "arm64")
-      described_class.allocate(vm_b1, [{"size_gib" => 20, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
-        {"size_gib" => 20, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])
+      described_class.allocate(vm_b1, [{"size_gib" => 20, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false},
+        {"size_gib" => 20, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}])
       vmh.reload
       vm_b1.reload
 
@@ -1472,8 +1470,8 @@ RSpec.describe Al do
 
       # Create a second burstable VM in a slice. It should go to the same slice
       vm_b2 = create_vm_from_size("burstable-2", "arm64")
-      described_class.allocate(vm_b2, [{"size_gib" => 20, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false},
-        {"size_gib" => 20, "use_bdev_ubi" => false, "skip_sync" => false, "encrypted" => true, "boot" => false}])
+      described_class.allocate(vm_b2, [{"size_gib" => 20, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false},
+        {"size_gib" => 20, "use_bdev_ubi" => false, "encrypted" => true, "boot" => false}])
       vmh.reload
       vm_b2.reload
       slice_b.reload


### PR DESCRIPTION
We originally introduced `skip_sync` during the SPDK-only phase to make flush I/O requests no-ops on GitHub runners, where durability across VM crashes or host reboots was not required. This worked because SPDK used a single I/O thread per VM, avoiding concurrency concerns.

With ubiblk (multi-threaded I/O), skipping flushes was not as simple as turning them into no-ops and led to correctness issues (notably in ubiblk v0.1.7). Since the feature provided limited practical value and increased maintenance complexity, we removed it from ubiblk in December 2025.

We no longer operate SPDK-based GitHub runner hosts, so `skip_sync` can also be removed from Ubicloud.

**Notes:**

1. This change updates both Clover and Rhizome in the same commit. This is safe because, the previous rhizome implementation defaults to false if the field is absent.
2. On the database side: `vm_storage_volume.skip_sync` and `vm_pool.storage_skip_sync` both default to false, so removing them will just put an ignored value of false in those tables. Database column removals will be handled in a separate migration PR.