### PR TITLE
Check new account email domains against SURBL blacklist

### DIFF
--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -197,6 +197,7 @@ class Clover < Roda
   def after_rodauth_create_account(account_id)
     account = Account[account_id]
     account.default_project = account.create_project_with_default_policy("Default")
+    Strand.create(prog: "CheckDomainBlacklist", label: "start", stack: [{subject_id: account_id}])
   end
 
   def current_account_id

--- a/prog/check_domain_blacklist.rb
+++ b/prog/check_domain_blacklist.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "resolv"
+
+class Prog::CheckDomainBlacklist < Prog::Base
+  subject_is :account
+
+  SURBL_LISTS = {
+    "DM" => 4,
+    "PH" => 8,
+    "MW" => 16,
+    "CT" => 32,
+    "ABUSE" => 64,
+    "CR" => 128
+  }.freeze
+
+  # Google Public DNS is used because the system default resolver may not
+  # recurse into the multi.surbl.org zone. Per SURBL guidelines, queries
+  # should go through a caching recursive resolver, not directly to their
+  # authoritative nameservers.
+  SURBL_DNS_NAMESERVER = "8.8.8.8"
+
+  label def start
+    domain = account.email.split("@", 2)[1]
+
+    begin
+      result = Resolv::DNS.new(nameserver: SURBL_DNS_NAMESERVER).getaddress("#{domain}.multi.surbl.org").to_s
+    rescue Resolv::ResolvError
+      pop "domain not listed in SURBL"
+    end
+
+    last_octet = result.split(".").last.to_i
+    if last_octet == 1
+      Clog.emit("SURBL access blocked", {surbl_access_blocked: {account_ubid: account.ubid, domain:}})
+      nap 60 * 60
+    end
+
+    matched_lists = SURBL_LISTS.filter_map { |name, bit| name if (last_octet & bit) > 0 }
+    if matched_lists.any?
+      Clog.emit("Account email domain listed in SURBL", {account_surbl_hit: {account_ubid: account.ubid, domain:, lists: matched_lists}})
+      account.suspend
+    end
+
+    pop "domain check completed"
+  end
+end

--- a/spec/prog/check_domain_blacklist_spec.rb
+++ b/spec/prog/check_domain_blacklist_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::CheckDomainBlacklist do
+  subject(:prog) { described_class.new(Strand.create(prog: "CheckDomainBlacklist", label: "start", stack: [{"subject_id" => account.id}])) }
+
+  let(:account) { Account.create(email: "test@suspicious-domain.com") }
+  let(:surbl_dns) { instance_double(Resolv::DNS) }
+
+  before do
+    allow(Resolv::DNS).to receive(:new).with(nameserver: "8.8.8.8").and_return(surbl_dns)
+  end
+
+  describe "#start" do
+    it "pops if domain is not listed" do
+      expect(surbl_dns).to receive(:getaddress).with("suspicious-domain.com.multi.surbl.org").and_raise(Resolv::ResolvError)
+
+      expect { prog.start }.to exit({"msg" => "domain not listed in SURBL"})
+    end
+
+    it "naps for an hour and logs if access is blocked" do
+      expect(surbl_dns).to receive(:getaddress).with("suspicious-domain.com.multi.surbl.org").and_return(Resolv::IPv4.create("127.0.0.1"))
+
+      expect(Clog).to receive(:emit).with("SURBL access blocked", {surbl_access_blocked: {account_ubid: account.ubid, domain: "suspicious-domain.com"}})
+
+      expect { prog.start }.to nap(60 * 60)
+    end
+
+    it "suspends account and logs when domain is on ABUSE list" do
+      expect(surbl_dns).to receive(:getaddress).with("suspicious-domain.com.multi.surbl.org").and_return(Resolv::IPv4.create("127.0.0.64"))
+
+      expect(Clog).to receive(:emit).with("Account email domain listed in SURBL", {account_surbl_hit: {account_ubid: account.ubid, domain: "suspicious-domain.com", lists: ["ABUSE"]}})
+      expect(prog.account).to receive(:suspend)
+
+      expect { prog.start }.to exit({"msg" => "domain check completed"})
+    end
+
+    it "suspends account and logs multiple lists when domain is on multiple lists" do
+      expect(surbl_dns).to receive(:getaddress).with("suspicious-domain.com.multi.surbl.org").and_return(Resolv::IPv4.create("127.0.0.80"))
+
+      expect(Clog).to receive(:emit).with("Account email domain listed in SURBL", {account_surbl_hit: {account_ubid: account.ubid, domain: "suspicious-domain.com", lists: ["MW", "ABUSE"]}})
+      expect(prog.account).to receive(:suspend)
+
+      expect { prog.start }.to exit({"msg" => "domain check completed"})
+    end
+
+    it "does not suspend account when result has no matching list bits" do
+      expect(surbl_dns).to receive(:getaddress).with("suspicious-domain.com.multi.surbl.org").and_return(Resolv::IPv4.create("127.0.0.2"))
+
+      expect(prog.account).not_to receive(:suspend)
+
+      expect { prog.start }.to exit({"msg" => "domain check completed"})
+    end
+  end
+end


### PR DESCRIPTION
Check new account email domains against SURBL blacklist
Abusers have been creating many accounts with custom domains that
are listed in the SURBL multi blacklist. To counter this, a new
background prog runs after account creation, querying the domain
against multi.surbl.org via DNS.

If the domain is listed, the account is suspended and the hit is
logged via Clog.emit with the matched lists (PH, MW, ABUSE, etc.).
If the query returns 127.0.0.1 (access blocked), it logs and
retries after one hour.

The system default DNS resolver does not recurse into the
multi.surbl.org zone, so a public recursive resolver (Google DNS)
is used instead. Per SURBL guidelines, queries should go through a
caching recursive resolver rather than directly to their
authoritative nameservers (a-j.surbl.org).

The prog is named CheckDomainBlacklist to allow adding other
blacklist databases in the future.
