### PR TITLE
Combine rhizome/{host,common}/Gemfile into rhizome/Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,6 @@
 # Used by rake by
 /bin/by
 
-# rhizome/Gemfile is combination of all Gemfiles in subdirectories, so does rhizome/Gemfile.lock
-/rhizome/*/Gemfile.lock
-
 # Frontend
 /node_modules
 

--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -53,7 +53,9 @@ class Prog::InstallRhizome < Prog::Base
   end
 
   label def install_gems
-    sshable.cmd("bundle config set --local path vendor/bundle && bundle install")
+    if frame["target_folder"] == "host"
+      sshable.cmd("bundle config set --local path vendor/bundle && bundle install")
+    end
 
     hop_validate
   end

--- a/rhizome/Gemfile
+++ b/rhizome/Gemfile
@@ -4,7 +4,14 @@
 # `BUNDLE_GEMFILE=rhizome/Gemfile bundle install` works from repository root,
 # as that is what rhizome CI uses.
 
-# Load Gemfiles
-Dir.glob("*/Gemfile", base: __dir__) do |file|
-  instance_eval File.read(File.join(__dir__, file))
+source "https://rubygems.org"
+
+gem "netaddr"
+
+if File.directory?(File.join(__dir__, "host"))
+  gem "base64"
+
+  group :test do
+    gem "rspec"
+  end
 end

--- a/rhizome/Gemfile
+++ b/rhizome/Gemfile
@@ -7,11 +7,8 @@
 source "https://rubygems.org"
 
 gem "netaddr"
+gem "base64"
 
-if File.directory?(File.join(__dir__, "host"))
-  gem "base64"
-
-  group :test do
-    gem "rspec"
-  end
+group :test do
+  gem "rspec"
 end

--- a/rhizome/Gemfile
+++ b/rhizome/Gemfile
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Use __dir__ to make sure that
-# `BUNDLE_GEMFILE=rhizome/Gemfile bundle install` works from repository root,
-# as that is what rhizome CI uses.
+# Only used by hosts
 
 source "https://rubygems.org"
 

--- a/rhizome/common/Gemfile
+++ b/rhizome/common/Gemfile
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-source "https://rubygems.org"
-
-gem "netaddr"

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/setup"
+require "bundler/setup" if File.directory?(File.expand_path("../../host", __dir__))
 require "open3"
 require "shellwords"
 require "openssl"

--- a/rhizome/host/Gemfile
+++ b/rhizome/host/Gemfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source "https://rubygems.org"
-
-gem "base64"
-
-group :test do
-  gem "rspec"
-end

--- a/rhizome/inference_endpoint/lib/replica_setup.rb
+++ b/rhizome/inference_endpoint/lib/replica_setup.rb
@@ -2,12 +2,7 @@
 
 require_relative "../../common/lib/util"
 
-require "fileutils"
-require "netaddr"
 require "json"
-require "openssl"
-require "base64"
-require "uri"
 
 class ReplicaSetup
   def prep(engine_start_cmd:, replica_ubid:, ssl_crt_path:, ssl_key_path:, gateway_port:, max_requests:)

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -41,9 +41,15 @@ RSpec.describe Prog::InstallRhizome do
   end
 
   describe "#install_gems" do
-    it "runs some commands and exits" do
+    it "runs some commands and hops" do
       expect(ir.sshable).to receive(:_cmd).with("bundle config set --local path vendor/bundle && bundle install")
-      expect { ir.install_gems }.to hop
+      expect { ir.install_gems }.to hop("validate")
+    end
+
+    it "hops without running commands if target folder is not host" do
+      refresh_frame(ir, new_values: {"target_folder" => "postgres"})
+      expect(ir.sshable).not_to receive(:_cmd)
+      expect { ir.install_gems }.to hop("validate")
     end
   end
 


### PR DESCRIPTION
To avoid the issues mentioned in #4947, combine the rhizome
host/common Gemfiles into a single Gemfile, so broken tooling that
automatically creates Gemfile.lock files still works.