### PR TITLE
Append triggered E2E workflow run URL to the /run-e2e comment

### DIFF
--- a/.github/workflows/trigger-e2e.yml
+++ b/.github/workflows/trigger-e2e.yml
@@ -62,10 +62,21 @@ jobs:
               const inputs = {}
               if (providers) inputs.providers = providers;
               if (testCases) inputs.test_cases = testCases;
-              await github.rest.actions.createWorkflowDispatch({
+              const dispatch = await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 workflow_id: 'e2e.yml',
                 ref: pullRequest.data.head.ref,
-                inputs: inputs
+                inputs: inputs,
+                return_run_details: true
               });
+
+              // Append the workflow run URL to the original comment
+              if (dispatch.data?.html_url) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: context.payload.comment.id,
+                  body: `${context.payload.comment.body}\n\nE2E tests triggered: ${dispatch.data.html_url}`
+                });
+              }


### PR DESCRIPTION
GitHub's workflow dispatch API now supports returning run details via the return_run_details parameter [1]. Use this to get the run URL directly from the response, then edit the original /run-e2e comment to append it. This gives immediate visibility into the triggered run.

[1] https://github.blog/changelog/2026-02-19-workflow-dispatch-api-now-returns-run-ids/