### PR TITLE
Add configurable days parameter to VM by IPv4 lookup

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -688,6 +688,7 @@ class CloverAdmin < Roda
     end
 
     r.get "vm-by-ipv4" do
+      @days = (typecast_params.pos_int("days") || 5).clamp(1, 15)
       if (@ips_param = typecast_params.nonempty_str("ips"))
         ips = @ips_param.split(",").filter_map {
           begin
@@ -708,7 +709,7 @@ class CloverAdmin < Roda
             project_id: it.project.ubid
           }
         }
-        archived_vms = ArchivedRecord.vms_by_ips(ips).map {
+        archived_vms = ArchivedRecord.vms_by_ips(ips, days: @days).map {
           {
             ip: it[:ip],
             created_at: it[:created_at],

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -193,11 +193,6 @@ code {
   }
 }
 
-#vm_by_ipv4_form {
-  display: flex;
-  gap: 10px;
-
-  & textarea {
-    flex-grow: 1;
-  }
+#vm_by_ipv4_form textarea {
+  width: 100%;
 }

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1052,10 +1052,12 @@ RSpec.describe CloverAdmin do
 
     visit "/vm-by-ipv4"
     fill_in "ips", with: "172.16.0.1, 172.16.1.1,,invalid-ip"
+    fill_in "days", with: "10"
     click_button "Show Virtual Machines"
 
     expect(page).to have_content("active-vm")
     expect(page).to have_content("archived-vm")
+    expect(page.find_field("days").value).to eq "10"
   end
 
   it "shows a message when no data available" do
@@ -1064,6 +1066,7 @@ RSpec.describe CloverAdmin do
     click_button "Show Virtual Machines"
 
     expect(page).to have_content("No data available for Virtual Machines table")
+    expect(page.find_field("days").value).to eq "5"
   end
 
   describe "archived-record-by-id" do

--- a/views/admin/vm_by_ipv4.erb
+++ b/views/admin/vm_by_ipv4.erb
@@ -1,12 +1,14 @@
 <% @page_title = "Find VM by IPv4 Address" %>
 
 <p>
-  This page allows you to find virtual machines associated with given IPv4 addresses, including archived ones from the
-  last 15 days. It's especially useful when investigating abuse reports.
+  This page allows you to find virtual machines associated with given IPv4 addresses, including archived ones. It's
+  especially useful when investigating abuse reports.
 </p>
 
-<% form(id: "vm_by_ipv4_form") do |f| %>
-  <%== f.input("textarea", key: "ips", placeholder: "Comma seperated IP list", value: @ips_param) %>
+<% form(id: "vm_by_ipv4_form", class: "form-vertical") do |f| %>
+  <%== f.input("textarea", key: "ips", placeholder: "Comma seperated IP list", rows: 4, value: @ips_param) %>
+  <%== f.input("number", key: "days", label: "Days", placeholder: "1-15", value: @days, min: 1, max: 15) %>
+  Higher day values will increase query duration significantly. Use the smallest value possible.
   <%== f.button("Show Virtual Machines") %>
 <% end %>
 


### PR DESCRIPTION
The archived VM query joins two archived_record tables and can be slow for large time ranges. With a 30-second web request timeout, the previous hardcoded 15-day window would sometimes fail to complete. Default to 5 days, which covers most abuse report investigations, while allowing operators to increase up to 15 days when needed.