### PR TITLE
Support ubiblk v0.4.1

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -156,7 +156,7 @@ jobs:
         SMTP_TLS: false
         STRIPE_PUBLIC_KEY: ${{ secrets.STRIPE_PUBLIC_KEY }}
         STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-        VHOST_BLOCK_BACKEND_VERSION: v0.4.0
+        VHOST_BLOCK_BACKEND_VERSION: v0.4.1
         OPERATOR_SSH_PUBLIC_KEYS: ${{ secrets.OPERATOR_SSH_PUBLIC_KEYS }}
       run: |
         set -o pipefail

--- a/prog/storage/setup_vhost_block_backend.rb
+++ b/prog/storage/setup_vhost_block_backend.rb
@@ -4,8 +4,8 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
   subject_is :sshable, :vm_host
 
   SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS = [
-    ["v0.4.0", "x64"],
-    ["v0.4.0", "arm64"],
+    ["v0.4.1", "x64"],
+    ["v0.4.1", "arm64"],
     ["v0.3.1", "x64"],
     ["v0.3.1", "arm64"],
     ["v0.2.2", "x64"],

--- a/rhizome/host/lib/vhost_block_backend.rb
+++ b/rhizome/host/lib/vhost_block_backend.rb
@@ -6,8 +6,8 @@ require_relative "../../common/lib/util"
 
 class VhostBlockBackend
   SHA256_BY_VERSION_AND_ARCH = {
-    ["v0.4.0", :x64] => "c74f1d4bef624d5f46e3763d6d63ac79ca3e8f3fccd1696840266398834d53d0",
-    ["v0.4.0", :arm64] => "65dd7354b087a07fca7d35bca00014532fd636e7aae838e32d87ee0d37284fad",
+    ["v0.4.1", :x64] => "8b6af36a1dd24be28cacde3221bdf9895c5afe6e997853b1bc1954acca5b5b35",
+    ["v0.4.1", :arm64] => "6a90963900b39241b6c8fc626ea500bb4199a9d284f1249f13284574829322cd",
     ["v0.3.1", :x64] => "3b4a6d3387a8da7c914d85203955c0a879168518aed76679a334070403630262",
     ["v0.3.1", :arm64] => "d7cd297468569a0fa197d48eb7d21b64aea9598895d1b5b97da8bec5e307d57b",
     ["v0.2.2", :x64] => "f5b7b2b88fa18e5070ff319b15363aed671e496d9f6cccec3bbcc48a6f38a44a",


### PR DESCRIPTION
Changes since v0.4.0:
- Update dependencies to address security issues
- Add `archive --stats` to report physical and logical sizes
- Add `export-archive` tool to export archives as raw images
- Add S3 timeout and max-attempt configs to bound time spent per stripe fetch