### PR TITLE
Fix missing require "stripe" in admin spec

### DIFF
--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "spec_helper"
+require "stripe"
 
 RSpec.describe CloverAdmin do
   def object_data


### PR DESCRIPTION
The admin spec uses Stripe::PaymentMethodService and
Stripe::StripeObject but was missing the require, causing
NameError in spec_separate runs.

Daily CI failure: https://github.com/ubicloud/ubicloud/actions/runs/22758358719/job/66008484457