### PR TITLE
Show link to search archived records on admin panel 404 page

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -107,7 +107,11 @@ class CloverAdmin < Roda
     raise "admin route not handled: #{request.path}" if Config.test? && !ENV["DONT_RAISE_ADMIN_ERRORS"]
 
     @page_title = "File Not Found"
-    view(content: "")
+    if (ubid = request.path.split("/").find { UBID_REGEXP.match?(it) })
+      view(content: "<p>Try <a href=\"/archived-record-by-id?id=#{h ubid}\">searching archived records</a></p>")
+    else
+      view(content: "")
+    end
   end
 
   plugin :route_csrf do |token|

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -822,6 +822,19 @@ RSpec.describe CloverAdmin do
     ENV.delete("DONT_RAISE_ADMIN_ERRORS")
   end
 
+  it "links to archived-record-by-id on 404 when path contains ubid" do
+    ENV["DONT_RAISE_ADMIN_ERRORS"] = "1"
+    vm = create_vm(name: "life-after-death")
+    visit "/model/Vm/#{vm.ubid}"
+    expect(page).to have_content("life-after-death")
+    vm.destroy
+    visit "/model/Vm/#{vm.ubid}"
+    click_link "searching archived records"
+    expect(page).to have_content("life-after-death")
+  ensure
+    ENV.delete("DONT_RAISE_ADMIN_ERRORS")
+  end
+
   it "raises errors by default in tests" do
     expect { visit "/error" }.to raise_error(RuntimeError)
   end


### PR DESCRIPTION
we often hit 404 on flaky alerts, for postgres server you might want to check on health of postgres resource, this makes next step more discoverable, hadn't realized this tool was in admin panel