### PR TITLE
Some E2E improvements

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -30,7 +30,7 @@ def test_metal(options, test_cases)
 
     # This tests encrypted VMs with slices, which will create both standard and
     # burstable VMs. The test will also test host reboot.
-    encrypted_vms_st = Prog::Test::VmGroup.assemble(boot_images: test_case["images"], test_reboot: true, test_slices: true)
+    encrypted_vms_st = Prog::Test::VmGroup.assemble(boot_images: test_case["images"], test_reboot: true)
     log(encrypted_vms_st, "storage_encrypted: true")
     # Not running in parallel but waiting, since host is rebooted during test.
     # Rebooting makes the next test to test reboot practically as well depending

--- a/bin/e2e
+++ b/bin/e2e
@@ -36,10 +36,6 @@ def test_metal(options, test_cases)
     # Rebooting makes the next test to test reboot practically as well depending
     # on when the host is rebooted and can cause flaky issues for github runner tests.
     wait_until(encrypted_vms_st)
-
-    # YYY: Remove this when all hosts use slices
-    Semaphore.incr(hetzner_server_st.id, "disallow_slices")
-    wait_until(hetzner_server_st, "wait")
   end
 
   if (gh_test_cases = test_cases.values_at(*options[:test_cases].select { it.include?("github_runner") })).any?

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -3,7 +3,7 @@
 require_relative "../../lib/util"
 
 class Prog::Test::HetznerServer < Prog::Test::Base
-  semaphore :verify_cleanup_and_destroy, :disallow_slices
+  semaphore :verify_cleanup_and_destroy
 
   def self.assemble(vm_host_id: nil, default_boot_images: [])
     frame = if vm_host_id
@@ -118,18 +118,7 @@ class Prog::Test::HetznerServer < Prog::Test::Base
       hop_verify_cleanup
     end
 
-    when_disallow_slices_set? do
-      hop_disallow_slices
-    end
-
     nap 15
-  end
-
-  label def disallow_slices
-    vm_host.disallow_slices
-    decr_disallow_slices
-
-    hop_wait
   end
 
   label def verify_cleanup

--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -103,6 +103,14 @@ class Prog::Test::Vm < Prog::Test::Base
       ]
     }
 
+    hop_verify_storage_rpc
+  end
+
+  label def verify_storage_rpc
+    response = vm.vm_storage_volumes.first.rpc(command: "version")
+    expected_version = Config.vhost_block_backend_version.delete_prefix("v")
+    fail_test "Failed to get vhost-block-backend version for VM #{vm.ubid} using RPC" unless response["version"] == expected_version
+
     hop_stop_semaphore
   end
 

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -3,14 +3,13 @@
 require_relative "../../lib/net_ssh"
 
 class Prog::Test::VmGroup < Prog::Test::Base
-  def self.assemble(boot_images:, test_reboot: true, test_slices: false, verify_host_capacity: true)
+  def self.assemble(boot_images:, test_reboot: true, verify_host_capacity: true)
     Strand.create(
       prog: "Test::VmGroup",
       label: "start",
       stack: [{
         "test_reboot" => test_reboot,
         "first_boot" => true,
-        "test_slices" => test_slices,
         "vms" => [],
         "boot_images" => boot_images,
         "verify_host_capacity" => verify_host_capacity,
@@ -24,9 +23,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
 
   label def setup_vms
     project = Project.create(name: "project-1")
-    test_slices = frame.fetch("test_slices")
-
-    size_options = test_slices ? ["standard-2", "burstable-1"] : ["standard-2"]
+    size_options = ["standard-2", "burstable-1"]
     subnets = Array.new(2) { Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-#{it}", location_id: Location::HETZNER_FSN1_ID) }
     encrypted = true
     boot_images = frame.fetch("boot_images")

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -84,23 +84,11 @@ class Prog::Test::VmGroup < Prog::Test::Base
     test_slices = frame.fetch("test_slices")
 
     if !test_slices || (retval&.dig("msg") == "Verified VM Host Slices!")
-      hop_verify_storage_rpc
+      hop_verify_firewall_rules
     end
 
     slices = frame["vms"].map { Vm[it].vm_host_slice&.id }.reject(&:nil?)
     push Prog::Test::VmHostSlices, {"slices" => slices}
-  end
-
-  label def verify_storage_rpc
-    frame["vms"].each do |id|
-      vm = Vm[id]
-      command = {command: "version"}.to_json
-      response = vm_host.sshable.cmd_json("sudo nc -U /var/storage/:inhost_name/0/rpc.sock -q 0", inhost_name: vm.inhost_name, stdin: command)
-      expected_version = Config.vhost_block_backend_version.delete_prefix("v")
-      fail_test "Failed to get vhost-block-backend version for VM #{vm.id} using RPC" unless response["version"] == expected_version
-    end
-
-    hop_verify_firewall_rules
   end
 
   label def verify_firewall_rules

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -3,14 +3,13 @@
 require_relative "../../lib/net_ssh"
 
 class Prog::Test::VmGroup < Prog::Test::Base
-  def self.assemble(boot_images:, test_reboot: true, test_slices: false, verify_host_capacity: true)
+  def self.assemble(boot_images:, test_reboot: true, verify_host_capacity: true)
     Strand.create(
       prog: "Test::VmGroup",
       label: "start",
       stack: [{
         "test_reboot" => test_reboot,
         "first_boot" => true,
-        "test_slices" => test_slices,
         "vms" => [],
         "boot_images" => boot_images,
         "verify_host_capacity" => verify_host_capacity,
@@ -24,9 +23,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
 
   label def setup_vms
     project = Project.create(name: "project-1")
-    test_slices = frame.fetch("test_slices")
-
-    size_options = test_slices ? ["standard-2", "burstable-1"] : ["standard-2"]
+    size_options = ["standard-2", "burstable-1"]
     subnets = Array.new(2) { Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-#{it}", location_id: Location::HETZNER_FSN1_ID) }
     encrypted = true
     boot_images = frame.fetch("boot_images")
@@ -81,9 +78,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   label def verify_vm_host_slices
-    test_slices = frame.fetch("test_slices")
-
-    if !test_slices || (retval&.dig("msg") == "Verified VM Host Slices!")
+    if retval&.dig("msg") == "Verified VM Host Slices!"
       hop_verify_firewall_rules
     end
 

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -165,21 +165,8 @@ RSpec.describe Prog::Test::HetznerServer do
       expect { hs_test.wait }.to hop("verify_cleanup")
     end
 
-    it "hops to disallow_slices when signaled" do
-      hs_test.incr_disallow_slices
-      expect { hs_test.wait }.to hop("disallow_slices")
-    end
-
     it "naps" do
       expect { hs_test.wait }.to nap(15)
-    end
-  end
-
-  describe "#disallow_slices" do
-    it "disallows slices" do
-      vm_host.update(accepts_slices: true)
-      expect { hs_test.disallow_slices }.to hop("wait")
-      expect(vm_host.reload.accepts_slices).to be(false)
     end
   end
 

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -31,23 +31,11 @@ RSpec.describe Prog::Test::VmGroup do
     it "provisions at least one vm for each boot image" do
       expect(vg_test).to receive(:update_stack).and_call_original
       refresh_frame(vg_test, new_values: {
-        "test_slices" => true,
         "boot_images" => ["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"],
       })
       expect { vg_test.setup_vms }.to hop("wait_vms")
       vm_images = vg_test.strand.stack.first["vms"].map { Vm[it].boot_image }
       expect(vm_images).to eq(["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"])
-    end
-
-    it "hops to wait_vms if test_slices" do
-      expect(vg_test).to receive(:update_stack).and_call_original
-      refresh_frame(vg_test, new_values: {
-        "test_reboot" => true,
-        "test_slices" => true,
-        "vms" => [],
-        "boot_images" => ["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"],
-      })
-      expect { vg_test.setup_vms }.to hop("wait_vms")
     end
   end
 

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -138,38 +138,10 @@ RSpec.describe Prog::Test::VmGroup do
       expect { vg_test.verify_vm_host_slices }.to hop("start", "Test::VmHostSlices")
     end
 
-    it "hops to verify_storage_rpc if tests are done" do
+    it "hops to verify_firewall_rules if tests are done" do
       refresh_frame(vg_test, new_values: {"test_slices" => true})
       st.retval = {"msg" => "Verified VM Host Slices!"}
-      expect { vg_test.verify_vm_host_slices }.to hop("verify_storage_rpc")
-    end
-  end
-
-  describe "#verify_storage_rpc" do
-    it "verifies vhost-block-backend version for each vm using RPC" do
-      command = {command: "version"}.to_json
-      expected_response = {version: Config.vhost_block_backend_version.delete_prefix("v")}.to_json + "\n"
-      vm_host = create_vm_host
-      vm1 = create_vm(vm_host_id: vm_host.id, name: "test-vm-1")
-      vm2 = create_vm(vm_host_id: vm_host.id, name: "test-vm-2")
-      refresh_frame(vg_test, new_values: {"vms" => [vm1.id, vm2.id]})
-
-      expect(vg_test.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm1.inhost_name}/0/rpc.sock -q 0", stdin: command).and_return(expected_response)
-      expect(vg_test.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm2.inhost_name}/0/rpc.sock -q 0", stdin: command).and_return(expected_response)
-
-      expect { vg_test.verify_storage_rpc }.to hop("verify_firewall_rules")
-    end
-
-    it "fails if unable to get vhost-block-backend version using RPC" do
-      command = {command: "version"}.to_json
-      vm_host = create_vm_host
-      vm1 = create_vm(vm_host_id: vm_host.id, name: "test-vm-1")
-      refresh_frame(vg_test, new_values: {"vms" => [vm1.id]})
-
-      expect(vg_test.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm1.inhost_name}/0/rpc.sock -q 0", stdin: command).and_return("{\"error\": \"some error\"}\n")
-
-      expect { vg_test.verify_storage_rpc }.to hop("failed")
-      expect(st.reload.exitval).to eq({"msg" => "Failed to get vhost-block-backend version for VM #{vm1.id} using RPC"})
+      expect { vg_test.verify_vm_host_slices }.to hop("verify_firewall_rules")
     end
   end
 

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -31,23 +31,11 @@ RSpec.describe Prog::Test::VmGroup do
     it "provisions at least one vm for each boot image" do
       expect(vg_test).to receive(:update_stack).and_call_original
       refresh_frame(vg_test, new_values: {
-        "test_slices" => true,
         "boot_images" => ["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"],
       })
       expect { vg_test.setup_vms }.to hop("wait_vms")
       vm_images = vg_test.strand.stack.first["vms"].map { Vm[it].boot_image }
       expect(vm_images).to eq(["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"])
-    end
-
-    it "hops to wait_vms if test_slices" do
-      expect(vg_test).to receive(:update_stack).and_call_original
-      refresh_frame(vg_test, new_values: {
-        "test_reboot" => true,
-        "test_slices" => true,
-        "vms" => [],
-        "boot_images" => ["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"],
-      })
-      expect { vg_test.setup_vms }.to hop("wait_vms")
     end
   end
 
@@ -133,13 +121,12 @@ RSpec.describe Prog::Test::VmGroup do
       vm1 = create_vm(vm_host_id: vm_host.id, vm_host_slice_id: slice1.id, name: "test-vm-1")
       vm2 = create_vm(vm_host_id: vm_host.id, vm_host_slice_id: slice2.id, name: "test-vm-2")
       vm3 = create_vm(vm_host_id: vm_host.id, name: "test-vm-3")
-      refresh_frame(vg_test, new_values: {"test_slices" => true, "vms" => [vm1.id, vm2.id, vm3.id]})
+      refresh_frame(vg_test, new_values: {"vms" => [vm1.id, vm2.id, vm3.id]})
 
       expect { vg_test.verify_vm_host_slices }.to hop("start", "Test::VmHostSlices")
     end
 
     it "hops to verify_firewall_rules if tests are done" do
-      refresh_frame(vg_test, new_values: {"test_slices" => true})
       st.retval = {"msg" => "Verified VM Host Slices!"}
       expect { vg_test.verify_vm_host_slices }.to hop("verify_firewall_rules")
     end

--- a/spec/prog/test/vm_spec.rb
+++ b/spec/prog/test/vm_spec.rb
@@ -24,8 +24,9 @@ RSpec.describe Prog::Test::Vm do
     Nic.create(private_subnet_id: subnet.id, vm_id: vm.id, name: "nic-1",
       private_ipv4: "192.168.0.1/32", private_ipv6: "fd01:db8:85a1::/64",
       mac: "00:00:00:00:00:01", state: "active")
-    VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false)
-    VmStorageVolume.create(vm_id: vm.id, boot: false, size_gib: 20, disk_index: 1, use_bdev_ubi: false)
+    sd = StorageDevice.create(vm_host_id: vm_host.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["sda"])
+    VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, storage_device_id: sd.id)
+    VmStorageVolume.create(vm_id: vm.id, boot: false, size_gib: 20, disk_index: 1, use_bdev_ubi: false, storage_device_id: sd.id)
     vm
   }
 
@@ -190,14 +191,14 @@ RSpec.describe Prog::Test::Vm do
       }
     }
 
-    it "verifies vm stats and hops to stop_semaphore" do
+    it "verifies vm stats and hops to verify_storage_rpc" do
       vm_stats_output = {
         "disk_0" => valid_disk_stats_output,
         "disk_1" => valid_disk_stats_output,
         "vm" => valid_vm_stats_output,
       }
       expect(vm_test.vm.vm_host.sshable).to receive(:_cmd).with("sudo host/bin/vm-stats #{vm_test.vm.inhost_name}").and_return(vm_stats_output.to_json)
-      expect { vm_test.verify_vm_stats }.to hop("stop_semaphore")
+      expect { vm_test.verify_vm_stats }.to hop("verify_storage_rpc")
     end
 
     it "fails if top level key vm is missing in vm-stats output" do
@@ -240,6 +241,22 @@ RSpec.describe Prog::Test::Vm do
       expect(vm_test.vm.vm_host.sshable).to receive(:_cmd).with("sudo host/bin/vm-stats #{vm_test.vm.inhost_name}").and_return(vm_stats_output.to_json)
       expect { vm_test.verify_vm_stats }.to hop("failed")
       expect(strand.reload.exitval).to eq({"msg" => "missing expected keys in disk_0 stats"})
+    end
+  end
+
+  describe "#verify_storage_rpc" do
+    it "hops to stop_semaphore when version matches" do
+      expected_version = Config.vhost_block_backend_version.delete_prefix("v")
+      request = {"command" => "version"}.to_json
+      expect(vm_test.vm.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm_test.vm.inhost_name}/0/rpc.sock -q 2 -w 2 | head -n 1", stdin: request).and_return({"version" => expected_version}.to_json)
+      expect { vm_test.verify_storage_rpc }.to hop("stop_semaphore")
+    end
+
+    it "fails if unable to get vhost-block-backend version using RPC" do
+      request = {"command" => "version"}.to_json
+      expect(vm_test.vm.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm_test.vm.inhost_name}/0/rpc.sock -q 2 -w 2 | head -n 1", stdin: request).and_return({"error" => "some error"}.to_json)
+      expect { vm_test.verify_storage_rpc }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "Failed to get vhost-block-backend version for VM #{vm_test.vm.ubid} using RPC"})
     end
   end
 


### PR DESCRIPTION
### E2E: replace manual volume RPC with `VmStorageVolume#rpc`
Move `Prog::Test::VmGroup::verify_storage_rpc` to `Prog::Test::Vm` and use `VmStorageVolume#rpc` (introduced in 9b30fbe) in E2E instead of constructing manual `nc` SSH commands.

### E2E: remove disallow_slices semaphore 
Its current usage caused GitHub runner, Postgres, and k8s tests to run without slices. All new hosts use slices, so remove the semaphore to better match the production environment.