### PR TITLE
Improve DNS Server VM Setup

### DIFF
--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -34,7 +34,7 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
   end
 
   def self.vms_in_sync?(vms)
-    return true if vms.nil? || vms.empty?
+    return true if vms.size <= 1
 
     outputs = vms.map do |vm|
       lines = vm.sshable.cmd("sudo -u knot knotc", stdin: "zone-read --", log: false).split("\n")

--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -44,7 +44,7 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
     return true if vms.nil? || vms.empty?
 
     outputs = vms.map do |vm|
-      lines = vm.sshable.cmd("sudo -u knot knotc", stdin: "zone-read --").split("\n")
+      lines = vm.sshable.cmd("sudo -u knot knotc", stdin: "zone-read --", log: false).split("\n")
 
       lines.map do |line|
         parts = line.split

--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -148,6 +148,8 @@ zone:
   label def sync_zones
     nap 5 if ds.dns_zones.any?(&:refresh_dns_servers_set?)
 
+    sshable.cmd "sudo rm -f /var/lib/knot/*.zone /var/lib/knot/journal/*"
+
     ds.dns_zones.each do |dz|
       zone_config = <<-CONF
 #{dz.name}.          3600    SOA     ns.#{dz.name}. #{dz.name}. 37 86400 7200 1209600 #{dz.neg_ttl}

--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -34,6 +34,7 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
         ],
         boot_image:,
         enable_ip4: true,
+        exclude_host_ids: dns_server.vms.filter_map(&:vm_host_id),
       )
 
       Strand.create(prog: "DnsZone::SetupDnsServerVm", label: "start", stack: [{subject_id: vm_st.id, dns_server_id:}])

--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -34,7 +34,7 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
         ],
         boot_image:,
         enable_ip4: true,
-        exclude_host_ids: dns_server.vms.filter_map(&:vm_host_id),
+        exclude_host_ids: Config.allow_unspread_servers ? [] : dns_server.vms_dataset.where(location_id:).select_map(:vm_host_id),
       )
 
       Strand.create(prog: "DnsZone::SetupDnsServerVm", label: "start", stack: [{subject_id: vm_st.id, dns_server_id:}])

--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -3,18 +3,10 @@
 class Prog::DnsZone::SetupDnsServerVm < Prog::Base
   subject_is :vm, :sshable
 
-  def self.assemble(dns_server_id, name: nil, vm_size: "standard-2", storage_size_gib: 30, location_id: Location::HETZNER_FSN1_ID, boot_image: "ubuntu-jammy")
-    unless (dns_server = DnsServer[dns_server_id])
-      fail "No existing Dns Server"
-    end
-
-    unless Project[Config.dns_service_project_id]
-      fail "No existing Project"
-    end
-
-    unless Location[location_id]
-      fail "No existing Location"
-    end
+  def self.assemble(dns_server, name: nil, vm_size: "standard-2", storage_size_gib: 30, location_id: Location::HETZNER_FSN1_ID, boot_image: "ubuntu-jammy")
+    fail "No existing Dns Server" unless dns_server
+    fail "No existing Project" unless Project[Config.dns_service_project_id]
+    fail "No existing Location" unless Location[location_id]
 
     # The .assemble function is meant to be run by an operator manually. If/when we want to make this more programmatic
     # we should move this check to a pre-validation label of the prog.
@@ -37,7 +29,7 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
         exclude_host_ids: Config.allow_unspread_servers ? [] : dns_server.vms_dataset.where(location_id:).select_map(:vm_host_id),
       )
 
-      Strand.create(prog: "DnsZone::SetupDnsServerVm", label: "start", stack: [{subject_id: vm_st.id, dns_server_id:}])
+      Strand.create(prog: "DnsZone::SetupDnsServerVm", label: "start", stack: [{subject_id: vm_st.id, dns_server_id: dns_server.id}])
     end
   end
 

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -59,11 +59,14 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       existing_vm.update(vm_host_id: vm_host.id)
       ds.add_vm(existing_vm)
 
-      expect(described_class).to receive(:vms_in_sync?).and_return(true)
+      {false => [existing_vm.vm_host_id], true => []}.each do |allow_unspread, expected_ids|
+        expect(Config).to receive(:allow_unspread_servers).and_return(allow_unspread)
+        expect(described_class).to receive(:vms_in_sync?).and_return(true)
 
-      st = described_class.assemble(ds.id)
-      vm_strand = Strand[st.stack.first["subject_id"]]
-      expect(vm_strand.stack.first["exclude_host_ids"]).to eq [existing_vm.vm_host_id]
+        st = described_class.assemble(ds.id)
+        vm_strand = Strand[st.stack.first["subject_id"]]
+        expect(vm_strand.stack.first["exclude_host_ids"]).to eq expected_ids
+      end
     end
 
     it "propagates parameters to the created vm" do

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       }.to raise_error RuntimeError, "No existing Project"
     end
 
+    it "excludes host ids of existing dns server vms" do
+      existing_vm = create_vm_with_sshable
+      vm_host = create_vm_host
+      existing_vm.update(vm_host_id: vm_host.id)
+      ds.add_vm(existing_vm)
+
+      expect(described_class).to receive(:vms_in_sync?).and_return(true)
+
+      st = described_class.assemble(ds.id)
+      vm_strand = Strand[st.stack.first["subject_id"]]
+      expect(vm_strand.stack.first["exclude_host_ids"]).to eq [existing_vm.vm_host_id]
+    end
+
     it "errors out if the DNS Server VMs are not in sync" do
       expect(described_class).to receive(:vms_in_sync?).and_return(false)
       expect {

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -196,6 +196,8 @@ k8s.ubicloud.com.          3600    SOA     ns.k8s.ubicloud.com. k8s.ubicloud.com
 k8s.ubicloud.com.          3600    NS      toruk.
       CONF
 
+      expect(prog.sshable).to receive(:_cmd).with("sudo rm -f /var/lib/knot/*.zone /var/lib/knot/journal/*")
+
       expect(prog.sshable).to receive(:_cmd).with("sudo -u knot tee /var/lib/knot/zone1.domain.io.zone > /dev/null", stdin: f1)
       expect(prog.sshable).to receive(:_cmd).with("sudo -u knot tee /var/lib/knot/zone2.domain.io.zone > /dev/null", stdin: f2)
       expect(prog.sshable).to receive(:_cmd).with("sudo -u knot tee /var/lib/knot/k8s.ubicloud.com.zone > /dev/null", stdin: f3)

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
 
       {false => [existing_vm.vm_host_id], true => []}.each do |allow_unspread, expected_ids|
         expect(Config).to receive(:allow_unspread_servers).and_return(allow_unspread)
-        expect(described_class).to receive(:vms_in_sync?).and_return(true)
 
         st = described_class.assemble(ds)
         vm_strand = Strand[st.stack.first["subject_id"]]
@@ -82,7 +81,13 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
     end
 
     it "errors out if the DNS Server VMs are not in sync" do
-      expect(described_class).to receive(:vms_in_sync?).and_return(false)
+      ds.add_vm(create_vm_with_sshable)
+      ds.add_vm(create_vm_with_sshable)
+      ds.reload
+
+      expect(ds.vms[0].sshable).to receive(:_cmd).and_return "foo"
+      expect(ds.vms[1].sshable).to receive(:_cmd).and_return "bar"
+
       expect {
         described_class.assemble(ds)
       }.to raise_error RuntimeError, "Existing DNS Server VMs are not in sync, try again later"
@@ -92,15 +97,9 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
   describe ".vms_in_sync?" do
     let(:vms) { [create_vm_with_sshable, create_vm_with_sshable] }
 
-    it "returns true if no VMs are given" do
-      expect(described_class.vms_in_sync?(nil)).to be true
+    it "returns true if the vm count is < 2" do
       expect(described_class.vms_in_sync?([])).to be true
-    end
-
-    it "returns false if the command outputs are do not match" do
-      expect(vms[0].sshable).to receive(:_cmd).and_return "foo"
-      expect(vms[1].sshable).to receive(:_cmd).and_return "bar"
-      expect(described_class.vms_in_sync?(vms)).to be false
+      expect(described_class.vms_in_sync?([vms.first])).to be true
     end
 
     it "returns true if the dns records match, irrespective of order" do

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -238,18 +238,18 @@ zone-flush zone2.domain.io
       dummy_sshable = prog.ds.vms.first.sshable
 
       expect(prog.vm.sshable).to receive(:_cmd).twice
-        .with("sudo -u knot knotc", stdin: "zone-read --")
+        .with("sudo -u knot knotc", log: false, stdin: "zone-read --")
         .and_return("line1\nline2")
 
       expect(dummy_sshable).to receive(:_cmd)
-        .with("sudo -u knot knotc", stdin: "zone-read --")
+        .with("sudo -u knot knotc", log: false, stdin: "zone-read --")
         .and_return("line1\nline3")
 
       # Different outputs
       expect { prog.validate }.to hop("sync_zones")
 
       expect(dummy_sshable).to receive(:_cmd)
-        .with("sudo -u knot knotc", stdin: "zone-read --")
+        .with("sudo -u knot knotc", log: false, stdin: "zone-read --")
         .and_return("line2\nline1")
 
       # Same output but different order, doesn't matter

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::DnsZone::SetupDnsServerVm do
   subject(:prog) {
-    st = described_class.assemble(ds.id)
+    st = described_class.assemble(ds)
     described_class.new(st)
   }
 
@@ -29,18 +29,18 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
   describe ".assemble" do
     it "validates input" do
       expect {
-        described_class.assemble(SecureRandom.uuid)
+        described_class.assemble(nil, name: nil)
       }.to raise_error RuntimeError, "No existing Dns Server"
 
       expect {
-        described_class.assemble(ds.id, name: "InVaLidNAME")
+        described_class.assemble(ds, name: "InVaLidNAME")
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: name"
 
       expect {
-        described_class.assemble(ds.id, location_id: nil)
+        described_class.assemble(ds, location_id: nil)
       }.to raise_error RuntimeError, "No existing Location"
 
-      expect(described_class.assemble(ds.id)).to be_a Strand
+      expect(described_class.assemble(ds)).to be_a Strand
 
       expect(Vm.count).to eq 1
       expect(Vm.first.unix_user).to eq "ubi"
@@ -49,7 +49,7 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
     it "errors out if the dns service project id is not put into config properly" do
       expect(Config).to receive(:dns_service_project_id).and_return(nil)
       expect {
-        described_class.assemble(ds.id)
+        described_class.assemble(ds)
       }.to raise_error RuntimeError, "No existing Project"
     end
 
@@ -63,14 +63,14 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
         expect(Config).to receive(:allow_unspread_servers).and_return(allow_unspread)
         expect(described_class).to receive(:vms_in_sync?).and_return(true)
 
-        st = described_class.assemble(ds.id)
+        st = described_class.assemble(ds)
         vm_strand = Strand[st.stack.first["subject_id"]]
         expect(vm_strand.stack.first["exclude_host_ids"]).to eq expected_ids
       end
     end
 
     it "propagates parameters to the created vm" do
-      described_class.assemble(ds.id, name: "custom-dns", vm_size: "standard-4", storage_size_gib: 37, boot_image: "almalinux-9", location_id: Location::LEASEWEB_WDC02_ID)
+      described_class.assemble(ds, name: "custom-dns", vm_size: "standard-4", storage_size_gib: 37, boot_image: "almalinux-9", location_id: Location::LEASEWEB_WDC02_ID)
 
       vm = Vm.first
       expect(vm.name).to eq "custom-dns"
@@ -84,7 +84,7 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
     it "errors out if the DNS Server VMs are not in sync" do
       expect(described_class).to receive(:vms_in_sync?).and_return(false)
       expect {
-        described_class.assemble(ds.id)
+        described_class.assemble(ds)
       }.to raise_error RuntimeError, "Existing DNS Server VMs are not in sync, try again later"
     end
   end

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       expect(vm_strand.stack.first["exclude_host_ids"]).to eq [existing_vm.vm_host_id]
     end
 
+    it "propagates parameters to the created vm" do
+      described_class.assemble(ds.id, name: "custom-dns", vm_size: "standard-4", storage_size_gib: 37, boot_image: "almalinux-9", location_id: Location::LEASEWEB_WDC02_ID)
+
+      vm = Vm.first
+      expect(vm.name).to eq "custom-dns"
+      expect(vm.family).to eq "standard"
+      expect(vm.vcpus).to eq 4
+      expect(vm.boot_image).to eq "almalinux-9"
+      expect(vm.location_id).to eq Location::LEASEWEB_WDC02_ID
+      expect(vm.strand.stack.first["storage_volumes"].first["size_gib"]).to eq 37
+    end
+
     it "errors out if the DNS Server VMs are not in sync" do
       expect(described_class).to receive(:vms_in_sync?).and_return(false)
       expect {

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -103,7 +103,6 @@ module ThawedMock
   allow_mocking(Prog::Ai::InferenceEndpointNexus, :assemble, :model_for_id)
   allow_mocking(Prog::Ai::InferenceEndpointReplicaNexus, :assemble)
   allow_mocking(Prog::Ai::InferenceRouterReplicaNexus, :assemble)
-  allow_mocking(Prog::DnsZone::SetupDnsServerVm, :vms_in_sync?)
   allow_mocking(Prog::Github::DestroyGithubInstallation, :assemble)
   allow_mocking(Prog::Github::GithubRunnerNexus, :assemble)
   allow_mocking(Prog::Minio::MinioClusterNexus, :assemble)


### PR DESCRIPTION
- Clean up stale zone files and journals before syncing: Removes old .zone files and journal data in /var/lib/knot at the start of sync_zones, ensuring a clean state when re-entering from validate.
- Suppress verbose zone-read logging in vms_in_sync?: The zone-read output can be very large; pass log: false to avoid cluttering logs since it's only used for comparison.
- Place new DNS server VM on a different host: Passes exclude_host_ids from existing DNS server VMs to assemble_with_sshable, improving availability by avoiding co-location on the same host.
- Add test coverage: Tests for exclude_host_ids propagation and assemble parameter forwarding (name, vm_size, storage_size_gib, location_id, boot_image).