### PR TITLE
Match GitHub API errors by message before rate-limit handling

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -173,35 +173,6 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
 
   def rescue_common_github_api_errors
     yield
-  rescue Octokit::TooManyRequests
-    rate_limit = client.rate_limit
-    installation_ubid = github_runner.installation.ubid
-    Prog::PageNexus.assemble(
-      "GitHub API rate limit exceeded for installation #{installation_ubid}",
-      ["GithubRateLimitExceeded", installation_ubid],
-      installation_ubid,
-      severity: "warning",
-      extra_data: {
-        remaining: rate_limit.remaining,
-        limit: rate_limit.limit,
-        resets_at: rate_limit.resets_at,
-      },
-    )
-    remaining_seconds = rate_limit.resets_at - Time.now
-    if destroying_set?
-      register_deadline(nil, 15 * 60, allow_extension: true)
-      if remaining_seconds >= 15 * 60
-        github_runner.incr_skip_deregistration
-        nap 0
-      end
-    else
-      register_deadline("wait", 10 * 60, allow_extension: true)
-      if remaining_seconds >= 10 * 60
-        github_runner.incr_destroy
-        nap 0
-      end
-    end
-    nap [remaining_seconds, 30].max
   rescue Octokit::Error => e
     installation_ubid = github_runner.installation.ubid
     page_args = case e.message
@@ -219,6 +190,37 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       github_runner.incr_destroy
       nap 0
     end
+
+    if e.message.include?("API rate limit exceeded")
+      rate_limit = client.rate_limit
+      Prog::PageNexus.assemble(
+        "GitHub API rate limit exceeded for installation #{installation_ubid}",
+        ["GithubRateLimitExceeded", installation_ubid],
+        installation_ubid,
+        severity: "warning",
+        extra_data: {
+          remaining: rate_limit.remaining,
+          limit: rate_limit.limit,
+          resets_at: rate_limit.resets_at,
+        },
+      )
+      remaining_seconds = rate_limit.resets_at - Time.now
+      if destroying_set?
+        register_deadline(nil, 15 * 60, allow_extension: true)
+        if remaining_seconds >= 15 * 60
+          github_runner.incr_skip_deregistration
+          nap 0
+        end
+      else
+        register_deadline("wait", 10 * 60, allow_extension: true)
+        if remaining_seconds >= 10 * 60
+          github_runner.incr_destroy
+          nap 0
+        end
+      end
+      nap [remaining_seconds, 30].max
+    end
+
     raise
   end
 

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -713,7 +713,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     it "naps until rate limit resets and creates a page when rate limited" do
       expect(client).to receive(:rate_limit).and_return(instance_double(Octokit::RateLimit, remaining: 0, limit: 5000, resets_at: now + 300))
       refresh_frame(nx, new_values: {"deadline_target" => "wait", "deadline_at" => (now - 5 * 60).to_s})
-      expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests } }.to nap(300)
+      expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests.new({body: "API rate limit exceeded"}) } }.to nap(300)
         .and change { Page.count }.by(1)
       expect(Time.parse(nx.frame["deadline_at"])).to eq(now + 10 * 60)
       expect(Page.first).to have_attributes(
@@ -727,13 +727,13 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(client).to receive(:rate_limit).and_return(instance_double(Octokit::RateLimit, remaining: 0, limit: 5000, resets_at: now + 5))
       nx.incr_destroying
       refresh_frame(nx, new_values: {"deadline_target" => nil, "deadline_at" => (now - 5 * 60).to_s})
-      expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests } }.to nap(30)
+      expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests.new({body: "API rate limit exceeded"}) } }.to nap(30)
       expect(Time.parse(nx.frame["deadline_at"])).to eq(now + 15 * 60)
     end
 
     it "destroys the runner if the rate limit reset is more than 10 minutes away while provisioning" do
       expect(client).to receive(:rate_limit).and_return(instance_double(Octokit::RateLimit, remaining: 0, limit: 5000, resets_at: now + 11 * 60))
-      expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests } }.to nap
+      expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests.new({body: "API rate limit exceeded"}) } }.to nap
         .and change { Page.count }.by(1)
       expect(runner.destroy_set?).to be(true)
     end
@@ -741,7 +741,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     it "skips the deregistration if the rate limit reset is more than 15 minutes away while destroying" do
       expect(client).to receive(:rate_limit).and_return(instance_double(Octokit::RateLimit, remaining: 0, limit: 5000, resets_at: now + 16 * 60))
       nx.incr_destroying
-      expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests } }.to nap
+      expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests.new({body: "API rate limit exceeded"}) } }.to nap
         .and change { Page.count }.by(1)
       expect(runner.skip_deregistration_set?).to be(true)
     end
@@ -766,8 +766,20 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(runner.destroy_set?).to be(true)
     end
 
+    it "destroys the runner if TooManyRequests is raised with a self-hosted runners disabled message" do
+      expect(client).not_to receive(:rate_limit)
+      expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests.new({body: "Repository level self-hosted runners are disabled"}) } }.to nap(0)
+        .and change { Page.count }.by(1)
+      expect(runner.destroy_set?).to be(true)
+    end
+
     it "re-raises unexpected Octokit errors" do
       expect { nx.rescue_common_github_api_errors { raise Octokit::Error.new({body: "Unexpected error"}) } }.to raise_error Octokit::Error
+    end
+
+    it "re-raises TooManyRequests without a rate limit message" do
+      expect(client).not_to receive(:rate_limit)
+      expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests.new({body: "Something else"}) } }.to raise_error Octokit::TooManyRequests
     end
   end
 


### PR DESCRIPTION
GitHub occasionally returns Octokit::TooManyRequests (HTTP 403) for errors that are not actually rate limits. For example, a request to generate a JIT config for a repository with self-hosted runners disabled raised:

    Octokit::TooManyRequests: POST .../generate-jitconfig: 403 -
    Rate Limit Exceeded
    Error summary: Repository level self-hosted runners are
    disabled on this repository

The previous rescue_common_github_api_errors handled TooManyRequests in a dedicated rescue clause that unconditionally called client.rate_limit and napped until the (non-existent) reset time, masking the real cause and wasting a runner slot until the deadline elapsed.

Collapse the two rescue clauses into a single rescue Octokit::Error. The message-based case/when now runs first so a TooManyRequests with a known page-worthy message pages and destroys the runner like any other Octokit::Error. Only if no page pattern matched and the message actually contains "API rate limit exceeded" do we fall into the rate-limit handling; otherwise the error is re-raised.