### PR TITLE
Honor user_config override when sizing pgbouncer max_db_connections

### DIFF
--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -179,5 +179,6 @@ if configure_hash["physical_slots"]
   end
 end
 
-pgbouncer_setup = PgBouncerSetup.new(v, configure_hash["configs"]["max_connections"], configure_hash["pgbouncer_instances"], configure_hash["pgbouncer_user_config"])
+max_connections = configure_hash["user_config"]["max_connections"] || configure_hash["configs"]["max_connections"]
+pgbouncer_setup = PgBouncerSetup.new(v, max_connections, configure_hash["pgbouncer_instances"], configure_hash["pgbouncer_user_config"])
 pgbouncer_setup.setup


### PR DESCRIPTION
PgBouncer's max_db_connections is derived by dividing Postgres max_connections across pgbouncer instances. We were reading it from configure_hash["configs"], which only reflects the service defaults (written to 001-service.conf). User overrides live in configure_hash["user_config"] (written to 099-user.conf) and take precedence on the server, so the pool could be sized against the wrong limit. Prefer the user_config value when present.