### PR TITLE
Validate init_script contains only ASCII characters

### DIFF
--- a/model/postgres/postgres_init_script.rb
+++ b/model/postgres/postgres_init_script.rb
@@ -8,6 +8,7 @@ class PostgresInitScript < Sequel::Model
   def validate
     super
     validates_max_length(3000, :init_script)
+    errors.add(:init_script, "must contain only ASCII characters") unless init_script&.ascii_only?
   end
 end
 

--- a/model/vm_init_script.rb
+++ b/model/vm_init_script.rb
@@ -8,6 +8,7 @@ class VmInitScript < Sequel::Model
   def validate
     super
     validates_max_length(2000, :init_script)
+    errors.add(:init_script, "must contain only ASCII characters") unless init_script&.ascii_only?
   end
 end
 


### PR DESCRIPTION
Sequel's column_encryption plugin returns decrypted values with ASCII-8BIT encoding, which causes Encoding::CompatibilityError when rendering in UTF-8 ERB templates. Enforcing ASCII-only scripts avoids this issue entirely.