### PR TITLE
Apply separate quota limits for arm64 GitHub runners

### DIFF
--- a/config/default_quotas.yml
+++ b/config/default_quotas.yml
@@ -1,5 +1,6 @@
 - { id: c088f732-0a30-454b-aa6b-542ce1d67bfb, resource_type: VmVCpu,                   limited_value: 16,  new_value: 32,   verified_value: 256 }
 - { id: 14fa6820-bf63-41d2-b35e-4a4dcefd1b15, resource_type: GithubRunnerVCpu,         limited_value: 128, new_value: 300,  verified_value: 300 }
+- { id: 452f14c5-4858-457e-9fb8-d5e81452c804, resource_type: GithubRunnerVCpuArm,      limited_value: 50,  new_value: 100,  verified_value: 100 }
 - { id: 0ac764de-48c5-4432-876d-389878da0885, resource_type: GithubRunnerCacheStorage, limited_value: 30,  new_value: 30,   verified_value: 30  }
 - { id: 91d616ea-a15b-4d54-90b7-aaa1e1bd2f19, resource_type: PostgresVCpu,             limited_value: 16,  new_value: 128,  verified_value: 256 }
 - { id: 3acfffdb-37d6-42ff-8d1f-78a1915c7912, resource_type: KubernetesVCpu,           limited_value: 16,  new_value: 32,   verified_value: 256 }

--- a/model/project.rb
+++ b/model/project.rb
@@ -150,7 +150,8 @@ class Project < Sequel::Model
   def current_resource_usage(resource_type)
     case resource_type
     when "VmVCpu" then vms_dataset.sum(:vcpus) || 0
-    when "GithubRunnerVCpu" then GithubRunner.where(installation_id: github_installations_dataset.select(:id)).total_active_runner_vcpus
+    when "GithubRunnerVCpu" then GithubRunner.where(installation_id: github_installations_dataset.select(:id)).exclude(Sequel.like(Sequel[:github_runner][:label], "%-arm%")).total_active_runner_vcpus
+    when "GithubRunnerVCpuArm" then GithubRunner.where(installation_id: github_installations_dataset.select(:id)).where(Sequel.like(Sequel[:github_runner][:label], "%-arm%")).total_active_runner_vcpus
     when "PostgresVCpu" then postgres_resources_dataset.association_join(servers: :vm).sum(:vcpus) || 0
     when "KubernetesVCpu" then kubernetes_clusters_dataset.select(Sequel[:kubernetes_cluster][:cp_node_count].as(:node_count), Sequel[:kubernetes_cluster][:target_node_size])
       .union(kubernetes_clusters_dataset.association_join(:nodepools).select(:node_count, Sequel[:nodepools][:target_node_size]), all: true)

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -211,7 +211,8 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     # requests. There are some remedies, but it would require some refactoring
     # that I'm not keen to do at the moment. Although it looks weird, passing 0
     # as requested_additional_usage keeps the existing behavior.
-    project.quota_available?("GithubRunnerVCpu", 0)
+    resource_type = x64? ? "GithubRunnerVCpu" : "GithubRunnerVCpuArm"
+    project.quota_available?(resource_type, 0)
   end
 
   label def wait_concurrency_limit

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -173,9 +173,12 @@ RSpec.describe Project do
     expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 0
     grst = Strand.new(id: gr.id, label: "start", prog: "Prog::Github::GithubRunnerNexus")
     expect { grst.update(label: "wait_vm") }.to change { project.current_resource_usage("GithubRunnerVCpu") }.from(0).to(2)
-    gr2 = gi.add_runner(label: "ubicloud-standard-60", repository_name: "a/a")
+    gr2 = gi.add_runner(label: "ubicloud-standard-16-arm", repository_name: "a/a")
     grst2 = Strand.new(id: gr2.id, label: "wait_concurrency_limit", prog: "Prog::Github::GithubRunnerNexus")
-    expect { grst2.update(label: "wait_vm") }.to change { project.current_resource_usage("GithubRunnerVCpu") }.from(2).to(62)
+    expect { grst2.update(label: "wait_vm") }.to change { project.current_resource_usage("GithubRunnerVCpuArm") }.from(0).to(16)
+    gr3 = gi.add_runner(label: "ubicloud-standard-60", repository_name: "a/a")
+    grst3 = Strand.new(id: gr3.id, label: "wait_concurrency_limit", prog: "Prog::Github::GithubRunnerNexus")
+    expect { grst3.update(label: "wait_vm") }.to change { project.current_resource_usage("GithubRunnerVCpu") }.from(2).to(62)
 
     expect(Config).to receive(:postgres_service_project_id).and_return(project.id).at_least(:once)
     expect {
@@ -203,17 +206,20 @@ RSpec.describe Project do
     project.add_quota(ProjectQuota.new(value: 1000).tap { it.quota_id = "14fa6820-bf63-41d2-b35e-4a4dcefd1b15" })
     expect(project.effective_quota_value("VmVCpu")).to eq 32
     expect(project.effective_quota_value("GithubRunnerVCpu")).to eq 1000
+    expect(project.effective_quota_value("GithubRunnerVCpuArm")).to eq 100
     expect(project.effective_quota_value("PostgresVCpu")).to eq 128
 
     project.reputation = "verified"
     expect(project.effective_quota_value("VmVCpu")).to eq 256
     expect(project.effective_quota_value("GithubRunnerVCpu")).to eq 1000
+    expect(project.effective_quota_value("GithubRunnerVCpuArm")).to eq 100
     expect(project.effective_quota_value("PostgresVCpu")).to eq 256
 
     project.reputation = "limited"
     project.quotas_dataset.destroy
     expect(project.effective_quota_value("VmVCpu")).to eq 16
     expect(project.effective_quota_value("GithubRunnerVCpu")).to eq 128
+    expect(project.effective_quota_value("GithubRunnerVCpuArm")).to eq 50
     expect(project.effective_quota_value("PostgresVCpu")).to eq 16
   end
 

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -452,7 +452,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       end
 
       it "allocates arm64 runners without checking premium utilization" do
-        expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpuArm", 0).and_return(false)
         runner.update(label: "ubicloud-standard-4-arm")
         VmHost[arch: "arm64"].update(used_cores: 8)
         expect { nx.wait_concurrency_limit }.to hop("allocate_vm")

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -547,6 +547,7 @@ RSpec.describe CloverAdmin do
     expect(page.all(".project-quota-table tbody tr").map { it.all("td").map(&:text) }).to eq [
       ["VmVCpu", "32", "16"],
       ["GithubRunnerVCpu", "400", "0"],
+      ["GithubRunnerVCpuArm", "100", "0"],
       ["PostgresVCpu", "128", "0"],
       ["KubernetesVCpu", "32", "0"]
     ]

--- a/views/admin/extras/Project.erb
+++ b/views/admin/extras/Project.erb
@@ -3,7 +3,7 @@
 <%== part("components/collapsible_table",
   title: "Quotas",
   table_class: "project-quota-table",
-  data: ["VmVCpu", "GithubRunnerVCpu", "PostgresVCpu", "KubernetesVCpu"].map {
+  data: ["VmVCpu", "GithubRunnerVCpu", "GithubRunnerVCpuArm", "PostgresVCpu", "KubernetesVCpu"].map {
     {
       "Resource" => it,
       "Quota" => obj.effective_quota_value(it),

--- a/views/github/runner.erb
+++ b/views/github/runner.erb
@@ -21,7 +21,7 @@
   <% end %>
 </dl>
 
-<% if @installation.project.reputation == "limited" && !@installation.project.quota_available?("GithubRunnerVCpu", 0) %>
+<% if @installation.project.reputation == "limited" && !(@installation.project.quota_available?("GithubRunnerVCpu", 0) && @installation.project.quota_available?("GithubRunnerVCpuArm", 0)) %>
   <div class="mb-3 -mt-2 rounded-md bg-red-50 p-4 flex items-center gap-3">
     <%== part("components/icon", name: "hero-squares-plus", classes: "h-5 w-5 text-red-400") %>
     <h3 class="text-sm font-medium text-red-800">


### PR DESCRIPTION
Our arm64 fleet is significantly smaller than x64, but both architectures shared the same 300 vCPU soft limit. This allowed a few customers to consume most of the arm64 capacity, creating unfair resource distribution.

Introduce a dedicated GithubRunnerVCpuArm quota with lower default limits (50/100/100 for limited/new/verified) and filter runner usage by label suffix to track each architecture independently.