### PR TITLE
Expose k8s upgrade in UI/CLI

### DIFF
--- a/cli-commands/kc/post/upgrade.rb
+++ b/cli-commands/kc/post/upgrade.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+UbiCli.on("kc").run_on("upgrade") do
+  desc "Upgrade a Kubernetes cluster to the next supported version"
+
+  banner "ubi kc (location/kc-name | kc-id) upgrade"
+
+  run do |opts, cmd|
+    data = sdk_object.upgrade
+    response("Scheduled version upgrade of Kubneretes cluster with id #{data.id} to version #{data.version}.")
+  end
+end

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -5,4 +5,4 @@
 - { name: postgres_ha,               images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_upgrade,          images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_firewall,         images: ["postgres-ubuntu-2204"] }
-- { name: kubernetes,                images: ["kubernetes-v1_35"]}
+- { name: kubernetes,                images: ["kubernetes-v1_34", "kubernetes-v1_35"]}

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -27,6 +27,13 @@ module Option
     MACHINE_IMAGE_SEARCH_LOCATIONS.fetch(location_id, [location_id])
   end
 
+  def self.kubernetes_upgrade_candidate(version)
+    {
+      "v1.33" => "v1.34",
+      "v1.34" => "v1.35",
+    }.freeze[version]
+  end
+
   def self.families
     Option::VmFamilies.select { it.visible }
   end

--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -119,6 +119,10 @@ class KubernetesCluster < Sequel::Model
     kubeadm_recorded_version&.[](/^v\d+\.\d+/)
   end
 
+  def available_upgrade_version
+    Option.kubernetes_upgrade_candidate(version)
+  end
+
   def cluster_health_report
     return unless connectivity_check_target
 

--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -32,6 +32,7 @@ class KubernetesCluster < Sequel::Model
   def display_state
     label = strand.label
     return "deleting" if destroying_set? || destroy_set?
+    return "upgrading" if upgrading?
     return "running" if label == "wait"
 
     "creating"
@@ -194,6 +195,20 @@ class KubernetesCluster < Sequel::Model
 
   def worker_functional_nodes
     nodepools.flat_map(&:functional_nodes)
+  end
+
+  def ready_for_upgrade?
+    !upgrading? && available_upgrade_version && strand.label == "wait" \
+    && !nodepools.empty? && nodepools.first.strand.label == "wait"
+  end
+
+  def upgrading?
+    upgrade_labels = %w[upgrade wait_upgrade].freeze
+    return true if upgrade_labels.include?(strand.label) || upgrade_set?
+
+    return false if nodepools.empty?
+    nodepool = nodepools.first
+    upgrade_labels.include?(nodepool.strand.label) || nodepool.upgrade_set?
   end
 end
 

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -738,6 +738,21 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Kubernetes Cluster
+  /project/{project_id}/location/{location}/kubernetes-cluster/{kubernetes_cluster_reference}/upgrade:
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/kubernetes_cluster_reference'
+    post:
+      operationId: upgradeKubernetesCluster
+      summary: Upgrade a kubernetes cluster
+      responses:
+        '200':
+          $ref: '#/components/responses/KubernetesCluster'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Kubernetes Cluster
   /project/{project_id}/location/{location}/load-balancer:
     get:
       operationId: listLocationLoadBalancers

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -254,9 +254,17 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     node_to_upgrade = kubernetes_cluster.nodes.find do |node|
       node_version = kubernetes_cluster.client(session: node.sshable.connect).version
       node_minor_version = node_version.match(/^v\d+\.(\d+)$/)&.captures&.first&.to_i
-      cluster_minor_version = kubernetes_cluster.version.match(/^v\d+\.(\d+)$/)&.captures&.first&.to_i
+      cluster_minor_version = kubernetes_cluster.version.match(/^v\d+\.(\d+)$/).captures.first.to_i
 
-      next false unless node_minor_version && cluster_minor_version
+      unless node_minor_version
+        Prog::PageNexus.assemble(
+          "Invalid version format for #{node.name} of cluster #{kubernetes_cluster.ubid}",
+          ["K8sInvalidVersion", kubernetes_cluster.ubid, node.name],
+          [kubernetes_cluster.ubid, node.ubid],
+          extra_data: {node_version:, cluster_version: kubernetes_cluster.version},
+        )
+        next false
+      end
 
       node_minor_version == cluster_minor_version - 1
     end

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -3,6 +3,10 @@
 class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
   subject_is :kubernetes_nodepool
 
+  def cluster
+    @cluster ||= kubernetes_nodepool.cluster
+  end
+
   def self.assemble(name:, node_count:, kubernetes_cluster_id:, target_node_size: "standard-2", target_node_storage_size_gib: nil)
     DB.transaction do
       unless KubernetesCluster[kubernetes_cluster_id]
@@ -61,12 +65,22 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
   label def upgrade
     decr_upgrade
 
+    nap 10 if %w[upgrade wait_upgrade].freeze.include?(cluster.strand.label) || cluster.upgrade_set?
+
     node_to_upgrade = kubernetes_nodepool.nodes.find do |node|
       node_version = kubernetes_nodepool.cluster.client(session: node.sshable.connect).version
       node_minor_version = node_version.match(/^v\d+\.(\d+)$/)&.captures&.first&.to_i
-      cluster_minor_version = kubernetes_nodepool.cluster.version.match(/^v\d+\.(\d+)$/)&.captures&.first&.to_i
+      cluster_minor_version = kubernetes_nodepool.cluster.version.match(/^v\d+\.(\d+)$/).captures.first.to_i
 
-      next false unless node_minor_version && cluster_minor_version
+      unless node_minor_version
+        Prog::PageNexus.assemble(
+          "Invalid version format for #{node.name} of cluster #{kubernetes_nodepool.cluster.ubid}",
+          ["K8sInvalidVersion", kubernetes_nodepool.cluster.ubid, node.name],
+          [kubernetes_nodepool.cluster.ubid, node.ubid],
+          extra_data: {node_version:, cluster_version: kubernetes_nodepool.cluster.version},
+        )
+        next false
+      end
 
       node_minor_version == cluster_minor_version - 1
     end

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -25,7 +25,7 @@ class Prog::Test::Kubernetes < Prog::Test::Base
       name: "kubernetes-test-standard",
       project_id: frame["kubernetes_test_project_id"],
       location_id: Location::HETZNER_FSN1_ID,
-      version: Option.kubernetes_versions.first,
+      version: Option.kubernetes_versions[1],
       cp_node_count: 1,
     ).subject
     Prog::Kubernetes::KubernetesNodepoolNexus.assemble(
@@ -141,7 +141,7 @@ STS
       kubernetes_cluster.sshable.d_run(
         unit_name,
         "bash", "-c",
-        "sudo kubectl --kubeconfig /etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c \"head -c 500M /dev/urandom | tee /etc/data/random-data-#{i} | sha256sum | awk '{print \\$1}'\" > /dev/shm/#{unit_name}.hash",
+        "sudo kubectl --kubeconfig /etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c \"head -c 300M /dev/urandom | tee /etc/data/random-data-#{i} | sha256sum | awk '{print \\$1}'\" > /dev/shm/#{unit_name}.hash",
       )
     end
     hop_wait_data_write
@@ -350,6 +350,49 @@ STS
     if pod_access_rules != frame["pod_access_rules_before_reboot"]
       update_stack({"fail_message" => "ip6 pod_access rules changed after reboot"})
     end
+    hop_test_upgrade
+  end
+
+  label def test_upgrade
+    upgrade_candidate = kubernetes_cluster.available_upgrade_version
+    unless upgrade_candidate
+      update_stack({"fail_message" => "No upgrade candidate available"})
+      hop_destroy_kubernetes
+    end
+
+    kubernetes_cluster.update(version: upgrade_candidate)
+    kubernetes_cluster.incr_upgrade
+    nodepool.incr_upgrade
+
+    Clog.emit("waiting for k8s cluster upgrade to #{upgrade_candidate}")
+    hop_wait_for_upgrade
+  end
+
+  label def wait_for_upgrade
+    unless kubernetes_cluster.display_state == "running"
+      kubernetes_cluster.all_nodes.each do |node|
+        unless node_host_entries_set?(node.name)
+          if vm_ready?(node.vm)
+            ensure_hosts_entry(node.sshable, kubernetes_cluster.api_server_lb.hostname)
+            set_node_entries_status(node.name)
+          end
+        end
+      end
+      nap 15
+    end
+
+    nodes = JSON.parse(kubernetes_cluster.client.kubectl("get nodes -o json"))["items"]
+    unless nodes.size == 3 && nodes.all? { |n| n.dig("status", "nodeInfo", "kubeletVersion").start_with?("#{kubernetes_cluster.version}.") }
+      update_stack({"fail_message" => "Not all #{nodes.size} nodes upgraded to #{kubernetes_cluster.version}:\n#{kubernetes_cluster.client.kubectl("get nodes")}"})
+      hop_destroy_kubernetes
+    end
+
+    hop_verify_data_after_upgrade
+  end
+
+  label def verify_data_after_upgrade
+    nap 5 unless pod_status == "Running"
+    verify_data_hashes("upgrade")
     hop_destroy_kubernetes
   end
 

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -42,23 +42,18 @@ class Prog::Test::Kubernetes < Prog::Test::Base
   label def update_loadbalancer_hostname
     nap 5 unless kubernetes_cluster.api_server_lb
     kubernetes_cluster.api_server_lb.update(custom_hostname: "k8s-e2e-test.ubicloud.test")
-    hop_update_all_nodes_hosts_entries
+    hop_update_all_nodes_dns_records
   end
 
-  label def update_all_nodes_hosts_entries
+  label def update_all_nodes_dns_records
     expected_node_count = kubernetes_cluster.cp_node_count + nodepool.node_count
-    current_nodes = kubernetes_cluster.nodes + nodepool.nodes
-    current_node_count = current_nodes.count
 
-    current_nodes.each { |node|
-      unless node_host_entries_set?(node.name)
-        nap 5 unless vm_ready?(node.vm)
-        ensure_hosts_entry(node.sshable, kubernetes_cluster.api_server_lb.hostname)
-        set_node_entries_status(node.name)
-      end
+    kubernetes_cluster.all_nodes.each { |node|
+      nap 5 unless node.vm.vm_host
+      ensure_dns_record(node.vm, kubernetes_cluster.api_server_lb.hostname)
     }
 
-    hop_wait_for_kubernetes_bootstrap if current_node_count == expected_node_count
+    hop_wait_for_kubernetes_bootstrap if kubernetes_cluster.all_nodes.count == expected_node_count
     nap 10
   end
 
@@ -371,12 +366,7 @@ STS
   label def wait_for_upgrade
     unless kubernetes_cluster.display_state == "running"
       kubernetes_cluster.all_nodes.each do |node|
-        unless node_host_entries_set?(node.name)
-          if vm_ready?(node.vm)
-            ensure_hosts_entry(node.sshable, kubernetes_cluster.api_server_lb.hostname)
-            set_node_entries_status(node.name)
-          end
-        end
+        ensure_dns_record(node.vm, kubernetes_cluster.api_server_lb.hostname) if node.vm.vm_host
       end
       nap 15
     end
@@ -414,12 +404,22 @@ STS
     nap 15
   end
 
-  def ensure_hosts_entry(sshable, api_hostname)
-    host_line = "#{kubernetes_cluster.sshable.host} #{api_hostname}"
-    output = sshable.cmd("cat /etc/hosts")
-    unless output.include?(host_line)
-      sshable.cmd("echo :host_line | sudo tee -a /etc/hosts > /dev/null", host_line:)
-    end
+  def ensure_dns_record(vm, api_hostname)
+    host_sshable = vm.vm_host.sshable
+    inhost_name = vm.inhost_name
+    dnsmasq_conf = "/vm/#{inhost_name}/dnsmasq.conf"
+    api_ip = kubernetes_cluster.sshable.host
+    address_line = "address=/#{api_hostname}/#{api_ip}"
+
+    conf = host_sshable.cmd("sudo cat :dnsmasq_conf", dnsmasq_conf:)
+    return if conf.include?(address_line)
+
+    host_sshable.cmd(<<~SH, dnsmasq_conf:, address_line:, service: "#{inhost_name}-dnsmasq")
+      set -ueo pipefail
+      sudo sed -i '/^address=/d' :dnsmasq_conf
+      echo :address_line | sudo tee -a :dnsmasq_conf > /dev/null
+      sudo systemctl restart :service
+    SH
   end
 
   def vm_ready?(vm)
@@ -441,17 +441,6 @@ STS
 
   def nodepool
     kubernetes_cluster.nodepools.first
-  end
-
-  def node_host_entries_set?(node_name)
-    strand.stack.first.dig("nodes_status", node_name) == true
-  end
-
-  def set_node_entries_status(node_name)
-    frame = strand.stack.first
-    frame["nodes_status"] ||= {}
-    frame["nodes_status"][node_name] = true
-    update_stack(frame)
   end
 
   def migration_number

--- a/rhizome/kubernetes/bin/join-node
+++ b/rhizome/kubernetes/bin/join-node
@@ -51,18 +51,6 @@ if is_control_plane
       "advertiseAddress" => node_ipv4,
       "bindPort" => 6443,
     },
-    "apiServer" => {
-      "extraArgs" => [
-        {
-          "name" => "bind-address",
-          "value" => "::",
-        },
-        {
-          "name" => "advertise-address",
-          "value" => node_ipv4,
-        },
-      ],
-    },
   }
 end
 

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -101,6 +101,28 @@ class Clover
           r.redirect kc
         end
       end
+
+      r.post "upgrade" do
+        authorize("KubernetesCluster:edit", kc)
+        upgrade_candidate = kc.available_upgrade_version
+        if upgrade_candidate
+          DB.transaction do
+            kc.update(version: upgrade_candidate)
+            kc.incr_upgrade
+            kc.nodepools.first.incr_upgrade
+            audit_log(kc, "upgrade")
+          end
+        else
+          raise CloverError.new(422, "UnprocessableContent", "There is no available upgrade option")
+        end
+
+        if api?
+          Serializers::KubernetesCluster.serialize(kc, {detailed: true})
+        else
+          flash["notice"] = "#{kc.name} will be upgraded to #{upgrade_candidate}"
+          r.redirect kc
+        end
+      end
     end
   end
 end

--- a/sdk/ruby/lib/ubicloud/model/kubernetes_cluster.rb
+++ b/sdk/ruby/lib/ubicloud/model/kubernetes_cluster.rb
@@ -6,7 +6,7 @@ module Ubicloud
 
     set_fragment "kubernetes-cluster"
 
-    set_columns :id, :name, :state, :location
+    set_columns :id, :name, :state, :location, :version
 
     # Return string with the contents of kubeconfig.yaml for the Kubernetes cluster.
     def kubeconfig
@@ -15,6 +15,11 @@ module Ubicloud
 
     def resize_nodepool(nodepool_ref, node_count)
       adapter.post(_path("/nodepool/#{nodepool_ref}/resize"), {node_count:})
+    end
+
+    # Upgrade the Kubernetes cluster to the latest available version.
+    def upgrade
+      merge_into_values(adapter.post(_path("/upgrade")))
     end
   end
 end

--- a/spec/lib/option_spec.rb
+++ b/spec/lib/option_spec.rb
@@ -62,4 +62,15 @@ RSpec.describe Option do
       expect(Option::POSTGRES_SIZE_OPTIONS["c4a-highmem-8"].memory_gib).to eq(64)
     end
   end
+
+  describe "#kubernetes_upgrade_candidate" do
+    it "returns upgrade version for upgradeable version" do
+      expect(described_class.kubernetes_upgrade_candidate("v1.33")).to eq("v1.34")
+      expect(described_class.kubernetes_upgrade_candidate("v1.34")).to eq("v1.35")
+    end
+
+    it "returns nil for latest version" do
+      expect(described_class.kubernetes_upgrade_candidate("v1.31")).to be_nil
+    end
+  end
 end

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -31,10 +31,49 @@ RSpec.describe KubernetesCluster do
   end
 
   it "#display_state shows appropriate state" do
+    np = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np", node_count: 1, kubernetes_cluster_id: kc.id).subject
+
     kc.strand.update(label: "wait")
+    np.strand.update(label: "wait")
+    kc.reload
     expect(kc.display_state).to eq "running"
+
     kc.strand.update(label: "start")
+    kc.reload
     expect(kc.display_state).to eq "creating"
+
+    kc.strand.update(label: "upgrade")
+    np.strand.update(label: "wait")
+    kc.reload
+    expect(kc.display_state).to eq "upgrading"
+
+    kc.strand.update(label: "wait_upgrade")
+    kc.reload
+    expect(kc.display_state).to eq "upgrading"
+
+    kc.strand.update(label: "wait")
+    np.strand.update(label: "upgrade")
+    kc.reload
+    np.reload
+    expect(kc.display_state).to eq "upgrading"
+
+    np.strand.update(label: "wait_upgrade")
+    kc.reload
+    np.reload
+    expect(kc.display_state).to eq "upgrading"
+
+    np.strand.update(label: "wait")
+    kc.incr_upgrade
+    kc.reload
+    expect(kc.display_state).to eq "upgrading"
+    Semaphore.where(strand_id: kc.id, name: "upgrade").destroy
+
+    np.incr_upgrade
+    kc.reload
+    np.reload
+    expect(kc.display_state).to eq "upgrading"
+    Semaphore.where(strand_id: np.id, name: "upgrade").destroy
+
     kc.incr_destroy
     kc.reload
     expect(kc.display_state).to eq "deleting"
@@ -68,6 +107,12 @@ RSpec.describe KubernetesCluster do
       expect(kc).to receive(:kubeadm_recorded_version).and_return(nil)
       expect(kc.kubeadm_recorded_minor_version).to be_nil
     end
+  end
+
+  it "#display_state shows appropriate state when nodepool is deleted" do
+    kc.strand.update(label: "wait")
+    expect(kc.nodepools).to be_empty
+    expect(kc.display_state).to eq "running"
   end
 
   describe "#available_upgrade_version" do

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe KubernetesCluster do
     end
   end
 
+  describe "#available_upgrade_version" do
+    it "returns upgrade version when available" do
+      kc.update(version: Option.kubernetes_versions[1])
+      expect(kc.available_upgrade_version).to eq(Option.kubernetes_versions.first)
+    end
+
+    it "returns nil when on latest version" do
+      expect(kc.available_upgrade_version).to be_nil
+    end
+  end
+
   it "initiates a new health monitor session" do
     sshable = Sshable.new
     expect(kc).to receive(:sshable).and_return(sshable)

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -567,12 +567,6 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(child.stack.first["old_node_id"]).to eq first_node.id
     end
 
-    it "hops to wait if cluster version is invalid" do
-      expect(kubernetes_cluster).to receive(:version).and_return("invalid").twice
-      expect(client).to receive(:version).and_return(older_version, older_version)
-      expect { nx.upgrade }.to hop("wait")
-    end
-
     it "does not select a node with a higher minor version than the cluster" do
       expect(client).to receive(:version).and_return(newer_version, cluster_version)
       expect { nx.upgrade }.to hop("wait")

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -3,13 +3,12 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
-  subject(:st) { Strand.new(id: "8148ebdf-66b8-8ed0-9c2f-8cfe93f5aa77") }
+  subject(:nx) { described_class.new(kn.strand) }
 
-  let(:nx) { described_class.new(st) }
   let(:project) { Project.create(name: "default") }
   let(:subnet) { PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id) }
   let(:kc) {
-    kc = KubernetesCluster.create(
+    kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "k8scluster",
       version: Option.kubernetes_versions.first,
       cp_node_count: 3,
@@ -17,7 +16,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       location_id: Location::HETZNER_FSN1_ID,
       project_id: project.id,
       target_node_size: "standard-2",
-    )
+    ).subject
 
     lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "somelb", health_check_endpoint: "/foo", project_id: project.id)
     LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 123, dst_port: 456)
@@ -27,7 +26,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
     kc.update(api_server_lb_id: lb.id)
   }
   let(:kn) {
-    kn = KubernetesNodepool.create(name: "k8stest-np", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2")
+    kn = described_class.assemble(name: "k8stest-np", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
     [create_vm, create_vm].each do |vm|
       KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
     end
@@ -35,6 +34,8 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
   }
 
   before do
+    prj = Project.create(name: "UbicloudKubernetesService")
+    allow(Config).to receive(:kubernetes_service_project_id).and_return(prj.id)
     allow(nx).to receive(:kubernetes_nodepool).and_return(kn)
   end
 
@@ -107,13 +108,13 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
 
   describe "#wait_worker_node" do
     it "hops back to bootstrap_worker_nodes if there are no sub-programs running" do
-      st.update(prog: "Kubernetes::KubernetesNodepoolNexus", label: "wait_worker_node", stack: [{}])
+      kn.strand.update(label: "wait_worker_node")
       expect { nx.wait_worker_node }.to hop("wait")
     end
 
     it "donates if there are sub-programs running" do
-      st.update(prog: "Kubernetes::KubernetesNodepoolNexus", label: "wait_worker_node", stack: [{}])
-      Strand.create(parent_id: st.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
+      kn.strand.update(label: "wait_worker_node")
+      Strand.create(parent_id: kn.strand.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", lease: Time.now + 10)
       expect { nx.wait_worker_node }.to nap(120)
     end
   end
@@ -140,84 +141,102 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
     let(:second_node) { kn.nodes[1] }
     let(:client) { instance_double(Kubernetes::Client) }
 
-    before do
-      sshable0, sshable1 = Sshable.new, instance_double(Sshable)
-      allow(first_node).to receive(:sshable).and_return(sshable0)
-      allow(second_node).to receive(:sshable).and_return(sshable1)
-      allow(sshable0).to receive(:connect)
-      allow(sshable1).to receive(:connect)
-
-      expect(kn.cluster).to receive(:client).and_return(client).at_least(:once)
+    it "naps when cluster strand is in upgrade label" do
+      kc.strand.update(label: "upgrade")
+      expect { nx.upgrade }.to nap(10)
     end
 
-    it "selects a node with minor version one less than the cluster's version" do
-      expect(kn.cluster).to receive(:version).and_return("v1.32").twice
-      expect(client).to receive(:version).and_return("v1.32", "v1.31")
-      expect(nx).to receive(:bud).with(Prog::Kubernetes::UpgradeKubernetesNode, {"nodepool_id" => kn.id, "old_node_id" => second_node.id, "subject_id" => kn.cluster.id})
-      expect { nx.upgrade }.to hop("wait_upgrade")
+    it "naps when cluster strand is in wait_upgrade label" do
+      kc.strand.update(label: "wait_upgrade")
+      expect { nx.upgrade }.to nap(10)
     end
 
-    it "hops to wait when all nodes are at the cluster's version" do
-      expect(kn.cluster).to receive(:version).and_return("v1.32").twice
-      expect(client).to receive(:version).and_return("v1.32", "v1.32")
-      expect { nx.upgrade }.to hop("wait")
+    it "naps when cluster upgrade semaphore is set" do
+      kc.strand.update(label: "wait")
+      kc.incr_upgrade
+      expect { nx.upgrade }.to nap(10)
     end
 
-    it "does not select a node with minor version more than one less than the cluster's version" do
-      expect(kn.cluster).to receive(:version).and_return("v1.32").twice
-      expect(client).to receive(:version).and_return("v1.30", "v1.32")
-      expect { nx.upgrade }.to hop("wait")
-    end
+    context "when cluster is not upgrading" do
+      before do
+        kc.strand.update(label: "wait")
+        sshable0, sshable1 = Sshable.new, instance_double(Sshable)
+        allow(first_node).to receive(:sshable).and_return(sshable0)
+        allow(second_node).to receive(:sshable).and_return(sshable1)
+        allow(sshable0).to receive(:connect)
+        allow(sshable1).to receive(:connect)
 
-    it "skips nodes with invalid version formats" do
-      expect(kn.cluster).to receive(:version).and_return("v1.32").twice
-      expect(client).to receive(:version).and_return("invalid", "v1.32")
-      expect { nx.upgrade }.to hop("wait")
-    end
+        expect(kn.cluster).to receive(:client).and_return(client).at_least(:once)
+      end
 
-    it "selects the first node that is one minor version behind" do
-      expect(kn.cluster).to receive(:version).and_return("v1.32")
-      expect(client).to receive(:version).and_return("v1.31")
-      expect(nx).to receive(:bud).with(Prog::Kubernetes::UpgradeKubernetesNode, {"nodepool_id" => kn.id, "old_node_id" => first_node.id, "subject_id" => kn.cluster.id})
-      expect { nx.upgrade }.to hop("wait_upgrade")
-    end
+      it "selects a node with minor version one less than the cluster's version" do
+        expect(client).to receive(:version).and_return(Option.kubernetes_versions.first, Option.kubernetes_versions[1])
+        expect { nx.upgrade }.to hop("wait_upgrade")
+        st = Strand[prog: "Kubernetes::UpgradeKubernetesNode"]
+        expect(st).not_to be_nil
+        expect(st.stack.first).to eq({"nodepool_id" => kn.id, "old_node_id" => second_node.id, "subject_id" => kn.cluster.id})
+      end
 
-    it "hops to wait if cluster version is invalid" do
-      expect(kn.cluster).to receive(:version).and_return("invalid").twice
-      expect(client).to receive(:version).and_return("v1.31", "v1.31")
-      expect { nx.upgrade }.to hop("wait")
-    end
+      it "hops to wait when all nodes are at the cluster's version" do
+        expect(client).to receive(:version).and_return(Option.kubernetes_versions.first, Option.kubernetes_versions.first)
+        expect { nx.upgrade }.to hop("wait")
+      end
 
-    it "does not select a node with a higher minor version than the cluster" do
-      expect(kn.cluster).to receive(:version).and_return("v1.32").twice
-      expect(client).to receive(:version).and_return("v1.33", "v1.32")
-      expect { nx.upgrade }.to hop("wait")
+      it "does not select a node with minor version more than one less than the cluster's version" do
+        expect(client).to receive(:version).and_return(Option.kubernetes_versions.last, Option.kubernetes_versions.first)
+        expect { nx.upgrade }.to hop("wait")
+      end
+
+      it "skips nodes with invalid version formats and creates a page" do
+        expect(client).to receive(:version).and_return("invalid", "invalid")
+        expect { nx.upgrade }.to hop("wait")
+
+        page = Page.from_tag_parts("K8sInvalidVersion", kc.ubid, first_node.name)
+        expect(page).not_to be_nil
+        expect(page.summary).to eq "Invalid version format for #{first_node.name} of cluster #{kc.ubid}"
+        expect(page.details["node_version"]).to eq "invalid"
+        expect(page.details["cluster_version"]).to eq Option.kubernetes_versions.first
+      end
+
+      it "selects the first node that is one minor version behind" do
+        expect(client).to receive(:version).and_return(Option.kubernetes_versions[1])
+        expect { nx.upgrade }.to hop("wait_upgrade")
+        st = Strand[prog: "Kubernetes::UpgradeKubernetesNode"]
+        expect(st).not_to be_nil
+        expect(st.stack.first).to eq({"nodepool_id" => kn.id, "old_node_id" => first_node.id, "subject_id" => kn.cluster.id})
+      end
+
+      it "does not select a node with a higher minor version than the cluster" do
+        kc.update(version: Option.kubernetes_versions[1])
+        expect(client).to receive(:version).and_return(Option.kubernetes_versions.first, Option.kubernetes_versions.first)
+        expect { nx.upgrade }.to hop("wait")
+      end
     end
   end
 
   describe "#wait_upgrade" do
     it "hops back to upgrade if there are no sub-programs running" do
-      st.update(prog: "Kubernetes::KubernetesNodepoolNexus", label: "wait_upgrade", stack: [{}])
+      kn.strand.update(label: "wait_upgrade")
       expect { nx.wait_upgrade }.to hop("upgrade")
     end
 
     it "donates if there are sub-programs running" do
-      st.update(prog: "Kubernetes::KubernetesNodepoolNexus", label: "wait_upgrade", stack: [{}])
-      Strand.create(parent_id: st.id, prog: "Kubernetes::UpgradeKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
+      kn.strand.update(label: "wait_upgrade")
+      Strand.create(parent_id: kn.strand.id, prog: "Kubernetes::UpgradeKubernetesNode", label: "start", lease: Time.now + 10)
       expect { nx.wait_upgrade }.to nap(120)
     end
   end
 
   describe "#destroy" do
     it "donates if there are sub-programs running (Provision...)" do
-      st.update(prog: "Kubernetes::KubernetesNodepoolNexus", label: "wait_upgrade", stack: [{}])
-      Strand.create(parent_id: st.id, prog: "Kubernetes::UpgradeKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
+      kn.strand.update(label: "wait_upgrade")
+      Strand.create(parent_id: kn.strand.id, prog: "Kubernetes::UpgradeKubernetesNode", label: "start", lease: Time.now + 10)
       expect { nx.destroy }.to nap(120)
     end
 
     it "completes destroy when nodes are gone" do
       KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kn.cluster.id, kubernetes_nodepool_id: kn.id)
-      st.update(prog: "Kubernetes::KubernetesNodepoolNexus", label: "destroy", stack: [{}])
+      kn.strand.update(label: "destroy")
       expect(kn.nodes).to all(receive(:incr_destroy))
 
       expect { nx.destroy }.to nap(5)

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Prog::Test::Kubernetes do
       cp_node_count: 1,
       target_node_size: "standard-2",
     ).subject
-    KubernetesNodepool.create(name: "test-cluster-np", node_count: 1, kubernetes_cluster_id: kc.id, target_node_size: "standard-2")
+    Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "test-cluster-np", node_count: 1, kubernetes_cluster_id: kc.id, target_node_size: "standard-2")
     allow(kc).to receive(:client).and_return(Kubernetes::Client.new(kc, session))
     kc
   }
@@ -256,7 +256,7 @@ RSpec.describe Prog::Test::Kubernetes do
     it "launches 3 parallel daemonized writes and hops to wait_data_write" do
       (1..3).each do |i|
         unit_name = "csi_data_write_#{i}"
-        bash_cmd = "sudo kubectl --kubeconfig /etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c \"head -c 500M /dev/urandom | tee /etc/data/random-data-#{i} | sha256sum | awk '{print \\$1}'\" > /dev/shm/#{unit_name}.hash"
+        bash_cmd = "sudo kubectl --kubeconfig /etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c \"head -c 300M /dev/urandom | tee /etc/data/random-data-#{i} | sha256sum | awk '{print \\$1}'\" > /dev/shm/#{unit_name}.hash"
         expected_cmd = "common/bin/daemonizer2 run #{unit_name} #{["bash", "-c", bash_cmd].shelljoin}"
         expect(sshable).to receive(:_cmd).with(expected_cmd, stdin: nil, log: true)
       end
@@ -774,7 +774,7 @@ RSpec.describe Prog::Test::Kubernetes do
       expect { kubernetes_test.verify_reboot_nftables }.to nap(5)
     end
 
-    it "hops to destroy_kubernetes when rules match" do
+    it "hops to test_upgrade when rules match" do
       kubernetes_test.update_stack({
         "reboot_node_id" => node.id,
         "nat_rules_before_reboot" => "table ip nat { ... }",
@@ -784,7 +784,7 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(sshable).to receive(:_cmd).with("uptime").and_return("up")
       expect(sshable).to receive(:_cmd).with("sudo nft list chain ip nat postrouting").and_return("table ip nat { ... }")
       expect(sshable).to receive(:_cmd).with("sudo nft list chain ip6 pod_access ingress_egress_control").and_return("table ip6 pod_access { ... }")
-      expect { kubernetes_test.verify_reboot_nftables }.to hop("destroy_kubernetes")
+      expect { kubernetes_test.verify_reboot_nftables }.to hop("test_upgrade")
     end
 
     it "sets fail_message when ip nat rules changed" do
@@ -811,8 +811,162 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(sshable).to receive(:_cmd).with("uptime").and_return("up")
       expect(sshable).to receive(:_cmd).with("sudo nft list chain ip nat postrouting").and_return("table ip nat { ... }")
       expect(sshable).to receive(:_cmd).with("sudo nft list chain ip6 pod_access ingress_egress_control").and_return("different pod_access rules")
-      expect { kubernetes_test.verify_reboot_nftables }.to hop("destroy_kubernetes")
+      expect { kubernetes_test.verify_reboot_nftables }.to hop("test_upgrade")
       expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("ip6 pod_access rules changed after reboot")
+    end
+  end
+
+  describe "#test_upgrade" do
+    before do
+      expect(kubernetes_test).to receive(:kubernetes_cluster).and_return(kubernetes_cluster).at_least(:once)
+    end
+
+    it "fails if no upgrade candidate is available" do
+      kubernetes_cluster.update(version: Option.kubernetes_versions.first)
+      expect { kubernetes_test.test_upgrade }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("No upgrade candidate available")
+    end
+
+    it "updates version, increments uprades semaphores, and hops to wait_for_upgrade" do
+      target_version = kubernetes_cluster.available_upgrade_version
+      expect { kubernetes_test.test_upgrade }.to hop("wait_for_upgrade")
+
+      kubernetes_cluster.reload
+      expect(kubernetes_cluster.version).to eq(target_version)
+      expect(kubernetes_cluster.upgrade_set?).to be true
+      expect(kubernetes_cluster.nodepools(reload: true).first.upgrade_set?).to be true
+    end
+  end
+
+  describe "#wait_for_upgrade" do
+    before do
+      expect(kubernetes_test).to receive(:kubernetes_cluster).and_return(kubernetes_cluster).at_least(:once)
+      cp_vm = create_vm(name: "cp-node")
+      Sshable.create_with_id(cp_vm.id)
+      KubernetesNode.create(vm_id: cp_vm.id, kubernetes_cluster_id: kubernetes_cluster.id)
+      wo_vm = create_vm(name: "wo-node")
+      Sshable.create_with_id(wo_vm.id)
+      KubernetesNode.create(vm_id: wo_vm.id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id)
+      lb = LoadBalancer.create(private_subnet_id: private_subnet.id, name: "api-lb", health_check_endpoint: "/healthz", project_id: kubernetes_test_project.id)
+      kubernetes_cluster.update(api_server_lb_id: lb.id)
+    end
+
+    it "naps and skips host entry update if vm is not ready" do
+      (kubernetes_cluster.nodes + kubernetes_cluster.nodepools.first.nodes).each do |node|
+        expect(node.vm.sshable).to receive(:_cmd).with("uptime").and_raise(StandardError)
+      end
+      expect { kubernetes_test.wait_for_upgrade }.to nap(15)
+    end
+
+    it "naps and skips host entry update if host entry is already set" do
+      kubernetes_test.set_node_entries_status(kubernetes_cluster.nodes.first.name)
+      kubernetes_test.set_node_entries_status(kubernetes_cluster.nodepools.first.nodes.first.name)
+      expect(kubernetes_test).not_to receive(:vm_ready?)
+      expect(kubernetes_test).not_to receive(:ensure_hosts_entry)
+      expect { kubernetes_test.wait_for_upgrade }.to nap(15)
+    end
+
+    it "naps and updates host entries on ready vms" do
+      hostname = kubernetes_cluster.api_server_lb.hostname
+      api_host = kubernetes_cluster.sshable.host
+      host_line = "#{api_host} #{hostname}"
+      (kubernetes_cluster.nodes + kubernetes_cluster.nodepools.first.nodes).each do |node|
+        expect(node.vm.sshable).to receive(:_cmd).with("uptime").and_return("up 1 day")
+        expect(node.vm.sshable).to receive(:_cmd).with("cat /etc/hosts").and_return("127.0.0.1 localhost")
+        expect(node.vm.sshable).to receive(:_cmd).with("echo #{host_line.shellescape} | sudo tee -a /etc/hosts > /dev/null").and_return("")
+      end
+      expect { kubernetes_test.wait_for_upgrade }.to nap(15)
+    end
+
+    it "fails if some nodes are not upgraded" do
+      kubernetes_cluster.strand.update(label: "wait")
+      kubernetes_cluster.nodepools.each { |np| np.strand.update(label: "wait") }
+      kubernetes_cluster.reload
+
+      nodes_json = {
+        "items" => [
+          {"status" => {"nodeInfo" => {"kubeletVersion" => "#{kubernetes_cluster.version}.1"}}},
+          {"status" => {"nodeInfo" => {"kubeletVersion" => "v1.30.1"}}},
+          {"status" => {"nodeInfo" => {"kubeletVersion" => "#{kubernetes_cluster.version}.1"}}},
+        ],
+      }
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(nodes_json), 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -o json").and_return(response)
+
+      response_raw = Net::SSH::Connection::Session::StringWithExitstatus.new("nodes_raw", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes").and_return(response_raw)
+
+      expect { kubernetes_test.wait_for_upgrade }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("Not all 3 nodes upgraded to #{kubernetes_cluster.version}:\nnodes_raw")
+    end
+
+    it "fails if node count is not 3" do
+      kubernetes_cluster.strand.update(label: "wait")
+      kubernetes_cluster.nodepools.each { |np| np.strand.update(label: "wait") }
+      kubernetes_cluster.reload
+
+      nodes_json = {
+        "items" => [
+          {"status" => {"nodeInfo" => {"kubeletVersion" => "#{kubernetes_cluster.version}.1"}}},
+        ],
+      }
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(nodes_json), 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -o json").and_return(response)
+
+      response_raw = Net::SSH::Connection::Session::StringWithExitstatus.new("nodes_raw", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes").and_return(response_raw)
+
+      expect { kubernetes_test.wait_for_upgrade }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("Not all 1 nodes upgraded to #{kubernetes_cluster.version}:\nnodes_raw")
+    end
+
+    it "hops to verify_data_after_upgrade if all 3 nodes are upgraded correctly" do
+      kubernetes_cluster.strand.update(label: "wait")
+      kubernetes_cluster.nodepools.each { |np| np.strand.update(label: "wait") }
+
+      nodes_json = {
+        "items" => [{"status" => {"nodeInfo" => {"kubeletVersion" => "#{kubernetes_cluster.version}.0"}}}] * 3,
+      }
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(nodes_json), 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -o json").and_return(response)
+
+      expect { kubernetes_test.wait_for_upgrade }.to hop("verify_data_after_upgrade")
+    end
+  end
+
+  describe "#verify_data_after_upgrade" do
+    before do
+      expect(kubernetes_test).to receive(:kubernetes_cluster).and_return(kubernetes_cluster).at_least(:once)
+    end
+
+    it "naps until pod is running" do
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv,pvc")
+      expect { kubernetes_test.verify_data_after_upgrade }.to nap(5)
+    end
+
+    it "verifies all data hashes and hops to destroy_kubernetes" do
+      kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      (1..3).each do |i|
+        response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
+        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
+      end
+      expect { kubernetes_test.verify_data_after_upgrade }.to hop("destroy_kubernetes")
+    end
+
+    it "sets fail_message and hops to destroy_kubernetes if a hash is wrong" do
+      kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("corrupted_hash", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-1\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
+
+      expect { kubernetes_test.verify_data_after_upgrade }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("data hash changed after upgrade for random-data-1, expected: hash1, got: corrupted_hash")
     end
   end
 

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -72,66 +72,55 @@ RSpec.describe Prog::Test::Kubernetes do
       expect { kubernetes_test.update_loadbalancer_hostname }.to nap(5)
     end
 
-    it "updates custom hostname and hops to update_all_nodes_hosts_entries" do
+    it "updates custom hostname and hops to update_all_nodes_dns_records" do
       lb = LoadBalancer.create(private_subnet_id: private_subnet.id, name: "api-lb", health_check_endpoint: "/healthz", project_id: kubernetes_test_project.id)
       kubernetes_cluster.update(api_server_lb_id: lb.id)
 
-      expect { kubernetes_test.update_loadbalancer_hostname }.to hop("update_all_nodes_hosts_entries")
+      expect { kubernetes_test.update_loadbalancer_hostname }.to hop("update_all_nodes_dns_records")
       expect(lb.reload.custom_hostname).to eq("k8s-e2e-test.ubicloud.test")
     end
   end
 
-  describe "#update_all_nodes_hosts_entries" do
-    let(:cp_sshable) { Sshable.new }
-    let(:worker_sshable) { Sshable.new }
-
+  describe "#update_all_nodes_dns_records" do
     before do
-      kubernetes_test.strand.update(label: "update_all_nodes_hosts_entries")
+      allow(kubernetes_cluster).to receive(:sshable).and_return(Sshable.create(host: "api-server-ip"))
+
+      kubernetes_test.strand.update(label: "update_all_nodes_dns_records")
       expect(kubernetes_test).to receive(:kubernetes_cluster).and_return(kubernetes_cluster).at_least(:once)
-      KubernetesNode.create(vm_id: create_vm(name: "cp-node").id, kubernetes_cluster_id: kubernetes_cluster.id)
-      KubernetesNode.create(vm_id: create_vm(name: "wo-node").id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id)
+      KubernetesNode.create(vm_id: create_vm(name: "cp-node", vm_host_id: create_vm_host.id).id, kubernetes_cluster_id: kubernetes_cluster.id)
+      KubernetesNode.create(vm_id: create_vm(name: "wo-node", vm_host_id: create_vm_host.id).id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id)
       lb = LoadBalancer.create(private_subnet_id: private_subnet.id, name: "api-lb", health_check_endpoint: "/healthz", project_id: kubernetes_test_project.id)
       kubernetes_cluster.update(api_server_lb_id: lb.id)
     end
 
-    it "naps if the first vm is not ready" do
-      expect(kubernetes_test).to receive(:vm_ready?).with(kubernetes_cluster.nodes.first.vm).and_return(false)
-      expect { kubernetes_test.update_all_nodes_hosts_entries }.to nap(5)
+    it "naps if the first vm has no vm_host" do
+      kubernetes_cluster.all_nodes.first.vm.update(vm_host_id: nil)
+      expect { kubernetes_test.update_all_nodes_dns_records }.to nap(5)
     end
 
-    it "ensures the host entires on the first cp vm and proceeds to next which makes it nap" do
+    it "ensures dns record on cp node and naps because worker has no vm_host" do
+      kubernetes_cluster.nodepools.first.nodes.first.vm.update(vm_host_id: nil)
       cp_node = kubernetes_cluster.nodes.first
-      expect(kubernetes_test).to receive(:vm_ready?).with(cp_node.vm).and_return(true)
-      expect(kubernetes_test).to receive(:ensure_hosts_entry).with(cp_node.sshable, kubernetes_cluster.api_server_lb.hostname)
-      expect(kubernetes_test).to receive(:vm_ready?).with(kubernetes_cluster.nodepools.first.nodes.first.vm).and_return(false)
-      expect { kubernetes_test.update_all_nodes_hosts_entries }.to nap(5)
+      address_line = "address=/#{kubernetes_cluster.api_server_lb.hostname}/api-server-ip"
+      expect(cp_node.vm.vm_host.sshable).to receive(:_cmd).with("sudo cat /vm/#{cp_node.vm.inhost_name}/dnsmasq.conf").and_return(address_line)
+      expect { kubernetes_test.update_all_nodes_dns_records }.to nap(5)
     end
 
-    it "ensures the host entires on the first worker vm and proceeds to wait_for_kubernetes_bootstrap" do
-      cp_node = kubernetes_cluster.nodes.first
-      worker_node = kubernetes_cluster.nodepools.first.nodes.first
-      hostname = kubernetes_cluster.api_server_lb.hostname
-      expect(kubernetes_test).to receive(:vm_ready?).with(cp_node.vm).and_return(true)
-      expect(kubernetes_test).to receive(:ensure_hosts_entry).with(cp_node.sshable, hostname)
-      expect(kubernetes_test).to receive(:vm_ready?).with(worker_node.vm).and_return(true)
-      expect(kubernetes_test).to receive(:ensure_hosts_entry).with(worker_node.sshable, hostname)
-      expect { kubernetes_test.update_all_nodes_hosts_entries }.to hop("wait_for_kubernetes_bootstrap")
+    it "ensures dns records on all nodes and hops to wait_for_kubernetes_bootstrap" do
+      address_line = "address=/#{kubernetes_cluster.api_server_lb.hostname}/api-server-ip"
+      kubernetes_cluster.all_nodes.each do |node|
+        expect(node.vm.vm_host.sshable).to receive(:_cmd).with("sudo cat /vm/#{node.vm.inhost_name}/dnsmasq.conf").and_return(address_line)
+      end
+      expect { kubernetes_test.update_all_nodes_dns_records }.to hop("wait_for_kubernetes_bootstrap")
     end
 
-    it "tries to ensure host entry on a not-ready worker node while the first cp node is taken care of" do
-      kubernetes_test.set_node_entries_status(kubernetes_cluster.nodes.first.name)
-      expect(kubernetes_test).to receive(:vm_ready?).with(kubernetes_cluster.nodepools.first.nodes.first.vm).and_return(false)
-      expect { kubernetes_test.update_all_nodes_hosts_entries }.to nap(5)
-    end
-
-    it "ensures the host entires on the first cp node but naps because worker vm is not created yet" do
-      cp_node = kubernetes_cluster.nodes.first
+    it "ensures dns record on cp node but naps because worker node is not created yet" do
+      cp_node = kubernetes_cluster.all_nodes.first
       kubernetes_cluster.nodepools.first.nodes.first.destroy
       kubernetes_cluster.reload
-      hostname = kubernetes_cluster.api_server_lb.hostname
-      expect(kubernetes_test).to receive(:vm_ready?).with(cp_node.vm).and_return(true)
-      expect(kubernetes_test).to receive(:ensure_hosts_entry).with(cp_node.sshable, hostname)
-      expect { kubernetes_test.update_all_nodes_hosts_entries }.to nap(10)
+      address_line = "address=/#{kubernetes_cluster.api_server_lb.hostname}/api-server-ip"
+      expect(kubernetes_cluster.all_nodes.first.vm.vm_host.sshable).to receive(:_cmd).with("sudo cat /vm/#{cp_node.vm.inhost_name}/dnsmasq.conf").and_return(address_line)
+      expect { kubernetes_test.update_all_nodes_dns_records }.to nap(10)
     end
   end
 
@@ -851,29 +840,17 @@ RSpec.describe Prog::Test::Kubernetes do
       kubernetes_cluster.update(api_server_lb_id: lb.id)
     end
 
-    it "naps and skips host entry update if vm is not ready" do
-      (kubernetes_cluster.nodes + kubernetes_cluster.nodepools.first.nodes).each do |node|
-        expect(node.vm.sshable).to receive(:_cmd).with("uptime").and_raise(StandardError)
-      end
+    it "naps and skips dns record update if vms have no vm_host" do
       expect { kubernetes_test.wait_for_upgrade }.to nap(15)
     end
 
-    it "naps and skips host entry update if host entry is already set" do
-      kubernetes_test.set_node_entries_status(kubernetes_cluster.nodes.first.name)
-      kubernetes_test.set_node_entries_status(kubernetes_cluster.nodepools.first.nodes.first.name)
-      expect(kubernetes_test).not_to receive(:vm_ready?)
-      expect(kubernetes_test).not_to receive(:ensure_hosts_entry)
-      expect { kubernetes_test.wait_for_upgrade }.to nap(15)
-    end
-
-    it "naps and updates host entries on ready vms" do
-      hostname = kubernetes_cluster.api_server_lb.hostname
-      api_host = kubernetes_cluster.sshable.host
-      host_line = "#{api_host} #{hostname}"
-      (kubernetes_cluster.nodes + kubernetes_cluster.nodepools.first.nodes).each do |node|
-        expect(node.vm.sshable).to receive(:_cmd).with("uptime").and_return("up 1 day")
-        expect(node.vm.sshable).to receive(:_cmd).with("cat /etc/hosts").and_return("127.0.0.1 localhost")
-        expect(node.vm.sshable).to receive(:_cmd).with("echo #{host_line.shellescape} | sudo tee -a /etc/hosts > /dev/null").and_return("")
+    it "naps and updates dns records on vms with vm_host" do
+      vm_host = create_vm_host
+      expect(kubernetes_cluster).to receive(:sshable).and_return(Sshable.create(host: "api-server-ip")).twice
+      address_line = "address=/#{kubernetes_cluster.api_server_lb.hostname}/api-server-ip"
+      kubernetes_cluster.all_nodes.each do |node|
+        node.vm.update(vm_host_id: vm_host.id)
+        expect(node.vm.vm_host.sshable).to receive(:_cmd).with("sudo cat /vm/#{node.vm.inhost_name}/dnsmasq.conf").and_return(address_line)
       end
       expect { kubernetes_test.wait_for_upgrade }.to nap(15)
     end
@@ -1011,28 +988,42 @@ RSpec.describe Prog::Test::Kubernetes do
     end
   end
 
-  describe "#ensure_hosts_entry" do
-    let(:sshable) { Sshable.new }
-    let(:api_hostname) { "api.example.com" }
+  describe "#ensure_dns_record" do
+    let(:vm_host) {
+      vh = create_vm_host
+      vh.sshable.update(host: "api.example.com")
+      vh
+    }
+    let(:vm) { create_vm(vm_host_id: vm_host.id) }
 
     before do
       expect(kubernetes_test).to receive(:kubernetes_cluster).and_return(kubernetes_cluster).at_least(:once)
-      sshable = create_mock_sshable(host: "first-api-server-ip")
-      expect(kubernetes_cluster).to receive(:sshable).and_return(sshable)
+      expect(kubernetes_cluster).to receive(:sshable).and_return(create_mock_sshable(host: "first-api-server-ip"))
     end
 
-    it "adds host entry if not present" do
-      expect(sshable).to receive(:_cmd).with("cat /etc/hosts").and_return("127.0.0.1 localhost")
-      expect(sshable).to receive(:_cmd).with("echo first-api-server-ip\\ api.example.com | sudo tee -a /etc/hosts > /dev/null")
+    it "adds dns record if not present" do
+      dnsmasq_conf = "/vm/#{vm.inhost_name}/dnsmasq.conf"
+      address_line = "address=/#{vm_host.sshable.host}/first-api-server-ip"
 
-      kubernetes_test.ensure_hosts_entry(sshable, api_hostname)
+      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo cat #{dnsmasq_conf}").and_return("some config")
+      expect(vm.vm_host.sshable).to receive(:_cmd).with(<<~SH)
+        set -ueo pipefail
+        sudo sed -i '/^address=/d' #{dnsmasq_conf}
+        echo #{address_line.shellescape} | sudo tee -a #{dnsmasq_conf} > /dev/null
+        sudo systemctl restart #{vm.inhost_name}-dnsmasq
+      SH
+
+      kubernetes_test.ensure_dns_record(vm, vm_host.sshable.host)
     end
 
-    it "does not add host entry if already present" do
-      expect(sshable).to receive(:_cmd).with("cat /etc/hosts").and_return("127.0.0.1 localhost\nfirst-api-server-ip api.example.com")
-      expect(sshable).not_to receive(:_cmd).with(/echo/)
+    it "does not modify dnsmasq if record already present" do
+      dnsmasq_conf = "/vm/#{vm.inhost_name}/dnsmasq.conf"
+      address_line = "address=/#{vm_host.sshable.host}/first-api-server-ip"
 
-      kubernetes_test.ensure_hosts_entry(sshable, api_hostname)
+      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo cat #{dnsmasq_conf}").and_return(address_line)
+      expect(vm.vm_host.sshable).not_to receive(:_cmd)
+
+      kubernetes_test.ensure_dns_record(vm, vm_host.sshable.host)
     end
   end
 
@@ -1069,45 +1060,6 @@ RSpec.describe Prog::Test::Kubernetes do
     it "returns the kubernetes cluster" do
       expect(kubernetes_test).to receive(:frame).and_return({"kubernetes_cluster_id" => kubernetes_cluster.id})
       expect(kubernetes_test.kubernetes_cluster).to eq(kubernetes_cluster)
-    end
-  end
-
-  describe "#node_host_entries_set?" do
-    it "returns false when node entries are not set" do
-      st = instance_double(Strand, stack: [
-        {
-          "kubernetes_service_project_id" => "uuid",
-        },
-      ])
-      expect(kubernetes_test).to receive(:strand).and_return(st)
-      expect(kubernetes_test.node_host_entries_set?("non-existing-node")).to be false
-    end
-
-    it "returns true when node entries are set" do
-      st = instance_double(Strand, stack: [
-        {
-          "kubernetes_service_project_id" => "uuid",
-          "nodes_status" => {
-            "existing-node" => true,
-          },
-        },
-      ])
-      expect(kubernetes_test).to receive(:strand).and_return(st)
-      expect(kubernetes_test.node_host_entries_set?("existing-node")).to be true
-    end
-  end
-
-  describe "#set_node_entries_status" do
-    it "sets the node entires status" do
-      st = Strand.new(prog: "Prog::Test::Kubernetes", label: "start", stack: [{"kubernetes_service_project_id" => "uuid"}])
-      expect(kubernetes_test).to receive(:strand).and_return(st)
-      expect(kubernetes_test).to receive(:update_stack).with({
-        "kubernetes_service_project_id" => "uuid",
-        "nodes_status" => {
-          "somenode" => true,
-        },
-      })
-      kubernetes_test.set_node_entries_status("somenode")
     end
   end
 

--- a/spec/routes/api/cli/golden-file-commands/success.txt
+++ b/spec/routes/api/cli/golden-file-commands/success.txt
@@ -196,3 +196,4 @@ vm list -l eu-north-h1
 vm list -l eu-north-h1 -f name,id
 vm list -N
 vm vmdzyppz6j166jh5e9t2dwrfas show
+kc eu-central-h1/test-kc upgrade

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -343,6 +343,7 @@ Post Commands:
     rename             Rename a Kubernetes cluster
     resize-nodepool    Resize a Kubernetes cluster nodepool
     show               Show details for a Kubernetes cluster
+    upgrade            Upgrade a Kubernetes cluster to the next supported version
 
 
 List Kubernetes clusters
@@ -418,6 +419,12 @@ Allowed Option Values:
     Nodepool Fields: id name node-count node-size vms
     Virtual Machine Fields: id name state location size unix-user
                             storage-size-gib ip6 ip4-enabled ip4
+
+
+Upgrade a Kubernetes cluster to the next supported version
+
+Usage:
+    ubi kc (location/kc-name | kc-id) upgrade
 
 
 Manage load balancers

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -42,6 +42,7 @@ ubi kc (location/kc-name | kc-id) kubeconfig
 ubi kc (location/kc-name | kc-id) rename new-name
 ubi kc (location/kc-name | kc-id) resize-nodepool (np-name | np-id) node-count
 ubi kc (location/kc-name | kc-id) show [options]
+ubi kc (location/kc-name | kc-id) upgrade
 ubi lb command [...]
 ubi lb (location/lb-name | lb-id) post-command [...]
 ubi lb list [options]

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -f node-size,version,nodepools,cp-vms.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -f node-size,version,nodepools,cp-vms.txt
@@ -1,5 +1,5 @@
 node-size: standard-2
-version: v1.35
+version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n id,name,node-count.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n id,name,node-count.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display-state: creating
 cp-node-count: 1
 node-size: standard-2
-version: v1.35
+version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n node-size,vms.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n node-size,vms.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display-state: creating
 cp-node-count: 1
 node-size: standard-2
-version: v1.35
+version: v1.34
 nodepool 1:
   node-size: standard-2
   vm 1:

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v id,name,state,location,size,unix-user,storage-size-gib.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v id,name,state,location,size,unix-user,storage-size-gib.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display-state: creating
 cp-node-count: 1
 node-size: standard-2
-version: v1.35
+version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v ip6,ip4-enabled,ip4.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v ip6,ip4-enabled,ip4.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display-state: creating
 cp-node-count: 1
 node-size: standard-2
-version: v1.35
+version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display-state: creating
 cp-node-count: 1
 node-size: standard-2
-version: v1.35
+version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc upgrade.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc upgrade.txt
@@ -1,0 +1,1 @@
+Scheduled version upgrade of Kubneretes cluster with id kcnzrctjjg4j4g6eqvdsvzthwp to version v1.35.

--- a/spec/routes/api/cli/golden-files/kc kcnzrctjjg4j4g6eqvdsvzthwp show.txt
+++ b/spec/routes/api/cli/golden-files/kc kcnzrctjjg4j4g6eqvdsvzthwp show.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display-state: creating
 cp-node-count: 1
 node-size: standard-2
-version: v1.35
+version: v1.34
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc list -N.txt
+++ b/spec/routes/api/cli/golden-files/kc list -N.txt
@@ -1,1 +1,1 @@
-eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating  v1.35  1
+eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating  v1.34  1

--- a/spec/routes/api/cli/golden-files/kc list -l eu-central-h1.txt
+++ b/spec/routes/api/cli/golden-files/kc list -l eu-central-h1.txt
@@ -1,2 +1,2 @@
 location       name     id                          display-state  version  cp-node-count
-eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.35    1            
+eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.34    1            

--- a/spec/routes/api/cli/golden-files/kc list.txt
+++ b/spec/routes/api/cli/golden-files/kc list.txt
@@ -1,2 +1,2 @@
 location       name     id                          display-state  version  cp-node-count
-eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.35    1            
+eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.34    1            

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Clover, "cli" do
     expect(Firewall).to receive(:generate_uuid).and_return("850f5687-1a76-8dfc-8949-a115826d20e7", "f26fd163-5a81-8dfc-a7f7-0802917b40c2", "0ec68714-d66c-81fc-ab4d-33235e8daea3")
     expect(FirewallRule).to receive(:generate_uuid).and_return("d5889073-4aed-89f8-8894-1c376ebea8f6", "0803b040-d565-81f8-b2ed-f4d28df19f7c", "753678ce-8c3c-8dfc-83ce-00abd4f0f3fe", "45b6f212-bedb-8dfc-b8f2-0bcbe963d5bb", "04dd799d-ef69-8dfc-b58a-1bef3dd69f86", "0acdc686-2462-85fc-9adb-cbd713cb33dd", "b62d8f1b-2c71-89fc-a087-fa4193dcd90b", "4fed0d91-99a9-8dfc-b392-36ad164bd580", "17bd4390-d26e-85fc-a2df-b22a6a0bb697", "32e35994-9dde-89fc-861a-44582c6528be", "ab1ceb1f-faec-81fc-8b4f-a17d15e17da0", "ffbcca2e-550e-81fc-a60d-b39e665c6aeb")
     expect(PrivateSubnet).to receive(:generate_ubid).and_return(UBID.parse("ps788q81w5w26h900k13ad8bkx"))
-    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.kubernetes_versions.first}])
+    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.kubernetes_versions[1]}])
 
     expect(Vm).to receive(:generate_ubid).and_return(UBID.parse("vmgbbazmznfa0mp49nzh5v0z25"), UBID.parse("vmnwfmjk5k462kkzsfa4n1h4xm"))
     expect(Nic).to receive(:generate_ubid).and_return(UBID.parse("ncnqx1bbxgra7k8r9k9qwvspwd"), UBID.parse("nc1c3bggqpxt5kqqrdtkym1g03"))

--- a/spec/routes/api/cli/kc/upgrade_spec.rb
+++ b/spec/routes/api/cli/kc/upgrade_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Clover, "cli kc upgrade" do
+  before do
+    expect(Config).to receive(:kubernetes_service_project_id).and_return(@project.id).at_least(:once)
+  end
+
+  it "upgrades cluster when upgrade is available" do
+    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.kubernetes_versions.last}])
+
+    body = cli(%w[kc eu-central-h1/test-kc upgrade])
+
+    kc = KubernetesCluster.first(name: "test-kc")
+    expect(body).to eq "Scheduled version upgrade of Kubneretes cluster with id #{kc.ubid} to version #{kc.version}.\n"
+  end
+end

--- a/spec/routes/api/project/location/kubernetes_cluster_spec.rb
+++ b/spec/routes/api/project/location/kubernetes_cluster_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Clover, "kubernetes-cluster" do
   let(:k8s_project) { Project.create(name: "UbicloudKubernetesService") }
   let(:subnet) { PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id) }
   let(:kc) {
-    Prog::Kubernetes::KubernetesClusterNexus.assemble(
+    kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "cluster",
       version: Option.kubernetes_versions.first,
       cp_node_count: 3,
@@ -18,6 +18,12 @@ RSpec.describe Clover, "kubernetes-cluster" do
       location_id: Location::HETZNER_FSN1_ID,
       target_node_size: "standard-2",
     ).subject
+    Prog::Kubernetes::KubernetesNodepoolNexus.assemble(
+      name: "np",
+      node_count: 2,
+      kubernetes_cluster_id: kc.id,
+    ).subject
+    kc
   }
 
   before do
@@ -34,6 +40,7 @@ RSpec.describe Clover, "kubernetes-cluster" do
         [:delete, "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.ubid}"],
         [:get, "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.name}"],
         [:get, "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.ubid}"],
+        [:post, "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.ubid}/upgrade"],
       ].each do |method, path|
         send method, path
 
@@ -130,13 +137,7 @@ RSpec.describe Clover, "kubernetes-cluster" do
     end
 
     describe "nodepool" do
-      let(:kn) do
-        Prog::Kubernetes::KubernetesNodepoolNexus.assemble(
-          name: "np",
-          node_count: 2,
-          kubernetes_cluster_id: kc.id,
-        ).subject
-      end
+      let(:kn) { kc.nodepools.first }
 
       describe "resize" do
         it "success" do
@@ -175,6 +176,28 @@ RSpec.describe Clover, "kubernetes-cluster" do
           expect(last_response.status).to eq(200)
           expect(kn.reload.node_count).to eq(4)
         end
+      end
+    end
+
+    describe "upgrade" do
+      it "upgrades cluster when upgrade is available" do
+        kc.update(version: Option.kubernetes_versions[1])
+
+        post "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.ubid}/upgrade"
+
+        expect(last_response.status).to eq(200)
+        expect(kc.reload.version).to eq(Option.kubernetes_versions.first)
+        expect(SemSnap.new(kc.id).set?("upgrade")).to be true
+        expect(SemSnap.new(kc.nodepools.first.id).set?("upgrade")).to be true
+      end
+
+      it "returns an error when no upgrade is available" do
+        original_version = kc.version
+
+        post "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.ubid}/upgrade"
+
+        expect(last_response.status).to eq(422)
+        expect(kc.reload.version).to eq(original_version)
       end
     end
   end

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -43,13 +43,19 @@ RSpec.describe Clover, "Kubernetes" do
   end
 
   let(:kc_no_perm) do
-    Prog::Kubernetes::KubernetesClusterNexus.assemble(
+    kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "not-my-k8s",
       version: Option.kubernetes_versions.first,
       project_id: project_wo_permissions.id,
       private_subnet_id: PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "othersubnet", location_id: Location::HETZNER_FSN1_ID, project_id: project_wo_permissions.id).id,
       location_id: Location::HETZNER_FSN1_ID,
     ).subject
+    Prog::Kubernetes::KubernetesNodepoolNexus.assemble(
+      name: "np-no-perm",
+      node_count: 2,
+      kubernetes_cluster_id: kc.id,
+    ).subject
+    kc
   end
 
   before do
@@ -418,6 +424,71 @@ RSpec.describe Clover, "Kubernetes" do
         AccessControlEntry.create(project_id: project_wo_permissions.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
         visit "#{project_wo_permissions.path}#{kc_no_perm.path}/settings"
         expect(page).to have_no_content("Resize")
+      end
+    end
+
+    describe "upgrade" do
+      it "shows upgrade button when upgrade is available and cluster is ready" do
+        kc.update(version: Option.kubernetes_versions[1])
+        kc.strand.update(label: "wait")
+        kc.nodepools.first.strand.update(label: "wait")
+
+        visit "#{project.path}#{kc.path}/settings"
+        expect(page).to have_content "Upgrade Cluster & Nodepool"
+        expect(page).to have_content "can be upgraded to version"
+        expect(page).to have_content Option.kubernetes_versions.first
+        expect(page).to have_button "Upgrade"
+      end
+
+      it "shows upgrading in progress when cluster strand is upgrading" do
+        kc.strand.update(label: "upgrade")
+        kc.nodepools.first.strand.update(label: "wait")
+
+        visit "#{project.path}#{kc.path}/settings"
+        expect(page).to have_content "Upgrade Cluster & Nodepool"
+        expect(page).to have_content "is currently in progress"
+        expect(page).to have_button "Upgrading...", disabled: true
+      end
+
+      it "shows upgrading in progress when nodepool strand is upgrading" do
+        kc.strand.update(label: "wait")
+        kc.nodepools.first.strand.update(label: "wait_upgrade")
+
+        visit "#{project.path}#{kc.path}/settings"
+        expect(page).to have_content "is currently in progress"
+        expect(page).to have_button "Upgrading...", disabled: true
+      end
+
+      it "shows not ready when upgrade is available but strands are busy" do
+        kc.update(version: Option.kubernetes_versions.last)
+        kc.strand.update(label: "wait")
+        kc.nodepools.first.strand.update(label: "bootstrap_worker_nodes")
+
+        visit "#{project.path}#{kc.path}/settings"
+        expect(page).to have_content "Cluster is not ready for upgrade"
+        expect(page).to have_button "Upgrade", disabled: true
+      end
+
+      it "shows up to date when no upgrade is available" do
+        kc.strand.update(label: "wait")
+        kc.nodepools.first.strand.update(label: "wait")
+
+        visit "#{project.path}#{kc.path}/settings"
+        expect(page).to have_content "Your cluster is up to date on version"
+        expect(page).to have_content Option.kubernetes_versions.first
+      end
+
+      it "can upgrade kubernetes cluster" do
+        kc.update(version: Option.kubernetes_versions[1])
+        kc.strand.update(label: "wait")
+        kc.nodepools.first.strand.update(label: "wait")
+
+        visit "#{project.path}#{kc.path}/settings"
+        click_button "Upgrade"
+
+        expect(page).to have_flash_notice("myk8s will be upgraded to #{Option.kubernetes_versions.first}")
+        expect(kc.reload.version).to eq Option.kubernetes_versions.first
+        expect(SemSnap.new(kc.id).set?("upgrade")).to be true
       end
     end
 

--- a/spec/serializers/kubernetes_cluster_spec.rb
+++ b/spec/serializers/kubernetes_cluster_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Serializers::KubernetesCluster do
       project = Project.create(name: "default")
       subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.kubernetes_versions.first, private_subnet_id: subnet.id).subject
-      kn = KubernetesNodepool.create(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2")
+      kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
       KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
 
       expected_result = {
@@ -32,7 +32,7 @@ RSpec.describe Serializers::KubernetesCluster do
       project = Project.create(name: "default")
       subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.kubernetes_versions.first, private_subnet_id: subnet.id).subject
-      kn = KubernetesNodepool.create(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2")
+      kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
       cp_vm = create_vm
       KubernetesNode.create(vm_id: cp_vm.id, kubernetes_cluster_id: kc.id)
       KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)

--- a/views/kubernetes-cluster/overview.erb
+++ b/views/kubernetes-cluster/overview.erb
@@ -11,7 +11,7 @@
   ["Worker Nodes", @kc.nodepools.sum { it.node_count }]
 ]
 
-if @kc.display_state == "running"
+if %w[running upgrading].include?(@kc.display_state)
   data.push(["Service URL", @kc.services_lb.hostname, { copyable: true }]) # TODO: Assign LB to a column properly
   data.push(["Kubeconfig", part("components/download_button", link: "#{path(@kc)}/kubeconfig"), { escape: false }])
 else

--- a/views/kubernetes-cluster/settings.erb
+++ b/views/kubernetes-cluster/settings.erb
@@ -36,6 +36,67 @@
       </div>
     </div>
   </div>
+
+  <div class="p-6">
+    <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
+      <div class="min-w-0 flex-1">
+        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+          Upgrade Cluster & Nodepool
+        </h3>
+      </div>
+    </div>
+
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <div class="px-4 py-5 sm:p-6">
+        <% if @kc.upgrading? %>
+          <div class="gap-6 sm:flex sm:items-center sm:justify-between">
+            <div class="flex-grow">
+              <p class="text-sm text-gray-700">
+                Upgrade to version
+                <strong><%= @kc.version %></strong>
+                is currently in progress. This may take a few minutes.
+              </p>
+            </div>
+            <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+              <%== part("components/button", text: "Upgrading...", attributes: { disabled: "disabled" }) %>
+            </div>
+          </div>
+        <% elsif @kc.ready_for_upgrade? %>
+          <% form(action: "#{path(@kc)}/upgrade", method: :post) do %>
+            <div class="gap-6 sm:flex sm:items-center sm:justify-between">
+              <div class="flex-grow">
+                <p class="text-sm text-gray-700">
+                  Your cluster is currently on version
+                  <strong><%= @kc.version %></strong>
+                  and can be upgraded to version
+                  <strong><%= @kc.available_upgrade_version %></strong>.
+                </p>
+              </div>
+              <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+                <%== part("components/button", text: "Upgrade") %>
+              </div>
+            </div>
+          <% end %>
+        <% elsif @kc.available_upgrade_version %>
+          <div class="gap-6 sm:flex sm:items-center sm:justify-between">
+            <div class="flex-grow">
+              <p class="text-sm text-gray-700">
+                Cluster is not ready for upgrade. Please wait for ongoing operations to complete.
+              </p>
+            </div>
+            <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+              <%== part("components/button", text: "Upgrade", attributes: { disabled: "disabled" }) %>
+            </div>
+          </div>
+        <% else %>
+          <p class="text-sm text-gray-700">
+            Your cluster is up to date on version
+            <strong><%= @kc.version %></strong>.
+          </p>
+        <% end %>
+      </div>
+    </div>
+  </div>
 <% end %>
 
 <% if has_permission?("KubernetesCluster:delete", @kc) %>


### PR DESCRIPTION
This PR introduces end-to-end support for Kubernetes cluster upgrades, exposing this capability across our API, CLI, and Web UI. It also refactors how node DNS resolution is handled during tests and provisioning by offloading it to the host dnsmasq, and includes a minor cleanup for CSI migrations.

1. Kubernetes Upgrades (API & Core Logic)
Added a new upgrade POST endpoint to KubernetesCluster to trigger cluster upgrades.
Implemented upgrade semaphore increments for both the Kubernetes cluster and its associated nodepools.
Updated nodepool upgrade logic to ensure worker nodes wait for the control plane to finish its own upgrade operation first.
Added a simple hash-based lookup to determine the next available cluster upgrade version.

2. Kubernetes Upgrades (Web UI & CLI)
Added a new CLI command to allow customers to easily upgrade their Kubernetes clusters from their terminal.
Added an Upgrade section to the Kubernetes settings tab in the Web UI, which dynamically manages 4 distinct states:
Up-to-date
Not ready for upgrade (prevents race conditions if a cluster is bootstrapping or another operation like node resize is actively running)
Upgradable (shows active button)
Upgrading (shows disabled button)
Introduced a new upgrading display state indicating an ongoing upgrade operation on either the cluster or its nodepool.

3. Testing & Infrastructure Improvements
Added comprehensive E2E test suite coverage for Kubernetes upgrades.
Refactored node DNS resolution to leverage the host's dnsmasq. This eliminates the race-prone manual /etc/hosts injection on individual K8s VMs. It delegates DNS resolution to the host infrastructure by injecting the API server host record straight into dnsmasq.conf on the hypervisor, drastically improving stability during cluster bootstrapping and upgrades.
Optimized standard K8s CSI migrations to run a single time.