### PR TITLE
Optimize AWS runner firewall rule calls

### DIFF
--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -241,13 +241,12 @@ class Prog::Vm::Aws::Nexus < Prog::Base
   end
 
   label def wait_sshable
-    unless vm.update_firewall_rules_set?
-      vm.incr_update_firewall_rules
-      # This is the first time we get into this state and we know that
-      # wait_sshable will take definitely more than 6 seconds. So, we nap here
-      # to reduce the amount of load on the control plane unnecessarily.
-      nap 6
-    end
+    vm.incr_update_firewall_rules unless is_runner? || vm.update_firewall_rules_set?
+
+    # On the first visit, wait_sshable will take definitely more than 6 seconds.
+    # Nap the remaining time to reduce unnecessary load on the control plane.
+    remaining = vm.allocated_at - Time.now + 6
+    nap remaining if remaining > 0
     addr = vm.ip4
     hop_create_billing_record unless addr
 

--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -43,16 +43,27 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
 
     private_subnet_aws_resource.update(security_group_id: security_group_response.group_id)
 
-    ssh_covered = false
+    ssh_covered_ip4 = false
+    ssh_covered_ip6 = false
     private_subnet.firewalls(eager: :firewall_rules).flat_map(&:firewall_rules).each do |firewall_rule|
-      next if firewall_rule.ip6?
-      ssh_covered = true if firewall_rule.port_range.first == 22 && firewall_rule.port_range.last - 1 == 22 && firewall_rule.cidr.to_s == "0.0.0.0/0"
-      allow_ingress(security_group_response.group_id, firewall_rule.port_range.first, firewall_rule.port_range.last - 1, firewall_rule.cidr.to_s)
+      first_port = firewall_rule.port_range.first
+      last_port = firewall_rule.port_range.last - 1
+      cidr = firewall_rule.cidr.to_s
+      if 22.between?(first_port, last_port)
+        case cidr
+        when "0.0.0.0/0"
+          ssh_covered_ip4 = true
+        when "::/0"
+          ssh_covered_ip6 = true
+        end
+      end
+      allow_ingress(security_group_response.group_id, first_port, last_port, cidr, firewall_rule.ip6?)
     end
 
     # Allow SSH ingress from the internet so that the controlplane can verify
     # that the VM is running.
-    allow_ingress(security_group_response.group_id, 22, 22, "0.0.0.0/0") unless ssh_covered
+    allow_ingress(security_group_response.group_id, 22, 22, "0.0.0.0/0", false) unless ssh_covered_ip4
+    allow_ingress(security_group_response.group_id, 22, 22, "::/0", true) unless ssh_covered_ip6
     hop_create_route_table
 
   end
@@ -253,16 +264,18 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
     @client ||= location.location_credential.client
   end
 
-  def allow_ingress(group_id, from_port, to_port, cidr)
-    client.authorize_security_group_ingress({
-      group_id:,
-      ip_permissions: [{
-        ip_protocol: "tcp",
-        from_port:,
-        to_port:,
-        ip_ranges: [{cidr_ip: cidr}],
-      }],
-    })
+  def allow_ingress(group_id, from_port, to_port, cidr, ip6)
+    perm = {
+      ip_protocol: "tcp",
+      from_port:,
+      to_port:,
+    }
+    if ip6
+      perm[:ipv_6_ranges] = [{cidr_ipv_6: cidr}]
+    else
+      perm[:ip_ranges] = [{cidr_ip: cidr}]
+    end
+    client.authorize_security_group_ingress({group_id:, ip_permissions: [perm]})
   rescue Aws::EC2::Errors::InvalidPermissionDuplicate
   end
 

--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -277,6 +277,7 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
     end
     client.authorize_security_group_ingress({group_id:, ip_permissions: [perm]})
   rescue Aws::EC2::Errors::InvalidPermissionDuplicate
+    nil
   end
 
   def private_subnet_aws_resource

--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -43,14 +43,16 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
 
     private_subnet_aws_resource.update(security_group_id: security_group_response.group_id)
 
+    ssh_covered = false
     private_subnet.firewalls(eager: :firewall_rules).flat_map(&:firewall_rules).each do |firewall_rule|
       next if firewall_rule.ip6?
+      ssh_covered = true if firewall_rule.port_range.first == 22 && firewall_rule.port_range.last - 1 == 22 && firewall_rule.cidr.to_s == "0.0.0.0/0"
       allow_ingress(security_group_response.group_id, firewall_rule.port_range.first, firewall_rule.port_range.last - 1, firewall_rule.cidr.to_s)
     end
 
     # Allow SSH ingress from the internet so that the controlplane can verify
     # that the VM is running.
-    allow_ingress(security_group_response.group_id, 22, 22, "0.0.0.0/0")
+    allow_ingress(security_group_response.group_id, 22, 22, "0.0.0.0/0") unless ssh_covered
     hop_create_route_table
 
   end

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -664,26 +664,35 @@ usermod -L ubuntu
   end
 
   describe "#wait_sshable" do
-    it "naps 6 seconds if it's the first time we execute wait_sshable" do
-      expect { nx.wait_sshable }.to nap(6)
+    it "naps and increments update_firewall_rules on first run" do
+      vm.update(allocated_at: Time.now)
+      expect { nx.wait_sshable }.to nap
         .and change { vm.reload.update_firewall_rules_set? }.from(false).to(true)
+    end
+
+    it "does not increment update_firewall_rules for runner vms" do
+      vm.update(allocated_at: Time.now, unix_user: "runneradmin")
+      expect { nx.wait_sshable }.to nap
+      expect(vm.reload.update_firewall_rules_set?).to be false
     end
 
     it "naps if not sshable" do
       AssignedVmAddress.create(dst_vm_id: vm.id, ip: "10.0.0.1/32")
-      vm.incr_update_firewall_rules
+      vm.update(allocated_at: Time.now - 10)
       expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1).and_raise Errno::ECONNREFUSED
       expect { nx.wait_sshable }.to nap(1)
     end
 
     it "hops to create_billing_record if sshable" do
       AssignedVmAddress.create(dst_vm_id: vm.id, ip: "10.0.0.1/32")
+      vm.update(allocated_at: Time.now - 10)
       vm.incr_update_firewall_rules
       expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1)
       expect { nx.wait_sshable }.to hop("create_billing_record")
     end
 
     it "skips a check if ipv4 is not enabled" do
+      vm.update(allocated_at: Time.now - 10)
       vm.incr_update_firewall_rules
       expect(vm.ip4).to be_nil
       expect { nx.wait_sshable }.to hop("create_billing_record")

--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
       expect { nx.wait_vpc_created }.to hop("create_route_table")
     end
 
+    it "skips explicit SSH ingress when a firewall rule already allows port 22 from 0.0.0.0/0" do
+      client.stub_responses(:describe_vpcs, vpcs: [{state: "available", vpc_id: "vpc-0123456789abcdefg"}])
+      FirewallRule.create(firewall_id: ps.firewalls.first.id, cidr: "0.0.0.0/0", port_range: 22..22)
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-0123456789abcdefg", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "0.0.0.0/0"}]}]}).once.and_call_original
+      expect { nx.wait_vpc_created }.to hop("create_route_table")
+    end
+
     it "does not create a security group if it already exists" do
       client.stub_responses(:describe_vpcs, vpcs: [{state: "available", vpc_id: "vpc-0123456789abcdefg"}])
       client.stub_responses(:create_security_group, Aws::EC2::Errors::InvalidGroupDuplicate.new(nil, nil))

--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -65,20 +65,25 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
       expect { nx.wait_vpc_created }.to nap(1)
     end
 
-    it "creates a security group and authorizes ingress" do
+    it "creates a security group and authorizes ingress for IPv4 and IPv6 rules" do
       client.stub_responses(:describe_vpcs, vpcs: [{state: "available", vpc_id: "vpc-0123456789abcdefg"}])
       expect(client).to receive(:describe_vpcs).with({filters: [{name: "vpc-id", values: ["vpc-0123456789abcdefg"]}]}).and_call_original
       expect(client).to receive(:create_security_group).with({group_name: "aws-us-west-2-#{ps.ubid}", description: "Security group for aws-us-west-2-#{ps.ubid}", vpc_id: "vpc-0123456789abcdefg", tag_specifications: Util.aws_tag_specifications("security-group", ps.name)}).and_call_original
-      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-0123456789abcdefg", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 80, ip_ranges: [{cidr_ip: "0.0.0.1/32"}]}]}).and_call_original
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-0123456789abcdefg", ip_permissions: [{ip_protocol: "tcp", from_port: 80, to_port: 80, ip_ranges: [{cidr_ip: "0.0.0.1/32"}]}]}).and_call_original
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-0123456789abcdefg", ip_permissions: [{ip_protocol: "tcp", from_port: 80, to_port: 80, ipv_6_ranges: [{cidr_ipv_6: "::/32"}]}]}).and_call_original
       expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-0123456789abcdefg", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "0.0.0.0/0"}]}]}).and_call_original
-      FirewallRule.create(firewall_id: ps.firewalls.first.id, cidr: "0.0.0.1/32", port_range: 22..80)
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-0123456789abcdefg", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ipv_6_ranges: [{cidr_ipv_6: "::/0"}]}]}).and_call_original
+      FirewallRule.create(firewall_id: ps.firewalls.first.id, cidr: "0.0.0.1/32", port_range: 80..80)
+      FirewallRule.create(firewall_id: ps.firewalls.first.id, cidr: "::/32", port_range: 80..80)
       expect { nx.wait_vpc_created }.to hop("create_route_table")
     end
 
-    it "skips explicit SSH ingress when a firewall rule already allows port 22 from 0.0.0.0/0" do
+    it "skips explicit SSH ingress when firewall rules already allow port 22 from 0.0.0.0/0 and ::/0" do
       client.stub_responses(:describe_vpcs, vpcs: [{state: "available", vpc_id: "vpc-0123456789abcdefg"}])
       FirewallRule.create(firewall_id: ps.firewalls.first.id, cidr: "0.0.0.0/0", port_range: 22..22)
+      FirewallRule.create(firewall_id: ps.firewalls.first.id, cidr: "::/0", port_range: 22..22)
       expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-0123456789abcdefg", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "0.0.0.0/0"}]}]}).once.and_call_original
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-0123456789abcdefg", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ipv_6_ranges: [{cidr_ipv_6: "::/0"}]}]}).once.and_call_original
       expect { nx.wait_vpc_created }.to hop("create_route_table")
     end
 
@@ -93,7 +98,8 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
 
     it "skips security group ingress rule if it already exists" do
       client.stub_responses(:describe_vpcs, vpcs: [{state: "available", vpc_id: "vpc-0123456789abcdefg"}])
-      client.stub_responses(:authorize_security_group_ingress, Aws::EC2::Errors::InvalidPermissionDuplicate.new(nil, nil), Aws::EC2::Errors::InvalidPermissionDuplicate.new(nil, nil))
+      dup = Aws::EC2::Errors::InvalidPermissionDuplicate.new(nil, nil)
+      client.stub_responses(:authorize_security_group_ingress, dup, dup, dup)
       FirewallRule.create(firewall_id: ps.firewalls.first.id, cidr: "0.0.0.1/32", port_range: 22..80)
       expect { nx.wait_vpc_created }.to hop("create_route_table")
     end


### PR DESCRIPTION
- **Skip duplicate SSH ingress call in AWS VPC setup**
  When firewall rules already include port 22 from 0.0.0.0/0,
  the explicit SSH allow_ingress call is redundant and causes
  an unnecessary authorize_security_group_ingress API call.
  
  

- **Apply IPv6 firewall rules in AWS VPC setup**
  Previously, IPv6 firewall rules were skipped in wait_vpc_created.
  Now both IPv4 and IPv6 rules are applied, and SSH ingress is
  added for both protocols unless already covered by firewall rules.
  
  

- **Skip firewall rules update for runner VMs in wait_sshable**
  Runner VMs don't need firewall rule updates. Use allocated_at to
  determine the initial nap duration so the optimization is preserved
  for all VMs.
  
  