### PR TITLE
Demock strand.update in test prog specs

### DIFF
--- a/spec/prog/test/firewall_rules_spec.rb
+++ b/spec/prog/test/firewall_rules_spec.rb
@@ -5,12 +5,14 @@ require "netaddr"
 
 RSpec.describe Prog::Test::FirewallRules do
   subject(:firewall_test) {
-    described_class.new(Strand.new(prog: "Test::FirewallRules"))
+    described_class.new(Strand.create(prog: "Test::FirewallRules", label: "start"))
   }
 
   let(:sshable) {
     Sshable.new
   }
+
+  let(:strand) { firewall_test.strand }
 
   let(:private_subnet_1) {
     nic = instance_double(Nic, private_ipv6: NetAddr::IPv6Net.parse("fd01:0db8:85a1::/64"), private_ipv4: NetAddr::IPv4Net.parse("192.168.0.1/32"))
@@ -155,8 +157,8 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("sudo systemctl start listening_ipv4.service")
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 1.1.1.1 8080").and_return("success!")
 
-      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm2 should not be able to connect to vm1 on port 8080"})
       expect { firewall_test.perform_tests_none }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "vm2 should not be able to connect to vm1 on port 8080"})
     end
   end
 
@@ -191,8 +193,8 @@ ExecStart=nc -l 8080 -6
       expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(false)
 
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 1.1.1.1 8080").and_raise("nc: connect to 1.1.1.1 port 8080 (tcp) timed out")
-      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm2 should be able to connect to 1.1.1.1 on port 8080"})
       expect { firewall_test.perform_tests_public_ipv4 }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "vm2 should be able to connect to 1.1.1.1 on port 8080"})
     end
 
     it "updates firewall rules and tests connectivity and fails when the VM2 can connect to VM1 but also the vm_outside can connect to VM1" do
@@ -208,8 +210,8 @@ ExecStart=nc -l 8080 -6
 
       vm_outside = instance_double(Vm, ip4: "1.1.1.3", inhost_name: "vm_outside", sshable:)
       expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
-      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm_outside should not be able to connect to vm1 on port 8080"})
       expect { firewall_test.perform_tests_public_ipv4 }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "vm_outside should not be able to connect to vm1 on port 8080"})
     end
 
     it "updates firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1 but not the vm_outside" do
@@ -265,8 +267,8 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("sudo systemctl start listening_ipv6.service")
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 2001:0db8:85a1::2 8080 -6").and_raise("nc: connect to 2001:0db8:85a1::/64 port 8080 (tcp) timed out")
 
-      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm2 should be able to connect to 2001:0db8:85a1::2 on port 8080"})
       expect { firewall_test.perform_tests_public_ipv6 }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "vm2 should be able to connect to 2001:0db8:85a1::2 on port 8080"})
     end
 
     it "updates firewall rules and tests connectivity and fails when the VM2 can connect to VM1 but also the vm_outside can connect to VM1" do
@@ -284,8 +286,8 @@ ExecStart=nc -l 8080 -6
       vm_outside = instance_double(Vm, inhost_name: "vm_outside", sshable:)
       expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 2001:0db8:85a1::2 8080 -6").and_return("success!").at_least(:once)
-      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm_outside should not be able to connect to 2001:0db8:85a1::2 on port 8080"})
       expect { firewall_test.perform_tests_public_ipv6 }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "vm_outside should not be able to connect to 2001:0db8:85a1::2 on port 8080"})
     end
 
     it "updates firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1 but not the vm_outside" do
@@ -341,8 +343,8 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("sudo systemctl stop listening_ipv6.service")
       expect(sshable).to receive(:_cmd).with("sudo systemctl start listening_ipv4.service")
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 192.168.0.1 8080").and_raise("nc: connect to 192.168.0.1 port 8080 (tcp) timed out")
-      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm2 should be able to connect to 192.168.0.1 on port 8080"})
       expect { firewall_test.perform_tests_private_ipv4 }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "vm2 should be able to connect to 192.168.0.1 on port 8080"})
     end
 
     it "does not update firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1" do
@@ -380,8 +382,8 @@ ExecStart=nc -l 8080 -6
       vm_outside = instance_double(Vm, ephemeral_net4: "1.1.1.3", inhost_name: "vm_outside", sshable:)
       expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 1.1.1.1 8080").and_return("success!").once
-      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm_outside should not be able to connect to 192.168.0.1 on port 8080"})
       expect { firewall_test.perform_tests_private_ipv4 }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "vm_outside should not be able to connect to 192.168.0.1 on port 8080"})
     end
   end
 
@@ -418,8 +420,8 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("sudo systemctl stop listening_ipv4.service")
       expect(sshable).to receive(:_cmd).with("sudo systemctl start listening_ipv6.service")
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 fd01:db8:85a1::2 8080 -6").and_raise("nc: connect to fd01:0db8:85a1::2 port 8080 (tcp) timed out")
-      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm2 should be able to connect to fd01:db8:85a1::2 on port 8080"})
       expect { firewall_test.perform_tests_private_ipv6 }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "vm2 should be able to connect to fd01:db8:85a1::2 on port 8080"})
     end
 
     it "does not update firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1" do
@@ -451,8 +453,8 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("sudo systemctl start listening_ipv6.service")
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 fd01:db8:85a1::2 8080 -6").and_return("success!").once
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 2001:0db8:85a1::2 8080 -6").and_return("success!").once
-      expect(firewall_test.strand).to receive(:update).with(exitval: {msg: "vm2 should not be able to connect to 2001:0db8:85a1::2 on port 8080"})
       expect { firewall_test.perform_tests_private_ipv6 }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "vm2 should not be able to connect to 2001:0db8:85a1::2 on port 8080"})
     end
   end
 

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Prog::Test::HetznerServer do
 
   let(:hetzner_api) { instance_double(Hosting::HetznerApis) }
   let(:vm_host) { Prog::Vm::HostNexus.assemble("1.1.1.1").subject }
+  let(:strand) { hs_test.strand }
 
   before {
     allow(Config).to receive(:e2e_hetzner_server_id).and_return("1.1.1.1")
@@ -230,20 +231,20 @@ RSpec.describe Prog::Test::HetznerServer do
 
     it "fails if used_cores not reclaimed" do
       vm_host.update(used_cores: 10)
-      expect(hs_test.strand).to receive(:update).with(exitval: {msg: "used_cores is expected to be zero, actual: 10"})
       expect { hs_test.verify_resources_reclaimed }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "used_cores is expected to be zero, actual: 10"})
     end
 
     it "fails if used_hugepages_1g not reclaimed" do
       vm_host.update(used_cores: 0, total_hugepages_1g: 384, used_hugepages_1g: 70)
-      expect(hs_test.strand).to receive(:update).with(exitval: {msg: "used_hugepages_1g is expected to be zero, actual: 70"})
       expect { hs_test.verify_resources_reclaimed }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "used_hugepages_1g is expected to be zero, actual: 70"})
     end
 
     it "fails if available_storage_gib not reclaimed" do
       expect(hs_test).to receive(:frame).and_return({"available_storage_gib" => 500}).at_least(:once)
-      expect(hs_test.strand).to receive(:update).with(exitval: {msg: "available_storage_gib was not reclaimed as expected: 500, actual: 860"})
       expect { hs_test.verify_resources_reclaimed }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "available_storage_gib was not reclaimed as expected: 500, actual: 860"})
     end
 
     it "hops to destroy after resource verified" do

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -118,11 +118,8 @@ RSpec.describe Prog::Test::VmGroup do
         cpus: [])
       expect(vg_test).to receive_messages(vm_host:, frame: {"verify_host_capacity" => true})
 
-      strand = instance_double(Strand)
-      allow(vg_test).to receive_messages(strand:)
-      expect(strand).to receive(:update).with(exitval: {msg: "Host used cores does not match the allocated VMs cores (vm_cores=2, slice_cores=1, used_cores=5)"})
-
       expect { vg_test.verify_host_capacity }.to hop("failed")
+      expect(st.reload.exitval).to eq({"msg" => "Host used cores does not match the allocated VMs cores (vm_cores=2, slice_cores=1, used_cores=5)"})
     end
   end
 
@@ -140,7 +137,7 @@ RSpec.describe Prog::Test::VmGroup do
 
     it "hops to verify_firewall_rules if tests are done" do
       expect(vg_test).to receive(:frame).and_return({"test_slices" => true})
-      expect(vg_test.strand).to receive(:retval).and_return({"msg" => "Verified VM Host Slices!"})
+      st.retval = {"msg" => "Verified VM Host Slices!"}
       expect { vg_test.verify_vm_host_slices }.to hop("verify_storage_rpc")
     end
   end
@@ -174,14 +171,14 @@ RSpec.describe Prog::Test::VmGroup do
 
       expect(vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/vm123456/0/rpc.sock -q 0", stdin: command).and_return("{\"error\": \"some error\"}\n")
 
-      expect(vg_test.strand).to receive(:update).with(exitval: {msg: "Failed to get vhost-block-backend version for VM vm1 using RPC"})
       expect { vg_test.verify_storage_rpc }.to hop("failed")
+      expect(st.reload.exitval).to eq({"msg" => "Failed to get vhost-block-backend version for VM vm1 using RPC"})
     end
   end
 
   describe "#verify_firewall_rules" do
     it "hops to test_reboot if tests are done" do
-      expect(vg_test.strand).to receive(:retval).and_return({"msg" => "Verified Firewall Rules!"})
+      st.retval = {"msg" => "Verified Firewall Rules!"}
       expect { vg_test.verify_firewall_rules }.to hop("verify_connected_subnets")
     end
 
@@ -195,7 +192,7 @@ RSpec.describe Prog::Test::VmGroup do
 
   describe "#verify_connected_subnets" do
     it "hops to test_reboot if tests are done" do
-      expect(vg_test.strand).to receive(:retval).and_return({"msg" => "Verified Connected Subnets!"})
+      st.retval = {"msg" => "Verified Connected Subnets!"}
       expect { vg_test.verify_connected_subnets }.to hop("test_reboot")
     end
 
@@ -218,7 +215,7 @@ RSpec.describe Prog::Test::VmGroup do
     end
 
     it "hops to destroy_resources if tests are done and reboot is not set" do
-      expect(vg_test.strand).to receive(:retval).and_return({"msg" => "Verified Connected Subnets!"})
+      st.retval = {"msg" => "Verified Connected Subnets!"}
       expect(vg_test).to receive(:frame).and_return({"test_reboot" => false})
       expect { vg_test.verify_connected_subnets }.to hop("destroy_resources")
     end

--- a/spec/prog/test/vm_host_slices_spec.rb
+++ b/spec/prog/test/vm_host_slices_spec.rb
@@ -5,8 +5,10 @@ require "netaddr"
 
 RSpec.describe Prog::Test::VmHostSlices do
   subject(:vm_host_slices) {
-    described_class.new(Strand.new(prog: "Test::VmHostSlices", label: "start"))
+    described_class.new(Strand.create(prog: "Test::VmHostSlices", label: "start"))
   }
+
+  let(:strand) { vm_host_slices.strand }
 
   # rubocop:disable RSpec/IndexedLet
   let(:slice1) {
@@ -55,14 +57,6 @@ RSpec.describe Prog::Test::VmHostSlices do
       sshable: create_mock_sshable(start_fresh_session: instance_double(Net::SSH::Connection::Session, shutdown!: nil, close: nil)))
   }
 
-  let(:strand) {
-    instance_double(Strand)
-  }
-
-  before do
-    allow(vm_host_slices).to receive_messages(strand:)
-  end
-
   describe "#start" do
     it "hops to verify_separation" do
       expect { vm_host_slices.start }.to hop("verify_separation")
@@ -72,16 +66,14 @@ RSpec.describe Prog::Test::VmHostSlices do
   describe "#verify_separation" do
     it "fails the test if the slices are the same" do
       allow(vm_host_slices).to receive_messages(slices: [slice1, slice1, slice2])
-      expect(strand).to receive(:update).with(exitval: {msg: /Two Vm instances placed in the same slice;/})
-
       expect { vm_host_slices.verify_separation }.to hop("failed")
+      expect(strand.reload.exitval["msg"]).to match(/Two Vm instances placed in the same slice;/)
     end
 
     it "fails the test if the slices are on the same CPUs" do
       allow(vm_host_slices).to receive_messages(slices: [slice2, slice3, slice2_overlap])
-      expect(strand).to receive(:update).with(exitval: {msg: /Two Vm instances are sharing at least one cpu;/})
-
       expect { vm_host_slices.verify_separation }.to hop("failed")
+      expect(strand.reload.exitval["msg"]).to match(/Two Vm instances are sharing at least one cpu;/)
     end
 
     it "handles burstable slices" do
@@ -112,9 +104,8 @@ RSpec.describe Prog::Test::VmHostSlices do
 
     it "fails the test if the slice is not setup correctly" do
       expect(slice3).to receive(:up?).and_return(false)
-      expect(strand).to receive(:update).with(exitval: {msg: "Slice #{slice3.id} is not setup correctly"})
-
       expect { vm_host_slices.verify_on_host }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "Slice #{slice3.id} is not setup correctly"})
     end
 
     it "hops to finish" do

--- a/spec/prog/test/vm_spec.rb
+++ b/spec/prog/test/vm_spec.rb
@@ -5,8 +5,10 @@ require "netaddr"
 
 RSpec.describe Prog::Test::Vm do
   subject(:vm_test) {
-    described_class.new(Strand.new(prog: "Test::Vm"))
+    described_class.new(Strand.create(prog: "Test::Vm", label: "start"))
   }
+
+  let(:strand) { vm_test.strand }
 
   let(:sshable) {
     Sshable.new
@@ -71,8 +73,8 @@ RSpec.describe Prog::Test::Vm do
       expect(sshable).to receive(:_cmd).with("dd if=/dev/urandom of=~/1.txt bs=512 count=1000000")
       expect(sshable).to receive(:_cmd).with("sync ~/1.txt")
       expect(sshable).to receive(:_cmd).with("ls -s ~/1.txt").and_return "300 /home/xyz/1.txt"
-      expect(vm_test.strand).to receive(:update).with(exitval: {msg: "unexpected size after dd"})
       expect { vm_test.verify_dd }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "unexpected size after dd"})
     end
   end
 
@@ -101,16 +103,16 @@ RSpec.describe Prog::Test::Vm do
     it "fails if number of files is unexpected" do
       expect(vm_test).to receive(:frame).and_return({"first_boot" => false})
       expect(sshable).to receive(:_cmd).with("ls ~/persistence_test").and_return("sha256_1\nsha256_2\nsha256_3\n")
-      expect(vm_test.strand).to receive(:update).with(exitval: {msg: "persistence test: unexpected number of files"})
       expect { vm_test.storage_persistence }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "persistence test: unexpected number of files"})
     end
 
     it "fails if file content mismatches" do
       expect(vm_test).to receive(:frame).and_return({"first_boot" => false})
       expect(sshable).to receive(:_cmd).with("ls ~/persistence_test").and_return("sha256_1\nsha256_2\nsha256_3\nsha256_4\nsha256_5\n")
       expect(sshable).to receive(:_cmd).with("sha256sum /home/ubi/persistence_test/sha256_1 | awk '{print $1}'").and_return("different_sha256")
-      expect(vm_test.strand).to receive(:update).with(exitval: {msg: "persistence test: file content mismatch"})
       expect { vm_test.storage_persistence }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "persistence test: file content mismatch"})
     end
   end
 
@@ -138,8 +140,8 @@ RSpec.describe Prog::Test::Vm do
 
     it "fails to install packages if the vm has unexpected boot image" do
       expect(vm_test).to receive(:vm).and_return(instance_double(Vm, boot_image: "windows")).at_least(:once)
-      expect(vm_test.strand).to receive(:update).with(exitval: {msg: "unexpected boot image: windows"})
       expect { vm_test.install_packages }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "unexpected boot image: windows"})
     end
   end
 
@@ -235,15 +237,15 @@ RSpec.describe Prog::Test::Vm do
 
     it "fails if read mbytes per sec exceeds the limit" do
       expect(vm_test).to receive(:get_read_bw_bytes).and_return 280 * 1024 * 1024
-      expect(vm_test.strand).to receive(:update).with(exitval: {msg: "exceeded read bw limit: 293601280"})
       expect { vm_test.verify_io_rates }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "exceeded read bw limit: 293601280"})
     end
 
     it "fails if write mbytes per sec exceeds the limit" do
       expect(vm_test).to receive(:get_read_bw_bytes).and_return 200 * 1024 * 1024
       expect(vm_test).to receive(:get_write_bw_bytes).and_return 320 * 1024 * 1024
-      expect(vm_test.strand).to receive(:update).with(exitval: {msg: "exceeded write bw limit: 335544320"})
       expect { vm_test.verify_io_rates }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "exceeded write bw limit: 335544320"})
     end
   end
 


### PR DESCRIPTION
Replace `expect(*.strand).to receive(:update).with(exitval: ...)` mocks with real strand updates by using Strand.create instead of Strand.new. Assert on strand.reload.exitval after the hop instead.