### PR TITLE
Fix usage alerts including previous month costs

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -128,8 +128,8 @@ class Project < Sequel::Model
     visible && accounts_dataset.exclude(suspended_at: nil).empty?
   end
 
-  def current_invoice
-    begin_time = invoices_dataset.get(:end_time) || Time.new(Time.now.year, Time.now.month, 1)
+  def current_invoice(since: nil)
+    begin_time = since || invoices_dataset.get(:end_time) || Time.new(Time.now.year, Time.now.month, 1)
     end_time = Time.now
 
     if (invoice = InvoiceGenerator.new(begin_time, end_time, project_ids: [id]).run.first)

--- a/prog/check_usage_alerts.rb
+++ b/prog/check_usage_alerts.rb
@@ -6,7 +6,7 @@ class Prog::CheckUsageAlerts < Prog::Base
 
     alerts = UsageAlert.eager(:project).where { last_triggered_at < begin_time }.all
     alerts.group_by(&:project).each do |project, project_alerts|
-      cost = project.current_invoice.content["cost"]
+      cost = project.current_invoice(since: begin_time).content["cost"]
       project_alerts.each do |alert|
         alert.trigger(cost) if cost > alert.limit
       end

--- a/spec/prog/check_usage_alerts_spec.rb
+++ b/spec/prog/check_usage_alerts_spec.rb
@@ -32,5 +32,57 @@ RSpec.describe Prog::CheckUsageAlerts do
       expect(alert1.reload.last_triggered_at).not_to eq(last_triggered_at)
       expect(alert2.reload.last_triggered_at).to eq(last_triggered_at)
     end
+
+    it "only considers current month usage even if previous month invoice is not yet generated" do
+      last_triggered_at = Time.now.round - 42 * 24 * 60 * 60
+      user_id = Account.create(email: "user@example.com").id
+      project = Project.create(name: "project1")
+      billing_rate = BillingRate.from_resource_properties("VmVCpu", "standard", "hetzner-hel1")
+
+      begin_of_current_month = Time.new(Time.now.year, Time.now.month, 1)
+      begin_of_previous_month = (begin_of_current_month.to_date << 1).to_time
+
+      # Simulate an old invoice ending at the beginning of the previous month,
+      # meaning the previous month's invoice has NOT been generated yet.
+      # Without the fix, current_invoice would use this end_time as begin_time,
+      # including the previous month's billing records in the cost calculation.
+      Invoice.create(
+        project_id: project.id,
+        invoice_number: "test-invoice-01",
+        content: {cost: 0},
+        begin_time: (begin_of_previous_month.to_date << 1).to_time,
+        end_time: begin_of_previous_month
+      )
+
+      # Previous month: high usage that would push total over the limit
+      BillingRecord.create(
+        project_id: project.id,
+        resource_id: "d5c1c540-407e-8374-a5f3-337204777db4",
+        resource_name: "test-prev",
+        span: Sequel::Postgres::PGRange.new(begin_of_previous_month, begin_of_current_month),
+        billing_rate_id: billing_rate["id"],
+        amount: 1_000_000
+      )
+
+      # Current month: low usage that is below the limit
+      BillingRecord.create(
+        project_id: project.id,
+        resource_id: "d5c1c540-407e-8374-a5f3-337204777db4",
+        resource_name: "test-curr",
+        span: Sequel::Postgres::PGRange.new(begin_of_current_month, Time.now + 1),
+        billing_rate_id: billing_rate["id"],
+        amount: 100
+      )
+
+      # Set limit between current month cost and combined (prev + current) cost
+      current_month_cost = project.current_invoice(since: begin_of_current_month).content["cost"]
+      combined_cost = project.current_invoice(since: begin_of_previous_month).content["cost"]
+      limit = (current_month_cost + combined_cost) / 2
+
+      alert = UsageAlert.create(project_id: project.id, name: "alert", user_id:, limit:, last_triggered_at:)
+
+      expect { prog.wait }.to nap(5 * 60)
+      expect(alert.reload.last_triggered_at).to eq(last_triggered_at)
+    end
   end
 end


### PR DESCRIPTION
Usage alerts check costs from the beginning of the current month, but current_invoice was using the last invoice's end_time as its start boundary. When the previous month's invoice has not yet been generated, that boundary falls to the start of the previous month, so the returned cost covers two months of billing records instead of one. This caused alerts to trigger on accumulated cross-month totals rather than the current month alone.

Add a `since:` parameter to Project#current_invoice so callers can specify an explicit start time, and pass the current month's begin_time from CheckUsageAlerts.