### PR TITLE
Aggregate GitHub usage by installation not project

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -245,6 +245,7 @@ class Project < Sequel::Model
     :enable_r8gd,
     :enable_r8id,
     :free_runner_upgrade_until,
+    :github_billing_by_repository,
     :gpu_vm,
     :ipv6_disabled,
     :postgres_enable_maintenance_window_days,

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -131,6 +131,12 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     github_runner.update(billed_vm_size:)
     rate_id = BillingRate.from_resource_properties("GitHubRunnerMinutes", billed_vm_size, "global")["id"]
 
+    resource_id, resource_label = if project.get_ff_github_billing_by_repository
+      [github_runner.repository_id, github_runner.repository_name]
+    else
+      [installation.id, installation.name]
+    end
+
     retries = 0
     begin
       begin_time = Time.now.to_date.to_time
@@ -139,7 +145,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       used_amount = (duration / 60).ceil
       github_runner.log_duration("runner_completed", duration)
       today_record = BillingRecord
-        .where(project_id: project.id, resource_id: installation.id, billing_rate_id: rate_id)
+        .where(project_id: project.id, resource_id:, billing_rate_id: rate_id)
         .where { Sequel.pg_range(it.span).overlaps(Sequel.pg_range(begin_time...end_time)) }
         .first
 
@@ -149,8 +155,8 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       else
         BillingRecord.create(
           project_id: project.id,
-          resource_id: installation.id,
-          resource_name: "Daily Usage #{begin_time.strftime("%Y-%m-%d")} (#{installation.name})",
+          resource_id:,
+          resource_name: "Daily Usage #{begin_time.strftime("%Y-%m-%d")} (#{resource_label})",
           billing_rate_id: rate_id,
           span: Sequel.pg_range(begin_time...end_time),
           amount: used_amount,

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -139,7 +139,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       used_amount = (duration / 60).ceil
       github_runner.log_duration("runner_completed", duration)
       today_record = BillingRecord
-        .where(project_id: project.id, resource_id: project.id, billing_rate_id: rate_id)
+        .where(project_id: project.id, resource_id: installation.id, billing_rate_id: rate_id)
         .where { Sequel.pg_range(it.span).overlaps(Sequel.pg_range(begin_time...end_time)) }
         .first
 
@@ -149,8 +149,8 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       else
         BillingRecord.create(
           project_id: project.id,
-          resource_id: project.id,
-          resource_name: "Daily Usage #{begin_time.strftime("%Y-%m-%d")}",
+          resource_id: installation.id,
+          resource_name: "Daily Usage #{begin_time.strftime("%Y-%m-%d")} (#{installation.name})",
           billing_rate_id: rate_id,
           span: Sequel.pg_range(begin_time...end_time),
           amount: used_amount,

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(BillingRecord).to receive(:create).and_call_original
       nx.update_billing_record
 
-      br = BillingRecord[resource_id: project.id]
+      br = BillingRecord[resource_id: installation.id]
       expect(br.amount).to eq(5)
       expect(br.duration(now, now)).to eq(1)
     end
@@ -203,7 +203,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(BillingRecord).to receive(:create).and_call_original
       nx.update_billing_record
 
-      br = BillingRecord[resource_id: project.id]
+      br = BillingRecord[resource_id: installation.id]
       expect(br.amount).to eq(5)
       expect(br.duration(now, now)).to eq(1)
       expect(br.billing_rate["resource_family"]).to eq("standard-2-arm")
@@ -217,7 +217,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(BillingRecord).to receive(:create).and_call_original
       nx.update_billing_record
 
-      br = BillingRecord[resource_id: project.id]
+      br = BillingRecord[resource_id: installation.id]
       expect(br.amount).to eq(5)
       expect(br.duration(now, now)).to eq(1)
       expect(br.billing_rate["resource_family"]).to eq("premium-2")
@@ -231,7 +231,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(BillingRecord).to receive(:create).and_call_original
       nx.update_billing_record
 
-      br = BillingRecord[resource_id: project.id]
+      br = BillingRecord[resource_id: installation.id]
       expect(br.amount).to eq(5)
       expect(br.duration(now, now)).to eq(1)
       expect(br.billing_rate["resource_family"]).to eq("standard-2")
@@ -246,7 +246,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(BillingRecord).to receive(:create).and_call_original
       nx.update_billing_record
 
-      br = BillingRecord[resource_id: project.id]
+      br = BillingRecord[resource_id: installation.id]
       expect(br.amount).to eq(5)
       expect(br.duration(now, now)).to eq(1)
       expect(br.billing_rate["resource_family"]).to eq("standard-2")
@@ -261,7 +261,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(BillingRecord).to receive(:create).and_call_original
       nx.update_billing_record
 
-      br = BillingRecord[resource_id: project.id]
+      br = BillingRecord[resource_id: installation.id]
       expect(br.amount).to eq(5)
       expect(br.duration(now, now)).to eq(1)
       expect(br.billing_rate["resource_family"]).to eq("standard-30")
@@ -276,7 +276,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       nx.update_billing_record
 
       expect { nx.update_billing_record }
-        .to change { BillingRecord[resource_id: project.id].amount }.from(5).to(10)
+        .to change { BillingRecord[resource_id: installation.id].amount }.from(5).to(10)
     end
 
     it "create a new record for a new day" do
@@ -293,9 +293,9 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(BillingRecord).to receive(:create).and_call_original
       # Create tomorrow record
       expect { nx.update_billing_record }
-        .to change { BillingRecord.where(resource_id: project.id).count }.from(1).to(2)
+        .to change { BillingRecord.where(resource_id: installation.id).count }.from(1).to(2)
 
-      expect(BillingRecord.where(resource_id: project.id).map(&:amount)).to eq([5, 5])
+      expect(BillingRecord.where(resource_id: installation.id).map(&:amount)).to eq([5, 5])
     end
 
     it "tries 3 times and creates single billing record" do
@@ -305,7 +305,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
       expect {
         3.times { nx.update_billing_record }
-      }.to change { BillingRecord.where(resource_id: project.id).count }.from(0).to(1)
+      }.to change { BillingRecord.where(resource_id: installation.id).count }.from(0).to(1)
     end
 
     it "tries 4 times and fails" do

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -279,6 +279,21 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
         .to change { BillingRecord[resource_id: installation.id].amount }.from(5).to(10)
     end
 
+    it "aggregates billing records by repository when the feature flag is enabled" do
+      project.set_ff_github_billing_by_repository(true)
+      repository = GithubRepository.create(name: "ubicloud/test-repo", installation_id: installation.id)
+      runner.update(repository_id: repository.id, ready_at: now - 5 * 60)
+
+      expect { nx.update_billing_record }
+        .to change { BillingRecord.where(resource_id: repository.id).count }.from(0).to(1)
+
+      expect { nx.update_billing_record }
+        .to change { BillingRecord[resource_id: repository.id].amount }.from(5).to(10)
+
+      expect(BillingRecord.where(resource_id: installation.id).count).to eq(0)
+      expect(BillingRecord[resource_id: repository.id].resource_name).to eq("Daily Usage 2026-02-05 (test-repo)")
+    end
+
     it "create a new record for a new day" do
       today = Time.now
       tomorrow = today + 24 * 60 * 60


### PR DESCRIPTION
We aggregate GitHub usage daily to reduce the number of billing records during implementation. Currently, we aggregate them by project. However, since a project can have multiple installations, it's difficult to determine which installation is responsible for the usage. Our UI is also installation-based, so having installation-level usage records makes it straightforward to display per-installation breakdowns. While the billing record already has a project ID column, using the installation ID as the resource ID is the right granularity.