### PR TITLE
Remove Page.active dataset scope

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -734,7 +734,7 @@ class CloverAdmin < Roda
         flash.now["error"] = "Invalid ubid/uuid provided"
       end
 
-      @grouped_pages = Page.active.reverse(:created_at, :summary).exclude(severity: "info").group_by_vm_host
+      @grouped_pages = Page.reverse(:created_at, :summary).exclude(severity: "info").group_by_vm_host
       @classes = available_classes
       @info_pages = Page.where(severity: "info").reverse(:created_at).all
 

--- a/model/page.rb
+++ b/model/page.rb
@@ -7,8 +7,6 @@ require "openssl"
 
 class Page < Sequel::Model
   dataset_module do
-    where :active, resolved_at: nil
-
     def group_by_vm_host
       pages = all
       related_resources = pages.flat_map { it.details["related_resources"] }.compact.to_h { [UBID.to_uuid(it), nil] }
@@ -98,7 +96,7 @@ class Page < Sequel::Model
 
   def self.from_tag_parts(*tag_parts)
     tag = Page.generate_tag(tag_parts)
-    Page.active.where(tag:).first
+    Page.where(tag:).first
   end
 
   SEVERITY_ORDER = {"info" => 0, "warning" => 1, "error" => 2, "critical" => 3}.freeze

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -8,7 +8,7 @@ class Prog::PageNexus < Prog::Base
       details = extra_data.merge({"related_resources" => Array(related_resources)})
       tag = Page.generate_tag(tag_parts)
 
-      if (existing_page = Page.active.first(tag:)) && Page.severity_order(severity) > Page.severity_order(existing_page.severity)
+      if (existing_page = Page.first(tag:)) && Page.severity_order(severity) > Page.severity_order(existing_page.severity)
         existing_page.incr_retrigger
       end
 

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -276,11 +276,11 @@ RSpec.describe Prog::Base do
       st.unsynchronized_run
       expect {
         st.unsynchronized_run
-      }.to change { Page.active.count }.from(0).to(1)
+      }.to change { Page.count }.from(0).to(1)
 
       expect {
         st.unsynchronized_run
-      }.not_to change { Page.active.count }.from(1)
+      }.not_to change { Page.count }.from(1)
     end
 
     it "resolves the page if the frame is popped" do
@@ -289,7 +289,7 @@ RSpec.describe Prog::Base do
       st.unsynchronized_run
       expect {
         st.unsynchronized_run
-      }.to change { Page.active.count }.from(0).to(1)
+      }.to change { Page.count }.from(0).to(1)
 
       expect {
         st.unsynchronized_run
@@ -297,7 +297,7 @@ RSpec.describe Prog::Base do
         page_id = Page.first.id
         Strand[page_id].unsynchronized_run
         Strand[page_id].unsynchronized_run
-      }.to change { Page.active.count }.from(1).to(0)
+      }.to change { Page.count }.from(1).to(0)
     end
 
     it "resolves the page of the budded prog when pop" do
@@ -306,7 +306,7 @@ RSpec.describe Prog::Base do
       st.unsynchronized_run
       expect {
         st.unsynchronized_run
-      }.to change { Page.active.count }.from(0).to(1)
+      }.to change { Page.count }.from(0).to(1)
 
       expect {
         st.unsynchronized_run
@@ -314,7 +314,7 @@ RSpec.describe Prog::Base do
         page_id = Page.first.id
         Strand[page_id].unsynchronized_run
         Strand[page_id].unsynchronized_run
-      }.to change { Page.active.count }.from(1).to(0)
+      }.to change { Page.count }.from(1).to(0)
     end
 
     it "resolves the page once the target is reached" do
@@ -328,7 +328,7 @@ RSpec.describe Prog::Base do
         st.unsynchronized_run
         Strand[page_id].unsynchronized_run
         Strand[page_id].unsynchronized_run
-      }.to change { Page.active.count }.from(1).to(0)
+      }.to change { Page.count }.from(1).to(0)
     end
 
     it "resolves the page once a new deadline is registered" do
@@ -346,7 +346,7 @@ RSpec.describe Prog::Base do
         page_id = Page.first.id
         Strand[page_id].unsynchronized_run
         Strand[page_id].unsynchronized_run
-      }.to change { Page.active.count }.from(1).to(0)
+      }.to change { Page.count }.from(1).to(0)
     end
 
     it "deletes the deadline information once the target is reached" do
@@ -371,7 +371,7 @@ RSpec.describe Prog::Base do
 
       expect {
         st.unsynchronized_run
-      }.to change { Page.active.count }.from(0).to(2)
+      }.to change { Page.count }.from(0).to(2)
 
       expect(Page.all.map(&:summary)).to include(
         "#{st.ubid} has an expired deadline! Test2.pusher2 did not reach t1 on time",
@@ -383,7 +383,7 @@ RSpec.describe Prog::Base do
       vm = create_vm
       st = Strand.create_with_id(vm, prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
       st.unsynchronized_run
-      page = Page.active.first
+      page = Page.first
       expect(page).not_to be_nil
       expect(page.details["location"]).to eq(vm.location.display_name)
       expect(page.details["vcpus"]).to eq(vm.vcpus)
@@ -393,7 +393,7 @@ RSpec.describe Prog::Base do
       vm = create_vm(vm_host: create_vm_host(data_center: "FSN1-DC1"))
       st = Strand.create_with_id(vm, prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
       st.unsynchronized_run
-      page = Page.active.first
+      page = Page.first
       expect(page).not_to be_nil
       expect(page.details["vm_host"]).to eq(vm.vm_host.ubid)
       expect(page.details["data_center"]).to eq(vm.vm_host.data_center)
@@ -404,7 +404,7 @@ RSpec.describe Prog::Base do
       create_vm(vm_host: vmh)
       st = Strand.create_with_id(vmh, prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
       st.unsynchronized_run
-      page = Page.active.first
+      page = Page.first
       expect(page).not_to be_nil
       expect(page.details["arch"]).to eq(vmh.arch)
       expect(page.details["vm_count"]).to eq(1)
@@ -414,7 +414,7 @@ RSpec.describe Prog::Base do
       slice = VmHostSlice.create(vm_host_id: create_vm_host.id, name: "standard", family: "standard", cores: 1, total_cpu_percent: 200, used_cpu_percent: 200, total_memory_gib: 8, used_memory_gib: 8)
       st = Strand.create_with_id(slice, prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
       st.unsynchronized_run
-      page = Page.active.first
+      page = Page.first
       expect(page).not_to be_nil
       expect(page.details["vm_host"]).to eq(slice.vm_host.ubid)
       expect(page.details["location"]).to eq(slice.vm_host.location.display_name)
@@ -425,7 +425,7 @@ RSpec.describe Prog::Base do
       runner = GithubRunner.create(label: "ubicloud-standard-2", repository_name: "my-repo", installation:)
       st = Strand.create_with_id(runner, prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
       st.unsynchronized_run
-      page = Page.active.first
+      page = Page.first
       expect(page).not_to be_nil
       expect(page.details["label"]).to eq("ubicloud-standard-2")
       expect(page.details["installation"]).to eq(installation.ubid)
@@ -437,7 +437,7 @@ RSpec.describe Prog::Base do
       runner = GithubRunner.create(label: "ubicloud-standard-2", repository_name: "my-repo", vm_id: vm.id, installation:)
       st = Strand.create_with_id(runner, prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
       st.unsynchronized_run
-      page = Page.active.first
+      page = Page.first
       expect(page).not_to be_nil
       expect(page.details["vm"]).to eq(vm.ubid)
       expect(page.details["data_center"]).to eq(vm.vm_host.data_center)

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -727,7 +727,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     it "destroys the runner if generate request fails due to self runners disabled error" do
       expect(client).to receive(:post).and_raise(Octokit::Error.new({body: "Repository level self-hosted runners are disabled"}))
       expect { nx.register_runner }.to nap(0)
-        .and change { Page.active.count }.by(1)
+        .and change { Page.count }.by(1)
       expect(runner.destroy_set?).to be(true)
     end
 
@@ -739,7 +739,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     it "destroys the runner if generate request fails due to IP allowlist enabled error" do
       expect(client).to receive(:post).and_raise(Octokit::Error.new({body: "your IP address is not permitted to access this resource"}))
       expect { nx.register_runner }.to nap(0)
-        .and change { Page.active.count }.by(1)
+        .and change { Page.count }.by(1)
       expect(runner.destroy_set?).to be(true)
     end
   end

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer --check take_postgres_backup").and_return("Succeeded")
 
       expect { nx.wait }.to nap(20 * 60)
-      expect(Page.active.count).to eq(1)
+      expect(Page.count).to eq(1)
     end
 
     it "resolves the missing page if last completed backup is more recent than 2 days" do


### PR DESCRIPTION
Pages are destroyed on resolve since 388de89fa67, so every row in the table has resolved_at IS NULL. The .active scope filtered on that column but was effectively a no-op, adding noise without value.