### PR TITLE
Make CreateVersionMetal consistent with CreateVersionMetalFromUrl

### DIFF
--- a/prog/machine_image/create_version_metal.rb
+++ b/prog/machine_image/create_version_metal.rb
@@ -3,9 +3,9 @@
 require "json"
 
 class Prog::MachineImage::CreateVersionMetal < Prog::Base
-  subject_is :machine_image_version_metal
+  subject_is :machine_image_version
 
-  def self.assemble(machine_image_version, source_vm, store, destroy_source_after: false, set_as_latest: true)
+  def self.assemble(machine_image, version, source_vm, store, destroy_source_after: false, set_as_latest: true)
     fail "source vm must be a metal vm" unless source_vm.vm_host
     fail "source vm must have only one storage volume" unless source_vm.vm_storage_volumes.count == 1
     fail "source vm must be stopped" unless source_vm.display_state == "stopped"
@@ -14,37 +14,35 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
     fail "source vm's vhost block backend must support archive" unless sv.vhost_block_backend&.supports_archive?
     fail "source vm's storage volume must be encrypted" unless sv.key_encryption_key_1
 
-    mi = machine_image_version.machine_image
-    version = machine_image_version.version
-    archive_kek = StorageKeyEncryptionKey.create_random(auth_data: "machine_image_version_#{machine_image_version.ubid}_#{version}")
+    DB.transaction do
+      miv = MachineImageVersion.create(
+        machine_image_id: machine_image.id,
+        version:,
+        actual_size_mib: source_vm.storage_size_gib * 1024,
+      )
+      archive_kek = StorageKeyEncryptionKey.create_random(auth_data: "machine_image_version_#{miv.ubid}_#{version}")
+      MachineImageVersionMetal.create_with_id(miv,
+        enabled: false,
+        archive_kek_id: archive_kek.id,
+        store_id: store.id,
+        store_prefix: "#{machine_image.project.ubid}/#{machine_image.ubid}/#{version}")
 
-    mi_version_metal = MachineImageVersionMetal.create_with_id(
-      machine_image_version,
-      enabled: false,
-      archive_kek_id: archive_kek.id,
-      store_id: store.id,
-      store_prefix: "#{mi.project.ubid}/#{mi.ubid}/#{version}",
-    )
-
-    Strand.create_with_id(
-      mi_version_metal,
-      prog: "MachineImage::CreateVersionMetal",
-      label: "archive",
-      stack: [{
-        "subject_id" => mi_version_metal.id,
-        "source_vm_id" => source_vm.id,
-        "destroy_source_after" => destroy_source_after,
-        "set_as_latest" => set_as_latest,
-      }],
-    )
+      Strand.create_with_id(miv,
+        prog: "MachineImage::CreateVersionMetal",
+        label: "archive",
+        stack: [{
+          "source_vm_id" => source_vm.id,
+          "destroy_source_after" => destroy_source_after,
+          "set_as_latest" => set_as_latest,
+        }])
+    end
   end
 
   label def archive
     register_deadline(nil, source_vm.storage_size_gib * 24) # 4 minutes per 10 GiB
 
     sv = source_vm.vm_storage_volumes.first
-    mi_version = machine_image_version_metal.machine_image_version
-    unit_name = "archive_#{mi_version.ubid}"
+    unit_name = "archive_#{machine_image_version.ubid}"
     sshable = source_vm.vm_host.sshable
 
     status = sshable.d_check(unit_name)
@@ -75,7 +73,7 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
   label def finish
     source_vm.vm_host.sshable.cmd("sudo rm -f :stats_path", stats_path: stats_file_path)
 
-    machine_image_version_metal.update(
+    machine_image_version.metal.update(
       enabled: true,
       archive_size_mib: (frame["archive_size_bytes"]/1048576r).ceil,
     )
@@ -83,15 +81,14 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
       source_vm.incr_destroy
     end
     if frame["set_as_latest"]
-      miv = machine_image_version_metal.machine_image_version
-      miv.machine_image.update(latest_version_id: miv.id)
+      machine_image_version.machine_image.update(latest_version_id: machine_image_version.id)
     end
     pop "Metal machine image version is created and enabled"
   end
 
   def archive_params_json
     sv = source_vm.vm_storage_volumes.first
-    store = machine_image_version_metal.store
+    store = machine_image_version.metal.store
 
     {
       kek: sv.key_encryption_key_1.secret_key_material_hash,
@@ -99,17 +96,16 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
         endpoint: store.endpoint,
         region: store.region,
         bucket: store.bucket,
-        prefix: machine_image_version_metal.store_prefix,
+        prefix: machine_image_version.metal.store_prefix,
         access_key_id: store.access_key,
         secret_access_key: store.secret_key,
-        archive_kek: machine_image_version_metal.archive_kek.secret_key_material_hash,
+        archive_kek: machine_image_version.metal.archive_kek.secret_key_material_hash,
       },
     }.to_json
   end
 
   def stats_file_path
-    mi_version = machine_image_version_metal.machine_image_version
-    "/tmp/archive_stats_#{mi_version.ubid}.json"
+    "/tmp/archive_stats_#{machine_image_version.ubid}.json"
   end
 
   def source_vm

--- a/spec/prog/machine_image/create_version_metal_spec.rb
+++ b/spec/prog/machine_image/create_version_metal_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
       prog: "MachineImage::CreateVersionMetal",
       label: "archive",
       stack: [{
-        "subject_id" => mi_version_metal.id,
         "source_vm_id" => source_vm.id,
         "destroy_source_after" => false,
       }],
@@ -70,7 +69,7 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
       vm_without_host = create_vm(project_id: project.id, name: "vm-without-host")
 
       expect {
-        described_class.assemble(mi_version, vm_without_host, store)
+        described_class.assemble(machine_image, "1.0", vm_without_host, store)
       }.to raise_error("source vm must be a metal vm")
     end
 
@@ -83,7 +82,7 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
       )
 
       expect {
-        described_class.assemble(mi_version, source_vm.reload, store)
+        described_class.assemble(machine_image, "1.0", source_vm.reload, store)
       }.to raise_error("source vm must have only one storage volume")
     end
 
@@ -97,7 +96,7 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
       )
 
       expect {
-        described_class.assemble(mi_version, running_vm, store)
+        described_class.assemble(machine_image, "1.0", running_vm, store)
       }.to raise_error("source vm must be stopped")
     end
 
@@ -113,7 +112,7 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
       )
 
       expect {
-        described_class.assemble(mi_version, old_vm, store)
+        described_class.assemble(machine_image, "1.0", old_vm, store)
       }.to raise_error("source vm's vhost block backend must support archive")
     end
 
@@ -127,7 +126,7 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
       )
 
       expect {
-        described_class.assemble(mi_version, unencrypted_vm, store)
+        described_class.assemble(machine_image, "1.0", unencrypted_vm, store)
       }.to raise_error("source vm's storage volume must be encrypted")
     end
 
@@ -141,20 +140,19 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
       )
 
       expect {
-        described_class.assemble(mi_version, no_backend_vm, store)
+        described_class.assemble(machine_image, "1.0", no_backend_vm, store)
       }.to raise_error("source vm's vhost block backend must support archive")
     end
 
-    it "creates a machine image version metal and strand" do
-      new_mi_version = MachineImageVersion.create(
-        machine_image_id: machine_image.id,
-        version: "2.0",
-        actual_size_mib: 5120,
-      )
+    it "creates a machine image version, its metal instance & archive_kek, and strand" do
+      strand = described_class.assemble(machine_image, "2.0", source_vm, store, destroy_source_after: true)
 
-      strand = described_class.assemble(new_mi_version, source_vm, store, destroy_source_after: true)
+      mi_version = MachineImageVersion[strand.id]
+      expect(mi_version).not_to be_nil
+      expect(mi_version.version).to eq("2.0")
+      expect(mi_version.actual_size_mib).to eq(source_vm.storage_size_gib * 1024)
 
-      mi_version_metal = MachineImageVersionMetal[strand.id]
+      mi_version_metal = mi_version.metal
       expect(mi_version_metal).not_to be_nil
       expect(mi_version_metal.enabled).to be false
       expect(mi_version_metal.store_id).to eq(store.id)
@@ -165,6 +163,7 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
       expect(strand.label).to eq("archive")
       expect(strand.stack.first["source_vm_id"]).to eq(source_vm.id)
       expect(strand.stack.first["destroy_source_after"]).to be true
+      expect(strand.stack.first["set_as_latest"]).to be true
     end
   end
 


### PR DESCRIPTION
`CreateVersionMetalFromUrl.assemble()` takes a machine image instance and a version, and constructs the MachineImageVersion and its metal instance. The reason is that the `actual_size_mib` field of MachineImageVersion cannot be known before this prog runs, so it makes sense to construct it as part of the prog.

Previously, we decoupled MachineImageVersion creation from the `CreateVersionMetal` prog. The initial motivation was to keep flexibility for future GCP and AWS machine image support. However, additional APIs can be introduced for those cases if needed, once real use cases emerge.

Therefore, move MachineImageVersion creation into `CreateVersionMetal.assemble()` to make the APIs consistent and simpler to use, and less error-prone.