### PR TITLE
Add read_only option to location associations

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -12,7 +12,7 @@ class PostgresResource < Sequel::Model
   one_through_one :timeline, class: :PostgresTimeline, join_table: :postgres_server, left_key: :resource_id, read_only: true
   one_to_many :metric_destinations, class: :PostgresMetricDestination, remover: nil, clearer: nil
   many_to_one :private_subnet, read_only: true
-  many_to_one :location
+  many_to_one :location, read_only: true
   one_to_many :read_replicas, class: :PostgresResource, key: :parent_id, conditions: {restore_target: nil}, read_only: true
   one_to_one :init_script, class: :PostgresInitScript, key: :id, read_only: true
 

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -7,7 +7,7 @@ class PostgresTimeline < Sequel::Model
   one_to_one :strand, key: :id, read_only: true
   many_to_one :parent, class: self
   one_to_one :leader, class: :PostgresServer, key: :timeline_id, conditions: {timeline_access: "push"}, is_used: true
-  many_to_one :location
+  many_to_one :location, read_only: true
 
   plugin ResourceMethods, encrypted_columns: :secret_key
   plugin ProviderDispatcher, __FILE__


### PR DESCRIPTION
Daily CI warning:

    Associations Option That Can Be Added:
    PostgresResource#location: , read_only: true
    PostgresTimeline#location: , read_only: true

https://github.com/ubicloud/ubicloud/actions/runs/22664242508