### PR TITLE
Add custom RSpec `push` matcher for cleaner prog push assertions

### DIFF
--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -141,11 +141,7 @@ RSpec.describe Prog::Vm::HostNexus do
 
   describe "#bootstrap_rhizome" do
     it "pushes a bootstrap rhizome process" do
-      expect { nx.bootstrap_rhizome }.to raise_error(Prog::Base::Hop) { |hop|
-        expect(hop.new_label).to eq("start")
-        expect(hop.new_prog).to eq("BootstrapRhizome")
-        expect(hop.strand_update_args[:stack].first).to include("target_folder" => "host")
-      }
+      expect { nx.bootstrap_rhizome }.to push("BootstrapRhizome").with("target_folder" => "host")
     end
 
     it "hops once BootstrapRhizome has returned" do
@@ -240,11 +236,7 @@ RSpec.describe Prog::Vm::HostNexus do
   describe "#setup_storage_backend" do
     it "pushes the vhost_block_backend program by default" do
       vm_host.update(arch: "x64")
-      expect { nx.setup_storage_backend }.to raise_error(Prog::Base::Hop) { |hop|
-        expect(hop.new_label).to eq("start")
-        expect(hop.new_prog).to eq("Storage::SetupVhostBlockBackend")
-        expect(hop.strand_update_args[:stack].first).to include("allocation_weight" => 100)
-      }
+      expect { nx.setup_storage_backend }.to push("Storage::SetupVhostBlockBackend").with("allocation_weight" => 100)
     end
 
     it "hops once SetupVhostBlockBackend has returned" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -195,6 +195,30 @@ RSpec.configure do |config|
     end
   end
 
+  # Custom matcher to expect Progs to push a new prog
+  RSpec::Matchers.define :push do |expected_prog, expected_label = "start"|
+    supports_block_expectations
+
+    chain :with do |expected_frame|
+      @expected_frame = expected_frame
+    end
+
+    match do |block|
+      block.call
+      false
+    rescue Prog::Base::Hop => hop
+      @hop = hop
+      hop.new_prog == expected_prog &&
+        hop.new_label == expected_label &&
+        (!@expected_frame || hop.strand_update_args[:stack].first >= @expected_frame)
+    end
+
+    failure_message do
+      "expected: hop #{expected_prog}##{expected_label}\n" \
+        "     got: #{@hop || "not hopped"}"
+    end
+  end
+
   # Custom matcher to expect Progs to exit
   # If expected_exitval is not provided, it expects to exit with any value.
   RSpec::Matchers.define :exit do |expected_exitval|


### PR DESCRIPTION
Replaces verbose `raise_error(Prog::Base::Hop)` blocks with a concise `push("ProgName").with(frame_key: value)` syntax, consistent with the existing `hop` and `exit` matchers.