### PR TITLE
Support LVM device-mapper devices in persistent_device_id

### DIFF
--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -273,10 +273,12 @@ class StorageVolume
       #  - SSDs: Use identifiers starting with 'wwn' (World Wide Name), globally unique.
       #  - NVMe: Use identifiers starting with 'nvme-eui', also globally unique.
       #  - MD devices: Use uuid identifiers.
+      #  - LVM/device-mapper: Use LVM uuid identifiers.
       dev = File.basename(dev_path)
       return id if (dev.start_with?("nvme") && id.include?("nvme-eui.")) ||
         (dev.start_with?("sd") && id.include?("wwn-")) ||
-        (dev.start_with?("md") && id.include?("md-uuid-"))
+        (dev.start_with?("md") && id.include?("md-uuid-")) ||
+        (dev.start_with?("dm") && id.include?("dm-uuid-"))
     rescue SystemCallError
       next
     end

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -647,6 +647,16 @@ RSpec.describe StorageVolume do
       expect(encrypted_sv.persistent_device_id("storage_path")).to eq(paths.last)
     end
 
+    it "returns the persistent device id for a path with LVM device-mapper device" do
+      paths = ["/dev/disk/by-id/dm-name-vg0-root", "/dev/disk/by-id/dm-uuid-LVM-abc123def456ghi789jkl012mno345pqr678stu901vwx234yz5678abcdef0123"]
+      expect(Dir).to receive(:[]).with("/dev/disk/by-id/*").and_return(paths)
+      expect(File).to receive(:realpath).with(paths[0]).and_return("/dev/dm-1")
+      expect(File).to receive(:realpath).with(paths[1]).and_return("/dev/dm-1")
+      expect(File).to receive(:stat).with("/dev/dm-1").and_return(instance_double(File::Stat, rdev_major: 252, rdev_minor: 1)).twice
+      expect(File).to receive(:stat).with("storage_path").and_return(instance_double(File::Stat, dev_major: 252, dev_minor: 1))
+      expect(encrypted_sv.persistent_device_id("storage_path")).to eq(paths.last)
+    end
+
     it "raises an error if no matching device is found" do
       expect(Dir).to receive(:[]).with("/dev/disk/by-id/*").and_return([])
       expect(File).to receive(:stat).with("storage_path").and_return(instance_double(File::Stat, dev_major: 8, dev_minor: 0))


### PR DESCRIPTION
## Summary

- `persistent_device_id` fails on hosts where storage is on LVM logical volumes, crashing VM prep with `No persistent device ID found for storage path`
- Add `dm-uuid-*` pattern matching for device-mapper devices alongside the existing `nvme-eui`, `wwn`, and `md-uuid` patterns

## Problem

Burstable VM creation gets stuck on the "creating" step on hosts with RAID + LVM storage. The `setup-vm prep` daemonizer fails in a loop and the VM never progresses.

The root cause is in `persistent_device_id`. When a VM has IO rate limits (burstable VMs have `max_read_mbytes_per_sec` and `max_write_mbytes_per_sec` set), `systemd_io_rate_limits` calls `persistent_device_id` to resolve the storage path to a stable `/dev/disk/by-id/` symlink for systemd's `IOReadBandwidthMax`/`IOWriteBandwidthMax` directives.

The method recognizes three device types:
- NVMe: `nvme-eui.*`
- SATA/SAS: `wwn-*`
- MD RAID: `md-uuid-*`

On hosts using RAID + LVM (e.g. Hetzner bare metal provisioned with `installimage`), storage lives on device-mapper devices (`/dev/dm-*`). These have `/dev/disk/by-id/dm-uuid-LVM-*` symlinks, which the method didn't recognize — raising `No persistent device ID found for storage path` and failing VM prep.

Standard VMs are not affected because they have no IO rate limits, so `persistent_device_id` is never called.

## Why this is safe

The fix adds one more pattern to an existing list — it doesn't change behavior for any of the existing device types. The matching logic is the same structure as the other three patterns: check that the resolved device name starts with `dm` and the symlink contains `dm-uuid-`. LVM UUID symlinks are stable across reboots, same as the other identifier types.

## Testing

- [x] Added spec for LVM device-mapper path resolution
- [x] Verified fix on a Hetzner bare metal host with RAID 0 + LVM — burstable VM went from stuck at "creating" to running after patching