### PR TITLE
Upgrade jquery to 3.7.1 and dompurify to 3.4.0

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -182,7 +182,7 @@ class Clover < Roda
     csp.style_src :self, "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css"
     csp.img_src :self, "data: image/svg+xml", "https://github.com", "https://avatars.githubusercontent.com"
     csp.form_action :self, "https://checkout.stripe.com", "https://github.com/login/oauth/authorize", "https://accounts.google.com/o/oauth2/auth"
-    csp.script_src :self, "https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js", "https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js", "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js", "https://challenges.cloudflare.com/turnstile/v0/api.js", "https://cdn.jsdelivr.net/npm/marked@15.0.5/marked.min.js", "https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js"
+    csp.script_src :self, "https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js", "https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js", "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js", "https://challenges.cloudflare.com/turnstile/v0/api.js", "https://cdn.jsdelivr.net/npm/marked@15.0.5/marked.min.js", "https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js"
     csp.frame_src :self, "https://challenges.cloudflare.com"
     csp.connect_src :self
     csp.base_uri :none

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -8,13 +8,13 @@
     <title><%= ["Ubicloud", @page_title].compact.join(" - ") %></title>
     <%== assets(:css) %>
     <script
-      src="https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js"
-      integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g="
+      src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"
+      integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"
-      integrity="sha256-QigBQMy2be3IqJD2ezKJUJ5gycSmyYlRHj2VGBuITpU="
+      src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js"
+      integrity="sha256-K99Onu4WoBQeNzYGhT5YstpmQ4pLwPxk6ECP4+/wjNc="
       crossorigin="anonymous"
     ></script>
     <% if @enable_datepicker %>


### PR DESCRIPTION
Dependabot is enabled for this repository, but it only tracks dependencies managed by package managers. These scripts are loaded directly from jsDelivr and pinned by URL and SRI hash in the CSP and layout, so Dependabot cannot update them for us.

jquery is bumped within the 3.x line; upgrading to 4.x is out of scope. dompurify has had security fixes since 3.0.5, so moving to the current 3.4.0 closes that gap.