### PR TITLE
Rename (Tags) link to (Manage Tags)

### DIFF
--- a/views/project/access-control.erb
+++ b/views/project/access-control.erb
@@ -66,7 +66,7 @@ end
                       href="<%= "#{@project.path}/user/access-control/tag/#{type.downcase}" %>"
                       class="text-orange-600 hover:text-orange-700 text-xs"
                     >
-                      (Tags)
+                      (Manage Tags)
                     </a>
                   <% end %>
                 </th>


### PR DESCRIPTION
This makes it more obvious to the user what the purpose of the link is.