### PR TITLE
Reduce false deadline pages for recycling Postgres servers

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -203,6 +203,9 @@ SQL
             {vm_host: vm_host.ubid, data_center: vm_host.data_center, location: vm_host.location.display_name, arch: vm_host.arch}
           when GithubRunner
             {label: sbj.label, installation: sbj.installation.ubid, vm: sbj.vm&.ubid, vm_host: sbj.vm&.vm_host&.ubid, data_center: sbj.vm&.vm_host&.data_center}
+          when PostgresServer
+            {resource_name: sbj.resource.name, role: sbj.primary? ? "primary" : "standby",
+             location: sbj.resource.location.display_name, needs_recycling: sbj.needs_recycling?}
           else
             {}
           end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -525,7 +525,8 @@ SQL
 
     when_checkup_set? do
       unless available?
-        register_deadline("wait", 5 * 60)
+        deadline = postgres_server.needs_recycling? ? 30 * 60 : 5 * 60
+        register_deadline("wait", deadline)
         hop_unavailable
       end
 

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -443,6 +443,34 @@ RSpec.describe Prog::Base do
       expect(page.details["vm"]).to eq(vm.ubid)
       expect(page.details["data_center"]).to eq(vm.vm_host.data_center)
     end
+
+    it "can create a page with extra data from a postgres server" do
+      project = Project.create(name: "test-project")
+      resource = create_postgres_resource(project:, location_id: Location[name: "hetzner-fsn1"].id)
+      server = create_postgres_server(resource:)
+      server.strand.update(prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
+      server.strand.unsynchronized_run
+      page = Page.first
+      expect(page).not_to be_nil
+      expect(page.details["resource_name"]).to eq(resource.name)
+      expect(page.details["role"]).to eq("primary")
+      expect(page.details["location"]).to eq(resource.location.display_name)
+      expect(page.details).to have_key("needs_recycling")
+    end
+
+    it "can create page with extra data as standby from a postgres server" do
+      project = Project.create(name: "test-project")
+      resource = create_postgres_resource(project:, location_id: Location[name: "hetzner-fsn1"].id)
+      server = create_postgres_server(resource:, is_representative: false)
+      server.strand.update(prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
+      server.strand.unsynchronized_run
+      page = Page.first
+      expect(page).not_to be_nil
+      expect(page.details["resource_name"]).to eq(resource.name)
+      expect(page.details["role"]).to eq("standby")
+      expect(page.details["location"]).to eq(resource.location.display_name)
+      expect(page.details).to have_key("needs_recycling")
+    end
   end
 
   describe "#before_run" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -908,6 +908,14 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.wait }.to hop("unavailable")
     end
 
+    it "registers a longer deadline when server needs recycling" do
+      nx.incr_checkup
+      expect(nx).to receive(:available?).and_return(false)
+      expect(nx.postgres_server).to receive(:needs_recycling?).and_return(true)
+      expect(nx).to receive(:register_deadline).with("wait", 30 * 60)
+      expect { nx.wait }.to hop("unavailable")
+    end
+
     it "naps if checkup is set but the server is available" do
       nx.incr_checkup
       expect(nx).to receive(:available?).and_return(true)


### PR DESCRIPTION
Use a 30-minute deadline (instead of 5 minutes) when a Postgres server needs recycling, since recycling servers are replaced rather than recovered. Also add resource context (name, role, location, recycling state) to deadline page extra_data for PostgresServer subjects.