### PR TITLE
Refuse to destroy representative server of an alive resource

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -86,7 +86,12 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
 
       if is_destroying || !postgres_server.taking_over?
         if !%w[destroy wait_children_destroy destroy_vm_and_pg].include?(strand.label)
-          hop_destroy
+          if postgres_server.is_representative && resource && !resource.destroy_set? && !resource.destroying_set?
+            Clog.emit("Postgres server deletion is cancelled, because it is the representative server of an alive resource; flip is_representative=false (via a proper failover) before destroying.", {ubid: postgres_server.ubid, resource_ubid: resource.ubid})
+            decr_destroy
+          else
+            hop_destroy
+          end
         elsif strand.stack.count > 1
           pop "operation is cancelled due to the destruction of the postgres server"
         end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -182,6 +182,19 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(Semaphore.where(strand_id: postgres_server.id, name: "destroy").count).to eq(0)
     end
 
+    it "cancels the destroy if the server is the representative of an alive resource" do
+      nx.incr_destroy
+      expect(Clog).to receive(:emit).with(/representative server of an alive resource/, hash_including(ubid: postgres_server.ubid))
+      expect { nx.before_run }.not_to hop("destroy")
+      expect(Semaphore.where(strand_id: postgres_server.id, name: "destroy").count).to eq(0)
+    end
+
+    it "allows destroy of a representative server when the resource itself is being destroyed" do
+      postgres_server.resource.incr_destroying
+      nx.incr_destroy
+      expect { nx.before_run }.to hop("destroy")
+    end
+
     it "pops additional operations from stack" do
       postgres_server.resource.strand.update(label: "destroy")
       nx.strand.update(label: "destroy", stack: [{"link" => ["Postgres::PostgresServerNexus", "wait"]}, {}])


### PR DESCRIPTION
A stuck unplanned failover on staging was mitigated by calling incr_destroy directly on the old primary (still is_representative=true) and on the taking-over standby. PostgresServerNexus#before_run happily hopped both into destroy, after which postgres_server.destroy removed the only rows whose is_representative column was true. The resource was left with representative_server = nil, which then 500s every list endpoint (Serializers::Postgres dereferences representative_server.* for each row), breaking list-instances across the whole control plane.

Add a guard in before_run: if the server is is_representative and its resource is still alive (destroy / destroying semaphores not set on the resource), cancel the destroy with a Clog.emit instead of hopping. Operators need to either destroy the resource, perform a proper failover, or flip is_representative=false first.

Legitimate callers keep working unchanged:

- Resource-level destroy: wait_children_destroyed calls servers.each(&:incr_destroy) after hop_destroy has already set the destroying semaphore on the resource, so the guard does not fire.
- Planned/unplanned takeover (Succeeded branch) flips the old primary's is_representative to false before incr_destroy, so the guard does not fire on the subsequent before_run.
- prune_servers destroys only non-representative servers.