### PR TITLE
Require spec_helper in top-level spec files

### DIFF
--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "spec_helper"
+
 RSpec.describe Config do
   it "can have float config" do
     described_class.class_eval do

--- a/spec/db_spec.rb
+++ b/spec/db_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "spec_helper"
+
 RSpec.describe "Database" do
   it "has no unexpectedly collated columns" do
     collated_columns = DB[:pg_class]

--- a/spec/resource_methods_spec.rb
+++ b/spec/resource_methods_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../model"
+require_relative "spec_helper"
 
 RSpec.describe ResourceMethods do
   let(:sa) { Sshable.create(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair) }

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "spec_helper"
+
 RSpec.describe UBID do
   let(:type_constants) { described_class.constants.select { it.start_with?("TYPE_") } }
   let(:all_types) { type_constants.map { described_class.const_get(it) } }


### PR DESCRIPTION
Some top-level spec files had this, but we should consistently require the appropriate spec helper for all spec files.