### PR TITLE
Allow running Prog::Test::PostgresResource for AWS in development/staging

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1067,17 +1067,18 @@ class CloverAdmin < Roda
         r.post do
           provider = typecast_params.nonempty_str("provider")
           raise "invalid local E2E provider" unless LOCAL_E2E_PROVIDERS.include?(provider)
+          progs = typecast_params.array!(:nonempty_str, "progs")
 
-          if typecast_params.bool("local_e2e_loop")
-            prog = "LocalE2eLoop"
-            args = {progs: typecast_params.array!(:nonempty_str, "progs")}
+          sts = if typecast_params.bool("loop")
+            [Prog::Test::LocalE2eLoop.assemble(provider:, progs:)]
           else
-            prog = typecast_params.nonempty_str("prog")
-            raise "invalid local E2E prog" unless LOCAL_E2E_PROGS.include?(prog)
+            progs.map do |prog|
+              Prog::Test::LocalE2eLoop.check_prog(prog)
+              Prog::Test.const_get(prog).assemble(provider:)
+            end
           end
 
-          st = Prog::Test.const_get(prog).assemble(provider:, **args)
-          flash["notice"] = "Started local E2E strand: #{st.ubid}"
+          flash["notice"] = "Started local E2E strand(s): #{sts.map(&:ubid).join(" ")}"
           r.redirect
         end
       end

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -496,6 +496,16 @@ class CloverAdmin < Roda
     ["VmHost", :boot_images] => "vm_host",
   }.freeze
 
+  LOCAL_E2E_PROGS = %w[
+    PostgresResource
+    HaPostgresResource
+    UpgradePostgresResource
+  ].freeze
+  LOCAL_E2E_PROVIDERS = %w[
+    aws
+    metal
+  ].freeze
+
   plugin :autoforme do
     # :nocov:
     register_by_name if Config.development?
@@ -1042,9 +1052,19 @@ class CloverAdmin < Roda
       view("authentication_audit_log")
     end
 
-    r.get "local-e2e" do
-      @strands = Strand.where(Sequel.like(:prog, "Test::%")).order(:prog, :id).all
-      view("local_e2e")
+    r.is "local-e2e" do
+      r.get do
+        @strands = Strand.where(Sequel.like(:prog, "Test::%")).order(:prog, :id).all
+        view("local_e2e")
+      end
+
+      r.post do
+        prog, provider = typecast_params.nonempty_str(%w[prog provider])
+        raise "invalid local E2E prog or provider" unless LOCAL_E2E_PROGS.include?(prog) && LOCAL_E2E_PROVIDERS.include?(provider)
+        st = Prog::Test.const_get(prog).assemble(provider:)
+        flash["notice"] = "Started local E2E strand: #{st.ubid}"
+        r.redirect
+      end
     end
 
     r.get "admin-list" do

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -503,11 +503,7 @@ class CloverAdmin < Roda
     ["VmHost", :boot_images] => "vm_host",
   }.freeze
 
-  LOCAL_E2E_PROGS = %w[
-    PostgresResource
-    HaPostgresResource
-    UpgradePostgresResource
-  ].freeze
+  LOCAL_E2E_PROGS = Prog::Test::LocalE2eLoop::ALLOWED_PROGS
   LOCAL_E2E_PROVIDERS = %w[
     aws
     metal
@@ -1064,14 +1060,23 @@ class CloverAdmin < Roda
 
       r.is do
         r.get do
-          @strands = strand_ds.order(:prog, :id).all
+          @strands = strand_ds.order(:prog, :id).eager(:semaphores).all
           view("local_e2e")
         end
 
         r.post do
-          prog, provider = typecast_params.nonempty_str(%w[prog provider])
-          raise "invalid local E2E prog or provider" unless LOCAL_E2E_PROGS.include?(prog) && LOCAL_E2E_PROVIDERS.include?(provider)
-          st = Prog::Test.const_get(prog).assemble(provider:)
+          provider = typecast_params.nonempty_str("provider")
+          raise "invalid local E2E provider" unless LOCAL_E2E_PROVIDERS.include?(provider)
+
+          if typecast_params.bool("local_e2e_loop")
+            prog = "LocalE2eLoop"
+            args = {progs: typecast_params.array!(:nonempty_str, "progs")}
+          else
+            prog = typecast_params.nonempty_str("prog")
+            raise "invalid local E2E prog" unless LOCAL_E2E_PROGS.include?(prog)
+          end
+
+          st = Prog::Test.const_get(prog).assemble(provider:, **args)
           flash["notice"] = "Started local E2E strand: #{st.ubid}"
           r.redirect
         end

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1042,6 +1042,11 @@ class CloverAdmin < Roda
       view("authentication_audit_log")
     end
 
+    r.get "local-e2e" do
+      @strands = Strand.where(Sequel.like(:prog, "Test::%")).order(:prog, :id).all
+      view("local_e2e")
+    end
+
     r.get "admin-list" do
       @admins = DB[:admin_account].select_order_map(:login)
       view("admin_list")

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -16,6 +16,12 @@ class CloverAdmin < Roda
     TableLink.new(...)
   end
 
+  TableFormButton = Data.define(:text, :attributes)
+
+  def table_form_button(text, **attributes)
+    TableFormButton.new(text, attributes)
+  end
+
   Unreloader.record_dependency("lib/audit_log.rb", __FILE__)
 
   MIN_AUDIT_LOG_END_DATE = Date.new(2025, 6)
@@ -102,6 +108,7 @@ class CloverAdmin < Roda
 
   plugin :symbol_matchers
   symbol_matcher(:ubid, /([a-tv-z0-9]{26})/)
+  symbol_matcher(:ubid_uuid, :ubid) { UBID.to_uuid(it) }
 
   plugin :not_found do
     raise "admin route not handled: #{request.path}" if Config.test? && !ENV["DONT_RAISE_ADMIN_ERRORS"]
@@ -1052,18 +1059,41 @@ class CloverAdmin < Roda
       view("authentication_audit_log")
     end
 
-    r.is "local-e2e" do
-      r.get do
-        @strands = Strand.where(Sequel.like(:prog, "Test::%")).order(:prog, :id).all
-        view("local_e2e")
+    r.on "local-e2e" do
+      strand_ds = Strand.where(Sequel.like(:prog, "Test::%"))
+
+      r.is do
+        r.get do
+          @strands = strand_ds.order(:prog, :id).all
+          view("local_e2e")
+        end
+
+        r.post do
+          prog, provider = typecast_params.nonempty_str(%w[prog provider])
+          raise "invalid local E2E prog or provider" unless LOCAL_E2E_PROGS.include?(prog) && LOCAL_E2E_PROVIDERS.include?(provider)
+          st = Prog::Test.const_get(prog).assemble(provider:)
+          flash["notice"] = "Started local E2E strand: #{st.ubid}"
+          r.redirect
+        end
       end
 
-      r.post do
-        prog, provider = typecast_params.nonempty_str(%w[prog provider])
-        raise "invalid local E2E prog or provider" unless LOCAL_E2E_PROGS.include?(prog) && LOCAL_E2E_PROVIDERS.include?(provider)
-        st = Prog::Test.const_get(prog).assemble(provider:)
-        flash["notice"] = "Started local E2E strand: #{st.ubid}"
-        r.redirect
+      r.post %w[pause unpause].freeze, :ubid_uuid do |action, strand_id|
+        unless (strand = strand_ds.with_pk(strand_id))
+          flash["error"] = "Strand not found, it was probably already deleted"
+          r.redirect "/local-e2e"
+        end
+
+        raise "invalid strand" unless LOCAL_E2E_PROGS.include?(strand.prog.split("::").last)
+
+        if action == "pause"
+          Semaphore.incr(strand.id, "pause")
+        else
+          Semaphore.where(strand_id: strand.id, name: "pause").destroy
+          strand.this.update(schedule: Sequel::CURRENT_TIMESTAMP)
+        end
+
+        flash["notice"] = "Strand #{strand.ubid} #{action}d"
+        r.redirect "/local-e2e"
       end
     end
 

--- a/config.rb
+++ b/config.rb
@@ -220,6 +220,9 @@ module Config
   optional :e2e_aws_secret_key, string, clear: true
   optional :e2e_cache_proxy_download_url, string
 
+  # Local e2e
+  optional :local_e2e_postgres_test_project_id, string
+
   # Load Balancer
   optional :load_balancer_service_project_id, uuid
   optional :load_balancer_service_hostname, string

--- a/prog/test/base.rb
+++ b/prog/test/base.rb
@@ -5,17 +5,4 @@ class Prog::Test::Base < Prog::Base
     strand.update(exitval: {msg:})
     hop_failed
   end
-
-  def self.postgres_test_location_options(provider)
-    if provider == "aws"
-      location = Location[provider: "aws", project_id: Config.local_e2e_postgres_test_project_id, name: "us-west-2"]
-      location.location_credential_aws ||
-        LocationCredentialAws.create_with_id(location, access_key: Config.e2e_aws_access_key, secret_key: Config.e2e_aws_secret_key)
-      family = "m8gd"
-      vcpus = 2
-      [location.id, Option.aws_instance_type_name(family, vcpus), Option::AWS_STORAGE_SIZE_OPTIONS[family][vcpus].first.to_i]
-    else
-      [Location::HETZNER_FSN1_ID, "standard-2", 128]
-    end
-  end
 end

--- a/prog/test/base.rb
+++ b/prog/test/base.rb
@@ -8,9 +8,9 @@ class Prog::Test::Base < Prog::Base
 
   def self.postgres_test_location_options(provider)
     if provider == "aws"
-      location = Location[provider: "aws", project_id: nil, name: "us-west-2"]
+      location = Location[provider: "aws", project_id: Config.local_e2e_postgres_test_project_id, name: "us-west-2"]
       location.location_credential_aws ||
-        LocationCredentialAws.create_with_id(location.id, access_key: Config.e2e_aws_access_key, secret_key: Config.e2e_aws_secret_key)
+        LocationCredentialAws.create_with_id(location, access_key: Config.e2e_aws_access_key, secret_key: Config.e2e_aws_secret_key)
       family = "m8gd"
       vcpus = 2
       [location.id, Option.aws_instance_type_name(family, vcpus), Option::AWS_STORAGE_SIZE_OPTIONS[family][vcpus].first.to_i]

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -4,15 +4,7 @@ require_relative "../../lib/util"
 
 class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   def self.assemble(provider: "metal")
-    postgres_test_project = Project.create(name: "Postgres-HA-Test-Project")
-    Project[Config.postgres_service_project_id] ||
-      Project.create_with_id(Config.postgres_service_project_id || Project.generate_uuid, name: "Postgres-Service-Project")
-
-    Strand.create(
-      prog: "Test::HaPostgresResource",
-      label: "start",
-      stack: [{"postgres_test_project_id" => postgres_test_project.id, "provider" => provider}],
-    )
+    super(provider:, project_name: "Postgres-HA-Test-Project")
   end
 
   label def start

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -107,7 +107,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   end
 
   label def finish
-    finish_test("Postgres tests are finished!")
+    finish_test
   end
 
   label def failed

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -19,7 +19,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
       ha_type: "async",
     )
 
-    update_stack({"postgres_resource_id" => st.id})
+    update_stack({"postgres_resource_id" => st.id, "private_subnet_id" => st.subject.private_subnet_id})
     hop_wait_postgres_resource
   end
 
@@ -103,6 +103,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
 
   label def wait_resources_destroyed
     nap 5 if postgres_resource
+    nap_if_private_subnet
     hop_finish
   end
 

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -3,6 +3,8 @@
 require_relative "../../lib/util"
 
 class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
+  semaphore :pause
+
   def self.assemble(provider: "metal")
     super(provider:, project_name: "Postgres-HA-Test-Project")
   end

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -106,11 +106,6 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
     hop_finish
   end
 
-  label def finish
-    finish_test
-  end
-
-  label def failed
-    nap 15
-  end
+  label :finish
+  label :failed
 end

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -8,19 +8,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   end
 
   label def start
-    location_id, target_vm_size, target_storage_size_gib = self.class.postgres_test_location_options(frame["provider"])
-
-    st = Prog::Postgres::PostgresResourceNexus.assemble(
-      project_id: frame["postgres_test_project_id"],
-      location_id:,
-      name: "postgres-test-ha",
-      target_vm_size:,
-      target_storage_size_gib:,
-      ha_type: "async",
-    )
-
-    update_stack({"postgres_resource_id" => st.id, "private_subnet_id" => st.subject.private_subnet_id})
-    hop_wait_postgres_resource
+    super(name: "postgres-test-ha", ha_type: "async")
   end
 
   label def wait_postgres_resource

--- a/prog/test/local_e2e_loop.rb
+++ b/prog/test/local_e2e_loop.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class Prog::Test::LocalE2eLoop < Prog::Test::Base
+  ALLOWED_PROGS = %w[
+    PostgresResource
+    HaPostgresResource
+    UpgradePostgresResource
+  ].freeze
+
+  semaphore :pause
+
+  def self.check_prog(prog)
+    raise "invalid local E2E prog" unless ALLOWED_PROGS.include?(prog)
+  end
+
+  def self.assemble(progs:, nap_between: 60, **args)
+    progs.each { check_prog(it) }
+
+    Strand.create(
+      prog: name.delete_prefix("Prog::"),
+      label: "start",
+      stack: [{
+        "progs" => progs,
+        "prog_args" => args,
+        "starts" => 0,
+        "successes" => 0,
+        "failures" => 0,
+        "nap" => false,
+        "nap_between" => nap_between.clamp(0, nil),
+        "current_strand" => nil,
+      }],
+    )
+  end
+
+  def before_run
+    super
+
+    if pause_set?
+      nap(60 * 60)
+    end
+  end
+
+  label def start
+    st = Prog::Test.const_get(frame["progs"].first).assemble(**frame["prog_args"].transform_keys(&:to_sym))
+    st.update(parent_id: strand.id)
+    update_stack(
+      "current_strand" => st.id,
+      "starts" => frame["starts"] + 1,
+      "progs" => frame["progs"].rotate,
+    )
+    hop_wait
+  end
+
+  label def wait
+    reap(:nap_between, reaper: lambda do |child|
+      key = (child.exitval["msg"] == "Postgres tests are finished!") ? "successes" : "failures"
+      update_stack(
+        "current_strand" => nil,
+        key => frame[key] + 1,
+        "nap" => true,
+      )
+    end)
+  end
+
+  label def nap_between
+    if frame["nap"]
+      update_stack("nap" => false)
+      nap frame["nap_between"]
+    else
+      hop_start
+    end
+  end
+end

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -31,6 +31,23 @@ class Prog::Test::PostgresBase < Prog::Test::Base
     end
   end
 
+  def start(**)
+    location_id, target_vm_size, target_storage_size_gib = self.class.postgres_test_location_options(frame["provider"])
+
+    st = Prog::Postgres::PostgresResourceNexus.assemble(
+      project_id: frame["postgres_test_project_id"],
+      location_id:,
+      target_vm_size:,
+      target_storage_size_gib:,
+      **,
+    )
+
+    frame = {"postgres_resource_id" => st.id, "private_subnet_id" => st.subject.private_subnet_id}
+    yield st.subject, frame if block_given?
+    update_stack(frame)
+    hop_wait_postgres_resource
+  end
+
   def postgres_test_project
     @postgres_test_project ||= Project[frame["postgres_test_project_id"]]
   end

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -31,6 +31,14 @@ class Prog::Test::PostgresBase < Prog::Test::Base
     end
   end
 
+  def before_run
+    super
+
+    if pause_set?
+      nap(60 * 60)
+    end
+  end
+
   def start(**)
     location_id, target_vm_size, target_storage_size_gib = self.class.postgres_test_location_options(frame["provider"])
 

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -51,9 +51,13 @@ class Prog::Test::PostgresBase < Prog::Test::Base
     File.read("./prog/test/testdata/order_analytics_read_queries.sql").freeze
   end
 
-  def finish_test
+  def finish
     postgres_test_project.destroy unless Config.local_e2e_postgres_test_project_id
     fail_test(frame["fail_message"]) if frame["fail_message"]
     pop "Postgres tests are finished!"
+  end
+
+  def failed
+    nap 15
   end
 end

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -51,6 +51,13 @@ class Prog::Test::PostgresBase < Prog::Test::Base
     File.read("./prog/test/testdata/order_analytics_read_queries.sql").freeze
   end
 
+  def nap_if_private_subnet
+    if PrivateSubnet[frame["private_subnet_id"]]
+      Clog.emit("Waiting for private subnet to be destroyed")
+      nap 5
+    end
+  end
+
   def finish
     postgres_test_project.destroy unless Config.local_e2e_postgres_test_project_id
     fail_test(frame["fail_message"]) if frame["fail_message"]

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -1,6 +1,23 @@
 # frozen_string_literal: true
 
 class Prog::Test::PostgresBase < Prog::Test::Base
+  def self.assemble(provider:, project_name:)
+    postgres_test_project = if Config.local_e2e_postgres_test_project_id
+      Project.with_pk!(Config.local_e2e_postgres_test_project_id)
+    else
+      Project.create(name: project_name)
+    end
+
+    Project[Config.postgres_service_project_id] ||
+      Project.create_with_id(Config.postgres_service_project_id || Project.generate_uuid, name: "Postgres-Service-Project")
+
+    Strand.create(
+      prog: name.delete_prefix("Prog::"),
+      label: "start",
+      stack: [{"provider" => provider, "postgres_test_project_id" => postgres_test_project.id}],
+    )
+  end
+
   def self.postgres_test_location_options(provider)
     if provider == "aws"
       location = Location[provider: "aws", project_id: Config.local_e2e_postgres_test_project_id, name: "us-west-2"]

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -51,9 +51,9 @@ class Prog::Test::PostgresBase < Prog::Test::Base
     File.read("./prog/test/testdata/order_analytics_read_queries.sql").freeze
   end
 
-  def finish_test(success_msg)
+  def finish_test
     postgres_test_project.destroy unless Config.local_e2e_postgres_test_project_id
     fail_test(frame["fail_message"]) if frame["fail_message"]
-    pop success_msg
+    pop "Postgres tests are finished!"
   end
 end

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -22,7 +22,7 @@ class Prog::Test::PostgresBase < Prog::Test::Base
   end
 
   def finish_test(success_msg)
-    postgres_test_project.destroy
+    postgres_test_project.destroy unless Config.local_e2e_postgres_test_project_id
     fail_test(frame["fail_message"]) if frame["fail_message"]
     pop success_msg
   end

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 class Prog::Test::PostgresBase < Prog::Test::Base
+  def self.postgres_test_location_options(provider)
+    if provider == "aws"
+      location = Location[provider: "aws", project_id: Config.local_e2e_postgres_test_project_id, name: "us-west-2"]
+      location.location_credential_aws ||
+        LocationCredentialAws.create_with_id(location, access_key: Config.e2e_aws_access_key, secret_key: Config.e2e_aws_secret_key)
+      family = "m8gd"
+      vcpus = 2
+      [location.id, Option.aws_instance_type_name(family, vcpus), Option::AWS_STORAGE_SIZE_OPTIONS[family][vcpus].first.to_i]
+    else
+      [Location::HETZNER_FSN1_ID, "standard-2", 128]
+    end
+  end
+
   def postgres_test_project
     @postgres_test_project ||= Project[frame["postgres_test_project_id"]]
   end

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -8,18 +8,7 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
   end
 
   label def start
-    location_id, target_vm_size, target_storage_size_gib = self.class.postgres_test_location_options(frame["provider"])
-
-    st = Prog::Postgres::PostgresResourceNexus.assemble(
-      project_id: frame["postgres_test_project_id"],
-      location_id:,
-      name: "postgres-test-standard",
-      target_vm_size:,
-      target_storage_size_gib:,
-    )
-
-    update_stack({"postgres_resource_id" => st.id, "private_subnet_id" => st.subject.private_subnet_id})
-    hop_wait_postgres_resource
+    super(name: "postgres-test-standard")
   end
 
   label def wait_postgres_resource

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -3,6 +3,8 @@
 require_relative "../../lib/util"
 
 class Prog::Test::PostgresResource < Prog::Test::PostgresBase
+  semaphore :pause
+
   def self.assemble(provider: "metal")
     super(provider:, project_name: "Postgres-Test-Project")
   end

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -55,11 +55,6 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
     hop_finish
   end
 
-  label def finish
-    finish_test
-  end
-
-  label def failed
-    nap 15
-  end
+  label :finish
+  label :failed
 end

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -4,25 +4,7 @@ require_relative "../../lib/util"
 
 class Prog::Test::PostgresResource < Prog::Test::PostgresBase
   def self.assemble(provider: "metal")
-    postgres_test_project = if Config.local_e2e_postgres_test_project_id
-      Project.with_pk!(Config.local_e2e_postgres_test_project_id)
-    else
-      Project.create(name: "Postgres-Test-Project")
-    end
-    postgres_service_project = Project[Config.postgres_service_project_id] ||
-      Project.create_with_id(Config.postgres_service_project_id || Project.generate_uuid, name: "Postgres-Service-Project")
-
-    frame = {
-      "provider" => provider,
-      "postgres_service_project_id" => postgres_service_project.id,
-      "postgres_test_project_id" => postgres_test_project.id,
-    }
-
-    Strand.create(
-      prog: "Test::PostgresResource",
-      label: "start",
-      stack: [frame],
-    )
+    super(provider:, project_name: "Postgres-Test-Project")
   end
 
   label def start

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -4,7 +4,11 @@ require_relative "../../lib/util"
 
 class Prog::Test::PostgresResource < Prog::Test::PostgresBase
   def self.assemble(provider: "metal")
-    postgres_test_project = Project.create(name: "Postgres-Test-Project")
+    postgres_test_project = if Config.local_e2e_postgres_test_project_id
+      Project.with_pk!(Config.local_e2e_postgres_test_project_id)
+    else
+      Project.create(name: "Postgres-Test-Project")
+    end
     postgres_service_project = Project[Config.postgres_service_project_id] ||
       Project.create_with_id(Config.postgres_service_project_id || Project.generate_uuid, name: "Postgres-Service-Project")
 

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -56,7 +56,7 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
   end
 
   label def finish
-    finish_test("Postgres tests are finished!")
+    finish_test
   end
 
   label def failed

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -18,7 +18,7 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
       target_storage_size_gib:,
     )
 
-    update_stack({"postgres_resource_id" => st.id})
+    update_stack({"postgres_resource_id" => st.id, "private_subnet_id" => st.subject.private_subnet_id})
     hop_wait_postgres_resource
   end
 
@@ -47,11 +47,7 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
 
   label def wait_resources_destroyed
     nap 5 if postgres_resource
-    if PrivateSubnet[project_id: frame["postgres_test_project_id"]]
-      Clog.emit("Waiting for private subnet to be destroyed")
-      nap 5
-    end
-
+    nap_if_private_subnet
     hop_finish
   end
 

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -20,7 +20,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
       target_version: "17",
     )
 
-    update_stack({"postgres_resource_id" => st.id})
+    update_stack({"postgres_resource_id" => st.id, "private_subnet_id" => st.subject.private_subnet_id})
     update_stack({"pre_upgrade_postgres_timeline_id" => PostgresResource[st.id].timeline.id})
     hop_wait_postgres_resource
   end
@@ -217,6 +217,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
 
   label def wait_resources_destroyed
     nap 5 if read_replica || postgres_resource || pre_upgrade_timeline
+    nap_if_private_subnet
     hop_finish
   end
 

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -221,7 +221,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   end
 
   label def finish
-    finish_test("Postgres upgrade tests are finished!")
+    finish_test
   end
 
   label def failed

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -3,6 +3,8 @@
 require_relative "../../lib/util"
 
 class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
+  semaphore :pause
+
   def self.assemble(provider: "metal")
     super(provider:, project_name: "Postgres-Upgrade-Test-Project")
   end

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -8,21 +8,9 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   end
 
   label def start
-    location_id, target_vm_size, target_storage_size_gib = self.class.postgres_test_location_options(frame["provider"])
-
-    st = Prog::Postgres::PostgresResourceNexus.assemble(
-      project_id: frame["postgres_test_project_id"],
-      location_id:,
-      name: "postgres-test-upgrade",
-      target_vm_size:,
-      target_storage_size_gib:,
-      ha_type: "async",
-      target_version: "17",
-    )
-
-    update_stack({"postgres_resource_id" => st.id, "private_subnet_id" => st.subject.private_subnet_id})
-    update_stack({"pre_upgrade_postgres_timeline_id" => PostgresResource[st.id].timeline.id})
-    hop_wait_postgres_resource
+    super(name: "postgres-test-upgrade", ha_type: "async", target_version: "17") do |resource, frame|
+      frame["pre_upgrade_postgres_timeline_id"] = resource.timeline.id
+    end
   end
 
   label def wait_postgres_resource

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -4,15 +4,7 @@ require_relative "../../lib/util"
 
 class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   def self.assemble(provider: "metal")
-    postgres_test_project = Project.create(name: "Postgres-Upgrade-Test-Project")
-    Project[Config.postgres_service_project_id] ||
-      Project.create_with_id(Config.postgres_service_project_id || Project.generate_uuid, name: "Postgres-Service-Project")
-
-    Strand.create(
-      prog: "Test::UpgradePostgresResource",
-      label: "start",
-      stack: [{"provider" => provider, "postgres_test_project_id" => postgres_test_project.id}],
-    )
+    super(provider:, project_name: "Postgres-Upgrade-Test-Project")
   end
 
   label def start

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -220,13 +220,8 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
     hop_finish
   end
 
-  label def finish
-    finish_test
-  end
-
-  label def failed
-    nap 15
-  end
+  label :finish
+  label :failed
 
   def read_replica
     @read_replica ||= PostgresResource[frame["read_replica_id"]]

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -28,6 +28,16 @@ input[type=submit] {
   #ubid_form & { font-size: 0.9em; }
 }
 
+#start-local-e2e-loop > div {
+  margin-top: 10px;
+}
+span.label {
+  display: block;
+}
+label.label-after:after {
+  content: "";
+}
+
 nav div.container, .associations {
   display: flex;
   justify-content: space-between;

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -28,7 +28,7 @@ input[type=submit] {
   #ubid_form & { font-size: 0.9em; }
 }
 
-#start-local-e2e-loop > div {
+#start-local-e2e > div {
   margin-top: 10px;
 }
 span.label {

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -3,7 +3,9 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Test::HaPostgresResource do
-  subject(:pgr_test) { described_class.new(described_class.assemble) }
+  subject(:pgr_test) { described_class.new(pgr_strand) }
+
+  let(:pgr_strand) { described_class.assemble }
 
   let(:postgres_service_project_id) { "546a1ed8-53e5-86d2-966c-fb782d2ae3ab" }
   let(:minio_service_project_id) { "f7207bf6-a031-4c98-aee6-4bb9cb03e821" }
@@ -21,6 +23,17 @@ RSpec.describe Prog::Test::HaPostgresResource do
       expect(st).to be_a Strand
       expect(st.label).to eq("start")
       expect(Project[name: "Postgres-HA-Test-Project"]).not_to be_nil
+    end
+  end
+
+  describe "#before_run" do
+    it "naps if pause is set" do
+      Semaphore.incr(pgr_strand.id, "pause")
+      expect { pgr_test.before_run }.to nap(60 * 60)
+    end
+
+    it "does nothing if pause is not set" do
+      expect(pgr_test.before_run).to be_nil
     end
   end
 

--- a/spec/prog/test/local_e2e_loop_spec.rb
+++ b/spec/prog/test/local_e2e_loop_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Test::LocalE2eLoop do
+  subject(:lel) { described_class.new(lel_strand) }
+
+  let(:lel_strand) { described_class.assemble(progs: ["PostgresResource", "HaPostgresResource"], provider: "metal") }
+
+  describe ".assemble" do
+    it "creates a strand" do
+      expect(lel_strand.prog).to eq "Test::LocalE2eLoop"
+      expect(lel_strand.label).to eq "start"
+      expect(lel_strand.stack).to eq [{
+        "progs" => %w[PostgresResource HaPostgresResource],
+        "prog_args" => {"provider" => "metal"},
+        "starts" => 0,
+        "successes" => 0,
+        "failures" => 0,
+        "nap" => false,
+        "nap_between" => 60,
+        "current_strand" => nil,
+      }]
+    end
+
+    it "fails if one of the progs is invalid" do
+      expect do
+        described_class.assemble(progs: ["PostgresResource", "LocalE2eLoop"], provider: "metal")
+      end.to raise_error(RuntimeError, "invalid local E2E prog")
+    end
+  end
+
+  describe "#before_run" do
+    it "naps if pause is set" do
+      Semaphore.incr(lel_strand.id, "pause")
+      expect { lel.before_run }.to nap(60 * 60)
+    end
+
+    it "does nothing if pause is not set" do
+      expect(lel.before_run).to be_nil
+    end
+  end
+
+  describe "#start" do
+    it "starts a child strand" do
+      service_project = Project.create(name: "Postgres-Service-Project")
+      expect(Config).to receive(:postgres_service_project_id).and_return(service_project.id)
+      expect { lel.start }.to hop("wait")
+        .and change { lel_strand.children_dataset.count }.from(0).to(1)
+      child = lel_strand.children.first
+      expect(
+        lel_strand.stack[0].values_at("current_strand", "starts", "progs"),
+      ).to eq [child.id, 1, %w[HaPostgresResource PostgresResource]]
+      expect(child.prog).to eq "Test::PostgresResource"
+      expect(child.stack[0]["provider"]).to eq "metal"
+    end
+  end
+
+  describe "#wait" do
+    it "hops to nap_between if there are no child strands" do
+      expect { lel.wait }.to hop("nap_between")
+      expect(
+        lel_strand.stack[0].values_at("current_strand", "successes", "failures", "nap"),
+      ).to eq [nil, 0, 0, false]
+    end
+
+    it "handles failed child strand" do
+      Strand.create(parent_id: lel_strand.id, prog: "Test::PostgresResource", label: "start", exitval: {})
+      expect { lel.wait }.to hop("nap_between")
+      expect(
+        lel_strand.stack[0].values_at("current_strand", "successes", "failures", "nap"),
+      ).to eq [nil, 0, 1, true]
+    end
+
+    it "handles successful child strand" do
+      Strand.create(parent_id: lel_strand.id, prog: "Test::PostgresResource", label: "start", exitval: {"msg" => "Postgres tests are finished!"})
+      expect { lel.wait }.to hop("nap_between")
+      expect(
+        lel_strand.stack[0].values_at("current_strand", "successes", "failures", "nap"),
+      ).to eq [nil, 1, 0, true]
+    end
+  end
+
+  describe "#nap_between" do
+    it "naps if nap is set" do
+      refresh_frame(lel, new_values: {"nap" => true})
+      expect { lel.nap_between }.to nap(60)
+    end
+
+    it "hops to start if nap is not set" do
+      expect { lel.nap_between }.to hop("start")
+    end
+  end
+end

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -115,7 +115,8 @@ RSpec.describe Prog::Test::PostgresResource do
 
     it "naps if the private subnet isn't deleted yet" do
       project_id = pgr_test.strand.stack.first["postgres_test_project_id"]
-      PrivateSubnet.create(name: "subnet", project_id:, location_id:, net4: "10.0.0.0/26", net6: "fd00::/64")
+      ps = PrivateSubnet.create(name: "subnet", project_id:, location_id:, net4: "10.0.0.0/26", net6: "fd00::/64")
+      refresh_frame(pgr_test, new_values: {"private_subnet_id" => ps.id})
       expect { pgr_test.wait_resources_destroyed }.to nap(5)
     end
 

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -33,9 +33,18 @@ RSpec.describe Prog::Test::PostgresResource do
 
   describe ".assemble" do
     it "creates a strand and service projects" do
-      st = described_class.assemble
+      st = nil
+      expect { st = described_class.assemble }.to change { Project.select_order_map(:name) }.from(["service-project"]).to(["Postgres-Test-Project", "service-project"])
       expect(st).to be_a Strand
       expect(st.label).to eq("start")
+    end
+
+    it "uses existing project if Config.local_e2e_postgres_test_project_id" do
+      st = nil
+      project = Project.create(name: "foo")
+      expect(Config).to receive(:local_e2e_postgres_test_project_id).and_return(project.id).at_least(:once)
+      expect { st = described_class.assemble }.not_to change { Project.select_order_map(:name) }
+      expect(st).to be_a Strand
     end
   end
 
@@ -116,8 +125,18 @@ RSpec.describe Prog::Test::PostgresResource do
   end
 
   describe "#finish" do
-    it "exits successfully if no failure happened" do
+    it "delete project and exits successfully if no failure happened" do
+      pgr_test
       expect { pgr_test.finish }.to exit({"msg" => "Postgres tests are finished!"})
+        .and change { Project.select_order_map(:name) }.from(["Postgres-Test-Project", "service-project"]).to(["service-project"])
+    end
+
+    it "not delete project if Config.local_e2e_postgres_test_project_id" do
+      pgr_test
+      project = Project.create(name: "foo")
+      expect(Config).to receive(:local_e2e_postgres_test_project_id).and_return(project.id).at_least(:once)
+      expect { pgr_test.finish }.to exit({"msg" => "Postgres tests are finished!"})
+        .and not_change { Project.select_order_map(:name) }
     end
 
     it "hops to failed if a failure happened" do

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -3,7 +3,9 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Test::PostgresResource do
-  subject(:pgr_test) { described_class.new(described_class.assemble) }
+  subject(:pgr_test) { described_class.new(pgr_strand) }
+
+  let(:pgr_strand) { described_class.assemble }
 
   let(:test_project) { Project.create(name: "test-project") }
   let(:service_project) { Project.create(name: "service-project") }
@@ -45,6 +47,17 @@ RSpec.describe Prog::Test::PostgresResource do
       expect(Config).to receive(:local_e2e_postgres_test_project_id).and_return(project.id).at_least(:once)
       expect { st = described_class.assemble }.not_to change { Project.select_order_map(:name) }
       expect(st).to be_a Strand
+    end
+  end
+
+  describe "#before_run" do
+    it "naps if pause is set" do
+      Semaphore.incr(pgr_strand.id, "pause")
+      expect { pgr_test.before_run }.to nap(60 * 60)
+    end
+
+    it "does nothing if pause is not set" do
+      expect(pgr_test.before_run).to be_nil
     end
   end
 

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -3,7 +3,9 @@
 require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Test::UpgradePostgresResource do
-  subject(:pgr_test) { described_class.new(described_class.assemble) }
+  subject(:pgr_test) { described_class.new(pgr_strand) }
+
+  let(:pgr_strand) { described_class.assemble }
 
   let(:postgres_service_project_id) { "546a1ed8-53e5-86d2-966c-fb782d2ae3ab" }
   let(:minio_service_project_id) { "f7207bf6-a031-4c98-aee6-4bb9cb03e821" }
@@ -21,6 +23,17 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       expect(st).to be_a Strand
       expect(st.label).to eq("start")
       expect(Project[name: "Postgres-Upgrade-Test-Project"]).not_to be_nil
+    end
+  end
+
+  describe "#before_run" do
+    it "naps if pause is set" do
+      Semaphore.incr(pgr_strand.id, "pause")
+      expect { pgr_test.before_run }.to nap(60 * 60)
+    end
+
+    it "does nothing if pause is not set" do
+      expect(pgr_test.before_run).to be_nil
     end
   end
 

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
   describe "#finish" do
     it "exits if no failure happened" do
       project = Project[pgr_test.frame["postgres_test_project_id"]]
-      expect { pgr_test.finish }.to exit({"msg" => "Postgres upgrade tests are finished!"})
+      expect { pgr_test.finish }.to exit({"msg" => "Postgres tests are finished!"})
       expect(Project[project.id]).to be_nil
     end
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1461,6 +1461,30 @@ RSpec.describe CloverAdmin do
     expect(created_at_cell).to have_content(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/)
   end
 
+  it "shows local E2E strand status" do
+    click_link "Manage Local E2E"
+    expect(page.title).to eq "Ubicloud Admin - Manage Local E2E"
+    expect(page).to have_content("No data available for Active Local E2E Strands")
+
+    local_e2e_path = page.current_path
+    project = Project.create(name: "Postgres-Service-Project")
+    expect(Config).to receive(:postgres_service_project_id).and_return(project.id).at_least(:once)
+    expect(Config).to receive(:local_e2e_postgres_test_project_id).and_return(nil).at_least(:once)
+
+    strand = Prog::Test::PostgresResource.assemble(provider: "metal")
+    page.refresh
+    expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", strand.ubid, '{"provider" => "metal"}']
+    click_link strand.ubid
+    expect(page.title).to eq "Ubicloud Admin - Strand #{strand.ubid}"
+
+    strand.run
+    pg_ubid = UBID.to_ubid(strand.stack[0]["postgres_resource_id"])
+    visit local_e2e_path
+    expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "wait_postgres_resource", "0", strand.ubid, "{\"provider\" => \"metal\", \"postgres_resource\" => \"#{pg_ubid}\"}"]
+    click_link pg_ubid
+    expect(page.title).to eq "Ubicloud Admin - PostgresResource #{pg_ubid}"
+  end
+
   it "shows admin list" do
     click_link "View Admin List"
     expect(page.title).to eq "Ubicloud Admin - Admin List"

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1461,47 +1461,52 @@ RSpec.describe CloverAdmin do
     expect(created_at_cell).to have_content(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/)
   end
 
-  it "shows local E2E strand status" do
-    click_link "Manage Local E2E"
-    expect(page.title).to eq "Ubicloud Admin - Manage Local E2E"
-    expect(page).to have_content("No data available for Active Local E2E Strands")
+  describe "local E2E" do
+    before do
+      project = Project.create(name: "Postgres-Service-Project")
+      expect(Config).to receive(:postgres_service_project_id).and_return(project.id).at_least(:once)
+      expect(Config).to receive(:local_e2e_postgres_test_project_id).and_return(nil).at_least(:once)
+      click_link "Manage Local E2E"
+    end
 
-    local_e2e_path = page.current_path
-    project = Project.create(name: "Postgres-Service-Project")
-    expect(Config).to receive(:postgres_service_project_id).and_return(project.id).at_least(:once)
-    expect(Config).to receive(:local_e2e_postgres_test_project_id).and_return(nil).at_least(:once)
+    it "shows strand status" do
+      expect(page.title).to eq "Ubicloud Admin - Manage Local E2E"
+      expect(page).to have_content("No data available for Active Local E2E Strands")
 
-    strand = Prog::Test::PostgresResource.assemble(provider: "metal")
-    page.refresh
-    expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", strand.ubid, '{"provider" => "metal"}']
-    click_link strand.ubid
-    expect(page.title).to eq "Ubicloud Admin - Strand #{strand.ubid}"
+      local_e2e_path = page.current_path
+      strand = Prog::Test::PostgresResource.assemble(provider: "metal")
+      page.refresh
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", strand.ubid, '{"provider" => "metal"}']
+      click_link strand.ubid
+      expect(page.title).to eq "Ubicloud Admin - Strand #{strand.ubid}"
 
-    strand.run
-    pg_ubid = UBID.to_ubid(strand.stack[0]["postgres_resource_id"])
-    visit local_e2e_path
-    expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "wait_postgres_resource", "0", strand.ubid, "{\"provider\" => \"metal\", \"postgres_resource\" => \"#{pg_ubid}\"}"]
-    click_link pg_ubid
-    expect(page.title).to eq "Ubicloud Admin - PostgresResource #{pg_ubid}"
-  end
+      strand.run
+      pg_ubid = UBID.to_ubid(strand.stack[0]["postgres_resource_id"])
+      visit local_e2e_path
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "wait_postgres_resource", "0", strand.ubid, "{\"provider\" => \"metal\", \"postgres_resource\" => \"#{pg_ubid}\"}"]
+      click_link pg_ubid
+      expect(page.title).to eq "Ubicloud Admin - PostgresResource #{pg_ubid}"
+    end
 
-  it "allows creation of local E2E strands" do
-    project = Project.create(name: "Postgres-Service-Project")
-    expect(Config).to receive(:postgres_service_project_id).and_return(project.id).at_least(:once)
-    expect(Config).to receive(:local_e2e_postgres_test_project_id).and_return(nil).at_least(:once)
+    it "allows creation of strands" do
+      local_e2e_path = page.current_path
+      expect { click_button "Start Local E2E Strand" }.to raise_error(RuntimeError)
 
-    click_link "Manage Local E2E"
-    local_e2e_path = page.current_path
-    expect { click_button "Start Local E2E Strand" }.to raise_error(RuntimeError)
+      visit local_e2e_path
+      within("#start-local-e2e") do
+        select "metal"
+      end
+      expect { click_button "Start Local E2E Strand" }.to raise_error(RuntimeError)
 
-    visit local_e2e_path
-    select "PostgresResource"
-    select "metal"
-    click_button "Start Local E2E Strand"
+      visit local_e2e_path
+      select "PostgresResource"
+      select "metal"
+      click_button "Start Local E2E Strand"
 
-    st = Strand.first(prog: "Test::PostgresResource")
-    expect(page).to have_flash_notice("Started local E2E strand: #{st.ubid}")
-    expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", st.ubid, '{"provider" => "metal"}']
+      st = Strand.first(prog: "Test::PostgresResource")
+      expect(page).to have_flash_notice("Started local E2E strand: #{st.ubid}")
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", st.ubid, '{"provider" => "metal"}']
+    end
   end
 
   it "shows admin list" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1493,37 +1493,47 @@ RSpec.describe CloverAdmin do
       expect { click_button "Start Local E2E Strand" }.to raise_error(RuntimeError)
 
       visit local_e2e_path
-      within("#start-local-e2e") do
-        select "metal"
-      end
+      select "metal"
+      expect { click_button "Start Local E2E Strand" }.to raise_error(Roda::RodaPlugins::TypecastParams::Error)
+
+      visit local_e2e_path
+      check "PostgresResource"
       expect { click_button "Start Local E2E Strand" }.to raise_error(RuntimeError)
 
       visit local_e2e_path
-      select "PostgresResource"
-      expect { click_button "Start Local E2E Strand" }.to raise_error(RuntimeError)
-
-      visit local_e2e_path
-      select "PostgresResource"
-      within("#start-local-e2e") do
-        select "metal"
-      end
+      check "PostgresResource"
+      select "metal"
       click_button "Start Local E2E Strand"
 
       st = Strand.first(prog: "Test::PostgresResource")
-      expect(page).to have_flash_notice("Started local E2E strand: #{st.ubid}")
+      expect(page).to have_flash_notice("Started local E2E strand(s): #{st.ubid}")
       expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", st.ubid, '{"provider" => "metal"}', ""]
     end
 
-    it "allows creation of local E2E loop strands" do
+    it "allows creation of multiple strands" do
       check "PostgresResource"
       check "HaPostgresResource"
-      within("#start-local-e2e-loop") do
-        select "metal"
-      end
-      click_button "Start Local E2E Loop Strand"
+      select "metal"
+      click_button "Start Local E2E Strand"
+
+      ha_pg_st = Strand.first(prog: "Test::HaPostgresResource")
+      pg_st = Strand.first(prog: "Test::PostgresResource")
+      expect(page).to have_flash_notice("Started local E2E strand(s): #{pg_st.ubid} #{ha_pg_st.ubid}")
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq [
+        "Test::HaPostgresResource", "start", "0", ha_pg_st.ubid, '{"provider" => "metal"}', "",
+        "Test::PostgresResource", "start", "0", pg_st.ubid, '{"provider" => "metal"}', "",
+      ]
+    end
+
+    it "allows creation of loop strands" do
+      check "PostgresResource"
+      check "HaPostgresResource"
+      select "metal"
+      check "Loop?"
+      click_button "Start Local E2E Strand"
 
       st = Strand.first(prog: "Test::LocalE2eLoop")
-      expect(page).to have_flash_notice("Started local E2E strand: #{st.ubid}")
+      expect(page).to have_flash_notice("Started local E2E strand(s): #{st.ubid}")
       expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::LocalE2eLoop", "start", "0", st.ubid, "{\"progs\" => [\"PostgresResource\", \"HaPostgresResource\"], \"prog_args\" => {\"provider\" => \"metal\"}}", ""]
 
       st.run
@@ -1537,10 +1547,8 @@ RSpec.describe CloverAdmin do
 
     it "allows pausing and unpausing strands" do
       local_e2e_path = page.current_path
-      select "PostgresResource"
-      within("#start-local-e2e") do
-        select "metal"
-      end
+      check "PostgresResource"
+      select "metal"
       click_button "Start Local E2E Strand"
 
       click_button "Pause"

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1485,6 +1485,25 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - PostgresResource #{pg_ubid}"
   end
 
+  it "allows creation of local E2E strands" do
+    project = Project.create(name: "Postgres-Service-Project")
+    expect(Config).to receive(:postgres_service_project_id).and_return(project.id).at_least(:once)
+    expect(Config).to receive(:local_e2e_postgres_test_project_id).and_return(nil).at_least(:once)
+
+    click_link "Manage Local E2E"
+    local_e2e_path = page.current_path
+    expect { click_button "Start Local E2E Strand" }.to raise_error(RuntimeError)
+
+    visit local_e2e_path
+    select "PostgresResource"
+    select "metal"
+    click_button "Start Local E2E Strand"
+
+    st = Strand.first(prog: "Test::PostgresResource")
+    expect(page).to have_flash_notice("Started local E2E strand: #{st.ubid}")
+    expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", st.ubid, '{"provider" => "metal"}']
+  end
+
   it "shows admin list" do
     click_link "View Admin List"
     expect(page.title).to eq "Ubicloud Admin - Admin List"

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1500,7 +1500,13 @@ RSpec.describe CloverAdmin do
 
       visit local_e2e_path
       select "PostgresResource"
-      select "metal"
+      expect { click_button "Start Local E2E Strand" }.to raise_error(RuntimeError)
+
+      visit local_e2e_path
+      select "PostgresResource"
+      within("#start-local-e2e") do
+        select "metal"
+      end
       click_button "Start Local E2E Strand"
 
       st = Strand.first(prog: "Test::PostgresResource")
@@ -1508,10 +1514,33 @@ RSpec.describe CloverAdmin do
       expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", st.ubid, '{"provider" => "metal"}', ""]
     end
 
+    it "allows creation of local E2E loop strands" do
+      check "PostgresResource"
+      check "HaPostgresResource"
+      within("#start-local-e2e-loop") do
+        select "metal"
+      end
+      click_button "Start Local E2E Loop Strand"
+
+      st = Strand.first(prog: "Test::LocalE2eLoop")
+      expect(page).to have_flash_notice("Started local E2E strand: #{st.ubid}")
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::LocalE2eLoop", "start", "0", st.ubid, "{\"progs\" => [\"PostgresResource\", \"HaPostgresResource\"], \"prog_args\" => {\"provider\" => \"metal\"}}", ""]
+
+      st.run
+      page.refresh
+      child_ubid = st.children[0].ubid
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq [
+        "Test::LocalE2eLoop", "wait", "0", st.ubid, "{\"progs\" => [\"HaPostgresResource\", \"PostgresResource\"], \"prog_args\" => {\"provider\" => \"metal\"}, \"current_strand\" => \"#{child_ubid}\"}", "",
+        "Test::PostgresResource", "start", "0", child_ubid, "{\"provider\" => \"metal\"}", "",
+      ]
+    end
+
     it "allows pausing and unpausing strands" do
       local_e2e_path = page.current_path
       select "PostgresResource"
-      select "metal"
+      within("#start-local-e2e") do
+        select "metal"
+      end
       click_button "Start Local E2E Strand"
 
       click_button "Pause"

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1476,14 +1476,14 @@ RSpec.describe CloverAdmin do
       local_e2e_path = page.current_path
       strand = Prog::Test::PostgresResource.assemble(provider: "metal")
       page.refresh
-      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", strand.ubid, '{"provider" => "metal"}']
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", strand.ubid, '{"provider" => "metal"}', ""]
       click_link strand.ubid
       expect(page.title).to eq "Ubicloud Admin - Strand #{strand.ubid}"
 
       strand.run
       pg_ubid = UBID.to_ubid(strand.stack[0]["postgres_resource_id"])
       visit local_e2e_path
-      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "wait_postgres_resource", "0", strand.ubid, "{\"provider\" => \"metal\", \"postgres_resource\" => \"#{pg_ubid}\"}"]
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "wait_postgres_resource", "0", strand.ubid, "{\"provider\" => \"metal\", \"postgres_resource\" => \"#{pg_ubid}\"}", ""]
       click_link pg_ubid
       expect(page.title).to eq "Ubicloud Admin - PostgresResource #{pg_ubid}"
     end
@@ -1505,7 +1505,33 @@ RSpec.describe CloverAdmin do
 
       st = Strand.first(prog: "Test::PostgresResource")
       expect(page).to have_flash_notice("Started local E2E strand: #{st.ubid}")
-      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", st.ubid, '{"provider" => "metal"}']
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", st.ubid, '{"provider" => "metal"}', ""]
+    end
+
+    it "allows pausing and unpausing strands" do
+      local_e2e_path = page.current_path
+      select "PostgresResource"
+      select "metal"
+      click_button "Start Local E2E Strand"
+
+      click_button "Pause"
+      st = Strand.first(prog: "Test::PostgresResource")
+      expect(page).to have_flash_notice("Strand #{st.ubid} paused")
+      expect(st.semaphores.map(&:name)).to eq ["pause"]
+
+      st.this.update(schedule: "2100-01-01")
+      click_button "Unpause"
+      expect(page).to have_flash_notice("Strand #{st.ubid} unpaused")
+      expect(st.semaphores(reload: true)).to eq []
+      expect(st.this.get(:schedule)).to be_within(10).of(Time.now)
+
+      st.this.update(prog: "Test::Base")
+      expect { click_button "Pause" }.to raise_error(RuntimeError)
+
+      visit local_e2e_path
+      st.destroy
+      click_button "Pause"
+      expect(page).to have_flash_error("Strand not found, it was probably already deleted")
     end
   end
 

--- a/views/admin/components/table.erb
+++ b/views/admin/components/table.erb
@@ -27,6 +27,8 @@
                 <pre><%== linkify_ubids(JSON.pretty_generate(v)) %></pre>
               <% elsif v.is_a?(CloverAdmin::TableLink) %>
                 <a href="<%= v.link %>"><%= v.value %></a>
+              <% elsif v.is_a?(CloverAdmin::TableFormButton) %>
+                <%== form(v.attributes, button: v.text) %>
               <% else %>
                 <%== linkify_ubids(v.to_s) %>
               <% end %>

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -54,6 +54,7 @@
       <a href="/authentication-audit-log">View Authentication Audit Logs</a> |
       <a href="/authentication-audit-log/admin">View Admin Authentication Audit Logs</a>
     </li>
+    <li><a href="/local-e2e">Manage Local E2E</a></li>
     <li><a href="/admin-list">View Admin List</a></li>
     <li><a href="/autoforme/Strand/search/1?<%= to_query_string(prog: "Vm::Metal::Nexus", label: "unavailable") %>">Show Unavailable VMs</a></li>
   </ul>

--- a/views/admin/local_e2e.erb
+++ b/views/admin/local_e2e.erb
@@ -1,0 +1,13 @@
+<% @page_title = "Manage Local E2E" %>
+
+<% data = @strands.map do |strand|
+  h = strand.values.slice(:prog, :label, :try)
+  frame = strand.stack[0]
+  h[:id] = strand.ubid
+  data = h[:data] = {}
+  data["provider"] = frame["provider"]
+  data["postgres_resource"] = UBID.to_ubid(frame["postgres_resource_id"]) if frame["postgres_resource_id"]
+  h
+end %>
+
+<%== part("components/table", title: "Active Local E2E Strands", table_class: "local-e2e-table", data:) %>

--- a/views/admin/local_e2e.erb
+++ b/views/admin/local_e2e.erb
@@ -7,6 +7,13 @@
   data = h[:data] = {}
   data["provider"] = frame["provider"]
   data["postgres_resource"] = UBID.to_ubid(frame["postgres_resource_id"]) if frame["postgres_resource_id"]
+
+  h[:pause] = if strand.semaphores.find { it.name == "pause" }
+    table_form_button("Unpause", action: "/local-e2e/unpause/#{strand.ubid}", method: "post")
+  else
+    table_form_button("Pause", action: "/local-e2e/pause/#{strand.ubid}", method: "post")
+  end
+
   h
 end %>
 

--- a/views/admin/local_e2e.erb
+++ b/views/admin/local_e2e.erb
@@ -11,3 +11,10 @@
 end %>
 
 <%== part("components/table", title: "Active Local E2E Strands", table_class: "local-e2e-table", data:) %>
+
+<h2>Start Local E2E Strand</h2>
+
+<% form({method: "post"}, button: "Start Local E2E Strand") do |f| %>
+  <%== f.input(:select, key: :prog, label: "E2E Prog", options: LOCAL_E2E_PROGS, add_blank: true, required: true) %>
+  <%== f.input(:select, key: :provider, label: "Provider", options: LOCAL_E2E_PROVIDERS, add_blank: true, required: true) %>
+<% end %>

--- a/views/admin/local_e2e.erb
+++ b/views/admin/local_e2e.erb
@@ -22,15 +22,8 @@ end %>
 
 <h2>Start Local E2E Strand</h2>
 
-<% form({method: "post", id: "start-local-e2e"}, button: "Start Local E2E Strand") do |f| %>
-  <%== f.input(:select, key: :prog, label: "E2E Prog", options: LOCAL_E2E_PROGS, add_blank: true, required: true) %>
-  <%== f.input(:select, key: :provider, label: "Provider", options: LOCAL_E2E_PROVIDERS, add_blank: true, required: true) %>
-<% end %>
-
-<h2>Start Local E2E Loop Strand</h2>
-
-<% form({method: "post", id: "start-local-e2e-loop"}, button: "Start Local E2E Loop Strand", wrapper: :div, tag_wrapper: :div) do |f| %>
-  <input type="hidden" name="local_e2e_loop" value="true">
+<% form({method: "post", id: "start-local-e2e"}, button: "Start Local E2E Strand", wrapper: :div) do |f| %>
   <%== f.input(:checkboxset, key: :progs, label: "E2E Progs", options: LOCAL_E2E_PROGS) %>
   <%== f.input(:select, key: :provider, label: "Provider", options: LOCAL_E2E_PROVIDERS, add_blank: true, required: true) %>
+  <%== f.input(:checkbox, key: :loop, label: "Loop?") %>
 <% end %>

--- a/views/admin/local_e2e.erb
+++ b/views/admin/local_e2e.erb
@@ -4,8 +4,9 @@
   h = strand.values.slice(:prog, :label, :try)
   frame = strand.stack[0]
   h[:id] = strand.ubid
-  data = h[:data] = {}
-  data["provider"] = frame["provider"]
+  data = h[:data] = frame.slice("provider", "progs", "prog_args")
+  data.compact!
+  data["current_strand"] = UBID.to_ubid(frame["current_strand"]) if frame["current_strand"]
   data["postgres_resource"] = UBID.to_ubid(frame["postgres_resource_id"]) if frame["postgres_resource_id"]
 
   h[:pause] = if strand.semaphores.find { it.name == "pause" }
@@ -21,7 +22,15 @@ end %>
 
 <h2>Start Local E2E Strand</h2>
 
-<% form({method: "post"}, button: "Start Local E2E Strand") do |f| %>
+<% form({method: "post", id: "start-local-e2e"}, button: "Start Local E2E Strand") do |f| %>
   <%== f.input(:select, key: :prog, label: "E2E Prog", options: LOCAL_E2E_PROGS, add_blank: true, required: true) %>
+  <%== f.input(:select, key: :provider, label: "Provider", options: LOCAL_E2E_PROVIDERS, add_blank: true, required: true) %>
+<% end %>
+
+<h2>Start Local E2E Loop Strand</h2>
+
+<% form({method: "post", id: "start-local-e2e-loop"}, button: "Start Local E2E Loop Strand", wrapper: :div, tag_wrapper: :div) do |f| %>
+  <input type="hidden" name="local_e2e_loop" value="true">
+  <%== f.input(:checkboxset, key: :progs, label: "E2E Progs", options: LOCAL_E2E_PROGS) %>
   <%== f.input(:select, key: :provider, label: "Provider", options: LOCAL_E2E_PROVIDERS, add_blank: true, required: true) %>
 <% end %>


### PR DESCRIPTION
This adds Config.e2e_postgres_test_project_id, which should be set to a valid project id in the environment if trying this. If set, instead of creating a new project, the test will create the Postgres resource in the given project, and it will not destroy the project after the test completes (it will still destroy the postgres resource and the created private subnet).

That project should have a us-west-2 location configured with an appropriate AWS location credential. It will use this location instead of creating a new location.

This may work with metal providers, but I didn't test that as it requires additional setup (minio, images, etc.).

If this approach looks good, I'll expand it to other postgres E2E tests. I also plan:

* An admin interface to monitor in-flight E2E tests
* The ability to start an E2E test via the admin site
* A prog that allows for continuously runs an E2E test (or set of E2E tests) as long as it is successful 