### PR TITLE
Add direct GitHub page links for installations and repositories

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -196,6 +196,10 @@ class CloverAdmin < Roda
     ObjectAction.define(...)
   end
 
+  github_page_action = object_action("GitHub Page", type: :direct) do |obj|
+    "http://github.com/#{obj.name}"
+  end
+
   OBJECT_ACTIONS = {
     "Account" => {
       "suspend" => object_action("Suspend", flash: "Account suspended", &:suspend)
@@ -205,10 +209,14 @@ class CloverAdmin < Roda
         obj.generate_download_link
       end
     },
+    "GithubInstallation" => {
+      "github_page" => github_page_action
+    },
     "GithubRunner" => {
       "provision" => object_action("Provision Spare Runner", flash: "Spare runner provisioned", type: :form, &:provision_spare_runner)
     },
     "GithubRepository" => {
+      "github_page" => github_page_action,
       "show_job_log" => object_action("Show Job Log", params: {job_id: {typecast: :pos_int!, type: "number", attr: {min: 1, max: 2**63 - 1}}}, type: :content) do |obj, job_id|
         url = obj.installation.client.workflow_run_job_logs(obj.name, job_id)
         "<a href=\"#{Erubi.h(url)}\">Download Job Log</a>"

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -876,6 +876,29 @@ RSpec.describe CloverAdmin do
     expect(page.all("#autoforme_content td").map(&:text)).to eq ["test-org/test-repo", repo.created_at.to_s, repo.last_job_at.to_s]
   end
 
+  it "links to GitHub page for GithubInstallation" do
+    ins = GithubInstallation.create(installation_id: 123, name: "test-org", type: "Organization")
+    visit "/model/GithubInstallation/#{ins.ubid}"
+    expect(page.title).to eq "Ubicloud Admin - GithubInstallation #{ins.ubid}"
+    expect(page).to have_link "GitHub Page"
+
+    page.driver.get "/model/GithubInstallation/#{ins.ubid}/github_page"
+    expect(page.driver.response.status).to eq 302
+    expect(page.driver.response.headers["Location"]).to eq "http://github.com/test-org"
+  end
+
+  it "links to GitHub page for GithubRepository" do
+    ins = GithubInstallation.create(installation_id: 123, name: "test-org", type: "Organization")
+    repo = GithubRepository.create(name: "test-org/test-repo", installation_id: ins.id)
+    visit "/model/GithubRepository/#{repo.ubid}"
+    expect(page.title).to eq "Ubicloud Admin - GithubRepository #{repo.ubid}"
+    expect(page).to have_link "GitHub Page"
+
+    page.driver.get "/model/GithubRepository/#{repo.ubid}/github_page"
+    expect(page.driver.response.status).to eq 302
+    expect(page.driver.response.headers["Location"]).to eq "http://github.com/test-org/test-repo"
+  end
+
   it "supports showing job log for GithubRepository" do
     ins = GithubInstallation.create(installation_id: 123, name: "test-org", type: "Organization")
     repo = GithubRepository.create(name: "test-org/test-repo", installation_id: ins.id)


### PR DESCRIPTION
I’ve found myself repeatedly copying the installation name, typing github.com in the address bar, and pasting it there.

Having a direct link to the GitHub page would make this much more convenient.