### PR TITLE
Exclude GitHub runner slices from health monitoring

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -50,7 +50,7 @@ else
     Vm.exclude(vm_host_id: nil).exclude(unix_user: "runneradmin").eager(:vm_host, :sshable, :vm_storage_volumes),
     MinioServer,
     GithubRunner.exclude(ready_at: nil),
-    VmHostSlice.eager(:vm_host),
+    VmHostSlice.exclude(id: Vm.where(unix_user: "runneradmin").exclude(vm_host_slice_id: nil).select(:vm_host_slice_id)).eager(:vm_host),
     LoadBalancerVmPort,
     KubernetesCluster,
     VictoriaMetricsServer,


### PR DESCRIPTION
Runner VMs are already excluded from monitor_models via `.exclude(unix_user: "runneradmin")`, but their associated VmHostSlice records were still being monitored. This is unnecessary since runners have their own monitoring entry via GithubRunner. Filter them out with a subquery on the vm table.