### PR TITLE
Don't fail VM systemd units on soft stop.

### DIFF
--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -124,10 +124,29 @@ class Prog::Test::Vm < Prog::Test::Base
 
   label def check_stopped_by_shutdown_command
     if vm.strand.label == "stopped" && !up?
-      hop_start_semaphore_after_shutdown
+      hop_verify_systemd_unit_status_after_shutdown
     end
 
     nap 5
+  end
+
+  label def verify_systemd_unit_status_after_shutdown
+    vm_state = begin
+      vm.vm_host.sshable.cmd("systemctl is-active :inhost_name", inhost_name: vm.inhost_name).strip
+    rescue Sshable::SshError => ex
+      ex.stdout.strip
+    end
+
+    case vm_state
+    when "active"
+      nap 5
+    when "inactive"
+      # nothing
+    else
+      fail_test "VM should be inactive after shutdown command, but is #{vm_state}"
+    end
+
+    hop_start_semaphore_after_shutdown
   end
 
   label def start_semaphore_after_shutdown

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -785,7 +785,6 @@ DNSMASQ_SERVICE
 
   ExecStart=#{exec_start_cmd}
 
-  ExecStop=#{@ch_version.ch_remote_bin} --api-socket #{vp.ch_api_sock} shutdown-vmm
   #{footer}
     SERVICE
   end

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -442,7 +442,6 @@ RSpec.describe VmSetup do
           --net mac=02:aa:bb:cc:dd:01,tap=tap0,ip=,mask=,num_queues=5
         ].each { |frag| expect(content).to include(frag) }
 
-        expect(content).to include("ExecStop=/opt/cloud-hypervisor/v35.1/ch-remote --api-socket /tmp/ch.sock shutdown-vmm")
         expect(content).to include("Restart=no")
         expect(content).to include("User=test")
         expect(content).to include("Group=test")

--- a/spec/prog/test/vm_spec.rb
+++ b/spec/prog/test/vm_spec.rb
@@ -363,7 +363,31 @@ RSpec.describe Prog::Test::Vm do
     it "hops if VM is down" do
       expect(vm_test.vm).to receive(:strand).and_return(instance_double(Strand, label: "stopped"))
       expect(vm_test.sshable).to receive(:_cmd).with("true").and_raise(Errno::ECONNREFUSED)
-      expect { vm_test.check_stopped_by_shutdown_command }.to hop("start_semaphore_after_shutdown")
+      expect { vm_test.check_stopped_by_shutdown_command }.to hop("verify_systemd_unit_status_after_shutdown")
+    end
+  end
+
+  describe "#verify_systemd_unit_status_after_shutdown" do
+    before {
+      sshable = Sshable.create
+      vm_host = instance_double(VmHost, sshable:)
+      allow(vm_test.vm).to receive_messages(vm_host:, inhost_name: "vm123456")
+    }
+
+    it "verifies systemd unit status and hops" do
+      expect(vm_test.vm.vm_host.sshable).to receive(:_cmd).with("systemctl is-active vm123456").and_raise(Sshable::SshError.new("systemctl is-active vm123456", "inactive\n", "", nil, nil))
+      expect { vm_test.verify_systemd_unit_status_after_shutdown }.to hop("start_semaphore_after_shutdown")
+    end
+
+    it "naps if VM is still active" do
+      expect(vm_test.vm.vm_host.sshable).to receive(:_cmd).with("systemctl is-active vm123456").and_return("active\n")
+      expect { vm_test.verify_systemd_unit_status_after_shutdown }.to nap(5)
+    end
+
+    it "fails if systemd unit status is unexpected" do
+      expect(vm_test.vm.vm_host.sshable).to receive(:_cmd).with("systemctl is-active vm123456").and_return("unknown\n")
+      expect { vm_test.verify_systemd_unit_status_after_shutdown }.to hop("failed")
+      expect(vm_test.strand.exitval).to eq({msg: "VM should be inactive after shutdown command, but is unknown"})
     end
   end
 


### PR DESCRIPTION
When a VM shuts down from inside the guest or a `power-button` command is sent via `ch-remote`, cloud-hypervisor exits and removes the API socket before systemd runs `ExecStop`. The stop command, which tries to send the `shutdown-vmm` command via the API socket, then fails with "Error opening HTTP socket: No such file or directory", causing the service to be marked as failed even though the shutdown was successful.

From `man systemd.service`:

> Also note that the stop operation is always performed if the service
> started successfully, even if the processes in the service terminated
> on their own or were killed. The stop commands must be prepared to
> deal with that case.

This commit fixes the issue by removing `ExecStop`. In this case, if Cloud-Hypervisor hasn't already exited, `systemctl stop` will send `SIGTERM` (followed by `SIGKILL` after the stop timeout, defaulting to 90 seconds). Cloud-Hypervisor's `SIGTERM` handler already causes a call to `vmm_shutdown()`, which is the desired behaviour.