### PR TITLE
Limit alien VM provisioning to runners with 16 or fewer vCPUs

### DIFF
--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -125,6 +125,14 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(picked_vm.strand.stack.first["alternative_families"]).to eq(["m7i", "m6a"])
     end
 
+    it "does not use alien vms for large vcpu runners" do
+      runner.update(label: "ubicloud-standard-30")
+      project.set_ff_aws_alien_runners_ratio(1.0)
+      picked_vm = nx.pick_vm
+      expect(picked_vm.family).to eq("standard")
+      expect(picked_vm.location.aws?).to be(false)
+    end
+
     it "uses alien vms if spilled over" do
       runner.incr_spill_over
       location = Location.create(name: "eu-central-1", provider: "aws", project_id: vm.project_id, display_name: "aws-eu-central-1", ui_name: "AWS Frankfurt", visible: true)


### PR DESCRIPTION
We provision 30–60 vCPUs instead of 32–64 vCPUs for allocation reasons.

With 30 vCPUs, the size calculation (30 / 4) results in a 7xlarge instance type, which AWS doesn’t support. We could round this up to 8xlarge (32 vCPUs), but spot instances of that size aren’t always available.

For now, we should provision alien runners only for smaller runner sizes.

Introduce a support_alien? helper that restricts both the random alien ratio path and the spill-over path to x64 runners with at most 16 vCPUs.