### PR TITLE
Fix PITR break during Postgres upgrades

### DIFF
--- a/rhizome/postgres/lib/postgres_upgrade.rb
+++ b/rhizome/postgres/lib/postgres_upgrade.rb
@@ -19,7 +19,7 @@ class PostgresUpgrade
   end
 
   def disable_archiving(version, reload: false)
-    r "echo 'archive_command = false' | sudo tee /etc/postgresql/#{version}/main/conf.d/100-upgrade.conf"
+    r "echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/#{version}/main/conf.d/100-upgrade.conf"
     r "sudo pg_ctlcluster #{version} main reload" if reload
   end
 

--- a/rhizome/postgres/lib/postgres_upgrade.rb
+++ b/rhizome/postgres/lib/postgres_upgrade.rb
@@ -49,10 +49,6 @@ class PostgresUpgrade
     pg_setup.create_cluster
   end
 
-  def stop_new_version
-    r "sudo systemctl stop postgresql@#{@version}-main"
-  end
-
   def run_check
     run_pg_upgrade_cmd("--check")
   end
@@ -112,8 +108,6 @@ class PostgresUpgrade
     promote @prev_version
     @logger.info("Initializing new version")
     initialize_new_version
-    @logger.info("Stop new version")
-    stop_new_version
     @logger.info("Running check")
     run_check
     @logger.info("Running pg upgrade")

--- a/rhizome/postgres/spec/postgres_upgrade_spec.rb
+++ b/rhizome/postgres/spec/postgres_upgrade_spec.rb
@@ -40,13 +40,13 @@ RSpec.describe PostgresUpgrade do
 
   describe "#disable_archiving" do
     it "disables archiving without reload by default" do
-      expect(postgres_upgrade).to receive(:r).with("echo 'archive_command = false' | sudo tee /etc/postgresql/17/main/conf.d/100-upgrade.conf")
+      expect(postgres_upgrade).to receive(:r).with("echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/17/main/conf.d/100-upgrade.conf")
       expect(postgres_upgrade).not_to receive(:r).with("sudo pg_ctlcluster 17 main reload")
       postgres_upgrade.disable_archiving(17)
     end
 
     it "disables archiving and reloads when reload: true" do
-      expect(postgres_upgrade).to receive(:r).with("echo 'archive_command = false' | sudo tee /etc/postgresql/16/main/conf.d/100-upgrade.conf")
+      expect(postgres_upgrade).to receive(:r).with("echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/16/main/conf.d/100-upgrade.conf")
       expect(postgres_upgrade).to receive(:r).with("sudo pg_ctlcluster 16 main reload")
       postgres_upgrade.disable_archiving(16, reload: true)
     end

--- a/rhizome/postgres/spec/postgres_upgrade_spec.rb
+++ b/rhizome/postgres/spec/postgres_upgrade_spec.rb
@@ -93,13 +93,6 @@ RSpec.describe PostgresUpgrade do
     end
   end
 
-  describe "#stop_new_version" do
-    it "stops new version service" do
-      expect(postgres_upgrade).to receive(:r).with("sudo systemctl stop postgresql@17-main")
-      postgres_upgrade.stop_new_version
-    end
-  end
-
   describe "#run_check" do
     it "runs pg_upgrade with --check option" do
       expect(postgres_upgrade).to receive(:run_pg_upgrade_cmd).with("--check")
@@ -202,7 +195,6 @@ RSpec.describe PostgresUpgrade do
       expect(postgres_upgrade).to receive(:wait_for_postgres_to_start).ordered
       expect(postgres_upgrade).to receive(:promote).with(16).ordered
       expect(postgres_upgrade).to receive(:initialize_new_version).ordered
-      expect(postgres_upgrade).to receive(:stop_new_version).ordered
       expect(postgres_upgrade).to receive(:run_check).ordered
       expect(postgres_upgrade).to receive(:run_pg_upgrade).ordered
       expect(postgres_upgrade).to receive(:disable_archiving).with(17).ordered


### PR DESCRIPTION
During upgrades, when a new cluster on the target version is created, it starts with the default postgres configs (even after pg_upgrade is run). Prior to this change, this introduced a window where postgres was run with `archive_mode=off`. This resulted in a WAL archival hole. When reconfigure and restart finished after the first base backup, this would cause standbys to get stuck indefinitely, waiting for missing WAL files to catch up. To fix this, the new cluster is configured to start with `archive_mode=on`, to make sure WAL is retained until the correct archival configuration is setup.