### PR TITLE
Require IMDSv2 on AWS

### DIFF
--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -167,6 +167,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
         enable_resource_name_dns_a_record: false,
         enable_resource_name_dns_aaaa_record: false
       },
+      metadata_options: {http_tokens: "required"},
       min_count: 1,
       max_count: 1,
       user_data: Base64.encode64(user_data.gsub(/^(\s*# .*)?\n/, "")),

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -334,6 +334,7 @@ usermod -L ubuntu
           enable_resource_name_dns_a_record: false,
           enable_resource_name_dns_aaaa_record: false
         },
+        metadata_options: {http_tokens: "required"},
         min_count: 1,
         max_count: 1,
         tag_specifications: Util.aws_tag_specifications("instance", vm.name),


### PR DESCRIPTION
Default is optional. IMDSv2 offers better security

Long term this endpoint should be disabled in favor of STS tokens