### PR TITLE
Add team development SSH keys to the E2E host

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -157,6 +157,7 @@ jobs:
         STRIPE_PUBLIC_KEY: ${{ secrets.STRIPE_PUBLIC_KEY }}
         STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
         VHOST_BLOCK_BACKEND_VERSION: v0.3.1
+        OPERATOR_SSH_PUBLIC_KEYS: ${{ secrets.OPERATOR_SSH_PUBLIC_KEYS }}
       run: |
         set -o pipefail
         timeout 83m foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"


### PR DESCRIPTION
This allows us to connect to the E2E host while tests are running and debug them if needed, without any manual work.

The only tricky part is that the keys in
`secrets.OPERATOR_SSH_PUBLIC_KEYS` must be separated by `\r\n`. Using just `\n` is not sufficient for a YAML multiline string.