### PR TITLE
Automatically disassociate storage volumes from machine image versions after catch-up

### DIFF
--- a/model/metal/vm.rb
+++ b/model/metal/vm.rb
@@ -170,6 +170,7 @@ class Vm < Sequel::Model
         "encrypted_access_key_id" => kek.encrypt(store.access_key, "archive-access-key"),
         "encrypted_secret_access_key" => kek.encrypt(store.secret_key, "archive-secret-key"),
         "encrypted_archive_kek" => kek.encrypt(Base64.decode64(metal.archive_kek.key), "archive-kek"),
+        "autofetch" => true,
       }
     end
 

--- a/model/storage_device.rb
+++ b/model/storage_device.rb
@@ -30,6 +30,14 @@ class StorageDevice < Sequel::Model
       device_name
     end
   end
+
+  def path
+    @path ||= if name == "DEFAULT"
+      "/var/storage/"
+    else
+      "/var/storage/devices/#{name}"
+    end
+  end
 end
 
 # Table: storage_device

--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -64,7 +64,7 @@ class VmStorageVolume < Sequel::Model
     # The rpc server sends each response in a separate line. The pipe through
     # `head -n 1` is to close the connection after receiving the first response,
     # otherwise the rpc server will keep the connection open waiting for the 2nd
-    # request.
+    # request, until the timeout is reached.
     #
     # `-q 2`: after stdin EOF, wait up to 2s for the response before exiting
     # `-w 2`: connection timeout

--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../model"
+require "json"
 
 class VmStorageVolume < Sequel::Model
   many_to_one :vm
@@ -53,6 +54,27 @@ class VmStorageVolume < Sequel::Model
       # SPDK volumes
       256
     end
+  end
+
+  def path
+    @path ||= File.join(storage_device.path, vm.inhost_name, disk_index.to_s)
+  end
+
+  def rpc(payload)
+    # The rpc server sends each response in a separate line. The pipe through
+    # `head -n 1` is to close the connection after receiving the first response,
+    # otherwise the rpc server will keep the connection open waiting for the 2nd
+    # request.
+    #
+    # `-q 2`: after stdin EOF, wait up to 2s for the response before exiting
+    # `-w 2`: connection timeout
+    rpc_socket = File.join(path, "rpc.sock")
+    vm.vm_host.sshable.cmd_json("sudo nc -U :rpc_socket -q 2 -w 2 | head -n 1", stdin: payload.to_json, rpc_socket:)
+  end
+
+  def caught_up?
+    stripes = rpc(command: "status").dig("status", "stripes")
+    stripes.fetch("fetched") == stripes.fetch("source")
   end
 end
 

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -197,6 +197,23 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     vm.update(display_state: "running", provisioned_at: Time.now)
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: (Time.now - vm.allocated_at).round(3)}}])
 
+    if vm.vm_storage_volumes.any?(&:machine_image_version_id)
+      register_deadline("wait", 1800, allow_extension: true)
+      hop_wait_storage_catchup
+    else
+      hop_wait
+    end
+  end
+
+  label def wait_storage_catchup
+    vm.vm_storage_volumes.each { |vol|
+      next unless vol.machine_image_version_id
+      if vol.caught_up?
+        vol.update(machine_image_version_id: nil)
+      else
+        nap 30
+      end
+    }
     hop_wait
   end
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -28,7 +28,12 @@ class Prog::Vm::Nexus < Prog::Base
 
     if machine_image_version_id
       fail "Machine images are only supported for metal locations" unless location.provider_dispatcher_group_name == "metal"
-      fail "No existing machine image version metal" unless MachineImageVersionMetal[machine_image_version_id]
+      miv_metal = MachineImageVersionMetal[machine_image_version_id]
+      fail "No existing machine image version metal" unless miv_metal
+      fail "Boot image cannot be specified when using machine image version" if boot_image
+      miv = miv_metal.machine_image_version
+      mi = miv.machine_image
+      boot_image = "#{mi.name}@#{miv.version}"
     end
 
     vm_size = Validation.validate_vm_size(size, arch)

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -424,6 +424,7 @@ class StorageVolume
         "prefix" => @archive_source["prefix"],
         "region" => @archive_source["region"],
         "endpoint" => @archive_source["endpoint"],
+        "autofetch" => @archive_source.fetch("autofetch", false),
         "access_key_id.ref" => "archive-access-key",
         "secret_access_key.ref" => "archive-secret-key",
         "archive_kek.ref" => "archive-kek",

--- a/spec/model/storage_device_spec.rb
+++ b/spec/model/storage_device_spec.rb
@@ -33,4 +33,14 @@ RSpec.describe StorageDevice do
       end
     end
   end
+
+  describe "#path" do
+    it "returns /var/storage/ for DEFAULT device" do
+      expect(described_class.new(name: "DEFAULT").path).to eq("/var/storage/")
+    end
+
+    it "returns /var/storage/devices/<name> for non-DEFAULT device" do
+      expect(described_class.new(name: "disk1").path).to eq("/var/storage/devices/disk1")
+    end
+  end
 end

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -440,6 +440,7 @@ RSpec.describe Vm do
       expect(src).to have_key("encrypted_access_key_id")
       expect(src).to have_key("encrypted_secret_access_key")
       expect(src).to have_key("encrypted_archive_kek")
+      expect(src["autofetch"]).to be(true)
 
       expect(volumes[1]).not_to have_key("archive_source")
     end

--- a/spec/model/vm_storage_volume_spec.rb
+++ b/spec/model/vm_storage_volume_spec.rb
@@ -3,6 +3,10 @@
 require_relative "spec_helper"
 
 RSpec.describe VmStorageVolume do
+  let(:vm_host) { create_vm_host }
+  let(:vm) { create_vm(vm_host_id: vm_host.id) }
+  let(:default_storage_device) { StorageDevice.create(vm_host_id: vm_host.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100) }
+
   it "can render a device_path" do
     vm = Vm.new(location: Location[Location::HETZNER_FSN1_ID]).tap { it.id = "eb3dbcb3-2c90-8b74-8fb4-d62a244d7ae5" }
     expect(described_class.new(disk_index: 7, vm:).device_path).to eq("/dev/disk/by-id/virtio-vmxcyvsc_7")
@@ -66,6 +70,44 @@ RSpec.describe VmStorageVolume do
       v = described_class.new(disk_index: 7)
       allow(v).to receive(:vhost_block_backend).and_return(VhostBlockBackend.new)
       expect(v.queue_size).to eq(64)
+    end
+  end
+
+  describe "#path" do
+    it "returns the correct path for the volume in the default storage device" do
+      vol = described_class.create(vm_id: vm.id, disk_index: 3, storage_device_id: default_storage_device.id, boot: false, size_gib: 10)
+      expect(vol.path).to eq("/var/storage/#{vm.inhost_name}/3")
+    end
+
+    it "returns the correct path for the volume in a non-default storage device" do
+      storage_device = StorageDevice.create(vm_host_id: vm.vm_host_id, name: "disk1", total_storage_gib: 100, available_storage_gib: 100)
+      vol = described_class.create(vm_id: vm.id, disk_index: 2, storage_device_id: storage_device.id, boot: false, size_gib: 10)
+      expect(vol.path).to eq("/var/storage/devices/disk1/#{vm.inhost_name}/2")
+    end
+  end
+
+  describe "#rpc" do
+    it "sends a json payload to the rpc socket and parses the response" do
+      vol = described_class.create(vm_id: vm.id, disk_index: 1, storage_device_id: default_storage_device.id, boot: false, size_gib: 10)
+      payload = {"command" => "version"}
+      allow(vol.vm.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm.inhost_name}/1/rpc.sock -q 2 -w 2 | head -n 1", stdin: payload.to_json).and_return('{"version":"v0.4.1"}')
+      expect(vol.rpc(**payload)).to eq({"version" => "v0.4.1"})
+    end
+  end
+
+  describe "#caught_up?" do
+    let(:vol) { described_class.create(vm_id: vm.id, disk_index: 1, storage_device_id: default_storage_device.id, boot: false, size_gib: 10) }
+
+    it "is true when stripes fetched equals source" do
+      payload = {"command" => "status"}
+      allow(vol.vm.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm.inhost_name}/1/rpc.sock -q 2 -w 2 | head -n 1", stdin: payload.to_json).and_return('{"status": {"stripes": {"fetched": 100, "source": 100}}}')
+      expect(vol.caught_up?).to be true
+    end
+
+    it "is false when stripes fetched differs from source" do
+      payload = {"command" => "status"}
+      allow(vol.vm.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm.inhost_name}/1/rpc.sock -q 2 -w 2 | head -n 1", stdin: payload.to_json).and_return('{"status": {"stripes": {"fetched": 50, "source": 100}}}')
+      expect(vol.caught_up?).to be false
     end
   end
 end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -119,10 +119,11 @@ RSpec.describe Prog::Vm::Metal::Nexus do
 
     it "sets machine_image_version_id if provided" do
       miv = create_machine_image_version_metal
-      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: 20}, {size_gib: 10, read_only: true, image: "model"}], machine_image_version_id: miv.id)
+      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: nil, storage_volumes: [{size_gib: 20}, {size_gib: 10, read_only: true, image: "model"}], machine_image_version_id: miv.id)
       vols = st.stack.first["storage_volumes"]
       expect(vols[0]["machine_image_version_id"]).to eq(miv.id)
       expect(vols[1]).not_to have_key("machine_image_version_id")
+      expect(st.subject.boot_image).to eq("test-mi@v1")
     end
 
     it "fails if MachineImageVersionMetal with given machine_image_version_id does not exist" do
@@ -133,11 +134,18 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       }.to raise_error RuntimeError, "No existing machine image version metal"
     end
 
+    it "fails if boot_image is specified when using machine_image_version_id" do
+      miv = create_machine_image_version_metal
+      expect {
+        Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "ubuntu-jammy", machine_image_version_id: miv.id)
+      }.to raise_error RuntimeError, "Boot image cannot be specified when using machine image version"
+    end
+
     it "fails if MachineImageVersionMetal with given machine_image_version_id is not enabled" do
       miv = create_machine_image_version_metal
       miv.update(enabled: false)
       expect {
-        Prog::Vm::Nexus.assemble("some_ssh key", project.id, machine_image_version_id: miv.id)
+        Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: nil, machine_image_version_id: miv.id)
       }.to raise_error RuntimeError, "machine image version #{miv.id} is not available"
     end
 

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -757,6 +757,43 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       allow(vm).to receive(:allocated_at).and_return(now - 100)
       expect { nx.wait_sshable }.to hop("wait")
     end
+
+    it "hops to wait_storage_catchup when a volume has machine_image_version_id" do
+      miv = create_machine_image_version_metal
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, machine_image_version_id: miv.id)
+      vm.incr_update_firewall_rules
+      allow(vm).to receive(:allocated_at).and_return(Time.now - 100)
+      expect { nx.wait_sshable }.to hop("wait_storage_catchup")
+    end
+  end
+
+  describe "#wait_storage_catchup" do
+    before do
+      sd = StorageDevice.create(vm_host_id: vm_host.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100)
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, storage_device_id: sd.id)
+      VmStorageVolume.create(vm_id: vm.id, boot: false, size_gib: 15, disk_index: 1, use_bdev_ubi: false, storage_device_id: sd.id)
+    end
+
+    it "hops to wait when no volume has machine_image_version_id" do
+      expect { nx.wait_storage_catchup }.to hop("wait")
+    end
+
+    it "naps if a volume is not caught up" do
+      miv = create_machine_image_version_metal
+      vm.vm_storage_volumes_dataset.where(boot: true).update(machine_image_version_id: miv.id)
+      payload = {command: "status"}
+      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm.inhost_name}/0/rpc.sock -q 2 -w 2 | head -n 1", stdin: payload.to_json).and_return('{"status": {"stripes": {"fetched": 50, "source": 100}}}')
+      expect { nx.wait_storage_catchup }.to nap(30)
+    end
+
+    it "clears machine_image_version_id and hops to wait when volume is caught up" do
+      miv = create_machine_image_version_metal
+      vm.vm_storage_volumes_dataset.where(boot: false).update(machine_image_version_id: miv.id)
+      payload = {command: "status"}
+      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm.inhost_name}/1/rpc.sock -q 2 -w 2 | head -n 1", stdin: payload.to_json).and_return('{"status": {"stripes": {"fetched": 100, "source": 100}}}')
+      expect { nx.wait_storage_catchup }.to hop("wait")
+      expect(vm.vm_storage_volumes.first.reload.machine_image_version_id).to be_nil
+    end
   end
 
   describe "#create_billing_record" do


### PR DESCRIPTION
### Rhizome: support setting archive source autofetch 
By default, an archive stripe source lazily fetches stripes from the remote object store on access. Enabling `autofetch` changes this to eager background fetching.

This (1) limits high disk access latency to the first few minutes of a VM’s lifetime, and (2) removes dependency on the remote archive. These are desirable in many cases.

However, it increases network traffic and should be used cautiously.

### Enable autofetch and wait for catch-up for machine image–backed VMs 
Enable `autofetch` for machine image–backed VMs so stripes are fetched from the object store in the background.

Add a step in `Vm::Metal::Nexus` to wait for catch-up before entering the `wait` label. After a volume catches up, disassociate it from the machine image version.

Benefits:
- Allows de-provisioning old machine image versions once storage volumes disassociate
- Limits high disk access latency to the first few minutes of a VM’s lifetime
- Reduces the window where object store errors can impact the VM

We currently do not use machine images for short-lived VMs (e.g. GitHub runner VMs), so enabling `autofetch` by default is acceptable. This can be revisited as use cases evolve.

### Set Vm.boot_image from machine image version when used 
Disallow providing both `boot_image` and `machine_image_version_id` to `Vm::Nexus.assemble`.

When a machine image is used, set `Vm.boot_image` to `name@version`. This preserves the source image for debugging, since storage volumes may disassociate from the machine image version after catch-up and no longer retain that association.