### PR TITLE
Add unsuspend account action to admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -183,7 +183,8 @@ class CloverAdmin < Roda
 
   OBJECT_ACTIONS = {
     "Account" => {
-      "suspend" => object_action("Suspend", flash: "Account suspended", &:suspend)
+      "suspend" => object_action("Suspend", flash: "Account suspended", &:suspend),
+      "unsuspend" => object_action("Unsuspend", flash: "Account unsuspended", &:unsuspend)
     },
     "Invoice" => {
       "download_pdf" => object_action("Download PDF", type: :direct) do |obj|

--- a/model/account.rb
+++ b/model/account.rb
@@ -58,6 +58,11 @@ class Account < Sequel::Model(:accounts)
     PaymentMethod.where(billing_info_id: projects_dataset.select(:billing_info_id)).update(fraud: true)
     ProjectInvitation.where(inviter_id: id).destroy
   end
+
+  def unsuspend
+    update(suspended_at: nil)
+    PaymentMethod.where(billing_info_id: projects_dataset.select(:billing_info_id)).update(fraud: false)
+  end
 end
 
 # Table: accounts

--- a/spec/model/account_spec.rb
+++ b/spec/model/account_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe Account do
       .and change { project.invitations_dataset.count }.from(1).to(0)
   end
 
+  it "unsuspend" do
+    project = account.create_project_with_default_policy("project-1")
+    project.update(billing_info_id: BillingInfo.create(stripe_id: "cus123").id)
+    payment_method = project.billing_info.add_payment_method(stripe_id: "pm123")
+    payment_method.update(fraud: true)
+    account.update(suspended_at: Time.now)
+    expect { account.unsuspend }
+      .to change(account, :suspended_at).to(nil)
+      .and change { payment_method.reload.fraud }.from(true).to(false)
+  end
+
   describe ".create_project_with_default_policy" do
     it "sets reputation new" do
       project = account.create_project_with_default_policy("project-2")

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -884,7 +884,7 @@ RSpec.describe CloverAdmin do
     expect(page).to have_content("Job not found")
   end
 
-  it "supports suspending Accounts" do
+  it "supports suspending and unsuspending Accounts" do
     account = create_account(with_project: false)
     fill_in "UBID or UUID", with: account.ubid
     click_button "Show Object"
@@ -896,6 +896,12 @@ RSpec.describe CloverAdmin do
     expect(page).to have_flash_notice("Account suspended")
     expect(page.title).to eq "Ubicloud Admin - Account #{account.ubid}"
     expect(account.reload.suspended_at).not_to be_nil
+
+    click_link "Unsuspend"
+    click_button "Unsuspend"
+    expect(page).to have_flash_notice("Account unsuspended")
+    expect(page.title).to eq "Ubicloud Admin - Account #{account.ubid}"
+    expect(account.reload.suspended_at).to be_nil
   end
 
   it "supports resolving Pages" do


### PR DESCRIPTION
Add Account#unsuspend method that clears suspended_at and resets
payment methods fraud flag back to false. Wire it up as an admin
object action.