### PR TITLE
Run postgresql-init scripts during database initialization

### DIFF
--- a/rhizome/postgres/bin/initialize-empty-database
+++ b/rhizome/postgres/bin/initialize-empty-database
@@ -61,3 +61,7 @@ DATABASE_INIT
 r "sudo -u postgres psql -v 'ON_ERROR_STOP=1'", stdin: role_creation_queries
 r "sudo -u postgres psql -v 'ON_ERROR_STOP=1'", stdin: database_init_queries
 r "sudo -u postgres psql -d template1 -v 'ON_ERROR_STOP=1'", stdin: database_init_queries
+
+Dir.glob("/var/cache/postgresql-init/*.sql").sort.each do |sql_file|
+  r "sudo -u postgres psql -v 'ON_ERROR_STOP=1'", stdin: File.read(sql_file)
+end


### PR DESCRIPTION
This can be used to create specific roles for managed service,
or setup extensions we want created by default