### PR TITLE
Allow ubi_replication access to postgres db in lockout pg_hba

### DIFF
--- a/rhizome/postgres/lib/postgres_lockout.rb
+++ b/rhizome/postgres/lib/postgres_lockout.rb
@@ -30,6 +30,7 @@ local   all             ubi_monitoring                          peer
 # Allow replication connection using special replication user for
 # HA standbys (SSL connections from ubi_replication user only)
 hostssl replication     ubi_replication all                     cert map=standby2replication
+hostssl postgres        ubi_replication all                     cert map=standby2replication
     PG_HBA
   end
 

--- a/rhizome/postgres/spec/postgres_lockout_spec.rb
+++ b/rhizome/postgres/spec/postgres_lockout_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe PostgresLockout do
       expect(config).to include("local   all             postgres")
       expect(config).to include("local   all             ubi_monitoring")
       expect(config).to include("hostssl replication     ubi_replication all")
+      expect(config).to include("hostssl postgres        ubi_replication all")
     end
   end
 


### PR DESCRIPTION
The lockout pg_hba was missing the hostssl postgres rule for ubi_replication. This was added to the normal pg_hba in cd0d9433e but not to the lockout pg_hba. It is needed for sync_replication_slots (PG17+ feature) where the standby's background worker connects to dbname=postgres on the primary to sync logical slot metadata. Without this rule, slot synchronization breaks during lockout.