### PR TITLE
Fix race condition in repartitioner stale partition test

### DIFF
--- a/spec/lib/repartitioner_spec.rb
+++ b/spec/lib/repartitioner_spec.rb
@@ -114,6 +114,10 @@ RSpec.describe Repartitioner do
       t.join(1)
       expect(t.value).to be true
 
+      # Wait for partition 2 notification to be received by listen loop
+      deadline = Time.now + 1
+      sleep 0.01 until mp.instance_variable_get(:@partition_times)[2] || Time.now > deadline
+
       expect(mp).to receive(:repartition).with(2).and_call_original
       mp.instance_variable_get(:@partition_times)[3] = Time.now - 60
       expect(repartition_2q.pop(timeout: 1)).to be true


### PR DESCRIPTION
The test was not waiting for partition 2's notification to be received by the listen loop before making partition 3 stale. This caused the recheck to find only partition 1 in @partition_times, calling repartition(1) instead of the expected repartition(2).

This caused intermittent failures with:

```
  1) Repartitioner#listen repartitions when an existing partition goes
stale
     Failure/Error: Unable to find matching line from backtrace

       expected true
            got nil

<Repartitioner ...> received :repartition with unexpected arguments
         expected: (2)
              got: (1)
```