### PR TITLE
Revert "Require physical slot for planned failover"

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -235,13 +235,8 @@ class PostgresServer < Sequel::Model
       .reject { it.is_representative }
       .select { it.strand.label == "wait" && !it.needs_recycling? }
 
-    if mode == "planned" && !read_replica?
-      ready = candidates.select { it.physical_slot_ready_id == resource.representative_server.id }
-      if ready.empty? && candidates.any?
-        Clog.emit("Planned failover waiting for physical slot ready", {ubid:, standby_count: candidates.count})
-      end
-      candidates = ready
-    end
+    # Planned failover requires physical slot ready to ensure logical slots are synced
+    candidates = candidates.select { it.physical_slot_ready_id == resource.representative_server.id } if mode == "planned" && !read_replica?
 
     target = candidates
       .map { {server: it, lsn: it.current_lsn} }
@@ -254,26 +249,7 @@ class PostgresServer < Sequel::Model
       return if lsn_diff(last_known_lsn, target[:lsn]) > 80 * 1024 * 1024 # 80 MB or ~5 WAL files
     end
 
-    if mode == "planned"
-      missing = unsynced_logical_failover_slots(target[:server])
-      unless missing.empty?
-        Clog.emit("Planned failover waiting for logical slot sync", {ubid:, standby: target[:server].ubid, missing_slots: missing})
-        return
-      end
-    end
-
     target[:server]
-  end
-
-  # PG17+: returns logical failover slot names from primary not yet synced on standby
-  def unsynced_logical_failover_slots(standby)
-    return [] if read_replica? || version.to_i < 17
-
-    primary_slot_names = run_query("SELECT slot_name FROM pg_replication_slots WHERE slot_type = 'logical' AND failover").split("\n")
-    return [] if primary_slot_names.empty?
-
-    synced_slot_names = standby.run_query("SELECT slot_name FROM pg_replication_slots WHERE slot_type = 'logical' AND synced AND NOT temporary").split("\n")
-    primary_slot_names - synced_slot_names
   end
 
   def lsn_function_name

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -157,7 +157,7 @@ class PostgresServer < Sequel::Model
       return false
     end
 
-    unless (standby = failover_target(mode:))
+    unless (standby = failover_target)
       Clog.emit("No suitable standby found for failover", {ubid:})
       return false
     end
@@ -230,17 +230,12 @@ class PostgresServer < Sequel::Model
     POSTGRES_MONITOR_DB[:postgres_lsn_monitor].where(postgres_server_id: id)
   end
 
-  def failover_target(mode: "unplanned")
-    candidates = resource.servers
+  def failover_target
+    target = resource.servers
       .reject { it.is_representative }
       .select { it.strand.label == "wait" && !it.needs_recycling? }
-
-    # Planned failover requires physical slot ready to ensure logical slots are synced
-    candidates = candidates.select { it.physical_slot_ready_id == resource.representative_server.id } if mode == "planned" && !read_replica?
-
-    target = candidates
       .map { {server: it, lsn: it.current_lsn} }
-      .max_by { [(it[:server].physical_slot_ready_id == resource.representative_server.id) ? 1 : 0, lsn2int(it[:lsn])] }
+      .max_by { [(it[:server].physical_slot_ready_id == resource.representative_server.id) ? 1 : 0, lsn2int(it[:lsn])] } # prefers physical slot ready servers
 
     return nil if target.nil?
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe PostgresServer do
 
     it "logs error when no suitable standby found" do
       expect(postgres_server).to receive(:is_representative).and_return(true)
-      expect(postgres_server).to receive(:failover_target).with(mode: "planned").and_return(nil)
+      expect(postgres_server).to receive(:failover_target).and_return(nil)
       expect(Clog).to receive(:emit).with("No suitable standby found for failover", instance_of(Hash))
       expect(postgres_server.trigger_failover(mode: "planned")).to be false
     end
@@ -180,7 +180,7 @@ RSpec.describe PostgresServer do
         timeline:, resource_id: resource.id, vm_id: create_hosted_vm(project, private_subnet, "standby").id,
         synchronization_status: "ready", timeline_access: "fetch", version: "16",
       )
-      expect(postgres_server).to receive(:failover_target).with(mode: "planned").and_return(standby)
+      expect(postgres_server).to receive(:failover_target).and_return(standby)
       expect(standby).to receive(:incr_planned_take_over)
       expect(postgres_server.trigger_failover(mode: "planned")).to be true
     end
@@ -257,21 +257,13 @@ RSpec.describe PostgresServer do
       POSTGRES_MONITOR_DB[:postgres_lsn_monitor].where(postgres_server_id: postgres_server.id).delete
     end
 
-    it "returns standby with physical_slot_ready_id nil as fallback for unplanned failover" do
+    it "returns standby with physical_slot_ready_id nil as fallback" do
       allow(resource).to receive(:servers).and_return([
         postgres_server,
         instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: nil, synchronization_status: "ready"),
       ])
       expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
       expect(postgres_server.failover_target.ubid).to eq("pgubidstandby1")
-    end
-
-    it "returns nil for planned failover when no standby has physical_slot_ready" do
-      expect(resource).to receive(:servers).and_return([
-        postgres_server,
-        instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: nil, synchronization_status: "ready"),
-      ]).at_least(:once)
-      expect(postgres_server.failover_target(mode: "planned")).to be_nil
     end
 
     it "prefers standby with physical_slot_ready_id set over higher lsn without" do

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -274,22 +274,6 @@ RSpec.describe PostgresServer do
       expect(postgres_server.failover_target(mode: "planned")).to be_nil
     end
 
-    it "returns nil for planned failover when logical slots not synced on standby" do
-      standby = instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready")
-      expect(resource).to receive(:servers).and_return([postgres_server, standby]).at_least(:once)
-      expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
-      expect(postgres_server).to receive(:unsynced_logical_failover_slots).with(standby).and_return(["slot1"])
-      expect(postgres_server.failover_target(mode: "planned")).to be_nil
-    end
-
-    it "returns standby for planned failover when logical slots are synced" do
-      standby = instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready")
-      expect(resource).to receive(:servers).and_return([postgres_server, standby]).at_least(:once)
-      expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
-      expect(postgres_server).to receive(:unsynced_logical_failover_slots).with(standby).and_return([])
-      expect(postgres_server.failover_target(mode: "planned").ubid).to eq("pgubidstandby1")
-    end
-
     it "prefers standby with physical_slot_ready_id set over higher lsn without" do
       allow(resource).to receive(:servers).and_return([
         postgres_server,
@@ -298,48 +282,6 @@ RSpec.describe PostgresServer do
       ])
       expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
       expect(postgres_server.failover_target.ubid).to eq("pgubidstandby1")
-    end
-  end
-
-  describe "#unsynced_logical_failover_slots" do
-    let(:standby) {
-      described_class.create(
-        timeline:, resource_id: resource.id, vm_id: create_hosted_vm(project, private_subnet, "standby").id,
-        synchronization_status: "ready", timeline_access: "fetch", version: "16",
-      )
-    }
-
-    it "returns empty for read replicas" do
-      expect(postgres_server).to receive(:read_replica?).and_return(true)
-      expect(postgres_server.unsynced_logical_failover_slots(standby)).to be_empty
-    end
-
-    it "returns empty for versions below 17" do
-      expect(postgres_server).to receive(:read_replica?).and_return(false)
-      expect(postgres_server.unsynced_logical_failover_slots(standby)).to be_empty
-    end
-
-    it "returns empty when primary has no logical failover slots" do
-      expect(postgres_server).to receive(:read_replica?).and_return(false)
-      postgres_server.update(version: "17")
-      expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("")
-      expect(postgres_server.unsynced_logical_failover_slots(standby)).to be_empty
-    end
-
-    it "returns empty when all primary logical failover slots are synced on standby" do
-      expect(postgres_server).to receive(:read_replica?).and_return(false)
-      postgres_server.update(version: "17")
-      expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("slot1\nslot2")
-      expect(standby.vm.sshable).to receive(:_cmd).and_return("slot1\nslot2")
-      expect(postgres_server.unsynced_logical_failover_slots(standby)).to be_empty
-    end
-
-    it "returns missing slot names when standby is missing a synced logical slot" do
-      expect(postgres_server).to receive(:read_replica?).and_return(false)
-      postgres_server.update(version: "17")
-      expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("slot1\nslot2")
-      expect(standby.vm.sshable).to receive(:_cmd).and_return("slot1")
-      expect(postgres_server.unsynced_logical_failover_slots(standby)).to eq(["slot2"])
     end
   end
 

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -337,8 +337,6 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       standby.update(physical_slot_ready_id: server.id)
       standby_from_assoc = nx.postgres_resource.servers.find { !it.is_representative }
       expect(standby_from_assoc.vm.sshable).to receive(:_cmd).and_return("0/1234567")
-      representative = nx.postgres_resource.representative_server
-      expect(representative.vm.sshable).to receive(:_cmd).and_return("")
       expect { nx.recycle_representative_server }.to nap(60)
       expect(standby.reload.planned_take_over_set?).to be true
     end


### PR DESCRIPTION
Upgrades break with this change, as they do planned failover with a fenced primary