### PR TITLE
Set default endpoint for external endpoints healthcheck

### DIFF
--- a/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - name: CSI_ENDPOINT
               value: "unix:///csi/csi.sock"
             - name: EXTERNAL_ENDPOINTS
-              value: ""
+              value: "ipv4.google.com:443"
           securityContext:
             privileged: true
             capabilities:


### PR DESCRIPTION
Set ipv4.google.com:443 as the default external endpoint to healthcheck in mesh connectivity checker.