### PR TITLE
Minor PostgreSQL operations and readability improvements

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -225,7 +225,7 @@ class PostgresServer < Sequel::Model
       resource.representative_server
     end
 
-    !parent_server || lsn_diff(parent_server.current_lsn, current_lsn) < 80 * 1024 * 1024
+    (parent_lsn = parent_server.last_known_lsn) && (lsn = last_known_lsn) && lsn_diff(parent_lsn, lsn) < 80 * 1024 * 1024
   end
 
   def current_lsn

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -217,10 +217,10 @@ class PostgresServer < Sequel::Model
   end
 
   def lsn_caught_up
-    return true if primary?
+    return true if primary? || (read_replica? && resource.parent.nil?)
 
     parent_server = if read_replica?
-      resource.parent&.representative_server
+      resource.parent.representative_server
     else
       resource.representative_server
     end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -232,6 +232,12 @@ class PostgresServer < Sequel::Model
     run_query(DB.select(Sequel.function(lsn_function_name)))
   end
 
+  def data_disk_usage
+    vm.sshable.cmd("df --output=used /dat | tail -n 1").strip.to_i
+  rescue
+    0
+  end
+
   def lsn_monitor_ds
     POSTGRES_MONITOR_DB[:postgres_lsn_monitor].where(postgres_server_id: id)
   end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -242,6 +242,10 @@ class PostgresServer < Sequel::Model
     POSTGRES_MONITOR_DB[:postgres_lsn_monitor].where(postgres_server_id: id)
   end
 
+  def last_known_lsn
+    lsn_monitor_ds.get(:last_known_lsn)
+  end
+
   def failover_target(mode: "unplanned")
     candidates = resource.servers
       .reject { it.is_representative }
@@ -262,8 +266,7 @@ class PostgresServer < Sequel::Model
     return nil if target.nil?
 
     if resource.ha_type == PostgresResource::HaType::ASYNC
-      return unless (last_known_lsn = lsn_monitor_ds.get(:last_known_lsn))
-      return if lsn_diff(last_known_lsn, target[:lsn]) > 80 * 1024 * 1024 # 80 MB or ~5 WAL files
+      return if (lsn = last_known_lsn).nil? || lsn_diff(lsn, target[:lsn]) > 80 * 1024 * 1024 # 80 MB or ~5 WAL files
     end
 
     if mode == "planned"

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -28,13 +28,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
     hop_wait_for_maintenance_window if postgres_resource.has_enough_ready_servers?
 
     waiting_servers = postgres_resource.servers(eager: [:semaphores, vm: [:vm_storage_volumes, :sshable]]).reject { it.is_representative || it.needs_recycling? }
-
-    total_disk_usage = waiting_servers.sum do |s|
-      s.vm.sshable.cmd("df --output=used /dat | tail -n 1").strip.to_i
-    rescue
-      # /dat missing before mount_data_disk, ignore errors, if persistent then deadline will be reached
-      0
-    end
+    total_disk_usage = waiting_servers.sum(&:data_disk_usage)
 
     total_lsn = waiting_servers.sum do |s|
       last_known_lsn = s.lsn_monitor_ds.get(:last_known_lsn)

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -30,10 +30,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
     waiting_servers = postgres_resource.servers(eager: [:semaphores, vm: [:vm_storage_volumes, :sshable]]).reject { it.is_representative || it.needs_recycling? }
     total_disk_usage = waiting_servers.sum(&:data_disk_usage)
 
-    total_lsn = waiting_servers.sum do |s|
-      last_known_lsn = s.lsn_monitor_ds.get(:last_known_lsn)
-      last_known_lsn ? s.lsn2int(last_known_lsn) : 0
-    end
+    total_lsn = waiting_servers.sum { |s| s.last_known_lsn ? s.lsn2int(s.last_known_lsn) : 0 }
 
     previous_total_disk_usage = strand.stack.first["total_disk_usage"] || 0
     previous_total_lsn = strand.stack.first["total_lsn"] || 0

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -533,6 +533,7 @@ SQL
 
   label def wait_catch_up
     if postgres_server.lsn_caught_up
+      delete_from_stack("previous_lsn", "previous_disk_usage")
       hop_wait if postgres_server.read_replica?
 
       postgres_server.update(synchronization_status: "ready")
@@ -546,6 +547,13 @@ SQL
       previous_lsn = strand.stack.first["previous_lsn"]
       if previous_lsn.nil? || postgres_server.lsn_diff(current_lsn, previous_lsn) > 0
         update_stack({"previous_lsn" => current_lsn})
+        register_deadline("wait", 10 * 60, allow_extension: 24 * 60 * 60)
+      end
+    else
+      disk_usage = postgres_server.data_disk_usage
+      previous_disk_usage = strand.stack.first["previous_disk_usage"] || 0
+      if disk_usage > previous_disk_usage
+        update_stack({"previous_disk_usage" => disk_usage})
         register_deadline("wait", 10 * 60, allow_extension: 24 * 60 * 60)
       end
     end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -533,11 +533,12 @@ SQL
 
   label def wait_catch_up
     unless postgres_server.lsn_caught_up
-      current_lsn = postgres_server.current_lsn
-      previous_lsn = strand.stack.first["current_lsn"]
-      if previous_lsn.nil? || postgres_server.lsn_diff(current_lsn, previous_lsn) > 0
-        update_stack({"current_lsn" => current_lsn})
-        register_deadline("wait", 10 * 60, allow_extension: 24 * 60 * 60)
+      if (current_lsn = postgres_server.last_known_lsn)
+        previous_lsn = strand.stack.first["previous_lsn"]
+        if previous_lsn.nil? || postgres_server.lsn_diff(current_lsn, previous_lsn) > 0
+          update_stack({"previous_lsn" => current_lsn})
+          register_deadline("wait", 10 * 60, allow_extension: 24 * 60 * 60)
+        end
       end
       nap 30
     end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -200,11 +200,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
       delete_from_stack("disk_usage", "initialize_database_from_backup_try_count")
       hop_refresh_certificates
     when "InProgress"
-      disk_usage = begin
-        vm.sshable.cmd("df --output=used /dat | tail -n 1").strip.to_i
-      rescue
-        0
-      end
+      disk_usage = postgres_server.data_disk_usage
       previous_disk_usage = frame["disk_usage"] || 0
       if disk_usage > previous_disk_usage
         update_stack({"disk_usage" => disk_usage})

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -532,24 +532,24 @@ SQL
   end
 
   label def wait_catch_up
-    unless postgres_server.lsn_caught_up
-      if (current_lsn = postgres_server.last_known_lsn)
-        previous_lsn = strand.stack.first["previous_lsn"]
-        if previous_lsn.nil? || postgres_server.lsn_diff(current_lsn, previous_lsn) > 0
-          update_stack({"previous_lsn" => current_lsn})
-          register_deadline("wait", 10 * 60, allow_extension: 24 * 60 * 60)
-        end
-      end
-      nap 30
+    if postgres_server.lsn_caught_up
+      hop_wait if postgres_server.read_replica?
+
+      postgres_server.update(synchronization_status: "ready")
+
+      resource.representative_server.incr_configure
+      hop_wait_synchronization if resource.ha_type == PostgresResource::HaType::SYNC
+      hop_wait
     end
 
-    hop_wait if postgres_server.read_replica?
-
-    postgres_server.update(synchronization_status: "ready")
-
-    resource.representative_server.incr_configure
-    hop_wait_synchronization if resource.ha_type == PostgresResource::HaType::SYNC
-    hop_wait
+    if (current_lsn = postgres_server.last_known_lsn)
+      previous_lsn = strand.stack.first["previous_lsn"]
+      if previous_lsn.nil? || postgres_server.lsn_diff(current_lsn, previous_lsn) > 0
+        update_stack({"previous_lsn" => current_lsn})
+        register_deadline("wait", 10 * 60, allow_extension: 24 * 60 * 60)
+      end
+    end
+    nap 30
   end
 
   label def wait_synchronization

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -472,6 +472,18 @@ RSpec.describe PostgresServer do
     end
   end
 
+  describe "#data_disk_usage" do
+    it "returns the used 1K blocks reported by df on /dat" do
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return("1024000\n")
+      expect(postgres_server.data_disk_usage).to eq(1024000)
+    end
+
+    it "returns 0 when the ssh command fails" do
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_raise(RuntimeError)
+      expect(postgres_server.data_disk_usage).to eq(0)
+    end
+  end
+
   it "initiates a new health monitor session" do
     forward = instance_double(Net::SSH::Service::Forward)
     expect(forward).to receive(:local_socket)

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -237,12 +237,7 @@ RSpec.describe PostgresServer do
       expect(postgres_server.failover_target.ubid).to eq("pgubidstandby3")
     end
 
-    it "returns nil if last_known_lsn in unknown for async replication" do
-      expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::ASYNC)
-      expect(postgres_server.failover_target).to be_nil
-    end
-
-    it "returns nil if no lsn_monitor for async replication" do
+    it "returns nil when last_known_lsn is unknown for async replication" do
       resource.update(ha_type: PostgresResource::HaType::ASYNC)
       expect(postgres_server.failover_target).to be_nil
     end
@@ -469,6 +464,18 @@ RSpec.describe PostgresServer do
       expect(postgres_server).to receive(:read_replica?).and_return(false)
       postgres_server.update(is_representative: false)
       expect(postgres_server.lsn_caught_up).to be(true)
+    end
+  end
+
+  describe "#last_known_lsn" do
+    it "returns the value recorded by the monitor" do
+      postgres_server.update_last_known_lsn("1/1234")
+      expect(postgres_server.last_known_lsn).to eq("1/1234")
+      postgres_server.lsn_monitor_ds.delete
+    end
+
+    it "returns nil when no pulse has been recorded" do
+      expect(postgres_server.last_known_lsn).to be_nil
     end
   end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -420,7 +420,7 @@ RSpec.describe PostgresServer do
 
       resource.update(parent: parent_resource)
       postgres_server.update(timeline_access: "fetch")
-      allow(resource.parent.representative_server).to receive(:current_lsn).and_return("F/F")
+      allow(resource.parent.representative_server).to receive(:last_known_lsn).and_return("F/F")
     end
 
     it "returns true immediately for primary" do
@@ -429,15 +429,15 @@ RSpec.describe PostgresServer do
     end
 
     it "returns true if the diff is less than 80MB" do
-      expect(postgres_server).to receive(:_run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("F/F")
+      expect(postgres_server).to receive(:last_known_lsn).and_return("F/F")
       expect(postgres_server.lsn_caught_up).to be_truthy
     end
 
     it "returns true if read replica and the parent representative server is nil" do
       postgres_server.resource.representative_server.update(is_representative: false)
       postgres_server.resource.update(restore_target: Time.now)
-      expect(postgres_server.resource.representative_server).to receive(:_run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("F/F")
-      expect(postgres_server).to receive(:_run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("F/F")
+      expect(postgres_server.resource.representative_server).to receive(:last_known_lsn).and_return("F/F")
+      expect(postgres_server).to receive(:last_known_lsn).and_return("F/F")
       expect(postgres_server.lsn_caught_up).to be_truthy
     end
 
@@ -448,16 +448,26 @@ RSpec.describe PostgresServer do
     end
 
     it "returns false if the diff is more than 80MB" do
-      expect(postgres_server).to receive(:_run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("1/00000000")
+      expect(postgres_server).to receive(:last_known_lsn).and_return("1/00000000")
       expect(postgres_server.lsn_caught_up).to be_falsey
     end
 
     it "returns true if the diff is less than 80MB for not read replica and uses the main representative server" do
       expect(postgres_server).to receive(:read_replica?).and_return(false).at_least(:once)
       resource.update(restore_target: Time.now)
-      expect(postgres_server.resource.representative_server).to receive(:_run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("F/F")
-      expect(postgres_server).to receive(:_run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("F/F")
+      expect(postgres_server.resource.representative_server).to receive(:last_known_lsn).and_return("F/F")
+      expect(postgres_server).to receive(:last_known_lsn).and_return("F/F")
       expect(postgres_server.lsn_caught_up).to be_truthy
+    end
+
+    it "returns false when the parent has no recorded lsn yet" do
+      expect(resource.parent.representative_server).to receive(:last_known_lsn).and_return(nil)
+      expect(postgres_server.lsn_caught_up).to be_falsey
+    end
+
+    it "returns false when self has no recorded lsn yet" do
+      expect(postgres_server).to receive(:last_known_lsn).and_return(nil)
+      expect(postgres_server.lsn_caught_up).to be_falsey
     end
   end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -453,17 +453,11 @@ RSpec.describe PostgresServer do
     end
 
     it "returns true if the diff is less than 80MB for not read replica and uses the main representative server" do
-      expect(postgres_server).to receive(:read_replica?).and_return(false)
+      expect(postgres_server).to receive(:read_replica?).and_return(false).at_least(:once)
       resource.update(restore_target: Time.now)
       expect(postgres_server.resource.representative_server).to receive(:_run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("F/F")
       expect(postgres_server).to receive(:_run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("F/F")
       expect(postgres_server.lsn_caught_up).to be_truthy
-    end
-
-    it "returns true when no representative server" do
-      expect(postgres_server).to receive(:read_replica?).and_return(false)
-      postgres_server.update(is_representative: false)
-      expect(postgres_server.lsn_caught_up).to be(true)
     end
   end
 

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       standby = create_server
       standby.strand.update(label: "wait_catch_up")
       standby_from_assoc = nx.postgres_resource.servers.find { !it.is_representative }
-      expect(standby_from_assoc.vm.sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return("1024000\n")
+      expect(standby_from_assoc).to receive(:data_disk_usage).and_return(1024000)
       standby.update_last_known_lsn("0/0")
       expect { nx.wait_servers_to_be_ready }.to nap
       expect(strand.reload.stack.first["total_disk_usage"]).to eq(1024000)
@@ -202,7 +202,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       standby = create_server
       standby.strand.update(label: "wait_catch_up")
       standby_from_assoc = nx.postgres_resource.servers.find { !it.is_representative }
-      expect(standby_from_assoc.vm.sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return("1024000\n")
+      expect(standby_from_assoc).to receive(:data_disk_usage).and_return(1024000)
       standby.update_last_known_lsn("0/1234567")
       strand.stack.first["total_disk_usage"] = 2048000
       strand.modified!(:stack)
@@ -218,7 +218,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       standby = create_server
       standby.strand.update(label: "wait_catch_up")
       standby_from_assoc = nx.postgres_resource.servers.find { !it.is_representative }
-      expect(standby_from_assoc.vm.sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return("1024000\n")
+      expect(standby_from_assoc).to receive(:data_disk_usage).and_return(1024000)
       standby.update_last_known_lsn("0/1234567")
       strand.stack.first["total_disk_usage"] = 2048000
       strand.stack.first["total_lsn"] = standby.lsn2int("0/FFFFFFF")
@@ -234,19 +234,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       standby = create_server
       standby.strand.update(label: "wait_catch_up")
       standby_from_assoc = nx.postgres_resource.servers.find { !it.is_representative }
-      expect(standby_from_assoc.vm.sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return("0\n")
-      expect(nx).not_to receive(:register_deadline)
-      expect { nx.wait_servers_to_be_ready }.to nap
-    end
-
-    it "handles failures gracefully when checking progress" do
-      pg.update(ha_type: "async")
-      create_server(is_representative: true)
-      standby = create_server
-      standby.strand.update(label: "wait_catch_up")
-      standby_from_assoc = nx.postgres_resource.servers.find { !it.is_representative }
-      expect(standby_from_assoc.vm.sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_raise(RuntimeError)
-      standby.update_last_known_lsn("0/0")
+      expect(standby_from_assoc).to receive(:data_disk_usage).and_return(0)
       expect(nx).not_to receive(:register_deadline)
       expect { nx.wait_servers_to_be_ready }.to nap
     end
@@ -263,9 +251,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       standby2.update_last_known_lsn("0/200")
 
       servers = nx.postgres_resource.servers
-      servers.reject { it.is_representative }.each do |s|
-        expect(s.vm.sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return("512000\n")
-      end
+      expect(servers.reject { it.is_representative }).to all(receive(:data_disk_usage).and_return(512000))
 
       expect { nx.wait_servers_to_be_ready }.to nap
       expect(strand.reload.stack.first["total_disk_usage"]).to eq(1024000)
@@ -282,9 +268,9 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       servers = nx.postgres_resource.servers
       recycling_from_assoc = servers.find { it.id == recycling_standby.id }
       fresh_from_assoc = servers.find { it.id == fresh_standby.id }
-      expect(recycling_from_assoc.vm.sshable).not_to receive(:_cmd)
+      expect(recycling_from_assoc).not_to receive(:data_disk_usage)
       recycling_standby.update_last_known_lsn("0/FFFFFFF")
-      expect(fresh_from_assoc.vm.sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return("1024000\n")
+      expect(fresh_from_assoc).to receive(:data_disk_usage).and_return(1024000)
       fresh_standby.update_last_known_lsn("0/0")
       expect { nx.wait_servers_to_be_ready }.to nap
       expect(strand.reload.stack.first["total_disk_usage"]).to eq(1024000)

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -993,9 +993,22 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.wait_catch_up }.to nap(30)
     end
 
-    it "naps without extending deadline when no lsn has been recorded yet" do
+    it "extends deadline based on disk growth when no lsn has been recorded yet" do
       expect(server).to receive(:lsn_caught_up).and_return(false)
       expect(server).to receive(:last_known_lsn).and_return(nil)
+      expect(server).to receive(:data_disk_usage).and_return(1024)
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60, allow_extension: 24 * 60 * 60)
+      expect { nx.wait_catch_up }.to nap(30)
+      expect(nx.strand.stack.first["previous_disk_usage"]).to eq(1024)
+    end
+
+    it "naps without extending deadline when no lsn is available and disk has not grown" do
+      nx.strand.stack.first["previous_disk_usage"] = 1024
+      nx.strand.modified!(:stack)
+      nx.strand.save_changes
+      expect(server).to receive(:lsn_caught_up).and_return(false)
+      expect(server).to receive(:last_known_lsn).and_return(nil)
+      expect(server).to receive(:data_disk_usage).and_return(1024)
       expect(nx).not_to receive(:register_deadline)
       expect { nx.wait_catch_up }.to nap(30)
     end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -976,19 +976,26 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   describe "#wait_catch_up" do
     it "naps if the lag is too high and extends deadline when lsn progresses" do
       expect(server).to receive(:lsn_caught_up).and_return(false)
-      expect(server).to receive(:current_lsn).and_return("0/1000000")
+      expect(server).to receive(:last_known_lsn).and_return("0/1000000")
       expect(nx).to receive(:register_deadline).with("wait", 10 * 60, allow_extension: 24 * 60 * 60)
       expect { nx.wait_catch_up }.to nap(30)
-      expect(nx.strand.stack.first["current_lsn"]).to eq("0/1000000")
+      expect(nx.strand.stack.first["previous_lsn"]).to eq("0/1000000")
     end
 
     it "naps without extending deadline when lsn has not progressed" do
-      nx.strand.stack.first["current_lsn"] = "0/1000000"
+      nx.strand.stack.first["previous_lsn"] = "0/1000000"
       nx.strand.modified!(:stack)
       nx.strand.save_changes
       expect(server).to receive(:lsn_caught_up).and_return(false)
-      expect(server).to receive(:current_lsn).and_return("0/1000000")
+      expect(server).to receive(:last_known_lsn).and_return("0/1000000")
       expect(server).to receive(:lsn_diff).with("0/1000000", "0/1000000").and_return(0)
+      expect(nx).not_to receive(:register_deadline)
+      expect { nx.wait_catch_up }.to nap(30)
+    end
+
+    it "naps without extending deadline when no lsn has been recorded yet" do
+      expect(server).to receive(:lsn_caught_up).and_return(false)
+      expect(server).to receive(:last_known_lsn).and_return(nil)
       expect(nx).not_to receive(:register_deadline)
       expect { nx.wait_catch_up }.to nap(30)
     end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -458,7 +458,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       standby_nx = create_standby_nexus
       standby_sshable = standby_nx.postgres_server.vm.sshable
       expect(standby_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_database_from_backup").and_return("InProgress")
-      expect(standby_sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return("1024000\n")
+      expect(standby_nx.postgres_server).to receive(:data_disk_usage).and_return(1024000)
       expect(standby_nx).to receive(:register_deadline).with("wait", 10 * 60, allow_extension: 24 * 60 * 60)
       expect { standby_nx.initialize_database_from_backup }.to nap(5)
       expect(frame_value(standby_nx, "disk_usage")).to eq(1024000)
@@ -469,18 +469,10 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       standby_sshable = standby_nx.postgres_server.vm.sshable
       refresh_frame(standby_nx, new_values: {"disk_usage" => 2048000})
       expect(standby_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_database_from_backup").and_return("InProgress")
-      expect(standby_sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return("2048000\n")
+      expect(standby_nx.postgres_server).to receive(:data_disk_usage).and_return(2048000)
       expect(standby_nx).not_to receive(:register_deadline)
       expect { standby_nx.initialize_database_from_backup }.to nap(5)
       expect(frame_value(standby_nx, "disk_usage")).to eq(2048000)
-    end
-
-    it "handles disk usage check failure gracefully during InProgress" do
-      standby_nx = create_standby_nexus
-      standby_sshable = standby_nx.postgres_server.vm.sshable
-      expect(standby_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_database_from_backup").and_return("InProgress")
-      expect(standby_sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_raise(RuntimeError)
-      expect { standby_nx.initialize_database_from_backup }.to nap(5)
     end
 
     it "increments try count on Failed" do


### PR DESCRIPTION
**Add data_disk_usage helper on PostgresServer**
Consolidate the duplicated `df --output=used /dat` calls in
`ConvergePostgresResource#wait_servers_to_be_ready` and
`PostgresServerNexus#initialize_database_from_backup` into a single
helper on `PostgresServer`, returning 0 on failure to match the prior
callers.

**Add last_known_lsn helper on PostgresServer**
Wrap `lsn_monitor_ds.get(:last_known_lsn)` in a reusable accessor so
callers in `failover_target` and `ConvergePostgresResource` no longer
reach into the monitor dataset directly.

**Simplify lsn_caught_up parent handling**
Short-circuit parentless read replicas up front instead of using
`&.representative_server`. Drops the now-redundant "no representative
server" case because we guarantee that resources would always have a
representative_server.

**Use stored last_known_lsn in lsn_caught_up**
Replace the live `pg_last_wal_replay_lsn()` query with the value
recorded by the monitor on both sides of the comparison. Avoids the
extra round-trip and returns false when either side has no pulse yet.
This ensures that we can use the last known lsn even if primary is not
available.

**Track last_known_lsn progress in wait_catch_up**
Switch the deadline-extension check from querying `current_lsn` live
to reading the monitor-recorded `last_known_lsn`.

**Flatten wait_catch_up control flow**
Promote the caught-up hops out of the nested unless so the method
reads top-down: finalize when caught up, otherwise track progress and
nap.

**Fall back to disk-growth tracking in wait_catch_up**
When no lsn has been recorded yet (e.g. when PG is not accepting
connections yet or before the monitor has pulsed), extend the deadline
based on `data_disk_usage` growth instead, mirroring
`ConvergePostgresResource#wait_servers_to_be_ready`.