### PR TITLE
MigrateSpdkVmToUbiblk: VM stop/start improvements

### DIFF
--- a/prog/storage/migrate_spdk_vm_to_ubiblk.rb
+++ b/prog/storage/migrate_spdk_vm_to_ubiblk.rb
@@ -162,9 +162,7 @@ class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
   end
 
   label def start_vm
-    vm.vm_host.sshable.cmd("sudo systemctl start :inhost_name", inhost_name:)
-    vm.strand.update(label: "wait")
-
+    vm.incr_start
     pop "Vm successfully migrated to ubiblk"
   end
 

--- a/spec/prog/storage/migrate_spdk_vm_to_ubiblk_spec.rb
+++ b/spec/prog/storage/migrate_spdk_vm_to_ubiblk_spec.rb
@@ -232,10 +232,7 @@ RSpec.describe Prog::Storage::MigrateSpdkVmToUbiblk do
 
   describe "#start_vm" do
     it "starts the vm and exits" do
-      st = instance_double(Strand)
-      expect(vm).to receive(:strand).and_return(st)
-      expect(st).to receive(:update).with(label: "wait")
-      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo systemctl start #{vm.inhost_name}")
+      expect(vm).to receive(:incr_start)
       expect { prog.start_vm }.to exit({"msg" => "Vm successfully migrated to ubiblk"})
     end
   end


### PR DESCRIPTION
### MigrateSpdkVmToUbiblk: fix stop condition.

37e9c1d changed the behaviour of stop semaphore to first try a soft stop followed by hard stop after 60s.

`systemctl is-active $vm` returns:

- `inactive` if hard stop succeeds.
- `failed` if soft stop succeeds. This is because in this case, C-H   fails with `Error opening HTTP socket: No such file or directory (os error 2)`. This failure will be fixed in a separate commit for future VMs, but we should handle it when migrating old VMs.

This commit changes the condition in `wait_vm_stop` for waiting to stop to handle both cases.

### MigrateSpdkVmToUbiblk: use incr_start to start the VM. 

8390cb0 re-introduced the `start` semaphore which can be used to start a stopped VM. So, we can use it in `MigrateSpdkVmToUbiblk` to start the VM after migration is done.