### PR TITLE
Handle Octokit::NotFound in Show Job Log admin action

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -197,6 +197,8 @@ class CloverAdmin < Roda
       "show_job_log" => object_action("Show Job Log", params: {job_id: :pos_int!}, type: :content) do |obj, job_id|
         url = obj.installation.client.workflow_run_job_logs(obj.name, job_id)
         "<a href=\"#{Erubi.h(url)}\">Download Job Log</a>"
+      rescue Octokit::NotFound
+        "Job not found"
       end
     },
     "Page" => {

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -868,6 +868,22 @@ RSpec.describe CloverAdmin do
     expect(page).to have_link("Download Job Log", href: "https://example.com/logs/12345.zip")
   end
 
+  it "shows job not found for GithubRepository when job id is invalid" do
+    ins = GithubInstallation.create(installation_id: 123, name: "test-org", type: "Organization")
+    repo = GithubRepository.create(name: "test-org/test-repo", installation_id: ins.id)
+
+    visit "/model/GithubRepository/#{repo.ubid}"
+    click_link "Show Job Log"
+
+    client = double
+    expect(Github).to receive(:installation_client).and_return(client)
+    expect(client).to receive(:workflow_run_job_logs).with("test-org/test-repo", 99999).and_raise(Octokit::NotFound)
+
+    fill_in "job_id", with: "99999"
+    click_button "Show Job Log"
+    expect(page).to have_content("Job not found")
+  end
+
   it "supports suspending Accounts" do
     account = create_account(with_project: false)
     fill_in "UBID or UUID", with: account.ubid


### PR DESCRIPTION
When an invalid workflow job ID is provided in the GithubRepository
Show Job Log admin action, rescue Octokit::NotFound and display
"Job not found" instead of returning HTTP 500.