### PR TITLE
Fix allocator excluding hosts without available IPv4 for IPv6-only VMs

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -132,7 +132,7 @@ module Scheduling::Allocator
     def self.candidate_hosts(request)
       ds = DB[:vm_host]
         .join(:storage_devices, vm_host_id: Sequel[:vm_host][:id])
-        .join(:available_ipv4, routed_to_host_id: Sequel[:vm_host][:id])
+        .left_join(:available_ipv4, routed_to_host_id: Sequel[:vm_host][:id])
         .left_join(:gpus, vm_host_id: Sequel[:vm_host][:id])
         .left_join(:gpu_partitions, vm_host_id: Sequel[:vm_host][:id])
         .left_join(:vm_provisioning, vm_host_id: Sequel[:vm_host][:id])
@@ -148,7 +148,7 @@ module Scheduling::Allocator
           :available_storage_gib,
           :total_storage_gib,
           :storage_devices,
-          :ipv4_available,
+          Sequel.function(:coalesce, :ipv4_available, false).as(:ipv4_available),
           Sequel.function(:coalesce, :num_gpus, 0).as(:num_gpus),
           Sequel.function(:coalesce, :available_gpus, 0).as(:available_gpus),
           Sequel.function(:coalesce, :use_gpu_partition, false).as(:use_gpu_partition),

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -413,6 +413,17 @@ RSpec.describe Al do
       expect(cand.size).to eq(2)
     end
 
+    it "retrieves candidates with no ipv4 addresses at all if not ip4_enabled" do
+      req.ip4_enabled = false
+      vmh1 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
+
+      cand = Al::Allocation.candidate_hosts(req)
+      expect(cand.size).to eq(1)
+      expect(cand.first[:vm_host_id]).to eq(vmh1.id)
+    end
+
     it "retrieves candidates with gpu if gpu_count > 0" do
       vmh1 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       vmh2 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)


### PR DESCRIPTION
## Issue
When a host has no available IPv4 addresses (e.g. all public IPs are assigned or the host only has its management IP), creating an IPv6-only VM gets stuck at "waiting for capacity" status even though the host has plenty of CPU, memory, and storage available. This makes it impossible to create IPv6-only VMs on hosts without spare IPv4 addresses.

## Root cause
The `available_ipv4` CTE in the allocator is joined with an INNER JOIN (`allocator.rb:135`), which eliminates hosts from the candidate list entirely if they have zero available IPv4 addresses. The conditional `WHERE ipv4_available` filter at line 239 correctly checks `request.ip4_enabled`, but it never gets a chance to run because the INNER JOIN already removed the host from the results.

## Fix
- Changed the INNER JOIN to a LEFT JOIN so hosts without available IPv4 addresses remain as candidates
- The existing conditional WHERE clause already handles filtering them out when IPv4 is actually requested
- Added a test that creates a host with no IPv4 addresses and verifies it's still returned as a candidate when `ip4_enabled` is false

## Testing
- [x] New test: host with no IPv4 addresses appears as candidate when `ip4_enabled=false` — passes with fix, fails without
- [x] All 107 existing allocator tests pass with the change