### PR TITLE
Add `View in Clover` links to admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -269,6 +269,11 @@ class CloverAdmin < Roda
   }.freeze
   OBJECT_ACTIONS.each_value(&:freeze)
 
+  OBJECTS_WITH_UI = {
+    "Vm" => lambda { |vm| "project/#{vm.project.ubid}/location/#{vm.location.display_name}/vm/#{vm.ubid}/overview" },
+    "PostgresResource" => lambda { |pg| "project/#{pg.project.ubid}/location/#{pg.location.display_name}/postgres/#{pg.name}/overview" }
+  }.freeze
+
   OBJECTS_WITH_EXTRAS = Dir["views/admin/extras/*.erb"]
     .map { File.basename(it, ".erb") }
     .each_with_object({}) { |name, h| h[name] = true }

--- a/config.rb
+++ b/config.rb
@@ -52,6 +52,7 @@ module Config
   mandatory :rack_env, string
 
   override :clover_admin_development_no_webauthn, false, bool
+  override :clover_admin_links_to_clover, false, bool
   optional :clover_runtime_token_secret, base64, clear: true
   optional :kms_decrypt_clover_column_encryption_key_with_arn, string
   optional :heartbeat_url, string

--- a/spec/routes/web/admin/model/postgres_resource_spec.rb
+++ b/spec/routes/web/admin/model/postgres_resource_spec.rb
@@ -18,5 +18,21 @@ RSpec.describe CloverAdmin, "PostgresResource" do
     click_link @instance.admin_label
     expect(page.status_code).to eq 200
     expect(page.title).to eq "Ubicloud Admin - PostgresResource #{@instance.ubid}"
+
+    expect(page.all("a").any? { |a| a.text == "View in Clover" }).to be(false)
+  end
+
+  it "links to clover when configured to" do
+    allow(Config).to receive(:clover_admin_links_to_clover).and_return(true)
+
+    click_link "PostgresResource"
+    expect(page.status_code).to eq 200
+
+    click_link @instance.admin_label
+    expect(page.status_code).to eq 200
+
+    link = page.all("a").find { |a| a.text == "View in Clover" }
+    expect(link).not_to be_nil
+    expect(link["href"]).to eq "http://localhost:9292/project/#{@instance.project.ubid}/location/#{@instance.location.display_name}/postgres/#{@instance.name}/overview"
   end
 end

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -19,6 +19,10 @@
   <% end %>
 </div>
 
+<% if Config.clover_admin_links_to_clover && (link = OBJECTS_WITH_UI[@klass.name]) %>
+  <p><a href="<%= Config.base_url %>/<%= link.call(@obj) %>">View in Clover</a></p>
+<% end %>
+
 <% if @klass.associations.include?(:semaphores) && !(semaphores = @obj.semaphores_dataset.select_order_map(:name)).empty? %>
   <p>Semaphores Set: <%= semaphores.join(", ") %></p>
 <% end %>


### PR DESCRIPTION
Useful for redistributors to easily drill down during investigation