### PR TITLE
Document restore `name` and `restoreTarget`

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1657,9 +1657,12 @@ paths:
               type: object
               properties:
                 name:
+                  description: Name for the newly restored Postgres database.
                   type: string
                 restore_target:
+                  description: The RFC 3339-formatted timestamp for the point in time at which to recover.
                   type: string
+                  format: date-time
                 pg_config:
                   type: object
                   example:

--- a/spec/routes/api/cli/pg/restore_spec.rb
+++ b/spec/routes/api/cli/pg/restore_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Clover, "cli pg restore" do
 
     cli(%w[pg eu-central-h1/test-pg create -s standard-2 -S 64])
     expect(PostgresResource.select_order_map(:name)).to eq %w[test-pg]
-    body = cli(%w[pg eu-central-h1/test-pg restore -c max_connections=99 -u max_client_conn=99 -t foo=bar,baz=quux test-pg-2] << Time.now.utc)
+    body = cli(%w[pg eu-central-h1/test-pg restore -c max_connections=99 -u max_client_conn=99 -t foo=bar,baz=quux test-pg-2] << Time.now.utc.to_datetime.rfc3339)
     expect(PostgresResource.select_order_map(:name)).to eq %w[test-pg test-pg-2]
     pg = PostgresResource.first(name: "test-pg-2")
     expect(pg.user_config).to eq({"max_connections" => "99"})

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -559,8 +559,7 @@ RSpec.describe Clover, "postgres" do
 
         post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore", {
           name: "restored-pg",
-          restore_target:
-
+          restore_target: restore_target.to_datetime.rfc3339
         }.to_json
 
         expect(last_response.status).to eq(200)
@@ -575,7 +574,7 @@ RSpec.describe Clover, "postgres" do
 
         post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore", {
           name: "restored-pg-with-init-script",
-          restore_target:
+          restore_target: restore_target.to_datetime.rfc3339
         }.to_json
 
         expect(last_response.status).to eq(200)
@@ -588,7 +587,7 @@ RSpec.describe Clover, "postgres" do
       it "restore invalid target" do
         post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore", {
           name: "restored-pg",
-          restore_target: Time.now.utc
+          restore_target: Time.now.utc.to_datetime.rfc3339
         }.to_json
 
         expect(last_response).to have_api_error(400, "Validation failed for following fields: restore_target")
@@ -597,7 +596,7 @@ RSpec.describe Clover, "postgres" do
       it "rejects restoring with invalid config" do
         post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/restore", {
           name: "restored-pg-invalid-config",
-          restore_target: Time.now.utc,
+          restore_target: Time.now.utc.to_datetime.rfc3339,
           pg_config: {"wal_level" => "invalid"}
         }.to_json
 

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -568,7 +568,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "can create a read replica of a PostgreSQL database" do
-        pg.timeline.update(cached_earliest_backup_at: Time.now.utc)
+        pg.timeline.update(cached_earliest_backup_at: Time.now.utc.to_datetime.rfc3339)
         VmStorageVolume.create(vm_id: pg.representative_server.vm.id, size_gib: pg.target_storage_size_gib, boot: false, disk_index: 0)
         visit "#{project.path}#{pg.path}/read-replica"
 
@@ -584,7 +584,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "cannot create a read replica if there is no backup, yet" do
-        pg.timeline.update(cached_earliest_backup_at: Time.now.utc)
+        pg.timeline.update(cached_earliest_backup_at: Time.now.utc.to_datetime.rfc3339)
         visit "#{project.path}#{pg.path}/read-replica"
         pg.timeline.update(cached_earliest_backup_at: nil)
 
@@ -597,7 +597,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "can promote a read replica" do
-        pg.timeline.update(cached_earliest_backup_at: Time.now.utc)
+        pg.timeline.update(cached_earliest_backup_at: Time.now.utc.to_datetime.rfc3339)
         VmStorageVolume.create(vm_id: pg.representative_server.vm.id, size_gib: pg.target_storage_size_gib, boot: false, disk_index: 0)
         visit "#{project.path}#{pg.path}/read-replica"
 
@@ -614,7 +614,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "fails to promote if not a read replica" do
-        pg.timeline.update(cached_earliest_backup_at: Time.now.utc)
+        pg.timeline.update(cached_earliest_backup_at: Time.now.utc.to_datetime.rfc3339)
         VmStorageVolume.create(vm_id: pg.representative_server.vm.id, size_gib: pg.target_storage_size_gib, boot: false, disk_index: 0)
         visit "#{project.path}#{pg.path}/read-replica"
         expect(page).to have_content "Read Replicas"


### PR DESCRIPTION
Document the `name` and `restoreTarget` properties in the restore API. Update the tests to use proper `rfc3339` syntax.