### PR TITLE
Upgrade rubocop-capybara to 2.22.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,9 @@
 # Modified from https://www.fastruby.io/blog/ruby/code-quality/how-we-use-rubocop-and-standardrb.html
 require:
-  - rubocop-capybara
   - standard
 
 plugins:
+  - rubocop-capybara
   - rubocop-erb
   - rubocop-performance
   - rubocop-rake
@@ -108,6 +108,12 @@ Sequel/IrreversibleMigration:
 
 Capybara/ClickLinkOrButtonStyle:
   EnforcedStyle: strict
+
+Capybara/FindAllFirst:
+  Enabled: false
+
+Capybara/NegationMatcherAfterVisit:
+  Enabled: false
 
 Lint/UselessTimes:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ group :development do
 end
 
 group :rubocop do
-  gem "rubocop-capybara", "< 2.22"
+  gem "rubocop-capybara"
   gem "rubocop-erb"
   gem "rubocop-performance"
   gem "rubocop-rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
     parallel (1.27.0)
     parallel_tests (4.10.1)
       parallel
-    parser (3.3.10.1)
+    parser (3.3.10.2)
       ast (~> 2.4.1)
       racc
     pdf-core (0.10.0)
@@ -276,7 +276,7 @@ GEM
       ttfunk (~> 1.8)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    prism (1.8.0)
+    prism (1.9.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -330,7 +330,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.6)
-    rubocop (1.82.1)
+    rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -338,14 +338,15 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.48.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.49.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
-    rubocop-capybara (2.21.0)
-      rubocop (~> 1.41)
+    rubocop-capybara (2.22.1)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
     rubocop-erb (0.7.0)
       herb (~> 0.7)
       lint_roller (~> 1.1)
@@ -385,10 +386,10 @@ GEM
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
-    standard (1.53.0)
+    standard (1.54.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.82.0)
+      rubocop (~> 1.84.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.8)
     standard-custom (1.0.2)
@@ -500,7 +501,7 @@ DEPENDENCIES
   rotp
   rqrcode
   rspec
-  rubocop-capybara (< 2.22)
+  rubocop-capybara
   rubocop-erb
   rubocop-performance
   rubocop-rake


### PR DESCRIPTION
rubocop-capybara 2.21.0 is incompatible with rubocop 1.84.2, crashing with "Passing a project root directory to inject_defaults! is no longer supported."

Remove the < 2.22 pin that was added to work around Capybara/FindAllFirst issues (rubocop/rubocop-capybara#150). The upstream issue is marked as resolved, but the auto-corrected rewrites still break our tests, so disable FindAllFirst instead.

Also disable the new NegationMatcherAfterVisit cop which flags legitimate test patterns.