### PR TITLE
Add PostgresResource and PostgresServer tables to admin panel

### DIFF
--- a/spec/routes/web/admin/model/postgres_resource_spec.rb
+++ b/spec/routes/web/admin/model/postgres_resource_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CloverAdmin, "PostgresResource" do
   it "displays the PostgresResource instance page correctly" do
     click_link "PostgresResource"
     expect(page.status_code).to eq 200
-    expect(page.title).to eq "Ubicloud Admin - PostgresResource"
+    expect(page.title).to eq "Ubicloud Admin - PostgresResource - Browse"
 
     click_link @instance.admin_label
     expect(page.status_code).to eq 200

--- a/spec/routes/web/admin/model/postgres_server_spec.rb
+++ b/spec/routes/web/admin/model/postgres_server_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CloverAdmin, "PostgresServer" do
   it "displays the PostgresServer instance page correctly" do
     click_link "PostgresServer"
     expect(page.status_code).to eq 200
-    expect(page.title).to eq "Ubicloud Admin - PostgresServer"
+    expect(page.title).to eq "Ubicloud Admin - PostgresServer - Browse"
 
     click_link @instance.admin_label
     expect(page.status_code).to eq 200


### PR DESCRIPTION
### Skip eager loading on Vm when fetched as an association

AutoForme's :eager option runs every time a record is fetched, not
just on the listing page. PostgresServer eagerly loads [:resource,
:vm], and Vm eagerly loads [:location, :vm_host, :project]. Since
PostgresResource also eagerly loads [:project, :location, :parent],
visiting the PostgresServer list causes duplicate project and location
queries through both associations.

AutoForme supports a block form for :eager that receives the fetch
type, similar to Rodauth's per-request configuration. When a Vm is
fetched as an association (type == :association), the display only
needs name or ubid, so skip the eager loads in that case.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

### Add PostgresResource and PostgresServer tables to admin panel
