### PR TITLE
Don't increment storage_auto_scale_not_cancellable redundantly

### DIFF
--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -130,7 +130,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
 
       # Acquire advisory lock to prevent race with cancel_storage_auto_scale
       nap 5 unless DB.get(Sequel.function(:pg_try_advisory_xact_lock, postgres_resource.storage_auto_scale_lock_key))
-      postgres_resource.incr_storage_auto_scale_not_cancellable
+      postgres_resource.incr_storage_auto_scale_not_cancellable unless postgres_resource.storage_auto_scale_not_cancellable_set?
 
       register_deadline(nil, 10 * 60)
       postgres_resource.representative_server.trigger_failover(mode: "planned")

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -330,6 +330,16 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect { nx.recycle_representative_server }.to nap(5)
     end
 
+    it "does not increment storage_auto_scale_not_cancellable redundantly" do
+      server = create_server(is_representative: true)
+      server.incr_recycle
+      create_server(is_representative: false)
+      expect { nx.recycle_representative_server }.to nap(60)
+      nx.postgres_resource.reload # break semaphores cache
+      expect { nx.recycle_representative_server }.to nap(60)
+      expect(nx.postgres_resource.reload.semaphores.count { it.name == "storage_auto_scale_not_cancellable" }).to eq(1)
+    end
+
     it "triggers failover when representative needs recycling and standby is ready" do
       server = create_server(is_representative: true)
       server.incr_recycle


### PR DESCRIPTION
We had a stuck failover that collected 474 of these