### PR TITLE
Add Leaseweb bare metal API integration

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -103,6 +103,10 @@ module Config
   optional :hetzner_user, string, clear: true
   optional :hetzner_password, string, clear: true
   override :hetzner_connection_string, "https://robot-ws.your-server.de", string
+  optional :leaseweb_api_key, string, clear: true
+  optional :leaseweb_user, string, clear: true
+  optional :leaseweb_password, string, clear: true
+  override :leaseweb_connection_string, "https://api.leaseweb.com", string
   override :managed_service, false, bool
   override :sanctioned_countries, "CU,IR,KP,SY", array(string)
   override :hetzner_ssh_public_key, nil, string

--- a/lib/hosting/apis.rb
+++ b/lib/hosting/apis.rb
@@ -5,6 +5,8 @@ class Hosting::Apis
   def self.pull_ips(vm_host)
     if vm_host.provider_name == HostProvider::HETZNER_PROVIDER_NAME
       vm_host.provider.api.pull_ips
+    elsif vm_host.provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
+      vm_host.provider.api.pull_ips
     else
       raise "unknown provider #{vm_host.provider_name}"
     end
@@ -13,6 +15,8 @@ class Hosting::Apis
   def self.reimage_server(vm_host)
     if vm_host.provider_name == HostProvider::HETZNER_PROVIDER_NAME
       vm_host.provider.api.reimage(vm_host.provider.server_identifier)
+    elsif vm_host.provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
+      raise "Leaseweb provider does not support reimage_server"
     else
       raise "unknown provider #{vm_host.provider_name}"
     end
@@ -25,6 +29,8 @@ class Hosting::Apis
   def self.hardware_reset_server(vm_host)
     if vm_host.provider_name == HostProvider::HETZNER_PROVIDER_NAME
       vm_host.provider.api.reset(vm_host.provider.server_identifier)
+    elsif vm_host.provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
+      raise "Leaseweb provider does not support hardware_reset_server"
     else
       raise "unknown provider #{vm_host.provider_name}"
     end
@@ -33,6 +39,8 @@ class Hosting::Apis
   def self.pull_data_center(vm_host)
     if vm_host.provider_name == HostProvider::HETZNER_PROVIDER_NAME
       vm_host.provider.api.pull_dc(vm_host.provider.server_identifier)
+    elsif vm_host.provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
+      nil
     else
       raise "unknown provider #{vm_host.provider_name}"
     end
@@ -41,6 +49,8 @@ class Hosting::Apis
   def self.set_server_name(vm_host)
     if vm_host.provider_name == HostProvider::HETZNER_PROVIDER_NAME
       vm_host.provider.api.set_server_name(vm_host.provider.server_identifier, vm_host.ubid)
+    elsif vm_host.provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
+      raise "Leaseweb provider does not support set_server_name"
     else
       raise "unknown provider #{vm_host.provider_name}"
     end

--- a/lib/hosting/leaseweb_apis.rb
+++ b/lib/hosting/leaseweb_apis.rb
@@ -28,7 +28,7 @@ class Hosting::LeasewebApis
     )
 
     data = JSON.parse(response.body)
-    data.dig("networkInterfaces", "public", "ip")
+    strip_cidr(data.dig("networkInterfaces", "public", "ip"))
   end
 
   def create_connection
@@ -68,13 +68,13 @@ class Hosting::LeasewebApis
     public_ips = ips.select { |ip| ip["networkType"] == "PUBLIC" && ip["type"] == "NORMAL_IP" }
 
     main_ip_entry = public_ips.find { |ip| ip["mainIp"] }
-    main_ip4 = main_ip_entry&.dig("ip")
+    main_ip4 = strip_cidr(main_ip_entry&.dig("ip"))
 
     result = []
     subnet_groups = {}
 
     public_ips.each do |ip_entry|
-      ip = ip_entry["ip"]
+      ip = strip_cidr(ip_entry["ip"])
       prefix = ip_entry["prefixLength"]
       gateway = ip_entry["gateway"]
       is_main = ip_entry["mainIp"]
@@ -121,6 +121,11 @@ class Hosting::LeasewebApis
     end
 
     result
+  end
+
+  def strip_cidr(ip)
+    return nil if ip.nil?
+    ip.split("/").first
   end
 
   def gateway_present?(gateway)

--- a/lib/hosting/leaseweb_apis.rb
+++ b/lib/hosting/leaseweb_apis.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "excon"
+require "ipaddr"
+
+class Hosting::LeasewebApis
+  def initialize(leaseweb_host)
+    @host = leaseweb_host
+  end
+
+  IpInfo = Struct.new(:ip_address, :source_host_ip, :is_failover, :gateway, :mask, keyword_init: true)
+
+  INFRA_IP_TYPES = %w[NETWORK GATEWAY BROADCAST ROUTER1 ROUTER2].freeze
+
+  def pull_ips
+    server_id = @host.server_identifier
+    connection = create_connection
+
+    all_ips = fetch_all_ips(connection, server_id)
+    process_ips(all_ips)
+  end
+
+  def get_main_ip4
+    server_id = @host.server_identifier
+    response = create_connection.get(
+      path: "/bareMetals/v2/servers/#{server_id}",
+      expects: 200
+    )
+
+    data = JSON.parse(response.body)
+    data.dig("networkInterfaces", "public", "ip")
+  end
+
+  def create_connection
+    Excon.new(@host.connection_string,
+      headers: {
+        "X-Lsw-Auth" => Config.leaseweb_api_key,
+        "Content-Type" => "application/json"
+      })
+  end
+
+  private
+
+  def fetch_all_ips(connection, server_id)
+    ips = []
+    offset = 0
+    limit = 50
+
+    loop do
+      response = connection.get(
+        path: "/bareMetals/v2/servers/#{server_id}/ips",
+        query: {limit:, offset:},
+        expects: 200
+      )
+
+      data = JSON.parse(response.body)
+      ips.concat(data["ips"])
+
+      total = data.dig("_metadata", "totalCount")
+      break if ips.length >= total
+      offset += limit
+    end
+
+    ips
+  end
+
+  def process_ips(ips)
+    public_ips = ips.select { |ip| ip["networkType"] == "PUBLIC" && ip["type"] == "NORMAL_IP" }
+
+    main_ip_entry = public_ips.find { |ip| ip["mainIp"] }
+    main_ip4 = main_ip_entry&.dig("ip")
+
+    result = []
+    subnet_groups = {}
+
+    public_ips.each do |ip_entry|
+      ip = ip_entry["ip"]
+      prefix = ip_entry["prefixLength"]
+      gateway = ip_entry["gateway"]
+      is_main = ip_entry["mainIp"]
+
+      if ip.include?("_")
+        # IPv6 normalization: "2607:f5b7:1:30:9::_112" → "2607:f5b7:1:30:9::/112"
+        normalized = ip.tr("_", "/")
+        parts = normalized.split("/")
+        ip = parts[0]
+        prefix = parts[1].to_i
+
+        result << IpInfo.new(
+          ip_address: "#{ip}/#{prefix}",
+          source_host_ip: main_ip4,
+          is_failover: false,
+          gateway: normalize_gateway(gateway),
+          mask: prefix
+        )
+      elsif is_main || gateway_present?(gateway)
+        # Main IP or IP with explicit gateway stays as /32
+        result << IpInfo.new(
+          ip_address: "#{ip}/32",
+          source_host_ip: main_ip4,
+          is_failover: false,
+          gateway: normalize_gateway(gateway),
+          mask: prefix
+        )
+      else
+        # Subnet IP without gateway - group into network CIDR
+        network = IPAddr.new("#{ip}/#{prefix}").to_s
+        key = "#{network}/#{prefix}"
+        subnet_groups[key] ||= {mask: prefix}
+      end
+    end
+
+    subnet_groups.each do |cidr, info|
+      result << IpInfo.new(
+        ip_address: cidr,
+        source_host_ip: main_ip4,
+        is_failover: false,
+        gateway: nil,
+        mask: info[:mask]
+      )
+    end
+
+    result
+  end
+
+  def gateway_present?(gateway)
+    gateway.is_a?(String) && !gateway.empty?
+  end
+
+  def normalize_gateway(gateway)
+    gateway_present?(gateway) ? gateway : nil
+  end
+end

--- a/migrate/20260325_add_address_gateway.rb
+++ b/migrate/20260325_add_address_gateway.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:address) do
+      add_column :gateway, :text, null: true
+      add_column :mask, :integer, null: true
+    end
+  end
+end

--- a/model/address.rb
+++ b/model/address.rb
@@ -52,6 +52,8 @@ end
 #  cidr              | cidr    | NOT NULL
 #  is_failover_ip    | boolean | NOT NULL DEFAULT false
 #  routed_to_host_id | uuid    | NOT NULL
+#  gateway           | text    |
+#  mask              | integer |
 # Indexes:
 #  address_pkey     | PRIMARY KEY btree (id)
 #  address_cidr_key | UNIQUE btree (cidr)

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -205,7 +205,9 @@ class VmHost < Sequel::Model
             fail "BUG: source host #{source_host_ip} isn't added to the database"
           end
 
-          adr = Address.create(cidr: ip_addr, routed_to_host_id: id, is_failover_ip:)
+          gateway = ip_record.respond_to?(:gateway) ? ip_record.gateway : nil
+          mask = ip_record.respond_to?(:mask) ? ip_record.mask : nil
+          adr = Address.create(cidr: ip_addr, routed_to_host_id: id, is_failover_ip:, gateway:, mask:)
         end
 
         unless is_failover_ip

--- a/prog/learn_network.rb
+++ b/prog/learn_network.rb
@@ -29,7 +29,7 @@ class Prog::LearnNetwork < Prog::Base
   end
 
   label def leaseweb_learn_ipv6
-    adr = vm_host.assigned_subnets.find { |a| a.cidr.version == 6 }
+    adr = vm_host.assigned_subnets.select { |a| a.cidr.version == 6 }.min_by { |a| a.cidr.netmask.prefix_len }
 
     if adr
       vm_host.update(
@@ -71,16 +71,11 @@ class Prog::LearnNetwork < Prog::Base
   def parse_ip_addr_j(s)
     case s
     in [iface]
-      case iface.fetch("addr_info").filter_map { |info|
-             if (local = info["local"]) && (prefixlen = info["prefixlen"]) && prefixlen <= 112
-               Ip6.new(local, prefixlen)
-             end
-           }
-      in [net6]
-        net6
-      else
-        fail "only one global unique address prefix supported on interface"
-      end
+      iface.fetch("addr_info").filter_map { |info|
+        if (local = info["local"]) && (prefixlen = info["prefixlen"]) && prefixlen <= 112
+          Ip6.new(local, prefixlen)
+        end
+      }.min_by(&:prefixlen)
     in []
       nil
     else

--- a/prog/learn_network.rb
+++ b/prog/learn_network.rb
@@ -6,6 +6,42 @@ class Prog::LearnNetwork < Prog::Base
   subject_is :sshable, :vm_host
 
   label def start
+    if vm_host.provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
+      hop_setup_leaseweb_networking
+    end
+
+    learn_network_from_host
+  end
+
+  label def setup_leaseweb_networking
+    subnets = vm_host.assigned_subnets.map { |a|
+      {cidr: a.cidr.to_s, gateway: a.gateway}
+    }
+    sshable.cmd("sudo host/bin/setup-leaseweb-networking :json", json: subnets.to_json)
+
+    hop_leaseweb_verify_networking
+  end
+
+  label def leaseweb_verify_networking
+    sshable.cmd("ping -c 3 -w 10 8.8.8.8")
+
+    hop_leaseweb_learn_ipv6
+  end
+
+  label def leaseweb_learn_ipv6
+    adr = vm_host.assigned_subnets.find { |a| a.cidr.version == 6 }
+
+    if adr
+      vm_host.update(
+        ip6: adr.cidr.nth(1).to_s,
+        net6: adr.cidr.to_s
+      )
+    end
+
+    pop "learned network information"
+  end
+
+  def learn_network_from_host
     ip6 = parse_ip_addr_j(sshable.cmd_json("/usr/sbin/ip -j -6 addr show scope global"))
 
     # While it would be ideal for NetAddr's IPv6 support to convey

--- a/prog/learn_storage.rb
+++ b/prog/learn_storage.rb
@@ -42,6 +42,10 @@ class Prog::LearnStorage < Prog::Base
   end
 
   label def start
+    if vm_host.provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
+      sshable.cmd("sudo host/bin/setup-storage-devices")
+    end
+
     make_model_instances.each do |sd|
       sd.skip_auto_validations(:unique) do
         sd.insert_conflict(target: [:vm_host_id, :name],

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -30,6 +30,8 @@ class Prog::Vm::HostNexus < Prog::Base
         vmh.set_data_center
         # Avoid overriding custom server names for development hosts.
         vmh.set_server_name unless Config.development?
+      elsif provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
+        vmh.create_addresses
       else
         Address.create_with_id(id, cidr: sshable_hostname, routed_to_host_id: id)
         AssignedHostAddress.create(ip: sshable_hostname, address_id: id, host_id: id)

--- a/rhizome/host/bin/setup-leaseweb-networking
+++ b/rhizome/host/bin/setup-leaseweb-networking
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "yaml"
+require "json"
+require "fileutils"
+
+NETPLAN_PATH = "/etc/netplan/01-netcfg.yaml"
+
+unless (subnets_json = ARGV.shift)
+  fail "No subnets JSON provided"
+end
+
+subnets = JSON.parse(subnets_json)
+
+# Read existing netplan config
+netplan = YAML.safe_load_file(NETPLAN_PATH)
+
+# Find the primary ethernet interface
+ethernets = netplan.dig("network", "ethernets")
+fail "No ethernets found in netplan config" unless ethernets&.any?
+
+iface_name = ethernets.keys.first
+iface = ethernets[iface_name]
+
+existing_addresses = iface["addresses"] || []
+existing_routes = iface["routes"] || []
+
+subnets.each do |subnet|
+  cidr = subnet["cidr"]
+  gateway = subnet["gateway"]
+
+  next if existing_addresses.include?(cidr)
+
+  existing_addresses << cidr
+
+  if gateway && !gateway.empty?
+    route = {
+      "to" => "default",
+      "via" => gateway,
+      "metric" => 100,
+      "on-link" => true
+    }
+
+    # Only add if no duplicate route exists
+    unless existing_routes.any? { |r| r["via"] == gateway && r["to"] == "default" }
+      existing_routes << route
+    end
+  end
+end
+
+iface["addresses"] = existing_addresses
+iface["routes"] = existing_routes unless existing_routes.empty?
+
+safe_write_to_file(NETPLAN_PATH, YAML.dump(netplan))
+
+# Validate the config
+r("netplan generate --debug")
+
+# Apply with automatic rollback on failure
+r("netplan try --timeout 120")

--- a/rhizome/host/bin/setup-storage-devices
+++ b/rhizome/host/bin/setup-storage-devices
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "json"
+require "fileutils"
+
+# Identifies non-OS, non-RAID storage devices, creates GPT partition tables,
+# formats with ext4, mounts at /var/storage/devices/disk{N}, and updates fstab.
+# Idempotent: safe to re-run — skips already-partitioned/mounted devices.
+
+STORAGE_BASE = "/var/storage/devices"
+
+def root_device
+  # Find the device backing the root filesystem
+  output = r("findmnt -n -o SOURCE /")
+  source = output.strip
+  # Strip partition suffix to get the base device: /dev/sda1 -> /dev/sda, /dev/nvme0n1p1 -> /dev/nvme0n1
+  source.sub(/p?\d+$/, "")
+end
+
+def raid_devices
+  # Find devices that are part of RAID arrays
+  return [] unless File.exist?("/proc/mdstat")
+  mdstat = File.read("/proc/mdstat")
+  mdstat.scan(/\b(sd[a-z]+|nvme\d+n\d+)\b/).flatten.uniq.map { |d| "/dev/#{d}" }
+end
+
+def all_block_devices
+  # List all non-loopback, non-dm, non-md block devices (whole disks only)
+  output = r("lsblk -d -n -o NAME,TYPE -J")
+  devices = JSON.parse(output)["blockdevices"]
+  devices
+    .select { |d| d["type"] == "disk" }
+    .map { |d| "/dev/#{d["name"]}" }
+end
+
+def already_mounted?(device)
+  output = r("lsblk -n -o MOUNTPOINT #{device}")
+  output.strip.split("\n").any? { |line| !line.strip.empty? }
+end
+
+def setup_device(device, disk_number)
+  partition = partition_path(device)
+  mount_point = "#{STORAGE_BASE}/disk#{disk_number}"
+
+  # Create GPT partition table with a single partition
+  r("parted -s #{device} mklabel gpt")
+  r("parted -s #{device} mkpart primary ext4 0% 100%")
+
+  # Wait for partition device to appear
+  r("udevadm settle --timeout=10")
+
+  # Format with ext4
+  r("mkfs.ext4 -F #{partition}")
+
+  # Create mount point and mount
+  FileUtils.mkdir_p(mount_point)
+  r("mount #{partition} #{mount_point}")
+
+  # Add fstab entry using UUID for persistence
+  uuid = r("blkid -s UUID -o value #{partition}").strip
+  fstab_entry = "UUID=#{uuid} #{mount_point} ext4 defaults,nofail 0 2"
+
+  fstab = File.read("/etc/fstab")
+  unless fstab.include?(uuid)
+    File.open("/etc/fstab", "a") { |f| f.puts(fstab_entry) }
+  end
+end
+
+def partition_path(device)
+  # /dev/sda -> /dev/sda1, /dev/nvme0n1 -> /dev/nvme0n1p1
+  if device.include?("nvme")
+    "#{device}p1"
+  else
+    "#{device}1"
+  end
+end
+
+root_dev = root_device
+raid_devs = raid_devices
+
+candidates = all_block_devices.reject { |d|
+  d == root_dev || raid_devs.include?(d) || already_mounted?(d)
+}
+
+if candidates.empty?
+  puts "No unpartitioned storage devices found"
+  exit 0
+end
+
+FileUtils.mkdir_p(STORAGE_BASE)
+
+# Find the next available disk number (to be idempotent across re-runs)
+existing = Dir.glob("#{STORAGE_BASE}/disk*").map { |p| p[/disk(\d+)$/, 1].to_i }
+next_disk = existing.empty? ? 0 : existing.max + 1
+
+candidates.each_with_index do |device, i|
+  disk_number = next_disk + i
+  puts "Setting up #{device} as disk#{disk_number}"
+  setup_device(device, disk_number)
+end
+
+puts "Storage device setup complete: #{candidates.length} device(s) configured"

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe Config do
     }.to raise_error("invalid uuid invalid")
   end
 
+  it "has correct defaults for Leaseweb config entries" do
+    expect(described_class.leaseweb_connection_string).to eq("https://api.leaseweb.com")
+    expect(described_class.leaseweb_api_key).to be_nil
+    expect(described_class.leaseweb_user).to be_nil
+    expect(described_class.leaseweb_password).to be_nil
+  end
+
   it "ignores LoadError when .env.rb is not present" do
     main = TOPLEVEL_BINDING.eval("self")
     expect(main).to receive(:require_relative).with("lib/casting_config_helpers")

--- a/spec/lib/hosting/apis_spec.rb
+++ b/spec/lib/hosting/apis_spec.rb
@@ -21,10 +21,35 @@ RSpec.describe Hosting::Apis do
     )
   }
 
+  let(:leaseweb_vm_host) {
+    instance_double(
+      VmHost,
+      ubid: "vhlswtest00000000000000001",
+      provider: leaseweb_host,
+      provider_name: HostProvider::LEASEWEB_PROVIDER_NAME
+    )
+  }
+  let(:leaseweb_apis) { instance_double(Hosting::LeasewebApis, pull_ips: []) }
+  let(:leaseweb_host) {
+    instance_double(
+      HostProvider,
+      connection_string: "https://api.leaseweb.com",
+      user: nil, password: nil,
+      api: leaseweb_apis,
+      server_identifier: "91478",
+      provider_name: HostProvider::LEASEWEB_PROVIDER_NAME
+    )
+  }
+
   describe "pull_ips" do
-    it "can pull data from the API" do
+    it "can pull data from the Hetzner API" do
       expect(hetzner_apis).to receive(:pull_ips).and_return([])
       described_class.pull_ips(vm_host)
+    end
+
+    it "can pull data from the Leaseweb API" do
+      expect(leaseweb_apis).to receive(:pull_ips).and_return([])
+      described_class.pull_ips(leaseweb_vm_host)
     end
 
     it "raises an error if the provider is unknown" do
@@ -34,9 +59,13 @@ RSpec.describe Hosting::Apis do
   end
 
   describe "reimage_server" do
-    it "can reimage a server" do
+    it "can reimage a Hetzner server" do
       expect(hetzner_apis).to receive(:reimage).with(123).and_return(true)
       described_class.reimage_server(vm_host)
+    end
+
+    it "raises an error for Leaseweb provider" do
+      expect { described_class.reimage_server(leaseweb_vm_host) }.to raise_error RuntimeError, "Leaseweb provider does not support reimage_server"
     end
 
     it "raises an error if the provider is unknown" do
@@ -46,9 +75,13 @@ RSpec.describe Hosting::Apis do
   end
 
   describe "hardware_reset_server" do
-    it "can hardware reset a server" do
+    it "can hardware reset a Hetzner server" do
       expect(hetzner_apis).to receive(:reset).with(123).and_return(true)
       described_class.hardware_reset_server(vm_host)
+    end
+
+    it "raises an error for Leaseweb provider" do
+      expect { described_class.hardware_reset_server(leaseweb_vm_host) }.to raise_error RuntimeError, "Leaseweb provider does not support hardware_reset_server"
     end
 
     it "raises an error if the provider is unknown" do
@@ -58,9 +91,13 @@ RSpec.describe Hosting::Apis do
   end
 
   describe "pull_dc" do
-    it "can set dc of a server" do
+    it "can pull dc of a Hetzner server" do
       expect(hetzner_apis).to receive(:pull_dc).with(123).and_return("dc1")
       described_class.pull_data_center(vm_host)
+    end
+
+    it "returns nil for Leaseweb provider" do
+      expect(described_class.pull_data_center(leaseweb_vm_host)).to be_nil
     end
 
     it "raises an error if the provider is unknown" do
@@ -70,9 +107,13 @@ RSpec.describe Hosting::Apis do
   end
 
   describe "set_server_name" do
-    it "can set server name" do
+    it "can set Hetzner server name" do
       expect(hetzner_apis).to receive(:set_server_name).with(123, "vhgkz40v22ny2qkf4maddr8xv1").and_return(nil)
       described_class.set_server_name(vm_host)
+    end
+
+    it "raises an error for Leaseweb provider" do
+      expect { described_class.set_server_name(leaseweb_vm_host) }.to raise_error RuntimeError, "Leaseweb provider does not support set_server_name"
     end
 
     it "raises an error if the provider is unknown" do

--- a/spec/lib/hosting/leaseweb_apis_spec.rb
+++ b/spec/lib/hosting/leaseweb_apis_spec.rb
@@ -1,0 +1,293 @@
+# frozen_string_literal: true
+
+RSpec.describe Hosting::LeasewebApis do
+  let(:vmh) {
+    vmh = create_vm_host
+    vmh.sshable.update(host: "23.105.171.112")
+    vmh
+  }
+  let(:leaseweb_host) {
+    HostProvider.create do |hp|
+      hp.id = vmh.id
+      hp.server_identifier = "91478"
+      hp.provider_name = HostProvider::LEASEWEB_PROVIDER_NAME
+    end
+  }
+  let(:leaseweb_apis) { described_class.new(leaseweb_host) }
+
+  before do
+    allow(Config).to receive(:leaseweb_api_key).and_return("test-api-key")
+  end
+
+  describe "create_connection" do
+    it "sets correct auth header and content type" do
+      stub = stub_request(:get, "https://api.leaseweb.com/test")
+        .with(headers: {"X-Lsw-Auth" => "test-api-key", "Content-Type" => "application/json"})
+        .to_return(status: 200, body: "")
+
+      leaseweb_apis.create_connection.get(path: "/test")
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe "get_main_ip4" do
+    it "returns the main IPv4 address" do
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/91478")
+        .to_return(status: 200, body: JSON.dump({
+          "networkInterfaces" => {"public" => {"ip" => "23.105.171.112"}}
+        }))
+
+      expect(leaseweb_apis.get_main_ip4).to eq("23.105.171.112")
+    end
+
+    it "raises an error on failure" do
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/91478")
+        .to_return(status: 404, body: "")
+
+      expect { leaseweb_apis.get_main_ip4 }.to raise_error(Excon::Error::NotFound)
+    end
+  end
+
+  describe "pull_ips" do
+    let(:base_url) { "https://api.leaseweb.com/bareMetals/v2/servers/91478/ips" }
+
+    it "fetches and returns PUBLIC NORMAL_IP records" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+          ],
+          "_metadata" => {"totalCount" => 1}
+        }))
+
+      result = leaseweb_apis.pull_ips
+      expect(result.length).to eq(1)
+      expect(result[0].ip_address).to eq("23.105.171.112/32")
+      expect(result[0].source_host_ip).to eq("23.105.171.112")
+      expect(result[0].is_failover).to be false
+      expect(result[0].gateway).to eq("23.105.171.126")
+      expect(result[0].mask).to eq(26)
+    end
+
+    it "handles pagination across multiple pages" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+          ],
+          "_metadata" => {"totalCount" => 2}
+        }))
+
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 50})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.176.1", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+          ],
+          "_metadata" => {"totalCount" => 2}
+        }))
+
+      result = leaseweb_apis.pull_ips
+      expect(result.length).to eq(2)
+    end
+
+    it "filters out non-PUBLIC IPs such as REMOTE_MANAGEMENT" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "10.0.0.1", "prefixLength" => 24, "gateway" => "10.0.0.254", "mainIp" => false, "networkType" => "REMOTE_MANAGEMENT", "type" => "NORMAL_IP"}
+          ],
+          "_metadata" => {"totalCount" => 2}
+        }))
+
+      result = leaseweb_apis.pull_ips
+      expect(result.length).to eq(1)
+      expect(result[0].ip_address).to eq("23.105.171.112/32")
+    end
+
+    it "filters out infrastructure IP types (NETWORK, GATEWAY, BROADCAST, ROUTER1, ROUTER2)" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "23.105.176.0", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NETWORK"},
+            {"ip" => "23.105.176.6", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "GATEWAY"},
+            {"ip" => "23.105.176.7", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "BROADCAST"},
+            {"ip" => "23.105.176.4", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "ROUTER1"},
+            {"ip" => "23.105.176.5", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "ROUTER2"}
+          ],
+          "_metadata" => {"totalCount" => 6}
+        }))
+
+      result = leaseweb_apis.pull_ips
+      expect(result.length).to eq(1)
+      expect(result[0].ip_address).to eq("23.105.171.112/32")
+    end
+
+    it "normalizes IPv6 underscore format" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "2607:f5b7:1:30:9::_112", "prefixLength" => 64, "gateway" => "2607:f5b7:1:30::1", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+          ],
+          "_metadata" => {"totalCount" => 2}
+        }))
+
+      result = leaseweb_apis.pull_ips
+      ipv6_result = result.find { |r| r.ip_address.include?(":") }
+      expect(ipv6_result.ip_address).to eq("2607:f5b7:1:30:9::/112")
+      expect(ipv6_result.gateway).to eq("2607:f5b7:1:30::1")
+      expect(ipv6_result.mask).to eq(112)
+      expect(ipv6_result.source_host_ip).to eq("23.105.171.112")
+      expect(ipv6_result.is_failover).to be false
+    end
+
+    it "treats main IP with gateway as /32" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+          ],
+          "_metadata" => {"totalCount" => 1}
+        }))
+
+      result = leaseweb_apis.pull_ips
+      expect(result[0].ip_address).to eq("23.105.171.112/32")
+      expect(result[0].gateway).to eq("23.105.171.126")
+      expect(result[0].mask).to eq(26)
+    end
+
+    it "treats non-main IP with explicit gateway as /32" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "5.6.7.8", "prefixLength" => 24, "gateway" => "5.6.7.1", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+          ],
+          "_metadata" => {"totalCount" => 2}
+        }))
+
+      result = leaseweb_apis.pull_ips
+      extra_ip = result.find { |r| r.ip_address == "5.6.7.8/32" }
+      expect(extra_ip).not_to be_nil
+      expect(extra_ip.gateway).to eq("5.6.7.1")
+      expect(extra_ip.mask).to eq(24)
+    end
+
+    it "groups subnet IPs without gateway into network CIDR" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "23.105.176.1", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "23.105.176.2", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "23.105.176.3", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+          ],
+          "_metadata" => {"totalCount" => 4}
+        }))
+
+      result = leaseweb_apis.pull_ips
+      subnet_result = result.find { |r| r.ip_address.include?("/29") }
+      expect(subnet_result).not_to be_nil
+      expect(subnet_result.ip_address).to eq("23.105.176.0/29")
+      expect(subnet_result.gateway).to be_nil
+      expect(subnet_result.mask).to eq(29)
+      expect(subnet_result.source_host_ip).to eq("23.105.171.112")
+    end
+
+    it "normalizes empty gateway string to nil" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+          ],
+          "_metadata" => {"totalCount" => 1}
+        }))
+
+      result = leaseweb_apis.pull_ips
+      expect(result[0].gateway).to be_nil
+    end
+
+    it "normalizes nil gateway to nil" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => nil, "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+          ],
+          "_metadata" => {"totalCount" => 1}
+        }))
+
+      result = leaseweb_apis.pull_ips
+      expect(result[0].gateway).to be_nil
+    end
+
+    it "returns correct IpInfo struct fields for all IP types" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "2607:f5b7:1:30:9::_112", "prefixLength" => 64, "gateway" => "2607:f5b7:1:30::1", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "23.105.176.1", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "23.105.176.2", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+          ],
+          "_metadata" => {"totalCount" => 4}
+        }))
+
+      expected = [
+        described_class::IpInfo.new(ip_address: "23.105.171.112/32", source_host_ip: "23.105.171.112", is_failover: false, gateway: "23.105.171.126", mask: 26),
+        described_class::IpInfo.new(ip_address: "2607:f5b7:1:30:9::/112", source_host_ip: "23.105.171.112", is_failover: false, gateway: "2607:f5b7:1:30::1", mask: 112),
+        described_class::IpInfo.new(ip_address: "23.105.176.0/29", source_host_ip: "23.105.171.112", is_failover: false, gateway: nil, mask: 29)
+      ]
+
+      expect(leaseweb_apis.pull_ips).to eq(expected)
+    end
+
+    it "handles empty IP list" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [],
+          "_metadata" => {"totalCount" => 0}
+        }))
+
+      expect(leaseweb_apis.pull_ips).to eq([])
+    end
+
+    it "raises an error on HTTP failure" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 500, body: "")
+
+      expect { leaseweb_apis.pull_ips }.to raise_error(Excon::Error::InternalServerError)
+    end
+
+    it "handles IPv6 with underscore format and no gateway" do
+      stub_request(:get, base_url)
+        .with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.dump({
+          "ips" => [
+            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "2607:f5b7:1:30:9::_112", "prefixLength" => 64, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+          ],
+          "_metadata" => {"totalCount" => 2}
+        }))
+
+      result = leaseweb_apis.pull_ips
+      ipv6_result = result.find { |r| r.ip_address.include?(":") }
+      expect(ipv6_result.gateway).to be_nil
+    end
+  end
+end

--- a/spec/lib/hosting/leaseweb_apis_spec.rb
+++ b/spec/lib/hosting/leaseweb_apis_spec.rb
@@ -34,10 +34,19 @@ RSpec.describe Hosting::LeasewebApis do
     it "returns the main IPv4 address" do
       stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/91478")
         .to_return(status: 200, body: JSON.dump({
-          "networkInterfaces" => {"public" => {"ip" => "23.105.171.112"}}
+          "networkInterfaces" => {"public" => {"ip" => "23.105.171.112/26"}}
         }))
 
       expect(leaseweb_apis.get_main_ip4).to eq("23.105.171.112")
+    end
+
+    it "strips the CIDR suffix from the IP" do
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/91478")
+        .to_return(status: 200, body: JSON.dump({
+          "networkInterfaces" => {"public" => {"ip" => "192.168.1.1/24"}}
+        }))
+
+      expect(leaseweb_apis.get_main_ip4).to eq("192.168.1.1")
     end
 
     it "raises an error on failure" do
@@ -56,7 +65,7 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+            {"ip" => "23.105.171.112/26", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
           ],
           "_metadata" => {"totalCount" => 1}
         }))
@@ -75,7 +84,7 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+            {"ip" => "23.105.171.112/26", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
           ],
           "_metadata" => {"totalCount" => 2}
         }))
@@ -84,7 +93,7 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 50})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.176.1", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+            {"ip" => "23.105.176.1/29", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
           ],
           "_metadata" => {"totalCount" => 2}
         }))
@@ -98,8 +107,8 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
-            {"ip" => "10.0.0.1", "prefixLength" => 24, "gateway" => "10.0.0.254", "mainIp" => false, "networkType" => "REMOTE_MANAGEMENT", "type" => "NORMAL_IP"}
+            {"ip" => "23.105.171.112/26", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "10.0.0.1/24", "prefixLength" => 24, "gateway" => "10.0.0.254", "mainIp" => false, "networkType" => "REMOTE_MANAGEMENT", "type" => "NORMAL_IP"}
           ],
           "_metadata" => {"totalCount" => 2}
         }))
@@ -114,12 +123,12 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
-            {"ip" => "23.105.176.0", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NETWORK"},
-            {"ip" => "23.105.176.6", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "GATEWAY"},
-            {"ip" => "23.105.176.7", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "BROADCAST"},
-            {"ip" => "23.105.176.4", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "ROUTER1"},
-            {"ip" => "23.105.176.5", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "ROUTER2"}
+            {"ip" => "23.105.171.112/26", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "23.105.176.0/29", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NETWORK"},
+            {"ip" => "23.105.176.6/29", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "GATEWAY"},
+            {"ip" => "23.105.176.7/29", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "BROADCAST"},
+            {"ip" => "23.105.176.4/29", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "ROUTER1"},
+            {"ip" => "23.105.176.5/29", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "ROUTER2"}
           ],
           "_metadata" => {"totalCount" => 6}
         }))
@@ -134,8 +143,8 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
-            {"ip" => "2607:f5b7:1:30:9::_112", "prefixLength" => 64, "gateway" => "2607:f5b7:1:30::1", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+            {"ip" => "23.105.171.112/26", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "2607:f5b7:1:30:9::_112/64", "prefixLength" => 64, "gateway" => "2607:f5b7:1:30::1", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
           ],
           "_metadata" => {"totalCount" => 2}
         }))
@@ -154,7 +163,7 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+            {"ip" => "23.105.171.112/26", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
           ],
           "_metadata" => {"totalCount" => 1}
         }))
@@ -170,8 +179,8 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
-            {"ip" => "5.6.7.8", "prefixLength" => 24, "gateway" => "5.6.7.1", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+            {"ip" => "23.105.171.112/26", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "5.6.7.8/24", "prefixLength" => 24, "gateway" => "5.6.7.1", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
           ],
           "_metadata" => {"totalCount" => 2}
         }))
@@ -188,10 +197,10 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
-            {"ip" => "23.105.176.1", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
-            {"ip" => "23.105.176.2", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
-            {"ip" => "23.105.176.3", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+            {"ip" => "23.105.171.112/26", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "23.105.176.1/29", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "23.105.176.2/29", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "23.105.176.3/29", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
           ],
           "_metadata" => {"totalCount" => 4}
         }))
@@ -210,7 +219,7 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+            {"ip" => "23.105.171.112/26", "prefixLength" => 26, "gateway" => "", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
           ],
           "_metadata" => {"totalCount" => 1}
         }))
@@ -224,7 +233,7 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => nil, "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+            {"ip" => "23.105.171.112/26", "prefixLength" => 26, "gateway" => nil, "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
           ],
           "_metadata" => {"totalCount" => 1}
         }))
@@ -238,10 +247,10 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
-            {"ip" => "2607:f5b7:1:30:9::_112", "prefixLength" => 64, "gateway" => "2607:f5b7:1:30::1", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
-            {"ip" => "23.105.176.1", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
-            {"ip" => "23.105.176.2", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+            {"ip" => "23.105.171.112/26", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "2607:f5b7:1:30:9::_112/64", "prefixLength" => 64, "gateway" => "2607:f5b7:1:30::1", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "23.105.176.1/29", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "23.105.176.2/29", "prefixLength" => 29, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
           ],
           "_metadata" => {"totalCount" => 4}
         }))
@@ -279,8 +288,8 @@ RSpec.describe Hosting::LeasewebApis do
         .with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.dump({
           "ips" => [
-            {"ip" => "23.105.171.112", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
-            {"ip" => "2607:f5b7:1:30:9::_112", "prefixLength" => 64, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
+            {"ip" => "23.105.171.112/26", "prefixLength" => 26, "gateway" => "23.105.171.126", "mainIp" => true, "networkType" => "PUBLIC", "type" => "NORMAL_IP"},
+            {"ip" => "2607:f5b7:1:30:9::_112/64", "prefixLength" => 64, "gateway" => "", "mainIp" => false, "networkType" => "PUBLIC", "type" => "NORMAL_IP"}
           ],
           "_metadata" => {"totalCount" => 2}
         }))

--- a/spec/model/address_spec.rb
+++ b/spec/model/address_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe Address do
   end
 
   it "populates ipv4_address table with addresses in cidr without first and last, when using leaseweb" do
+    leaseweb_ips = [
+      Hosting::LeasewebApis::IpInfo.new(ip_address: "1.2.3.4/32", source_host_ip: "1.2.3.4", is_failover: false, gateway: "1.2.3.1", mask: 32)
+    ]
+    expect(Hosting::Apis).to receive(:pull_ips).and_return(leaseweb_ips)
     vm_host = Prog::Vm::HostNexus.assemble("1.2.3.4", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "1").subject
     described_class.create(cidr: "0.0.0.0/30", vm_host:)
     expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq %w[0.0.0.1 0.0.0.2]

--- a/spec/model/address_spec.rb
+++ b/spec/model/address_spec.rb
@@ -42,4 +42,15 @@ RSpec.describe Address do
     described_class.create(cidr: "0.0.0.0/30", vm_host:)
     expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq %w[0.0.0.1 0.0.0.2]
   end
+
+  it "stores gateway and mask columns" do
+    leaseweb_ips = [
+      Hosting::LeasewebApis::IpInfo.new(ip_address: "1.2.3.4/32", source_host_ip: "1.2.3.4", is_failover: false, gateway: "1.2.3.1", mask: 26)
+    ]
+    expect(Hosting::Apis).to receive(:pull_ips).and_return(leaseweb_ips)
+    vm_host = Prog::Vm::HostNexus.assemble("1.2.3.4", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "2").subject
+    addr = vm_host.assigned_subnets.find { it.cidr.to_s == "1.2.3.4/32" }
+    expect(addr.gateway).to eq("1.2.3.1")
+    expect(addr.mask).to eq(26)
+  end
 end

--- a/spec/prog/learn_network_spec.rb
+++ b/spec/prog/learn_network_spec.rb
@@ -52,6 +52,110 @@ JSON
       expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j -6 addr show scope global").and_return("[]")
       expect { ln.start }.to exit({"msg" => "learned network information"})
     end
+
+    context "when provider is leaseweb" do
+      let(:leaseweb_ips) {
+        [
+          Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.171.112/32", source_host_ip: "23.105.171.112", is_failover: false, gateway: "23.105.171.126", mask: 26),
+          Hosting::LeasewebApis::IpInfo.new(ip_address: "2607:f5b7:1:30:9::/112", source_host_ip: "23.105.171.112", is_failover: false, gateway: "2607:f5b7:1:30::1", mask: 112),
+          Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.176.0/29", source_host_ip: "23.105.171.112", is_failover: false, gateway: nil, mask: 29)
+        ]
+      }
+
+      let(:leaseweb_vm_host) {
+        expect(Hosting::Apis).to receive(:pull_ips).and_return(leaseweb_ips)
+        Prog::Vm::HostNexus.assemble("23.105.171.112", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "91478").subject
+      }
+
+      let(:leaseweb_ln) { described_class.new(Strand.new(stack: [{"subject_id" => leaseweb_vm_host.id}])) }
+
+      it "hops to setup_leaseweb_networking for leaseweb hosts" do
+        expect { leaseweb_ln.start }.to hop("setup_leaseweb_networking")
+      end
+    end
+  end
+
+  describe "#setup_leaseweb_networking" do
+    let(:leaseweb_ips) {
+      [
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.171.112/32", source_host_ip: "23.105.171.112", is_failover: false, gateway: "23.105.171.126", mask: 26),
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "2607:f5b7:1:30:9::/112", source_host_ip: "23.105.171.112", is_failover: false, gateway: "2607:f5b7:1:30::1", mask: 112),
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.176.0/29", source_host_ip: "23.105.171.112", is_failover: false, gateway: nil, mask: 29)
+      ]
+    }
+
+    let(:leaseweb_vm_host) {
+      expect(Hosting::Apis).to receive(:pull_ips).and_return(leaseweb_ips)
+      Prog::Vm::HostNexus.assemble("23.105.171.112", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "91478").subject
+    }
+
+    let(:leaseweb_ln) { described_class.new(Strand.new(stack: [{"subject_id" => leaseweb_vm_host.id}])) }
+
+    it "sends subnet info to the host and hops to verify" do
+      subnets = leaseweb_vm_host.assigned_subnets.map { |a| {cidr: a.cidr.to_s, gateway: a.gateway} }
+      expected_json = subnets.to_json.shellescape
+
+      expect(leaseweb_ln.sshable).to receive(:_cmd).with("sudo host/bin/setup-leaseweb-networking #{expected_json}").and_return("")
+      expect { leaseweb_ln.setup_leaseweb_networking }.to hop("leaseweb_verify_networking")
+    end
+  end
+
+  describe "#leaseweb_verify_networking" do
+    let(:leaseweb_ips) {
+      [
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.171.112/32", source_host_ip: "23.105.171.112", is_failover: false, gateway: "23.105.171.126", mask: 26)
+      ]
+    }
+
+    let(:leaseweb_vm_host) {
+      expect(Hosting::Apis).to receive(:pull_ips).and_return(leaseweb_ips)
+      Prog::Vm::HostNexus.assemble("23.105.171.112", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "91478").subject
+    }
+
+    let(:leaseweb_ln) { described_class.new(Strand.new(stack: [{"subject_id" => leaseweb_vm_host.id}])) }
+
+    it "pings to verify connectivity and hops to learn ipv6" do
+      expect(leaseweb_ln.sshable).to receive(:_cmd).with("ping -c 3 -w 10 8.8.8.8").and_return("")
+      expect { leaseweb_ln.leaseweb_verify_networking }.to hop("leaseweb_learn_ipv6")
+    end
+  end
+
+  describe "#leaseweb_learn_ipv6" do
+    let(:leaseweb_ips) {
+      [
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.171.112/32", source_host_ip: "23.105.171.112", is_failover: false, gateway: "23.105.171.126", mask: 26),
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "2607:f5b7:1:30:9::/112", source_host_ip: "23.105.171.112", is_failover: false, gateway: "2607:f5b7:1:30::1", mask: 112),
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.176.0/29", source_host_ip: "23.105.171.112", is_failover: false, gateway: nil, mask: 29)
+      ]
+    }
+
+    let(:leaseweb_vm_host) {
+      expect(Hosting::Apis).to receive(:pull_ips).and_return(leaseweb_ips)
+      Prog::Vm::HostNexus.assemble("23.105.171.112", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "91478").subject
+    }
+
+    let(:leaseweb_ln) { described_class.new(Strand.new(stack: [{"subject_id" => leaseweb_vm_host.id}])) }
+
+    it "learns ipv6 from assigned subnets and pops" do
+      expect { leaseweb_ln.leaseweb_learn_ipv6 }.to exit({"msg" => "learned network information"})
+      leaseweb_vm_host.reload
+      expect(leaseweb_vm_host.ip6.to_s).to eq("2607:f5b7:1:30:9::1")
+      expect(leaseweb_vm_host.net6.to_s).to eq("2607:f5b7:1:30:9::/112")
+    end
+
+    it "pops without setting ipv6 when no ipv6 subnet assigned" do
+      leaseweb_ips_no_v6 = [
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.171.112/32", source_host_ip: "23.105.171.112", is_failover: false, gateway: "23.105.171.126", mask: 26)
+      ]
+      expect(Hosting::Apis).to receive(:pull_ips).and_return(leaseweb_ips_no_v6)
+      vmh = Prog::Vm::HostNexus.assemble("23.105.171.112", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "91479").subject
+      ln = described_class.new(Strand.new(stack: [{"subject_id" => vmh.id}]))
+
+      expect { ln.leaseweb_learn_ipv6 }.to exit({"msg" => "learned network information"})
+      vmh.reload
+      expect(vmh.ip6).to be_nil
+      expect(vmh.net6).to be_nil
+    end
   end
 
   describe "#parse_ip_addr_j" do

--- a/spec/prog/learn_network_spec.rb
+++ b/spec/prog/learn_network_spec.rb
@@ -143,6 +143,22 @@ JSON
       expect(leaseweb_vm_host.net6.to_s).to eq("2607:f5b7:1:30:9::/112")
     end
 
+    it "picks the largest ipv6 subnet when multiple are assigned" do
+      leaseweb_ips_multi_v6 = [
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.171.112/32", source_host_ip: "23.105.171.112", is_failover: false, gateway: "23.105.171.126", mask: 26),
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "2607:f5b7:1:30:9::/112", source_host_ip: "23.105.171.112", is_failover: false, gateway: "2607:f5b7:1:30::1", mask: 112),
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "2607:f5b7:1:30:9::/64", source_host_ip: "23.105.171.112", is_failover: false, gateway: "2607:f5b7:1:30::1", mask: 64)
+      ]
+      expect(Hosting::Apis).to receive(:pull_ips).and_return(leaseweb_ips_multi_v6)
+      vmh = Prog::Vm::HostNexus.assemble("23.105.171.112", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "91480").subject
+      ln = described_class.new(Strand.new(stack: [{"subject_id" => vmh.id}]))
+
+      expect { ln.leaseweb_learn_ipv6 }.to exit({"msg" => "learned network information"})
+      vmh.reload
+      expect(vmh.ip6.to_s).to eq("2607:f5b7:1:30::1")
+      expect(vmh.net6.to_s).to eq("2607:f5b7:1:30::/64")
+    end
+
     it "pops without setting ipv6 when no ipv6 subnet assigned" do
       leaseweb_ips_no_v6 = [
         Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.171.112/32", source_host_ip: "23.105.171.112", is_failover: false, gateway: "23.105.171.126", mask: 26)
@@ -174,7 +190,7 @@ JSON
       }.to raise_error RuntimeError, "only one interface supported"
     end
 
-    it "crashes if more than one global unique address prefix is provided" do
+    it "picks the largest prefix when multiple global unique address prefixes are provided" do
       json = JSON.parse(<<~JSON)
         [
           {
@@ -182,18 +198,19 @@ JSON
             "addr_info": [
               {
                 "local": "2a01:4f8:173:1ed3::2",
-                "prefixlen": 64
+                "prefixlen": 112
               },
               {
-                "local": "2a01:4f8:173:1ed3::3",
+                "local": "2a01:4f8:173:1ed3::",
                 "prefixlen": 64
               }
             ]
           }
         ]
       JSON
-      expect { lm.parse_ip_addr_j(json) }
-        .to raise_error RuntimeError, "only one global unique address prefix supported on interface"
+      result = lm.parse_ip_addr_j(json)
+      expect(result.addr).to eq("2a01:4f8:173:1ed3::")
+      expect(result.prefixlen).to eq(64)
     end
   end
 end

--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -4,6 +4,49 @@ require_relative "../model/spec_helper"
 
 RSpec.describe Prog::LearnStorage do
   describe "#start" do
+    it "runs setup-storage-devices for Leaseweb hosts before discovery" do
+      expect(Hosting::Apis).to receive(:pull_ips).and_return([
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.171.112/32", source_host_ip: "23.105.171.112", is_failover: false, gateway: "23.105.171.126", mask: 26)
+      ])
+      vmh = Prog::Vm::HostNexus.assemble("23.105.171.112", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "91478").subject
+      ls = described_class.new(Strand.new(stack: [{"subject_id" => vmh.id}]))
+      expect(ls.sshable).to receive(:_cmd).with("sudo host/bin/setup-storage-devices").and_return("Storage device setup complete: 1 device(s) configured")
+      expect(ls.sshable).to receive(:_cmd).with("df -B1 --output=source,target,size,avail").and_return(<<EOS)
+Filesystem     Mounted on                   1B-blocks        Avail
+/dev/sda       /                            205520896     99571712
+/dev/sdb       /var/storage/devices/disk0   205520896     99571712
+EOS
+      expect(ls.sshable).to receive(:_cmd).with("df -B1 --output=source,target,size,avail /var/storage").and_return(<<EOS)
+Filesystem     Mounted on                   1B-blocks        Avail
+/dev/sdb       /var/storage/devices/disk0   205520896     99571712
+EOS
+      allow(ls.sshable).to receive(:_cmd).with("ls -l /dev/disk/by-id/ | grep sdb\\$ | grep 'wwn-' | sed -E 's/.*(wwn[^ ]*).*/\\1/'").and_return("wwn-some-random-id1")
+
+      expect { ls.start }.to exit({"msg" => "created StorageDevice records"}).and change {
+        StorageDevice.all.map { |d| [d.name, d.unix_device_list.sort] }.sort
+      }.from([]).to([
+        ["DEFAULT", ["wwn-some-random-id1"]],
+        ["disk0", ["wwn-some-random-id1"]]
+      ])
+    end
+
+    it "does not run setup-storage-devices for non-Leaseweb hosts" do
+      vmh = Prog::Vm::HostNexus.assemble("::1").subject
+      ls = described_class.new(Strand.new(stack: [{"subject_id" => vmh.id}]))
+      expect(ls.sshable).not_to receive(:_cmd).with("sudo host/bin/setup-storage-devices")
+      expect(ls.sshable).to receive(:_cmd).with("df -B1 --output=source,target,size,avail").and_return(<<EOS)
+Filesystem     Mounted on                   1B-blocks        Avail
+/dev/sda       /                            205520896     99571712
+EOS
+      expect(ls.sshable).to receive(:_cmd).with("df -B1 --output=source,target,size,avail /var/storage").and_return(<<EOS)
+Filesystem     Mounted on                   1B-blocks        Avail
+/dev/sda       /                            205520896     99571712
+EOS
+      allow(ls.sshable).to receive(:_cmd).with("ls -l /dev/disk/by-id/ | grep sda\\$ | grep 'wwn-' | sed -E 's/.*(wwn[^ ]*).*/\\1/'").and_return("wwn-some-random-id1")
+
+      expect { ls.start }.to exit({"msg" => "created StorageDevice records"})
+    end
+
     it "exits, saving StorageDevice model instances" do
       vmh = Prog::Vm::HostNexus.assemble("::1").subject
       ls = described_class.new(Strand.new(stack: [{"subject_id" => vmh.id}]))

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -62,6 +62,23 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(st.subject.data_center).to eq("fsn1-dc14")
     end
 
+    it "creates addresses properly for a leaseweb host" do
+      leaseweb_ips = [
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.171.112/32", source_host_ip: "23.105.171.112", is_failover: false, gateway: "23.105.171.126", mask: 32),
+        Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.176.0/29", source_host_ip: "23.105.171.112", is_failover: false, gateway: nil, mask: 29)
+      ]
+      expect(Hosting::Apis).to receive(:pull_ips).and_return(leaseweb_ips)
+      st = described_class.assemble("23.105.171.112", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "91478")
+      expect(st).to be_a Strand
+      expect(st.label).to eq("start")
+      expect(st.subject.assigned_subnets.count).to eq(2)
+      expect(st.subject.assigned_subnets.map { it.cidr.to_s }.sort).to eq(["23.105.171.112/32", "23.105.176.0/29"].sort)
+
+      expect(st.subject.assigned_host_addresses.count).to eq(2)
+      expect(st.subject.assigned_host_addresses.map { it.ip.to_s }.sort).to eq(["23.105.171.112/32", "23.105.176.0/29"])
+      expect(st.subject.provider_name).to eq(HostProvider::LEASEWEB_PROVIDER_NAME)
+    end
+
     it "does not set the server name in development" do
       expect(Config).to receive(:development?).and_return(true)
       expect(Hosting::Apis).to receive(:pull_ips).and_return(hetzner_ips)

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -68,11 +68,21 @@ RSpec.describe Prog::Vm::HostNexus do
         Hosting::LeasewebApis::IpInfo.new(ip_address: "23.105.176.0/29", source_host_ip: "23.105.171.112", is_failover: false, gateway: nil, mask: 29)
       ]
       expect(Hosting::Apis).to receive(:pull_ips).and_return(leaseweb_ips)
+      expect(Hosting::Apis).not_to receive(:pull_data_center)
+      expect(Hosting::Apis).not_to receive(:set_server_name)
       st = described_class.assemble("23.105.171.112", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "91478")
       expect(st).to be_a Strand
       expect(st.label).to eq("start")
       expect(st.subject.assigned_subnets.count).to eq(2)
       expect(st.subject.assigned_subnets.map { it.cidr.to_s }.sort).to eq(["23.105.171.112/32", "23.105.176.0/29"].sort)
+
+      main_addr = st.subject.assigned_subnets.find { it.cidr.to_s == "23.105.171.112/32" }
+      expect(main_addr.gateway).to eq("23.105.171.126")
+      expect(main_addr.mask).to eq(32)
+
+      subnet_addr = st.subject.assigned_subnets.find { it.cidr.to_s == "23.105.176.0/29" }
+      expect(subnet_addr.gateway).to be_nil
+      expect(subnet_addr.mask).to eq(29)
 
       expect(st.subject.assigned_host_addresses.count).to eq(2)
       expect(st.subject.assigned_host_addresses.map { it.ip.to_s }.sort).to eq(["23.105.171.112/32", "23.105.176.0/29"])


### PR DESCRIPTION
## Summary
- Implements `Hosting::LeasewebApis` client matching the Hetzner pattern (pull_ips, get_main_ip4, pagination, IPv6 normalization)
- Updates `Hosting::Apis` dispatcher to route Leaseweb calls
- Adds Leaseweb config entries (API key auth via `X-Lsw-Auth` header)
- Updates `HostNexus.assemble` to initialize Leaseweb hosts with `create_addresses`
- Adds Address model gateway/mask columns for Leaseweb IP patterns
- Implements netplan-based network setup for Leaseweb hosts (rhizome script + LearnNetwork prog)
- Integrates storage device partitioning into host provisioning flow
- Handles multiple IPv6 prefixes (picks largest /64 over /112)
- 100% line and branch coverage on all new code

## Test plan
- [x] All 5177 tests pass (2 pre-existing failures unrelated to this PR)
- [x] 100% line and branch coverage on all changed files
- [x] Rubocop clean
- [x] Validated on live Leaseweb server 91478: storage, networking (IPv4 + IPv6 + subnets), SSH keys
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)