### PR TITLE
Add a page retention window

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1312,13 +1312,13 @@ class CloverAdmin < Roda
         r.redirect("/search?q=#{Rack::Utils.escape(id)}")
       end
 
-      @grouped_pages = Page
+      @grouped_pages = Page.active
         .reverse(:created_at, :summary)
         .exclude(severity: "info")
         .left_join(:page_root_resource, page_id: :id)
         .to_hash_groups(:root_resource_id)
       @classes = available_classes
-      @info_pages = Page.where(severity: "info").reverse(:created_at).all
+      @info_pages = Page.active.where(severity: "info").reverse(:created_at).all
 
       view("index")
     end

--- a/model/page.rb
+++ b/model/page.rb
@@ -68,6 +68,10 @@ class Page < Sequel::Model
     end
   end
 
+  dataset_module do
+    where :active, resolved_at: nil
+  end
+
   # Used by PageNexus to eager load appropriately.
   # Kept here as it is easier to keep in sync with root_resources directly below.
   EAGER_ROOT_RESOURCES = {}
@@ -137,10 +141,13 @@ class Page < Sequel::Model
     client.trigger(tag, summary:, severity:, details:, links:)
   end
 
-  def resolve
-    this.update(resolved_at: Sequel::CURRENT_TIMESTAMP)
+  def resolve(notify: true)
+    DB.transaction do
+      this.update(resolved_at: Sequel::CURRENT_TIMESTAMP)
+      DB[:page_root_resource].where(page_id: id).delete
+    end
 
-    client.resolve(tag, summary:)
+    client.resolve(tag, summary:) if notify
   end
 
   def self.generate_tag(*tag_parts)
@@ -149,7 +156,7 @@ class Page < Sequel::Model
 
   def self.from_tag_parts(*tag_parts)
     tag = Page.generate_tag(tag_parts)
-    Page.where(tag:).first
+    Page.active.where(tag:).first
   end
 
   SEVERITY_ORDER = {"info" => 0, "warning" => 1, "error" => 2, "critical" => 3}.freeze

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -9,7 +9,7 @@ class Prog::PageNexus < Prog::Base
       details = extra_data.merge({"related_resources" => related_resources})
       tag = Page.generate_tag(tag_parts)
 
-      if (existing_page = Page.first(tag:)) && Page.severity_order(severity) > Page.severity_order(existing_page.severity)
+      if (existing_page = Page.active.first(tag:)) && Page.severity_order(severity) > Page.severity_order(existing_page.severity)
         existing_page.incr_retrigger
       end
 
@@ -36,7 +36,7 @@ class Prog::PageNexus < Prog::Base
         group_ids = uuid_map.values.compact.flat_map { Page.root_resources(it) }
         frame = {}
 
-        # Check if the new page is related to an existing recent page that did not suppress triggers.
+        # Check if the new page is related to an existing recent active page that did not suppress triggers.
         # If so, suppress triggers for the current page.
         duplicate = !DB[:page_root_resource]
           .where(root_resource_id: group_ids, duplicate: false) { at > Time.now - 15 * 60 }
@@ -68,11 +68,19 @@ class Prog::PageNexus < Prog::Base
     end
 
     when_resolve_set? do
-      page.resolve unless frame["suppress_triggers"]
-      page.destroy
-      pop "page is resolved"
+      page.resolve(notify: !frame["suppress_triggers"])
+      hop_wait_retention
     end
 
     nap 6 * 60 * 60
+  end
+
+  RETENTION_SECONDS = 14 * 24 * 60 * 60 # 2 weeks
+  CLOCK_SKEW_SECONDS = 3600
+
+  label def wait_retention
+    nap RETENTION_SECONDS unless Time.now - page.resolved_at > RETENTION_SECONDS + CLOCK_SKEW_SECONDS
+    page.destroy
+    pop "page is resolved"
   end
 end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -312,11 +312,11 @@ RSpec.describe Prog::Base do
       st.unsynchronized_run
       expect {
         st.unsynchronized_run
-      }.to change { Page.count }.from(0).to(1)
+      }.to change { Page.active.count }.from(0).to(1)
 
       expect {
         st.unsynchronized_run
-      }.not_to change { Page.count }.from(1)
+      }.not_to change { Page.active.count }.from(1)
     end
 
     it "resolves the page if the frame is popped" do
@@ -325,7 +325,7 @@ RSpec.describe Prog::Base do
       st.unsynchronized_run
       expect {
         st.unsynchronized_run
-      }.to change { Page.count }.from(0).to(1)
+      }.to change { Page.active.count }.from(0).to(1)
 
       expect {
         st.unsynchronized_run
@@ -333,7 +333,7 @@ RSpec.describe Prog::Base do
         page_id = Page.first.id
         Strand[page_id].unsynchronized_run
         Strand[page_id].unsynchronized_run
-      }.to change { Page.count }.from(1).to(0)
+      }.to change { Page.active.count }.from(1).to(0)
     end
 
     it "resolves the page of the budded prog when pop" do
@@ -342,7 +342,7 @@ RSpec.describe Prog::Base do
       st.unsynchronized_run
       expect {
         st.unsynchronized_run
-      }.to change { Page.count }.from(0).to(1)
+      }.to change { Page.active.count }.from(0).to(1)
 
       expect {
         st.unsynchronized_run
@@ -350,7 +350,7 @@ RSpec.describe Prog::Base do
         page_id = Page.first.id
         Strand[page_id].unsynchronized_run
         Strand[page_id].unsynchronized_run
-      }.to change { Page.count }.from(1).to(0)
+      }.to change { Page.active.count }.from(1).to(0)
     end
 
     it "resolves the page once the target is reached" do
@@ -364,7 +364,7 @@ RSpec.describe Prog::Base do
         st.unsynchronized_run
         Strand[page_id].unsynchronized_run
         Strand[page_id].unsynchronized_run
-      }.to change { Page.count }.from(1).to(0)
+      }.to change { Page.active.count }.from(1).to(0)
     end
 
     it "resolves the page once a new deadline is registered" do
@@ -382,7 +382,7 @@ RSpec.describe Prog::Base do
         page_id = Page.first.id
         Strand[page_id].unsynchronized_run
         Strand[page_id].unsynchronized_run
-      }.to change { Page.count }.from(1).to(0)
+      }.to change { Page.active.count }.from(1).to(0)
     end
 
     it "deletes the deadline information once the target is reached" do
@@ -408,7 +408,7 @@ RSpec.describe Prog::Base do
 
       expect {
         st.unsynchronized_run
-      }.to change { Page.count }.from(0).to(2)
+      }.to change { Page.active.count }.from(0).to(2)
 
       expect(Page.all.map(&:summary)).to include(
         "#{st.ubid} has an expired deadline! Test2.pusher2 did not reach t1 on time",
@@ -420,7 +420,7 @@ RSpec.describe Prog::Base do
       vm = create_vm
       st = Strand.create_with_id(vm, prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
       st.unsynchronized_run
-      page = Page.first
+      page = Page.active.first
       expect(page).not_to be_nil
       expect(page.details["location"]).to eq(vm.location.display_name)
       expect(page.details["vcpus"]).to eq(vm.vcpus)
@@ -430,7 +430,7 @@ RSpec.describe Prog::Base do
       vm = create_vm(vm_host: create_vm_host(data_center: "FSN1-DC1"))
       st = Strand.create_with_id(vm, prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
       st.unsynchronized_run
-      page = Page.first
+      page = Page.active.first
       expect(page).not_to be_nil
       expect(page.details["vm_host"]).to eq(vm.vm_host.ubid)
       expect(page.details["data_center"]).to eq(vm.vm_host.data_center)
@@ -441,7 +441,7 @@ RSpec.describe Prog::Base do
       create_vm(vm_host: vmh)
       st = Strand.create_with_id(vmh, prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
       st.unsynchronized_run
-      page = Page.first
+      page = Page.active.first
       expect(page).not_to be_nil
       expect(page.details["arch"]).to eq(vmh.arch)
       expect(page.details["vm_count"]).to eq(1)
@@ -451,7 +451,7 @@ RSpec.describe Prog::Base do
       slice = VmHostSlice.create(vm_host_id: create_vm_host.id, name: "standard", family: "standard", cores: 1, total_cpu_percent: 200, used_cpu_percent: 200, total_memory_gib: 8, used_memory_gib: 8)
       st = Strand.create_with_id(slice, prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
       st.unsynchronized_run
-      page = Page.first
+      page = Page.active.first
       expect(page).not_to be_nil
       expect(page.details["vm_host"]).to eq(slice.vm_host.ubid)
       expect(page.details["location"]).to eq(slice.vm_host.location.display_name)
@@ -462,7 +462,7 @@ RSpec.describe Prog::Base do
       runner = GithubRunner.create(label: "ubicloud-standard-2", repository_name: "my-repo", installation:)
       st = Strand.create_with_id(runner, prog: "Test", label: :napper, stack: [{"deadline_at" => Time.now - 1, "deadline_target" => "start"}])
       st.unsynchronized_run
-      page = Page.first
+      page = Page.active.first
       expect(page).not_to be_nil
       expect(page.details["label"]).to eq("ubicloud-standard-2")
       expect(page.details["installation"]).to eq(installation.ubid)
@@ -474,7 +474,7 @@ RSpec.describe Prog::Base do
       runner = GithubRunner.create(label: "ubicloud-standard-2", repository_name: "my-repo", vm_id: vm.id, installation:)
       st = Strand.create_with_id(runner, prog: "Test", label: :napper, stack: [{"deadline_at" => (Time.now - 1).to_s, "deadline_target" => "start"}])
       st.unsynchronized_run
-      page = Page.first
+      page = Page.active.first
       expect(page).not_to be_nil
       expect(page.details["vm"]).to eq(vm.ubid)
       expect(page.details["data_center"]).to eq(vm.vm_host.data_center)
@@ -522,7 +522,7 @@ RSpec.describe Prog::Base do
       expect(st.stack.first).not_to have_key("deadline_at")
       Strand[page_id].unsynchronized_run
       Strand[page_id].unsynchronized_run
-      expect(Page.where(id: Page.where(id: page_id).get(:id)).count).to eq(0)
+      expect(Page[page_id].resolved_at).not_to be_nil
     end
 
     it "unregister_deadline clears fields even when no page exists" do

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -755,7 +755,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     it "handles common GitHub API errors during registration" do
       expect(client).to receive(:post).and_raise(Octokit::Error.new({body: "Repository level self-hosted runners are disabled"}))
       expect { nx.register_runner }.to nap(0)
-        .and change { Page.count }.by(1)
+        .and change { Page.active.count }.by(1)
       expect(runner.destroy_set?).to be(true)
     end
   end
@@ -785,7 +785,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     it "destroys the runner if the rate limit reset is more than 10 minutes away while provisioning" do
       expect(client).to receive(:rate_limit).and_return(instance_double(Octokit::RateLimit, remaining: 0, limit: 5000, resets_at: now + 11 * 60))
       expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests.new({body: "API rate limit exceeded"}) } }.to nap
-        .and change { Page.count }.by(1)
+        .and change { Page.active.count }.by(1)
       expect(runner.destroy_set?).to be(true)
     end
 

--- a/spec/prog/page_nexus_spec.rb
+++ b/spec/prog/page_nexus_spec.rb
@@ -25,19 +25,21 @@ RSpec.describe Prog::PageNexus do
   end
 
   describe "#wait" do
-    it "resolves and exits when resolved" do
+    it "resolves and hops to wait_retention when resolved" do
+      DB[:page_root_resource].insert(page_id: pg.id, root_resource_id: VmHost.generate_uuid, duplicate: false)
       pn.incr_resolve
-      expect(pg).to receive(:resolve).and_call_original
-      expect { pn.wait }.to exit({"msg" => "page is resolved"})
-      expect(pg.exists?).to be false
+      expect(pg).to receive(:resolve).with(notify: true).and_call_original
+      expect { pn.wait }.to hop("wait_retention")
+      expect(pg.reload.resolved_at).not_to be_nil
+      expect(DB[:page_root_resource].where(page_id: pg.id)).to be_empty
     end
 
-    it "skips resolving and exits when resolved when triggers are suppressed" do
+    it "skips notifying and hops to wait_retention when resolved when triggers are suppressed" do
       pn.incr_resolve
       refresh_frame(pn, new_values: {"suppress_triggers" => true})
-      expect(pg).not_to receive(:resolve)
-      expect { pn.wait }.to exit({"msg" => "page is resolved"})
-      expect(pg.exists?).to be false
+      expect(pg).to receive(:resolve).with(notify: false).and_call_original
+      expect { pn.wait }.to hop("wait_retention")
+      expect(pg.reload.resolved_at).not_to be_nil
     end
 
     it "triggers page when retrigger semaphore is set" do
@@ -58,6 +60,25 @@ RSpec.describe Prog::PageNexus do
 
     it "naps" do
       expect { pn.wait }.to nap(6 * 60 * 60)
+    end
+  end
+
+  describe "#wait_retention" do
+    before { pg.update(resolved_at: Time.now) }
+
+    it "naps when retention period has not elapsed" do
+      expect { pn.wait_retention }.to nap(described_class::RETENTION_SECONDS)
+    end
+
+    it "naps when retention period elapsed but within clock skew buffer" do
+      pg.update(resolved_at: Time.now - described_class::RETENTION_SECONDS - 1)
+      expect { pn.wait_retention }.to nap(described_class::RETENTION_SECONDS)
+    end
+
+    it "destroys page after retention period plus clock skew" do
+      pg.update(resolved_at: Time.now - described_class::RETENTION_SECONDS - described_class::CLOCK_SKEW_SECONDS - 1)
+      expect { pn.wait_retention }.to exit({"msg" => "page is resolved"})
+      expect(pg.exists?).to be false
     end
   end
 
@@ -234,6 +255,26 @@ RSpec.describe Prog::PageNexus do
       described_class.assemble(summary, tag_parts, related_resources, severity: "error")
 
       expect(existing_page.semaphores.map(&:name)).not_to include("retrigger")
+    end
+
+    it "creates a new page when a resolved page exists with the same tag" do
+      existing_page = described_class.assemble(
+        "Old Summary",
+        tag_parts,
+        [Vm.generate_ubid.to_s],
+        severity: "error",
+      ).subject
+
+      existing_page.update(resolved_at: Time.now)
+
+      expect {
+        described_class.assemble(summary, tag_parts, related_resources, severity:, extra_data:)
+      }.to change(Page, :count).by(1)
+
+      new_page = Page.active.where(tag: "TestTag-resource123").first
+      expect(new_page.id).not_to eq(existing_page.id)
+      expect(new_page.summary).to eq(summary)
+      expect(new_page.resolved_at).to be_nil
     end
   end
 end

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer --check take_postgres_backup").and_return("Succeeded")
 
       expect { nx.wait }.to nap(20 * 60)
-      expect(Page.count).to eq(1)
+      expect(Page.active.count).to eq(1)
     end
 
     it "resolves the missing page if last completed backup is more recent than 2 days" do

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -492,14 +492,14 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(vm.waiting_for_capacity_set?).to be(false)
       expect { nx.start }.to nap(5)
       expect(vm.reload.waiting_for_capacity_set?).to be(true)
-      expect(Page.count).to eq(1)
+      expect(Page.active.count).to eq(1)
       expect(Page.from_tag_parts("NoCapacity", Location[vm.location_id].display_name, vm.arch, vm.family)).not_to be_nil
 
       # Second run does not generate another page
       vm.created_at = Time.now - 11 * 60
       expect(nx).not_to receive(:incr_waiting_for_capacity)
       expect { nx.start }.to nap(5)
-      expect(Page.count).to eq(1)
+      expect(Page.active.count).to eq(1)
     end
 
     it "does not create a page if VM has been waiting less than 10 minutes" do
@@ -507,7 +507,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
 
       vm.created_at = Time.now + 10
       expect { nx.start }.to nap(30)
-      expect(Page.count).to eq(0)
+      expect(Page.active.count).to eq(0)
     end
 
     it "waits 1 hour before creating a page for github-runners" do
@@ -552,27 +552,27 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       vm.created_at = Time.now - 11 * 60
       expect(Scheduling::Allocator).to receive(:allocate).and_raise(RuntimeError.new("no space left on any eligible host"))
       expect { nx.start }.to nap(5)
-      expect(Page.count).to eq(1)
+      expect(Page.active.count).to eq(1)
 
       # Second run is able to allocate, but there are still vms in the queue, so we don't resolve the page
       expect(Scheduling::Allocator).to receive(:allocate)
       expect { nx.start }.to hop("create_unix_user")
         .and change { vm.reload.waiting_for_capacity_set? }.from(true).to(false)
-      expect(Page.count).to eq(1)
-      expect(Page.first.resolve_set?).to be false
+      expect(Page.active.count).to eq(1)
+      expect(Page.active.first.resolve_set?).to be false
 
       # Third run is able to allocate and there are no vms left in the queue, but it's not 15 minutes yet, so we don't resolve the page
       expect(Scheduling::Allocator).to receive(:allocate)
       expect { nx.start }.to hop("create_unix_user")
-      expect(Page.count).to eq(1)
-      expect(Page.first.resolve_set?).to be false
+      expect(Page.active.count).to eq(1)
+      expect(Page.active.first.resolve_set?).to be false
 
       # Fourth run is able to allocate and there are no vms left in the queue after 15 minutes, so we resolve the page
-      Page.first.update(created_at: Time.now - 16 * 60)
+      Page.active.first.update(created_at: Time.now - 16 * 60)
       expect(Scheduling::Allocator).to receive(:allocate)
       expect { nx.start }.to hop("create_unix_user")
-      expect(Page.count).to eq(1)
-      expect(Page.first.resolve_set?).to be true
+      expect(Page.active.count).to eq(1)
+      expect(Page.active.first.resolve_set?).to be true
     end
 
     it "re-raises exceptions other than lack of capacity" do


### PR DESCRIPTION
Adds a page retention window, currently hard-coded to 2w.

Simplest conceivable implementation; adds a stage with a 2w nap (unless 2w has elapsed).

Caveat: if someone schedules the thread to run early, it'll give it another two weeks... unless it's been two weeks, in which case, it'll be collected immediately. We could have the `wait_retention` step compute the remaining time between now and a 2w resolution if this behavior was undesirable, but I consider it to be usefully quirky and so not worth additional code to fix.
