### PR TITLE
Add VNC console support for QEMU VMs

### DIFF
--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -52,6 +52,7 @@ class VmPath
     cloudinit.img
     ch-api.sock
     serial.log
+    vnc.sock
     hugepages
     public_ipv4
     nftables_conf

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -843,8 +843,8 @@ DNSMASQ_SERVICE
 
     serial_parts = [
       "-serial file:#{vp.serial_log}",
-      "-display none",
-      "-vga none"
+      "-vnc unix:#{vp.vnc_sock}",
+      "-vga std"
     ]
 
     kernel_parts = [


### PR DESCRIPTION
## Summary

- Enable VNC access for VMs running under the QEMU hypervisor by exposing a unix socket at `/vm/<name>/vnc.sock` instead of running headless with `-display none`
- Add `vnc.sock` to the VM path registry in `vm_path.rb`

## Motivation

Currently, QEMU VMs run with `-display none -vga none`, making it impossible to interact with the VM console. This is a problem for:

- **Debugging boot failures** — when a VM fails before SSH comes up, there's no way to see what's happening
- **Non-Linux guest OS images** — VMware ESXi, FreeBSD, Windows, and other operating systems that don't support cloud-init or SSH provisioning need graphical console access for initial setup
- **Self-hosted operators** — anyone running Ubicloud on-prem benefits from console access for troubleshooting

## Changes

| File | Change |
|------|--------|
| `rhizome/host/lib/vm_setup.rb` | Replace `-display none -vga none` with `-vnc unix:<socket> -vga std` in `build_qemu_service` |
| `rhizome/host/lib/vm_path.rb` | Add `vnc.sock` to VM path registry |

## Usage

After a QEMU VM boots, operators can bridge the VNC unix socket to TCP for remote access:

```bash
socat TCP-LISTEN:5900,reuseaddr,fork UNIX-CONNECT:/vm/<vmname>/vnc.sock
```

Then connect with any VNC client (TightVNC, UltraVNC, etc.).

## Test plan

- [ ] Verify QEMU VM starts with VNC socket at `/vm/<name>/vnc.sock`
- [ ] Verify VNC connection works via socat TCP bridge
- [ ] Verify no regression for Cloud Hypervisor VMs (unaffected, separate code path)
- [ ] Verify `-vga std` provides usable graphical output

Tested on a self-hosted Ubicloud deployment with ESXi 6.7 and Ubuntu Noble guests.