### PR TITLE
Add monitor metric for attached resources

### DIFF
--- a/lib/monitor_runner.rb
+++ b/lib/monitor_runner.rb
@@ -80,6 +80,7 @@ class MonitorRunner
         active_threads_count: Thread.list.count - @internal_threads,
         threads_waiting_for_db_connection: DB.pool.num_waiting,
         total_monitor_resources: @monitor_resources.resources.size,
+        total_monitor_attached_resources: @monitor_resources.resources.each_value.sum(&:num_attached_resources),
         total_metric_export_resources: @metric_export_resources.resources.size,
         monitor_submit_queue_length: @monitor_resources.submit_queue.length,
         metric_export_submit_queue_length: @metric_export_resources.submit_queue.length,

--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -18,6 +18,10 @@ class MonitorableResource
     end
   end
 
+  def num_attached_resources
+    @attached_resources&.size || 0
+  end
+
   def attached_resources_sync(&)
     @attached_resources_mutex.synchronize(&)
   end

--- a/spec/lib/monitor_runner_spec.rb
+++ b/spec/lib/monitor_runner_spec.rb
@@ -110,12 +110,19 @@ RSpec.describe MonitorRunner do
       expect(hash).to eq({
         threads_waiting_for_db_connection: 0,
         total_monitor_resources: 0,
+        total_monitor_attached_resources: 0,
         total_metric_export_resources: 0,
         monitor_submit_queue_length: 0,
         metric_export_submit_queue_length: 0
       })
 
-      monitor_resources.resources["a0000000-0000-0000-0000-000000000000"] = true
+      vmh = VmHost.new_with_id
+      vm = Vm.new_with_id
+      pg = PostgresResource.new_with_id
+      mvmh = MonitorableResource.new(vmh)
+      mvmh.attached_resources[vm.id] = MonitorableResource.new(vm)
+      monitor_resources.resources[vmh.id] = mvmh
+      monitor_resources.resources[pg.id] = MonitorableResource.new(pg)
       metric_export_resources.resources["90000000-0000-0000-0000-000000000000"] = true
       metric_export_resources.resources["a0000000-0000-0000-0000-000000000000"] = true
 
@@ -133,8 +140,9 @@ RSpec.describe MonitorRunner do
       expect(hash.delete(:active_threads_count)).to be_a Integer
       expect(hash).to eq({
         threads_waiting_for_db_connection: 0,
-        total_monitor_resources: 1,
+        total_monitor_resources: 2,
         total_metric_export_resources: 2,
+        total_monitor_attached_resources: 1,
         monitor_submit_queue_length: 1,
         metric_export_submit_queue_length: 0,
         monitor_idle_worker_threads: 0,


### PR DESCRIPTION
When we made monitor more efficient by moving the Vm and VmHostSlice resources under the VmHost resource, we lost the count of those resources. This adds it back as a separate metric.