### PR TITLE
Require stripe gem in billing specs

### DIFF
--- a/spec/model/billing_info_spec.rb
+++ b/spec/model/billing_info_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "stripe"
 require_relative "spec_helper"
 
 RSpec.describe BillingInfo do

--- a/spec/model/invoice_spec.rb
+++ b/spec/model/invoice_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "stripe"
 require_relative "spec_helper"
 
 RSpec.describe Invoice do

--- a/spec/model/payment_method_spec.rb
+++ b/spec/model/payment_method_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "stripe"
 require_relative "spec_helper"
 
 RSpec.describe PaymentMethod do


### PR DESCRIPTION
When running specs in isolation (e.g. rspec
spec/model/billing_info_spec.rb:21), the Stripe constant is never
loaded, causing "uninitialized constant Stripe" errors. Other
specs that reference Stripe types already require the gem
explicitly.


Failed run: https://github.com/ubicloud/ubicloud/actions/runs/22570880115
