### PR TITLE
Fix failover slot failover logic failing during upgrades

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ on:
       test_cases:
         description: 'Comma-separated list of test cases (vm)'
         required: true
-        default: 'vm,github_runner_ubuntu_2404,github_runner_ubuntu_2204,postgres_standard,postgres_ha,postgres_upgrade,kubernetes'
+        default: 'vm,github_runner_ubuntu_2404,github_runner_ubuntu_2204,postgres_standard,postgres_ha,postgres_upgrade,postgres_upgrade16,kubernetes'
         type: string
       providers:
         description: 'Comma-separated list of providers (metal,aws)'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ on:
       test_cases:
         description: 'Comma-separated list of test cases (vm)'
         required: true
-        default: 'vm,github_runner_ubuntu_2404,github_runner_ubuntu_2204,postgres_standard,postgres_ha,postgres_upgrade,postgres_firewall,kubernetes'
+        default: 'vm,github_runner_ubuntu_2404,github_runner_ubuntu_2204,postgres_standard,postgres_ha,postgres_upgrade,postgres_upgrade16,postgres_firewall,kubernetes'
         type: string
       providers:
         description: 'Comma-separated list of providers (metal,aws,gcp)'

--- a/bin/e2e
+++ b/bin/e2e
@@ -55,6 +55,9 @@ def test_metal(options, test_cases)
   if options[:test_cases].include?("postgres_upgrade")
     tests_to_wait << Prog::Test::UpgradePostgresResource.assemble
   end
+  if options[:test_cases].include?("postgres_upgrade16")
+    tests_to_wait << Prog::Test::UpgradePostgresResource.assemble(start_version: "16")
+  end
 
   if options[:test_cases].include?("kubernetes")
     tests_to_wait << Prog::Test::Kubernetes.assemble
@@ -88,6 +91,9 @@ def test_aws(options, test_cases)
   end
   if options[:test_cases].include?("postgres_upgrade")
     tests_to_wait << Prog::Test::UpgradePostgresResource.assemble(provider: "aws")
+  end
+  if options[:test_cases].include?("postgres_upgrade16")
+    tests_to_wait << Prog::Test::UpgradePostgresResource.assemble(provider: "aws", start_version: "16")
   end
 
   tests_to_wait.each { |st| wait_until(st) }

--- a/bin/e2e
+++ b/bin/e2e
@@ -51,6 +51,9 @@ def test_metal(options, test_cases)
   if options[:test_cases].include?("postgres_upgrade")
     tests_to_wait << Prog::Test::UpgradePostgresResource.assemble
   end
+  if options[:test_cases].include?("postgres_upgrade16")
+    tests_to_wait << Prog::Test::UpgradePostgresResource.assemble(start_version: "16")
+  end
 
   # Skip postgres_firewall on metal: the assertion at
   # Prog::Test::PostgresFirewall#test_block_all_rules has the VM nc its
@@ -103,6 +106,9 @@ def test_aws(options, test_cases)
   end
   if options[:test_cases].include?("postgres_upgrade")
     tests_to_wait << Prog::Test::UpgradePostgresResource.assemble(provider: "aws")
+  end
+  if options[:test_cases].include?("postgres_upgrade16")
+    tests_to_wait << Prog::Test::UpgradePostgresResource.assemble(provider: "aws", start_version: "16")
   end
 
   if options[:test_cases].include?("postgres_firewall")

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -4,4 +4,5 @@
 - { name: postgres_standard,         images: ["postgres-ubuntu-2204"] }
 - { name: postgres_ha,               images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_upgrade,          images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
+- { name: postgres_upgrade16,        images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: kubernetes,                images: ["kubernetes-v1_35"]}

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -4,5 +4,6 @@
 - { name: postgres_standard,         images: ["postgres-ubuntu-2204"] }
 - { name: postgres_ha,               images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_upgrade,          images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
+- { name: postgres_upgrade16,        images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_firewall,         images: ["postgres-ubuntu-2204"] }
 - { name: kubernetes,                images: ["ubuntu-noble","kubernetes-v1_35", "kubernetes-v1_36"]}

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -164,7 +164,12 @@ class PostgresServer < Sequel::Model
       return false
     end
 
-    standby.send(:"incr_#{mode}_take_over")
+    if mode == "unplanned"
+      standby.incr_unplanned_take_over
+    else
+      standby.incr_planned_take_over
+    end
+
     true
   end
 
@@ -256,6 +261,7 @@ class PostgresServer < Sequel::Model
       return if lsn_diff(last_known_lsn, target[:lsn]) > 80 * 1024 * 1024 # 80 MB or ~5 WAL files
     end
 
+    # Upgrade mode can't query primary, was verified before fencing
     if mode == "planned"
       missing = unsynced_logical_failover_slots(target[:server])
       unless missing.empty?

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -312,18 +312,20 @@ class PostgresServer < Sequel::Model
     target[:server]
   end
 
-  # PG17+: returns logical failover slot names from primary not yet synced on standby.
+  # PG17+: returns logical failover slot names from primary not yet caught up on standby.
+  # A slot counts as synced only when its standby copy's confirmed_flush has reached the
+  # primary's, otherwise pg_upgrade on a promoted standby rejects it for pending WAL.
   # Returns [] when the primary is fenced (stopped). Callers relying on this during
   # a fenced-primary failover (e.g. upgrade) must verify sync before the fence.
   def unsynced_logical_failover_slots(standby)
     return [] if read_replica? || version.to_i < 17
     return [] if strand.label == "wait_in_fence"
 
-    primary_slot_names = run_query("SELECT slot_name FROM pg_replication_slots WHERE slot_type = 'logical' AND failover").split("\n")
-    return [] if primary_slot_names.empty?
+    primary_slots = run_query("SELECT slot_name, confirmed_flush_lsn FROM pg_replication_slots WHERE slot_type = 'logical' AND failover").split("\n").map { it.split(",") }
+    return [] if primary_slots.empty?
 
-    synced_slot_names = standby.run_query("SELECT slot_name FROM pg_replication_slots WHERE slot_type = 'logical' AND synced AND NOT temporary").split("\n")
-    primary_slot_names - synced_slot_names
+    synced = standby.run_query("SELECT slot_name, confirmed_flush_lsn FROM pg_replication_slots WHERE slot_type = 'logical' AND synced AND NOT temporary").split("\n").to_h { it.split(",") }
+    primary_slots.reject { |name, lsn| synced[name] && lsn_diff(synced[name], lsn) >= 0 }.map(&:first)
   end
 
   def lsn_function_name

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -133,7 +133,9 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
       postgres_resource.incr_storage_auto_scale_not_cancellable
 
       register_deadline(nil, 10 * 60)
-      postgres_resource.representative_server.trigger_failover(mode: "planned")
+      # Upgrade path reaches here with a fenced primary which normal planned mode cannot handle
+      mode = (postgres_resource.representative_server.strand.label == "wait_in_fence") ? "upgrade" : "planned"
+      postgres_resource.representative_server.trigger_failover(mode:)
     end
 
     nap 60

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -89,7 +89,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
     when "Failed"
       hop_upgrade_failed
     when "NotStarted"
-      upgrade_candidate.vm.sshable.d_run("upgrade_postgres", "sudo", "postgres/bin/upgrade", postgres_resource.target_version)
+      upgrade_candidate.vm.sshable.d_run("upgrade_postgres", "sudo", "postgres/bin/upgrade", postgres_resource.target_version, stdin: JSON.generate(upgrade_candidate.configure_hash))
     end
 
     nap 5

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -86,7 +86,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
     when "Failed"
       hop_upgrade_failed
     when "NotStarted"
-      upgrade_candidate.vm.sshable.d_run("upgrade_postgres", "sudo", "postgres/bin/upgrade", postgres_resource.target_version)
+      upgrade_candidate.vm.sshable.d_run("upgrade_postgres", "sudo", "postgres/bin/upgrade", postgres_resource.target_version, stdin: JSON.generate(upgrade_candidate.configure_hash))
     end
 
     nap 5

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -3,7 +3,7 @@
 require_relative "../../lib/util"
 
 class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
-  def self.assemble(provider: "metal")
+  def self.assemble(provider: "metal", start_version: "17")
     postgres_test_project = Project.create(name: "Postgres-Upgrade-Test-Project")
     Project[Config.postgres_service_project_id] ||
       Project.create_with_id(Config.postgres_service_project_id || Project.generate_uuid, name: "Postgres-Service-Project")
@@ -11,21 +11,26 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
     Strand.create(
       prog: "Test::UpgradePostgresResource",
       label: "start",
-      stack: [{"provider" => provider, "postgres_test_project_id" => postgres_test_project.id}],
+      stack: [{"provider" => provider, "start_version" => start_version, "postgres_test_project_id" => postgres_test_project.id}],
     )
   end
 
   label def start
     location_id, target_vm_size, target_storage_size_gib = self.class.postgres_test_location_options(frame["provider"])
 
+    user_config = {}
+    # sync_replication_slots is PG17+. Enabling it on PG16 would reject config.
+    user_config["sync_replication_slots"] = "on" if start_version.to_i >= 17
+
     st = Prog::Postgres::PostgresResourceNexus.assemble(
       project_id: frame["postgres_test_project_id"],
       location_id:,
-      name: "postgres-test-upgrade",
+      name: "postgres-test-upgrade-pg#{start_version}",
       target_vm_size:,
       target_storage_size_gib:,
       ha_type: "async",
-      target_version: "17",
+      target_version: start_version,
+      user_config:,
     )
 
     update_stack({"postgres_resource_id" => st.id})
@@ -36,6 +41,38 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   label def wait_postgres_resource
     servers = postgres_resource.servers
     nap 10 if servers.count != postgres_resource.target_server_count || servers.filter { it.strand.label != "wait" }.any?
+    hop_setup_failover_slot
+  end
+
+  label def setup_failover_slot
+    # PG17+ preserves logical replication slots across pg_upgrade, and adds the
+    # failover argument plus sync on standbys. PG16 logical slots are dropped by
+    # pg_upgrade; we still create one to assert the upgrade does not hang.
+    unless (standby = postgres_resource.servers.find { !it.is_representative })
+      update_stack({"fail_message" => "No standby found to verify failover slot sync"})
+      hop_destroy_postgres
+    end
+
+    existing = representative_server.run_query("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").strip
+    if existing.empty?
+      Clog.emit("Creating logical replication slot", {failover: start_version.to_i >= 17})
+      create_sql = if start_version.to_i >= 17
+        "SELECT pg_create_logical_replication_slot('upgrade_test_slot', 'pgoutput', false, false, true)"
+      else
+        "SELECT pg_create_logical_replication_slot('upgrade_test_slot', 'pgoutput', false, false)"
+      end
+      representative_server.run_query(create_sql)
+    end
+
+    # PG16 does not sync replication slots to standbys; skip the wait.
+    hop_test_postgres_before_read_replica if start_version.to_i < 17
+
+    synced = standby.run_query("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot' AND synced AND NOT temporary").strip
+    if synced.empty?
+      Clog.emit("Waiting for failover slot sync on standby", {standby: standby.ubid})
+      nap 10
+    end
+
     hop_test_postgres_before_read_replica
   end
 
@@ -62,6 +99,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
       name: "postgres-test-upgrade-replica",
       target_vm_size:,
       target_storage_size_gib:,
+      target_version: postgres_resource.version,
       user_config: {},
       pgbouncer_user_config: {},
     )
@@ -95,12 +133,12 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   end
 
   label def trigger_upgrade
-    Clog.emit("Starting upgrade from version 17 to 18")
+    Clog.emit("Starting upgrade from version #{start_version} to #{target_version}")
     Clog.emit("Postgres servers before upgrade: #{postgres_resource.servers.map { [it.ubid, it.version, it.timeline_access, it.strand.label].inspect }.join(", ")}")
     Clog.emit("Read replica servers before upgrade: #{read_replica.servers.map { [it.ubid, it.version, it.timeline_access, it.strand.label].inspect }.join(", ")}")
 
-    postgres_resource.update(target_version: "18")
-    postgres_resource.read_replicas_dataset.update(target_version: "18")
+    postgres_resource.update(target_version:)
+    postgres_resource.read_replicas_dataset.update(target_version:)
 
     hop_check_upgrade_progress
   end
@@ -144,9 +182,9 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
       end
     end
 
-    # Check if all servers have been upgraded to version 18
-    primary_upgraded = postgres_resource.servers.all? { |s| s.version == "18" && s.strand.label == "wait" }
-    replica_upgraded = read_replica.servers.all? { |s| s.version == "18" && s.strand.label == "wait" }
+    # Check if all servers have been upgraded
+    primary_upgraded = postgres_resource.servers.all? { |s| s.version == target_version && s.strand.label == "wait" }
+    replica_upgraded = read_replica.servers.all? { |s| s.version == target_version && s.strand.label == "wait" }
 
     if primary_upgraded && replica_upgraded
       Clog.emit("Upgrade completed successfully!")
@@ -167,19 +205,19 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   end
 
   label def test_postgres_after_upgrade
-    Clog.emit("Testing Postgres after upgrade to version 18")
+    Clog.emit("Testing Postgres after upgrade to version #{target_version}")
     Clog.emit("Final server states:")
     Clog.emit("Primary servers: #{postgres_resource.servers.map { |s| "[#{s.ubid}, v#{s.version}, #{s.timeline_access}, #{s.strand.label}]" }.join(", ")}")
     Clog.emit("Replica servers: #{read_replica.servers.map { |s| "[#{s.ubid}, v#{s.version}, #{s.timeline_access}, #{s.strand.label}]" }.join(", ")}")
 
-    # Verify all servers are at version 18
-    unless postgres_resource.servers.all? { |s| s.version == "18" }
-      update_stack({"fail_message" => "Not all primary servers upgraded to version 18"})
+    # Verify all servers upgraded to target_version
+    unless postgres_resource.servers.all? { |s| s.version == target_version }
+      update_stack({"fail_message" => "Not all primary servers upgraded to version #{target_version}"})
       hop_destroy_postgres
     end
 
-    unless read_replica.servers.all? { |s| s.version == "18" }
-      update_stack({"fail_message" => "Not all replica servers upgraded to version 18"})
+    unless read_replica.servers.all? { |s| s.version == target_version }
+      update_stack({"fail_message" => "Not all replica servers upgraded to version #{target_version}"})
       hop_destroy_postgres
     end
 
@@ -197,7 +235,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
       hop_destroy_postgres
     end
 
-    # Test write queries on primary (should work on v18)
+    # Test write queries on primary
     Clog.emit("Running write queries on primary after upgrade")
     unless representative_server.run_query(test_queries_sql) == "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to run write queries after upgrade"})
@@ -208,6 +246,16 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
     Clog.emit("Verifying replica can read updated data")
     unless read_replica.representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to read updated data on replica after upgrade"})
+      hop_destroy_postgres
+    end
+
+    # PG17+: pg_upgrade preserves failover-enabled logical slots.
+    # PG16: logical slots are dropped by pg_upgrade; assert the slot is gone.
+    Clog.emit("Verifying logical slot state after upgrade")
+    slot_row = representative_server.run_query("SELECT failover FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").strip
+    expected_row = (start_version.to_i >= 17) ? "t" : ""
+    unless slot_row == expected_row
+      update_stack({"fail_message" => "Unexpected slot state after upgrade from v#{start_version}: expected #{expected_row.inspect}, got #{slot_row.inspect}"})
       hop_destroy_postgres
     end
 
@@ -238,6 +286,14 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
 
   def read_replica
     @read_replica ||= PostgresResource[frame["read_replica_id"]]
+  end
+
+  def start_version
+    frame["start_version"]
+  end
+
+  def target_version
+    (start_version.to_i + 1).to_s
   end
 
   def pre_upgrade_timeline

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -3,12 +3,23 @@
 class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   semaphore :pause, :destroy
 
-  def self.assemble(provider: "metal", **)
-    super(provider:, project_name: "Postgres-Upgrade-Test-Project", **)
+  def self.assemble(provider: "metal", start_version: "17", **)
+    st = super(provider:, project_name: "Postgres-Upgrade-Test-Project", **)
+    st.update(stack: [st.stack.first.merge("start_version" => start_version)])
+    st
   end
 
   label def start
-    super(name: "postgres-test-upgrade", ha_type: "async", target_version: "17") do |resource, frame|
+    # wal_level=logical needed to create the logical replication slot under test
+    user_config = {"wal_level" => "logical"}
+    if start_version.to_i >= 17
+      # sync_replication_slots is PG17+; PG16 would reject config
+      # hot_standby_feedback=on required on standby for PG17 logical slot sync
+      user_config["sync_replication_slots"] = "on"
+      user_config["hot_standby_feedback"] = "on"
+    end
+
+    super(name: "postgres-test-upgrade-pg#{start_version}", ha_type: "async", target_version: start_version, user_config:) do |resource, frame|
       frame["pre_upgrade_postgres_timeline_id"] = resource.timeline.id
     end
   end
@@ -16,6 +27,45 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   label def wait_postgres_resource
     servers = postgres_resource.servers
     nap 10 if servers.count != postgres_resource.target_server_count || servers.filter { it.strand.label != "wait" }.any?
+    hop_setup_failover_slot
+  end
+
+  label def setup_failover_slot
+    # PG17+ preserves logical slots across pg_upgrade & adds failover plus sync on standbys
+    # PG16 logical slots are dropped by pg_upgrade, still create one to assert upgrade does not hang
+    unless (standby = postgres_resource.servers.find { !it.is_representative })
+      update_stack({"fail_message" => "No standby found to verify failover slot sync"})
+      hop_destroy
+    end
+
+    existing = representative_server.run_query("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").strip
+    if existing.empty?
+      Clog.emit("Creating logical replication slot", {failover: start_version.to_i >= 17})
+      create_sql = if start_version.to_i >= 17
+        "SELECT pg_create_logical_replication_slot('upgrade_test_slot', 'pgoutput', false, false, true)"
+      else
+        "SELECT pg_create_logical_replication_slot('upgrade_test_slot', 'pgoutput', false, false)"
+      end
+      representative_server.run_query(create_sql)
+    end
+
+    # PG16 does not sync replication slots to standbys; skip the wait.
+    hop_test_postgres_before_read_replica if start_version.to_i < 17
+
+    # Idle slot stays temporary on standby; advance it & emit standby snapshots each pass so
+    # restart_lsn passes the standby's reserved point, letting the sync worker persist the slot
+    representative_server.run_query(<<SQL)
+SELECT pg_log_standby_snapshot();
+SELECT pg_replication_slot_advance('upgrade_test_slot', pg_current_wal_lsn());
+SELECT pg_log_standby_snapshot();
+SQL
+
+    synced = standby.run_query("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot' AND synced AND NOT temporary").strip
+    if synced.empty?
+      Clog.emit("Waiting for failover slot sync on standby", {standby: standby.ubid})
+      nap 10
+    end
+
     hop_test_postgres_before_read_replica
   end
 
@@ -38,6 +88,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
       location_id: frame["location_id"],
       parent_id: postgres_resource.id,
       name: "postgres-test-upgrade-replica",
+      target_version: postgres_resource.version,
       target_vm_size: postgres_resource.target_vm_size,
       target_storage_size_gib: postgres_resource.target_storage_size_gib,
       user_config: {},
@@ -73,12 +124,19 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   end
 
   label def trigger_upgrade
-    Clog.emit("Starting upgrade from version 17 to 18")
+    Clog.emit("Starting upgrade from version #{start_version} to #{target_version}")
     Clog.emit("Postgres servers before upgrade: #{postgres_resource.servers.map { [it.ubid, it.version, it.timeline_access, it.strand.label].inspect }.join(", ")}")
     Clog.emit("Read replica servers before upgrade: #{read_replica.servers.map { [it.ubid, it.version, it.timeline_access, it.strand.label].inspect }.join(", ")}")
 
-    postgres_resource.update(target_version: "18")
-    postgres_resource.read_replicas_dataset.update(target_version: "18")
+    # pg_upgrade rejects logical slots with unconsumed (decodable) WAL after confirmed_flush.
+    # Real upgrades rely on the subscriber draining the slot; the test has none, so advance it
+    # to the WAL tip. Convergence waits for the candidate's synced copy to catch up before fencing.
+    if start_version.to_i >= 17
+      representative_server.run_query("SELECT pg_replication_slot_advance('upgrade_test_slot', pg_current_wal_lsn())")
+    end
+
+    postgres_resource.update(target_version:)
+    postgres_resource.read_replicas_dataset.update(target_version:)
 
     hop_check_upgrade_progress
   end
@@ -122,9 +180,9 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
       end
     end
 
-    # Check if all servers have been upgraded to version 18
-    primary_upgraded = postgres_resource.servers.all? { |s| s.version == "18" && s.strand.label == "wait" }
-    replica_upgraded = read_replica.servers.all? { |s| s.version == "18" && s.strand.label == "wait" }
+    # Check if all servers have been upgraded
+    primary_upgraded = postgres_resource.servers.all? { |s| s.version == target_version && s.strand.label == "wait" }
+    replica_upgraded = read_replica.servers.all? { |s| s.version == target_version && s.strand.label == "wait" }
 
     if primary_upgraded && replica_upgraded
       Clog.emit("Upgrade completed successfully!")
@@ -145,19 +203,18 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   end
 
   label def test_postgres_after_upgrade
-    Clog.emit("Testing Postgres after upgrade to version 18")
+    Clog.emit("Testing Postgres after upgrade to version #{target_version}")
     Clog.emit("Final server states:")
     Clog.emit("Primary servers: #{postgres_resource.servers.map { |s| "[#{s.ubid}, v#{s.version}, #{s.timeline_access}, #{s.strand.label}]" }.join(", ")}")
     Clog.emit("Replica servers: #{read_replica.servers.map { |s| "[#{s.ubid}, v#{s.version}, #{s.timeline_access}, #{s.strand.label}]" }.join(", ")}")
 
-    # Verify all servers are at version 18
-    unless postgres_resource.servers.all? { |s| s.version == "18" }
-      update_stack({"fail_message" => "Not all primary servers upgraded to version 18"})
+    unless postgres_resource.servers.all? { |s| s.version == target_version }
+      update_stack({"fail_message" => "Not all primary servers upgraded to version #{target_version}"})
       hop_destroy
     end
 
-    unless read_replica.servers.all? { |s| s.version == "18" }
-      update_stack({"fail_message" => "Not all replica servers upgraded to version 18"})
+    unless read_replica.servers.all? { |s| s.version == target_version }
+      update_stack({"fail_message" => "Not all replica servers upgraded to version #{target_version}"})
       hop_destroy
     end
 
@@ -175,7 +232,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
       hop_destroy
     end
 
-    # Test write queries on primary (should work on v18)
+    # Test write queries on primary
     Clog.emit("Running write queries on primary after upgrade")
     unless representative_server.run_query(test_queries_sql) == "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to run write queries after upgrade"})
@@ -186,6 +243,16 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
     Clog.emit("Verifying replica can read updated data")
     unless read_replica.representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to read updated data on replica after upgrade"})
+      hop_destroy
+    end
+
+    # PG17+ pg_upgrade preserves failover-enabled logical slots
+    # PG16 pg_upgrade drops logical slots, assert slot is gone
+    Clog.emit("Verifying logical slot state after upgrade")
+    slot_row = representative_server.run_query("SELECT failover FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").strip
+    expected_row = (start_version.to_i >= 17) ? "t" : ""
+    unless slot_row == expected_row
+      update_stack({"fail_message" => "Unexpected slot state after upgrade from v#{start_version}: expected #{expected_row.inspect}, got #{slot_row.inspect}"})
       hop_destroy
     end
 
@@ -216,5 +283,13 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
 
   def read_replica
     @read_replica ||= PostgresResource[frame["read_replica_id"]]
+  end
+
+  def start_version
+    frame["start_version"]
+  end
+
+  def target_version
+    (start_version.to_i + 1).to_s
   end
 end

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -34,8 +34,8 @@ configs = configure_hash["configs"].map { |k, v| "#{k} = #{v}" }.join("\n")
 safe_write_to_file("/etc/postgresql/#{v}/main/conf.d/001-service.conf", configs)
 
 # Remove upgrade override file if it exists (set during major version upgrade)
-FileUtils.rm_f("/etc/postgresql/#{v}/main/conf.d/100-upgrade.conf")
-FileUtils.rm_f("/etc/postgresql/#{v}/main/conf.d/101-upgrade.conf")
+upgrade_override = "/etc/postgresql/#{v}/main/conf.d/100-upgrade.conf"
+FileUtils.rm_f(upgrade_override)
 
 # Update postgresql.conf with custom settings
 user_configs = configure_hash["user_config"].map { |k, v| "#{k} = #{v}" }.join("\n")

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -34,8 +34,8 @@ configs = configure_hash["configs"].map { |k, v| "#{k} = #{v}" }.join("\n")
 safe_write_to_file("/etc/postgresql/#{v}/main/conf.d/001-service.conf", configs)
 
 # Remove upgrade override file if it exists (set during major version upgrade)
-upgrade_override = "/etc/postgresql/#{v}/main/conf.d/100-upgrade.conf"
-FileUtils.rm_f(upgrade_override)
+FileUtils.rm_f("/etc/postgresql/#{v}/main/conf.d/100-upgrade.conf")
+FileUtils.rm_f("/etc/postgresql/#{v}/main/conf.d/101-upgrade.conf")
 
 # Update postgresql.conf with custom settings
 user_configs = configure_hash["user_config"].map { |k, v| "#{k} = #{v}" }.join("\n")

--- a/rhizome/postgres/bin/upgrade
+++ b/rhizome/postgres/bin/upgrade
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "json"
 require_relative "../../common/lib/util"
 require_relative "../lib/postgres_upgrade"
 
@@ -9,5 +10,6 @@ if ARGV.count != 1
 end
 
 v = Integer(ARGV[0])
+configure_hash = JSON.parse($stdin.read)
 
-PostgresUpgrade.new(v, Logger.new($stdout)).upgrade
+PostgresUpgrade.new(v, Logger.new($stdout)).upgrade(configure_hash)

--- a/rhizome/postgres/lib/postgres_upgrade.rb
+++ b/rhizome/postgres/lib/postgres_upgrade.rb
@@ -50,14 +50,10 @@ class PostgresUpgrade
     pg_setup.create_cluster
   end
 
-  def count_old_cluster_logical_slots
-    Integer(r("sudo -u postgres psql -t -c \"SELECT count(*) FROM pg_replication_slots WHERE slot_type = 'logical' AND NOT temporary\"").strip, 10)
-  end
-
-  # pg_upgrade requires configuration for preserved logical slots (PG17+)
-  def prepare_new_cluster_for_logical_slots(slot_count)
-    max_slots = [slot_count, 10].max
-    r "echo 'wal_level = logical\nmax_replication_slots = #{max_slots}' | sudo tee /etc/postgresql/#{@version}/main/conf.d/101-upgrade.conf"
+  # pg_upgrade needs user config so settings like wal_level & max_replication_slots are there for preserved logical slots
+  def apply_user_config(user_config)
+    contents = user_config.map { |k, v| "#{k} = #{v}" }.join("\n")
+    safe_write_to_file("/etc/postgresql/#{@version}/main/conf.d/099-user.conf", contents)
   end
 
   def run_check
@@ -106,7 +102,7 @@ class PostgresUpgrade
     end
   end
 
-  def upgrade
+  def upgrade(configure_hash)
     @logger.info("Creating upgrade directory")
     create_upgrade_dir
     @logger.info("Removing WAL-G credentials")
@@ -117,13 +113,10 @@ class PostgresUpgrade
     wait_for_postgres_to_start
     @logger.info("Promoting previous version")
     promote @prev_version
-    logical_slots = count_old_cluster_logical_slots
     @logger.info("Initializing new version")
     initialize_new_version
-    if logical_slots > 0
-      @logger.info("Preparing new cluster for preserved logical slot")
-      prepare_new_cluster_for_logical_slots(logical_slots)
-    end
+    @logger.info("Applying user config to new cluster")
+    apply_user_config(configure_hash["user_config"])
     @logger.info("Running check")
     run_check
     @logger.info("Running pg upgrade")

--- a/rhizome/postgres/lib/postgres_upgrade.rb
+++ b/rhizome/postgres/lib/postgres_upgrade.rb
@@ -50,6 +50,16 @@ class PostgresUpgrade
     pg_setup.create_cluster
   end
 
+  def count_old_cluster_logical_slots
+    Integer(r("sudo -u postgres psql -t -c \"SELECT count(*) FROM pg_replication_slots WHERE slot_type = 'logical' AND NOT temporary\"").strip, 10)
+  end
+
+  # pg_upgrade requires configuration for preserved logical slots (PG17+)
+  def prepare_new_cluster_for_logical_slots(slot_count)
+    max_slots = [slot_count, 10].max
+    r "echo 'wal_level = logical\nmax_replication_slots = #{max_slots}' | sudo tee /etc/postgresql/#{@version}/main/conf.d/101-upgrade.conf"
+  end
+
   def run_check
     run_pg_upgrade_cmd("--check")
   end
@@ -107,8 +117,13 @@ class PostgresUpgrade
     wait_for_postgres_to_start
     @logger.info("Promoting previous version")
     promote @prev_version
+    logical_slots = count_old_cluster_logical_slots
     @logger.info("Initializing new version")
     initialize_new_version
+    if logical_slots > 0
+      @logger.info("Preparing new cluster for preserved logical slot")
+      prepare_new_cluster_for_logical_slots(logical_slots)
+    end
     @logger.info("Running check")
     run_check
     @logger.info("Running pg upgrade")

--- a/rhizome/postgres/lib/postgres_upgrade.rb
+++ b/rhizome/postgres/lib/postgres_upgrade.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../../common/lib/util"
+require_relative "postgres_config"
 require_relative "postgres_setup"
 require_relative "postgres_extensions"
 require "logger"
@@ -51,6 +52,12 @@ class PostgresUpgrade
     pg_setup.create_cluster
   end
 
+  # pg_upgrade needs user config so settings like wal_level & max_replication_slots are there for preserved logical slots
+  # Reuse PostgresConfig.format so quoting matches configure's 099-user.conf
+  def apply_user_config(user_config)
+    safe_write_to_file("/etc/postgresql/#{@version}/main/conf.d/099-user.conf", PostgresConfig.format(user_config))
+  end
+
   def run_check
     run_pg_upgrade_cmd("--check")
   end
@@ -98,7 +105,7 @@ class PostgresUpgrade
     end
   end
 
-  def upgrade
+  def upgrade(configure_hash)
     @logger.info("Creating upgrade directory")
     create_upgrade_dir
     @logger.info("Removing WAL-G credentials")
@@ -111,6 +118,8 @@ class PostgresUpgrade
     promote @prev_version
     @logger.info("Initializing new version")
     initialize_new_version
+    @logger.info("Applying user config to new cluster")
+    apply_user_config(configure_hash["user_config"])
     @logger.info("Running check")
     run_check
     @logger.info("Running pg upgrade")

--- a/rhizome/postgres/spec/postgres_upgrade_spec.rb
+++ b/rhizome/postgres/spec/postgres_upgrade_spec.rb
@@ -99,6 +99,25 @@ RSpec.describe PostgresUpgrade do
     end
   end
 
+  describe "#count_old_cluster_logical_slots" do
+    it "parses the count from psql output" do
+      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c \"SELECT count(*) FROM pg_replication_slots WHERE slot_type = 'logical' AND NOT temporary\"").and_return("   3\n")
+      expect(postgres_upgrade.count_old_cluster_logical_slots).to eq(3)
+    end
+  end
+
+  describe "#prepare_new_cluster_for_logical_slots" do
+    it "writes wal_level=logical and max_replication_slots clamped to at least 10" do
+      expect(postgres_upgrade).to receive(:r).with("echo 'wal_level = logical\nmax_replication_slots = 10' | sudo tee /etc/postgresql/17/main/conf.d/101-upgrade.conf")
+      postgres_upgrade.prepare_new_cluster_for_logical_slots(3)
+    end
+
+    it "raises max_replication_slots above 10 when old cluster has more slots" do
+      expect(postgres_upgrade).to receive(:r).with("echo 'wal_level = logical\nmax_replication_slots = 42' | sudo tee /etc/postgresql/17/main/conf.d/101-upgrade.conf")
+      postgres_upgrade.prepare_new_cluster_for_logical_slots(42)
+    end
+  end
+
   describe "#run_check" do
     it "runs pg_upgrade with --check option" do
       expect(postgres_upgrade).to receive(:run_pg_upgrade_cmd).with("--check")
@@ -200,7 +219,9 @@ RSpec.describe PostgresUpgrade do
       expect(postgres_upgrade).to receive(:disable_archiving).with(16, reload: true).ordered
       expect(postgres_upgrade).to receive(:wait_for_postgres_to_start).ordered
       expect(postgres_upgrade).to receive(:promote).with(16).ordered
+      expect(postgres_upgrade).to receive(:count_old_cluster_logical_slots).and_return(0).ordered
       expect(postgres_upgrade).to receive(:initialize_new_version).ordered
+      expect(postgres_upgrade).not_to receive(:prepare_new_cluster_for_logical_slots)
       expect(postgres_upgrade).to receive(:run_check).ordered
       expect(postgres_upgrade).to receive(:run_pg_upgrade).ordered
       expect(postgres_upgrade).to receive(:disable_archiving).with(17).ordered
@@ -210,6 +231,28 @@ RSpec.describe PostgresUpgrade do
       expect(postgres_upgrade).to receive(:run_post_upgrade_extension_update).ordered
 
       # Mock puts calls
+      allow(postgres_upgrade).to receive(:puts)
+
+      postgres_upgrade.upgrade
+    end
+
+    it "prepares the new cluster for logical slot migration when old cluster has logical slots" do
+      expect(postgres_upgrade).to receive(:create_upgrade_dir).ordered
+      expect(postgres_upgrade).to receive(:remove_walg_credentials).ordered
+      expect(postgres_upgrade).to receive(:disable_archiving).with(16, reload: true).ordered
+      expect(postgres_upgrade).to receive(:wait_for_postgres_to_start).ordered
+      expect(postgres_upgrade).to receive(:promote).with(16).ordered
+      expect(postgres_upgrade).to receive(:count_old_cluster_logical_slots).and_return(2).ordered
+      expect(postgres_upgrade).to receive(:initialize_new_version).ordered
+      expect(postgres_upgrade).to receive(:prepare_new_cluster_for_logical_slots).with(2).ordered
+      expect(postgres_upgrade).to receive(:run_check).ordered
+      expect(postgres_upgrade).to receive(:run_pg_upgrade).ordered
+      expect(postgres_upgrade).to receive(:disable_archiving).with(17).ordered
+      expect(postgres_upgrade).to receive(:enable_new_version).ordered
+      expect(postgres_upgrade).to receive(:wait_for_postgres_to_start).ordered
+      expect(postgres_upgrade).to receive(:run_post_upgrade_scripts).ordered
+      expect(postgres_upgrade).to receive(:run_post_upgrade_extension_update).ordered
+
       allow(postgres_upgrade).to receive(:puts)
 
       postgres_upgrade.upgrade

--- a/rhizome/postgres/spec/postgres_upgrade_spec.rb
+++ b/rhizome/postgres/spec/postgres_upgrade_spec.rb
@@ -99,22 +99,15 @@ RSpec.describe PostgresUpgrade do
     end
   end
 
-  describe "#count_old_cluster_logical_slots" do
-    it "parses the count from psql output" do
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c \"SELECT count(*) FROM pg_replication_slots WHERE slot_type = 'logical' AND NOT temporary\"").and_return("   3\n")
-      expect(postgres_upgrade.count_old_cluster_logical_slots).to eq(3)
-    end
-  end
-
-  describe "#prepare_new_cluster_for_logical_slots" do
-    it "writes wal_level=logical and max_replication_slots clamped to at least 10" do
-      expect(postgres_upgrade).to receive(:r).with("echo 'wal_level = logical\nmax_replication_slots = 10' | sudo tee /etc/postgresql/17/main/conf.d/101-upgrade.conf")
-      postgres_upgrade.prepare_new_cluster_for_logical_slots(3)
+  describe "#apply_user_config" do
+    it "writes user config to 099-user.conf" do
+      expect(postgres_upgrade).to receive(:safe_write_to_file).with("/etc/postgresql/17/main/conf.d/099-user.conf", "wal_level = logical\nmax_replication_slots = 20")
+      postgres_upgrade.apply_user_config({"wal_level" => "logical", "max_replication_slots" => "20"})
     end
 
-    it "raises max_replication_slots above 10 when old cluster has more slots" do
-      expect(postgres_upgrade).to receive(:r).with("echo 'wal_level = logical\nmax_replication_slots = 42' | sudo tee /etc/postgresql/17/main/conf.d/101-upgrade.conf")
-      postgres_upgrade.prepare_new_cluster_for_logical_slots(42)
+    it "writes an empty file when user config is empty" do
+      expect(postgres_upgrade).to receive(:safe_write_to_file).with("/etc/postgresql/17/main/conf.d/099-user.conf", "")
+      postgres_upgrade.apply_user_config({})
     end
   end
 
@@ -214,37 +207,14 @@ RSpec.describe PostgresUpgrade do
 
   describe "#upgrade" do
     it "executes complete upgrade workflow in correct order" do
+      user_config = {"wal_level" => "logical"}
       expect(postgres_upgrade).to receive(:create_upgrade_dir).ordered
       expect(postgres_upgrade).to receive(:remove_walg_credentials).ordered
       expect(postgres_upgrade).to receive(:disable_archiving).with(16, reload: true).ordered
       expect(postgres_upgrade).to receive(:wait_for_postgres_to_start).ordered
       expect(postgres_upgrade).to receive(:promote).with(16).ordered
-      expect(postgres_upgrade).to receive(:count_old_cluster_logical_slots).and_return(0).ordered
       expect(postgres_upgrade).to receive(:initialize_new_version).ordered
-      expect(postgres_upgrade).not_to receive(:prepare_new_cluster_for_logical_slots)
-      expect(postgres_upgrade).to receive(:run_check).ordered
-      expect(postgres_upgrade).to receive(:run_pg_upgrade).ordered
-      expect(postgres_upgrade).to receive(:disable_archiving).with(17).ordered
-      expect(postgres_upgrade).to receive(:enable_new_version).ordered
-      expect(postgres_upgrade).to receive(:wait_for_postgres_to_start).ordered
-      expect(postgres_upgrade).to receive(:run_post_upgrade_scripts).ordered
-      expect(postgres_upgrade).to receive(:run_post_upgrade_extension_update).ordered
-
-      # Mock puts calls
-      allow(postgres_upgrade).to receive(:puts)
-
-      postgres_upgrade.upgrade
-    end
-
-    it "prepares the new cluster for logical slot migration when old cluster has logical slots" do
-      expect(postgres_upgrade).to receive(:create_upgrade_dir).ordered
-      expect(postgres_upgrade).to receive(:remove_walg_credentials).ordered
-      expect(postgres_upgrade).to receive(:disable_archiving).with(16, reload: true).ordered
-      expect(postgres_upgrade).to receive(:wait_for_postgres_to_start).ordered
-      expect(postgres_upgrade).to receive(:promote).with(16).ordered
-      expect(postgres_upgrade).to receive(:count_old_cluster_logical_slots).and_return(2).ordered
-      expect(postgres_upgrade).to receive(:initialize_new_version).ordered
-      expect(postgres_upgrade).to receive(:prepare_new_cluster_for_logical_slots).with(2).ordered
+      expect(postgres_upgrade).to receive(:apply_user_config).with(user_config).ordered
       expect(postgres_upgrade).to receive(:run_check).ordered
       expect(postgres_upgrade).to receive(:run_pg_upgrade).ordered
       expect(postgres_upgrade).to receive(:disable_archiving).with(17).ordered
@@ -255,7 +225,7 @@ RSpec.describe PostgresUpgrade do
 
       allow(postgres_upgrade).to receive(:puts)
 
-      postgres_upgrade.upgrade
+      postgres_upgrade.upgrade({"user_config" => user_config})
     end
   end
 end

--- a/rhizome/postgres/spec/postgres_upgrade_spec.rb
+++ b/rhizome/postgres/spec/postgres_upgrade_spec.rb
@@ -99,6 +99,18 @@ RSpec.describe PostgresUpgrade do
     end
   end
 
+  describe "#apply_user_config" do
+    it "writes user config to 099-user.conf" do
+      expect(postgres_upgrade).to receive(:safe_write_to_file).with("/etc/postgresql/17/main/conf.d/099-user.conf", "wal_level = 'logical'\nmax_replication_slots = '20'")
+      postgres_upgrade.apply_user_config({"wal_level" => "logical", "max_replication_slots" => "20"})
+    end
+
+    it "writes an empty file when user config is empty" do
+      expect(postgres_upgrade).to receive(:safe_write_to_file).with("/etc/postgresql/17/main/conf.d/099-user.conf", "")
+      postgres_upgrade.apply_user_config({})
+    end
+  end
+
   describe "#run_check" do
     it "runs pg_upgrade with --check option" do
       expect(postgres_upgrade).to receive(:run_pg_upgrade_cmd).with("--check")
@@ -195,12 +207,14 @@ RSpec.describe PostgresUpgrade do
 
   describe "#upgrade" do
     it "executes complete upgrade workflow in correct order" do
+      user_config = {"wal_level" => "logical"}
       expect(postgres_upgrade).to receive(:create_upgrade_dir).ordered
       expect(postgres_upgrade).to receive(:remove_walg_credentials).ordered
       expect(postgres_upgrade).to receive(:disable_archiving).with(16, reload: true).ordered
       expect(postgres_upgrade).to receive(:wait_for_postgres_to_start).ordered
       expect(postgres_upgrade).to receive(:promote).with(16).ordered
       expect(postgres_upgrade).to receive(:initialize_new_version).ordered
+      expect(postgres_upgrade).to receive(:apply_user_config).with(user_config).ordered
       expect(postgres_upgrade).to receive(:run_check).ordered
       expect(postgres_upgrade).to receive(:run_pg_upgrade).ordered
       expect(postgres_upgrade).to receive(:disable_archiving).with(17).ordered
@@ -209,10 +223,9 @@ RSpec.describe PostgresUpgrade do
       expect(postgres_upgrade).to receive(:run_post_upgrade_scripts).ordered
       expect(postgres_upgrade).to receive(:run_post_upgrade_extension_update).ordered
 
-      # Mock puts calls
       allow(postgres_upgrade).to receive(:puts)
 
-      postgres_upgrade.upgrade
+      postgres_upgrade.upgrade({"user_config" => user_config})
     end
   end
 end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -188,6 +188,26 @@ RSpec.describe PostgresServer do
       expect(standby).to receive(:incr_planned_take_over)
       expect(postgres_server.trigger_failover(mode: "planned")).to be true
     end
+
+    it "routes upgrade mode through planned take over" do
+      standby = described_class.create(
+        timeline:, resource_id: resource.id, vm_id: create_hosted_vm(project, private_subnet, "standby").id,
+        synchronization_status: "ready", timeline_access: "fetch", version: "16",
+      )
+      expect(postgres_server).to receive(:failover_target).with(mode: "upgrade").and_return(standby)
+      expect(standby).to receive(:incr_planned_take_over)
+      expect(postgres_server.trigger_failover(mode: "upgrade")).to be true
+    end
+
+    it "triggers unplanned take over when mode is unplanned" do
+      standby = described_class.create(
+        timeline:, resource_id: resource.id, vm_id: create_hosted_vm(project, private_subnet, "standby").id,
+        synchronization_status: "ready", timeline_access: "fetch", version: "16",
+      )
+      expect(postgres_server).to receive(:failover_target).with(mode: "unplanned").and_return(standby)
+      expect(standby).to receive(:incr_unplanned_take_over)
+      expect(postgres_server.trigger_failover(mode: "unplanned")).to be true
+    end
   end
 
   it "#read_replica?" do
@@ -292,6 +312,24 @@ RSpec.describe PostgresServer do
       expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
       expect(postgres_server).to receive(:unsynced_logical_failover_slots).with(standby).and_return([])
       expect(postgres_server.failover_target(mode: "planned").ubid).to eq("pgubidstandby1")
+    end
+
+    it "returns standby for upgrade failover when physical_slot_ready_id is nil" do
+      expect(resource).to receive(:servers).and_return([
+        postgres_server,
+        instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: nil, synchronization_status: "ready"),
+      ]).at_least(:once)
+      expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
+      expect(postgres_server).not_to receive(:unsynced_logical_failover_slots)
+      expect(postgres_server.failover_target(mode: "upgrade").ubid).to eq("pgubidstandby1")
+    end
+
+    it "does not query unsynced logical slots for upgrade mode" do
+      standby = instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready")
+      expect(resource).to receive(:servers).and_return([postgres_server, standby]).at_least(:once)
+      expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
+      expect(postgres_server).not_to receive(:unsynced_logical_failover_slots)
+      expect(postgres_server.failover_target(mode: "upgrade").ubid).to eq("pgubidstandby1")
     end
 
     it "prefers standby with physical_slot_ready_id set over higher lsn without" do

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -468,12 +468,12 @@ RSpec.describe PostgresServer do
       expect(postgres_server.unsynced_logical_failover_slots(standby)).to be_empty
     end
 
-    it "returns empty when all primary logical failover slots are synced on standby" do
+    it "returns empty when all primary logical failover slots are synced and caught up on standby" do
       expect(postgres_server).to receive(:read_replica?).and_return(false)
       postgres_server.update(version: "17")
       Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
-      expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("slot1\nslot2")
-      expect(standby.vm.sshable).to receive(:_cmd).and_return("slot1\nslot2")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("slot1,0/100\nslot2,0/200")
+      expect(standby.vm.sshable).to receive(:_cmd).and_return("slot1,0/100\nslot2,0/200")
       expect(postgres_server.unsynced_logical_failover_slots(standby)).to be_empty
     end
 
@@ -481,9 +481,18 @@ RSpec.describe PostgresServer do
       expect(postgres_server).to receive(:read_replica?).and_return(false)
       postgres_server.update(version: "17")
       Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
-      expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("slot1\nslot2")
-      expect(standby.vm.sshable).to receive(:_cmd).and_return("slot1")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("slot1,0/100\nslot2,0/200")
+      expect(standby.vm.sshable).to receive(:_cmd).and_return("slot1,0/100")
       expect(postgres_server.unsynced_logical_failover_slots(standby)).to eq(["slot2"])
+    end
+
+    it "returns slot names whose synced confirmed_flush lags the primary" do
+      expect(postgres_server).to receive(:read_replica?).and_return(false)
+      postgres_server.update(version: "17")
+      Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("slot1,0/200")
+      expect(standby.vm.sshable).to receive(:_cmd).and_return("slot1,0/100")
+      expect(postgres_server.unsynced_logical_failover_slots(standby)).to eq(["slot1"])
     end
   end
 

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -342,6 +342,20 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect { nx.recycle_representative_server }.to nap(60)
       expect(standby.reload.planned_take_over_set?).to be true
     end
+
+    it "uses upgrade mode when primary is fenced (upgrade path)" do
+      server = create_server(is_representative: true)
+      server.incr_recycle
+      server.strand.update(label: "wait_in_fence")
+      standby = create_server(is_representative: false)
+      standby.update(physical_slot_ready_id: server.id)
+      standby_from_assoc = nx.postgres_resource.servers.find { !it.is_representative }
+      expect(standby_from_assoc.vm.sshable).to receive(:_cmd).and_return("0/1234567")
+      # Upgrade mode must not query the fenced primary for logical slot sync.
+      expect(nx.postgres_resource.representative_server).not_to receive(:unsynced_logical_failover_slots)
+      expect { nx.recycle_representative_server }.to nap(60)
+      expect(standby.reload.planned_take_over_set?).to be true
+    end
   end
 
   describe "#wait_for_maintenance_window" do

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -445,7 +445,8 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
     it "starts upgrade when not started" do
       expect(candidate.vm.sshable).to receive(:d_check).with("upgrade_postgres").and_return("NotStarted")
-      expect(candidate.vm.sshable).to receive(:d_run).with("upgrade_postgres", "sudo", "postgres/bin/upgrade", "17")
+      expect(candidate).to receive(:configure_hash).and_return({"user_config" => {"wal_level" => "logical"}})
+      expect(candidate.vm.sshable).to receive(:d_run).with("upgrade_postgres", "sudo", "postgres/bin/upgrade", "17", stdin: JSON.generate({"user_config" => {"wal_level" => "logical"}}))
       expect { nx.upgrade_standby }.to nap(5)
     end
 

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -504,7 +504,8 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
     it "starts upgrade when not started" do
       expect(candidate.vm.sshable).to receive(:d_check).with("upgrade_postgres").and_return("NotStarted")
-      expect(candidate.vm.sshable).to receive(:d_run).with("upgrade_postgres", "sudo", "postgres/bin/upgrade", "17")
+      expect(candidate).to receive(:configure_hash).and_return({"user_config" => {"wal_level" => "logical"}})
+      expect(candidate.vm.sshable).to receive(:d_run).with("upgrade_postgres", "sudo", "postgres/bin/upgrade", "17", stdin: JSON.generate({"user_config" => {"wal_level" => "logical"}}))
       expect { nx.upgrade_standby }.to nap(5)
     end
 

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       expect { aws_pgr_test.start }.to hop("wait_postgres_resource")
       expect(LocationCredentialAws[location.id].access_key).to eq("access_key")
     end
+
+    it "creates a PG16 resource without sync_replication_slots when start_version is 16" do
+      pg16_test = described_class.new(described_class.assemble(start_version: "16"))
+      expect { pg16_test.start }.to hop("wait_postgres_resource")
+      pg = PostgresResource[frame_value(pg16_test, "postgres_resource_id")]
+      expect(pg.version).to eq("16")
+      expect(pg.user_config).not_to include("sync_replication_slots")
+    end
   end
 
   describe "#wait_postgres_resource" do
@@ -57,11 +65,49 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       expect { pgr_test.wait_postgres_resource }.to nap(10)
     end
 
-    it "hops to test_postgres_before_read_replica if the postgres resource is ready" do
+    it "hops to setup_failover_slot if the postgres resource is ready" do
       pg = pgr_test.postgres_resource
       Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg.id, timeline_id: pg.timeline.id, timeline_access: "fetch")
       pg.servers.each { |server| server.strand.update(label: "wait") }
-      expect { pgr_test.wait_postgres_resource }.to hop("test_postgres_before_read_replica")
+      expect { pgr_test.wait_postgres_resource }.to hop("setup_failover_slot")
+    end
+  end
+
+  describe "#setup_failover_slot" do
+    before do
+      pg_strand = Prog::Postgres::PostgresResourceNexus.assemble(project_id: pgr_test.frame["postgres_test_project_id"], location_id: Location::HETZNER_FSN1_ID, name: "test-pg", target_vm_size: "standard-2", target_storage_size_gib: 128, ha_type: "async", target_version: "17")
+      Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg_strand.id, timeline_id: PostgresResource[pg_strand.id].timeline.id, timeline_access: "fetch")
+      refresh_frame(pgr_test, new_values: {"postgres_resource_id" => pg_strand.id})
+    end
+
+    it "creates the slot and naps while the standby has not synced yet" do
+      standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot/).and_return("upgrade_test_slot")
+      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("")
+      expect { pgr_test.setup_failover_slot }.to nap(10)
+    end
+
+    it "hops to test_postgres_before_read_replica once the slot is synced on the standby" do
+      standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("1")
+      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("1")
+      expect { pgr_test.setup_failover_slot }.to hop("test_postgres_before_read_replica")
+    end
+
+    it "fails if no standby exists" do
+      pgr_test.postgres_resource.servers.reject(&:is_representative).each(&:destroy)
+      pgr_test.postgres_resource.reload
+      expect { pgr_test.setup_failover_slot }.to hop("destroy_postgres")
+      refresh_frame(pgr_test)
+      expect(frame_value(pgr_test, "fail_message")).to eq("No standby found to verify failover slot sync")
+    end
+
+    it "creates a non-failover slot and skips sync wait for PG16" do
+      refresh_frame(pgr_test, new_values: {"start_version" => "16"})
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot\('upgrade_test_slot', 'pgoutput', false, false\)\Z/).and_return("upgrade_test_slot")
+      expect { pgr_test.setup_failover_slot }.to hop("test_postgres_before_read_replica")
     end
   end
 
@@ -334,11 +380,41 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
 
     it "hops to destroy_postgres if all tests pass" do
-      allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1")
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1", "t")
       allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "4159.90\n415.99\n4.1")
       expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy_postgres")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to be_nil
+    end
+
+    it "fails if the failover slot is missing after PG17+ upgrade" do
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1", "")
+      allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "4159.90\n415.99\n4.1")
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy_postgres")
+      refresh_frame(pgr_test)
+      expect(frame_value(pgr_test, "fail_message")).to start_with("Unexpected slot state")
+    end
+
+    it "passes when PG16 upgrade drops the logical slot" do
+      refresh_frame(pgr_test, new_values: {"start_version" => "16"})
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1", "")
+      allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "4159.90\n415.99\n4.1")
+      pgr_test.postgres_resource.servers.each { |s| s.update(version: "17") }
+      pgr_test.read_replica.servers.each { |s| s.update(version: "17") }
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy_postgres")
+      refresh_frame(pgr_test)
+      expect(frame_value(pgr_test, "fail_message")).to be_nil
+    end
+
+    it "fails when PG16 upgrade leaves a slot that should have been dropped" do
+      refresh_frame(pgr_test, new_values: {"start_version" => "16"})
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1", "f")
+      allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "4159.90\n415.99\n4.1")
+      pgr_test.postgres_resource.servers.each { |s| s.update(version: "17") }
+      pgr_test.read_replica.servers.each { |s| s.update(version: "17") }
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy_postgres")
+      refresh_frame(pgr_test)
+      expect(frame_value(pgr_test, "fail_message")).to start_with("Unexpected slot state")
     end
   end
 

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -132,6 +132,14 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       expect { aws_pgr_test.start }.to hop("wait_postgres_resource")
       expect(LocationCredentialAws[location.id].access_key).to eq("access_key")
     end
+
+    it "creates a PG16 resource without sync_replication_slots when start_version is 16" do
+      pg16_test = described_class.new(described_class.assemble(start_version: "16"))
+      expect { pg16_test.start }.to hop("wait_postgres_resource")
+      pg = PostgresResource[frame_value(pg16_test, "postgres_resource_id")]
+      expect(pg.version).to eq("16")
+      expect(pg.user_config).not_to include("sync_replication_slots")
+    end
   end
 
   describe "#wait_postgres_resource" do
@@ -144,11 +152,51 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       expect { pgr_test.wait_postgres_resource }.to nap(10)
     end
 
-    it "hops to test_postgres_before_read_replica if the postgres resource is ready" do
+    it "hops to setup_failover_slot if the postgres resource is ready" do
       pg = pgr_test.postgres_resource
       Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg.id, timeline_id: pg.timeline.id, timeline_access: "fetch")
       pg.servers.each { |server| server.strand.update(label: "wait") }
-      expect { pgr_test.wait_postgres_resource }.to hop("test_postgres_before_read_replica")
+      expect { pgr_test.wait_postgres_resource }.to hop("setup_failover_slot")
+    end
+  end
+
+  describe "#setup_failover_slot" do
+    before do
+      pg_strand = Prog::Postgres::PostgresResourceNexus.assemble(project_id: pgr_test.frame["postgres_test_project_id"], location_id: Location::HETZNER_FSN1_ID, name: "test-pg", target_vm_size: "standard-2", target_storage_size_gib: 128, ha_type: "async", target_version: "17")
+      Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg_strand.id, timeline_id: PostgresResource[pg_strand.id].timeline.id, timeline_access: "fetch")
+      refresh_frame(pgr_test, new_values: {"postgres_resource_id" => pg_strand.id})
+    end
+
+    it "creates the slot and naps while the standby has not synced yet" do
+      standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot/).and_return("upgrade_test_slot")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
+      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("")
+      expect { pgr_test.setup_failover_slot }.to nap(10)
+    end
+
+    it "hops to test_postgres_before_read_replica once the slot is synced on the standby" do
+      standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("1")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
+      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("1")
+      expect { pgr_test.setup_failover_slot }.to hop("test_postgres_before_read_replica")
+    end
+
+    it "fails if no standby exists" do
+      pgr_test.postgres_resource.servers.reject(&:is_representative).each(&:destroy)
+      pgr_test.postgres_resource.reload
+      expect { pgr_test.setup_failover_slot }.to hop("destroy")
+      refresh_frame(pgr_test)
+      expect(frame_value(pgr_test, "fail_message")).to eq("No standby found to verify failover slot sync")
+    end
+
+    it "creates a non-failover slot and skips sync wait for PG16" do
+      refresh_frame(pgr_test, new_values: {"start_version" => "16"})
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot\('upgrade_test_slot', 'pgoutput', false, false\)\Z/).and_return("upgrade_test_slot")
+      expect { pgr_test.setup_failover_slot }.to hop("test_postgres_before_read_replica")
     end
   end
 
@@ -243,11 +291,22 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
 
     it "updates target_version to 18 and hops to check_upgrade_progress" do
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
       expect { pgr_test.trigger_upgrade }.to hop("check_upgrade_progress")
       pgr_test.postgres_resource.reload
       pgr_test.read_replica.reload
       expect(pgr_test.postgres_resource.target_version).to eq("18")
       expect(pgr_test.read_replica.target_version).to eq("18")
+    end
+
+    it "skips slot advance when start_version is below 17" do
+      refresh_frame(pgr_test, new_values: {"start_version" => "16"})
+      expect(pgr_test.representative_server).not_to receive(:_run_query)
+      expect { pgr_test.trigger_upgrade }.to hop("check_upgrade_progress")
+      pgr_test.postgres_resource.reload
+      pgr_test.read_replica.reload
+      expect(pgr_test.postgres_resource.target_version).to eq("17")
+      expect(pgr_test.read_replica.target_version).to eq("17")
     end
   end
 
@@ -421,11 +480,41 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
 
     it "hops to destroy if all tests pass" do
-      allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1")
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1", "t")
       allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "4159.90\n415.99\n4.1")
       expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to be_nil
+    end
+
+    it "fails if the failover slot is missing after PG17+ upgrade" do
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1", "")
+      allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "4159.90\n415.99\n4.1")
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy")
+      refresh_frame(pgr_test)
+      expect(frame_value(pgr_test, "fail_message")).to start_with("Unexpected slot state")
+    end
+
+    it "passes when PG16 upgrade drops the logical slot" do
+      refresh_frame(pgr_test, new_values: {"start_version" => "16"})
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1", "")
+      allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "4159.90\n415.99\n4.1")
+      pgr_test.postgres_resource.servers.each { |s| s.update(version: "17") }
+      pgr_test.read_replica.servers.each { |s| s.update(version: "17") }
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy")
+      refresh_frame(pgr_test)
+      expect(frame_value(pgr_test, "fail_message")).to be_nil
+    end
+
+    it "fails when PG16 upgrade leaves a slot that should have been dropped" do
+      refresh_frame(pgr_test, new_values: {"start_version" => "16"})
+      allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1", "f")
+      allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "4159.90\n415.99\n4.1")
+      pgr_test.postgres_resource.servers.each { |s| s.update(version: "17") }
+      pgr_test.read_replica.servers.each { |s| s.update(version: "17") }
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy")
+      refresh_frame(pgr_test)
+      expect(frame_value(pgr_test, "fail_message")).to start_with("Unexpected slot state")
     end
   end
 


### PR DESCRIPTION
Logical failover slots are unsynced until standby catches up:
unsynced_logical_failover_slots compared only slot names between primary
& standby, counting a slot as synced the moment its name appeared on the
standby. But a synced slot's confirmed_flush_lsn on the standby needs to
catch up. When such a standby is promoted during an upgrade, pg_upgrade
rejects the slot for pending WAL past confirmed_flush, failing upgrade

New database started without user_config, so wal_level &
max_replication_slots were missing. Pipe configure_hash to bin/upgrade
so 099-user.conf exists before running pg_upgrade

Add e2e test for this

Followup to #5284