### PR TITLE
Add disk-full-check on postgres vm to manage default_transaction_read_only

### DIFF
--- a/rhizome/.rubocop.yml
+++ b/rhizome/.rubocop.yml
@@ -3,3 +3,7 @@ inherit_from: ../.rubocop.yml
 AllCops:
   TargetRubyVersion: 3.0
   NewCops: enable
+
+RSpec/DescribeClass:
+  Exclude:
+    - postgres/spec/disk_full_check_spec.rb

--- a/rhizome/postgres/bin/disk-full-check
+++ b/rhizome/postgres/bin/disk-full-check
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -eu
+
+DAT=${DAT:-/dat}
+
+read name btotal bused bavailable usedp mount_path <<< "$(df -P -B1 "$DAT" | tail -n +2)"
+PGDATA="$DAT/$1/data"
+
+if test "$btotal" -le 68719476736; then # Smaller thresholds for disks <= 64GB (hobby)
+  recover_threshold=2147483648    # 2GB
+  readonly_threshold=1073741824   # 1GB
+  restart_threshold=536870912     # 512MB
+  human_buffer_size=500M
+else
+  recover_threshold=7516192768    # 7GB
+  readonly_threshold=5368709120   # 5GB
+  restart_threshold=3221225472    # 3GB
+  human_buffer_size=1G
+fi
+
+if test "$bavailable" -gt "$recover_threshold"; then
+  if grep -q "default_transaction_read_only = 'on'" "$PGDATA/postgresql.auto.conf"; then
+    sed -i "/default_transaction_read_only = 'on'/d" "$PGDATA/postgresql.auto.conf"
+    test -f "$DAT/disk-full-read-only-pending-restart-$1" && rm -f "$DAT/disk-full-read-only-pending-restart-$1"
+    pg_ctlcluster "$1" main reload
+  elif ! test -f "$DAT/disk-full-human-buffer"; then
+    fallocate -l "$human_buffer_size" "$DAT/disk-full-human-buffer"
+  fi
+elif test "$bavailable" -lt "$readonly_threshold"; then
+  if ! grep -q "default_transaction_read_only = 'on'" "$PGDATA/postgresql.auto.conf"; then
+    if test -n "$(tail -c 1 "$PGDATA/postgresql.auto.conf")"; then
+      echo >> "$PGDATA/postgresql.auto.conf"
+    fi
+    echo "default_transaction_read_only = 'on'" >> "$PGDATA/postgresql.auto.conf"
+    touch "$DAT/disk-full-read-only-pending-restart-$1"
+    pg_ctlcluster "$1" main reload
+  elif test "$bavailable" -lt "$restart_threshold" && test -f "$DAT/disk-full-read-only-pending-restart-$1"; then
+    pg_ctlcluster "$1" main restart
+    rm -f "$DAT/disk-full-read-only-pending-restart-$1"
+  fi
+fi

--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -47,6 +47,40 @@ class PostgresSetup
     r "rm -rf /etc/postgresql/#{@version}"
 
     r "echo \"data_directory = '/dat/#{@version}/data'\" | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf"
+
+    # Install to path postgres can access
+    r "install -m 0755 #{File.expand_path("../bin/disk-full-check", __dir__).shellescape} /usr/local/sbin/disk-full-check"
+
+    safe_write_to_file("/etc/systemd/system/disk-full-check@.service", <<~DISKFULL)
+      [Unit]
+      Wants=disk-full-check@%i.timer
+      Description=Mitigate disk full scenarios
+
+      [Service]
+      Type=oneshot
+      User=postgres
+      ExecStart=/usr/local/sbin/disk-full-check %i
+
+      [Install]
+      WantedBy=multi-user.target
+    DISKFULL
+
+    safe_write_to_file("/etc/systemd/system/disk-full-check@.timer", <<~DISKFULL)
+      [Unit]
+      Description=Schedule disk full check
+
+      [Timer]
+      OnBootSec=30s
+      OnUnitActiveSec=20s
+      AccuracySec=1s
+      Unit=disk-full-check@%i.service
+
+      [Install]
+      WantedBy=timers.target
+    DISKFULL
+
+    r "sudo systemctl daemon-reload"
+    r "sudo systemctl enable --now disk-full-check@#{@version}.timer"
   end
 
   def create_cluster

--- a/rhizome/postgres/lib/postgres_upgrade.rb
+++ b/rhizome/postgres/lib/postgres_upgrade.rb
@@ -39,6 +39,7 @@ class PostgresUpgrade
   end
 
   def disable_previous_version
+    r "sudo systemctl disable --now disk-full-check@#{@version}.timer"
     r "sudo systemctl disable --now postgresql@#{@prev_version}-main"
   end
 
@@ -60,6 +61,7 @@ class PostgresUpgrade
 
   def enable_new_version
     r "sudo systemctl enable --now postgresql@#{@version}-main"
+    r "sudo systemctl enable --now disk-full-check@#{@version}.timer"
   end
 
   def wait_for_postgres_to_start

--- a/rhizome/postgres/spec/disk_full_check_spec.rb
+++ b/rhizome/postgres/spec/disk_full_check_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "fileutils"
+require "open3"
+
+RSpec.describe "disk-full-check" do
+  let(:script) { File.expand_path("../bin/disk-full-check", __dir__) }
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:dat) { File.join(tmpdir, "dat") }
+  let(:bin) { File.join(tmpdir, "bin") }
+  let(:auto_conf) { File.join(dat, "16", "data", "postgresql.auto.conf") }
+  let(:pending_restart) { File.join(dat, "disk-full-read-only-pending-restart-16") }
+  let(:human_buffer) { File.join(dat, "disk-full-human-buffer") }
+
+  before do
+    FileUtils.mkdir_p(File.join(dat, "16", "data"))
+    FileUtils.mkdir_p(bin)
+    FileUtils.touch(File.join(dat, "pg_ctl_calls"))
+
+    File.write(File.join(bin, "pg_ctlcluster"), <<~SH)
+      #!/bin/sh
+      echo "$3" >> "#{dat}/pg_ctl_calls"
+    SH
+    File.chmod(0o755, File.join(bin, "pg_ctlcluster"))
+
+    File.write(File.join(bin, "fallocate"), <<~SH)
+      #!/bin/sh
+      touch "$3"
+    SH
+    File.chmod(0o755, File.join(bin, "fallocate"))
+
+    File.write(auto_conf, "\n")
+  end
+
+  after do
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  def fake_df(usedp, avail)
+    File.write(File.join(bin, "df"), <<~SH)
+      #!/bin/sh
+      echo "Filesystem     1B-blocks          Used     Available Use% Mounted on"
+      echo "/dev/sda1      107374182400 53687091200 #{avail} #{usedp}% #{dat}"
+    SH
+    File.chmod(0o755, File.join(bin, "df"))
+  end
+
+  def run_check
+    stdout, stderr, status = Open3.capture3({"PATH" => "#{bin}:#{ENV["PATH"]}", "DAT" => dat}, "bash", script, "16")
+    raise "disk-full-check failed: #{stderr}" unless status.success?
+    stdout
+  end
+
+  def pg_ctl_calls
+    File.read(File.join(dat, "pg_ctl_calls")).strip
+  end
+
+  def auto_conf_content
+    File.read(auto_conf)
+  end
+
+  describe "recovery, >7GB available" do
+    before { fake_df(50, 53_687_091_200) }
+
+    it "creates human buffer" do
+      run_check
+      expect(File.exist?(human_buffer)).to be true
+    end
+
+    it "does not recreate existing buffer" do
+      FileUtils.touch(human_buffer)
+      run_check
+      expect(pg_ctl_calls).to eq ""
+    end
+
+    it "clears read-only and removes pending restart marker" do
+      File.write(auto_conf, "default_transaction_read_only = 'on'\n")
+      FileUtils.touch(pending_restart)
+      run_check
+      expect(auto_conf_content).not_to include("default_transaction_read_only")
+      expect(File.exist?(pending_restart)).to be false
+      expect(pg_ctl_calls).to eq "reload"
+    end
+  end
+
+  describe "margin, 5-7GB available" do
+    before { fake_df(50, 6_000_000_000) }
+
+    it "takes no action" do
+      run_check
+      expect(pg_ctl_calls).to eq ""
+      expect(File.exist?(human_buffer)).to be false
+    end
+  end
+
+  describe "readonly, <5GB available" do
+    before { fake_df(50, 4_000_000_000) }
+
+    it "sets read-only and reloads" do
+      run_check
+      expect(auto_conf_content).to include("default_transaction_read_only = 'on'")
+      expect(File.exist?(pending_restart)).to be true
+      expect(pg_ctl_calls).to eq "reload"
+    end
+
+    it "does not reload while read-only" do
+      File.write(auto_conf, "default_transaction_read_only = 'on'\n")
+      run_check
+      expect(pg_ctl_calls).to eq ""
+      expect(File.exist?(pending_restart)).to be false
+    end
+
+    it "appends newline before read-only when file lacks trailing newline" do
+      File.write(auto_conf, "some_setting = 'value'")
+      run_check
+      expect(auto_conf_content).to eq "some_setting = 'value'\ndefault_transaction_read_only = 'on'\n"
+    end
+  end
+
+  describe "critical, <3GB available" do
+    before { fake_df(50, 2_000_000_000) }
+
+    it "restarts when pending restart marker exists" do
+      File.write(auto_conf, "default_transaction_read_only = 'on'\n")
+      FileUtils.touch(pending_restart)
+      run_check
+      expect(pg_ctl_calls).to eq "restart"
+      expect(File.exist?(pending_restart)).to be false
+    end
+
+    it "does not restart without pending restart marker" do
+      File.write(auto_conf, "default_transaction_read_only = 'on'\n")
+      run_check
+      expect(pg_ctl_calls).to eq ""
+    end
+  end
+end


### PR DESCRIPTION
Above 7GiB turn off default read only & recreate 1GB buffer file
Below 5G default transaction mode becomes readonly
Below 3G postgres is restarted, killing long running connections

For disks smaller than 64GB this is compressed to 2GB/1GB/512MB

Long running connections can be a problem since they wouldn't be read only,
hence need to restart when disk usage becomes critical

fixed #4332, now with testing on dev environment & without tinkering

Fixes from previously:
1. install script as /usr/local/sbin/disk-full-check so postgres can access
2. Pass %i to ExecStart
3. WantedBy=timers.target
4. systemctl setup: daemon-reload, enable --now
5. fix timer to start itself
6. replace pg_ctl with pg_ctlcluster; pg_ctl not on path