### PR TITLE
Tweaks to overcommit configuration

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -143,6 +143,7 @@ class PostgresServer < Sequel::Model
       pgbouncer_instances: (vm.vcpus / 2.0).ceil.clamp(1, 8),
       metrics_config:,
       disk_throughput_baseline_mbps:,
+      strict_overcommit: !resource.skip_strict_memory_overcommit_set?,
     }
   end
 

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -5,6 +5,7 @@ require "json"
 require "fileutils"
 require_relative "../../common/lib/util"
 require_relative "../lib/pg_bouncer_setup"
+require_relative "../lib/postgres_setup"
 
 if ARGV.count != 1
   fail "Wrong number of arguments. Expected 1, Given #{ARGV.count}"
@@ -12,6 +13,8 @@ end
 
 v = ARGV[0]
 configure_hash = JSON.parse($stdin.read)
+
+PostgresSetup.new(v).configure_memory_overcommit(strict: configure_hash["strict_overcommit"])
 
 # Update /etc/hosts
 hosts = <<-HOSTS

--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -18,7 +18,10 @@ class PostgresSetup
   def configure_memory_overcommit(strict: false)
     if strict
       total_mem_kb = File.read("/proc/meminfo").match(/MemTotal:\s+(\d+)/)[1].to_i
-      overcommit_kbytes = (total_mem_kb * 0.8 + 2 * 1048576).round
+      # 25% of memory is reserved for hugepages, which do not count towards the
+      # commit limit, so only the remaining 75% is available for overcommit.
+      non_hugepage_mem_kb = total_mem_kb * 0.75
+      overcommit_kbytes = (non_hugepage_mem_kb * 0.8 + 2 * 1048576).round
       safe_write_to_file("/etc/sysctl.d/99-overcommit.conf", "vm.overcommit_memory=2\nvm.overcommit_kbytes=#{overcommit_kbytes}\n")
     else
       r "sudo rm -f /etc/sysctl.d/99-overcommit.conf"

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -12,17 +12,9 @@ RSpec.describe PostgresSetup do
 
   describe "#configure_memory_overcommit" do
     it "sets strict overcommit settings when strict is true" do
-      # 8 GB = 8388608 KB -> kbytes = 8388608 * 0.8 + 2 * 1048576 = 8808038
+      # 8 GB = 8388608 KB -> kbytes = 8388608 * 0.75 * 0.8 + 2 * 1048576 = 7130317
       allow(File).to receive(:read).with("/proc/meminfo").and_return("MemTotal:        8388608 kB\n")
-      expect(pg_setup).to receive(:safe_write_to_file).with("/etc/sysctl.d/99-overcommit.conf", "vm.overcommit_memory=2\nvm.overcommit_kbytes=8808038\n")
-      expect(pg_setup).to receive(:r).with("sudo sysctl --system")
-      pg_setup.configure_memory_overcommit(strict: true)
-    end
-
-    it "calculates correct kbytes for smaller memory" do
-      # 4 GB = 4194304 KB -> kbytes = 4194304 * 0.8 + 2 * 1048576 = 5452595
-      allow(File).to receive(:read).with("/proc/meminfo").and_return("MemTotal:        4194304 kB\n")
-      expect(pg_setup).to receive(:safe_write_to_file).with("/etc/sysctl.d/99-overcommit.conf", "vm.overcommit_memory=2\nvm.overcommit_kbytes=5452595\n")
+      expect(pg_setup).to receive(:safe_write_to_file).with("/etc/sysctl.d/99-overcommit.conf", "vm.overcommit_memory=2\nvm.overcommit_kbytes=7130317\n")
       expect(pg_setup).to receive(:r).with("sudo sysctl --system")
       pg_setup.configure_memory_overcommit(strict: true)
     end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -150,6 +150,15 @@ RSpec.describe PostgresServer do
       postgres_server.update(version: "17")
       expect(postgres_server.configure_hash[:configs]).to include("allow_alter_system" => "off")
     end
+
+    it "sets strict_overcommit to true by default" do
+      expect(postgres_server.configure_hash[:strict_overcommit]).to be true
+    end
+
+    it "sets strict_overcommit to false when skip_strict_memory_overcommit semaphore is set" do
+      resource.incr_skip_strict_memory_overcommit
+      expect(postgres_server.configure_hash[:strict_overcommit]).to be false
+    end
   end
 
   describe "#trigger_failover" do


### PR DESCRIPTION
**Apply skip_strict_memory_overcommit from the configure step**
Until now, the skip_strict_memory_overcommit semaphore was only honored
during the initial provisioning scripts, so toggling the flag on an
existing resource had no effect until the server was reinitialized.
Plumb strict_overcommit through configure_hash and invoke
configure_memory_overcommit from bin/configure so the sysctl setting
is reconciled on every configure run.

**Exclude hugepage memory from overcommit limit calculation**
Postgres VMs reserve 25% of total memory for hugepages (see
rhizome/postgres/bin/setup-hugepages), and hugepage memory does not
count towards the kernel's commit accounting. Applying the 0.8
coefficient to total memory therefore overstated the usable headroom,
leaving the commit limit above the memory actually available for
non-hugepage allocations. Scale by the non-hugepage share (3/4) so the
limit reflects what processes can actually commit.