### PR TITLE
Move pagerduty gem back to the default Bundler group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "nokogiri"
 gem "octokit"
 gem "omniauth-github"
 gem "omniauth-google-oauth2"
+gem "pagerduty", ">= 4.0"
 gem "prawn"
 gem "prawn-table"
 gem "pry"
@@ -55,10 +56,6 @@ end
 
 group :aws_rds_iam do
   gem "pg-aws_rds_iam", github: "haines/pg-aws_rds_iam", ref: "fb91b9232837e350aa9c8440b7340346adae845e"
-end
-
-group :pagerduty do
-  gem "pagerduty", ">= 4.0"
 end
 
 group :development do


### PR DESCRIPTION
58d8acfc4 moved the pagerduty gem into an optional :pagerduty Bundler group to avoid installing it in environments that only use incident.io. However, loader.rb configures Bundler with:

    Bundler.setup(:default, rack_env.to_sym)

This only makes gems from the :default and :production (or :development) groups available on the load path. Even though the :pagerduty group is not in BUNDLE_WITHOUT and the gem is installed, it is invisible to require at runtime. This causes the monitor process to crash during Page.freeze -> Client.new:

    cannot load such file -- pagerduty (LoadError)
    from model/page.rb:10:in 'Page::Client#initialize'

The web process was unaffected because Puma does not call Page.freeze in the same code path.

The simplest fix is to keep pagerduty in the default group. The gem is only loaded when Config.pagerduty_key is set (the require is inside an if-guard in Client#initialize), so environments using incident.io pay only the install cost, not any runtime cost.