### PR TITLE
Add VMware ESXi/NSX image support for QEMU VMs

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -163,7 +163,7 @@ class Prog::Vm::Nexus < Prog::Base
           "gpu_count" => gpu_count,
           "gpu_device" => gpu_device,
           "hugepages" => hugepages,
-          "hypervisor" => hypervisor,
+          "hypervisor" => boot_image&.start_with?("vmware-") ? "qemu" : hypervisor,
           "ch_version" => ch_version,
           "firmware_version" => firmware_version,
           "alternative_families" => alternative_families,

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -52,6 +52,7 @@ class VmPath
     cloudinit.img
     ch-api.sock
     serial.log
+    vnc.sock
     hugepages
     public_ipv4
     nftables_conf

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -790,23 +790,39 @@ DNSMASQ_SERVICE
   end
 
   def build_qemu_service(header:, footer:, slice_name:, mem_gib:, max_vcpus:, cpu_topology:, storage_volumes:, storage_params:, nics:, pci_devices:)
-    disk_parts = storage_volumes.each_with_index.flat_map do |vol, i|
-      if vol.read_only
-        [
-          "-drive if=none,file=#{vol.image_path},format=raw,readonly=on,id=disk#{i}",
-          "-device virtio-blk-pci,drive=disk#{i},romfile="
-        ]
-      else
-        [
-          "-chardev socket,id=vhostblk#{i},path=#{vol.vhost_sock},server=off",
-          "-device vhost-user-blk-pci,chardev=vhostblk#{i},num-queues=#{vol.num_queues},queue-size=#{vol.queue_size},romfile="
+    vmware_mode = storage_params.any? { |p| p["image"]&.start_with?("vmware-") }
+
+    disk_parts = if vmware_mode
+      # VMware ESXi/NSX don't have virtio drivers — use AHCI/SATA
+      ahci = ["-device ahci,id=ahci0"]
+      storage_volumes.each_with_index do |vol, i|
+        ahci += [
+          "-drive if=none,file=#{vol.disk_file},format=raw,id=disk#{i}",
+          "-device ide-hd,drive=disk#{i},bus=ahci0.#{i}"
         ]
       end
+      ahci
+    else
+      storage_volumes.each_with_index.flat_map do |vol, i|
+        if vol.read_only
+          [
+            "-drive if=none,file=#{vol.image_path},format=raw,readonly=on,id=disk#{i}",
+            "-device virtio-blk-pci,drive=disk#{i},romfile="
+          ]
+        else
+          [
+            "-chardev socket,id=vhostblk#{i},path=#{vol.vhost_sock},server=off",
+            "-device vhost-user-blk-pci,chardev=vhostblk#{i},num-queues=#{vol.num_queues},queue-size=#{vol.queue_size},romfile="
+          ]
+        end
+      end
     end
-    disk_parts += [
-      "-drive if=none,file=#{vp.cloudinit_img},format=raw,readonly=on,id=cidrive",
-      "-device virtio-blk-pci,drive=cidrive,romfile="
-    ]
+    unless vmware_mode
+      disk_parts += [
+        "-drive if=none,file=#{vp.cloudinit_img},format=raw,readonly=on,id=cidrive",
+        "-device virtio-blk-pci,drive=cidrive,romfile="
+      ]
+    end
 
     mem_parts =
       if @hugepages
@@ -828,10 +844,17 @@ DNSMASQ_SERVICE
     ]
 
     net_parts = nics.each_with_index.flat_map { |nic, i|
-      [
-        "-netdev tap,id=net#{i},ifname=#{nic.tap},script=no,downscript=no,queues=#{max_vcpus * 2 + 1},vhost=on",
-        "-device virtio-net-pci,mac=#{nic.mac},netdev=net#{i},mq=on,romfile="
-      ]
+      if vmware_mode
+        [
+          "-netdev tap,id=net#{i},ifname=#{nic.tap},script=no,downscript=no,queues=1",
+          "-device e1000,mac=#{nic.mac},netdev=net#{i},romfile="
+        ]
+      else
+        [
+          "-netdev tap,id=net#{i},ifname=#{nic.tap},script=no,downscript=no,queues=#{max_vcpus * 2 + 1},vhost=on",
+          "-device virtio-net-pci,mac=#{nic.mac},netdev=net#{i},mq=on,romfile="
+        ]
+      end
     }
 
     pci_parts = pci_devices.map.with_index(1) do |(bdf), i|
@@ -843,8 +866,8 @@ DNSMASQ_SERVICE
 
     serial_parts = [
       "-serial file:#{vp.serial_log}",
-      "-display none",
-      "-vga none"
+      "-vnc unix:#{vp.vnc_sock}",
+      "-vga std"
     ]
 
     kernel_parts = [


### PR DESCRIPTION
## Summary

- Add VMware compatibility mode to QEMU service builder for running ESXi and NSX-V appliance images
- Auto-select QEMU hypervisor for `vmware-*` boot images
- Enable VNC console for all QEMU VMs

## Motivation

VMware ESXi and NSX-V are widely used in enterprise environments. Being able to run these as nested VMs on Ubicloud enables:

- **VMware lab environments** for testing, training, and certification prep
- **NSX-V to NSX-T migration testing** without dedicated hardware
- **vSphere cluster development** — ESXi VMs can be added to vCenter and run nested workloads

These images lack virtio drivers and require legacy device emulation that Cloud Hypervisor doesn't support, making QEMU the right hypervisor choice.

## Changes

| File | Change |
|------|--------|
| `rhizome/host/lib/vm_setup.rb` | Add `vmware_mode` to `build_qemu_service`: AHCI/IDE-HD for disks, e1000 for NICs, skip cloud-init disk, enable VNC console |
| `rhizome/host/lib/vm_path.rb` | Add `vnc.sock` to VM path registry |
| `prog/vm/nexus.rb` | Auto-select `hypervisor: "qemu"` for `vmware-*` boot images |

### VMware mode details

When a storage volume's image name starts with `vmware-`:
- **Disks**: AHCI controller + `ide-hd` devices (ESXi has no virtio-blk drivers)
- **Network**: `e1000` NIC with single-queue tap (ESXi 6.7 has no virtio-net drivers)
- **Cloud-init**: Skipped (VMware guests don't use it)
- **VNC**: Enabled via unix socket for console access

Non-VMware QEMU VMs are unaffected — they continue using virtio devices.

## Test plan

- [x] ESXi 6.7 boots via UEFI on AHCI disk
- [x] ESXi gets DHCP address via e1000 NIC
- [x] vSphere Web Client accessible via HTTPS
- [x] ESXi added to vCenter successfully
- [x] Nested VM (CentOS 8) runs inside ESXi
- [x] VNC console accessible via socat bridge
- [x] NSX-V 6.4.6 image boots (BIOS mode via OVMF CSM)
- [ ] Verify no regression for standard Linux QEMU VMs
- [ ] Verify no regression for Cloud Hypervisor VMs

Tested on a self-hosted Ubicloud deployment on Hetzner dedicated server.