### PR TITLE
Allow AWS e2e jobs to run in parallel across workflow runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       providers: ${{ steps.set-providers.outputs.providers }}
+      has_github_runner: ${{ steps.set-providers.outputs.has_github_runner }}
     steps:
       - name: Set provider matrix
         id: set-providers
@@ -36,7 +37,12 @@ jobs:
             providers="${{ inputs.providers }}"
           fi
           # Convert comma-separated list to JSON array
+          has_github_runner=false
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" || "${{ inputs.test_cases }}" == *"github_runner"* ]]; then
+            has_github_runner=true
+          fi
           echo "providers=$(echo "$providers" | jq -Rc 'split(",")')" >> $GITHUB_OUTPUT
+          echo "has_github_runner=$has_github_runner" >> $GITHUB_OUTPUT
 
   e2e:
     needs: setup
@@ -48,7 +54,7 @@ jobs:
     runs-on: ubicloud-standard-4
     environment: E2E-${{ matrix.provider }}
     timeout-minutes: 93
-    concurrency: E2E-${{ matrix.provider }}
+    concurrency: ${{ (matrix.provider == 'metal' && 'E2E-metal') || (needs.setup.outputs.has_github_runner == 'true' && 'E2E-aws') || format('E2E-aws-{0}', github.run_id) }}
 
     steps:
     - name: Check out code
@@ -70,9 +76,11 @@ jobs:
       run: npm run prod
 
     - name: Install cloudflared
+      if: needs.setup.outputs.has_github_runner == 'true'
       run: curl -L --output cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb && sudo dpkg -i cloudflared.deb
 
     - name: Set cloudflared token
+      if: needs.setup.outputs.has_github_runner == 'true'
       run: sudo cloudflared service install ${{ secrets.CLOUDFLARED_TOKEN }}
 
     - name: Install mailpit


### PR DESCRIPTION
Metal jobs remain serialized in a shared concurrency group since they
target a single dedicated host. AWS jobs with GitHub runner tests are
also serialized because we have only one app for AWS environment. That
said, AWS jobs without runner tests can be parallelized. This commit
introduces a new concurrency group for AWS jobs without runner tests,
allowing them to run in parallel across workflow runs.