### PR TITLE
Handle InvalidIPAddressInUse in AWS NIC creation for idempotency

### DIFF
--- a/prog/vnet/aws/nic_nexus.rb
+++ b/prog/vnet/aws/nic_nexus.rb
@@ -37,17 +37,29 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
   end
 
   label def create_network_interface
-    network_interface_response = client.create_network_interface({
-      subnet_id: nic.nic_aws_resource.subnet_id,
-      private_ip_address: nic.private_ipv4.network.to_s,
-      ipv_6_prefix_count: 1,
-      groups: [
-        private_subnet.private_subnet_aws_resource.security_group_id
-      ],
-      tag_specifications: Util.aws_tag_specifications("network-interface", nic.name),
-      client_token: nic.id
-    })
-    network_interface_id = network_interface_response.network_interface.network_interface_id
+    begin
+      network_interface_response = client.create_network_interface({
+        subnet_id: nic.nic_aws_resource.subnet_id,
+        private_ip_address: nic.private_ipv4.network.to_s,
+        ipv_6_prefix_count: 1,
+        groups: [
+          private_subnet.private_subnet_aws_resource.security_group_id
+        ],
+        tag_specifications: Util.aws_tag_specifications("network-interface", nic.name),
+        client_token: nic.id
+      })
+      network_interface_id = network_interface_response.network_interface.network_interface_id
+    rescue Aws::EC2::Errors::InvalidIPAddressInUse
+      network_interfaces = client.describe_network_interfaces({
+        filters: [
+          {name: "subnet-id", values: [nic.nic_aws_resource.subnet_id]},
+          {name: "addresses.private-ip-address", values: [nic.private_ipv4.network.to_s]},
+          {name: "status", values: ["available"]}
+        ]
+      }).network_interfaces
+      fail "No available network interface found for IP #{nic.private_ipv4.network}" if network_interfaces.empty?
+      network_interface_id = network_interfaces[0].network_interface_id
+    end
     nic.nic_aws_resource.update(network_interface_id:)
 
     hop_assign_ipv6_address

--- a/spec/prog/vnet/aws/nic_nexus_spec.rb
+++ b/spec/prog/vnet/aws/nic_nexus_spec.rb
@@ -75,6 +75,26 @@ RSpec.describe Prog::Vnet::Aws::NicNexus do
       expect(client).to receive(:create_network_interface).with({subnet_id: "subnet-0123456789abcdefg", private_ip_address: nic.private_ipv4.network.to_s, ipv_6_prefix_count: 1, groups: ["sg-0123456789abcdefg"], tag_specifications: Util.aws_tag_specifications("network-interface", nic.name), client_token: nic.id}).and_call_original
       expect { nx.create_network_interface }.to hop("assign_ipv6_address")
     end
+
+    it "finds existing network interface when IP is already in use" do
+      expect(client).to receive(:create_network_interface).and_raise(Aws::EC2::Errors::InvalidIPAddressInUse.new(nil, "The IP address '10.0.0.1' is already in use."))
+      client.stub_responses(:describe_network_interfaces, network_interfaces: [{network_interface_id: "eni-existing123", status: "available"}])
+      expect(client).to receive(:describe_network_interfaces).with({
+        filters: [
+          {name: "subnet-id", values: [nic.nic_aws_resource.subnet_id]},
+          {name: "addresses.private-ip-address", values: [nic.private_ipv4.network.to_s]},
+          {name: "status", values: ["available"]}
+        ]
+      }).and_call_original
+      expect { nx.create_network_interface }.to hop("assign_ipv6_address")
+      expect(nic.nic_aws_resource.reload.network_interface_id).to eq("eni-existing123")
+    end
+
+    it "fails when IP is in use but no available network interface found" do
+      expect(client).to receive(:create_network_interface).and_raise(Aws::EC2::Errors::InvalidIPAddressInUse.new(nil, "The IP address '10.0.0.1' is already in use."))
+      client.stub_responses(:describe_network_interfaces, network_interfaces: [])
+      expect { nx.create_network_interface }.to raise_error(RuntimeError, /No available network interface found for IP/)
+    end
   end
 
   describe "#assign_ipv6_address" do


### PR DESCRIPTION
It is possible that the API request succeeds but for one reason or another, we couldn't persist the change in our metadata database. In that case, if we retry the same request, we will get InvalidIPAddressInUse error from AWS because the NIC was actually created with the requested private IP address. This change adds handling for this error to make the operation idempotent.