### PR TITLE
Reduce `Vm::Metal::Nexus::stopped` nap time from 15 to 5 minutes.

### DIFF
--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -373,7 +373,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       hop_wait
     end
 
-    nap 15 * 60
+    nap 5 * 60
   end
 
   # Unavailable label is for cases where VM was not manually stopped, and is

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -959,7 +959,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
 
     it "does not stop if already stopped" do
       expect(sshable).to receive(:_cmd).with("systemctl is-active #{vm.inhost_name} #{vm.inhost_name}-dnsmasq").and_return("inactive\nactive\n")
-      expect { nx.stopped }.to nap(15 * 60)
+      expect { nx.stopped }.to nap(5 * 60)
     end
 
     it "hops to unavailable if available" do


### PR DESCRIPTION
We might have a semaphore race condition which causes `incr_start` to not immediately schedule the strand. So, starting a stopped VM might take up to the nap time.

We are investigating that issue separately. However, we sometimes hit this issue in E2E tests. Therefore, this commit just changes the nap time from 15 to 5 minutes to reduce the impact of this issue on E2E running time.