### PR TITLE
Force use of a different env key for admin sessions

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -43,6 +43,7 @@ class CloverAdmin < Roda
 
   plugin :sessions,
     key: "_CloverAdmin.session",
+    env_key: "clover.admin.session",
     cookie_options: {secure: !(Config.development? || Config.test?)},
     secret: OpenSSL::HMAC.digest("SHA512", Config.clover_session_secret, "admin-site")
 


### PR DESCRIPTION
Without this, if the CloverAdmin and the Clover accessed the session while handling the same request, they could potentially see the session for which application first accessed the session. While I don't think we currently have code that will do that, it's best to avoid the possibility entirely by storing the CloverAdmin session in a different key in the rack env.