### PR TITLE
Fix forks running post installation script

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -568,6 +568,7 @@ SQL
 
     if !is_in_recovery
       postgres_server.switch_to_new_timeline
+      decr_initial_provisioning
       hop_configure
     end
 


### PR DESCRIPTION
switch_to_new_timeline call above makes the server primary. In the configure label we hop after here, if initial_provisioning semaphore is set and the server is primary, we hop to update_superuser_password and then hop to run_post_installation_script. This was not intentional, for forks we don't want to run post installation script because they get whatever the post installation script does through base backup.

The fix is to decrement initial_provisioning semaphore after switching to new timeline, so that when we evantually complete configuring, we don't hop to update_superuser_password and run_post_installation_script labels.