### PR TITLE
Avoid apoptosis in Prog::Github::GithubRepositoryNexus#check_queued_jobs

### DIFF
--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -25,11 +25,16 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
     @polling_interval ||= 5 * 60
   end
 
+  def clock_time
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
   def check_queued_jobs
     unless github_repository.installation.project.active?
       @polling_interval = 24 * 60 * 60
       return
     end
+    deadline = clock_time + 80
     client = github_repository.installation.client(auto_paginate: true)
     queued_runs = client.repository_workflow_runs(github_repository.name, {status: "queued"})[:workflow_runs]
     Clog.emit("polled queued runs", {polled_queued_runs: {repository_name: github_repository.name, count: queued_runs.count}})
@@ -47,6 +52,7 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
 
     queued_labels = Hash.new(0)
     queued_runs.first(200).each do |run|
+      raise "strand runtime too long, exiting to avoid apoptosis" if deadline < clock_time
       jobs = client.workflow_run_attempt_jobs(github_repository.name, run[:id], run[:run_attempt])[:jobs]
 
       jobs.each do |job|

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -76,6 +76,15 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
       expect(nx.polling_interval).to eq(5 * 60)
     end
 
+    it "raises if runtime is too long" do
+      expect(nx).to receive(:clock_time).and_return(0, 81)
+      expect(client).to receive(:repository_workflow_runs).and_return({workflow_runs: [
+        {id: 1, run_attempt: 2, status: "queued"}
+      ]})
+      expect(client).to receive(:rate_limit).and_return(instance_double(Octokit::RateLimit, remaining: 100, limit: 100)).at_least(:once)
+      expect { nx.check_queued_jobs }.to raise_error(RuntimeError)
+    end
+
     it "naps until the resets_at if remaining quota is low" do
       expect(client).to receive(:repository_workflow_runs).and_return({workflow_runs: []})
       expect(client).to receive(:rate_limit).and_return(instance_double(Octokit::RateLimit, remaining: 8, limit: 100, resets_at: now + 8 * 60)).at_least(:once)


### PR DESCRIPTION
The apoptosis timeout is 89 seconds, and each
client.workflow_run_attempt_jobs has a 5 second timeout. This raises an exception after 80 seconds to prevent apoptosis.