### PR TITLE
Add CreateVersionMetalFromUrl prog for archiving images from URLs

### DIFF
--- a/model/vhost_block_backend.rb
+++ b/model/vhost_block_backend.rb
@@ -3,7 +3,7 @@
 require_relative "../model"
 
 class VhostBlockBackend < Sequel::Model
-  MIN_ARCHIVE_SUPPORT_VERSION = 400
+  MIN_ARCHIVE_SUPPORT_VERSION = 401
 
   plugin ResourceMethods, etc_type: true
 

--- a/prog/machine_image/create_version_metal.rb
+++ b/prog/machine_image/create_version_metal.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "aws-sdk-s3"
 require "json"
 
 class Prog::MachineImage::CreateVersionMetal < Prog::Base
@@ -51,6 +50,9 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
     status = sshable.d_check(unit_name)
     case status
     when "Succeeded"
+      stats_json = sshable.cmd("cat :stats_path", stats_path: stats_file_path)
+      stats = JSON.parse(stats_json)
+      update_stack("archive_size_bytes" => stats["physical_size_bytes"])
       sshable.d_clean(unit_name)
       hop_finish
     when "Failed"
@@ -58,7 +60,7 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
       nap 60
     when "NotStarted"
       sshable.d_run(unit_name,
-        "sudo", "host/bin/archive-storage-volume", source_vm.inhost_name, sv.storage_device.name, sv.disk_index, sv.vhost_block_backend.version,
+        "sudo", "host/bin/archive-storage-volume", source_vm.inhost_name, sv.storage_device.name, sv.disk_index, sv.vhost_block_backend.version, stats_file_path,
         stdin: archive_params_json, log: false)
       nap 30
     when "InProgress"
@@ -71,9 +73,11 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
   end
 
   label def finish
+    source_vm.vm_host.sshable.cmd("sudo rm -f :stats_path", stats_path: stats_file_path)
+
     machine_image_version_metal.update(
       enabled: true,
-      archive_size_mib: (archive_size_bytes/1048576r).ceil,
+      archive_size_mib: (frame["archive_size_bytes"]/1048576r).ceil,
     )
     if frame["destroy_source_after"]
       source_vm.incr_destroy
@@ -103,21 +107,9 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
     }.to_json
   end
 
-  def archive_size_bytes
-    store = machine_image_version_metal.store
-
-    s3 = Aws::S3::Client.new(
-      region: store.region,
-      endpoint: store.endpoint,
-      access_key_id: store.access_key,
-      secret_access_key: store.secret_key,
-    )
-
-    total = 0
-    s3.list_objects_v2(bucket: store.bucket, prefix: machine_image_version_metal.store_prefix).each_page do |page|
-      total += page.contents.sum(&:size)
-    end
-    total
+  def stats_file_path
+    mi_version = machine_image_version_metal.machine_image_version
+    "/tmp/archive_stats_#{mi_version.ubid}.json"
   end
 
   def source_vm

--- a/prog/machine_image/create_version_metal_from_url.rb
+++ b/prog/machine_image/create_version_metal_from_url.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "json"
+
+class Prog::MachineImage::CreateVersionMetalFromUrl < Prog::Base
+  subject_is :machine_image_version
+
+  def self.assemble(machine_image, version, url, sha256sum, store, set_as_latest: true)
+    vbb = VhostBlockBackend
+      .where(vm_host_id: VmHost.where(location_id: machine_image.location_id).select(:id))
+      .where { version_code >= VhostBlockBackend::MIN_ARCHIVE_SUPPORT_VERSION }
+      .order { random.function }
+      .first
+
+    fail "no vm host with archive support found in location" unless vbb
+
+    DB.transaction do
+      miv = MachineImageVersion.create(
+        machine_image_id: machine_image.id,
+        version:,
+        actual_size_mib: 0,
+      )
+      archive_kek = StorageKeyEncryptionKey.create_random(auth_data: "machine_image_version_#{miv.ubid}_#{version}")
+      MachineImageVersionMetal.create_with_id(miv,
+        enabled: false,
+        archive_kek_id: archive_kek.id,
+        store_id: store.id,
+        store_prefix: "#{machine_image.project.ubid}/#{machine_image.ubid}/#{version}")
+
+      Strand.create_with_id(miv,
+        prog: "MachineImage::CreateVersionMetalFromUrl",
+        label: "archive",
+        stack: [{
+          "url" => url,
+          "sha256sum" => sha256sum,
+          "vm_host_id" => vbb.vm_host_id,
+          "vhost_block_backend_version" => vbb.version,
+          "set_as_latest" => set_as_latest,
+        }])
+    end
+  end
+
+  label def archive
+    register_deadline(nil, 3600)
+
+    unit_name = "archive_#{machine_image_version.ubid}"
+    sshable = vm_host.sshable
+
+    status = sshable.d_check(unit_name)
+    case status
+    when "Succeeded"
+      stats_json = sshable.cmd("cat :stats_path", stats_path: stats_file_path)
+      stats = JSON.parse(stats_json)
+      update_stack(stats.slice("physical_size_bytes", "logical_size_bytes"))
+      sshable.d_clean(unit_name)
+      hop_finish
+    when "Failed"
+      sshable.d_restart(unit_name)
+      nap 60
+    when "NotStarted"
+      sshable.d_run(unit_name,
+        "sudo", "host/bin/archive-url", frame["url"], frame["sha256sum"], frame["vhost_block_backend_version"], stats_file_path,
+        stdin: archive_params_json, log: false)
+      nap 30
+    when "InProgress"
+      nap 30
+    else
+      Clog.emit("Unexpected daemonizer2 status: #{status}")
+      nap 60
+    end
+  end
+
+  label def finish
+    vm_host.sshable.cmd("sudo rm -f :stats_path", stats_path: stats_file_path)
+
+    machine_image_version.metal.update(
+      enabled: true,
+      archive_size_mib: (frame["physical_size_bytes"]/1048576r).ceil,
+    )
+
+    machine_image_version.update(actual_size_mib: (frame["logical_size_bytes"]/1048576r).ceil)
+
+    if frame["set_as_latest"]
+      machine_image_version.machine_image.update(latest_version_id: machine_image_version.id)
+    end
+
+    pop "Metal machine image version is created and enabled"
+  end
+
+  def archive_params_json
+    store = machine_image_version.metal.store
+
+    {
+      target_conf: {
+        endpoint: store.endpoint,
+        region: store.region,
+        bucket: store.bucket,
+        prefix: machine_image_version.metal.store_prefix,
+        access_key_id: store.access_key,
+        secret_access_key: store.secret_key,
+        archive_kek: machine_image_version.metal.archive_kek.secret_key_material_hash,
+      },
+    }.to_json
+  end
+
+  def stats_file_path
+    mi_version = machine_image_version.metal.machine_image_version
+    "/tmp/archive_stats_#{mi_version.ubid}.json"
+  end
+
+  def vm_host
+    @vm_host ||= VmHost[frame["vm_host_id"]]
+  end
+end

--- a/rhizome/host/bin/archive-storage-volume
+++ b/rhizome/host/bin/archive-storage-volume
@@ -37,6 +37,11 @@ unless (kek = params["kek"])
   exit 1
 end
 
+unless (stats_file = ARGV.shift)
+  puts "expected stats_file as argument"
+  exit 1
+end
+
 storage_path = StoragePath.new(vm_name, device, disk_index)
 StorageArchive.new(
   storage_path.vhost_backend_config,
@@ -44,4 +49,5 @@ StorageArchive.new(
   kek,
   target_conf,
   vhost_block_backend_version,
+  stats_file,
 ).archive

--- a/rhizome/host/bin/archive-url
+++ b/rhizome/host/bin/archive-url
@@ -19,6 +19,11 @@ unless (vhost_block_backend_version = ARGV.shift)
   exit 1
 end
 
+unless (stats_file = ARGV.shift)
+  puts "expected stats_file as argument"
+  exit 1
+end
+
 params = JSON.parse($stdin.read)
 
 unless (target_conf = params["target_conf"])
@@ -26,4 +31,4 @@ unless (target_conf = params["target_conf"])
   exit 1
 end
 
-StorageArchive.archive_url(url, sha256sum, target_conf, vhost_block_backend_version)
+StorageArchive.archive_url(url, sha256sum, target_conf, vhost_block_backend_version, stats_file)

--- a/rhizome/host/lib/storage_archive.rb
+++ b/rhizome/host/lib/storage_archive.rb
@@ -12,7 +12,7 @@ class StorageArchive
   include Toml
   extend Toml
 
-  def initialize(disk_config_path, disk_kek_path, disk_kek, target_conf, vhost_block_backend_version)
+  def initialize(disk_config_path, disk_kek_path, disk_kek, target_conf, vhost_block_backend_version, stats_file)
     validate_keys(
       "target_conf",
       %w[bucket prefix region endpoint access_key_id secret_access_key archive_kek],
@@ -31,9 +31,10 @@ class StorageArchive
     @disk_kek_path = disk_kek_path
     @disk_kek = disk_kek
     @target_conf = target_conf
+    @stats_file = stats_file
   end
 
-  def self.archive_url(url, sha256sum, target_conf, vhost_block_backend_version)
+  def self.archive_url(url, sha256sum, target_conf, vhost_block_backend_version, stats_file)
     Dir.mktmpdir do |dir|
       # download the image and convert it to raw format.
       boot_image = BootImage.new("image", nil, image_root: dir)
@@ -56,7 +57,7 @@ class StorageArchive
       r({"RUST_LOG" => "info"}, vp.init_metadata_path, "--config", config_path)
 
       # archive
-      StorageArchive.new(config_path, nil, nil, target_conf, vhost_block_backend_version).archive
+      StorageArchive.new(config_path, nil, nil, target_conf, vhost_block_backend_version, stats_file).archive
     end
   end
 
@@ -67,6 +68,7 @@ class StorageArchive
       "--target-config", "/dev/stdin",
       "--compression", "zstd",
       "--zstd-level", "3",
+      "--stats", @stats_file,
     ]
     env = {"RUST_LOG" => "info"}
     target_config = build_target_config

--- a/rhizome/host/spec/storage_archive_spec.rb
+++ b/rhizome/host/spec/storage_archive_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe StorageArchive do
       invalid_target_conf.delete("bucket")
 
       expect {
-        described_class.new(disk_config_path, disk_kek_path, disk_kek, invalid_target_conf, "v0.4.0")
+        described_class.new(disk_config_path, disk_kek_path, disk_kek, invalid_target_conf, "v0.4.0", "/path/to/stats.json")
       }.to raise_error(ArgumentError, "Missing required keys in target_conf: bucket")
     end
 
     it "fails when vhost block backend does not support archive" do
       expect {
-        described_class.new(disk_config_path, disk_kek_path, disk_kek, target_conf, "v0.3.0")
+        described_class.new(disk_config_path, disk_kek_path, disk_kek, target_conf, "v0.3.0", "/path/to/stats.json")
       }.to raise_error(RuntimeError, "vhost block backend version v0.3.0 does not support archive")
     end
 
@@ -39,25 +39,25 @@ RSpec.describe StorageArchive do
       invalid_disk_kek = {"algorithm" => "rsa", "key" => "Zm9v"}
 
       expect {
-        described_class.new(disk_config_path, disk_kek_path, invalid_disk_kek, target_conf, "v0.4.0")
+        described_class.new(disk_config_path, disk_kek_path, invalid_disk_kek, target_conf, "v0.4.0", "/path/to/stats.json")
       }.to raise_error(RuntimeError, "unsupported key encryption algorithm rsa for disk_kek")
     end
 
     it "does not require disk KEK" do
       expect {
-        described_class.new(disk_config_path, nil, nil, target_conf, "v0.4.0")
+        described_class.new(disk_config_path, nil, nil, target_conf, "v0.4.0", "/path/to/stats.json")
       }.not_to raise_error
     end
 
     it "fails when disk KEK is provided without path" do
       expect {
-        described_class.new(disk_config_path, nil, disk_kek, target_conf, "v0.4.0")
+        described_class.new(disk_config_path, nil, disk_kek, target_conf, "v0.4.0", "/path/to/stats.json")
       }.to raise_error(RuntimeError, "disk KEK provided without path")
     end
 
     it "fails when disk KEK path is provided without KEK" do
       expect {
-        described_class.new(disk_config_path, disk_kek_path, nil, target_conf, "v0.4.0")
+        described_class.new(disk_config_path, disk_kek_path, nil, target_conf, "v0.4.0", "/path/to/stats.json")
       }.to raise_error(RuntimeError, "disk KEK path provided without KEK")
     end
 
@@ -65,14 +65,14 @@ RSpec.describe StorageArchive do
       invalid_target_conf = target_conf.merge("archive_kek" => {"algorithm" => "rsa", "key" => "Zm9v"})
 
       expect {
-        described_class.new(disk_config_path, disk_kek_path, disk_kek, invalid_target_conf, "v0.4.0")
+        described_class.new(disk_config_path, disk_kek_path, disk_kek, invalid_target_conf, "v0.4.0", "/path/to/stats.json")
       }.to raise_error(RuntimeError, "unsupported key encryption algorithm rsa for target_conf archive_kek")
     end
   end
 
   describe "#build_target_config" do
     it "includes session token configuration when provided" do
-      archive = described_class.new(disk_config_path, disk_kek_path, disk_kek, target_conf.merge("session_token" => "ghi"), "v0.4.0")
+      archive = described_class.new(disk_config_path, disk_kek_path, disk_kek, target_conf.merge("session_token" => "ghi"), "v0.4.0", "/path/to/stats.json")
       config = archive.build_target_config.lines.map(&:strip)
 
       expect(config).to include("session_token.ref = \"s3-session-token\"")
@@ -81,7 +81,7 @@ RSpec.describe StorageArchive do
     end
 
     it "builds the target config" do
-      archive = described_class.new(disk_config_path, disk_kek_path, disk_kek, target_conf, "v0.4.0")
+      archive = described_class.new(disk_config_path, disk_kek_path, disk_kek, target_conf, "v0.4.0", "/path/to/stats.json")
       config = archive.build_target_config
       expected_config = <<~CONFIG
 [target]
@@ -114,7 +114,7 @@ allow_inline_plaintext_secrets = true
 
   describe "#archive" do
     it "uses KEK pipe flow when disk KEK path is set" do
-      archive = described_class.new(disk_config_path, disk_kek_path, disk_kek, target_conf, "v0.4.0")
+      archive = described_class.new(disk_config_path, disk_kek_path, disk_kek, target_conf, "v0.4.0", "/path/to/stats.json")
       built_config = "[target]\n"
       allow(archive).to receive(:build_target_config).and_return(built_config)
 
@@ -125,6 +125,7 @@ allow_inline_plaintext_secrets = true
           "--target-config", "/dev/stdin",
           "--compression", "zstd",
           "--zstd-level", "3",
+          "--stats", "/path/to/stats.json",
         ],
         kek_pipe: disk_kek_path,
         kek_content: "Zm9v",
@@ -136,7 +137,7 @@ allow_inline_plaintext_secrets = true
     end
 
     it "runs archive command directly when disk KEK path is not set" do
-      archive = described_class.new(disk_config_path, nil, nil, target_conf, "v0.4.0")
+      archive = described_class.new(disk_config_path, nil, nil, target_conf, "v0.4.0", "/path/to/stats.json")
       built_config = "[target]\n"
       allow(archive).to receive(:build_target_config).and_return(built_config)
 
@@ -147,6 +148,7 @@ allow_inline_plaintext_secrets = true
         "--target-config", "/dev/stdin",
         "--compression", "zstd",
         "--zstd-level", "3",
+        "--stats", "/path/to/stats.json",
         stdin: built_config,
       )
 
@@ -171,10 +173,11 @@ allow_inline_plaintext_secrets = true
           "--target-config", "/dev/stdin",
           "--compression", "zstd",
           "--zstd-level", "3",
+          "--stats", "/path/to/stats.json",
           stdin: instance_of(String),
         )
 
-        described_class.archive_url("https://example.com/image.raw", "abc123", target_conf, "v0.4.0")
+        described_class.archive_url("https://example.com/image.raw", "abc123", target_conf, "v0.4.0", "/path/to/stats.json")
 
         expect(File.size("#{tmpdir}/disk.raw")).to eq(6 * 1024 * 1024)
         expect(File.read("#{tmpdir}/vhost-backend.conf")).to eq(<<~CONFIG)

--- a/spec/prog/machine_image/create_version_metal_from_url_spec.rb
+++ b/spec/prog/machine_image/create_version_metal_from_url_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::MachineImage::CreateVersionMetalFromUrl do
+  subject(:prog) { described_class.new(strand) }
+
+  let(:vm_host) { create_vm_host }
+  let(:mi_version_metal) { create_machine_image_version_metal }
+  let(:project) { machine_image.project }
+  let(:mi_version) { mi_version_metal.machine_image_version }
+  let(:machine_image) { mi_version.machine_image }
+  let(:store) { mi_version_metal.store }
+  let(:archive_kek) { mi_version_metal.archive_kek }
+  let(:url) { "https://example.com/image.raw" }
+  let(:sha256sum) { "abc123" }
+  let(:strand) {
+    vbb = create_vhost_block_backend(version: "v0.4.1", allocation_weight: 1, vm_host_id: vm_host.id)
+    Strand.create_with_id(
+      mi_version_metal,
+      prog: "MachineImage::CreateVersionMetalFromUrl",
+      label: "archive",
+      stack: [{
+        "subject_id" => mi_version_metal.id,
+        "url" => url,
+        "sha256sum" => sha256sum,
+        "vm_host_id" => vm_host.id,
+        "vhost_block_backend_version" => vbb.version,
+        "set_as_latest" => false,
+      }],
+    )
+  }
+
+  describe ".assemble" do
+    it "creates a machine image version metal and strand" do
+      vbb = create_vhost_block_backend(version: "v0.4.1", allocation_weight: 50, vm_host_id: vm_host.id)
+      strand = described_class.assemble(machine_image, "2.0", url, sha256sum, store)
+
+      mi_version_metal = MachineImageVersionMetal[strand.id]
+      expect(mi_version_metal).not_to be_nil
+      expect(mi_version_metal.enabled).to be false
+      expect(mi_version_metal.store_id).to eq(store.id)
+      expect(mi_version_metal.store_prefix).to eq("#{project.ubid}/#{machine_image.ubid}/2.0")
+      expect(mi_version_metal.archive_kek).not_to be_nil
+
+      expect(strand.prog).to eq("MachineImage::CreateVersionMetalFromUrl")
+      expect(strand.label).to eq("archive")
+      expect(strand.stack.first["url"]).to eq(url)
+      expect(strand.stack.first["sha256sum"]).to eq(sha256sum)
+      expect(strand.stack.first["vm_host_id"]).to eq(vm_host.id)
+      expect(strand.stack.first["vhost_block_backend_version"]).to eq(vbb.version)
+      expect(strand.stack.first["set_as_latest"]).to be true
+    end
+
+    it "selects only from backends that support archive" do
+      create_vhost_block_backend(version: "v0.3.0", allocation_weight: 5000, vm_host_id: vm_host.id)
+      vbb = create_vhost_block_backend(version: "v0.4.1", allocation_weight: 1, vm_host_id: vm_host.id)
+
+      strand = described_class.assemble(machine_image, "2.0", url, sha256sum, store)
+
+      expect(strand.stack.first["vhost_block_backend_version"]).to eq(vbb.version)
+    end
+
+    it "fails when no vm host with archive support exists in location" do
+      expect {
+        described_class.assemble(machine_image, "v0.1", url, sha256sum, store)
+      }.to raise_error("no vm host with archive support found in location")
+    end
+  end
+
+  describe "#archive" do
+    let(:sshable) { vm_host.sshable }
+    let(:daemon_name) { "archive_#{mi_version.ubid}" }
+    let(:stats_path) { "/tmp/archive_stats_#{mi_version.ubid}.json" }
+
+    before do
+      allow(prog).to receive(:vm_host).and_return(vm_host)
+    end
+
+    it "reads stats, cleans daemon and hops to finish when daemon succeeded" do
+      expect(sshable).to receive(:d_check).with(daemon_name).and_return("Succeeded")
+      expect(sshable).to receive(:_cmd).with("cat #{stats_path}").and_return('{"physical_size_bytes": 10485760, "logical_size_bytes": 1073741824}')
+      expect(sshable).to receive(:d_clean).with(daemon_name)
+
+      expect { prog.archive }.to hop("finish")
+      expect(strand.stack.first["physical_size_bytes"]).to eq(10485760)
+      expect(strand.stack.first["logical_size_bytes"]).to eq(1073741824)
+    end
+
+    it "restarts daemon when it failed" do
+      expect(sshable).to receive(:d_check).with(daemon_name).and_return("Failed")
+      expect(sshable).to receive(:d_restart).with(daemon_name)
+      expect { prog.archive }.to nap(60)
+    end
+
+    it "starts daemon when status is NotStarted" do
+      expect(sshable).to receive(:d_check).with(daemon_name).and_return("NotStarted")
+      expect(sshable).to receive(:d_run).with(daemon_name,
+        "sudo", "host/bin/archive-url", url, sha256sum, "v0.4.1", stats_path,
+        stdin: prog.archive_params_json, log: false)
+
+      expect { prog.archive }.to nap(30)
+    end
+
+    it "naps when daemon is still running" do
+      expect(sshable).to receive(:d_check).with(daemon_name).and_return("InProgress")
+
+      expect { prog.archive }.to nap(30)
+    end
+
+    it "handles unexpected daemon status" do
+      expect(sshable).to receive(:d_check).with(daemon_name).and_return("UnknownStatus")
+      expect(Clog).to receive(:emit).with("Unexpected daemonizer2 status: UnknownStatus")
+
+      expect { prog.archive }.to nap(60)
+    end
+  end
+
+  describe "#finish" do
+    before {
+      refresh_frame(prog, new_values: {"physical_size_bytes" => 10 * 1024 * 1024, "logical_size_bytes" => 20 * 1024 * 1024})
+      allow(prog).to receive(:vm_host).and_return(vm_host)
+      expect(vm_host.sshable).to receive(:_cmd).with("sudo rm -f /tmp/archive_stats_#{mi_version.ubid}.json")
+    }
+
+    it "enables machine image version metal and sets archive size" do
+      expect { prog.finish }.to exit({"msg" => "Metal machine image version is created and enabled"})
+
+      mi_version_metal.reload
+      machine_image.reload
+      expect(mi_version_metal.enabled).to be true
+      expect(mi_version_metal.archive_size_mib).to eq(10)
+      expect(mi_version.reload.actual_size_mib).to eq(20)
+    end
+
+    it "sets machine image latest version when configured" do
+      refresh_frame(prog, new_values: {"set_as_latest" => true})
+
+      expect { prog.finish }.to exit({"msg" => "Metal machine image version is created and enabled"})
+
+      machine_image.reload
+      expect(machine_image.latest_version.id).to eq(mi_version_metal.id)
+    end
+  end
+
+  describe "#archive_params_json" do
+    it "generates JSON payload with store credentials" do
+      result = JSON.parse(prog.archive_params_json)
+
+      expect(result["target_conf"]).to include(
+        "endpoint" => store.endpoint,
+        "region" => store.region,
+        "bucket" => store.bucket,
+        "prefix" => mi_version_metal.store_prefix,
+        "access_key_id" => store.access_key,
+        "secret_access_key" => store.secret_key,
+        "archive_kek" => archive_kek.secret_key_material_hash,
+      )
+    end
+  end
+
+  describe "#stats_file_path" do
+    it "returns the expected path" do
+      expect(prog.stats_file_path).to eq("/tmp/archive_stats_#{mi_version.ubid}.json")
+    end
+  end
+
+  describe "#vm_host" do
+    it "returns the vm host from the frame" do
+      vm_host = create_vm_host
+      refresh_frame(prog, new_values: {"vm_host_id" => vm_host.id})
+      expect(prog.vm_host).to eq(vm_host)
+    end
+  end
+end

--- a/spec/prog/machine_image/create_version_metal_spec.rb
+++ b/spec/prog/machine_image/create_version_metal_spec.rb
@@ -171,16 +171,19 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
   describe "#archive" do
     let(:sshable) { source_vm.vm_host.sshable }
     let(:daemon_name) { "archive_#{mi_version.ubid}" }
+    let(:stats_path) { "/tmp/archive_stats_#{mi_version.ubid}.json" }
 
     before do
       allow(prog).to receive_messages(archive_params_json: "{\"field\":\"value\"}", source_vm:)
     end
 
-    it "cleans daemon and hops to finish when daemon succeeded" do
+    it "reads stats, cleans daemon and hops to finish when daemon succeeded" do
       expect(sshable).to receive(:d_check).with(daemon_name).and_return("Succeeded")
+      expect(sshable).to receive(:_cmd).with("cat #{stats_path}").and_return('{"physical_size_bytes": 10485760, "logical_size_bytes": 1073741824}')
       expect(sshable).to receive(:d_clean).with(daemon_name)
 
       expect { prog.archive }.to hop("finish")
+      expect(strand.stack.first["archive_size_bytes"]).to eq(10485760)
     end
 
     it "restarts daemon when it failed" do
@@ -192,7 +195,7 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
     it "starts daemon when status is NotStarted" do
       expect(sshable).to receive(:d_check).with(daemon_name).and_return("NotStarted")
       expect(sshable).to receive(:d_run).with(daemon_name,
-        "sudo", "host/bin/archive-storage-volume", source_vm.inhost_name, "vda", 0, vhost_block_backend.version,
+        "sudo", "host/bin/archive-storage-volume", source_vm.inhost_name, "vda", 0, vhost_block_backend.version, stats_path,
         stdin: "{\"field\":\"value\"}", log: false)
 
       expect { prog.archive }.to nap(30)
@@ -213,7 +216,11 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
   end
 
   describe "#finish" do
-    before { allow(prog).to receive(:archive_size_bytes).and_return(10 * 1024 * 1024) }
+    before {
+      refresh_frame(prog, new_values: {"archive_size_bytes" => 10 * 1024 * 1024})
+      allow(prog).to receive(:source_vm).and_return(source_vm)
+      expect(source_vm.vm_host.sshable).to receive(:_cmd).with("sudo rm -f /tmp/archive_stats_#{mi_version.ubid}.json")
+    }
 
     it "enables machine image version metal and sets archive size" do
       expect { prog.finish }.to exit({"msg" => "Metal machine image version is created and enabled"})
@@ -226,7 +233,7 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
     end
 
     it "destroys source vm when configured" do
-      refresh_frame(prog, new_values: {"destroy_source_after" => true})
+      refresh_frame(prog, new_values: {"archive_size_bytes" => 10 * 1024 * 1024, "destroy_source_after" => true})
 
       expect { prog.finish }.to exit({"msg" => "Metal machine image version is created and enabled"})
 
@@ -234,7 +241,7 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
     end
 
     it "sets machine image latest version when configured" do
-      refresh_frame(prog, new_values: {"set_as_latest" => true})
+      refresh_frame(prog, new_values: {"archive_size_bytes" => 10 * 1024 * 1024, "set_as_latest" => true})
 
       expect { prog.finish }.to exit({"msg" => "Metal machine image version is created and enabled"})
 
@@ -266,23 +273,9 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
     end
   end
 
-  describe "#archive_size_bytes" do
-    it "sums object sizes across pages" do
-      s3 = Aws::S3::Client.new(stub_responses: true)
-      s3.stub_responses(
-        :list_objects_v2,
-        {contents: [{size: 10}, {size: 20}], is_truncated: true, next_continuation_token: "token"},
-        {contents: [{size: 5}], is_truncated: false},
-      )
-
-      allow(Aws::S3::Client).to receive(:new).with(
-        region: store.region,
-        endpoint: store.endpoint,
-        access_key_id: store.access_key,
-        secret_access_key: store.secret_key,
-      ).and_return(s3)
-
-      expect(prog.archive_size_bytes).to eq(35)
+  describe "#stats_file_path" do
+    it "returns the expected path" do
+      expect(prog.stats_file_path).to eq("/tmp/archive_stats_#{mi_version.ubid}.json")
     end
   end
 end

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -935,9 +935,9 @@ RSpec.describe Al do
       expect { al.update(vm1) }.to raise_error(RuntimeError, "concurrent GPU partition allocation")
     end
 
-    it "succeeds allocation when track_written is set and host has vhost block backend v0.4.0+" do
+    it "succeeds allocation when track_written is set and host has vhost block backend v0.4.1+" do
       vmh = VmHost.first
-      create_vhost_block_backend(vm_host_id: vmh.id, version: "v0.4.0", allocation_weight: 100)
+      create_vhost_block_backend(vm_host_id: vmh.id, version: "v0.4.1", allocation_weight: 100)
 
       vm = create_vm
       vol = [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => false, "boot" => false, "track_written" => true, "vring_workers" => 1}]
@@ -947,14 +947,14 @@ RSpec.describe Al do
       expect(vm.vm_storage_volumes.first.track_written).to be(true)
     end
 
-    it "fails allocation when track_written is set but no host has vhost block backend v0.4.0+" do
+    it "fails allocation when track_written is set but no host has vhost block backend v0.4.1+" do
       vm = create_vm
       vol = [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => false, "boot" => false, "track_written" => true}]
       expect { described_class.allocate(vm, vol) }.to raise_error(RuntimeError, /no space left on any eligible host/)
     end
 
     it "allocates without boot image filter when using machine_image_version_id" do
-      create_vhost_block_backend(vm_host_id: VmHost.first.id, version: "v0.4.0", allocation_weight: 100)
+      create_vhost_block_backend(vm_host_id: VmHost.first.id, version: "v0.4.1", allocation_weight: 100)
       vm = create_vm
       miv = create_machine_image_version_metal
       vol = [{
@@ -969,7 +969,7 @@ RSpec.describe Al do
       expect(vm.vm_storage_volumes.first.machine_image_version_id).to eq(miv.id)
     end
 
-    it "fails allocation when machine_image_version_id is set but no host has vhost block backend v0.4.0+" do
+    it "fails allocation when machine_image_version_id is set but no host has vhost block backend v0.4.1+" do
       vm = create_vm
       miv = create_machine_image_version_metal
       vol = [{"size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => false, "boot" => true, "machine_image_version_id" => miv.id}]


### PR DESCRIPTION
### Persist archive size stats on archive-url and archive-storage-volume 

Ubiblk v0.4.1 adds `archive --stats <PATH>`, which writes:

```
{
  "physical_size_bytes": 41946957,
  "logical_size_bytes": 1073741824
}
```

Logical size is the input disk size. Physical size is the actual space used in the object store (typically smaller due to compression).

Pass `--stats` to `archive` and persist the results. This addresses:

1. `bin/archive-url` downloads an image, converts it to raw on the Rhizome side, and removes the raw file before returning. Clover still needs the raw image size so it can persist it to the database, so the size must be saved before cleanup.
2. Clover also needs the actual archive size in the object store. Previously this was computed by listing archive objects from Clover, which can require many paginated S3 list-objects requests for large archives (for example, around 40 pages / 40k stripes for a 40 GiB source disk). That can exceed 60 seconds and makes per-label time bounding harder. With `--stats`, the size is computed more efficiently on the Rhizome side, and Clover only polls for the saved result asynchronously.

### CreateVersionMetal: use archive --stats to calculate archive size 

Replace pgainated S3 list objects with reading the `--stats` JSON from `archive-storage-volume`, avoiding many S3 requests for large archives.

A machine image created from a 40G VM could have up to about 40k objects, which results in about 40 list requests. This could potentially take a long time. With the new approach, the archive size calculation is done asynchronously in Rhizome.

### UMI: Add CreateVersionMetalFromUrl for archiving images from URLs

New prog that creates a MachineImageVersionMetal by downloading an image from a URL and archiving it via `bin/archive-url`.

It can be created like the following:

```
st = Prog::MachineImage::CreateVersionMetalFromUrl.assemble(
       machine_image, version, url, sha256sum, store,
       set_as_latest: true)
```

### Update MIN_ARCHIVE_SUPPORT_VERSION to v0.4.1 

In a previous commit we started using the `archive --stats` arg when creating machine images which is available since ubiblk v0.4.1.