### PR TITLE
Rescue another S3 exception class in GH cache commits

### DIFF
--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -183,7 +183,7 @@ class Clover
             upload_id:,
             multipart_upload: {parts: etags.map.with_index { {part_number: _2 + 1, etag: _1} }}
           })
-        rescue Aws::S3::Errors::InvalidPart, Aws::S3::Errors::NoSuchUpload => ex
+        rescue Aws::S3::Errors::InvalidPart, Aws::S3::Errors::NoSuchUpload, Aws::S3::Errors::EntityTooSmall => ex
           Clog.emit("could not complete multipart upload", {failed_multipart_upload: Util.exception_to_hash(ex, into: {ubid: runner.ubid, repository_ubid: repository.ubid})})
           fail CloverError.new(400, "InvalidRequest", "Wrong parameters")
         rescue Aws::S3::Errors::ServiceUnavailable => ex


### PR DESCRIPTION
Should fix a production exception:

```
Aws::S3::Errors::EntityTooSmall
Your proposed upload is smaller than the minimum allowed object size.
/app/routes/runtime/github.rb:180:in 'block (3 levels) in <class:Clover>'
```