### PR TITLE
Rescue Excon::Error::Timeout when setting up blob storage

### DIFF
--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -93,7 +93,7 @@ class Clover
         r.post do
           begin
             repository.setup_blob_storage unless repository.access_key
-          rescue Excon::Error::HTTPStatus => ex
+          rescue Excon::Error::HTTPStatus, Excon::Error::Timeout => ex
             Clog.emit("Unable to setup blob storage", {failed_blob_storage_setup: {ubid: runner.ubid, repository_ubid: repository.ubid, response: ex.response.body}})
             fail CloverError.new(400, "InvalidRequest", "unable to setup blob storage")
           end


### PR DESCRIPTION
We already rescue Excon::Error::HTTPStatus. Handles a couple production exceptions.