### PR TITLE
Enable direct I/O on CSI loop devices

### DIFF
--- a/kubernetes/csi/lib/ubi_csi/node_service.rb
+++ b/kubernetes/csi/lib/ubi_csi/node_service.rb
@@ -156,7 +156,7 @@ module Csi
         is_new_loop_device = loop_device.nil?
         if is_new_loop_device
           log_with_id(req_id, "Setting up new loop device for: #{backing_file}")
-          output, ok = run_cmd("losetup", "--find", "--show", backing_file, req_id:)
+          output, ok = run_cmd("losetup", "--direct-io=on", "--find", "--show", backing_file, req_id:)
           loop_device = output.strip
           unless ok && !loop_device.empty?
             raise "Failed to setup loop device: #{output}"

--- a/kubernetes/csi/spec/csi/v1/node_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/node_service_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe Csi::V1::NodeService do
         is_mounted?: false,
         find_loop_device: nil
       )
-      allow(service).to receive(:run_cmd).with("losetup", "--find", "--show", backing_file, req_id:).and_return(["/dev/loop0", true])
+      allow(service).to receive(:run_cmd).with("losetup", "--direct-io=on", "--find", "--show", backing_file, req_id:).and_return(["/dev/loop0", true])
       allow(service).to receive(:run_cmd).with("mkfs.ext4", "/dev/loop0", req_id:).and_return(["", true])
       allow(Dir).to receive(:exist?).with(staging_path).and_return(false)
       allow(service).to receive(:run_cmd).with("mount", "/dev/loop0", staging_path, req_id:).and_return(["", true])
@@ -276,14 +276,14 @@ RSpec.describe Csi::V1::NodeService do
 
       it "handles loop device setup failure" do
         expect(service).to receive(:find_loop_device).and_return(nil)
-        expect(service).to receive(:run_cmd).with("losetup", "--find", "--show", backing_file, req_id:).and_return(["Error setting up loop device", false])
+        expect(service).to receive(:run_cmd).with("losetup", "--direct-io=on", "--find", "--show", backing_file, req_id:).and_return(["Error setting up loop device", false])
 
         expect { service.perform_node_stage_volume(req_id, pvc, req, nil) }.to raise_error("Failed to setup loop device: Error setting up loop device")
       end
 
       it "handles empty loop device output" do
         expect(service).to receive(:find_loop_device).and_return(nil)
-        expect(service).to receive(:run_cmd).with("losetup", "--find", "--show", backing_file, req_id:).and_return(["", true])
+        expect(service).to receive(:run_cmd).with("losetup", "--direct-io=on", "--find", "--show", backing_file, req_id:).and_return(["", true])
 
         expect { service.perform_node_stage_volume(req_id, pvc, req, nil) }.to raise_error("Failed to setup loop device: ")
       end
@@ -352,7 +352,7 @@ RSpec.describe Csi::V1::NodeService do
           find_loop_device: nil,  # New loop device
           find_file_system: ""
         )
-        expect(service).to receive(:run_cmd).with("losetup", "--find", "--show", backing_file, req_id:).and_return(["/dev/loop0", true])
+        expect(service).to receive(:run_cmd).with("losetup", "--direct-io=on", "--find", "--show", backing_file, req_id:).and_return(["/dev/loop0", true])
         expect(service).to receive(:run_cmd).with("mkfs.ext4", "/dev/loop0", req_id:).and_return(["mkfs error", false])
 
         expect { service.perform_node_stage_volume(req_id, pvc, req, nil) }.to raise_error("Failed to format device /dev/loop0 with ext4: mkfs error")


### PR DESCRIPTION
The CSI driver creates a backing .img file on the host's ext4 filesystem, attaches it as a loop device, and formats it with ext4. This ext4-on-ext4 stacking causes the host page cache to buffer data that the inner filesystem is also caching, roughly halving the effective memory available for caching and adding write amplification.

Adding --direct-io=on to losetup causes the loop driver to open the backing file with O_DIRECT, bypassing the host page cache entirely. The inner filesystem's page cache remains the single caching layer, which is the correct behavior. This flag has been stable since Linux 4.10, and ext4 backing filesystems support O_DIRECT. Existing volumes require no migration; the flag takes effect the next time a loop device is attached.