### PR TITLE
Guard VM user/group cleanup in create_unix_user

### DIFF
--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -120,10 +120,17 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     uid = rand(1100..59999)
     command = <<~COMMAND
       set -ueo pipefail
-      # Make this script idempotent
-      sudo userdel --remove --force :vm_name || true
-      sudo groupdel -f :vm_name || true
-      # Create vm's user and home directory
+      if id :vm_name &>/dev/null; then
+        procs=$(ps -u :vm_name -o pid,comm,args --no-headers) || [ $? -eq 1 ]
+        if [ -n "$procs" ]; then
+          echo "Terminating :vm_name processes:"
+          echo "$procs"
+          sudo pkill -u :vm_name || [ $? -eq 1 ]
+          sleep 1
+        fi
+        sudo userdel -r :vm_name
+      fi
+      if getent group :vm_name &>/dev/null; then sudo groupdel :vm_name; fi
       sudo adduser --disabled-password --gecos '' --home :vm_home --uid :uid :vm_name
       # Enable KVM access for VM user
       sudo usermod -a -G kvm :vm_name


### PR DESCRIPTION
The old `userdel --remove --force || true` and `groupdel -f || true` suppress all errors to achieve idempotency.  This masks real problems: -f silently kills lingering processes or removes groups with other members, and || true swallows permission and I/O errors.

Replace with explicit guards: check `id`/`getent group` before removal, terminate lingering processes with logged output, and drop -f from both commands.  Failures now propagate and the control plane retries with backoff until the host is clean.