### PR TITLE
Configure tight sysctl tcp keepalive for postgres

### DIFF
--- a/rhizome/postgres/bin/initialize-database-from-backup
+++ b/rhizome/postgres/bin/initialize-database-from-backup
@@ -15,6 +15,7 @@ strict_overcommit = ARGV[2] == "true"
 pg_setup = PostgresSetup.new(v)
 pg_setup.install_packages
 pg_setup.configure_memory_overcommit(strict: strict_overcommit)
+pg_setup.configure_tcp_keepalive
 pg_setup.setup_data_directory
 
 r "sudo -u postgres wal-g backup-fetch /dat/#{v}/data #{backup_label} --config /etc/postgresql/wal-g.env"

--- a/rhizome/postgres/bin/initialize-empty-database
+++ b/rhizome/postgres/bin/initialize-empty-database
@@ -14,5 +14,6 @@ strict_overcommit = ARGV[1] == "true"
 pg_setup = PostgresSetup.new(v)
 pg_setup.install_packages
 pg_setup.configure_memory_overcommit(strict: strict_overcommit)
+pg_setup.configure_tcp_keepalive
 pg_setup.setup_data_directory
 pg_setup.create_cluster

--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -27,6 +27,15 @@ class PostgresSetup
     r "sudo sysctl --system"
   end
 
+  def configure_tcp_keepalive
+    safe_write_to_file("/etc/sysctl.d/99-tcp-keepalive.conf", <<~SYSCTL)
+      net.ipv4.tcp_keepalive_time=30
+      net.ipv4.tcp_keepalive_probes=3
+      net.ipv4.tcp_keepalive_intvl=10
+    SYSCTL
+    r "sudo sysctl --system"
+  end
+
   def setup_data_directory
     r "chown postgres /dat"
 

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -39,4 +39,16 @@ RSpec.describe PostgresSetup do
       pg_setup.configure_memory_overcommit
     end
   end
+
+  describe "#configure_tcp_keepalive" do
+    it "writes sysctl drop-in for 3 probes at 20s interval" do
+      expect(pg_setup).to receive(:safe_write_to_file).with("/etc/sysctl.d/99-tcp-keepalive.conf", <<~SYSCTL)
+        net.ipv4.tcp_keepalive_time=30
+        net.ipv4.tcp_keepalive_probes=3
+        net.ipv4.tcp_keepalive_intvl=10
+      SYSCTL
+      expect(pg_setup).to receive(:r).with("sudo sysctl --system")
+      pg_setup.configure_tcp_keepalive
+    end
+  end
 end


### PR DESCRIPTION
Linux's default is to wait 2 hours before declaring a connection dead

That makes no sense in our world, instead drop after 1 minute