### PR TITLE
Disable archiving for candidate during upgrade until timeline switch

### DIFF
--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "fileutils"
 require_relative "../../common/lib/util"
 require_relative "../lib/pg_bouncer_setup"
 
@@ -28,6 +29,10 @@ safe_write_to_file("/etc/hosts", hosts)
 # Update postgresql.conf
 configs = configure_hash["configs"].map { |k, v| "#{k} = #{v}" }.join("\n")
 safe_write_to_file("/etc/postgresql/#{v}/main/conf.d/001-service.conf", configs)
+
+# Remove upgrade override file if it exists (set during major version upgrade)
+upgrade_override = "/etc/postgresql/#{v}/main/conf.d/100-upgrade.conf"
+FileUtils.rm_f(upgrade_override)
 
 # Update postgresql.conf with custom settings
 user_configs = configure_hash["user_config"].map { |k, v| "#{k} = #{v}" }.join("\n")

--- a/rhizome/postgres/lib/postgres_upgrade.rb
+++ b/rhizome/postgres/lib/postgres_upgrade.rb
@@ -18,9 +18,14 @@ class PostgresUpgrade
     r "sudo chown postgres:postgres /dat/upgrade/#{@version}"
   end
 
-  def disable_archive_mode
-    r "echo 'archive_command = true' | sudo tee /etc/postgresql/#{@prev_version}/main/conf.d/100-upgrade.conf"
-    r "sudo pg_ctlcluster #{@prev_version} main reload"
+  def disable_archiving(version, reload: false)
+    r "echo 'archive_command = false' | sudo tee /etc/postgresql/#{version}/main/conf.d/100-upgrade.conf"
+    r "sudo pg_ctlcluster #{version} main reload" if reload
+  end
+
+  def remove_walg_credentials
+    r "sudo rm -f /etc/postgresql/wal-g.env"
+    r "sudo systemctl stop wal-g", expect: [0, 1, 4, 5]
   end
 
   def promote(version)
@@ -97,8 +102,10 @@ class PostgresUpgrade
   def upgrade
     @logger.info("Creating upgrade directory")
     create_upgrade_dir
-    @logger.info("Disabling archive mode")
-    disable_archive_mode
+    @logger.info("Removing WAL-G credentials")
+    remove_walg_credentials
+    @logger.info("Disabling archiving for previous version")
+    disable_archiving(@prev_version, reload: true)
     @logger.info("Waiting for postgres to start")
     wait_for_postgres_to_start
     @logger.info("Promoting previous version")
@@ -111,6 +118,8 @@ class PostgresUpgrade
     run_check
     @logger.info("Running pg upgrade")
     run_pg_upgrade
+    @logger.info("Disabling archiving for new version")
+    disable_archiving(@version)
     @logger.info("Enabling new version")
     enable_new_version
     @logger.info("Waiting for postgres to start")

--- a/rhizome/postgres/spec/postgres_upgrade_spec.rb
+++ b/rhizome/postgres/spec/postgres_upgrade_spec.rb
@@ -38,11 +38,17 @@ RSpec.describe PostgresUpgrade do
     end
   end
 
-  describe "#disable_archive_mode" do
-    it "disables archive mode and reloads configuration" do
-      expect(postgres_upgrade).to receive(:r).with("echo 'archive_command = true' | sudo tee /etc/postgresql/16/main/conf.d/100-upgrade.conf")
+  describe "#disable_archiving" do
+    it "disables archiving without reload by default" do
+      expect(postgres_upgrade).to receive(:r).with("echo 'archive_command = false' | sudo tee /etc/postgresql/17/main/conf.d/100-upgrade.conf")
+      expect(postgres_upgrade).not_to receive(:r).with("sudo pg_ctlcluster 17 main reload")
+      postgres_upgrade.disable_archiving(17)
+    end
+
+    it "disables archiving and reloads when reload: true" do
+      expect(postgres_upgrade).to receive(:r).with("echo 'archive_command = false' | sudo tee /etc/postgresql/16/main/conf.d/100-upgrade.conf")
       expect(postgres_upgrade).to receive(:r).with("sudo pg_ctlcluster 16 main reload")
-      postgres_upgrade.disable_archive_mode
+      postgres_upgrade.disable_archiving(16, reload: true)
     end
   end
 
@@ -58,6 +64,14 @@ RSpec.describe PostgresUpgrade do
       expect(postgres_upgrade).not_to receive(:r).with("sudo pg_ctlcluster promote 16 main", expect: [0, 1])
       expect(logger).to receive(:info).with("Server is already promoted (not in recovery mode)")
       postgres_upgrade.promote(16)
+    end
+  end
+
+  describe "#remove_walg_credentials" do
+    it "stops wal-g daemon and removes credentials file" do
+      expect(postgres_upgrade).to receive(:r).with("sudo systemctl stop wal-g", expect: [0, 1, 4, 5])
+      expect(postgres_upgrade).to receive(:r).with("sudo rm -f /etc/postgresql/wal-g.env")
+      postgres_upgrade.remove_walg_credentials
     end
   end
 
@@ -183,13 +197,15 @@ RSpec.describe PostgresUpgrade do
   describe "#upgrade" do
     it "executes complete upgrade workflow in correct order" do
       expect(postgres_upgrade).to receive(:create_upgrade_dir).ordered
-      expect(postgres_upgrade).to receive(:disable_archive_mode).ordered
+      expect(postgres_upgrade).to receive(:remove_walg_credentials).ordered
+      expect(postgres_upgrade).to receive(:disable_archiving).with(16, reload: true).ordered
       expect(postgres_upgrade).to receive(:wait_for_postgres_to_start).ordered
       expect(postgres_upgrade).to receive(:promote).with(16).ordered
       expect(postgres_upgrade).to receive(:initialize_new_version).ordered
       expect(postgres_upgrade).to receive(:stop_new_version).ordered
       expect(postgres_upgrade).to receive(:run_check).ordered
       expect(postgres_upgrade).to receive(:run_pg_upgrade).ordered
+      expect(postgres_upgrade).to receive(:disable_archiving).with(17).ordered
       expect(postgres_upgrade).to receive(:enable_new_version).ordered
       expect(postgres_upgrade).to receive(:wait_for_postgres_to_start).ordered
       expect(postgres_upgrade).to receive(:run_post_upgrade_scripts).ordered


### PR DESCRIPTION
Previously, the upgrade candidate on a new version (after pg_upgrade) was able to push WAL to the old timeline, which could break PITR in case a read replica is started meanwhile or the upgrade fails and is reverted to the old version.