### PR TITLE
Create AwsSubnet with single query

### DIFF
--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -74,21 +74,23 @@ class Prog::Vnet::SubnetNexus < Prog::Base
 
     raise "Not enough subnet space for even a single AZ. Use a range size <= 28" if azs.empty?
 
-    azs.each_with_index do |az, idx|
-      ipv4_cidr = vpc_ipv4.nth_subnet(ipv4_prefix, idx)
-      # if the vpc size and the subnet sizes are the same, nth_subnet will
-      # return nil. For example:
-      # NetAddr::IPv4Net.parse("10.159.0.0/16").nth_subnet(16,0)
-      # => nil
-      ipv4_cidr = vpc_ipv4 if vpc_ipv4.netmask.prefix_len == ipv4_prefix && idx == 0
+    DB.ignore_duplicate_queries do
+      azs.each_with_index do |az, idx|
+        ipv4_cidr = vpc_ipv4.nth_subnet(ipv4_prefix, idx)
+        # if the vpc size and the subnet sizes are the same, nth_subnet will
+        # return nil. For example:
+        # NetAddr::IPv4Net.parse("10.159.0.0/16").nth_subnet(16,0)
+        # => nil
+        ipv4_cidr = vpc_ipv4 if vpc_ipv4.netmask.prefix_len == ipv4_prefix && idx == 0
 
-      AwsSubnet.create(
-        private_subnet_aws_resource_id: ps_aws_resource.id,
-        location_aws_az_id: az.id,
-        ipv4_cidr: ipv4_cidr.to_s,
-        ipv6_cidr: nil,  # Will be set when VPC is created
-        subnet_id: nil,   # Will be set when AWS subnet is created
-      )
+        AwsSubnet.create(
+          private_subnet_aws_resource_id: ps_aws_resource.id,
+          location_aws_az_id: az.id,
+          ipv4_cidr: ipv4_cidr.to_s,
+          ipv6_cidr: nil,  # Will be set when VPC is created
+          subnet_id: nil,   # Will be set when AWS subnet is created
+        )
+      end
     end
   end
 

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -74,22 +74,14 @@ class Prog::Vnet::SubnetNexus < Prog::Base
 
     raise "Not enough subnet space for even a single AZ. Use a range size <= 28" if azs.empty?
 
-    azs.each_with_index do |az, idx|
+    rows = azs.map.with_index do |az, idx|
       ipv4_cidr = vpc_ipv4.nth_subnet(ipv4_prefix, idx)
-      # if the vpc size and the subnet sizes are the same, nth_subnet will
-      # return nil. For example:
-      # NetAddr::IPv4Net.parse("10.159.0.0/16").nth_subnet(16,0)
-      # => nil
+      # if vpc size and subnet sizes are the same, nth_subnet returns nil, eg
+      # NetAddr::IPv4Net.parse("10.159.0.0/16").nth_subnet(16,0) => nil
       ipv4_cidr = vpc_ipv4 if vpc_ipv4.netmask.prefix_len == ipv4_prefix && idx == 0
-
-      AwsSubnet.create(
-        private_subnet_aws_resource_id: ps_aws_resource.id,
-        location_aws_az_id: az.id,
-        ipv4_cidr: ipv4_cidr.to_s,
-        ipv6_cidr: nil,  # Will be set when VPC is created
-        subnet_id: nil,   # Will be set when AWS subnet is created
-      )
+      [ps_aws_resource.id, az.id, ipv4_cidr.to_s]
     end
+    AwsSubnet.import([:private_subnet_aws_resource_id, :location_aws_az_id, :ipv4_cidr], rows)
   end
 
   def self.random_private_ipv6(location, project)


### PR DESCRIPTION
```
times:6
sql:SELECT $1::int4 AS "one" FROM "aws_subnet" WHERE (("private_subnet_aws_resource_id" = $2) AND ("location_aws_az_id" = $3)) LIMIT 1 backtrace (filtered):
lib/resource_methods.rb:78:in 'ResourceMethods::InstanceMethods#validate' prog/vnet/subnet_nexus.rb:85:in 'block in Prog::Vnet::SubnetNexus.create_aws_subnet_records' prog/vnet/subnet_nexus.rb:77:in 'Array#each'
prog/vnet/subnet_nexus.rb:77:in 'Enumerable#each_with_index' prog/vnet/subnet_nexus.rb:77:in 'Prog::Vnet::SubnetNexus.create_aws_subnet_records' prog/vnet/subnet_nexus.rb:58:in 'block in Prog::Vnet::SubnetNexus.assemble' prog/vnet/subnet_nexus.rb:26:in 'Prog::Vnet::SubnetNexus.assemble' prog/postgres/postgres_resource_nexus.rb:63:in 'block in Prog::Postgres::PostgresResourceNexus.assemble' prog/postgres/postgres_resource_nexus.rb:27:in 'Prog::Postgres::PostgresResourceNexus.assemble' helpers/postgres.rb:41:in 'block in Clover#postgres_post' helpers/postgres.rb:40:in 'Clover#postgres_post'
routes/project/postgres.rb:16:in 'block (3 levels) in <class:Clover>' routes/project/postgres.rb:11:in 'block (2 levels) in <class:Clover>' routes/project/postgres.rb:10:in 'block in <class:Clover>' routes/project.rb:160:in 'block (2 levels) in <class:Clover>' routes/project.rb:103:in 'block in <class:Clover>' clover.rb:1081:in 'block in <class:Clover>'

times:6
sql:INSERT INTO "aws_subnet" ("private_subnet_aws_resource_id", "location_aws_az_id", "ipv4_cidr", "ipv6_cidr", "subnet_id", "id") VALUES ($1, $2, $3::cidr, NULL, NULL, $4) RETURNING * backtrace (filtered):
prog/vnet/subnet_nexus.rb:85:in 'block in Prog::Vnet::SubnetNexus.create_aws_subnet_records' prog/vnet/subnet_nexus.rb:77:in 'Array#each'
prog/vnet/subnet_nexus.rb:77:in 'Enumerable#each_with_index' prog/vnet/subnet_nexus.rb:77:in 'Prog::Vnet::SubnetNexus.create_aws_subnet_records' prog/vnet/subnet_nexus.rb:58:in 'block in Prog::Vnet::SubnetNexus.assemble' prog/vnet/subnet_nexus.rb:26:in 'Prog::Vnet::SubnetNexus.assemble' prog/postgres/postgres_resource_nexus.rb:63:in 'block in Prog::Postgres::PostgresResourceNexus.assemble' prog/postgres/postgres_resource_nexus.rb:27:in 'Prog::Postgres::PostgresResourceNexus.assemble' helpers/postgres.rb:41:in 'block in Clover#postgres_post' helpers/postgres.rb:40:in 'Clover#postgres_post'
routes/project/postgres.rb:16:in 'block (3 levels) in <class:Clover>' routes/project/postgres.rb:11:in 'block (2 levels) in <class:Clover>' routes/project/postgres.rb:10:in 'block in <class:Clover>' routes/project.rb:160:in 'block (2 levels) in <class:Clover>' routes/project.rb:103:in 'block in <class:Clover>' clover.rb:1081:in 'block in <class:Clover>'
```