### PR TITLE
Fix AWS private subnet leak on insufficient capacity

### DIFF
--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -193,8 +193,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
         end
         runner.provision_spare_runner
         runner.incr_destroy
-        vm.incr_destroy
-        nap 0
+        nap 60
       end
 
       retry_in_different_az(e)

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -416,12 +416,12 @@ usermod -L ubuntu
 
       it "recreates runner when alternative_families is nil" do
         set_alternative_families(nil)
-        expect { nx.create_instance }.to nap(0).and change(GithubRunner, :count).by(1)
+        expect { nx.create_instance }.to nap(60).and change(GithubRunner, :count).by(1)
       end
 
       it "recreates runner when alternative_families is empty" do
         set_alternative_families([])
-        expect { nx.create_instance }.to nap(0).and change(GithubRunner, :count).by(1)
+        expect { nx.create_instance }.to nap(60).and change(GithubRunner, :count).by(1)
       end
 
       it "creates runner with the first alternative when current_family is the initial family" do
@@ -442,7 +442,7 @@ usermod -L ubuntu
       it "recreates runner when current_family is the last family" do
         vm.update(family: "m6a")
         set_alternative_families(["m7i", "m6a"])
-        expect { nx.create_instance }.to nap(0).and change(GithubRunner, :count).by(1)
+        expect { nx.create_instance }.to nap(60).and change(GithubRunner, :count).by(1)
       end
     end
 


### PR DESCRIPTION
When an AWS instance lacks capacity, the runner is destroyed and a spare is provisioned. Previously, we also triggered vm.incr_destroy alongside runner.incr_destroy. Because the VM prog (Vm::Aws::Nexus) now manages the AWS instance directly, unlike the old separate Aws::Instance prog, destroying the VM before the GitHub runner processes its cleanup causes the runner to skip private subnet teardown, leaving it orphaned.

Remove the redundant vm.incr_destroy call so that the GitHub runner nexus handles the full teardown sequence, including the private subnet:

https://github.com/ubicloud/ubicloud/blob/7fe14dc95/prog/github/github_runner_nexus.rb#L534-L544

Also extend the nap from 0 to 60 seconds, giving the current runner time to clean up before retrying.