### PR TITLE
Guard metrics scraping against missing done directory

### DIFF
--- a/lib/metrics_target_methods.rb
+++ b/lib/metrics_target_methods.rb
@@ -47,6 +47,8 @@ module MetricsTargetMethods
   end
 
   def scrape_endpoints(session)
+    return [] unless metrics_done_dir_exists?(session)
+
     scrape_files = session[:ssh_session].exec!("ls :metrics_dir/done | sort | head -n :fetch_count", metrics_dir:, fetch_count: MAX_SCRAPE_FETCH_COUNT).split("\n")
 
     scrape_files.filter_map do |file|
@@ -69,5 +71,9 @@ module MetricsTargetMethods
 
   def metrics_dir
     metrics_config[:metrics_dir]
+  end
+
+  def metrics_done_dir_exists?(session)
+    session[:ssh_session].exec!("[ -d :metrics_dir/done ] && echo yes || echo no", metrics_dir:).strip == "yes"
   end
 end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -462,6 +462,8 @@ class PostgresServer < Sequel::Model
   end
 
   def observe_metrics_backlog(session)
+    return unless metrics_done_dir_exists?(session)
+
     metrics_done_dir = "#{metrics_config[:metrics_dir]}/done"
     result = session[:ssh_session].exec!(
       "find :metrics_done_dir -name '*.txt' | wc -l",

--- a/spec/lib/metrics_target_methods_spec.rb
+++ b/spec/lib/metrics_target_methods_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe MetricsTargetMethods do
   describe "#export_metrics" do
     context "when scrape results are empty" do
       before do
+        expect(mock_ssh_session).to receive(:_exec!).with(/\[ -d.*done \]/).and_return("yes")
         expect(mock_ssh_session).to receive(:_exec!).with(/ls.*done/).and_return("")
       end
 
@@ -46,6 +47,7 @@ RSpec.describe MetricsTargetMethods do
       let(:time_b) { Time.new(2023, 1, 1, 12, 15, 0) }
 
       def stub_scrape_ssh_expectations
+        expect(mock_ssh_session).to receive(:_exec!).with(/\[ -d.*done \]/).and_return("yes")
         expect(mock_ssh_session).to receive(:_exec!).with(/ls.*done/).and_return("2023-01-01T12-00-00-000000000.prom\n2023-01-01T12-15-00-000000000.prom")
         expect(mock_ssh_session).to receive(:_exec!).with(/cat.*done/, status: anything) do |_, options|
           options[:status][:exit_code] = 0
@@ -90,11 +92,17 @@ RSpec.describe MetricsTargetMethods do
     let(:status_hash) { {exit_code: 0} }
 
     before do
+      allow(mock_ssh_session).to receive(:_exec!).with(/\[ -d.*done \]/).and_return("yes")
       allow(mock_ssh_session).to receive(:_exec!).with(/ls.*done/).and_return(file_list)
       allow(mock_ssh_session).to receive(:_exec!).with(/cat.*done/, status: anything) do |_, options|
         options[:status][:exit_code] = status_hash[:exit_code]
         file_content
       end
+    end
+
+    it "returns empty array when done dir does not exist" do
+      expect(mock_ssh_session).to receive(:_exec!).with(/\[ -d.*done \]/).and_return("no")
+      expect(test_instance.scrape_endpoints(session)).to eq([])
     end
 
     context "when files can be read successfully" do

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -851,6 +851,7 @@ RSpec.describe PostgresServer do
         metrics_dir: "/home/ubi/postgres/metrics",
         interval: "15s"
       })
+      allow(session[:ssh_session]).to receive(:_exec!).with(/\[ -d.*done \]/).and_return("yes")
     end
 
     it "checks metrics backlog and does nothing if it is within limits" do
@@ -923,6 +924,13 @@ RSpec.describe PostgresServer do
       postgres_server.observe_metrics_backlog(session)
 
       expect(existing_page.reload.semaphores.map(&:name)).not_to include("resolve")
+    end
+
+    it "does nothing if the done dir does not exist" do
+      expect(session[:ssh_session]).to receive(:_exec!).with(/\[ -d.*done \]/).and_return("no")
+      expect(session[:ssh_session]).not_to receive(:_exec!).with(/find.*done/)
+
+      postgres_server.observe_metrics_backlog(session)
     end
   end
 


### PR DESCRIPTION
- On a freshly provisioned VM the metrics agent hasn't run yet, so the `done/` directory does not exist. Without a guard, SSH calls to ls/cat/find that directory raise errors.
- Extract `metrics_done_dir_exists?` into `MetricsTargetMethods` so the check is defined once and shared.
- `scrape_endpoints` guards on it and returns `[]` early; `observe_metrics_backlog` reuses the same helper, removing the duplicate inline check it previously had.