### PR TITLE
Rename destroy label to finish in e2e test progs

### DIFF
--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -3,8 +3,6 @@
 require_relative "../../lib/util"
 
 class Prog::Test::HaPostgresResource < Prog::Test::Base
-  semaphore :destroy
-
   def self.assemble
     postgres_test_project = Project.create(name: "Postgres-HA-Test-Project")
 
@@ -106,10 +104,10 @@ class Prog::Test::HaPostgresResource < Prog::Test::Base
 
   label def wait_resources_destroyed
     nap 5 if postgres_resource
-    hop_destroy
+    hop_finish
   end
 
-  label def destroy
+  label def finish
     postgres_test_project.destroy
 
     fail_test(frame["fail_message"]) if frame["fail_message"]

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -3,8 +3,6 @@
 require_relative "../../lib/util"
 
 class Prog::Test::Kubernetes < Prog::Test::Base
-  semaphore :destroy
-
   MIGRATION_TRIES = 2
 
   def self.assemble
@@ -327,10 +325,10 @@ STS
 
   label def destroy_kubernetes
     kubernetes_cluster.incr_destroy
-    hop_destroy
+    hop_finish
   end
 
-  label def destroy
+  label def finish
     nap 5 if kubernetes_cluster
     kubernetes_test_project.destroy
 

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -3,8 +3,6 @@
 require_relative "../../lib/util"
 
 class Prog::Test::PostgresResource < Prog::Test::Base
-  semaphore :destroy
-
   def self.assemble(provider: "metal")
     postgres_test_project = Project.create(name: "Postgres-Test-Project")
     postgres_service_project = Project[Config.postgres_service_project_id] ||
@@ -75,10 +73,10 @@ class Prog::Test::PostgresResource < Prog::Test::Base
       nap 5
     end
 
-    hop_destroy
+    hop_finish
   end
 
-  label def destroy
+  label def finish
     postgres_test_project.destroy
 
     fail_test(frame["fail_message"]) if frame["fail_message"]

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -3,8 +3,6 @@
 require_relative "../../lib/util"
 
 class Prog::Test::UpgradePostgresResource < Prog::Test::Base
-  semaphore :destroy
-
   def self.assemble
     postgres_test_project = Project.create(name: "Postgres-Upgrade-Test-Project")
 
@@ -191,10 +189,10 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::Base
 
   label def wait_resources_destroyed
     nap 5 if read_replica || postgres_resource
-    hop_destroy
+    hop_finish
   end
 
-  label def destroy
+  label def finish
     postgres_test_project.destroy
 
     fail_test(frame["fail_message"]) if frame["fail_message"]

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -166,23 +166,23 @@ RSpec.describe Prog::Test::HaPostgresResource do
       expect { pgr_test.wait_resources_destroyed }.to nap(5)
     end
 
-    it "hops to destroy if the postgres resource destroyed" do
+    it "hops to finish if the postgres resource destroyed" do
       refresh_frame(pgr_test, new_values: {"postgres_resource_id" => nil})
-      expect { pgr_test.wait_resources_destroyed }.to hop("destroy")
+      expect { pgr_test.wait_resources_destroyed }.to hop("finish")
     end
   end
 
-  describe "#destroy" do
+  describe "#finish" do
     it "exits if no failure happened" do
       project = Project[pgr_test.frame["postgres_test_project_id"]]
-      expect { pgr_test.destroy }.to exit({"msg" => "Postgres tests are finished!"})
+      expect { pgr_test.finish }.to exit({"msg" => "Postgres tests are finished!"})
       expect(Project[project.id]).to be_nil
     end
 
     it "hops to failed if a failure happened" do
       refresh_frame(pgr_test, new_values: {"fail_message" => "Test failed"})
       project_id = pgr_test.frame["postgres_test_project_id"]
-      expect { pgr_test.destroy }.to hop("failed")
+      expect { pgr_test.finish }.to hop("failed")
       expect(Project[project_id]).to be_nil
     end
   end

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -703,18 +703,18 @@ RSpec.describe Prog::Test::Kubernetes do
   end
 
   describe "#destroy_kubernetes" do
-    it "increments destroy and hops to destroy" do
+    it "increments destroy and hops to finish" do
       expect(kubernetes_test).to receive(:kubernetes_cluster).and_return(kubernetes_cluster).at_least(:once)
       expect(kubernetes_cluster).to receive(:incr_destroy)
 
-      expect { kubernetes_test.destroy_kubernetes }.to hop("destroy")
+      expect { kubernetes_test.destroy_kubernetes }.to hop("finish")
     end
   end
 
-  describe "#destroy" do
+  describe "#finish" do
     it "naps if kubernetes cluster is not destroyed yet" do
       expect(kubernetes_test).to receive(:kubernetes_cluster).and_return(kubernetes_cluster)
-      expect { kubernetes_test.destroy }.to nap(5)
+      expect { kubernetes_test.finish }.to nap(5)
     end
 
     it "destroys test project and exits successfully" do
@@ -723,7 +723,7 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(kubernetes_test_project).to receive(:destroy)
       expect(kubernetes_test).to receive(:frame).and_return({}).twice
 
-      expect { kubernetes_test.destroy }.to exit({"msg" => "Kubernetes tests are finished!"})
+      expect { kubernetes_test.finish }.to exit({"msg" => "Kubernetes tests are finished!"})
     end
 
     it "destroys test project and fails if there is a fail message" do
@@ -733,7 +733,7 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(kubernetes_test).to receive(:frame).and_return({"fail_message" => "Test failed"}).thrice
       expect(kubernetes_test).to receive(:fail_test).with("Test failed")
 
-      expect { kubernetes_test.destroy }.to exit({"msg" => "Kubernetes tests are finished!"})
+      expect { kubernetes_test.finish }.to exit({"msg" => "Kubernetes tests are finished!"})
     end
   end
 

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -136,14 +136,14 @@ RSpec.describe Prog::Test::PostgresResource do
       expect { pgr_test.wait_resources_destroyed }.to nap(5)
     end
 
-    it "hops to destroy if the postgres resource destroyed" do
-      expect { pgr_test.wait_resources_destroyed }.to hop("destroy")
+    it "hops to finish if the postgres resource destroyed" do
+      expect { pgr_test.wait_resources_destroyed }.to hop("finish")
     end
   end
 
-  describe "#destroy" do
+  describe "#finish" do
     it "exits successfully if no failure happened" do
-      expect { pgr_test.destroy }.to exit({"msg" => "Postgres tests are finished!"})
+      expect { pgr_test.finish }.to exit({"msg" => "Postgres tests are finished!"})
     end
 
     it "hops to failed if a failure happened" do
@@ -151,7 +151,7 @@ RSpec.describe Prog::Test::PostgresResource do
       pgr_test.strand.modified!(:stack)
       pgr_test.strand.save_changes
       fresh_pgr_test = described_class.new(pgr_test.strand)
-      expect { fresh_pgr_test.destroy }.to hop("failed")
+      expect { fresh_pgr_test.finish }.to hop("failed")
     end
   end
 

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -283,23 +283,23 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       expect { pgr_test.wait_resources_destroyed }.to nap(5)
     end
 
-    it "hops to destroy if all resources are destroyed" do
+    it "hops to finish if all resources are destroyed" do
       refresh_frame(pgr_test, new_values: {"postgres_resource_id" => nil, "read_replica_id" => nil})
-      expect { pgr_test.wait_resources_destroyed }.to hop("destroy")
+      expect { pgr_test.wait_resources_destroyed }.to hop("finish")
     end
   end
 
-  describe "#destroy" do
+  describe "#finish" do
     it "exits if no failure happened" do
       project = Project[pgr_test.frame["postgres_test_project_id"]]
-      expect { pgr_test.destroy }.to exit({"msg" => "Postgres upgrade tests are finished!"})
+      expect { pgr_test.finish }.to exit({"msg" => "Postgres upgrade tests are finished!"})
       expect(Project[project.id]).to be_nil
     end
 
     it "hops to failed if a failure happened" do
       refresh_frame(pgr_test, new_values: {"fail_message" => "Test failed"})
       project_id = pgr_test.frame["postgres_test_project_id"]
-      expect { pgr_test.destroy }.to hop("failed")
+      expect { pgr_test.finish }.to hop("failed")
       expect(Project[project_id]).to be_nil
     end
   end


### PR DESCRIPTION
The destroy label in test progs is not a true destroy: it cleans up the test project and pops in the happy path, but not for failed case. Its failure path (hop to failed, then nap) did not match the expected terminal semantics of a real destroy label. Naming it "destroy" caused the framework to reserve a destroy semaphore that was never used

When hop_destroy is called, it also increments the destroying semaphore,
but it never decrements it when it fails and naps forever. It blocks to
destroy strand.

Rename it to "finish" to avoid the special-cased destroy semantics and
remove the unnecessary semaphore declarations.

example failure: https://github.com/ubicloud/ubicloud/actions/runs/22472940506/job/65093850325