### PR TITLE
Use random ubids and not timestamp ubids for strands

### DIFF
--- a/ubid.rb
+++ b/ubid.rb
@@ -112,11 +112,10 @@ class UBID
   # Common entropy-based type for everything else
   TYPE_ETC = "et"
 
-  CURRENT_TIMESTAMP_TYPES = [TYPE_STRAND, TYPE_SEMAPHORE]
+  CURRENT_TIMESTAMP_TYPES = [TYPE_SEMAPHORE].freeze
 
   def self.generate(type)
-    case type
-    when *CURRENT_TIMESTAMP_TYPES
+    if type == TYPE_SEMAPHORE
       generate_from_current_ts(type)
     else
       generate_random(type)


### PR DESCRIPTION
Timestamp ubids make it so all strand ubids are executed by the same respirate partition. Random ubids spread the load across partitions.

Keep using timestamp ubids for semaphores, because we have code that extracts the timestamp for those.

This keeps the CURRENT_TIMESTAMP_TYPES constant as it is used by the tests.