### PR TITLE
UMI: filter hosts & backends by required vhost block backend version

### DIFF
--- a/model/vhost_block_backend.rb
+++ b/model/vhost_block_backend.rb
@@ -5,8 +5,16 @@ require_relative "../model"
 class VhostBlockBackend < Sequel::Model
   plugin ResourceMethods, etc_type: true
 
+  def self.parse_version(version_str)
+    Gem::Version.new(version_str.delete_prefix("v"))
+  end
+
+  def parsed_version
+    @parsed_version ||= self.class.parse_version(version)
+  end
+
   def supports_archive?
-    Gem::Version.new(version.delete_prefix("v")) >= Gem::Version.new("0.4.0")
+    parsed_version >= Gem::Version.new("0.4.0")
   end
 end
 

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -650,7 +650,12 @@ module Scheduling::Allocator
       rand_choice.id
     end
 
-    def self.allocate_vhost_block_backend(backends)
+    def self.allocate_vhost_block_backend(backends, min_version: nil)
+      if min_version
+        parsed_min_version = VhostBlockBackend.parse_version(min_version)
+        backends.select! { |b| b.parsed_version >= parsed_min_version }
+      end
+
       total_weight = backends.sum(&:allocation_weight)
       fail "Total weight of all eligible vhost_block_backends shouldn't be zero." if total_weight == 0
 
@@ -696,7 +701,10 @@ module Scheduling::Allocator
           spdk_installation_id = StorageAllocation.allocate_spdk_installation(vm_host.spdk_installations)
           use_bdev_ubi = SpdkInstallation[spdk_installation_id].supports_bdev_ubi? && volume["boot"]
         else
-          vhost_block_backend_id = StorageAllocation.allocate_vhost_block_backend(vm_host.vhost_block_backends)
+          vhost_block_backend_id = StorageAllocation.allocate_vhost_block_backend(
+            vm_host.vhost_block_backends,
+            min_version: @request.minimum_vhost_block_backend_version
+          )
           use_bdev_ubi = false
         end
 

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -26,7 +26,9 @@ module Scheduling::Allocator
       true, # use slices
       Option::VmFamilies.find { it.name == vm.family }&.require_shared_slice || false,
       vm.project.get_ff_allocator_diagnostics || false,
-      family_filter
+      family_filter,
+      os_filter,
+      (storage_volumes.any? { it["track_written"] }) ? "v0.4.0" : nil
     )
     allocation = Allocation.best_allocation(request)
     fail "#{vm} no space left on any eligible host" unless allocation
@@ -60,7 +62,8 @@ module Scheduling::Allocator
     :require_shared_slice,
     :diagnostics,
     :family_filter,
-    :os_filter
+    :os_filter,
+    :minimum_vhost_block_backend_version
   ) do
     def initialize(*args)
       super
@@ -238,6 +241,22 @@ module Scheduling::Allocator
 
       # Temporary while testing CloudHypervisor 46 rollout
       ds = ds.where(Sequel[:vm_host][:os_version] => request.os_filter) if request.os_filter
+
+      if request.minimum_vhost_block_backend_version
+        vbb = Sequel[:vhost_block_backend]
+
+        version = Sequel.cast(Sequel.function(:string_to_array, Sequel.function(:ltrim, vbb[:version], "v"), "."), "integer[]")
+        min_version = VhostBlockBackend.parse_version(request.minimum_vhost_block_backend_version).segments
+
+        subquery = DB[:vhost_block_backend]
+          .where(vbb[:vm_host_id] => Sequel[:vm_host][:id])
+          .exclude(Sequel[vbb][:allocation_weight] => 0)
+          .where { vbb[:version] =~ /^v\d+\.\d+\.\d+$/ }
+          .where(version >= Sequel.pg_array(min_version, :integer))
+          .select(1)
+
+        ds = ds.where(subquery.exists)
+      end
 
       # If we dont's want to use slices, place those only on hosts that do not accept them
       # If we require a shared slice (for burstable vm), allocate those only on hosts that accept slices

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Al do
 
   # Creates a Request object with the given parameters
   #
-  def create_req(vm, storage_volumes, target_host_utilization: 0.55, distinct_storage_devices: false, gpu_count: 0, gpu_device: nil, allocation_state_filter: ["accepting"], host_filter: [], host_exclusion_filter: [], data_center_exclusion_filter: [], location_filter: [], location_preference: [], use_slices: true, require_shared_slice: false, diagnostics: false, family_filter: [], os_filter: nil)
+  def create_req(vm, storage_volumes, target_host_utilization: 0.55, distinct_storage_devices: false, gpu_count: 0, gpu_device: nil, allocation_state_filter: ["accepting"], host_filter: [], host_exclusion_filter: [], data_center_exclusion_filter: [], location_filter: [], location_preference: [], use_slices: true, require_shared_slice: false, diagnostics: false, family_filter: [], os_filter: nil, minimum_vhost_block_backend_version: nil)
     Al::Request.new(
       vm.id,
       vm.vcpus,
@@ -41,7 +41,8 @@ RSpec.describe Al do
       require_shared_slice,
       diagnostics,
       family_filter,
-      os_filter
+      os_filter,
+      minimum_vhost_block_backend_version
     )
   end
 
@@ -314,6 +315,51 @@ RSpec.describe Al do
 
       expect(cand.size).to eq(1)
       expect(cand.first[:vm_host_id]).to eq(vmh1.id)
+    end
+
+    it "filters hosts by minimum vhost block backend version" do
+      vmh1 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      vmh2 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
+      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
+      VhostBlockBackend.create(vm_host_id: vmh1.id, version: "v0.4.0", allocation_weight: 100)
+      VhostBlockBackend.create(vm_host_id: vmh2.id, version: "v0.3.0", allocation_weight: 100)
+      # old versions used a different versioning scheme, ensure they don't cause issues
+      VhostBlockBackend.create(vm_host_id: vmh2.id, version: "v0.1-7", allocation_weight: 100)
+
+      req.minimum_vhost_block_backend_version = "v0.4.0"
+      cand = Al::Allocation.candidate_hosts(req)
+
+      expect(cand.size).to eq(1)
+      expect(cand.first[:vm_host_id]).to eq(vmh1.id)
+    end
+
+    it "excludes hosts with zero-weight vhost block backend even if version matches" do
+      vmh1 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
+      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
+      VhostBlockBackend.create(vm_host_id: vmh1.id, version: "v0.4.0", allocation_weight: 0)
+
+      req.minimum_vhost_block_backend_version = "v0.4.0"
+      cand = Al::Allocation.candidate_hosts(req)
+
+      expect(cand).to be_empty
+    end
+
+    it "does not filter by vhost block backend version when not requested" do
+      vmh1 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
+      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
+
+      cand = Al::Allocation.candidate_hosts(req)
+
+      expect(cand.size).to eq(1)
     end
 
     it "retrieves candidates with enough storage devices" do
@@ -901,10 +947,11 @@ RSpec.describe Al do
     end
 
     it "creates volume with track_written set to true" do
+      VhostBlockBackend.create(vm_host_id: VmHost.first.id, version: "v0.4.0", allocation_weight: 100)
       vm = create_vm
       vol = [{
         "size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => false,
-        "boot" => false, "track_written" => true
+        "boot" => false, "track_written" => true, "vring_workers" => 1
       }]
       described_class.allocate(vm, vol)
       expect(vm.vm_storage_volumes.first.track_written).to be(true)
@@ -918,6 +965,23 @@ RSpec.describe Al do
       }]
       described_class.allocate(vm, vol)
       expect(vm.vm_storage_volumes.first.track_written).to be(false)
+    end
+
+    it "succeeds allocation when track_written is set and host has vhost block backend v0.4.0+" do
+      vmh = VmHost.first
+      VhostBlockBackend.create(vm_host_id: vmh.id, version: "v0.4.0", allocation_weight: 100)
+
+      vm = create_vm
+      vol = [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => false, "boot" => false, "track_written" => true, "vring_workers" => 1}]
+      described_class.allocate(vm, vol)
+      expect(vm.reload.vm_host_id).to eq(vmh.id)
+      expect(vm.vm_storage_volumes.first.track_written).to be(true)
+    end
+
+    it "fails allocation when track_written is set but no host has vhost block backend v0.4.0+" do
+      vm = create_vm
+      vol = [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => false, "boot" => false, "track_written" => true}]
+      expect { described_class.allocate(vm, vol) }.to raise_error(RuntimeError, /no space left on any eligible host/)
     end
 
     it "creates volume with no rate limits" do

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -1642,5 +1642,17 @@ RSpec.describe Al do
       vbb_2 = VhostBlockBackend.new(allocation_weight: 100) { it.id = VhostBlockBackend.generate_uuid }
       expect(Al::StorageAllocation.allocate_vhost_block_backend([vbb_1, vbb_2])).to eq(vbb_2.id)
     end
+
+    it "filters backends by min_version" do
+      vbb_1 = VhostBlockBackend.new_with_id(allocation_weight: 100, version: "v0.3.0")
+      vbb_2 = VhostBlockBackend.new_with_id(allocation_weight: 1, version: "v0.4.0")
+      vbb_3 = VhostBlockBackend.new_with_id(allocation_weight: 100, version: "v0.1-7")
+      expect(Al::StorageAllocation.allocate_vhost_block_backend([vbb_1, vbb_2, vbb_3], min_version: "v0.4.0")).to eq(vbb_2.id)
+    end
+
+    it "fails if no backends meet min_version" do
+      vbb_1 = VhostBlockBackend.new_with_id(allocation_weight: 100, version: "v0.3.0")
+      expect { Al::StorageAllocation.allocate_vhost_block_backend([vbb_1], min_version: "v0.4.0") }.to raise_error "Total weight of all eligible vhost_block_backends shouldn't be zero."
+    end
   end
 end


### PR DESCRIPTION
### UMI: filter hosts by min vhost block backend version for UMI source VMs

When `track_written` is enabled, the VM must be allocated only on hosts with ubiblk version `v0.4.0` or later, since archiving support was introduced in `v0.4.0`.

### UMI: respect minimum version in allocate_vhost_block_backend() 

Some features (e.g., archiving) require a minimum ubiblk version. Update `allocate_vhost_block_backend()` to enforce the minimum eligible version when selecting backends installed on the host.