### PR TITLE
Quote MAC addresses in cloud-init network-config YAML

### DIFF
--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -235,10 +235,20 @@ RSpec.describe VmSetup do
         ethernets:
           enx3ebda596f7b9:
             match:
-              macaddress: 3e:bd:a5:96:f7:b9
+              macaddress: "3e:bd:a5:96:f7:b9"
             dhcp6: true
             dhcp4: true
       YAML
+    end
+
+    it "quotes MAC addresses that YAML 1.1 would parse as sexagesimal" do
+      sexagesimal_nics = [VmSetup::Nic.new("fd48:666c:a296:ce4b:2cc6::/79", "192.168.5.50/32", "nctest", "12:40:37:27:57:41", "10.0.0.254/32")]
+      vs.cloudinit("user", ["key"], "fddf:53d2:4c89:2305:46a0::/79", sexagesimal_nics, nil, "ubuntu-noble", "10.0.0.2", ipv6_disabled: false)
+      raw_yaml = vps.writes["network-config"]
+      expect(raw_yaml).to include('macaddress: "12:40:37:27:57:41"')
+      config = YAML.safe_load(raw_yaml)
+      expect(config["ethernets"]["enx124037275741"]["match"]["macaddress"]).to eq("12:40:37:27:57:41")
+      expect(config["ethernets"]["enx124037275741"]["match"]["macaddress"]).to be_a(String)
     end
 
     it "generates network-config with multiple NICs" do


### PR DESCRIPTION
https://github.com/ubicloud/ubicloud/commit/60427ce920a793bdbc845827abfd0d79a2d76c2f switched cloud-init config generation from heredoc string
interpolation to YAML.dump.  This lost the explicit double-quoting
on MAC addresses that was added in https://github.com/ubicloud/ubicloud/pull/746 to fix a YAML 1.1
compatibility issue.

Ruby's Psych emits colon-separated all-numeric values like
"12:40:37:27:57:41" unquoted, because YAML 1.2 has no sexagesimal
type.  Cloud-init uses Python's PyYAML, which defaults to YAML 1.1
and parses these as base-60 integers.  When the VM happens to
receive a MAC where every octet is purely numeric and <=59, PyYAML
converts it to an integer, the interface match fails, and the guest
never requests a DHCP lease.

Post-process the YAML.dump output to force double-quoting on MAC
address values so cloud-init always receives a string.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>