### PR TITLE
Handle NoSuchBucket errors in GitHub cache entry cleanup

### DIFF
--- a/model/github/github_cache_entry.rb
+++ b/model/github/github_cache_entry.rb
@@ -44,13 +44,13 @@ class GithubCacheEntry < Sequel::Model
     if committed_at.nil?
       begin
         repository.blob_storage_client.abort_multipart_upload(bucket:, key:, upload_id:)
-      rescue Aws::S3::Errors::NoSuchUpload
+      rescue Aws::S3::Errors::NoSuchUpload, Aws::S3::Errors::NoSuchBucket
       end
     end
 
     begin
       repository.blob_storage_client.delete_object(bucket:, key:)
-    rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::Unauthorized
+    rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::Unauthorized, Aws::S3::Errors::NoSuchBucket
       nil
     end
   end


### PR DESCRIPTION
When a GitHub cache entry is destroyed, the after_destroy hook attempts to clean up S3 objects. If the bucket itself has already been deleted, these calls raise NoSuchBucket which is unhandled. Rescue this error alongside the existing S3 error handling in both the abort_multipart_upload and delete_object calls.