### PR TITLE
Add incident.io as alternative pager

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ gem "nokogiri"
 gem "octokit"
 gem "omniauth-github"
 gem "omniauth-google-oauth2"
-gem "pagerduty", ">= 4.0"
 gem "prawn"
 gem "prawn-table"
 gem "pry"
@@ -56,6 +55,10 @@ end
 
 group :aws_rds_iam do
   gem "pg-aws_rds_iam", github: "haines/pg-aws_rds_iam", ref: "fb91b9232837e350aa9c8440b7340346adae845e"
+end
+
+group :pagerduty do
+  gem "pagerduty", ">= 4.0"
 end
 
 group :development do

--- a/config.rb
+++ b/config.rb
@@ -158,6 +158,10 @@ module Config
   optional :pagerduty_key, string, clear: true
   optional :pagerduty_log_link, string
 
+  # incident.io
+  optional :incidentio_key, string, clear: true
+  optional :incidentio_alert_source_config_id, string
+
   # Postgres
   optional :postgres_service_project_id, uuid
   override :postgres_service_hostname, "postgres.ubicloud.com", string

--- a/model/page.rb
+++ b/model/page.rb
@@ -2,10 +2,72 @@
 
 require_relative "../model"
 
-require "pagerduty"
 require "openssl"
-
 class Page < Sequel::Model
+  class Client
+    def initialize
+      if Config.pagerduty_key
+        require "pagerduty"
+        @client = Pagerduty.build(integration_key: Config.pagerduty_key, api_version: 2)
+      end
+    end
+
+    def trigger(tag, summary:, severity:, details:, links:)
+      if Config.pagerduty_key
+        pagerduty_incident(tag).trigger(summary:, severity:, source: "clover", custom_details: details, links:)
+      elsif Config.incidentio_key
+        metadata = (details || {}).merge({severity:})
+        link, *links = links
+        metadata[:links] = links unless links.empty?
+        body = {
+          deduplication_key: deduplication_key(tag),
+          status: "firing",
+          title: summary,
+          source_url: link&.[](:href),
+          metadata:
+        }.to_json
+        Excon.post(incidentio_uri, body:, headers: {
+          "Authorization" => "Bearer #{Config.incidentio_key}",
+          "Content-Type" => "application/json"
+        })
+      else
+        Clog.emit("page triggered", {page_triggered: {tag:, summary:, severity:, details:, links:}})
+      end
+    end
+
+    def resolve(tag, summary:)
+      if Config.pagerduty_key
+        pagerduty_incident(tag).resolve
+      elsif Config.incidentio_key
+        body = {
+          deduplication_key: deduplication_key(tag),
+          status: "resolved",
+          title: summary
+        }.to_json
+        Excon.post(incidentio_uri, body:, headers: {
+          "Authorization" => "Bearer #{Config.incidentio_key}",
+          "Content-Type" => "application/json"
+        })
+      else
+        Clog.emit("page resolved", {page_resolved: {tag:}})
+      end
+    end
+
+    private
+
+    def pagerduty_incident(tag)
+      @client.incident(deduplication_key(tag))
+    end
+
+    def incidentio_uri
+      "https://api.incident.io/v2/alert_events/http/#{Config.incidentio_alert_source_config_id}"
+    end
+
+    def deduplication_key(tag)
+      OpenSSL::HMAC.hexdigest("SHA256", "ubicloud-page-key", tag)
+    end
+  end
+
   dataset_module do
     def group_by_vm_host
       pages = all
@@ -55,39 +117,35 @@ class Page < Sequel::Model
   # This cannot be covered, as the current coverage tests run without freezing models.
   # :nocov:
   def self.freeze
-    pagerduty_client
+    client
     super
   end
   # :nocov:
 
-  def self.pagerduty_client
-    @pagerduty_client ||= Pagerduty.build(integration_key: Config.pagerduty_key, api_version: 2)
+  def self.client
+    @client ||= Client.new
   end
 
   plugin SemaphoreMethods, :resolve, :retrigger
   plugin ResourceMethods
 
-  def pagerduty_client
-    self.class.pagerduty_client
+  def client
+    self.class.client
   end
 
   def trigger
-    return unless Config.pagerduty_key
-
     links = [{href: "#{Config.admin_url}/model/Page/#{ubid}", text: "Admin Page"}]
     details.fetch("related_resources", []).each do |ubid|
       links << {href: Config.pagerduty_log_link.gsub("<ubid>", ubid), text: "View #{ubid} Logs"} if Config.pagerduty_log_link
     end
 
-    pagerduty_incident.trigger(summary:, severity:, source: "clover", custom_details: details, links:)
+    client.trigger(tag, summary:, severity:, details:, links:)
   end
 
   def resolve
     this.update(resolved_at: Sequel::CURRENT_TIMESTAMP)
 
-    return unless Config.pagerduty_key
-
-    pagerduty_incident.resolve
+    client.resolve(tag, summary:)
   end
 
   def self.generate_tag(*tag_parts)
@@ -103,12 +161,6 @@ class Page < Sequel::Model
 
   def self.severity_order(severity)
     SEVERITY_ORDER.fetch(severity)
-  end
-
-  private
-
-  def pagerduty_incident
-    pagerduty_client.incident(OpenSSL::HMAC.hexdigest("SHA256", "ubicloud-page-key", tag))
   end
 end
 

--- a/spec/model/page_spec.rb
+++ b/spec/model/page_spec.rb
@@ -3,6 +3,7 @@
 require_relative "spec_helper"
 
 require "json"
+require "pagerduty"
 
 RSpec.describe Page do
   subject(:p) { described_class.create(tag: "dummy-tag") }
@@ -45,37 +46,131 @@ RSpec.describe Page do
     end
   end
 
-  describe "#trigger" do
+  context "with pager duty" do
     before do
       expect(Config).to receive(:pagerduty_key).and_return("dummy-key").at_least(:once)
       stub_request(:post, "https://events.pagerduty.com/v2/enqueue")
         .to_return(status: 200, body: {dedup_key: "dummy-dedup-key", message: "Event processed", status: "success"}.to_json, headers: {})
+      # reinitialize to setup @client
+      p.client.send(:initialize)
     end
 
-    it "triggers a page in Pagerduty if key is present" do
-      expect(p).to receive(:details).and_return({}).at_least(:once)
-      p.trigger
+    describe "#trigger" do
+      it "triggers a page in Pagerduty if key is present" do
+        expect(p).to receive(:details).and_return({}).at_least(:once)
+        p.trigger
+      end
+
+      it "triggers a page with custom_details" do
+        expect(p).to receive(:details).and_return({"related_resources" => ["a410a91a-dc31-4119-9094-3c6a1fb49601"]}).at_least(:once)
+        p.trigger
+      end
+
+      it "triggers a page with custom_details and log link" do
+        expect(Config).to receive(:pagerduty_log_link).and_return("https://logviewer.com?q=<ubid>").at_least(:once)
+        expect(p).to receive(:details).and_return({"related_resources" => ["a410a91a-dc31-4119-9094-3c6a1fb49601"]}).at_least(:once)
+        p.trigger
+      end
     end
 
-    it "triggers a page with custom_details" do
-      expect(p).to receive(:details).and_return({"related_resources" => ["a410a91a-dc31-4119-9094-3c6a1fb49601"]}).at_least(:once)
-      p.trigger
-    end
-
-    it "triggers a page with custom_details and log link" do
-      expect(Config).to receive(:pagerduty_log_link).and_return("https://logviewer.com?q=<ubid>").at_least(:once)
-      expect(p).to receive(:details).and_return({"related_resources" => ["a410a91a-dc31-4119-9094-3c6a1fb49601"]}).at_least(:once)
-      p.trigger
+    describe "#resolve" do
+      it "resolves the page in Pagerduty if key is present" do
+        expect(p.client).to receive(:resolve).and_call_original
+        p.resolve
+      end
     end
   end
 
-  describe "#resolve" do
-    it "resolves the page in Pagerduty if key is present" do
-      expect(Config).to receive(:pagerduty_key).and_return("dummy-key").at_least(:once)
-      stub_request(:post, "https://events.pagerduty.com/v2/enqueue")
-        .to_return(status: 200, body: {dedup_key: "dummy-dedup-key", message: "Event processed", status: "success"}.to_json, headers: {})
+  context "with incident.io" do
+    before do
+      expect(Config).to receive(:incidentio_key).and_return("dummy-key").at_least(:once)
+      expect(Config).to receive(:incidentio_alert_source_config_id).and_return("source-id").at_least(:once)
+    end
 
-      p.resolve
+    describe "#trigger" do
+      it "triggers a page if key is present" do
+        Excon.stub({
+          url: "https://api.incident.io/v2/alert_events/http/source-id",
+          method: "post",
+          body: {
+            deduplication_key: p.client.send(:deduplication_key, p.tag),
+            status: "firing",
+            title: p.summary,
+            source_url: "#{Config.admin_url}/model/Page/#{p.ubid}",
+            metadata: {severity: p.severity}
+          }.to_json,
+          headers: {
+            "Authorization" => "Bearer dummy-key",
+            "Content-Type" => "application/json"
+          }
+        }, {status: 202})
+        expect(p.trigger.status).to eq(202)
+      end
+
+      it "triggers a page with extra links" do
+        Excon.stub({
+          url: "https://api.incident.io/v2/alert_events/http/source-id",
+          method: "post",
+          body: {
+            deduplication_key: p.client.send(:deduplication_key, p.tag),
+            status: "firing",
+            title: "title",
+            source_url: nil,
+            metadata: {
+              severity: "low",
+              links: ["https://example.com"]
+            }
+          }.to_json,
+          headers: {
+            "Authorization" => "Bearer dummy-key",
+            "Content-Type" => "application/json"
+          }
+        }, {status: 202})
+        expect(p.client.trigger(p.tag, summary: "title", severity: "low", details: {}, links: [nil, "https://example.com"]).status).to eq(202)
+      end
+    end
+
+    describe "#resolve" do
+      it "resolves the page if key is present" do
+        Excon.stub({
+          url: "https://api.incident.io/v2/alert_events/http/source-id",
+          method: "post",
+          body: {
+            deduplication_key: p.client.send(:deduplication_key, p.tag),
+            status: "resolved",
+            title: p.summary
+          }.to_json,
+          headers: {
+            "Authorization" => "Bearer dummy-key",
+            "Content-Type" => "application/json"
+          }
+        }, {status: 202})
+        expect(p.resolve.status).to eq(202)
+      end
+    end
+  end
+
+  context "without any api" do
+    describe "#trigger" do
+      it "triggers a page if key is present" do
+        expect(Clog).to receive(:emit).with("page triggered", {page_triggered: {
+          tag: p.tag,
+          summary: p.summary,
+          severity: p.severity,
+          details: p.details,
+          links: [{href: "#{Config.admin_url}/model/Page/#{p.ubid}", text: "Admin Page"}]
+        }})
+        p.trigger
+      end
+    end
+
+    describe "#resolve" do
+      it "resolves the page if key is present" do
+        expect(Clog).to receive(:emit).with("page resolved", {page_resolved: {
+          tag: p.tag
+        }})
+        p.resolve
+      end
     end
   end
 


### PR DESCRIPTION
we are decommissioning PagerDuty in favor of incident.io, deadline far off in May *(but already incident.io is what we use via PagerDuty integration)*

tested that this works, but don't think conditional duck typed class is way to go, want to get direction here before adding tests