### PR TITLE
Configure admin url for use by model/page.rb

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -83,6 +83,7 @@ module Config
   override :smtp_tls, true, bool
 
   override :base_url, "http://localhost:9292", string
+  override :admin_url, "http://admin.localhost:9292", string
   override :database_timeout, 10, int
   override :db_pool, 5, int
   override :db_pool_web, Config.db_pool, int

--- a/model/page.rb
+++ b/model/page.rb
@@ -76,7 +76,7 @@ class Page < Sequel::Model
   def trigger
     return unless Config.pagerduty_key
 
-    links = [{href: "https://admin.ubicloud.com/model/Page/#{ubid}", text: "Admin Page"}]
+    links = [{href: "#{Config.admin_url}/model/Page/#{ubid}", text: "Admin Page"}]
     details.fetch("related_resources", []).each do |ubid|
       links << {href: Config.pagerduty_log_link.gsub("<ubid>", ubid), text: "View #{ubid} Logs"} if Config.pagerduty_log_link
     end


### PR DESCRIPTION
Our alerts are currently linking to non-existant pages on admin.ubicloud.com