### PR TITLE
Require accounts for admin requests

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -632,6 +632,7 @@ class CloverAdmin < Roda
     check_csrf!
     r.rodauth
     rodauth.require_authentication
+    rodauth.require_account
 
     # :nocov:
     rodauth.require_two_factor_setup unless skip_webauthn_requirement

--- a/spec/routes/web/admin/auth_spec.rb
+++ b/spec/routes/web/admin/auth_spec.rb
@@ -65,6 +65,17 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin"
   end
 
+  it "requires account to still exist" do
+    admin_account_setup_and_login
+    expect(page.title).to eq "Ubicloud Admin"
+    DB[:admin_webauthn_key].delete
+    DB[:admin_webauthn_user_id].delete
+    DB[:admin_password_hash].delete
+    DB[:admin_account].delete
+    page.refresh
+    expect(page.title).to eq "Ubicloud Admin - Login"
+  end
+
   it "supports changing password" do
     admin_account_setup_and_login
     click_link "Change Password"


### PR DESCRIPTION
Now that we allow closing admin accounts, we should make it so that a closed admin account immediately cuts off access, even if the admin was currently logged in. The simplest way to do that is to use rodauth.require_account.