### PR TITLE
Simplify GitHub runner e2e tests to use a single workflow run

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -165,6 +165,15 @@ jobs:
       if: always()
       run: grep -h -v -E "sleep_duration_sec|monitor.1" foreman.log
 
+    - name: Extract GitHub workflow run
+      if: always()
+      continue-on-error: true
+      run: |
+        html_url="$(grep 'github_workflow_run' foreman.log | cut -d'|' -f2 | jq -r '.github_workflow_run.html_url' | head -1)"
+        if [ -n "$html_url" ] && [ "$html_url" != "null" ]; then
+          echo "### GitHub workflow run: ${html_url}" >> $GITHUB_STEP_SUMMARY
+        fi
+
     - name: Extract image download time
       if: always() && matrix.provider == 'metal'
       id: extract_download

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -1,6 +1,6 @@
 - { name: vm,                        images: ["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"] }
-- { name: github_runner_ubuntu_2404, images: ["github-ubuntu-2404"], details: {repo_name: tahcloud/github-e2e-tests, workflow_name: test_2404.yml, branch_name: main} }
-- { name: github_runner_ubuntu_2204, images: ["github-ubuntu-2204"], details: {repo_name: tahcloud/github-e2e-tests, workflow_name: test_2204.yml, branch_name: main} }
+- { name: github_runner_ubuntu_2404, images: ["github-ubuntu-2404"] }
+- { name: github_runner_ubuntu_2204, images: ["github-ubuntu-2204"] }
 - { name: postgres_standard,         images: ["postgres-ubuntu-2204"] }
 - { name: postgres_ha,               images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_upgrade,          images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -4,55 +4,59 @@ require "octokit"
 require "yaml"
 
 class Prog::Test::GithubRunner < Prog::Test::Base
-  FAIL_CONCLUSIONS = ["action_required", "cancelled", "failure", "skipped", "stale", "timed_out"]
-  IN_PROGRESS_CONCLUSIONS = ["in_progress", "queued", "requested", "waiting", "pending", "neutral"]
+  FAIL_CONCLUSIONS = %w[action_required cancelled failure skipped stale timed_out].freeze
+  IN_PROGRESS_CONCLUSIONS = %w[in_progress queued requested waiting pending neutral].freeze
+  REPOSITORY_NAME_PREFIX = "tahcloud/github-e2e-tests"
+  WORKFLOW_NAME = "test.yml"
+  BRANCH_NAME = "enes/simply-tests"
 
   def self.assemble(test_cases, provider: "metal")
-    github_service_project = Project.create_with_id(Config.github_runner_service_project_id, name: "Github-Runner-Service-Project")
-    vm_pool_service_project = Project.create_with_id(Config.vm_pool_project_id, name: "Vm-Pool-Service-Project")
-    github_test_project = Project.create(name: "Github-Runner-Test-Project")
+    service_project = Project.create_with_id(Config.github_runner_service_project_id, name: "Github-Runner-Service-Project")
+    Project.create_with_id(Config.vm_pool_project_id, name: "Vm-Pool-Service-Project")
+    customer_project = Project.create(name: "Github-Runner-Customer-Project")
 
     if provider == "aws"
-      github_test_project.set_ff_aws_alien_runners_ratio(1)
-      location = Location.create_with_id(Config.github_runner_aws_location_id, name: "eu-central-1", provider: "aws", project_id: github_service_project.id, display_name: "aws-e2e", ui_name: "aws-e2e", visible: true)
+      customer_project.set_ff_aws_alien_runners_ratio(1)
+      location = Location.create_with_id(Config.github_runner_aws_location_id, name: "eu-central-1", provider: "aws", project_id: service_project.id, display_name: "aws-e2e", ui_name: "aws-e2e", visible: true)
       LocationCredential.create_with_id(location.id, access_key: Config.e2e_aws_access_key, secret_key: Config.e2e_aws_secret_key)
     end
 
     if (url = Config.e2e_cache_proxy_download_url) && !url.empty?
-      github_test_project.set_ff_cache_proxy_download_url({x64: url})
+      customer_project.set_ff_cache_proxy_download_url({x64: url})
     end
 
     GithubInstallation.create(
       installation_id: Config.e2e_github_installation_id,
       name: "TestUser",
       type: "User",
-      project_id: github_test_project.id,
+      project_id: customer_project.id,
       created_at: Time.now - 8 * 24 * 60 * 60
     )
+
+    labels = []
+    labels << "ubicloud-standard-2-ubuntu-2204" if test_cases.any? { it["name"].include?("2204") }
+    labels << "ubicloud-standard-2-ubuntu-2404" if test_cases.any? { it["name"].include?("2404") }
 
     Strand.create(
       prog: "Test::GithubRunner",
       label: "start",
       stack: [{
-        "created_at" => Time.now.utc,
         "provider" => provider,
-        "test_cases" => test_cases,
-        "github_service_project_id" => github_service_project.id,
-        "vm_pool_service_project" => vm_pool_service_project.id,
-        "github_test_project_id" => github_test_project.id
+        "customer_project_id" => customer_project.id,
+        "labels" => labels
       }]
     )
   end
 
   label def start
-    hop_trigger_test_runs if frame["provider"] == "aws"
+    hop_trigger_test_run if frame["provider"] == "aws"
     hop_create_vm_pool
   end
 
   label def create_vm_pool
-    label_data = Github.runner_labels["ubicloud"]
+    label_data = Github.runner_labels[frame["labels"].first]
     pool = Prog::Vm::VmPool.assemble(
-      size: 1,
+      size: 2,
       vm_size: label_data["vm_size"],
       boot_image: label_data["boot_image"],
       location_id: Location::GITHUB_RUNNERS_ID,
@@ -73,49 +77,40 @@ class Prog::Test::GithubRunner < Prog::Test::Base
     # This simplifies the process of verifying at the end of the test that VMs
     # were correctly picked from the pool.
     pool.update(size: 0)
-    hop_trigger_test_runs
+    hop_trigger_test_run
   end
 
-  label def trigger_test_runs
-    test_runs.each do |test_run|
-      unless trigger_test_run(repo_name(test_run["repo_name"]), test_run["workflow_name"], test_run["branch_name"])
-        update_stack({"fail_message" => "Can not trigger workflow for #{repo_name(test_run["repo_name"])}, #{test_run["workflow_name"]}, #{test_run["branch_name"]}"})
-        hop_clean_resources
-      end
+  label def trigger_test_run
+    inputs = {triggered_by: ENV["GITHUB_RUN_ID"], provider: frame["provider"], runners: frame["labels"].to_json}
+    response = client.post("repos/#{repository_name}/actions/workflows/#{WORKFLOW_NAME}/dispatches", {ref: BRANCH_NAME, inputs:, return_run_details: true})
+    unless response
+      update_stack({"fail_message" => "Couldn't trigger workflow"})
+      hop_clean_resources
     end
 
-    # To make sure that test runs are triggered
-    # We sill still check the runs in the next step in
-    # case an incident happens on the github side
-    sleep 30
-
-    hop_check_test_runs
+    Clog.emit("Triggered GitHub workflow run", {github_workflow_run: {run_id: response[:workflow_run_id], html_url: response[:html_url]}})
+    update_stack({"test_run_id" => response[:workflow_run_id]})
+    hop_check_test_run
   end
 
-  label def check_test_runs
-    test_runs.each do |test_run|
-      latest_run = latest_run(repo_name(test_run["repo_name"]), test_run["workflow_name"], test_run["branch_name"])
-
-      # In case the run can not be triggered in the previous state
-      if latest_run[:created_at] < Time.parse(frame["created_at"])
-        update_stack({"fail_message" => "Can not trigger workflow for #{repo_name(test_run["repo_name"])}, #{test_run["workflow_name"]}, #{test_run["branch_name"]}"})
-        break
-      end
-
-      conclusion = latest_run[:conclusion]
-      if FAIL_CONCLUSIONS.include?(conclusion)
-        update_stack({"fail_message" => "Test run for #{repo_name(test_run["repo_name"])}, #{test_run["workflow_name"]}, #{test_run["branch_name"]} failed with conclusion #{conclusion}"})
-        break
-      elsif IN_PROGRESS_CONCLUSIONS.include?(conclusion) || conclusion.nil?
-        nap 15
-      end
+  label def check_test_run
+    run = client.workflow_run(repository_name, frame["test_run_id"])
+    conclusion = run[:conclusion]
+    if FAIL_CONCLUSIONS.include?(conclusion)
+      update_stack({"fail_message" => "Test run failed with conclusion: #{conclusion}"})
+    elsif IN_PROGRESS_CONCLUSIONS.include?(conclusion) || conclusion.nil?
+      nap 15
     end
 
     hop_clean_resources
   end
 
   label def clean_resources
-    cancel_test_runs
+    begin
+      client.cancel_workflow_run(repository_name, frame["test_run_id"]) if frame["test_run_id"]
+    rescue Octokit::Error
+      Clog.emit("Workflow run #{frame["test_run_id"]} has already been finished")
+    end
 
     if GithubRunner.any?
       Clog.emit("Waiting runners to finish their jobs")
@@ -140,9 +135,9 @@ class Prog::Test::GithubRunner < Prog::Test::Base
       nap 15
     end
 
-    Project[frame["github_service_project_id"]]&.destroy
-    Project[frame["vm_pool_service_project"]]&.destroy
-    Project[frame["github_test_project_id"]]&.destroy
+    Project[Config.github_runner_service_project_id]&.destroy
+    Project[Config.vm_pool_project_id]&.destroy
+    Project[frame["customer_project_id"]]&.destroy
 
     frame["fail_message"] ? fail_test(frame["fail_message"]) : hop_finish
   end
@@ -155,36 +150,8 @@ class Prog::Test::GithubRunner < Prog::Test::Base
     nap 15
   end
 
-  def trigger_test_run(repo_name, workflow_name, branch_name)
-    client.post("repos/#{repo_name}/actions/workflows/#{workflow_name}/dispatches", {ref: branch_name, inputs: {triggered_by: ENV["GITHUB_RUN_ID"]}})
-  end
-
-  def latest_run(repo_name, workflow_name, branch_name)
-    runs = client.workflow_runs(repo_name, workflow_name, {branch: branch_name})
-    runs[:workflow_runs].first
-  end
-
-  def cancel_test_runs
-    test_runs.each do |test_run|
-      cancel_test_run(repo_name(test_run["repo_name"]), test_run["workflow_name"], test_run["branch_name"])
-    end
-  end
-
-  def cancel_test_run(repo_name, workflow_name, branch_name)
-    run_id = latest_run(repo_name, workflow_name, branch_name)[:id]
-    begin
-      client.cancel_workflow_run(repo_name, run_id)
-    rescue
-      Clog.emit("Workflow run #{run_id} for #{repo_name} has already been finished")
-    end
-  end
-
-  def test_runs
-    @test_runs ||= frame["test_cases"].map { it["details"] }
-  end
-
-  def repo_name(base_name)
-    "#{base_name}-#{frame["provider"]}"
+  def repository_name
+    "#{REPOSITORY_NAME_PREFIX}-#{frame["provider"]}"
   end
 
   def client

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -3,13 +3,14 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Test::GithubRunner do
-  subject(:gr_test) { described_class.new(described_class.assemble([{"name" => "github_runner_ubuntu_2204", "images" => ["github-ubuntu-2204"], "details" => {"repo_name" => "tahcloud/github-e2e-tests", "workflow_name" => "test_2204.yml", "branch_name" => "main"}}])) }
+  subject(:gr_test) {
+    described_class.new(described_class.assemble([{"name" => "github_runner_ubuntu_2204"}]))
+  }
 
   let(:client) { instance_double(Octokit::Client) }
 
   before do
-    expect(Config).to receive(:github_runner_service_project_id).and_return("fabd95f8-d002-8ed2-9f4c-00625eb7f574")
-    expect(Config).to receive(:vm_pool_project_id).and_return("c3fd495f-9888-82d2-8100-7fae94e87e27")
+    allow(Config).to receive_messages(github_runner_service_project_id: "fabd95f8-d002-8ed2-9f4c-00625eb7f574", vm_pool_project_id: "c3fd495f-9888-82d2-8100-7fae94e87e27")
     expect(Config).to receive(:e2e_github_installation_id).and_return(123456).at_least(:once)
     allow(Github).to receive(:installation_client).with(Config.e2e_github_installation_id, auto_paginate: true).and_return(client)
   end
@@ -24,8 +25,12 @@ RSpec.describe Prog::Test::GithubRunner do
       described_class.assemble([], provider: "aws")
       expect(Location[location_id]).not_to be_nil
       expect(LocationCredential[location_id].access_key).to eq("access_key")
-      expect(LocationCredential[location_id].access_key).to eq("access_key")
       expect(GithubInstallation.first.project.get_ff_cache_proxy_download_url).to eq({"x64" => "http://example.com/cache-proxy"})
+    end
+
+    it "assembles labels based on test case names" do
+      strand = described_class.assemble([{"name" => "github_runner_ubuntu_2204"}, {"name" => "github_runner_ubuntu_2404"}])
+      expect(strand.stack.first["labels"]).to eq(["ubicloud-standard-2-ubuntu-2204", "ubicloud-standard-2-ubuntu-2404"])
     end
   end
 
@@ -34,29 +39,29 @@ RSpec.describe Prog::Test::GithubRunner do
       expect { gr_test.start }.to hop("create_vm_pool")
     end
 
-    it "hops to trigger_test_runs when provider is aws" do
+    it "hops to trigger_test_run when provider is aws" do
       expect(gr_test).to receive(:frame).and_return({"provider" => "aws"})
-      expect { gr_test.start }.to hop("trigger_test_runs")
+      expect { gr_test.start }.to hop("trigger_test_run")
     end
   end
 
   describe "#create_vm_pool" do
     it "creates pool and hops to wait_vm_pool_to_be_ready" do
-      label_data = Github.runner_labels["ubicloud"]
+      label_data = Github.runner_labels["ubicloud-standard-2-ubuntu-2204"]
       expect(Prog::Vm::VmPool).to receive(:assemble)
-        .with(hash_including(size: 1, vm_size: label_data["vm_size"]))
+        .with(hash_including(size: 2, vm_size: label_data["vm_size"]))
         .and_return(instance_double(Strand, subject: instance_double(VmPool, id: 12345)))
       expect { gr_test.create_vm_pool }.to hop("wait_vm_pool_to_be_ready")
     end
   end
 
   describe "#wait_vm_pool_to_be_ready" do
-    it "hops to trigger_test_runs when the pool is ready" do
+    it "hops to trigger_test_run when the pool is ready" do
       pool = instance_double(VmPool, size: 1)
       expect(VmPool).to receive(:[]).and_return(pool)
       expect(pool).to receive(:vms_dataset).and_return(instance_double(Sequel::Dataset, exclude: [instance_double(Vm)]))
       expect(pool).to receive(:update).with(size: 0)
-      expect { gr_test.wait_vm_pool_to_be_ready }.to hop("trigger_test_runs")
+      expect { gr_test.wait_vm_pool_to_be_ready }.to hop("trigger_test_run")
     end
 
     it "naps if the vm in the pool not provisioned yet" do
@@ -67,66 +72,66 @@ RSpec.describe Prog::Test::GithubRunner do
     end
   end
 
-  describe "#trigger_test_runs" do
-    it "triggers test runs" do
+  describe "#trigger_test_run" do
+    it "triggers test run and stores run id from response" do
       allow(ENV).to receive(:[]).and_call_original
       expect(ENV).to receive(:[]).with("GITHUB_RUN_ID").and_return("12345")
-      expect(client).to receive(:post).with("repos/tahcloud/github-e2e-tests-metal/actions/workflows/test_2204.yml/dispatches", {ref: "main", inputs: {triggered_by: "12345"}}).and_return({workflow_run_id: 123456789})
-      expect(gr_test).to receive(:sleep).with(30)
-      expect { gr_test.trigger_test_runs }.to hop("check_test_runs")
+      expect(client).to receive(:post).with(
+        "repos/tahcloud/github-e2e-tests-metal/actions/workflows/test.yml/dispatches",
+        {ref: "enes/simply-tests", inputs: {triggered_by: "12345", provider: "metal", runners: gr_test.frame["labels"].to_json}, return_run_details: true}
+      ).and_return({workflow_run_id: 123456789})
+      expect { gr_test.trigger_test_run }.to hop("check_test_run")
     end
 
-    it "can not triggers test runs" do
+    it "hops to clean_resources when trigger fails" do
       allow(ENV).to receive(:[]).and_call_original
       expect(ENV).to receive(:[]).with("GITHUB_RUN_ID").and_return("12345")
-      expect(client).to receive(:post).with("repos/tahcloud/github-e2e-tests-metal/actions/workflows/test_2204.yml/dispatches", {ref: "main", inputs: {triggered_by: "12345"}}).and_return(false)
-      expect { gr_test.trigger_test_runs }.to hop("clean_resources")
+      expect(client).to receive(:post).with(
+        "repos/tahcloud/github-e2e-tests-metal/actions/workflows/test.yml/dispatches",
+        {ref: "enes/simply-tests", inputs: {triggered_by: "12345", provider: "metal", runners: gr_test.frame["labels"].to_json}, return_run_details: true}
+      ).and_return(false)
+      expect { gr_test.trigger_test_run }.to hop("clean_resources")
     end
   end
 
-  describe "#check_test_runs" do
-    it "check test runs completed" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "success", created_at: Time.now + 10}]})
-      expect { gr_test.check_test_runs }.to hop("clean_resources")
+  describe "#check_test_run" do
+    before { refresh_frame(gr_test, new_values: {"test_run_id" => 99}) }
+
+    it "hops to clean_resources on success" do
+      expect(client).to receive(:workflow_run).with("tahcloud/github-e2e-tests-metal", 99)
+        .and_return({conclusion: "success"})
+      expect { gr_test.check_test_run }.to hop("clean_resources")
     end
 
-    it "check test runs completed for alien runners" do
-      expect(gr_test).to receive(:frame).and_return(gr_test.frame.merge({"github_runner_aws_location_id" => "c4cf8b4c-70ec-8820-b311-13284f205306"})).at_least(:once)
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "success", created_at: Time.now + 10}]})
-      expect { gr_test.check_test_runs }.to hop("clean_resources")
+    it "naps when conclusion is nil" do
+      expect(client).to receive(:workflow_run).with("tahcloud/github-e2e-tests-metal", 99)
+        .and_return({conclusion: nil})
+      expect { gr_test.check_test_run }.to nap(15)
     end
 
-    it "check test runs in progress with nil" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: nil, created_at: Time.now + 10}]})
-      expect { gr_test.check_test_runs }.to nap(15)
+    it "naps when conclusion is in_progress" do
+      expect(client).to receive(:workflow_run).with("tahcloud/github-e2e-tests-metal", 99)
+        .and_return({conclusion: "in_progress"})
+      expect { gr_test.check_test_run }.to nap(15)
     end
 
-    it "check test runs in progress state" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "in_progress", created_at: Time.now + 10}]})
-      expect { gr_test.check_test_runs }.to nap(15)
-    end
-
-    it "check test runs failed" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "failure", created_at: Time.now + 10}]})
-      expect { gr_test.check_test_runs }.to hop("clean_resources")
-    end
-
-    it "check test runs created before" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{conclusion: "failure", created_at: Time.now - 2 * 60 * 60}]})
-      expect { gr_test.check_test_runs }.to hop("clean_resources")
+    it "hops to clean_resources on failure" do
+      expect(client).to receive(:workflow_run).with("tahcloud/github-e2e-tests-metal", 99)
+        .and_return({conclusion: "failure"})
+      expect { gr_test.check_test_run }.to hop("clean_resources")
     end
   end
 
   describe "#clean_resources" do
     it "waits runners to finish their jobs" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
+      refresh_frame(gr_test, new_values: {"test_run_id" => 10})
       expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests-metal", 10)
       GithubRunner.create(repository_name: "test-repo", label: "ubicloud")
       expect { gr_test.clean_resources }.to nap(15)
     end
 
     it "waits vm pools to be destroyed" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
+      refresh_frame(gr_test, new_values: {"test_run_id" => 10})
       expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests-metal", 10)
       pool = Prog::Vm::VmPool.assemble(size: 1, vm_size: "standard-2", location_id: Location::HETZNER_FSN1_ID, boot_image: "github-ubuntu-2204", storage_size_gib: 86, storage_encrypted: true,
         arch: "x64").subject
@@ -135,7 +140,7 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "waits repositories to be destroyed" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
+      refresh_frame(gr_test, new_values: {"test_run_id" => 10})
       expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests-metal", 10)
       installation = GithubInstallation.create(installation_id: 123, name: "test-user", type: "User")
       repo = Prog::Github::GithubRepositoryNexus.assemble(installation, "ubicloud/ubicloud", "master").subject
@@ -144,7 +149,7 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources and hop finish" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
+      refresh_frame(gr_test, new_values: {"test_run_id" => 10})
       expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests-metal", 10)
       expect(GithubRunner).to receive(:any?).and_return(false)
       expect(VmPool).to receive(:[]).with(anything).and_return(instance_double(VmPool, vms: [], incr_destroy: nil))
@@ -153,19 +158,23 @@ RSpec.describe Prog::Test::GithubRunner do
     end
 
     it "cleans resources and hop failed" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
+      refresh_frame(gr_test, new_values: {"test_run_id" => 10, "fail_message" => "Failed test"})
       expect(client).to receive(:cancel_workflow_run).with("tahcloud/github-e2e-tests-metal", 10)
       expect(GithubRunner).to receive(:any?).and_return(false)
       expect(VmPool).to receive(:[]).with(anything).and_return(instance_double(VmPool, vms: [instance_double(Vm)], incr_destroy: nil))
       expect(Project).to receive(:[]).with(anything).and_return(nil).at_least(:once)
-      refresh_frame(gr_test, new_values: {"fail_message" => "Failed test"})
-      # expect(gr_test).to receive(:frame).and_return({"fail_message" => "Failed test", "test_cases" => gr_test.frame["test_cases"]}).at_least(:once)
       expect { gr_test.clean_resources }.to hop("failed")
     end
 
-    it "cleans resources already cancelled" do
-      expect(client).to receive(:workflow_runs).with("tahcloud/github-e2e-tests-metal", "test_2204.yml", {branch: "main"}).and_return({workflow_runs: [{id: 10}]})
-      expect(client).to receive(:cancel_workflow_run).and_raise(StandardError)
+    it "skips cancel when no test_run_id" do
+      expect(client).not_to receive(:cancel_workflow_run)
+      expect(GithubRunner).to receive(:any?).and_return(true)
+      expect { gr_test.clean_resources }.to nap(15)
+    end
+
+    it "handles already cancelled workflow run" do
+      refresh_frame(gr_test, new_values: {"test_run_id" => 10})
+      expect(client).to receive(:cancel_workflow_run).and_raise(Octokit::Error)
       expect(GithubRunner).to receive(:any?).and_return(true)
       expect { gr_test.clean_resources }.to nap(15)
     end


### PR DESCRIPTION
Previously each test case triggered and tracked a separate workflow
(test_2204.yml, test_2404.yml, etc.), complicating the prog with
per-case iteration in trigger, check, and cancel steps. A single
workflow dispatched with the runner labels as an input can spawn
multiple jobs internally, so we only need to track one run.

The test case config no longer carries per-case workflow details; the
prog derives the required runner labels from the test case names and
passes them to the workflow.

Use the new return_run_details parameter in the workflow dispatch API
to get the run ID directly from the response, eliminating the need to
poll workflow runs and search by creation time and name. This removes
the 30-second sleep and the created_at tracking from the stack frame.

https://github.blog/changelog/2026-02-19-workflow-dispatch-api-now-returns-run-ids/

The branch is pinned to "enes/simply-tests" temporarily because the
workflow file on the target repository is not yet on main. It will
be switched to main once existing branches are rebased.
