### PR TITLE
Add upgrade_stage alongside upgrade_status in api

### DIFF
--- a/cli-commands/pg/post/show-upgrade-status.rb
+++ b/cli-commands/pg/post/show-upgrade-status.rb
@@ -10,6 +10,7 @@ UbiCli.on("pg").run_on("show-upgrade-status") do
     body = []
     body << "Major version upgrade of PostgreSQL database #{sdk_object.id} to version #{upgrade_status[:target_version]}\n"
     body << "Status: #{upgrade_status[:upgrade_status]}\n"
+    body << "Stage: #{upgrade_status[:upgrade_stage] || "N/A"}\n"
     response(body)
   end
 end

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -3461,6 +3461,9 @@ components:
                 type: string
               upgrade_status:
                 type: string
+              upgrade_stage:
+                type: string
+                nullable: true
             additionalProperties: false
             required:
               - current_version

--- a/serializers/postgres_upgrade.rb
+++ b/serializers/postgres_upgrade.rb
@@ -5,7 +5,8 @@ class Serializers::PostgresUpgrade < Serializers::Base
     {
       current_version: postgres_resource.version,
       target_version: postgres_resource.target_version,
-      upgrade_status: postgres_resource.upgrade_status
+      upgrade_status: postgres_resource.upgrade_status,
+      upgrade_stage: postgres_resource.upgrade_stage
     }
   end
 end

--- a/spec/routes/api/cli/pg/show-upgrade-status_spec.rb
+++ b/spec/routes/api/cli/pg/show-upgrade-status_spec.rb
@@ -22,11 +22,12 @@ RSpec.describe Clover, "cli pg show-upgrade-status" do
 
   it "shows upgrade status when database needs upgrade" do
     @pg.update(target_version: 17)
-    @pg.strand.children_dataset.where(prog: "Postgres::ConvergePostgresResource").first&.update(label: "start")
+    Strand.create(parent_id: @pg.strand.id, prog: "Postgres::ConvergePostgresResource", label: "start")
 
     output = cli(%W[pg #{@ref} show-upgrade-status])
     expect(output).to include("Major version upgrade of PostgreSQL database #{@pg.ubid} to version 17")
     expect(output).to include("Status: running")
+    expect(output).to include("Stage: start")
   end
 
   it "shows upgrade status when upgrade failed" do
@@ -36,5 +37,15 @@ RSpec.describe Clover, "cli pg show-upgrade-status" do
     output = cli(%W[pg #{@ref} show-upgrade-status])
     expect(output).to include("Major version upgrade of PostgreSQL database #{@pg.ubid} to version 17")
     expect(output).to include("Status: failed")
+    expect(output).to include("Stage: upgrade_failed")
+  end
+
+  it "shows upgrade stage N/A when strand unavailable" do
+    @pg.update(target_version: 17)
+
+    output = cli(%W[pg #{@ref} show-upgrade-status])
+    expect(output).to include("Major version upgrade of PostgreSQL database #{@pg.ubid} to version 17")
+    expect(output).to include("Status: running")
+    expect(output).to include("Stage: N/A")
   end
 end


### PR DESCRIPTION
not_running / running / failed lacks fidelity of detail necessary to present a UI similar to Ubicloud's own upgrade status page