### PR TITLE
Minor improvements in PG E2E tests

### DIFF
--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -2,7 +2,7 @@
 
 require_relative "../../lib/util"
 
-class Prog::Test::HaPostgresResource < Prog::Test::Base
+class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   def self.assemble(provider: "metal")
     postgres_test_project = Project.create(name: "Postgres-HA-Test-Project")
     Project[Config.postgres_service_project_id] ||
@@ -114,34 +114,10 @@ class Prog::Test::HaPostgresResource < Prog::Test::Base
   end
 
   label def finish
-    postgres_test_project.destroy
-
-    fail_test(frame["fail_message"]) if frame["fail_message"]
-
-    pop "Postgres tests are finished!"
+    finish_test("Postgres tests are finished!")
   end
 
   label def failed
     nap 15
-  end
-
-  def postgres_test_project
-    @postgres_test_project ||= Project[frame["postgres_test_project_id"]]
-  end
-
-  def postgres_resource
-    @postgres_resource ||= PostgresResource[frame["postgres_resource_id"]]
-  end
-
-  def representative_server
-    @representative_server ||= postgres_resource.representative_server
-  end
-
-  def test_queries_sql
-    File.read("./prog/test/testdata/order_analytics_queries.sql").freeze
-  end
-
-  def read_queries_sql
-    File.read("./prog/test/testdata/order_analytics_read_queries.sql").freeze
   end
 end

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -52,7 +52,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
     update_stack({"primary_ubid" => primary.ubid})
     version = postgres_resource.version
 
-    primary.vm.sshable.cmd("echo -e '\nfoobar' | sudo tee -a /etc/postgresql/:version/main/conf.d/001-service.conf", version:)
+    primary.vm.sshable.cmd("echo -e '\nfoobar = baz' | sudo tee -a /etc/postgresql/:version/main/conf.d/999-break.conf", version:)
 
     # Get postgres pid and send SIGKILL
     primary.vm.sshable.cmd("ps aux | grep -v grep | grep /usr/lib/postgresql/:version/bin/postgres | awk '{print $2}' | xargs sudo kill -9", version:)

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -32,8 +32,11 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   end
 
   label def wait_postgres_resource
-    server_count = postgres_resource.servers.count
-    nap 10 if server_count != postgres_resource.target_server_count || postgres_resource.servers.filter { it.strand.label != "wait" }.any?
+    missing_servers = postgres_resource.servers.count < postgres_resource.target_server_count
+    servers_not_ready = postgres_resource.servers.any? { it.strand.label != "wait" || it.semaphores.any? }
+    in_convergence = !postgres_resource.strand.children_dataset.where(prog: "Postgres::ConvergePostgresResource").empty?
+
+    nap 10 if missing_servers || servers_not_ready || in_convergence
     hop_test_postgres
   end
 

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -8,16 +8,10 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
     Project[Config.postgres_service_project_id] ||
       Project.create_with_id(Config.postgres_service_project_id || Project.generate_uuid, name: "Postgres-Service-Project")
 
-    frame = {
-      "provider" => provider,
-      "postgres_test_project_id" => postgres_test_project.id,
-      "failover_wait_started" => false,
-    }
-
     Strand.create(
       prog: "Test::HaPostgresResource",
       label: "start",
-      stack: [frame],
+      stack: [{"postgres_test_project_id" => postgres_test_project.id, "provider" => provider}],
     )
   end
 
@@ -67,26 +61,30 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   end
 
   label def wait_failover
-    # Wait 3 minutes for the failover to finish.
-    failover_wait_started = frame["failover_wait_started"]
-    update_stack({"failover_wait_started" => true})
+    deadline = frame["failover_deadline"]
+    unless deadline
+      deadline = Time.now.to_i + 600
+      update_stack({"failover_deadline" => deadline})
+    end
 
-    nap 180 unless failover_wait_started
+    new_primary = postgres_resource.servers(eager: :strand).find { |s| s.ubid != frame["primary_ubid"] && s.timeline_access == "push" && s.strand.label == "wait" }
+    hop_test_postgres_after_failover if new_primary
 
-    hop_test_postgres_after_failover
+    if Time.now.to_i >= deadline
+      update_stack({"fail_message" => "Failover did not complete within 600 seconds"})
+      hop_destroy_postgres
+    end
+
+    nap 10
   end
 
   label def test_postgres_after_failover
     Clog.emit("Postgres servers after failover: #{postgres_resource.servers.map { |s| "[#{s.ubid}, #{s.timeline_access}, #{s.strand.label}]" }.join(", ")}")
 
     new_candidate = postgres_resource.servers.filter { |s| s.ubid != frame["primary_ubid"] }.min_by(&:created_at)
-    if new_candidate
-      # Get last few log lines from the new candidate for debugging.
-      log_lines = new_candidate.vm.sshable.cmd("sudo find /dat/:version/data/pg_log/ -name 'postgresql-*.log' -exec tail -n 20 {} \\;", version: new_candidate.version)
-      Clog.emit("Last log lines from new candidate (#{new_candidate.ubid}):\n#{log_lines}")
-    else
-      Clog.emit("No new primary found after failover")
-    end
+    # Get last few log lines from the new candidate for debugging.
+    log_lines = new_candidate.vm.sshable.cmd("sudo find /dat/:version/data/pg_log/ -name 'postgresql-*.log' -exec tail -n 20 {} \\;", version: new_candidate.version)
+    Clog.emit("Last log lines from new candidate (#{new_candidate.ubid}):\n#{log_lines}")
 
     Clog.emit("Running read queries after failover")
     unless representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Prog::Test::PostgresBase < Prog::Test::Base
+  def postgres_test_project
+    @postgres_test_project ||= Project[frame["postgres_test_project_id"]]
+  end
+
+  def postgres_resource
+    @postgres_resource ||= PostgresResource[frame["postgres_resource_id"]]
+  end
+
+  def representative_server
+    @representative_server ||= postgres_resource.representative_server
+  end
+
+  def test_queries_sql
+    File.read("./prog/test/testdata/order_analytics_queries.sql").freeze
+  end
+
+  def read_queries_sql
+    File.read("./prog/test/testdata/order_analytics_read_queries.sql").freeze
+  end
+
+  def finish_test(success_msg)
+    postgres_test_project.destroy
+    fail_test(frame["fail_message"]) if frame["fail_message"]
+    pop success_msg
+  end
+end

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -2,7 +2,7 @@
 
 require_relative "../../lib/util"
 
-class Prog::Test::PostgresResource < Prog::Test::Base
+class Prog::Test::PostgresResource < Prog::Test::PostgresBase
   def self.assemble(provider: "metal")
     postgres_test_project = Project.create(name: "Postgres-Test-Project")
     postgres_service_project = Project[Config.postgres_service_project_id] ||
@@ -70,30 +70,10 @@ class Prog::Test::PostgresResource < Prog::Test::Base
   end
 
   label def finish
-    postgres_test_project.destroy
-
-    fail_test(frame["fail_message"]) if frame["fail_message"]
-
-    pop "Postgres tests are finished!"
+    finish_test("Postgres tests are finished!")
   end
 
   label def failed
     nap 15
-  end
-
-  def postgres_test_project
-    @postgres_test_project ||= Project[frame["postgres_test_project_id"]]
-  end
-
-  def postgres_resource
-    @postgres_resource ||= PostgresResource[frame["postgres_resource_id"]]
-  end
-
-  def representative_server
-    @representative_server ||= postgres_resource.representative_server
-  end
-
-  def test_queries_sql
-    File.read("./prog/test/testdata/order_analytics_queries.sql").freeze
   end
 end

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -2,7 +2,7 @@
 
 require_relative "../../lib/util"
 
-class Prog::Test::UpgradePostgresResource < Prog::Test::Base
+class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   def self.assemble(provider: "metal")
     postgres_test_project = Project.create(name: "Postgres-Upgrade-Test-Project")
     Project[Config.postgres_service_project_id] ||
@@ -229,42 +229,18 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::Base
   end
 
   label def finish
-    postgres_test_project.destroy
-
-    fail_test(frame["fail_message"]) if frame["fail_message"]
-
-    pop "Postgres upgrade tests are finished!"
+    finish_test("Postgres upgrade tests are finished!")
   end
 
   label def failed
     nap 15
   end
 
-  def postgres_test_project
-    Project[frame["postgres_test_project_id"]]
-  end
-
-  def postgres_resource
-    PostgresResource[frame["postgres_resource_id"]]
-  end
-
   def read_replica
     @read_replica ||= PostgresResource[frame["read_replica_id"]]
   end
 
-  def representative_server
-    @representative_server ||= postgres_resource.representative_server
-  end
-
   def pre_upgrade_timeline
     PostgresTimeline[frame["pre_upgrade_postgres_timeline_id"]]
-  end
-
-  def test_queries_sql
-    File.read("./prog/test/testdata/order_analytics_queries.sql").freeze
-  end
-
-  def read_queries_sql
-    File.read("./prog/test/testdata/order_analytics_read_queries.sql").freeze
   end
 end

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Prog::Test::HaPostgresResource do
       sshable = Sshable.new
       allow(primary.vm).to receive(:sshable).and_return(sshable)
       allow(sshable).to receive(:_cmd).with("ps aux | grep -v grep | grep /usr/lib/postgresql/17/bin/postgres | awk '{print $2}' | xargs sudo kill -9").and_return("")
-      allow(sshable).to receive(:_cmd).with("echo -e '\nfoobar' | sudo tee -a /etc/postgresql/17/main/conf.d/001-service.conf").and_return("")
+      allow(sshable).to receive(:_cmd).with("echo -e '\nfoobar = baz' | sudo tee -a /etc/postgresql/17/main/conf.d/999-break.conf").and_return("")
       expect { pgr_test.trigger_failover }.to hop("wait_failover")
     end
   end

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -100,15 +100,37 @@ RSpec.describe Prog::Test::HaPostgresResource do
   end
 
   describe "#wait_failover" do
-    it "naps for 3 minutes for the 1st time" do
-      expect { pgr_test.wait_failover }.to nap(180)
-      refresh_frame(pgr_test)
-      expect(frame_value(pgr_test, "failover_wait_started")).to be true
+    before do
+      pg_strand = Prog::Postgres::PostgresResourceNexus.assemble(project_id: pgr_test.frame["postgres_test_project_id"], location_id: Location::HETZNER_FSN1_ID, name: "test-pg", target_vm_size: "standard-2", target_storage_size_gib: 128, ha_type: "async")
+      primary = pg_strand.subject.servers.first
+      refresh_frame(pgr_test, new_values: {"postgres_resource_id" => pg_strand.id, "primary_ubid" => primary.ubid})
     end
 
-    it "hops to test_postgres_after_failover 2nd time" do
-      refresh_frame(pgr_test, new_values: {"failover_wait_started" => true})
+    it "sets a deadline and naps on first entry" do
+      expect { pgr_test.wait_failover }.to nap(10)
+      refresh_frame(pgr_test)
+      expect(frame_value(pgr_test, "failover_deadline")).to be > Time.now.to_i
+    end
+
+    it "naps while no new primary is ready" do
+      refresh_frame(pgr_test, new_values: {"failover_deadline" => Time.now.to_i + 300})
+      expect { pgr_test.wait_failover }.to nap(10)
+    end
+
+    it "hops to test_postgres_after_failover once a new primary reaches wait" do
+      refresh_frame(pgr_test, new_values: {"failover_deadline" => Time.now.to_i + 300})
+      pg = pgr_test.postgres_resource
+      Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg.id, timeline_id: pg.timeline.id, timeline_access: "push")
+      new_primary = pg.reload.servers.find { |s| s.ubid != pgr_test.frame["primary_ubid"] }
+      new_primary.strand.update(label: "wait")
       expect { pgr_test.wait_failover }.to hop("test_postgres_after_failover")
+    end
+
+    it "fails when the deadline passes without a new primary" do
+      refresh_frame(pgr_test, new_values: {"failover_deadline" => Time.now.to_i - 1})
+      expect { pgr_test.wait_failover }.to hop("destroy_postgres")
+      refresh_frame(pgr_test)
+      expect(frame_value(pgr_test, "fail_message")).to match(/Failover did not complete/)
     end
   end
 
@@ -131,18 +153,6 @@ RSpec.describe Prog::Test::HaPostgresResource do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("")
       expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run read queries after failover")
-    end
-
-    it "logs that no primary was found after failover" do
-      refresh_frame(pgr_test, new_values: {"primary_ubid" => pgr_test.postgres_resource.representative_server.ubid})
-      allow(pgr_test.representative_server).to receive(:_run_query).and_return("")
-      expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
-      expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run read queries after failover")
-      expect(Clog).to receive(:emit).with(/Postgres servers after failover: .*/).once.ordered
-      expect(Clog).to receive(:emit).with("No new primary found after failover").once.ordered
-      expect(Clog).to receive(:emit).with("Running read queries after failover").once.ordered
-
-      expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
     end
 
     it "hops to destroy_postgres if the standby does not exit read-only mode" do


### PR DESCRIPTION
**Extract shared base class for postgres e2e tests**
The three postgres e2e tests (standard, HA, upgrade) each duplicated
the postgres_test_project / postgres_resource / representative_server
accessors, the test_queries_sql / read_queries_sql helpers, and the
body of the finish label. Move them into a shared Prog::Test::PostgresBase
so bug fixes and new helpers land in one place.

**Poll for failover instead of sleeping a flat 3 minutes**
wait_failover previously slept 180 seconds unconditionally and then
optimistically hopped forward, masking slow failovers and adding idle
time to every HA test run. Replace the flat sleep with a poll that
advances as soon as a standby reports timeline_access=push in the wait
state, and fails the test if the failover does not complete within 10
minutes. Drop the now-unused failover_wait_started frame value.

Now that wait_failover guarantees a new primary exists before hopping
to test_postgres_after_failover, drop the dead "no new primary" branch
in that label and its corresponding spec.