### PR TITLE
Update postgres images to 20260409.1.0

### DIFF
--- a/migrate/20260410_update_pg_amis.rb
+++ b/migrate/20260410_update_pg_amis.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  ami_ids = [
+    ["us-west-2", "x64", "ami-test-x64-uswest2", "ami-022ac113b5f22b2c2"],
+    ["us-east-1", "x64", "ami-test-x64-useast1", "ami-0bc62be1b75cf5910"],
+    ["us-west-2", "arm64", "ami-test-arm64-uswest2", "ami-01f4e1d9d91166335"],
+    ["us-east-1", "arm64", "ami-test-arm64-useast1", "ami-07b5ee7bf00c63369"],
+  ]
+
+  up do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: old_ami)
+        .update(aws_ami_id: new_ami)
+    end
+  end
+
+  down do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: new_ami)
+        .update(aws_ami_id: old_ami)
+    end
+  end
+end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -142,7 +142,7 @@ class Prog::DownloadBootImage < Prog::Base
     },
     "postgres-ubuntu-2204" => {
       "x64" => {
-        "20260409.1.0" => "c1901b210c105f4e3dac60c61d6d959fa4b616a5ec05cf6234869553f64a4744",
+        "20260409.1.0" => "dummy_x64_sha256_for_testing_0123456789abcdef",
       },
     },
     "postgres16-ubuntu-2204" => {


### PR DESCRIPTION
## Summary
- Updates boot image version and SHA256 hashes in `prog/download_boot_image.rb`
- Adds migration to update AWS AMI IDs in `pg_aws_ami` table

## Image Version
`20260409.1.0`

## Changes
- x64 SHA256: `dummy_x64_sha256_for_testing_0123456789abcdef`
- arm64 SHA256: `dummy_arm64_sha256_for_testing_fedcba9876543210`

🤖 Generated by [postgres-vm-images](https://github.com/ubicloud/postgres-vm-images) workflow