### PR TITLE
Make Vm#load_balancer_state handle missing VM ports

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -61,9 +61,9 @@ class Vm < Sequel::Model
   def load_balancer_state
     return nil unless load_balancer
     if load_balancer.stack == "dual"
-      %w[ipv4 ipv6].map! { |stack| load_balancer_vm_ports.find { it.stack == stack }.state }
+      %w[ipv4 ipv6].map! { |stack| load_balancer_vm_ports.find { it.stack == stack }&.state }
     else
-      [load_balancer_vm_ports.first.state]
+      [load_balancer_vm_ports.first&.state]
     end
   end
 

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -82,6 +82,18 @@ RSpec.describe Vm do
     it "returns nil if there is related object" do
       expect(vm.load_balancer_state).to be_nil
     end
+
+    it "handles load balancer without vm ports" do
+      project_id = Project.create(name: "test").id
+      private_subnet_id = PrivateSubnet.create(name: "test", project_id:, net6: "1234::/16", net4: "10.0.0.0/8", location_id: Location::HETZNER_FSN1_ID).id
+      load_balancer = LoadBalancer.create(name: "test", health_check_endpoint: "/", project_id:, private_subnet_id:)
+      vm = create_vm
+      LoadBalancerVm.create(vm_id: vm.id, load_balancer_id: load_balancer.id)
+      expect(vm.load_balancer_state).to eq [nil, nil]
+
+      vm.load_balancer.update(stack: LoadBalancer::Stack::IPV4)
+      expect(vm.load_balancer_state).to eq [nil]
+    end
   end
 
   describe "#cloud_hypervisor_cpu_topology" do


### PR DESCRIPTION
We had a couple production exceptions related to this:

```
NoMethodError - undefined method 'state' for nil
/app/model/vm.rb:64:in 'block in Vm#load_balancer_state'
```

Unless there is a way to avoid the situation and ensure that if a VM has a load balancer, that the VM ports must be available, we need to handle this case.