### PR TITLE
Fix backup credential race during postgres upgrade

### DIFF
--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -67,12 +67,8 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
   end
 
   label def update_metadata
-    new_timeline_id = Prog::Postgres::PostgresTimelineNexus.assemble(
-      location_id: postgres_resource.location_id
-    ).id
-    upgrade_candidate.update(version: postgres_resource.target_version, timeline_id: new_timeline_id, timeline_access: "push")
-
-    upgrade_candidate.incr_refresh_walg_credentials
+    upgrade_candidate.update(version: postgres_resource.target_version)
+    upgrade_candidate.switch_to_new_timeline(parent_id: nil)
     upgrade_candidate.incr_configure
     upgrade_candidate.incr_restart
 

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -334,15 +334,14 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
     before do
       strand.update(label: "update_metadata")
-      candidate # force lazy let to create the candidate
+      nx.instance_variable_set(:@upgrade_candidate, candidate)
     end
 
-    it "creates new timeline and updates candidate server metadata" do
-      expect { nx.update_metadata }.to hop("wait_upgrade_candidate").and change(PostgresTimeline, :count).by(1)
+    it "switches to new timeline with credentials and hops to wait_upgrade_candidate" do
+      expect(candidate).to receive(:switch_to_new_timeline).with(parent_id: nil)
+      expect { nx.update_metadata }.to hop("wait_upgrade_candidate")
       expect(candidate.reload).to have_attributes(
         version: "17",
-        timeline_access: "push",
-        refresh_walg_credentials_set?: true,
         configure_set?: true,
         restart_set?: true
       )


### PR DESCRIPTION
During a postgres version upgrade, the timeline nexus and server nexus run as independent strands. The timeline nexus could reach take_backup before the server nexus had written the new timeline's credentials to wal-g.env, causing the backup to push to the wrong bucket.

Use switch_to_new_timeline in the upgrade flow to write credentials synchronously before the timeline strand can trigger a backup.