### PR TITLE
Add resource_type and tags columns to billing records

### DIFF
--- a/migrate/20260317_billing_record_tags.rb
+++ b/migrate/20260317_billing_record_tags.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:billing_record) do
+      add_column :tags, :jsonb, null: false, default: "[]"
+      add_column :resource_type, :text, collate: '"C"', null: false, default: ""
+    end
+  end
+end

--- a/model/billing_record.rb
+++ b/model/billing_record.rb
@@ -7,6 +7,19 @@ class BillingRecord < Sequel::Model
 
   dataset_module do
     where(:active, Sequel.function(:upper, :span) => nil)
+
+    def overlapping(start_time, end_time)
+      where(Sequel.pg_range(:span).overlaps(start_time...end_time))
+    end
+
+    def with_resource_types(resource_types)
+      where(resource_type: resource_types)
+    end
+
+    def distinct_resource
+      distinct(:resource_id, :resource_type)
+        .order(:resource_id, :resource_type, Sequel.desc(Sequel.function(:lower, :span)))
+    end
   end
 
   plugin ResourceMethods
@@ -63,6 +76,8 @@ end
 #  span            | tstzrange | NOT NULL DEFAULT tstzrange(now(), NULL::timestamp with time zone, '[)'::text)
 #  amount          | numeric   | NOT NULL
 #  billing_rate_id | uuid      | NOT NULL
+#  resource_type   | text      | NOT NULL DEFAULT ''
+#  tags            | jsonb     | NOT NULL DEFAULT '[]'::jsonb
 # Indexes:
 #  billing_record_pkey              | PRIMARY KEY btree (id)
 #  billing_record_project_id_index  | btree (project_id)

--- a/prog/ai/inference_endpoint_replica_nexus.rb
+++ b/prog/ai/inference_endpoint_replica_nexus.rb
@@ -246,6 +246,7 @@ class Prog::Ai::InferenceEndpointReplicaNexus < Prog::Base
             resource_id: inference_endpoint.id,
             resource_name: "#{resource_family} #{begin_time.strftime("%Y-%m-%d")}",
             billing_rate_id: rate_id,
+            resource_type: "InferenceTokens",
             span: Sequel.pg_range(begin_time...end_time),
             amount: tokens
           )

--- a/prog/ai/inference_router_replica_nexus.rb
+++ b/prog/ai/inference_router_replica_nexus.rb
@@ -363,6 +363,7 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
             resource_id: inference_router.id,
             resource_name: "#{resource_family} #{begin_time.strftime("%Y-%m-%d")}",
             billing_rate_id: rate_id,
+            resource_type: "InferenceTokens",
             span: Sequel.pg_range(begin_time...end_time),
             amount: tokens
           )

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -145,6 +145,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
           resource_id: project.id,
           resource_name: "Daily Usage #{begin_time.strftime("%Y-%m-%d")}",
           billing_rate_id: rate_id,
+          resource_type: "GitHubRunnerMinutes",
           span: Sequel.pg_range(begin_time...end_time),
           amount: used_amount
         )

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -181,6 +181,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
           resource_id: kubernetes_cluster.id,
           resource_name: kubernetes_cluster.name,
           billing_rate_id: billing_rate_for(record[:type], record[:family])["id"],
+          resource_type: record[:type],
           amount: record[:amount]
         )
       end

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -239,26 +239,28 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       new_billing_records = postgres_resource.target_server_count.times.flat_map do |index|
         resource_type = index.zero? ? "" : "Standby"
         [
-          {billing_rate_id: BillingRate.from_resource_properties("Postgres#{resource_type}VCpu", "#{flavor}-#{vm_family}", location.name, location.byoc)["id"], amount: vcpu_count},
-          {billing_rate_id: BillingRate.from_resource_properties("Postgres#{resource_type}Storage", flavor, location.name, location.byoc)["id"], amount: storage_size_gib}
+          {billing_rate_id: BillingRate.from_resource_properties("Postgres#{resource_type}VCpu", "#{flavor}-#{vm_family}", location.name, location.byoc)["id"], resource_type: "Postgres#{resource_type}VCpu", amount: vcpu_count},
+          {billing_rate_id: BillingRate.from_resource_properties("Postgres#{resource_type}Storage", flavor, location.name, location.byoc)["id"], resource_type: "Postgres#{resource_type}Storage", amount: storage_size_gib}
         ]
       end
 
       existing_billing_records = postgres_resource.active_billing_records.map do |br|
-        {billing_rate_id: br.billing_rate_id, amount: br.amount}
+        {billing_rate_id: br.billing_rate_id, resource_type: br.resource_type, amount: br.amount}
       end
 
       if new_billing_records.sort_by { it.values } != existing_billing_records.sort_by { it.values }
         postgres_resource.active_billing_records.each(&:finalize)
 
         new_billing_records.each do |br|
-          BillingRecord.create(
+          billing_record = BillingRecord.create(
             project_id: postgres_resource.project_id,
             resource_id: postgres_resource.id,
             resource_name: postgres_resource.name,
             billing_rate_id: br[:billing_rate_id],
+            resource_type: br[:resource_type],
             amount: br[:amount]
           )
+          after_billing_record_created(billing_record, postgres_resource)
         end
       end
     end
@@ -330,6 +332,9 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
       pop "postgres resource is deleted"
     end
+  end
+
+  def after_billing_record_created(billing_record, postgres_resource)
   end
 
   def create_certificate

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -273,6 +273,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
       resource_id: vm.id,
       resource_name: vm.name,
       billing_rate_id: BillingRate.from_resource_properties("VmVCpu", vm.family, vm.location.name)["id"],
+      resource_type: "VmVCpu",
       amount: vm.vcpus
     )
 

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -202,6 +202,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
         resource_id: vm.id,
         resource_name: vm.name,
         billing_rate_id: BillingRate.from_resource_properties("VmVCpu", vm.family, vm.location.name)["id"],
+        resource_type: "VmVCpu",
         amount: vm.vcpus
       )
 
@@ -211,6 +212,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
           resource_id: vm.id,
           resource_name: "Disk ##{vol["disk_index"]} of #{vm.name}",
           billing_rate_id: BillingRate.from_resource_properties("VmStorage", vm.family, vm.location.name)["id"],
+          resource_type: "VmStorage",
           amount: vol["size_gib"]
         )
       end
@@ -221,6 +223,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
           resource_id: vm.id,
           resource_name: vm.assigned_vm_address.ip,
           billing_rate_id: BillingRate.from_resource_properties("IPAddress", "IPv4", vm.location.name)["id"],
+          resource_type: "IPAddress",
           amount: 1
         )
       end
@@ -234,6 +237,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
           resource_id: vm.id,
           resource_name: "GPUs of #{vm.name}",
           billing_rate_id: BillingRate.from_resource_properties("Gpu", gpu.device, vm.location.name)["id"],
+          resource_type: "Gpu",
           amount: gpu_count
         )
       end


### PR DESCRIPTION
ClickHouse billing integration needs to query billing records by
resource type and attach provider-specific metadata (region, instance
type, HA configuration, etc.) without joining against each resource
table. Today, determining the resource type requires looking up the
billing rate, and there is no structured place to store contextual
tags alongside a billing record.

Add a migration that introduces two columns to billing_record:
- resource_type (text): classifies the record (e.g. VmVCpu,
  PostgresStorage, GitHubRunnerMinutes, InferenceTokens)
- tags (jsonb): stores arbitrary key-value metadata

Populate resource_type at every BillingRecord.create call site across
all nexus programs (VM, Postgres, Kubernetes, GitHub runners, and
inference endpoints).

For Postgres resources, introduce an after_billing_record_created hook
with an override mechanism that attaches provider, region, instance
type, HA type, flavor, server count, storage size, and any
user-defined tags to each billing record.

Add dataset helper methods on BillingRecord (overlapping,
with_resource_types, distinct_resource) to support efficient querying
by the billing API.