### PR TITLE
Adjust requested hugepage count by a safety ratio

### DIFF
--- a/prog/setup_hugepages.rb
+++ b/prog/setup_hugepages.rb
@@ -8,7 +8,10 @@ class Prog::SetupHugepages < Prog::Base
 
     # Reserve 5G of overhead for the host. SPDK will use 2 of the hugepages +
     # upto about 1G of the 5G as not all SPDK allocations are from hugepages.
-    hugepage_cnt = vm_host.total_mem_gib - 5
+    # On production servers we have observed total memory to be up to ~1/43
+    # lower than the reported physical memory. We therefore use 42/43 as a
+    # safety ratio to avoid overcommitting memory for hugepages.
+    hugepage_cnt = vm_host.total_mem_gib * 42 / 43 - 5
 
     sshable.cmd("sudo sed -i '/^GRUB_CMDLINE_LINUX=\"/ s/\"$/ hugetlb_free_vmemmap=on default_hugepagesz=':hugepage_size' hugepagesz=':hugepage_size' hugepages=':hugepage_cnt'&/' /etc/default/grub", hugepage_size:, hugepage_cnt:)
     sshable.cmd("sudo update-grub")

--- a/spec/prog/setup_hugepages_spec.rb
+++ b/spec/prog/setup_hugepages_spec.rb
@@ -8,7 +8,18 @@ RSpec.describe Prog::SetupHugepages do
       vm_host = Prog::Vm::HostNexus.assemble("::1").subject
       vm_host.update(total_mem_gib: 64)
       sh = described_class.new(Strand.new(stack: [{"subject_id" => vm_host.id}], prog: "SetupHugepages"))
-      expect(sh.sshable).to receive(:_cmd).with("sudo sed -i '/^GRUB_CMDLINE_LINUX=\"/ s/\"$/ hugetlb_free_vmemmap=on default_hugepagesz='1G' hugepagesz='1G' hugepages='59'&/' /etc/default/grub")
+      expect(sh.sshable).to receive(:_cmd).with("sudo sed -i '/^GRUB_CMDLINE_LINUX=\"/ s/\"$/ hugetlb_free_vmemmap=on default_hugepagesz='1G' hugepagesz='1G' hugepages='57'&/' /etc/default/grub")
+      expect(sh.sshable).to receive(:_cmd).with("sudo update-grub")
+      expect { sh.start }.to exit({"msg" => "hugepages installed"})
+    end
+
+    it "allocates 120 hugepages for a 128G system" do
+      # To fit premium-30 VMs on AX-102 hosts, we need to be able to allocate
+      # 120 hugepages on a 128G system.
+      vm_host = Prog::Vm::HostNexus.assemble("::1").subject
+      vm_host.update(total_mem_gib: 128)
+      sh = described_class.new(Strand.new(stack: [{"subject_id" => vm_host.id}], prog: "SetupHugepages"))
+      expect(sh.sshable).to receive(:_cmd).with("sudo sed -i '/^GRUB_CMDLINE_LINUX=\"/ s/\"$/ hugetlb_free_vmemmap=on default_hugepagesz='1G' hugepagesz='1G' hugepages='120'&/' /etc/default/grub")
       expect(sh.sshable).to receive(:_cmd).with("sudo update-grub")
       expect { sh.start }.to exit({"msg" => "hugepages installed"})
     end


### PR DESCRIPTION
On a production host with 256 GB of RAM we observed only ~250 GB of total memory, indicating that usable memory can be roughly up to 1/43 lower than the reported physical memory.

To avoid overcommitting memory when allocating hugepages and leaving too little regular memory available, this change applies a safety ratio of 42/43 to physical memory instead of assuming the entire amount is usable.

This ratio also satisfies our requirement of being able to fit premium-30 VMs on AX 102 hosts.

We use the physical memory with a safety ratio instead of reported total memory to get more predictable number of hugepages.

Note that this applies only to future host setups; existing hosts must be adjusted manually.