### PR TITLE
Stop cloudflared at end of e2e job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -309,6 +309,10 @@ jobs:
       if: ${{ failure() && github.ref_name == 'main' }}
       run: sleep 600
 
+    - name: Stop cloudflared
+      if: always()
+      run: sudo systemctl stop cloudflared || true
+
     - name: Cleanup AWS resources
       if: always() && matrix.provider == 'aws'
       env:


### PR DESCRIPTION
We assumed the cloudflared service would stop when the runner VM was destroyed after the job finished. That assumption breaks when a developer increments prevent_destroy on the runner VM to debug an e2e issue: the VM survives, and so does its cloudflared connector. Subsequent e2e runs then install another connector for the same public address, so traffic gets routed to one of several live connectors at random, making the tests flaky and the debugging session unusable.

Stop the service explicitly at the end of the job. The step runs with if: always() so it fires regardless of test outcome, and uses || true so it is a no-op on matrix entries that never installed cloudflared (only github_runner cases do) or when the service is already stopped.