### PR TITLE
Add safety checks for boot image download

### DIFF
--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -297,9 +297,9 @@ class Prog::DownloadBootImage < Prog::Base
   end.freeze
 
   def sha256sum
-    # YYY: In future all images should be checked for sha256 sum, so the nil
-    # default will be removed.
-    BOOT_IMAGE_SHA256.dig(image_name, vm_host.arch, version)
+    sum = BOOT_IMAGE_SHA256.dig(image_name, vm_host.arch, version)
+    fail "Cannot download images without a SHA256 checksum in production" if !sum && Config.production?
+    sum
   end
 
   def r2_signed_url(key)

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -374,6 +374,7 @@ class Prog::DownloadBootImage < Prog::Base
 
   label def update_available_storage_space
     image_size_bytes = sshable.cmd("stat -c %s :image_path", image_path: image.path).to_i
+    fail "Downloaded boot image has zero size" unless image_size_bytes > 0
     image_size_gib = (image_size_bytes / 1024.0**3).ceil
     StorageDevice.where(vm_host_id: vm_host.id, name: "DEFAULT").update(
       available_storage_gib: Sequel[:available_storage_gib] - image_size_gib,

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -235,6 +235,12 @@ RSpec.describe Prog::DownloadBootImage do
   end
 
   describe "#update_available_storage_space" do
+    it "fails if image size is zero" do
+      BootImage.create(vm_host_id: vm_host.id, name: "my-image", version: "20230303", size_gib: 0)
+      expect(sshable).to receive(:_cmd).with("stat -c %s /var/storage/images/my-image-20230303.raw").and_return("0")
+      expect { dbi.update_available_storage_space }.to raise_error RuntimeError, "Downloaded boot image has zero size"
+    end
+
     it "updates available storage space" do
       bi = BootImage.create(vm_host_id: vm_host.id, name: "my-image", version: "20230303", size_gib: 0)
       sd = StorageDevice.create(

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe Prog::DownloadBootImage do
   let(:sshable) { dbi.sshable }
   let(:vm_host) { dbi.vm_host }
 
+  describe ".sha256sum" do
+    it "fails if image is unknown in production" do
+      allow(Config).to receive(:production?).and_return(true)
+      refresh_frame(dbi, new_values: {"version" => "20260101"})
+      expect { dbi.sha256sum }.to raise_error RuntimeError, "Cannot download images without a SHA256 checksum in production"
+    end
+
+    it "allows to download unknown images in development" do
+      allow(Config).to receive(:production?).and_return(false)
+      refresh_frame(dbi, new_values: {"version" => "20260101"})
+      expect(dbi.sha256sum).to be_nil
+    end
+  end
+
   describe "#start" do
     it "creates database record and hops" do
       expect { dbi.start }.to hop("download")


### PR DESCRIPTION
- **Require SHA256 checksum for boot image downloads in production**
  We had an incident where a boot image with unexisting version was
  downloaded without checksum verification. This resulted in a 0 GB image
  being activated, causing failures on hosts that received it.
  
  Previously, sha256sum returned nil for unknown images, allowing any
  download to proceed unchecked. Now it raises an error in production
  when no checksum is found, while still permitting nil in development
  for testing convenience.
  
  Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
  

- **Fail boot image download when image size is zero**
  A zero-byte boot image clearly indicates a failed or corrupt download.
  Activating such an image causes incidents in production, as hosts end
  up with a broken image that cannot boot VMs.
  
  Check the file size immediately after download completes and before
  updating storage accounting or activating the image. This prevents
  a bad image from propagating further.
  
  Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
  