### PR TITLE
Don't have rubocop scan the coverage/views/admin directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ AllCops:
     - public/**/*
     - vendor/**/*
     - node_modules/**/*
-    - coverage/views/*
+    - coverage/views/**/*
 
 RSpec:
   Enabled: true


### PR DESCRIPTION
This directory is now used for CloverAdmin view coverage, but just like the Clover view coverage directory, it should be ignored by rubocop.