### PR TITLE
Set tcp_user_timeout on standby replication connections

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -117,6 +117,7 @@ class PostgresResource < Sequel::Model
       sslmode: dns_zone ? "verify-full" : "require",
       dbname: "postgres",
       application_name:,
+      tcp_user_timeout: 30000,
     }.map { |k, v| "#{k}=#{v}" }.join("&")
 
     URI::Generic.build2(scheme: "postgres", userinfo: "ubi_replication", host: dns_zone ? identity : representative_server.vm.ip4_string, query: query_parameters).to_s

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe PostgresResource do
   it "returns replication_connection_string" do
     expect(postgres_resource).to receive(:dns_zone).and_return(instance_double(DnsZone)).at_least(:once)
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
-    expect(s).to include("ubi_replication@#{postgres_resource.ubid}.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt")
+    expect(s).to include("ubi_replication@#{postgres_resource.ubid}.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
   end
 
   it "returns replication_connection_string with ip when no dns_zone exists" do
@@ -65,7 +65,7 @@ RSpec.describe PostgresResource do
     AssignedVmAddress.create(dst_vm_id: vm.id, ip: "1.2.3.4/32")
     expect(postgres_resource.dns_zone).to be_nil
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
-    expect(s).to include("ubi_replication@1.2.3.4", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt")
+    expect(s).to include("ubi_replication@1.2.3.4", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
   end
 
   it "client_ca_certificates is nil while either client_root_cert_1 or client_root_cert_2 also nil" do


### PR DESCRIPTION
ShutDownSlotSync() blocks the promote code path while waiting for
the slot sync worker to exit. If the primary has crashed, the
worker is stuck on a dead TCP connection that takes ~15 minutes
to time out (tcp_retries2=15), leaving the standby in read-only
mode with zero log output for the duration. This affects
PostgreSQL 17+, where slot sync was introduced.

Add tcp_user_timeout=30000 (30 s) to primary_conninfo as a
short-term workaround. 30 seconds is long enough to tolerate
transient network issues, short enough to unblock promote
promptly.

A long-term fix is under discussion on pgsql-hackers:
https://www.mail-archive.com/pgsql-hackers@lists.postgresql.org/msg223372.html