### PR TITLE
Decrease e2e timeout by 15 minutes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
     name: E2E - ${{ matrix.provider }}
     runs-on: ubicloud-standard-4
     environment: E2E-${{ matrix.provider }}
-    timeout-minutes: 85
+    timeout-minutes: 70
     concurrency: E2E-${{ matrix.provider }}
 
     steps:
@@ -160,7 +160,7 @@ jobs:
         OPERATOR_SSH_PUBLIC_KEYS: ${{ secrets.OPERATOR_SSH_PUBLIC_KEYS }}
       run: |
         set -o pipefail
-        timeout 83m foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"
+        timeout 68m foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"
 
     - name: Print logs
       if: always()


### PR DESCRIPTION
The average e2e metal runtime is 57m and all runs were under 1h. 70m is high enough to cover outliers, and there is no need to wait 15 minutes in case of stuck tests.