### PR TITLE
Add provider selection to /run-e2e PR comment trigger

### DIFF
--- a/.github/workflows/trigger-e2e.yml
+++ b/.github/workflows/trigger-e2e.yml
@@ -26,10 +26,14 @@ jobs:
               const contributorIds = contributors.data.map(c => c.id);
               const isContributor = contributorIds.includes(context.payload.comment.user.id);
 
-              // Check if the given test cases string is secure or empty
-              const testCases = (context.payload.comment.body.trim().split(/\s+/)[1]) || '';
+              // Parse arguments: /run-e2e [providers] [test_cases]
+              const args = context.payload.comment.body.trim().split(/\s+/);
+              const providers = args[1] || '';
+              const testCases = args[2] || '';
+              console.log(`providers: ${providers}`);
               console.log(`testCases: ${testCases}`);
-              const isValid = testCases ? /^[a-zA-Z0-9_,-]+$/.test(testCases) : true;
+              const inputPattern = /^[a-zA-Z0-9_,-]+$/;
+              const isValid = (!providers || inputPattern.test(providers)) && (!testCases || inputPattern.test(testCases));
               console.log(`Is valid: ${isValid}`);
 
               const allowedToRun = isContributor && isValid;
@@ -55,7 +59,9 @@ jobs:
               });
 
               // Create a workflow dispatch event
-              const inputs = testCases ? { test_cases: testCases } : {}
+              const inputs = {}
+              if (providers) inputs.providers = providers;
+              if (testCases) inputs.test_cases = testCases;
               await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
The E2E workflow already supports a providers input for choosing which providers to run against, but the /run-e2e comment trigger only exposed the test_cases argument. This meant contributors had to use the GitHub UI to trigger provider-scoped runs.

The comment syntax is now `/run-e2e [providers] [test_cases]`, e.g. `/run-e2e metal vm,postgres_ha`. Both arguments remain optional and are validated with the same alphanumeric pattern.