### PR TITLE
Add more columns to runner usage table

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1065,15 +1065,28 @@ class CloverAdmin < Roda
       premium_sizes = [2, 4, 8, 16, 30]
       alien_sizes = [2, 4, 8, 16]
 
+      quota_default = ProjectQuota.default_quotas[(@arch == "arm64") ? "GithubRunnerVCpuArm" : "GithubRunnerVCpu"]
+      quota_expr = Sequel.function(
+        :coalesce,
+        Sequel[:pq][:value],
+        Sequel.case(
+          {"new" => quota_default["new_value"], "verified" => quota_default["verified_value"], "limited" => quota_default["limited_value"]},
+          nil,
+          Sequel[:p][:reputation],
+        ),
+      )
+
       @data = DB.from(runners.as(:r))
         .left_join(Sequel[:github_installation].as(:i), id: Sequel[:r][:installation_id])
         .left_join(Sequel[:project].as(:p), id: Sequel[:i][:project_id])
+        .left_join(Sequel[:project_quota].as(:pq), project_id: Sequel[:p][:id], quota_id: quota_default["id"])
         .left_join(Sequel[:vm].as(:v), id: Sequel[:r][:vm_id])
         .select(
           Sequel[:i][:id],
           Sequel[:i][:name],
           Sequel.pg_jsonb(Sequel[:i][:allocator_preferences]).get("family_filter").contains(["premium"]).as(:premium),
           Sequel.cast(Sequel.pg_jsonb_op(Sequel[:p][:feature_flags]).get_text("spill_to_alien_runners"), :boolean).as(:spill),
+          quota_expr.as(:quota),
         )
         .select_append(
           *standard_sizes.map { count_f.call(r_vcpus => it).as(:"r#{it}") },
@@ -1087,7 +1100,7 @@ class CloverAdmin < Roda
           *premium_sizes.map { count_f.call(v_family => "premium", v_vcpus => it).as(:"p#{it}") },
           *alien_sizes.map { count_f.call(v_family.like("m%") & Sequel.expr(v_vcpus => it)).as(:"a#{it}") },
         )
-        .group(Sequel[:i][:id], Sequel[:i][:name], :premium, :spill)
+        .group(Sequel[:i][:id], Sequel[:i][:name], :premium, :spill, :quota)
         .reverse(:runner_vcpus, :vm_vcpus)
         .all
 

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1067,11 +1067,13 @@ class CloverAdmin < Roda
 
       @data = DB.from(runners.as(:r))
         .left_join(Sequel[:github_installation].as(:i), id: Sequel[:r][:installation_id])
+        .left_join(Sequel[:project].as(:p), id: Sequel[:i][:project_id])
         .left_join(Sequel[:vm].as(:v), id: Sequel[:r][:vm_id])
         .select(
           Sequel[:i][:id],
           Sequel[:i][:name],
           Sequel.pg_jsonb(Sequel[:i][:allocator_preferences]).get("family_filter").contains(["premium"]).as(:premium),
+          Sequel.cast(Sequel.pg_jsonb_op(Sequel[:p][:feature_flags]).get_text("spill_to_alien_runners"), :boolean).as(:spill),
         )
         .select_append(
           *standard_sizes.map { count_f.call(r_vcpus => it).as(:"r#{it}") },
@@ -1085,7 +1087,7 @@ class CloverAdmin < Roda
           *premium_sizes.map { count_f.call(v_family => "premium", v_vcpus => it).as(:"p#{it}") },
           *alien_sizes.map { count_f.call(v_family.like("m%") & Sequel.expr(v_vcpus => it)).as(:"a#{it}") },
         )
-        .group(Sequel[:i][:id], Sequel[:i][:name], :premium)
+        .group(Sequel[:i][:id], Sequel[:i][:name], :premium, :spill)
         .reverse(:runner_vcpus, :vm_vcpus)
         .all
 

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1084,7 +1084,7 @@ class CloverAdmin < Roda
         .select(
           Sequel[:i][:id],
           Sequel[:i][:name],
-          Sequel.pg_jsonb(Sequel[:i][:allocator_preferences]).get("family_filter").contains(["premium"]).as(:premium),
+          Sequel.pg_jsonb(Sequel[:i][:allocator_preferences]).get("family_filter").contains(["premium"]).as(:prem),
           Sequel.cast(Sequel.pg_jsonb_op(Sequel[:p][:feature_flags]).get_text("spill_to_alien_runners"), :boolean).as(:spill),
           quota_expr.as(:quota),
         )
@@ -1100,7 +1100,7 @@ class CloverAdmin < Roda
           *premium_sizes.map { count_f.call(v_family => "premium", v_vcpus => it).as(:"p#{it}") },
           *alien_sizes.map { count_f.call(v_family.like("m%") & Sequel.expr(v_vcpus => it)).as(:"a#{it}") },
         )
-        .group(Sequel[:i][:id], Sequel[:i][:name], :premium, :spill, :quota)
+        .group(Sequel[:i][:id], Sequel[:i][:name], :prem, :spill, :quota)
         .reverse(:runner_vcpus, :vm_vcpus)
         .all
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1471,7 +1471,9 @@ RSpec.describe CloverAdmin do
   end
 
   it "shows GitHub runner x64 VM usage" do
-    installation = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User")
+    project = Project.create(name: "test-project")
+    project.add_quota(quota_id: ProjectQuota.default_quotas["GithubRunnerVCpu"]["id"], value: 400)
+    installation = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User", project_id: project.id)
     installation_id = installation.id
     repository_name = "test-repo"
     GithubRunner.create(installation_id:, repository_name:, label: "ubicloud", allocated_at: Time.now)
@@ -1485,13 +1487,13 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - GitHub Runner x64 VM Usage"
     expect(page).to have_link "Show arm64"
     expect(page.all("#content td").map(&:text)).to eq [
-      "TOTAL", "",
+      "TOTAL", "", "", "400",
       "2", "1", "1", "0", "1", "0",
       "16 / 46", "2 / 14",
       "1", "0", "0", "0", "0", "0",
       "0", "1", "0", "0", "0",
       "0", "0", "1", "0",
-      "test-installation", "true",
+      "test-installation", "true", "", "400",
       "2", "1", "1", "0", "1", "0",
       "16 / 46", "2 / 14",
       "1", "0", "0", "0", "0", "0",
@@ -1507,7 +1509,8 @@ RSpec.describe CloverAdmin do
     click_link "GitHub Runner VM Usage"
     expect(page.all("#content td").map(&:text)).to eq []
 
-    installation = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User")
+    project = Project.create(name: "test-project")
+    installation = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User", project_id: project.id)
     GithubRunner.create(installation_id: installation.id, repository_name: "test-repo", label: "ubicloud-arm")
     GithubRunner.create(installation_id: installation.id, repository_name: "test-repo", label: "ubicloud")
 
@@ -1516,13 +1519,13 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - GitHub Runner arm64 VM Usage"
     expect(page).to have_link "Show x64"
     expect(page.all("#content td").map(&:text)).to eq [
-      "TOTAL", "",
+      "TOTAL", "", "", "100",
       "1", "0", "0", "0", "0", "0",
       "0 / 2", "0 / 0",
       "0", "0", "0", "0", "0", "0",
       "0", "0", "0", "0", "0",
       "0", "0", "0", "0",
-      "test-installation", "true",
+      "test-installation", "true", "", "100",
       "1", "0", "0", "0", "0", "0",
       "0 / 2", "0 / 0",
       "0", "0", "0", "0", "0", "0",

--- a/views/admin/github_runner_usage.erb
+++ b/views/admin/github_runner_usage.erb
@@ -25,6 +25,8 @@ end
   Whether premium runners are enabled. Even when enabled, runners can still fall back to standard.</p>
 <p><strong>spill:</strong>
   Whether the spill_to_alien_runners feature flag is enabled for the project.</p>
+<p><strong>quota:</strong>
+  Effective GithubRunnerVCpu quota for the project.</p>
 <p><strong>r*:</strong>
   Number of requested runners with the specified vCPU count.</p>
 <p><strong>runner_vcpus:</strong>

--- a/views/admin/github_runner_usage.erb
+++ b/views/admin/github_runner_usage.erb
@@ -12,7 +12,7 @@ end
 types.each do |type|
   total[:"#{type}_vcpus"] = "#{total.delete(:"allocated_#{type}_vcpus")} / #{total[:"#{type}_vcpus"]}"
 end
-@data.prepend({name: "TOTAL", premium: "", spill: "", **total}) if @data.any? %>
+@data.prepend({name: "TOTAL", prem: "", spill: "", **total}) if @data.any? %>
 
 <%== part("components/table", title: nil, table_class: "github-runner-usage-table", data: @data, use_admin_label: false) %>
 
@@ -21,7 +21,7 @@ end
     <%= other_arch %></a></h3>
 
 <h3>Columns</h3>
-<p><strong>premium:</strong>
+<p><strong>prem:</strong>
   Whether premium runners are enabled. Even when enabled, runners can still fall back to standard.</p>
 <p><strong>spill:</strong>
   Whether the spill_to_alien_runners feature flag is enabled for the project.</p>

--- a/views/admin/github_runner_usage.erb
+++ b/views/admin/github_runner_usage.erb
@@ -12,7 +12,7 @@ end
 types.each do |type|
   total[:"#{type}_vcpus"] = "#{total.delete(:"allocated_#{type}_vcpus")} / #{total[:"#{type}_vcpus"]}"
 end
-@data.prepend({name: "TOTAL", premium: "", **total}) if @data.any? %>
+@data.prepend({name: "TOTAL", premium: "", spill: "", **total}) if @data.any? %>
 
 <%== part("components/table", title: nil, table_class: "github-runner-usage-table", data: @data, use_admin_label: false) %>
 
@@ -23,6 +23,8 @@ end
 <h3>Columns</h3>
 <p><strong>premium:</strong>
   Whether premium runners are enabled. Even when enabled, runners can still fall back to standard.</p>
+<p><strong>spill:</strong>
+  Whether the spill_to_alien_runners feature flag is enabled for the project.</p>
 <p><strong>r*:</strong>
   Number of requested runners with the specified vCPU count.</p>
 <p><strong>runner_vcpus:</strong>


### PR DESCRIPTION
- **Show spill_to_alien_runners flag in runner usage table**
  The spill_to_alien_runners feature flag controls whether a project's
  GitHub runners can spill over to AWS alien runners under sustained
  high utilization. Surface it as a "spill" column in the admin GitHub
  runner usage table so operators can see which installations have the
  flag enabled without opening each project individually.
  
  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
  

- **Show GithubRunnerVCpu quota in runner usage table**
  When an installation hits its concurrency limit, the runner_vcpus
  column shows allocated vs. requested vCPUs but not the cap driving
  the limit. Surface the effective GithubRunnerVCpu quota (or
  GithubRunnerVCpuArm on the arm64 page) as a "quota" column in the
  admin GitHub runner usage table so operators can see at a glance
  whether a backlog is caused by the project hitting its quota.
  
  The quota is computed in SQL mirroring Project#effective_quota_value:
  COALESCE the project_quota override with the reputation-tier default
  from config/default_quotas.yml.
  
  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
  

- **Abbreviate premium column to prem in runner usage table**
  The admin GitHub runner usage table is already wide, and "premium"
  is the longest non-vcpus header. Shorten it to "prem" to tighten
  the layout; the column doc still spells out the full meaning.
  
  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
  