### PR TITLE
Replicate PG E2E tests to AWS

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -83,6 +83,12 @@ def test_aws(options, test_cases)
   if options[:test_cases].include?("postgres_standard")
     tests_to_wait << Prog::Test::PostgresResource.assemble(provider: "aws")
   end
+  if options[:test_cases].include?("postgres_ha")
+    tests_to_wait << Prog::Test::HaPostgresResource.assemble(provider: "aws")
+  end
+  if options[:test_cases].include?("postgres_upgrade")
+    tests_to_wait << Prog::Test::UpgradePostgresResource.assemble(provider: "aws")
+  end
 
   tests_to_wait.each { |st| wait_until(st) }
 end

--- a/prog/test/base.rb
+++ b/prog/test/base.rb
@@ -5,4 +5,17 @@ class Prog::Test::Base < Prog::Base
     strand.update(exitval: {msg:})
     hop_failed
   end
+
+  def self.postgres_test_location_options(provider)
+    if provider == "aws"
+      location = Location[provider: "aws", project_id: nil, name: "us-west-2"]
+      location.location_credential_aws ||
+        LocationCredentialAws.create_with_id(location.id, access_key: Config.e2e_aws_access_key, secret_key: Config.e2e_aws_secret_key)
+      family = "m8gd"
+      vcpus = 2
+      [location.id, Option.aws_instance_type_name(family, vcpus), Option::AWS_STORAGE_SIZE_OPTIONS[family][vcpus].first.to_i]
+    else
+      [Location::HETZNER_FSN1_ID, "standard-2", 128]
+    end
+  end
 end

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -3,10 +3,13 @@
 require_relative "../../lib/util"
 
 class Prog::Test::HaPostgresResource < Prog::Test::Base
-  def self.assemble
+  def self.assemble(provider: "metal")
     postgres_test_project = Project.create(name: "Postgres-HA-Test-Project")
+    Project[Config.postgres_service_project_id] ||
+      Project.create_with_id(Config.postgres_service_project_id || Project.generate_uuid, name: "Postgres-Service-Project")
 
     frame = {
+      "provider" => provider,
       "postgres_test_project_id" => postgres_test_project.id,
       "failover_wait_started" => false,
     }
@@ -19,12 +22,14 @@ class Prog::Test::HaPostgresResource < Prog::Test::Base
   end
 
   label def start
+    location_id, target_vm_size, target_storage_size_gib = self.class.postgres_test_location_options(frame["provider"])
+
     st = Prog::Postgres::PostgresResourceNexus.assemble(
       project_id: frame["postgres_test_project_id"],
-      location_id: Location::HETZNER_FSN1_ID,
+      location_id:,
       name: "postgres-test-ha",
-      target_vm_size: "standard-2",
-      target_storage_size_gib: 128,
+      target_vm_size:,
+      target_storage_size_gib:,
       ha_type: "async",
     )
 

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -22,15 +22,7 @@ class Prog::Test::PostgresResource < Prog::Test::Base
   end
 
   label def start
-    location_id, target_vm_size, target_storage_size_gib = if frame["provider"] == "aws"
-      location = Location[provider: "aws", project_id: nil, name: "us-west-2"]
-      LocationCredentialAws.create_with_id(location.id, access_key: Config.e2e_aws_access_key, secret_key: Config.e2e_aws_secret_key)
-      family = "m8gd"
-      vcpus = 2
-      [location.id, Option.aws_instance_type_name(family, vcpus), Option::AWS_STORAGE_SIZE_OPTIONS[family][vcpus].first.to_i]
-    else
-      [Location::HETZNER_FSN1_ID, "standard-2", 128]
-    end
+    location_id, target_vm_size, target_storage_size_gib = self.class.postgres_test_location_options(frame["provider"])
 
     st = Prog::Postgres::PostgresResourceNexus.assemble(
       project_id: frame["postgres_test_project_id"],

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -3,23 +3,27 @@
 require_relative "../../lib/util"
 
 class Prog::Test::UpgradePostgresResource < Prog::Test::Base
-  def self.assemble
+  def self.assemble(provider: "metal")
     postgres_test_project = Project.create(name: "Postgres-Upgrade-Test-Project")
+    Project[Config.postgres_service_project_id] ||
+      Project.create_with_id(Config.postgres_service_project_id || Project.generate_uuid, name: "Postgres-Service-Project")
 
     Strand.create(
       prog: "Test::UpgradePostgresResource",
       label: "start",
-      stack: [{"postgres_test_project_id" => postgres_test_project.id}],
+      stack: [{"provider" => provider, "postgres_test_project_id" => postgres_test_project.id}],
     )
   end
 
   label def start
+    location_id, target_vm_size, target_storage_size_gib = self.class.postgres_test_location_options(frame["provider"])
+
     st = Prog::Postgres::PostgresResourceNexus.assemble(
       project_id: frame["postgres_test_project_id"],
-      location_id: Location::HETZNER_FSN1_ID,
+      location_id:,
       name: "postgres-test-upgrade",
-      target_vm_size: "standard-2",
-      target_storage_size_gib: 128,
+      target_vm_size:,
+      target_storage_size_gib:,
       ha_type: "async",
       target_version: "17",
     )
@@ -48,14 +52,16 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::Base
   label def create_read_replica
     Clog.emit("Creating read replica for upgrade test")
 
+    location_id, target_vm_size, target_storage_size_gib = self.class.postgres_test_location_options(frame["provider"])
+
     # Create read replica using the PostgresResourceNexus with parent_id
     st = Prog::Postgres::PostgresResourceNexus.assemble(
       project_id: frame["postgres_test_project_id"],
-      location_id: Location::HETZNER_FSN1_ID,
+      location_id:,
       parent_id: postgres_resource.id,
       name: "postgres-test-upgrade-replica",
-      target_vm_size: "standard-2",
-      target_storage_size_gib: 128,
+      target_vm_size:,
+      target_storage_size_gib:,
       user_config: {},
       pgbouncer_user_config: {},
     )

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe Prog::Test::HaPostgresResource do
       expect(postgres_resource_id).not_to be_nil
       expect(PostgresResource[postgres_resource_id]).not_to be_nil
     end
+
+    it "creates resource on aws and hops to wait_postgres_resource" do
+      expect(Config).to receive(:e2e_aws_access_key).and_return("access_key")
+      expect(Config).to receive(:e2e_aws_secret_key).and_return("secret_key")
+      aws_strand = described_class.assemble(provider: "aws")
+      aws_pgr_test = described_class.new(aws_strand)
+      location = Location[provider: "aws", project_id: nil, name: "us-west-2"]
+      LocationAz.create(location_id: location.id, az: "a", zone_id: "usw2-az1")
+      expect { aws_pgr_test.start }.to hop("wait_postgres_resource")
+      expect(LocationCredentialAws[location.id].access_key).to eq("access_key")
+    end
   end
 
   describe "#wait_postgres_resource" do

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       expect(pg.version).to eq("17")
       expect(pg.ha_type).to eq("async")
     end
+
+    it "creates resource on aws and hops to wait_postgres_resource" do
+      expect(Config).to receive(:e2e_aws_access_key).and_return("access_key")
+      expect(Config).to receive(:e2e_aws_secret_key).and_return("secret_key")
+      aws_strand = described_class.assemble(provider: "aws")
+      aws_pgr_test = described_class.new(aws_strand)
+      location = Location[provider: "aws", project_id: nil, name: "us-west-2"]
+      LocationAz.create(location_id: location.id, az: "a", zone_id: "usw2-az1")
+      expect { aws_pgr_test.start }.to hop("wait_postgres_resource")
+      expect(LocationCredentialAws[location.id].access_key).to eq("access_key")
+    end
   end
 
   describe "#wait_postgres_resource" do


### PR DESCRIPTION
It is much faster to run the tests on AWS compared to bare metal. For quick E2E test runs, we can use AWS and for full suite, we can run the tests on both AWS and bare metal.