### PR TITLE
Wait for logical failover slot sync before fencing upgrade primary

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -265,9 +265,12 @@ class PostgresServer < Sequel::Model
     target[:server]
   end
 
-  # PG17+: returns logical failover slot names from primary not yet synced on standby
+  # PG17+: returns logical failover slot names from primary not yet synced on standby.
+  # Returns [] when the primary is fenced (stopped). Callers relying on this during
+  # a fenced-primary failover (e.g. upgrade) must verify sync before the fence.
   def unsynced_logical_failover_slots(standby)
     return [] if read_replica? || version.to_i < 17
+    return [] if strand.label == "wait_in_fence"
 
     primary_slot_names = run_query("SELECT slot_name FROM pg_replication_slots WHERE slot_type = 'logical' AND failover").split("\n")
     return [] if primary_slot_names.empty?

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -60,6 +60,14 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
     # recycle servers, which are provisioned at the target version instead of
     # the current version.
     if postgres_resource.version != postgres_resource.target_version && !postgres_resource.read_replica?
+      # Verify logical failover slots are synced to the upgrade candidate before
+      # fencing. Once the primary is stopped we can no longer query its slot
+      # list, so failover_target's planned-mode sync check becomes a no-op.
+      missing = postgres_resource.representative_server.unsynced_logical_failover_slots(upgrade_candidate)
+      unless missing.empty?
+        Clog.emit("Upgrade waiting for logical slot sync", {resource_id: postgres_resource.id, missing_slots: missing})
+        nap 30
+      end
       postgres_resource.representative_server.incr_fence
       hop_wait_fence_primary
     end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -319,9 +319,18 @@ RSpec.describe PostgresServer do
       expect(postgres_server.unsynced_logical_failover_slots(standby)).to be_empty
     end
 
+    it "returns empty when primary is fenced (avoids querying a stopped server)" do
+      expect(postgres_server).to receive(:read_replica?).and_return(false)
+      postgres_server.update(version: "17")
+      Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait_in_fence")
+      expect(postgres_server.vm.sshable).not_to receive(:_cmd)
+      expect(postgres_server.unsynced_logical_failover_slots(standby)).to be_empty
+    end
+
     it "returns empty when primary has no logical failover slots" do
       expect(postgres_server).to receive(:read_replica?).and_return(false)
       postgres_server.update(version: "17")
+      Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
       expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("")
       expect(postgres_server.unsynced_logical_failover_slots(standby)).to be_empty
     end
@@ -329,6 +338,7 @@ RSpec.describe PostgresServer do
     it "returns empty when all primary logical failover slots are synced on standby" do
       expect(postgres_server).to receive(:read_replica?).and_return(false)
       postgres_server.update(version: "17")
+      Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
       expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("slot1\nslot2")
       expect(standby.vm.sshable).to receive(:_cmd).and_return("slot1\nslot2")
       expect(postgres_server.unsynced_logical_failover_slots(standby)).to be_empty
@@ -337,6 +347,7 @@ RSpec.describe PostgresServer do
     it "returns missing slot names when standby is missing a synced logical slot" do
       expect(postgres_server).to receive(:read_replica?).and_return(false)
       postgres_server.update(version: "17")
+      Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
       expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("slot1\nslot2")
       expect(standby.vm.sshable).to receive(:_cmd).and_return("slot1")
       expect(postgres_server.unsynced_logical_failover_slots(standby)).to eq(["slot2"])

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -363,9 +363,19 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
     it "fences primary and hops to wait_fence_primary if in maintenance window and upgrading" do
       server = create_server(is_representative: true, version: "16")
-      create_server(version: "16", upgrade_candidate: true)
+      candidate = create_server(version: "16", upgrade_candidate: true)
+      expect(nx.postgres_resource.representative_server).to receive(:unsynced_logical_failover_slots).with(candidate).and_return([])
       expect { nx.wait_for_maintenance_window }.to hop("wait_fence_primary")
       expect(server.reload.fence_set?).to be true
+    end
+
+    it "naps without fencing when upgrade candidate has unsynced logical failover slots" do
+      server = create_server(is_representative: true, version: "16")
+      candidate = create_server(version: "16", upgrade_candidate: true)
+      expect(nx.postgres_resource.representative_server).to receive(:unsynced_logical_failover_slots).with(candidate).and_return(["slot1"])
+      expect(Clog).to receive(:emit).with("Upgrade waiting for logical slot sync", hash_including(missing_slots: ["slot1"]))
+      expect { nx.wait_for_maintenance_window }.to nap(30)
+      expect(server.reload.fence_set?).to be false
     end
 
     it "hops to recycle_representative_server if in maintenance window and upgrading for read replicas" do


### PR DESCRIPTION
The upgrade path in ConvergePostgresResource fences the primary and then later calls trigger_failover(mode: "planned") on it. We recently changed failover_target to check unsynced logical failover slots, which queries pg_replication_slots on the primary, but the primary is already fenced, causing an SshError and blocking the upgrade.

Move the slot-sync check to just before the fence, while the primary is still up and queryable. The helper now short-circuits to [] when the primary's strand is in wait_in_fence, since the invariant has already been established.