### PR TITLE
Support context-sensitive help for the CLI

### DIFF
--- a/cli-commands/help.rb
+++ b/cli-commands/help.rb
@@ -29,9 +29,7 @@ UbiCli.on("help") do
               body << banner << "\n"
             end
           else
-            # When we want to switch to context-sensitive help
-            # body << cmd.context_help(self) << "\n\n"
-            body << cmd.help << "\n\n"
+            body << cmd.context_help(self) << "\n\n"
           end
         end
         response(body)
@@ -42,9 +40,7 @@ UbiCli.on("help") do
         end
         response(body)
       else
-        # When we want to switch to context-sensitive help
-        # response(command.context_help(self))
-        response(command.help)
+        response(command.context_help(self))
       end
     else
       orig_command.raise_failure("invalid command: #{argv.join(" ")}")

--- a/cli-commands/vm/post/create.rb
+++ b/cli-commands/vm/post/create.rb
@@ -17,7 +17,7 @@ UbiCli.on("vm").run_on("create") do
     on("-u", "--unix-user=username", "username (default: ubi)")
   end
   help_option_values("Boot Image:", Option::BootImages.map(&:name))
-  help_option_values("Size:", server_sizes)
+  help_option_values("Size:") { server_sizes }
   help_option_values("Storage Size:", storage_sizes)
 
   help_example 'ubi vm eu-central-h1/my-vm-name create "$(cat ~/.ssh/id_ed25519.pub)"'

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -77,9 +77,12 @@ class UbiCli
     [status, {"content-type" => "text/plain", "content-length" => message.bytesize.to_s}, [message]]
   rescue Rodish::CommandFailure => e
     status = 400
-    message = e.message_with_usage.dup
+    message = e.message.dup
     message[0] = "! #{message[0].capitalize}"
-    message += "\n" unless message.end_with?("\n")
+    if e.command
+      message << "\n\n" << e.command.context_help(new(env))
+    end
+    message << "\n" unless message.end_with?("\n")
 
     [status, {"content-type" => "text/plain", "content-length" => message.bytesize.to_s}, [message]]
   end


### PR DESCRIPTION
This allows help option text in the CLI to be context-sensitive, returning different values depending on the user or project.

This gives an example of how it is used in the vm create command:

```ruby
  help_option_values("Size:") { server_sizes }
```

The block here is evaluated in the context of the UbiCli instance, the same context that the run block is exectued in.

Note that the CLI does not implement any authorization, only authentication. The internal request to the API handles authorization. This is the reason direct database access from the CLI layer is not allowed.

In order to get the above code to correctly show which sizes are available to the current user/project, we would need to expose an API endpoint that lists the allowed sizes (because direct querying is not allowed). So this isn't currently useful by itself, but it is a necessary change if we do want to support context-specific help.

I'm currently leaving this in draft, because I don't think we should merge it until it's actually used to filter allowed sizes for VMs or PostgresResources.

Related to #4257, #4307, #4737