### PR TITLE
Increase the AWS nic nexus start deadline to 5 minutes

### DIFF
--- a/prog/vnet/aws/nic_nexus.rb
+++ b/prog/vnet/aws/nic_nexus.rb
@@ -95,7 +95,7 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
   end
 
   label def destroy
-    register_deadline(nil, 5 * 60)
+    register_deadline(nil, 10 * 60)
     hop_destroy_entities unless nic.nic_aws_resource
 
     begin


### PR DESCRIPTION
The next label already has a 3-minute deadline, so it doesn’t make sense to add another 3-minute deadline at the start to the wait, since that time would also include the next label.

Additionally, we’ve experienced several short-lived pages in production due to rate limits and similar issues.