### PR TITLE
Fix nondeterministic spec

### DIFF
--- a/spec/lib/access_control_model_tag_spec.rb
+++ b/spec/lib/access_control_model_tag_spec.rb
@@ -37,10 +37,12 @@
     end
 
     it "#remove_members moves deleted records to archived_records" do
+      column = model.table_name.to_s.sub("tag", "id")
+      ds = DB[:archived_record].where(model_name: "applied_#{model.table_name}")
+      ds.delete
       tag.add_members([tag1.id, tag2.id])
       tag.remove_members([tag1.id, tag2.id])
-      column = model.table_name.to_s.sub("tag", "id")
-      rows = DB[:archived_record].where(model_name: "applied_#{model.table_name}").select_map(:model_values)
+      rows = ds.select_map(:model_values)
       expect(rows.length).to eq 2
       expect(rows.map { it["tag_id"] }.uniq).to eq [tag.id]
       expect(rows.map { it[column] }.sort).to eq [tag1.id, tag2.id].sort


### PR DESCRIPTION
Should fix an error I've seen both locally and now in CI:

```
  1) ActionTag #remove_members moves deleted records to archived_records
     Failure/Error: expect(rows.length).to eq 2

       expected: 2
            got: 3

       (compared using ==)
     # ./spec/lib/access_control_model_tag_spec.rb:44:in 'block (3 levels) in <top (required)>'
```