### PR TITLE
Remove test_slices option in e2e

### DIFF
--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -3,14 +3,13 @@
 require_relative "../../lib/net_ssh"
 
 class Prog::Test::VmGroup < Prog::Test::Base
-  def self.assemble(boot_images:, test_reboot: true, test_slices: false, verify_host_capacity: true)
+  def self.assemble(boot_images:, test_reboot: true, verify_host_capacity: true)
     Strand.create(
       prog: "Test::VmGroup",
       label: "start",
       stack: [{
         "test_reboot" => test_reboot,
         "first_boot" => true,
-        "test_slices" => test_slices,
         "vms" => [],
         "boot_images" => boot_images,
         "verify_host_capacity" => verify_host_capacity,
@@ -24,9 +23,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
 
   label def setup_vms
     project = Project.create(name: "project-1")
-    test_slices = frame.fetch("test_slices")
-
-    size_options = test_slices ? ["standard-2", "burstable-1"] : ["standard-2"]
+    size_options = ["standard-2", "burstable-1"]
     subnets = Array.new(2) { Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-#{it}", location_id: Location::HETZNER_FSN1_ID) }
     encrypted = true
     boot_images = frame.fetch("boot_images")

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -31,23 +31,11 @@ RSpec.describe Prog::Test::VmGroup do
     it "provisions at least one vm for each boot image" do
       expect(vg_test).to receive(:update_stack).and_call_original
       refresh_frame(vg_test, new_values: {
-        "test_slices" => true,
         "boot_images" => ["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"],
       })
       expect { vg_test.setup_vms }.to hop("wait_vms")
       vm_images = vg_test.strand.stack.first["vms"].map { Vm[it].boot_image }
       expect(vm_images).to eq(["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"])
-    end
-
-    it "hops to wait_vms if test_slices" do
-      expect(vg_test).to receive(:update_stack).and_call_original
-      refresh_frame(vg_test, new_values: {
-        "test_reboot" => true,
-        "test_slices" => true,
-        "vms" => [],
-        "boot_images" => ["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"],
-      })
-      expect { vg_test.setup_vms }.to hop("wait_vms")
     end
   end
 


### PR DESCRIPTION
All new hosts use slices and we only pass it as true in tests. So it's not required anymore.