### PR TITLE
Add non-SSH based fencing approach for AWS PG

### DIFF
--- a/prog/postgres/postgres_lockout.rb
+++ b/prog/postgres/postgres_lockout.rb
@@ -10,7 +10,7 @@ class Prog::Postgres::PostgresLockout < Prog::Base
       send("lockout_with_#{mechanism}")
       Clog.emit("Fenced unresponsive primary", {fenced_unresponsive_primary: {server_ubid: postgres_server.ubid, mechanism:}})
       pop "lockout_succeeded"
-    rescue *Sshable::SSH_CONNECTION_ERRORS, Sshable::SshError
+    rescue *Sshable::SSH_CONNECTION_ERRORS, Sshable::SshError, Aws::EC2::Errors::ServiceError
       pop "lockout_failed"
     end
   end
@@ -35,6 +35,18 @@ class Prog::Postgres::PostgresLockout < Prog::Base
     postgres_server.vm.vm_host.sshable.cmd(
       "timeout 10 sudo ip link set :interface down", interface: "vetho#{postgres_server.vm.inhost_name}",
       timeout: 15,
+    )
+  end
+
+  def lockout_with_detach_nic
+    nar = postgres_server.vm.nic.nic_aws_resource
+    client = postgres_server.vm.location.location_credential_aws.client
+    network_interface = client.describe_network_interfaces(
+      network_interface_ids: [nar.network_interface_id],
+    ).network_interfaces.first
+    client.detach_network_interface(
+      attachment_id: network_interface.attachment.attachment_id,
+      force: true,
     )
   end
 end

--- a/prog/postgres/postgres_server_aws_nic_migration.rb
+++ b/prog/postgres/postgres_server_aws_nic_migration.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require "aws-sdk-ec2"
+
+# :nocov:
+class Prog::Postgres::PostgresServerAwsNicMigration < Prog::Base
+  subject_is :postgres_server
+
+  MIGRATION_DEADLINE_SECONDS = 48 * 60 * 60
+  DRAIN_POLL_INTERVAL_SECONDS = 60
+
+  label def start
+    register_deadline(nil, MIGRATION_DEADLINE_SECONDS)
+    nic = postgres_server.vm.nic
+    nar = nic.nic_aws_resource
+    fail "PostgresServer #{postgres_server.ubid} is not on AWS" unless postgres_server.aws?
+
+    instance_enis = client.describe_instances(
+      instance_ids: [postgres_server.vm.aws_instance.instance_id],
+    ).reservations.first.instances.first.network_interfaces
+    fail "PostgresServer #{postgres_server.ubid} already has more than one attached ENI" if instance_enis.length > 1
+
+    update_stack({
+      "old_network_interface_id" => nar.network_interface_id,
+      "old_eip_allocation_id" => nar.eip_allocation_id,
+      "old_private_ipv4" => nic.private_ipv4.to_s,
+      "old_public_ipv4" => postgres_server.vm.sshable.host,
+    })
+    hop_create_new_nic
+  end
+
+  label def create_new_nic
+    if frame["new_network_interface_id"].nil?
+      response = client.create_network_interface(
+        subnet_id: nic.nic_aws_resource.subnet_id,
+        ipv_6_prefix_count: 1,
+        groups: [nic.private_subnet.private_subnet_aws_resource.security_group_id],
+        tag_specifications: Util.aws_tag_specifications("network-interface", "#{nic.name}-mig"),
+        client_token: "#{strand.id}-nic",
+      )
+      update_stack({"new_network_interface_id" => response.network_interface.network_interface_id})
+    end
+    hop_wait_new_nic_created
+  end
+
+  label def wait_new_nic_created
+    new_nic = client.describe_network_interfaces(
+      network_interface_ids: [frame["new_network_interface_id"]],
+    ).network_interfaces.first
+    nap 1 unless new_nic&.status == "available"
+
+    update_stack({"new_private_ipv4" => new_nic.private_ip_address})
+    hop_attach_new_nic
+  end
+
+  label def attach_new_nic
+    if frame["new_attachment_id"].nil?
+      response = client.attach_network_interface(
+        network_interface_id: frame["new_network_interface_id"],
+        instance_id: postgres_server.vm.aws_instance.instance_id,
+        device_index: 1,
+      )
+      update_stack({"new_attachment_id" => response.attachment_id})
+    end
+    hop_allocate_new_eip
+  end
+
+  label def allocate_new_eip
+    if frame["new_eip_allocation_id"].nil?
+      response = client.allocate_address(
+        tag_specifications: Util.aws_tag_specifications("elastic-ip", "#{nic.name}-mig"),
+      )
+      update_stack({"new_eip_allocation_id" => response.allocation_id})
+    end
+    hop_associate_new_eip
+  end
+
+  label def associate_new_eip
+    address = client.describe_addresses(
+      filters: [{name: "allocation-id", values: [frame["new_eip_allocation_id"]]}],
+    ).addresses.first
+
+    unless address&.network_interface_id
+      client.associate_address(
+        allocation_id: frame["new_eip_allocation_id"],
+        network_interface_id: frame["new_network_interface_id"],
+      )
+      address = client.describe_addresses(
+        filters: [{name: "allocation-id", values: [frame["new_eip_allocation_id"]]}],
+      ).addresses.first
+    end
+
+    update_stack({"new_public_ipv4" => address.public_ip})
+    hop_wait_guest_sees_eth1
+  end
+
+  label def wait_guest_sees_eth1
+    postgres_server.vm.sshable.cmd("ip -br addr show eth1 | grep -q UP")
+    hop_flip_hosts_file
+  rescue Sshable::SshError
+    nap 2
+  end
+
+  label def flip_hosts_file
+    DB.transaction do
+      nic.update(private_ipv4: "#{frame["new_private_ipv4"]}/32")
+      AssignedVmAddress.where(dst_vm_id: postgres_server.vm.id).update(ip: "#{frame["new_public_ipv4"]}/32")
+    end
+    resource.servers.each(&:incr_configure)
+    hop_wait_configure_propagated
+  end
+
+  label def wait_configure_propagated
+    nap 5 if resource.servers.any?(&:configure_set?)
+    hop_update_dns_record
+  end
+
+  label def update_dns_record
+    resource.incr_refresh_dns_record
+    hop_wait_dns_propagated
+  end
+
+  label def wait_dns_propagated
+    unless frame["dns_propagation_waited"]
+      update_stack({"dns_propagation_waited" => true})
+      nap 60
+    end
+    hop_wait_old_connections_drain
+  end
+
+  label def wait_old_connections_drain
+    old_ip = frame["old_private_ipv4"].split("/").first
+    ds = DB[:pg_stat_activity]
+      .where(Sequel.lit("client_addr = ?::inet", old_ip))
+      .where(backend_type: "client backend")
+      .select(Sequel.function(:count, Sequel.lit("*")))
+    count = Integer(postgres_server.run_query(ds), 10)
+
+    Clog.emit("waiting for old NIC connections to drain", {
+      aws_nic_migration_drain: {server_ubid: postgres_server.ubid, remaining: count, old_ip: frame["old_private_ipv4"]},
+    })
+
+    if count.zero?
+      hop_swap_ssh_host
+    else
+      nap DRAIN_POLL_INTERVAL_SECONDS
+    end
+  end
+
+  label def swap_ssh_host
+    postgres_server.vm.sshable.update(host: frame["new_public_ipv4"])
+    postgres_server.vm.sshable.cmd("true")
+    hop_disassociate_old_eip
+  end
+
+  label def disassociate_old_eip
+    old_address = client.describe_addresses(
+      filters: [{name: "allocation-id", values: [frame["old_eip_allocation_id"]]}],
+    ).addresses.first
+
+    if old_address&.association_id
+      client.disassociate_address(association_id: old_address.association_id)
+    end
+    hop_release_old_eip
+  end
+
+  label def release_old_eip
+    client.release_address(allocation_id: frame["old_eip_allocation_id"])
+    hop_switch_nic_aws_resource
+  rescue Aws::EC2::Errors::InvalidAllocationIDNotFound
+    hop_switch_nic_aws_resource
+  end
+
+  label def switch_nic_aws_resource
+    nic.nic_aws_resource.update(
+      network_interface_id: frame["new_network_interface_id"],
+      eip_allocation_id: frame["new_eip_allocation_id"],
+    )
+    Clog.emit("AWS NIC migration complete", {
+      aws_nic_migration_complete: {server_ubid: postgres_server.ubid, new_network_interface_id: frame["new_network_interface_id"]},
+    })
+    pop "aws nic migration complete"
+  end
+
+  def nic
+    @nic ||= postgres_server.vm.nic
+  end
+
+  def resource
+    @resource ||= postgres_server.resource
+  end
+
+  def client
+    @client ||= postgres_server.vm.location.location_credential_aws.client
+  end
+end
+# :nocov:

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -767,7 +767,9 @@ SQL
 
     bud Prog::Postgres::PostgresLockout, {"mechanism" => "pg_stop"}
     bud Prog::Postgres::PostgresLockout, {"mechanism" => "hba"}
-    unless resource.location.aws?
+    if resource.location.aws?
+      bud Prog::Postgres::PostgresLockout, {"mechanism" => "detach_nic"}
+    else
       bud Prog::Postgres::PostgresLockout, {"mechanism" => "host_routing"}
     end
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -60,6 +60,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
         availability_zone:,
         exclude_data_centers:,
         swap_size_bytes: postgres_resource.target_vm_size.start_with?("hobby") ? 4 * 1024 * 1024 * 1024 : nil,
+        use_secondary_nic: postgres_resource.location.aws?,
       )
 
       synchronization_status = (is_representative && !postgres_resource.read_replica?) ? "ready" : "catching_up"

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -140,6 +140,20 @@ class Prog::Vm::Aws::Nexus < Prog::Base
       end
     end
 
+    network_interfaces_param = if frame["use_secondary_nic"]
+      [
+        {
+          device_index: 0,
+          subnet_id: nic.nic_aws_resource.subnet_id,
+          groups: [nic.private_subnet.private_subnet_aws_resource.security_group_id],
+          delete_on_termination: true,
+        },
+        {network_interface_id: nic.nic_aws_resource.network_interface_id, device_index: 1},
+      ]
+    else
+      [{network_interface_id: nic.nic_aws_resource.network_interface_id, device_index: 0}]
+    end
+
     params = {
       image_id: vm.boot_image, # AMI ID
       instance_type: Option.aws_instance_type_name(vm.family, vm.vcpus),
@@ -156,12 +170,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
           },
         },
       ],
-      network_interfaces: [
-        {
-          network_interface_id: nic.nic_aws_resource.network_interface_id,
-          device_index: 0,
-        },
-      ],
+      network_interfaces: network_interfaces_param,
       private_dns_name_options: {
         hostname_type: "ip-name",
         enable_resource_name_dns_a_record: false,
@@ -231,8 +240,9 @@ class Prog::Vm::Aws::Nexus < Prog::Base
         instance_response.dig(:state, :name) == "running"
       nap 1
     end
-    public_ipv4 = instance_response.dig(:network_interfaces, 0, :association, :public_ip)
-    public_ipv6 = instance_response.dig(:network_interfaces, 0, :ipv_6_addresses, 0, :ipv_6_address)
+    tracked_ni = instance_response.network_interfaces.find { it.network_interface_id == nic.nic_aws_resource.network_interface_id }
+    public_ipv4 = tracked_ni.association.public_ip
+    public_ipv6 = tracked_ni.ipv_6_addresses.first&.ipv_6_address
     AssignedVmAddress.create(dst_vm_id: vm.id, ip: public_ipv4)
     vm.sshable&.update(host: public_ipv4)
     vm.update(cores: vm.vcpus / 2, allocated_at: Time.now, ephemeral_net6: public_ipv6)

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -13,7 +13,7 @@ class Prog::Vm::Nexus < Prog::Base
     hugepages: true, hypervisor: nil, ch_version: nil, firmware_version: nil, new_private_subnet_name: nil,
     exclude_availability_zones: [], availability_zone: nil, alternative_families: [],
     allow_private_subnet_in_other_project: false, init_script: nil, exclude_data_centers: [],
-    machine_image_version_id: nil)
+    machine_image_version_id: nil, use_secondary_nic: false)
 
     unless (project = Project[project_id])
       fail "No existing project"
@@ -180,6 +180,7 @@ class Prog::Vm::Nexus < Prog::Base
           "firmware_version" => firmware_version,
           "alternative_families" => alternative_families,
           "private_subnet_id" => subnet.id,
+          "use_secondary_nic" => use_secondary_nic,
         }],
       ) { it.id = vm.id }
     end

--- a/spec/prog/postgres/postgres_lockout_spec.rb
+++ b/spec/prog/postgres/postgres_lockout_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Prog::Postgres::PostgresLockout do
 
   describe "#start" do
     it "uses the appropriate lockout mechanism" do
-      ["pg_stop", "hba", "host_routing"].each do |mechanism|
+      ["pg_stop", "hba", "host_routing", "detach_nic"].each do |mechanism|
         refresh_frame(nx, new_frame: {"mechanism" => mechanism})
         expect(nx).to receive("lockout_with_#{mechanism}").and_return(true)
         expect(Clog).to receive(:emit).with("Fenced unresponsive primary", {fenced_unresponsive_primary: {server_ubid: server.ubid, mechanism:}})
@@ -39,6 +39,12 @@ RSpec.describe Prog::Postgres::PostgresLockout do
         "timeout 10 sudo pg_ctlcluster 17 main stop -m immediate",
         timeout: 15,
       ).and_raise(Sshable::SshError.new("", "", "", "", ""))
+      expect { nx.start }.to exit({"msg" => "lockout_failed"})
+    end
+
+    it "returns false for AWS API failures" do
+      refresh_frame(nx, new_frame: {"mechanism" => "detach_nic"})
+      expect(nx).to receive(:lockout_with_detach_nic).and_raise(Aws::EC2::Errors::ServiceError.new(nil, "boom"))
       expect { nx.start }.to exit({"msg" => "lockout_failed"})
     end
   end
@@ -78,6 +84,30 @@ RSpec.describe Prog::Postgres::PostgresLockout do
         timeout: 15,
       ).and_return(true)
       expect { nx.lockout_with_host_routing }.not_to raise_error
+    end
+  end
+
+  describe "#lockout_with_detach_nic" do
+    let(:aws_location) {
+      loc = Location.create(name: "us-west-2", display_name: "aws-us-west-2", ui_name: "aws-us-west-2", visible: true, provider: "aws", project_id: project.id)
+      LocationCredentialAws.create_with_id(loc, access_key: "k", secret_key: "s")
+      LocationAz.create(location_id: loc.id, az: "a", zone_id: "usw2-az1")
+      loc
+    }
+    let(:aws_resource) { create_postgres_resource(project:, location_id: aws_location.id) }
+    let(:aws_server) { create_postgres_server(resource: aws_resource, timeline: postgres_timeline) }
+    let(:aws_nx) { described_class.new(aws_server.strand) }
+    let(:ec2_client) { Aws::EC2::Client.new(stub_responses: true) }
+
+    before do
+      NicAwsResource.create_with_id(aws_server.vm.nics.first, network_interface_id: "eni-abc")
+      allow(Aws::EC2::Client).to receive(:new).with(credentials: anything, region: "us-west-2").and_return(ec2_client)
+    end
+
+    it "looks up the attachment id and detaches the tracked ENI" do
+      ec2_client.stub_responses(:describe_network_interfaces, network_interfaces: [{network_interface_id: "eni-abc", attachment: {attachment_id: "eni-attach-123"}}])
+      expect(ec2_client).to receive(:detach_network_interface).with(attachment_id: "eni-attach-123", force: true).and_call_original
+      expect { aws_nx.lockout_with_detach_nic }.not_to raise_error
     end
   end
 end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1318,7 +1318,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(Semaphore.where(strand_id: server.id, name: "lockout").count).to eq(0)
     end
 
-    it "skips host_routing lockout on AWS" do
+    it "dispatches detach_nic instead of host_routing on AWS" do
       aws_location = Location.create(
         name: "us-west-2",
         display_name: "aws-us-west-2",
@@ -1334,6 +1334,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
       expect(aws_nx).to receive(:bud).with(Prog::Postgres::PostgresLockout, {"mechanism" => "pg_stop"})
       expect(aws_nx).to receive(:bud).with(Prog::Postgres::PostgresLockout, {"mechanism" => "hba"})
+      expect(aws_nx).to receive(:bud).with(Prog::Postgres::PostgresLockout, {"mechanism" => "detach_nic"})
       expect(aws_nx).not_to receive(:bud).with(Prog::Postgres::PostgresLockout, {"mechanism" => "host_routing"})
       expect { aws_nx.lockout }.to hop("wait_lockout_attempt")
     end

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -354,6 +354,29 @@ usermod -L ubuntu
       expect(vm.aws_instance).to have_attributes(instance_id: "i-0123456789abcdefg", az_id: "use1-az1", iam_role: "testvm", ipv4_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com")
     end
 
+    it "emits a placeholder primary ENI plus the tracked ENI at device_index 1 when use_secondary_nic is set" do
+      vm_nic = vm.nic
+      nic_aws_resource.update(subnet_id: "subnet-12345678")
+      vm_nic.private_subnet.private_subnet_aws_resource.update(security_group_id: "sg-0123456789abcdefg")
+      refresh_frame(nx, new_values: {"use_secondary_nic" => true})
+      client.stub_responses(:run_instances, instances: [{instance_id: "i-0123456789abcdefg", network_interfaces: [{subnet_id: "subnet-12345678"}], public_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com"}])
+      expect(client).to receive(:run_instances).with(hash_including(
+        network_interfaces: [
+          {
+            device_index: 0,
+            subnet_id: "subnet-12345678",
+            groups: ["sg-0123456789abcdefg"],
+            delete_on_termination: true,
+          },
+          {
+            network_interface_id: "eni-0123456789abcdefg",
+            device_index: 1,
+          },
+        ],
+      )).and_call_original
+      expect { nx.create_instance }.to hop("wait_instance_created")
+    end
+
     it "skips instance profile creation for runner instances" do
       client.stub_responses(:run_instances, instances: [{instance_id: "i-0123456789abcdefg", network_interfaces: [{subnet_id: "subnet-12345678"}], public_dns_name: "ec2-44-224-119-46.us-west-2.compute.amazonaws.com"}])
       vm.update(unix_user: "runneradmin")
@@ -570,7 +593,8 @@ usermod -L ubuntu
   describe "#wait_instance_created" do
     before do
       aws_instance
-      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "running"}, network_interfaces: [{association: {public_ip: "1.2.3.4"}, ipv_6_addresses: [{ipv_6_address: "2a01:4f8:173:1ed3:aa7c::/79"}]}]}]}])
+      nic_aws_resource
+      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "running"}, network_interfaces: [{network_interface_id: "eni-0123456789abcdefg", association: {public_ip: "1.2.3.4"}, ipv_6_addresses: [{ipv_6_address: "2a01:4f8:173:1ed3:aa7c::/79"}]}]}]}])
     end
 
     it "updates the vm" do
@@ -606,6 +630,16 @@ usermod -L ubuntu
       client.stub_responses(:describe_instances, reservations: [])
       expect { nx.wait_instance_created }.to nap(1)
     end
+
+    it "looks up the tracked NIC by id when there are multiple ENIs" do
+      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "running"}, network_interfaces: [
+        {network_interface_id: "eni-placeholder", association: {public_ip: "9.9.9.9"}, ipv_6_addresses: []},
+        {network_interface_id: "eni-0123456789abcdefg", association: {public_ip: "1.2.3.4"}, ipv_6_addresses: [{ipv_6_address: "2a01:4f8:173:1ed3:aa7c::/79"}]},
+      ]}]}])
+      expect { nx.wait_instance_created }.to hop("wait_sshable")
+      expect(vm.sshable.reload.host).to eq("1.2.3.4")
+      expect(vm.reload.ephemeral_net6.to_s).to eq("2a01:4f8:173:1ed3:aa7c::/79")
+    end
   end
 
   describe "#wait_instance_created", "without sshable" do
@@ -614,7 +648,8 @@ usermod -L ubuntu
 
     before do
       aws_instance
-      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "running"}, network_interfaces: [{association: {public_ip: "1.2.3.4"}, ipv_6_addresses: [{ipv_6_address: "2a01:4f8:173:1ed3:aa7c::/79"}]}]}]}])
+      nic_aws_resource
+      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "running"}, network_interfaces: [{network_interface_id: "eni-0123456789abcdefg", association: {public_ip: "1.2.3.4"}, ipv_6_addresses: [{ipv_6_address: "2a01:4f8:173:1ed3:aa7c::/79"}]}]}]}])
     end
 
     it "handles vm without sshable" do


### PR DESCRIPTION
**I'm not fully decided on the proper approach to achieve this. Opening this PR as draft to share the idea.**

**Route AWS PG traffic through a secondary ENI**
We need a fence mechanism that cuts networking at the AWS fabric without
any guest cooperation (the AWS equivalent of bare-metal host_routing).
AWS forbids detaching the primary ENI from a running instance, so the
only fenceable via detaching NIC is a secondary one.

Every AWS PG VM now has two ENIs: an untracked placeholder at
primary ENI (required by AWS, no EIP, delete_on_termination) and the
tracked ENI carrying SSH, PG, replication, and the EIP.

Vm::Nexus.assemble accepts a use_secondary_nic kwarg, which
PostgresServerNexus.assemble sets to postgres_resource.location.aws?.
The flag lives in the VM strand's stack and is read by
Vm::Aws::Nexus#create_instance to emit the right network_interfaces
shape to run_instances.

Non-AWS VMs and AWS runners are unchanged. They continue to get a single
NIC.

**Fence AWS PG primary by detaching its tracked ENI**
Bare-metal PG's lockout has three mechanisms: pg_stop, hba, and
host_routing. host_routing is the strongest because it cuts networking
at the hypervisor level and works even when the guest is hung. AWS had
only the two SSH-dependent mechanisms, leaving the old primary unfenced
if a primary became unresponsive.

lockout_with_detach_nic calls DetachNetworkInterface on the tracked
ENI's attachment id. AWS allows detaching any device_index >= 1
instantly and statelessly; the guest kernel sees PCIe removal, the
interface disappears, and every socket on it (SSH, PG, replication)
dies, matching host_routing's total isolation. SSH is severed too,
which is acceptable because bare-metal host_routing has the same
property; post-mortem access is via EC2 Serial Console or through
primary ENI (manual set up for now)

The PostgresServerNexus#lockout label now buds detach_nic for AWS in
place of host_routing. The rescue in PostgresLockout#start is widened
to Aws::EC2::Errors::ServiceError so API failures map cleanly to
lockout_failed.

**Add migration prog for existing AWS PG instances**
Existing AWS PG VMs have their tracked NIC at device_index 0. AWS
forbids detaching device_index 0 from a running instance, so we cannot
rearrange the layout in place by removing the old NIC. The migration
prog instead adds a new ENI at device_index 1, moves all traffic onto
it, and leaves the old NIC attached as an untracked placeholder.

Resumable across crashes; every label stores its state in the strand
stack and is idempotent. listen_addresses stays '*', so PG's wildcard
listener socket automatically accepts connections on the new ENI's IP
the moment the kernel hotplugs it; no PG restart or reload is required
anywhere in the flow.

The drain phase polls pg_stat_activity and waits until all
backend_type = 'client backend' connections from the old private IP
reach zero, with a 48h deadline. No user session is force-terminated.
Walsenders are excluded from the drain, they won't drain on their own,
but get reset as a side effect of disassociating the old EIP, after
which standbys reconnect through the updated /etc/hosts entry. SSH host
swaps only after verifying the new path works, so a mid-migration
failure never leaves the VM unreachable.