### PR TITLE
Add custom label management UI

### DIFF
--- a/model/github/github_custom_label.rb
+++ b/model/github/github_custom_label.rb
@@ -4,6 +4,11 @@ require_relative "../../model"
 
 class GithubCustomLabel < Sequel::Model
   plugin ResourceMethods
+
+  def validate
+    super
+    errors.add(:name, "is reserved. Custom labels cannot start with 'ubicloud'") if name.start_with?("ubicloud")
+  end
 end
 
 # Table: github_custom_label

--- a/model/project.rb
+++ b/model/project.rb
@@ -232,7 +232,8 @@ class Project < Sequel::Model
     :visible_locations,
     :vm_public_ssh_keys,
     :postgres_aws_use_different_azs_for_standbys,
-    :cache_proxy_download_url
+    :cache_proxy_download_url,
+    :custom_runner_labels
   )
 end
 

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -47,6 +47,9 @@ class Clover
       end
 
       r.get web?, "setting" do
+        if @project.get_ff_custom_runner_labels
+          @custom_labels = @installation.custom_labels_dataset.order(:name).all
+        end
         view "github/setting"
       end
 
@@ -92,6 +95,59 @@ class Clover
           no_audit_log
         end
         r.redirect @installation, "/setting"
+      end
+
+      r.on web?, "custom-label" do
+        next unless @project.get_ff_custom_runner_labels
+
+        r.get "create" do
+          view "github/custom_label_form"
+        end
+
+        r.post "create" do
+          handle_validation_failure("github/custom_label_form")
+          label = GithubCustomLabel.new(installation_id: @installation.id)
+          label.name = typecast_params.nonempty_str!("name")
+          label.alias_for = typecast_params.nonempty_str!("alias_for")
+          label.concurrent_runner_count_limit = typecast_params.pos_int("concurrent_runner_count_limit")
+          DB.transaction do
+            label.save_changes
+            audit_log(label, "create")
+          end
+          flash["notice"] = "Custom label '#{label.name}' created"
+          r.redirect @installation, "/setting"
+        end
+
+        r.on :ubid_uuid do |id|
+          @custom_label = @installation.custom_labels_dataset.with_pk(id)
+          check_found_object(@custom_label)
+
+          r.get true do
+            view "github/custom_label_form"
+          end
+
+          r.post "patch" do
+            handle_validation_failure("github/custom_label_form")
+            @custom_label.name = typecast_params.nonempty_str!("name")
+            @custom_label.alias_for = typecast_params.nonempty_str!("alias_for")
+            @custom_label.concurrent_runner_count_limit = typecast_params.pos_int("concurrent_runner_count_limit")
+            DB.transaction do
+              @custom_label.save_changes
+              audit_log(@custom_label, "update")
+            end
+            flash["notice"] = "Custom label '#{@custom_label.name}' updated"
+            r.redirect @installation, "/setting"
+          end
+
+          r.delete true do
+            DB.transaction do
+              @custom_label.destroy
+              audit_log(@custom_label, "destroy")
+            end
+            flash["notice"] = "Custom label '#{@custom_label.name}' deleted"
+            r.redirect @installation, "/setting"
+          end
+        end
       end
 
       r.on web?, "runner" do

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -115,7 +115,7 @@ class Clover
             audit_log(label, "create")
           end
           flash["notice"] = "Custom label '#{label.name}' created"
-          r.redirect @installation, "/setting"
+          r.redirect @installation, "/setting#custom-labels-table"
         end
 
         r.on :ubid_uuid do |id|
@@ -136,7 +136,7 @@ class Clover
               audit_log(@custom_label, "update")
             end
             flash["notice"] = "Custom label '#{@custom_label.name}' updated"
-            r.redirect @installation, "/setting"
+            r.redirect @installation, "/setting#custom-labels-table"
           end
 
           r.delete true do
@@ -145,7 +145,7 @@ class Clover
               audit_log(@custom_label, "destroy")
             end
             flash["notice"] = "Custom label '#{@custom_label.name}' deleted"
-            r.redirect @installation, "/setting"
+            r.redirect @installation, "/setting#custom-labels-table"
           end
         end
       end

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -346,6 +346,145 @@ RSpec.describe Clover, "github" do
     end
   end
 
+  describe "custom-label" do
+    before do
+      project.set_ff_custom_runner_labels(true)
+    end
+
+    it "returns 404 when feature flag is not set" do
+      project.set_ff_custom_runner_labels(nil)
+
+      visit "#{project.path}/github/#{installation.ubid}/custom-label/create"
+
+      expect(page.status_code).to eq(404)
+    end
+
+    it "shows custom labels section on settings page" do
+      GithubCustomLabel.create(installation_id: installation.id, name: "my-label", alias_for: "ubicloud-standard-4-ubuntu-2404")
+      GithubCustomLabel.create(installation_id: installation.id, name: "big-runner", alias_for: "ubicloud-standard-16-ubuntu-2404", concurrent_runner_count_limit: 5)
+
+      visit "#{project.path}/github/#{installation.ubid}/setting"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content "Custom Labels"
+      expect(page).to have_content "big-runner"
+      expect(page).to have_content "my-label"
+      expect(page).to have_content "ubicloud-standard-4-ubuntu-2404"
+      expect(page).to have_content "ubicloud-standard-16-ubuntu-2404"
+      expect(page).to have_content "5"
+      expect(page).to have_content "Unlimited"
+    end
+
+    it "does not show custom labels section when feature flag is not set" do
+      project.set_ff_custom_runner_labels(nil)
+
+      visit "#{project.path}/github/#{installation.ubid}/setting"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_no_content "Custom Labels"
+    end
+
+    it "shows empty state when no custom labels" do
+      visit "#{project.path}/github/#{installation.ubid}/setting"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content "No custom labels"
+      expect(page).to have_content "Create custom runner labels to define friendly aliases or set concurrency limits for specific runner types."
+      expect(page).to have_link "Add Custom Label"
+    end
+
+    it "renders create form" do
+      visit "#{project.path}/github/#{installation.ubid}/custom-label/create"
+
+      expect(page.status_code).to eq(200)
+      expect(page.title).to eq("Ubicloud - Add Custom Label")
+      expect(page).to have_field "name"
+      expect(page).to have_select "alias_for"
+    end
+
+    it "creates a custom label" do
+      visit "#{project.path}/github/#{installation.ubid}/custom-label/create"
+
+      fill_in "name", with: "my-label"
+      select "ubicloud-standard-4-ubuntu-2404", from: "alias_for"
+      fill_in "concurrent_runner_count_limit", with: "3"
+      click_button "Add Custom Label"
+
+      expect(page).to have_flash_notice("Custom label 'my-label' created")
+      expect(GithubCustomLabel.first(name: "my-label")).not_to be_nil
+      expect(GithubCustomLabel.first(name: "my-label").concurrent_runner_count_limit).to eq(3)
+    end
+
+    it "creates a custom label without concurrency limit" do
+      visit "#{project.path}/github/#{installation.ubid}/custom-label/create"
+
+      fill_in "name", with: "my-label"
+      select "ubicloud-standard-4-ubuntu-2404", from: "alias_for"
+      click_button "Add Custom Label"
+
+      expect(page).to have_flash_notice("Custom label 'my-label' created")
+      expect(GithubCustomLabel.first(name: "my-label").concurrent_runner_count_limit).to be_nil
+    end
+
+    it "fails to create with validation error" do
+      GithubCustomLabel.create(installation_id: installation.id, name: "existing-label", alias_for: "ubicloud-standard-4-ubuntu-2404")
+
+      visit "#{project.path}/github/#{installation.ubid}/custom-label/create"
+
+      fill_in "name", with: "existing-label"
+      select "ubicloud-standard-4-ubuntu-2404", from: "alias_for"
+      click_button "Add Custom Label"
+
+      expect(page.status_code).to eq(400)
+      expect(page.title).to eq("Ubicloud - Add Custom Label")
+    end
+
+    it "renders edit form with existing values" do
+      label = GithubCustomLabel.create(installation_id: installation.id, name: "my-label", alias_for: "ubicloud-standard-4-ubuntu-2404", concurrent_runner_count_limit: 5)
+
+      visit "#{project.path}/github/#{installation.ubid}/custom-label/#{label.ubid}"
+
+      expect(page.status_code).to eq(200)
+      expect(page.title).to eq("Ubicloud - Edit Custom Label")
+      expect(page).to have_field "name", with: "my-label"
+      expect(page).to have_select "alias_for", selected: "ubicloud-standard-4-ubuntu-2404"
+      expect(page).to have_field "concurrent_runner_count_limit", with: "5"
+    end
+
+    it "updates a custom label" do
+      label = GithubCustomLabel.create(installation_id: installation.id, name: "my-label", alias_for: "ubicloud-standard-4-ubuntu-2404")
+
+      visit "#{project.path}/github/#{installation.ubid}/custom-label/#{label.ubid}"
+
+      fill_in "name", with: "updated-label"
+      select "ubicloud-standard-16-ubuntu-2404", from: "alias_for"
+      fill_in "concurrent_runner_count_limit", with: "10"
+      click_button "Edit Custom Label"
+
+      expect(page).to have_flash_notice("Custom label 'updated-label' updated")
+      label.reload
+      expect(label.name).to eq("updated-label")
+      expect(label.alias_for).to eq("ubicloud-standard-16-ubuntu-2404")
+      expect(label.concurrent_runner_count_limit).to eq(10)
+    end
+
+    it "deletes a custom label" do
+      label = GithubCustomLabel.create(installation_id: installation.id, name: "my-label", alias_for: "ubicloud-standard-4-ubuntu-2404")
+
+      visit "#{project.path}/github/#{installation.ubid}/setting"
+
+      find("#label-#{label.ubid} .delete-btn").click
+      expect(page).to have_flash_notice("Custom label 'my-label' deleted")
+      expect(GithubCustomLabel[label.id]).to be_nil
+    end
+
+    it "returns 404 when custom label not found" do
+      visit "#{project.path}/github/#{installation.ubid}/custom-label/#{GithubCustomLabel.generate_ubid}"
+
+      expect(page.status_code).to eq(404)
+    end
+  end
+
   describe "cache" do
     def create_cache_entry(**)
       GithubCacheEntry.create(key: "k#{Random.rand}", version: "v1", scope: "main", repository_id: repository.id, created_by: "3c9a861c-ab14-8218-a175-875ebb652f7b", committed_at: Time.now, **)

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -439,6 +439,18 @@ RSpec.describe Clover, "github" do
       expect(page.title).to eq("Ubicloud - Add Custom Label")
     end
 
+    it "fails to create with name starting with ubicloud" do
+      visit "#{project.path}/github/#{installation.ubid}/custom-label/create"
+
+      fill_in "name", with: "ubicloud-my-label"
+      select "ubicloud-standard-4-ubuntu-2404", from: "alias_for"
+      click_button "Add Custom Label"
+
+      expect(page.status_code).to eq(400)
+      expect(page).to have_flash_error("name is reserved. Custom labels cannot start with 'ubicloud'")
+      expect(page.title).to eq("Ubicloud - Add Custom Label")
+    end
+
     it "renders edit form with existing values" do
       label = GithubCustomLabel.create(installation_id: installation.id, name: "my-label", alias_for: "ubicloud-standard-4-ubuntu-2404", concurrent_runner_count_limit: 5)
 

--- a/views/github/custom_label_form.erb
+++ b/views/github/custom_label_form.erb
@@ -1,0 +1,52 @@
+<% if (cl = @custom_label)
+  heading = "Edit"
+  action = "#{path(@installation)}/custom-label/#{cl.ubid}/patch"
+  name = cl.name
+  alias_for = cl.alias_for
+  concurrent_runner_count_limit = cl.concurrent_runner_count_limit
+else
+  heading = "Add"
+  action = "#{path(@installation)}/custom-label/create"
+end
+
+@page_title = "#{heading} Custom Label" %>
+
+<%== render("github/tabbar") %>
+
+<% form(action:, method: :post) do %>
+  <div class="grid gap-6">
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white">
+      <div class="px-4 py-5 sm:p-6">
+        <div class="space-y-12">
+          <div class="mt-2 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+            <div class="col-span-full">
+              <%== part("components/form/text", name: "name", label: "Name", attributes: {required: true, placeholder: "my-ubicloud-runner-concurrency-2"}, value: name) %>
+            </div>
+
+            <div class="col-span-full">
+              <%== part(
+                "components/form/select",
+                label: "Alias For",
+                name: "alias_for",
+                placeholder: "Select a runner label",
+                attributes: {required: true},
+                selected: alias_for,
+                options: Github.runner_labels.keys.select { it.include?("standard") && it.include?("ubuntu") }.map { [it, it] }
+              ) %>
+            </div>
+
+            <div class="col-span-full">
+              <%== part("components/form/text", name: "concurrent_runner_count_limit", label: "Concurrency Limit (optional)", type: "number", attributes: {min: 1, placeholder: "Unlimited"}, value: concurrent_runner_count_limit) %>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="px-4 py-5 sm:p-6">
+        <div class="flex items-center justify-end gap-x-6">
+          <a href="<%= path(@installation) %>/setting" class="text-sm font-semibold leading-6 text-gray-900">Cancel</a>
+          <%== part("components/form/submit_button", text: @page_title) %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/views/github/setting.erb
+++ b/views/github/setting.erb
@@ -136,4 +136,33 @@
       </div>
     </div>
   </div>
+  <% if @custom_labels %>
+    <% installation_path = path(@installation) %>
+    <%== part(
+      "components/table_card",
+      title: "Custom Labels",
+      right_items: @custom_labels.empty? ? nil : [part("components/button", text: "Add Custom Label", link: "#{installation_path}/custom-label/create")],
+      headers: ["Name", "Alias For", "Concurrency Limit", "Active Runners", "", ""],
+      rows: @custom_labels.map do |label|
+        [
+          [
+            label.name,
+            label.alias_for,
+            (label.concurrent_runner_count_limit || "Unlimited").to_s,
+            label.allocated_runner_count.to_s,
+            ["button", {component: {text: "", icon: "hero-pencil", link: "#{installation_path}/custom-label/#{label.ubid}"}, extra_class: "w-px text-right"}],
+            ["delete_button", {component: {url: "#{installation_path}/custom-label/#{label.ubid}", text: ""}, extra_class: "w-px text-right"}]
+          ],
+          {id: "label-#{label.ubid}"}
+        ]
+      end,
+      empty_state: {
+        icon: "hero-squares-plus",
+        title: "No custom labels",
+        description: "Create custom runner labels to define friendly aliases or set concurrency limits for specific runner types.",
+        button_link: "#{installation_path}/custom-label/create",
+        button_title: "Add Custom Label"
+      }
+    ) %>
+  <% end %>
 </div>

--- a/views/github/setting.erb
+++ b/views/github/setting.erb
@@ -140,6 +140,7 @@
     <% installation_path = path(@installation) %>
     <%== part(
       "components/table_card",
+      id: "custom-labels-table",
       title: "Custom Labels",
       right_items: @custom_labels.empty? ? nil : [part("components/button", text: "Add Custom Label", link: "#{installation_path}/custom-label/create")],
       headers: ["Name", "Alias For", "Concurrency Limit", "Active Runners", "", ""],


### PR DESCRIPTION
- **Add custom label CRUD routes for GitHub installations**
  GithubCustomLabel records let users create friendly runner label
  aliases (e.g. my-team-large -> ubicloud-standard-16) with optional
  concurrency limits. Until now these could only be managed via the
  admin panel or directly in the database.
  
  Add feature flag custom_runner_labels and a full set of web routes
  (list, create, edit, delete) under /github/:installation/custom-label,
  gated behind the flag. All mutations are audit-logged.
  
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Add custom labels views, tab, and tests for GitHub installations**
  Add the list page, create/edit form, and a conditional "Custom
  Labels" tab in the GitHub installation tabbar. The tab only appears
  when the custom_runner_labels feature flag is enabled.
  
  The list page shows each label's name, alias, concurrency limit,
  and allocated runner count with edit and delete controls. The form
  provides a dropdown of all available runner labels from the config.
  
  Tests cover feature flag gating, CRUD operations, validation errors,
  and 404 handling.
  
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Disallow custom labels with names starting with "ubicloud"**
  The "ubicloud" prefix is reserved for built-in runner labels.
  Allowing custom labels with this prefix would create ambiguity
  during runner provisioning. Add a model-level validation so the
  constraint is enforced regardless of the entry point.
  
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Scroll to custom labels table after create/update/delete operations**
  Add id to the custom labels table_card and append #custom-labels-table
  anchor to redirect URLs so the browser scrolls to the relevant section.
  
  Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


<img width="2430" height="1006" alt="CleanShot 2026-03-19 at 01 11 22@2x" src="https://github.com/user-attachments/assets/56ab32f6-cf23-4413-b109-d352650241d3" />

<img width="2442" height="788" alt="CleanShot 2026-03-19 at 01 12 13@2x" src="https://github.com/user-attachments/assets/b79636d1-5f8c-4c5d-8992-99a2b02087c1" />

<img width="3024" height="1672" alt="CleanShot 2026-03-19 at 01 12 21@2x" src="https://github.com/user-attachments/assets/eb62e04e-10c2-433d-94df-575e2b0cfee1" />

