### PR TITLE
Use Ubuntu Noble in SetupDnsServerVm prog

### DIFF
--- a/model/dns_zone/dns_server.rb
+++ b/model/dns_zone/dns_server.rb
@@ -8,6 +8,15 @@ class DnsServer < Sequel::Model
 
   plugin ResourceMethods
 
+  def retire_vm(vm_id, force: false)
+    DB.transaction do
+      raise "Cannot retire the only VM of DnsServer #{name}" if !force && vms_dataset.count <= 1
+      deleted = DB[:dns_servers_vms].where(dns_server_id: id, vm_id:).delete
+      raise "VM #{UBID.to_ubid(vm_id)} is not associated with DnsServer #{name}" if deleted.zero?
+      Semaphore.incr(vm_id, "destroy")
+    end
+  end
+
   def run_commands_on_all_vms(commands)
     vms.each do |vm|
       Clog.emit("Starting knotc", vm_ubid: vm.ubid, commands:)

--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -3,7 +3,7 @@
 class Prog::DnsZone::SetupDnsServerVm < Prog::Base
   subject_is :vm, :sshable
 
-  def self.assemble(dns_server, name: nil, vm_size: "standard-2", storage_size_gib: 30, location_id: Location::HETZNER_FSN1_ID, boot_image: "ubuntu-jammy")
+  def self.assemble(dns_server, name: nil, vm_size: "standard-2", storage_size_gib: 30, location_id: Location::HETZNER_FSN1_ID, boot_image: "ubuntu-noble")
     fail "No existing Dns Server" unless dns_server
     fail "No existing Project" unless Project[Config.dns_service_project_id]
     fail "No existing Location" unless Location[location_id]
@@ -79,14 +79,16 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
 
   label def prepare
     sshable.cmd(<<~SH, inhost_name: vm.inhost_name)
+set -euo pipefail
 sudo sed -i 's/#DNSStubListener=yes/DNSStubListener=no/' /etc/systemd/resolved.conf
 sudo sed -i ':a;N;$!ba;s/127.0.0.1 localhost\\n\\n#/127.0.0.1 localhost\\n127.0.0.1 ':inhost_name'\\n\\n#/' /etc/hosts
 sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 sudo apt-get update
 sudo apt-get -y install apt-transport-https ca-certificates wget
 sudo wget -O /usr/share/keyrings/cznic-labs-pkg.gpg https://pkg.labs.nic.cz/gpg
-echo "deb [signed-by=/usr/share/keyrings/cznic-labs-pkg.gpg] https://pkg.labs.nic.cz/knot-dns jammy main" | sudo tee /etc/apt/sources.list.d/cznic-labs-knot-dns.list
+echo "deb [signed-by=/usr/share/keyrings/cznic-labs-pkg.gpg] https://pkg.labs.nic.cz/knot-dns noble main" | sudo tee /etc/apt/sources.list.d/cznic-labs-knot-dns.list
 sudo apt-get update
+sudo apt-get -y install knot
 sudo systemctl reboot
     SH
 
@@ -96,10 +98,7 @@ sudo systemctl reboot
   label def setup_knot
     nap 5 unless sshable.available?
 
-    sshable.cmd <<~SH
-sudo apt-get -y install knot
-echo "KNOTD_ARGS="-C /var/lib/knot/confdb"" | sudo tee -a /etc/default/knot
-    SH
+    sshable.write_file("/etc/default/knot", "KNOTD_ARGS=\"-C /var/lib/knot/confdb\"")
 
     knot_config = <<-CONF
 server:

--- a/spec/model/dns_zone/dns_server_spec.rb
+++ b/spec/model/dns_zone/dns_server_spec.rb
@@ -54,4 +54,100 @@ RSpec.describe DnsServer do
       expect(unrelated_vm.destroy_set?).to be false
     end
   end
+
+  describe "#run_commands_on_all_vms" do
+    let(:vm1) {
+      v = create_vm(name: "ubi-1")
+      Sshable.create_with_id(v.id, unix_user: "root", host: "host-1")
+      v
+    }
+    let(:vm2) {
+      v = create_vm(name: "ubi-2")
+      Sshable.create_with_id(v.id, unix_user: "root", host: "host-2")
+      v
+    }
+    let(:commands) {
+      [
+        "zone-abort tahcloud.io",
+        "zone-begin tahcloud.io",
+        "zone-set tahcloud.io foo 10 A 1.2.3.4",
+        "zone-unset tahcloud.io bar 10 A 5.6.7.8",
+        "zone-commit tahcloud.io",
+      ]
+    }
+
+    it "does nothing when no vms are associated" do
+      expect { dns_server.run_commands_on_all_vms(commands) }.not_to raise_error
+    end
+
+    it "runs commands on every associated vm via stdin" do
+      dns_server.add_vm(vm1)
+      dns_server.add_vm(vm2)
+      dns_server.vms.each do |vm|
+        expect(vm.sshable).to receive(:_cmd).with("sudo -u knot knotc", stdin: commands.join("\n")).and_return("OK\nOK\nOK\nOK\nOK")
+      end
+      dns_server.run_commands_on_all_vms(commands)
+    end
+
+    it "ignores 'no active transaction' on the first command" do
+      dns_server.add_vm(vm1)
+      expect(dns_server.vms.first.sshable).to receive(:_cmd).and_return("no active transaction\nOK\nOK\nOK\nOK")
+      expect { dns_server.run_commands_on_all_vms(commands) }.not_to raise_error
+    end
+
+    it "does not ignore 'no active transaction' on non-first commands" do
+      dns_server.add_vm(vm1)
+      expect(dns_server.vms.first.sshable).to receive(:_cmd).and_return("OK\nno active transaction\nOK\nOK\nOK")
+      expect {
+        dns_server.run_commands_on_all_vms(commands)
+      }.to raise_error(RuntimeError, "Rectify failed on #{dns_server}. Command: #{commands[1]}. Output: no active transaction")
+    end
+
+    it "ignores 'such record already exists in zone' for zone-set commands" do
+      dns_server.add_vm(vm1)
+      expect(dns_server.vms.first.sshable).to receive(:_cmd).and_return("OK\nOK\nsuch record already exists in zone\nOK\nOK")
+      expect { dns_server.run_commands_on_all_vms(commands) }.not_to raise_error
+    end
+
+    it "ignores 'no such record in zone found' for zone-unset commands" do
+      dns_server.add_vm(vm1)
+      expect(dns_server.vms.first.sshable).to receive(:_cmd).and_return("OK\nOK\nOK\nno such record in zone found\nOK")
+      expect { dns_server.run_commands_on_all_vms(commands) }.not_to raise_error
+    end
+
+    it "raises when a zone-set command returns 'no such record in zone found'" do
+      dns_server.add_vm(vm1)
+      expect(dns_server.vms.first.sshable).to receive(:_cmd).and_return("OK\nOK\nno such record in zone found\nOK\nOK")
+      expect {
+        dns_server.run_commands_on_all_vms(commands)
+      }.to raise_error(RuntimeError, "Rectify failed on #{dns_server}. Command: #{commands[2]}. Output: no such record in zone found")
+    end
+
+    it "raises when a zone-unset command returns 'such record already exists in zone'" do
+      dns_server.add_vm(vm1)
+      expect(dns_server.vms.first.sshable).to receive(:_cmd).and_return("OK\nOK\nOK\nsuch record already exists in zone\nOK")
+      expect {
+        dns_server.run_commands_on_all_vms(commands)
+      }.to raise_error(RuntimeError, "Rectify failed on #{dns_server}. Command: #{commands[3]}. Output: such record already exists in zone")
+    end
+
+    it "raises on any other unexpected output" do
+      dns_server.add_vm(vm1)
+      expect(dns_server.vms.first.sshable).to receive(:_cmd).and_return("OK\nOK\nOK\nOK\nboom")
+      expect {
+        dns_server.run_commands_on_all_vms(commands)
+      }.to raise_error(RuntimeError, "Rectify failed on #{dns_server}. Command: #{commands[4]}. Output: boom")
+    end
+
+    it "raises without contacting the second vm when the first vm fails" do
+      dns_server.add_vm(vm1)
+      dns_server.add_vm(vm2)
+      first_vm, second_vm = dns_server.vms
+      expect(first_vm.sshable).to receive(:_cmd).and_return("error\nOK\nOK\nOK\nOK")
+      expect(second_vm.sshable).not_to receive(:_cmd)
+      expect {
+        dns_server.run_commands_on_all_vms(commands)
+      }.to raise_error(RuntimeError, "Rectify failed on #{dns_server}. Command: #{commands[0]}. Output: error")
+    end
+  end
 end

--- a/spec/model/dns_zone/dns_server_spec.rb
+++ b/spec/model/dns_zone/dns_server_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe DnsServer do
+  subject(:dns_server) { described_class.create(name: "ns.ubicloud.com") }
+
+  describe "#retire_vm" do
+    let(:vm1) {
+      v = create_vm(name: "vm1")
+      Strand.create_with_id(v, prog: "Vm::Nexus", label: "wait")
+      v
+    }
+    let(:vm2) {
+      v = create_vm(name: "vm2")
+      Strand.create_with_id(v, prog: "Vm::Nexus", label: "wait")
+      v
+    }
+
+    it "raises if the vm is the only one and force is not set" do
+      dns_server.add_vm(vm1)
+      expect {
+        dns_server.retire_vm(vm1.id)
+      }.to raise_error(RuntimeError, "Cannot retire the only VM of DnsServer #{dns_server.name}")
+      expect(dns_server.vms_dataset.all).to eq [vm1]
+      expect(vm1.destroy_set?).to be false
+    end
+
+    it "retires the only vm when force: true is passed" do
+      dns_server.add_vm(vm1)
+      dns_server.retire_vm(vm1.id, force: true)
+      expect(dns_server.vms_dataset.all).to be_empty
+      expect(vm1.destroy_set?).to be true
+    end
+
+    it "retires a vm when multiple vms are associated" do
+      dns_server.add_vm(vm1)
+      dns_server.add_vm(vm2)
+      dns_server.retire_vm(vm1.id)
+      expect(dns_server.vms_dataset.all).to eq [vm2]
+      expect(vm1.destroy_set?).to be true
+      expect(vm2.destroy_set?).to be false
+    end
+
+    it "raises if the vm is not associated with the dns server" do
+      dns_server.add_vm(vm1)
+      dns_server.add_vm(vm2)
+      unrelated_vm = create_vm
+      Strand.create_with_id(unrelated_vm, prog: "Vm::Nexus", label: "wait")
+      expect {
+        dns_server.retire_vm(unrelated_vm.id)
+      }.to raise_error(RuntimeError, "VM #{unrelated_vm.ubid} is not associated with DnsServer #{dns_server.name}")
+      expect(dns_server.vms_dataset.order(:name).all).to contain_exactly(vm1, vm2)
+      expect(unrelated_vm.destroy_set?).to be false
+    end
+  end
+end

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -43,7 +43,10 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       expect(described_class.assemble(ds)).to be_a Strand
 
       expect(Vm.count).to eq 1
-      expect(Vm.first.unix_user).to eq "ubi"
+
+      vm = Vm.first
+      expect(vm.boot_image).to eq "ubuntu-noble"
+      expect(vm.unix_user).to eq "ubi"
     end
 
     it "errors out if the dns service project id is not put into config properly" do
@@ -171,7 +174,7 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
     it "runs some commands to prepare vm for knot installation and restarts" do
       prog.vm.strand.update(label: "wait")
 
-      expect(prog.sshable).to receive(:_cmd).with(/sudo ln -sf \/run\/systemd\/resolve\/resolv.conf \/etc\/resolv.conf[\S\s]*sudo systemctl reboot/)
+      expect(prog.sshable).to receive(:_cmd).with(/sudo ln -sf \/run\/systemd\/resolve\/resolv.conf \/etc\/resolv.conf[\S\s]*sudo apt-get -y install knot\nsudo systemctl reboot/)
 
       expect { prog.prepare }.to hop("setup_knot")
     end
@@ -193,7 +196,7 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
   - domain: "zone2.domain.io."
       CONF
 
-      expect(prog.sshable).to receive(:_cmd).with(/sudo apt-get -y install knot/)
+      expect(prog.sshable).to receive(:_cmd).with("sudo tee /etc/default/knot > /dev/null", stdin: "KNOTD_ARGS=\"-C /var/lib/knot/confdb\"")
       expect(prog.sshable).to receive(:_cmd).with("sudo tee /etc/knot/knot.conf > /dev/null", stdin: /#{zone_conf}/)
 
       expect { prog.setup_knot }.to hop("sync_zones")
@@ -298,7 +301,7 @@ zone-flush zone2.domain.io
   def create_vm_with_sshable
     vm = Vm.create(unix_user: "ubi", public_key: "ssh-ed25519 key", name: Vm.generate_uuid, family: "standard",
       cores: 0, vcpus: 2, cpu_percent_limit: 200, cpu_burst_percent_limit: 0, memory_gib: 8, arch: "x64",
-      location_id: Location::HETZNER_FSN1_ID, boot_image: "ubuntu-jammy", display_state: "running",
+      location_id: Location::HETZNER_FSN1_ID, boot_image: "ubuntu-noble", display_state: "running",
       ip4_enabled: false, created_at: Time.now, project_id: project.id)
     Sshable.create_with_id(vm)
     vm


### PR DESCRIPTION
This PR makes SetupDnsServerVm prog to create VMs with Ubuntu Noble by default, and assumes it within the installation steps. It also adds `retire_vm` helper function as well as some missing unit test cases.