### PR TITLE
Validate VM IPv4 compatibility when attaching to load balancer

### DIFF
--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -39,6 +39,10 @@ class Clover
               fail Validation::ValidationFailed.new("vm_id" => "VM is already attached to a load balancer")
             end
 
+            if lb.ipv4_enabled?
+              fail Validation::ValidationFailed.new("vm_id" => "You cannot attach a VM to a load balancer with IPv4 enabled if the VM does not have IPv4 enabled") unless vm.ip4_enabled
+            end
+
             lb.add_vm(vm)
             audit_log(lb, "attach_vm", vm)
             actioned = "attached to"

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -253,6 +253,21 @@ RSpec.describe Clover, "load-balancer" do
       }
 
       it "success" do
+        vm.update(project_id: project.id, ip4_enabled: true)
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/attach-vm", {vm_id: vm.ubid}.to_json
+
+        expect(last_response.status).to eq(200)
+      end
+
+      it "fails for vm without ip4 when lb has ipv4 enabled" do
+        vm.update(project_id: project.id)
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/attach-vm", {vm_id: vm.ubid}.to_json
+
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: vm_id")
+      end
+
+      it "success for vm without ip4 when lb is ipv6 only" do
+        lb.update(stack: "ipv6")
         vm.update(project_id: project.id)
         post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/attach-vm", {vm_id: vm.ubid}.to_json
 

--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe Clover, "load balancer" do
         cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
         cert.update(cert: "cert", csr_key: Clec::Cert.ec_key.to_der)
         lb.add_cert(cert)
-        vm = Prog::Vm::Nexus.assemble("k y", project.id, name: "dummy-vm-1", private_subnet_id: ps.id).subject
+        vm = Prog::Vm::Nexus.assemble("k y", project.id, name: "dummy-vm-1", private_subnet_id: ps.id, enable_ip4: true).subject
 
         visit "#{project.path}#{lb.path}/vms"
         select vm.name, from: "vm_id"
@@ -315,7 +315,7 @@ RSpec.describe Clover, "load balancer" do
         cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
         cert.update(cert: "cert", csr_key: Clec::Cert.ec_key.to_der)
         lb1.add_cert(cert)
-        vm = Prog::Vm::Nexus.assemble("k y", project.id, name: "dummy-vm-1", private_subnet_id: ps.id).subject
+        vm = Prog::Vm::Nexus.assemble("k y", project.id, name: "dummy-vm-1", private_subnet_id: ps.id, enable_ip4: true).subject
 
         visit "#{project.path}#{lb2.path}"
         within("#load-balancer-submenu") { click_link "Virtual Machines" }
@@ -331,7 +331,7 @@ RSpec.describe Clover, "load balancer" do
       it "can not attach vm when it does not exist" do
         ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location_id: Location::HETZNER_FSN1_ID).subject
         lb = Prog::Vnet::LoadBalancerNexus.assemble(ps.id, name: "dummy-lb-3", src_port: 80, dst_port: 8000).subject
-        vm = Prog::Vm::Nexus.assemble("k y", project.id, name: "dummy-vm-1", private_subnet_id: ps.id).subject
+        vm = Prog::Vm::Nexus.assemble("k y", project.id, name: "dummy-vm-1", private_subnet_id: ps.id, enable_ip4: true).subject
 
         visit "#{project.path}#{lb.path}/vms"
         select vm.name, from: "vm_id"
@@ -374,7 +374,7 @@ RSpec.describe Clover, "load balancer" do
         cert = Prog::Vnet::CertNexus.assemble("test-host-name", dz.id).subject
         cert.update(cert: "cert", csr_key: Clec::Cert.ec_key.to_der)
         lb.add_cert(cert)
-        vm = Prog::Vm::Nexus.assemble("k y", project.id, name: "dummy-vm-1", private_subnet_id: ps.id).subject
+        vm = Prog::Vm::Nexus.assemble("k y", project.id, name: "dummy-vm-1", private_subnet_id: ps.id, enable_ip4: true).subject
 
         visit "#{project.path}#{lb.path}/vms"
         select "dummy-vm-1", from: "vm_id"

--- a/views/networking/load_balancer/vms.erb
+++ b/views/networking/load_balancer/vms.erb
@@ -1,6 +1,10 @@
-<% attachable_vms = dataset_authorize(@lb.private_subnet.vms_dataset.eager(:location), "Vm:view")
-  .exclude(Sequel[:vm][:id] => @lb.vms_dataset.select(Sequel[:vm][:id]))
-  .all
+<% ds = @lb.private_subnet.vms_dataset.eager(:location)
+  if @lb.stack == "ipv4" || @lb.stack == "dual"
+    ds = ds.where(Sequel[:vm][:ip4_enabled] => true)
+  end
+  attachable_vms = dataset_authorize(ds, "Vm:view")
+    .exclude(Sequel[:vm][:id] => @lb.vms_dataset.select(Sequel[:vm][:id]))
+    .all
 load_balancer_path = "#{@project.path}#{@lb.path}"
 edit_perm = has_permission?("LoadBalancer:edit", @lb) %>
 


### PR DESCRIPTION
Previously, a VM without IPv4 could be attached to a load balancer with an IPv4 or dual stack, which would silently fail to route traffic. This adds a server-side validation that rejects the attach request when the load balancer requires IPv4 but the VM does not have it enabled.

The view is also updated to filter the attachable VM dropdown so that only IPv4-capable VMs appear for IPv4 and dual-stack load balancers, preventing users from selecting an incompatible VM in the first place.