### PR TITLE
Fix nondeterminism in ProvisionKubernetesNode spec

### DIFF
--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -102,8 +102,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
 
       expect(kubernetes_cluster.nodes.count).to eq(3)
 
-      new_vm = kubernetes_cluster.cp_vms.last
-      expect(new_vm.name).to start_with("#{kubernetes_cluster.ubid}-")
+      new_vm = kubernetes_cluster.cp_vms_dataset.first(name: /#{kubernetes_cluster.ubid}-/)
       expect(new_vm.sshable).not_to be_nil
       expect(new_vm.vcpus).to eq(4)
       expect(new_vm.strand.stack.first["storage_volumes"].first["size_gib"]).to eq(37)


### PR DESCRIPTION
kubernetes_cluster.cp_vms here returns 3 VMs. It is ordered by created_at, and as the specs use transactions, all created_at values are the same, the order is not deterministic. Pick the desired node to test with by searching for the name, instead of assuming the most recently created VM will be returned by last.