### PR TITLE
Override rollup to fix security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4957,9 +4957,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "prod": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css --minify",
     "watch": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css --watch"
   },
+  "overrides": {
+    "rollup": "^2.80.0"
+  },
   "engines": {
     "node": "24.12.0",
     "npm": "11.6.2"


### PR DESCRIPTION
@stoplight/spectral-cli pins rollup@~2.79.2 via
@stoplight/spectral-ruleset-bundler, and the spectral repository is not actively maintained. The earliest patched rollup version is 2.80.0, which falls outside that tilde range.

Use npm overrides to force rollup@^2.80.0, resolving the Dependabot alert without waiting for an upstream spectral release.

Fixes https://github.com/ubicloud/ubicloud/security/dependabot/77