### PR TITLE
Expose scope in GitHub cache entry API

### DIFF
--- a/cli-commands/gh/post/list-cache-entries.rb
+++ b/cli-commands/gh/post/list-cache-entries.rb
@@ -11,6 +11,6 @@ UbiCli.on("gh").run_on("list-cache-entries") do
 
   run do |opts|
     cache_entries = @repository.cache_entries.each { it.values[:size] = Clover.humanize_size(it[:size]) }
-    response(format_rows(%i[id size created_at last_accessed_at key], cache_entries, headers: opts[key][:"no-headers"] != false))
+    response(format_rows(%i[id scope size created_at last_accessed_at key], cache_entries, headers: opts[key][:"no-headers"] != false))
   end
 end

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -2779,6 +2779,9 @@ components:
         key:
           description: GitHub cache entry key
           type: string
+        scope:
+          description: Branch scope of the GitHub cache entry
+          type: string
         size:
           description: Size of the GitHub cache entry in bytes
           type: integer
@@ -2797,6 +2800,7 @@ components:
         - installation_name
         - repository_name
         - key
+        - scope
         - size
         - created_at
         - last_accessed_at

--- a/sdk/ruby/lib/ubicloud/model/github_cache_entry.rb
+++ b/sdk/ruby/lib/ubicloud/model/github_cache_entry.rb
@@ -4,7 +4,7 @@ module Ubicloud
   class GithubCacheEntry < Model
     set_prefix "ge"
 
-    set_columns :key, :size, :created_at, :last_accessed_at
+    set_columns :key, :scope, :size, :created_at, :last_accessed_at
 
     singleton_class.undef_method(:create)
     singleton_class.undef_method(:list)

--- a/serializers/github_cache_entry.rb
+++ b/serializers/github_cache_entry.rb
@@ -7,6 +7,7 @@ class Serializers::GithubCacheEntry < Serializers::Base
       installation_name: options[:installation].name,
       repository_name: options[:repository].name,
       key: cache_entry.key,
+      scope: cache_entry.scope,
       size: cache_entry.size,
       created_at: cache_entry.created_at.utc.iso8601,
       last_accessed_at: cache_entry.last_accessed_at&.utc&.iso8601,

--- a/spec/routes/api/cli/golden-files/gh list-cache-entries test-installation-name_test-repository-name.txt
+++ b/spec/routes/api/cli/golden-files/gh list-cache-entries test-installation-name_test-repository-name.txt
@@ -1,2 +1,2 @@
-id                          size     created-at            last-accessed-at      key     
-gejszqw0k8z24k4bzt4ynyctg2  10.2 GB  2025-11-21T15:22:32Z  2025-11-21T15:22:32Z  test-key
+id                          scope       size     created-at            last-accessed-at      key     
+gejszqw0k8z24k4bzt4ynyctg2  test-scope  10.2 GB  2025-11-21T15:22:32Z  2025-11-21T15:22:32Z  test-key

--- a/spec/routes/api/cli/golden-files/gh test-installation-name_test-repository-name list-cache-entries.txt
+++ b/spec/routes/api/cli/golden-files/gh test-installation-name_test-repository-name list-cache-entries.txt
@@ -1,2 +1,2 @@
-id                          size     created-at            last-accessed-at      key     
-gejszqw0k8z24k4bzt4ynyctg2  10.2 GB  2025-11-21T15:22:32Z  2025-11-21T15:22:32Z  test-key
+id                          scope       size     created-at            last-accessed-at      key     
+gejszqw0k8z24k4bzt4ynyctg2  test-scope  10.2 GB  2025-11-21T15:22:32Z  2025-11-21T15:22:32Z  test-key

--- a/spec/routes/api/project/github_spec.rb
+++ b/spec/routes/api/project/github_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Clover, "github" do
     expect(last_response.status).to eq(200)
     body = JSON.parse(last_response.body)
     expect(body["key"]).to eq(cache_entry.key)
+    expect(body["scope"]).to eq("main")
     expect(body).to have_key("created_at")
     expect(body).to have_key("last_accessed_at")
   end


### PR DESCRIPTION
The cache listing API did not return which branch a cache entry belongs to, making it impossible to filter by branch programmatically. The scope (branch name) was already stored in the database and shown in the web UI, but was missing from the project API, CLI, and SDK.

Closes https://github.com/ubicloud/ubicloud/discussions/5239