### PR TITLE
Handle already deleted API tokens when destroying cache entries

### DIFF
--- a/model/github/github_cache_entry.rb
+++ b/model/github/github_cache_entry.rb
@@ -51,6 +51,7 @@ class GithubCacheEntry < Sequel::Model
     begin
       repository.blob_storage_client.delete_object(bucket:, key:)
     rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::Unauthorized
+      nil
     end
   end
 end


### PR DESCRIPTION
Cache entry cleanup involves both a database deletion and blob storage operations (abort multipart upload, delete object). If a previous attempt partially succeeds, deleting the bucket or API token but failing to commit the database change, the retry will encounter errors from the storage client.

The existing rescue for Aws::S3::Errors::NoSuchKey handles the case where the blob was already removed. Add Aws::S3::Errors::Unauthorized to also handle the case where the API token has already been revoked.