### PR TITLE
Wait for kubelet CSR before approving it during node provisioning

### DIFF
--- a/lib/kubernetes/client.rb
+++ b/lib/kubernetes/client.rb
@@ -45,6 +45,14 @@ class Kubernetes::Client
     kubectl("delete node :node_name", node_name:)
   end
 
+  def get_csr(node_name, csr_status:)
+    kubectl("get csr --sort-by=.metadata.creationTimestamp | awk '/:csr_status/ && /kubelet-serving/ && /':node_name'/ {print $1}' | tail -1", node_name:, csr_status:).chomp
+  end
+
+  def approve_csr(csr_name)
+    kubectl("certificate approve :csr_name", csr_name:)
+  end
+
   def set_load_balancer_hostname(svc, hostname)
     patch_data = JSON.generate({
       "status" => {


### PR DESCRIPTION
The metrics server requires manually approving the kubelet-serving CSR whenever a new node joins the cluster. The previous code ran the approval immediately after installing the CNI, but sometimes the kubelet had not yet created the CSR by that point, causing the approval to silently do nothing.

The label now checks whether the CSR is already approved first, skipping approval entirely on retries. If not yet approved, it looks for a pending CSR and approves it. If neither exists, it naps to wait for the kubelet to create one.