### PR TITLE
Guard rhizome user cleanup in bootstrap

### DIFF
--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -63,7 +63,16 @@ if [ :no_bundler_install = false ]; then
   sudo apt-get -y install ruby-bundler
 fi
 sudo which bundle
-sudo userdel -rf rhizome || true
+if id rhizome &>/dev/null; then
+  procs=$(ps -u rhizome -o pid,comm,args --no-headers) || [ $? -eq 1 ]
+  if [ -n "$procs" ]; then
+    echo "Terminating rhizome processes:"
+    echo "$procs"
+    sudo pkill -u rhizome || [ $? -eq 1 ]
+    sleep 1
+  fi
+  sudo userdel -r rhizome
+fi
 sudo adduser --disabled-password --gecos '' rhizome
 echo 'rhizome ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-rhizome
 sudo install -d -o rhizome -g rhizome -m 0700 /home/rhizome/.ssh

--- a/spec/prog/bootstrap_rhizome_spec.rb
+++ b/spec/prog/bootstrap_rhizome_spec.rb
@@ -44,7 +44,16 @@ if [ false = false ]; then
   sudo apt-get -y install ruby-bundler
 fi
 sudo which bundle
-sudo userdel -rf rhizome || true
+if id rhizome &>/dev/null; then
+  procs=$(ps -u rhizome -o pid,comm,args --no-headers) || [ $? -eq 1 ]
+  if [ -n "$procs" ]; then
+    echo "Terminating rhizome processes:"
+    echo "$procs"
+    sudo pkill -u rhizome || [ $? -eq 1 ]
+    sleep 1
+  fi
+  sudo userdel -r rhizome
+fi
 sudo adduser --disabled-password --gecos '' rhizome
 echo 'rhizome ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/98-rhizome
 sudo install -d -o rhizome -g rhizome -m 0700 /home/rhizome/.ssh


### PR DESCRIPTION
The old `userdel -rf rhizome || true` suppresses all errors: -f forces removal even with active processes (e.g. an SSH session from a prior bootstrap attempt), and || true swallows everything from EPERM to corrupt passwd.

Replace with an explicit guard: check whether the user exists, terminate any lingering processes, then remove without -f.  If the user doesn't exist, skip entirely.  If userdel fails because processes survived SIGTERM, the control plane retries with backoff until the host is clean.