### PR TITLE
Escape and quote values for postgres config

### DIFF
--- a/lib/validation/postgres_config_validator.rb
+++ b/lib/validation/postgres_config_validator.rb
@@ -123,28 +123,14 @@ module Validation
         return "must match pattern: #{pattern.source.gsub(/[\\Az]/, "")}"
       end
 
-      # Check if string value needs quoting and is properly quoted
-      quoting_error = validate_string_quoting(value)
-      return quoting_error if quoting_error
-
-      nil
-    end
-
-    def validate_string_quoting(value)
-      # Ref: https://www.postgresql.org/docs/9.3/config-setting.html#CONFIG-SETTING-CONFIGURATION-FILE
-      is_quoted = value.start_with?("'") && value.end_with?("'")
-
-      if is_quoted
-        inner_value = value[1...-1]
-
-        # Single quotes inside should be escaped as '' or '\
-        escaped_quotes_removed = inner_value.gsub("''", "").gsub("\\'", "")
-
-        if escaped_quotes_removed.include?("'")
-          "contains unescaped single quotes - single quotes must be doubled ('') inside quoted strings"
-        end
-      elsif !value.match?(/\A[a-zA-Z0-9_]+\z/)
-        "must be wrapped in single quotes (e.g., '#{value.gsub("'", "''")}') because it contains special characters"
+      # Values are auto-quoted when written to postgresql.conf, so users
+      # should not wrap them in single quotes. Reject quoted values.
+      starts = value.start_with?("'")
+      ends = value.end_with?("'")
+      if starts && ends && value.length >= 2
+        "must not be wrapped in single quotes - quoting is handled automatically"
+      elsif starts != ends
+        "has a mismatched single quote"
       end
     end
 

--- a/migrate/20260511_strip_user_config_quotes.rb
+++ b/migrate/20260511_strip_user_config_quotes.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    has_unsupported_escape = lambda do |inner|
+      i = 0
+      while i < inner.length
+        if inner[i] == "\\"
+          nxt = inner[i + 1]
+          return true if nxt != "\\" && nxt != "'"
+          i += 2
+        elsif inner[i] == "'" && inner[i + 1] == "'"
+          i += 2
+        else
+          i += 1
+        end
+      end
+      false
+    end
+
+    unquote = ->(v) { v[1...-1].gsub("''", "'").gsub("\\'", "'").gsub("\\\\") { "\\" } }
+
+    from(:postgres_resource).select(:id, :user_config).each do |row|
+      user_config = row[:user_config]
+      next if user_config.nil? || user_config.empty?
+
+      changed = false
+      cleaned = user_config.each_with_object({}) do |(k, v), acc|
+        if v.is_a?(String) && v.length >= 2 && v.start_with?("'") && v.end_with?("'")
+          inner = v[1...-1]
+          if has_unsupported_escape.call(inner)
+            raise Sequel::Error, "postgres_resource #{row[:id]} key #{k.inspect}: unsupported escape in #{v.inspect}"
+          end
+          acc[k] = unquote.call(v)
+          changed = true
+        elsif v.is_a?(String) && v.start_with?("'") != v.end_with?("'")
+          raise Sequel::Error, "postgres_resource #{row[:id]} key #{k.inspect}: mismatched single quote in #{v.inspect}"
+        else
+          acc[k] = v
+        end
+      end
+
+      from(:postgres_resource).where(id: row[:id]).update(user_config: Sequel.pg_jsonb(cleaned)) if changed
+    end
+  end
+
+  down do
+    # No-op: forward-only. Pre-migration state mixed bare and manually-quoted
+    # values; the boundary cannot be reconstructed from the bare-only post state.
+  end
+end

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -5,6 +5,7 @@ require "json"
 require "fileutils"
 require_relative "../../common/lib/util"
 require_relative "../lib/pg_bouncer_setup"
+require_relative "../lib/postgres_config"
 require_relative "../lib/postgres_setup"
 
 if ARGV.count != 1
@@ -38,7 +39,7 @@ upgrade_override = "/etc/postgresql/#{v}/main/conf.d/100-upgrade.conf"
 FileUtils.rm_f(upgrade_override)
 
 # Update postgresql.conf with custom settings
-user_configs = configure_hash["user_config"].map { |k, v| "#{k} = #{v}" }.join("\n")
+user_configs = PostgresConfig.format(configure_hash["user_config"])
 safe_write_to_file("/etc/postgresql/#{v}/main/conf.d/099-user.conf", user_configs)
 
 # Update pg_hba.conf

--- a/rhizome/postgres/lib/postgres_config.rb
+++ b/rhizome/postgres/lib/postgres_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PostgresConfig
+  # Quote and escape a value for postgresql.conf single-quoted string syntax.
+  # Backslashes and single quotes are the only characters that need escaping.
+  def self.quote_value(v)
+    "'#{v.to_s.gsub("\\") { "\\\\" }.gsub("'", "''")}'"
+  end
+
+  # Format a hash of config key-value pairs for postgresql.conf.
+  def self.format(config)
+    config.map { |k, v| "#{k} = #{quote_value(v)}" }.join("\n")
+  end
+end

--- a/rhizome/postgres/spec/postgres_config_spec.rb
+++ b/rhizome/postgres/spec/postgres_config_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "../lib/postgres_config"
+
+RSpec.describe PostgresConfig do
+  describe ".quote_value" do
+    it "wraps a simple value in single quotes" do
+      expect(described_class.quote_value("value")).to eq("'value'")
+    end
+
+    it "wraps a value with spaces" do
+      expect(described_class.quote_value("read committed")).to eq("'read committed'")
+    end
+
+    it "escapes single quotes by doubling" do
+      expect(described_class.quote_value("my'app")).to eq("'my''app'")
+    end
+
+    it "escapes backslashes by doubling" do
+      expect(described_class.quote_value("test\\n")).to eq("'test\\\\n'")
+    end
+
+    it "escapes both single quotes and backslashes" do
+      expect(described_class.quote_value("it's a \\test")).to eq("'it''s a \\\\test'")
+    end
+
+    it "converts integers to string" do
+      expect(described_class.quote_value(100)).to eq("'100'")
+    end
+
+    it "handles empty string" do
+      expect(described_class.quote_value("")).to eq("''")
+    end
+
+    it "preserves double quotes" do
+      expect(described_class.quote_value('"/tmp/my dir", /tmp')).to eq(%('"/tmp/my dir", /tmp'))
+    end
+  end
+
+  describe ".format" do
+    it "formats a config hash for postgresql.conf" do
+      config = {"max_connections" => 100, "default_transaction_isolation" => "read committed"}
+      result = described_class.format(config)
+      expect(result).to eq("max_connections = '100'\ndefault_transaction_isolation = 'read committed'")
+    end
+
+    it "returns empty string for empty hash" do
+      expect(described_class.format({})).to eq("")
+    end
+
+    it "escapes values that need quoting" do
+      config = {"app" => "my'app", "cmd" => "test \\n"}
+      result = described_class.format(config)
+      expect(result).to eq("app = 'my''app'\ncmd = 'test \\\\n'")
+    end
+  end
+end

--- a/spec/lib/validation/postgres_config_validator_spec.rb
+++ b/spec/lib/validation/postgres_config_validator_spec.rb
@@ -36,33 +36,38 @@ RSpec.describe Validation::PostgresConfigValidator do
         expect { validator.validate(config) }.not_to raise_error
       end
 
-      it "returns no errors for properly quoted string with spaces" do
-        config = {"archive_command" => "'foo bar'"}
-        expect { validator.validate(config) }.not_to raise_error
-      end
-
       it "returns no errors for simple string without special characters" do
         config = {"application_name" => "my_app0001"}
         expect { validator.validate(config) }.not_to raise_error
       end
 
+      it "returns no errors for string with spaces" do
+        config = {"archive_command" => "foo bar"}
+        expect { validator.validate(config) }.not_to raise_error
+      end
+
       it "returns no errors for string with path characters" do
-        config = {"ssl_ca_file" => "'/etc/ssl/certs/ca.crt'"}
+        config = {"ssl_ca_file" => "/etc/ssl/certs/ca.crt"}
         expect { validator.validate(config) }.not_to raise_error
       end
 
-      it "returns no errors for properly quoted string with comma" do
-        config = {"shared_preload_libraries" => "'pg_cron,pg_stat_statements'"}
+      it "returns no errors for string with comma" do
+        config = {"shared_preload_libraries" => "pg_cron,pg_stat_statements"}
         expect { validator.validate(config) }.not_to raise_error
       end
 
-      it "returns no errors for properly quoted string with two escaped quotes" do
-        config = {"application_name" => "'my''app'"}
+      it "returns no errors for string with single quotes in the middle" do
+        config = {"application_name" => "my'app"}
         expect { validator.validate(config) }.not_to raise_error
       end
 
-      it "returns no errors for properly quoted string with escaped backslash" do
-        config = {"application_name" => "'my\\'app'"}
+      it "returns no errors for string with backslash" do
+        config = {"application_name" => "my\\app"}
+        expect { validator.validate(config) }.not_to raise_error
+      end
+
+      it "returns no errors for string with double quotes" do
+        config = {"unix_socket_directories" => '"/tmp/my socket dir", /tmp'}
         expect { validator.validate(config) }.not_to raise_error
       end
 
@@ -132,24 +137,25 @@ RSpec.describe Validation::PostgresConfigValidator do
         expect { validator.validate(config) }.to raise_error(Validation::ValidationFailed)
       end
 
-      it "returns error for unquoted string with spaces" do
-        config = {"archive_command" => "foo bar"}
-        expect { validator.validate(config) }.to raise_error(Validation::ValidationFailed)
+      it "returns error for string wrapped in single quotes" do
+        config = {"archive_command" => "'foo bar'"}
+        expect { validator.validate(config) }.to raise_error(Validation::ValidationFailed) do |error|
+          expect(error.details["archive_command"]).to include("must not be wrapped in single quotes - quoting is handled automatically")
+        end
       end
 
-      it "returns error for unquoted string with comma" do
-        config = {"shared_preload_libraries" => "pg_cron,pg_stat_statements"}
-        expect { validator.validate(config) }.to raise_error(Validation::ValidationFailed)
+      it "returns error for string with mismatched leading single quote" do
+        config = {"application_name" => "'my_app"}
+        expect { validator.validate(config) }.to raise_error(Validation::ValidationFailed) do |error|
+          expect(error.details["application_name"]).to include("has a mismatched single quote")
+        end
       end
 
-      it "returns error for quoted string with unescaped quotes" do
-        config = {"application_name" => "'my'app'"}
-        expect { validator.validate(config) }.to raise_error(Validation::ValidationFailed)
-      end
-
-      it "returns error for unquoted string with special characters" do
-        config = {"archive_command" => "/usr/bin/test && echo 'done'"}
-        expect { validator.validate(config) }.to raise_error(Validation::ValidationFailed)
+      it "returns error for string with mismatched trailing single quote" do
+        config = {"application_name" => "my_app'"}
+        expect { validator.validate(config) }.to raise_error(Validation::ValidationFailed) do |error|
+          expect(error.details["application_name"]).to include("has a mismatched single quote")
+        end
       end
     end
 


### PR DESCRIPTION
Values like default_transaction_isolation = read committed are invalid postgresql.conf syntax without quoting. Wrap all user config values in single quotes, and escape embedded single quotes and backslashes by doubling them, matching PostgreSQL's `escape_single_quotes_ascii`.