### PR TITLE
Use DNS upstreams sequentially in dnsmasq and prioritize Google DNS

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -507,14 +507,14 @@ dhcp-option=6,8.8.8.8
     else
       <<~IP4_CONFIG
 dhcp-range=#{guest_network.nth(2)},#{guest_network.nth(2)},#{guest_network.netmask.prefix_len}
-server=2606:4700:4700::1111
 server=2001:4860:4860::8888
+server=2606:4700:4700::1111
 dhcp-option=6,#{dns_ipv4}
 listen-address=#{dns_ipv4}
 dhcp-option=54,#{dns_ipv4}
 dhcp-option=option6:dns-server,#{dnsmasq_address_ip6}
 listen-address=#{dnsmasq_address_ip6}
-all-servers
+strict-order
       IP4_CONFIG
     end
     vp.write_dnsmasq_conf(<<DNSMASQ_CONF)


### PR DESCRIPTION
When multiple DNS servers are passed to dnsmasq with the `all-servers` config, it sends requests to all of them concurrently and uses the first response it receives even if that response is an error or empty.

Currently, Cloudflare's DNS servers return empty responses for a number of AWS hostnames, causing our runners to fail to resolve those hostnames. By putting Google DNS first, we can avoid this issue while still keeping Cloudflare as a fallback.

We also replaced `all-servers` with `strict-order` to ensure dnsmasq sends requests to upstreams in the listed order. This way, Google DNS is always tried first when available, and dnsmasq falls back to Cloudflare only if Google DNS is down or not responding.