### PR TITLE
Automatically set storage volume `track_written` when appropriate

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -160,6 +160,9 @@ module Config
   # Boot Images
   override :default_boot_image_name, "ubuntu-jammy", string
 
+  # Machine Images
+  override :machine_image_max_size_gib, 40, int
+
   # Pagerduty
   optional :pagerduty_key, string, clear: true
   optional :pagerduty_log_link, string

--- a/model/project.rb
+++ b/model/project.rb
@@ -225,6 +225,7 @@ class Project < Sequel::Model
     :free_runner_upgrade_until,
     :gpu_vm,
     :ipv6_disabled,
+    :machine_image,
     :postgres_hostname_override,
     :postgres_init_script,
     :postgres_lantern,

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -43,7 +43,11 @@ class Prog::Vm::Nexus < Prog::Base
       volume[:max_write_mbytes_per_sec] ||= vm_size.io_limits.max_write_mbytes_per_sec
       volume[:vring_workers] ||= vm_size.vring_workers
       volume[:encrypted] = true if !volume.has_key? :encrypted
-      volume[:track_written] = false if !volume.has_key? :track_written
+      if !volume.has_key? :track_written
+        volume[:track_written] = !!project.get_ff_machine_image &&
+          storage_volumes.length == 1 &&
+          volume[:size_gib] <= Config.machine_image_max_size_gib
+      end
       volume[:boot] = disk_index == boot_disk_index
       volume[:machine_image_version_id] = machine_image_version_id if volume[:boot] && machine_image_version_id
 

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -94,6 +94,29 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(st.stack.first["storage_volumes"].first["size_gib"]).to eq(40)
     end
 
+    it "sets track_written when ff_machine_image is set and single volume within size limit" do
+      project.set_ff_machine_image(true)
+      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: 20}])
+      expect(st.stack.first["storage_volumes"].first["track_written"]).to be(true)
+    end
+
+    it "does not set track_written when ff_machine_image is not set" do
+      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: 20}])
+      expect(st.stack.first["storage_volumes"].first["track_written"]).to be(false)
+    end
+
+    it "does not set track_written if there are multiple storage volumes" do
+      project.set_ff_machine_image(true)
+      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: 20}, {size_gib: 10}])
+      expect(st.stack.first["storage_volumes"].first["track_written"]).to be(false)
+    end
+
+    it "does not set track_written if storage volume size exceeds machine image max size even if ff_machine_image is set" do
+      project.set_ff_machine_image(true)
+      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: Config.machine_image_max_size_gib + 1}])
+      expect(st.stack.first["storage_volumes"].first["track_written"]).to be(false)
+    end
+
     it "sets machine_image_version_id if provided" do
       miv = create_machine_image_version_metal
       st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: 20}, {size_gib: 10, read_only: true, image: "model"}], machine_image_version_id: miv.id)


### PR DESCRIPTION
This is set to true whenever it is possible to use the VM as machine image source in future: Whenever VM has at most one storage volume, and its size is at most `Config.machine_image_max_size_gib`, and machine images are enabled for the project.