### PR TITLE
Destroy custom labels when destroying the installation

### DIFF
--- a/model/github/github_installation.rb
+++ b/model/github/github_installation.rb
@@ -9,6 +9,8 @@ class GithubInstallation < Sequel::Model
   one_to_many :custom_labels, class: :GithubCustomLabel, key: :installation_id, read_only: true
   many_to_many :cache_entries, join_table: :github_repository, right_key: :id, right_primary_key: :repository_id, left_key: :installation_id, class: :GithubCacheEntry, read_only: true
 
+  plugin :association_dependencies, custom_labels: :destroy
+
   plugin ResourceMethods
   dataset_module Pagination
 

--- a/spec/prog/github/destroy_github_installation_spec.rb
+++ b/spec/prog/github/destroy_github_installation_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Prog::Github::DestroyGithubInstallation do
     it "deletes resource and pops" do
       # No repositories or runners - installation can be destroyed
       installation_id = github_installation.id
+      GithubCustomLabel.create(installation_id:, name: "custom-label", alias_for: "ubicloud-standard-2")
       expect { dgi.wait_resource_destroy }.to exit({"msg" => "github installation destroyed"})
       expect(GithubInstallation[installation_id]).to be_nil
     end


### PR DESCRIPTION
Since there is a foreign key constraint, we need to delete the custom labels before deleting the installation; otherwise, it fails with a foreign key constraint error.