### PR TITLE
Sync all DNS server VMs in SetupDnsServerVm#sync_zones

### DIFF
--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -148,15 +148,17 @@ zone:
   label def sync_zones
     nap 5 if ds.dns_zones.any?(&:refresh_dns_servers_set?)
 
+    all_sshables = ds.vms.map(&:sshable) + [sshable]
+
     ds.dns_zones.each do |dz|
       zone_config = <<-CONF
 #{dz.name}.          3600    SOA     ns.#{dz.name}. #{dz.name}. 37 86400 7200 1209600 #{dz.neg_ttl}
 #{dz.name}.          3600    NS      #{ds.name}.
       CONF
-      sshable.write_file("/var/lib/knot/#{dz.name}.zone", zone_config, user: "knot")
+      all_sshables.each { |s| s.write_file("/var/lib/knot/#{dz.name}.zone", zone_config, user: "knot") }
     end
 
-    sshable.cmd "sudo systemctl restart knot"
+    all_sshables.each { |s| s.cmd "sudo systemctl restart knot" }
 
     ds.dns_zones.each(&:purge_obsolete_records)
 
@@ -167,8 +169,8 @@ zone:
         end + ["zone-commit #{dz.name}", "zone-flush #{dz.name}"]
     end
 
-    # Put records
-    sshable.cmd("sudo -u knot knotc", stdin: commands.join("\n"))
+    # Put records on all VMs
+    all_sshables.each { |s| s.cmd("sudo -u knot knotc", stdin: commands.join("\n")) }
 
     hop_validate
   end

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -226,6 +226,26 @@ zone-flush zone2.domain.io
 
       expect { prog.sync_zones }.to hop("validate")
     end
+
+    it "syncs all existing VMs along with the new VM" do
+      dummy_vm = create_vm_with_sshable
+      dzs
+      Semaphore.where(name: "refresh_dns_servers").destroy
+      prog
+      ds.add_vm(dummy_vm)
+      dummy_sshable = prog.ds.vms.first.sshable
+
+      # Expect zone files, restart, and knotc commands on both sshables
+      expect(prog.sshable).to receive(:_cmd).with(/sudo -u knot tee.*\.zone > \/dev\/null/, stdin: anything).exactly(3).times
+      expect(prog.sshable).to receive(:_cmd).with("sudo systemctl restart knot")
+      expect(prog.sshable).to receive(:_cmd).with("sudo -u knot knotc", stdin: anything)
+
+      expect(dummy_sshable).to receive(:_cmd).with(/sudo -u knot tee.*\.zone > \/dev\/null/, stdin: anything).exactly(3).times
+      expect(dummy_sshable).to receive(:_cmd).with("sudo systemctl restart knot")
+      expect(dummy_sshable).to receive(:_cmd).with("sudo -u knot knotc", stdin: anything)
+
+      expect { prog.sync_zones }.to hop("validate")
+    end
   end
 
   describe "#validate" do


### PR DESCRIPTION
Sync all DNS server VMs in SetupDnsServerVm#sync_zones

Previously, sync_zones only wrote zone files and ran knotc commands
on the new VM being set up. However, validate checks all existing
VMs plus the new one via vms_in_sync?, which compares zone-read
output across every VM. When existing VMs had stale state (different
SOA serials or missing records), the validation would never pass,
causing an infinite loop between sync_zones and validate.

Fix this by building an all_sshables list that includes both the
existing DNS server VMs and the new VM, then running all zone file
writes, knot restarts, and knotc commands on every VM in that list.