### PR TITLE
Wait for CSI volume detach before checking pending PVs

### DIFF
--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -76,7 +76,7 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
     sshable = cluster.sshable
     case sshable.d_check(unit_name)
     when "Succeeded"
-      hop_wait_for_copy
+      hop_wait_for_detach
     when "NotStarted"
       sshable.d_run(unit_name, "sudo", "kubectl", "--kubeconfig=/etc/kubernetes/admin.conf",
         "drain", kubernetes_node.name, "--ignore-daemonsets", "--delete-emptydir-data")
@@ -90,6 +90,18 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
       register_deadline("destroy", 0)
       nap 3 * 60 * 60
     end
+  end
+
+  label def wait_for_detach
+    attachments = JSON.parse(cluster.client.kubectl("get volumeattachments -ojson"))["items"]
+    node_attachments = attachments.select { |va|
+      va.dig("spec", "nodeName") == kubernetes_node.name &&
+        va.dig("spec", "attacher") == "csi.ubicloud.com"
+    }
+    if node_attachments.any?
+      nap 5
+    end
+    hop_wait_for_copy
   end
 
   label def wait_for_copy

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -173,9 +173,49 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       expect { nx.drain }.to nap(3 * 60 * 60)
     end
 
-    it "drains the old node and hops to wait_for_copy" do
+    it "drains the old node and hops to wait_for_detach" do
       expect(cluster_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check drain_node_vm").and_return("Succeeded")
-      expect { nx.drain }.to hop("wait_for_copy")
+      expect { nx.drain }.to hop("wait_for_detach")
+    end
+  end
+
+  describe "#wait_for_detach" do
+    let(:session) { Net::SSH::Connection::Session.allocate }
+    let(:client) { Kubernetes::Client.new(nx.cluster, session) }
+    let(:success_response) { Net::SSH::Connection::Session::StringWithExitstatus.new("", 0) }
+
+    before do
+      expect(nx.cluster).to receive(:client).and_return(client)
+    end
+
+    it "naps when ubicsi VolumeAttachments still reference this node" do
+      va_list = {"items" => [{
+        "spec" => {"nodeName" => nx.kubernetes_node.name, "attacher" => "csi.ubicloud.com"}
+      }]}
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get volumeattachments -ojson").and_return(success_response.replace(JSON.generate(va_list)))
+      expect { nx.wait_for_detach }.to nap(5)
+    end
+
+    it "hops to wait_for_copy when no VolumeAttachments reference this node" do
+      va_list = {"items" => []}
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get volumeattachments -ojson").and_return(success_response.replace(JSON.generate(va_list)))
+      expect { nx.wait_for_detach }.to hop("wait_for_copy")
+    end
+
+    it "hops to wait_for_copy when only non-ubicsi VolumeAttachments remain on this node" do
+      va_list = {"items" => [{
+        "spec" => {"nodeName" => nx.kubernetes_node.name, "attacher" => "other-csi-driver"}
+      }]}
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get volumeattachments -ojson").and_return(success_response.replace(JSON.generate(va_list)))
+      expect { nx.wait_for_detach }.to hop("wait_for_copy")
+    end
+
+    it "hops to wait_for_copy when ubicsi VolumeAttachments reference a different node" do
+      va_list = {"items" => [{
+        "spec" => {"nodeName" => "other-node", "attacher" => "csi.ubicloud.com"}
+      }]}
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get volumeattachments -ojson").and_return(success_response.replace(JSON.generate(va_list)))
+      expect { nx.wait_for_detach }.to hop("wait_for_copy")
     end
   end
 


### PR DESCRIPTION
After kubectl drain succeeds, the kubelet may still be running the CSI node_unstage_volume call which sets up the data migration annotations on PVs. The wait_for_copy step was checking pending_pvs immediately after drain, finding none, and proceeding to destroy the node before rsync could complete.

Add a wait_for_detach step between drain and wait_for_copy that polls VolumeAttachment objects filtered by the ubicsi CSI driver. This ensures the kubelet has fully completed the volume teardown lifecycle before the node removal proceeds.