### PR TITLE
Allow modifying pool timeouts per process

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -85,6 +85,9 @@ module Config
   override :base_url, "http://localhost:9292", string
   override :admin_url, "http://admin.localhost:9292", string
   override :database_timeout, 10, int
+  override :database_timeout_web, Config.database_timeout, int
+  override :database_timeout_respirate, Config.database_timeout, int
+  override :database_timeout_monitor, Config.database_timeout, int
   override :db_pool, 5, int
   override :db_pool_web, Config.db_pool, int
   override :db_pool_respirate, Config.db_pool, int

--- a/db.rb
+++ b/db.rb
@@ -15,16 +15,18 @@ end
 db_ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", "db_ca_bundle.crt")
 Util.safe_write_to_file(db_ca_bundle_filename, Config.clover_database_root_certs)
 
-max_connections = if ENV["SHARED_CONNECTION"] == "1"
-  1
+if ENV["SHARED_CONNECTION"] == "1"
+  max_connections = 1
 elsif (process_type = ENV["PROCESS_TYPE"])
-  Config.send(:"db_pool_#{process_type}") - 1
-else
-  Config.db_pool - 1
+  max_connections = Config.send(:"db_pool_#{process_type}") - 1
+  pool_timeout = Config.send(:"database_timeout_#{process_type}")
 end
 
+max_connections ||= Config.db_pool - 1
+pool_timeout ||= Config.database_timeout
+
 pg_auto_parameterize_min_array_size = 1 if Config.frozen_test?
-DB = Sequel.connect(Config.clover_database_url, max_connections:, pool_timeout: Config.database_timeout, treat_string_list_as_untyped_array: true, pg_auto_parameterize_min_array_size:, driver_options:)
+DB = Sequel.connect(Config.clover_database_url, max_connections:, pool_timeout:, treat_string_list_as_untyped_array: true, pg_auto_parameterize_min_array_size:, driver_options:)
 
 postgres_monitor_db_ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", "postgres_monitor_db.crt")
 Util.safe_write_to_file(postgres_monitor_db_ca_bundle_filename, Config.postgres_monitor_database_root_certs)


### PR DESCRIPTION
The reason for this is to give monitor a higher timeout than used for web, since monitor has a much higher tolerance for delays.

This doesn't actually matter for respirate, due to its use of coarse checkouts. The configuration value for respirate is only added to make the db.rb code simpler.