### PR TITLE
Accept machine images when creating a VM via API/CLI

### DIFF
--- a/cli-commands/vm/post/create.rb
+++ b/cli-commands/vm/post/create.rb
@@ -9,14 +9,14 @@ UbiCli.on("vm").run_on("create") do
 
   options("ubi vm location/vm-name create [options] public-key", key: :vm_create) do
     on("-6", "--ipv6-only", "do not enable IPv4")
-    on("-b", "--boot-image=image_name", Option::BootImages.map(&:name), "boot image")
+    on("-b", "--boot-image=image_name", "boot image")
     on("-i", "--init-script=script", "use given init script")
     on("-p", "--private-subnet-id=ps-id", "place VM into specific private subnet (also accepts ps-name)")
     on("-s", "--size=size", server_sizes, "server size")
     on("-S", "--storage-size=size", storage_sizes, "storage size")
     on("-u", "--unix-user=username", "username (default: ubi)")
   end
-  help_option_values("Boot Image:", Option::BootImages.map(&:name))
+  help_option_values("Boot Image:", Option::BootImages.map(&:name) + ["machine-image-name@version", "machine-image-name@latest"])
   help_option_values("Size:", server_sizes)
   help_option_values("Storage Size:", storage_sizes)
 

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -124,8 +124,8 @@ module Validation
   end
 
   def self.validate_boot_image(image_name)
-    unless Option::BootImages.find { it.name == image_name }
-      fail ValidationFailed.new({boot_image: "\"#{image_name}\" is not a valid boot image name. Available boot image names are: #{Option::BootImages.map(&:name)}"})
+    unless Option::BootImages.find { it.name == image_name } || image_name.include?("@")
+      fail ValidationFailed.new({boot_image: "\"#{image_name}\" is not a valid boot image name. Available boot image names are: #{Option::BootImages.map(&:name)}, or you can use machine-image-name@version, machine-image-name@latest"})
     end
   end
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -12,8 +12,7 @@ class Prog::Vm::Nexus < Prog::Base
     distinct_storage_devices: false, force_host_id: nil, exclude_host_ids: [], gpu_count: 0, gpu_device: nil,
     hugepages: true, hypervisor: nil, ch_version: nil, firmware_version: nil, new_private_subnet_name: nil,
     exclude_availability_zones: [], availability_zone: nil, alternative_families: [],
-    allow_private_subnet_in_other_project: false, init_script: nil, exclude_data_centers: [],
-    machine_image_version_id: nil)
+    allow_private_subnet_in_other_project: false, init_script: nil, exclude_data_centers: [])
 
     unless (project = Project[project_id])
       fail "No existing project"
@@ -26,14 +25,10 @@ class Prog::Vm::Nexus < Prog::Base
       fail "No existing location in project"
     end
 
-    if machine_image_version_id
+    if boot_image.include?("@")
       fail "Machine images are only supported for metal locations" unless location.provider_dispatcher_group_name == "metal"
-      miv_metal = MachineImageVersionMetal[machine_image_version_id]
-      fail "No existing machine image version metal" unless miv_metal
-      fail "Boot image cannot be specified when using machine image version" if boot_image
-      miv = miv_metal.machine_image_version
-      mi = miv.machine_image
-      boot_image = "#{mi.name}@#{miv.version}"
+      image_name, image_version = boot_image.split("@", 2)
+      machine_image_version = lookup_machine_image_version(project_id, location_id, image_name, image_version)
     end
 
     vm_size = Validation.validate_vm_size(size, arch)
@@ -54,7 +49,7 @@ class Prog::Vm::Nexus < Prog::Base
           volume[:size_gib] <= Config.machine_image_max_size_gib
       end
       volume[:boot] = disk_index == boot_disk_index
-      volume[:machine_image_version_id] = machine_image_version_id if volume[:boot] && machine_image_version_id
+      volume[:machine_image_version_id] = machine_image_version.id if volume[:boot] && machine_image_version
 
       if volume[:read_only]
         volume[:size_gib] = 0
@@ -201,5 +196,21 @@ class Prog::Vm::Nexus < Prog::Base
     st = assemble(ssh_key.public_key, *, **kwargs)
     Sshable.create_with_id(st, unix_user: sshable_unix_user, host: "temp_#{st.id}", raw_private_key_1: ssh_key.keypair)
     st
+  end
+
+  def self.lookup_machine_image_version(project_id, location_id, name, version)
+    mi = MachineImage.first(project_id:, location_id:, name:)
+    fail Validation::ValidationFailed.new({machine_image: "Machine image with name \"#{name}\" does not exist in the specified project and location"}) unless mi
+
+    miv = if version == "latest"
+      mi.latest_version
+    else
+      MachineImageVersion.first(machine_image_id: mi.id, version:)
+    end
+
+    fail Validation::ValidationFailed.new({machine_image_version: "Version \"#{version}\" does not exist for machine image \"#{name}\""}) unless miv
+    fail Validation::ValidationFailed.new({machine_image_version: "Machine image version \"#{version}\" does not have an active metal version"}) unless miv.metal&.enabled
+
+    miv
   end
 end

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -273,6 +273,7 @@ RSpec.describe Validation do
       it "valid boot image" do
         expect { described_class.validate_boot_image("ubuntu-jammy") }.not_to raise_error
         expect { described_class.validate_boot_image("almalinux-9") }.not_to raise_error
+        expect { described_class.validate_boot_image("my-image@latest") }.not_to raise_error
       end
 
       it "invalid boot image" do

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -125,10 +125,9 @@ usermod -L ubuntu
       expect(vm.vm_storage_volumes.sum { it.size_gib }).to equal(5000)
     end
 
-    it "fails if machine image version is provided for non-metal location" do
-      miv = create_machine_image_version_metal
+    it "fails if machine image is provided for non-metal location" do
       expect {
-        Prog::Vm::Nexus.assemble("some_ssh key", project.id, location_id: assemble_loc.id, machine_image_version_id: miv.id)
+        Prog::Vm::Nexus.assemble("some_ssh key", project.id, location_id: assemble_loc.id, boot_image: "test-image@1.0")
       }.to raise_error("Machine images are only supported for metal locations")
     end
   end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -117,36 +117,41 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(st.stack.first["storage_volumes"].first["track_written"]).to be(false)
     end
 
-    it "sets machine_image_version_id if provided" do
-      miv = create_machine_image_version_metal
-      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: nil, storage_volumes: [{size_gib: 20}, {size_gib: 10, read_only: true, image: "model"}], machine_image_version_id: miv.id)
+    it "sets machine_image_version_id on boot volume when boot_image is name@version" do
+      miv = create_machine_image_version_metal(project_id: project.id).machine_image_version
+      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "test-mi@v1", storage_volumes: [{size_gib: 20}, {size_gib: 10, read_only: true}])
       vols = st.stack.first["storage_volumes"]
       expect(vols[0]["machine_image_version_id"]).to eq(miv.id)
       expect(vols[1]).not_to have_key("machine_image_version_id")
-      expect(st.subject.boot_image).to eq("test-mi@v1")
     end
 
-    it "fails if MachineImageVersionMetal with given machine_image_version_id does not exist" do
-      miv = create_machine_image_version_metal.machine_image_version
+    it "fails if machine image name does not exist in project/location" do
+      expect {
+        Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "missing-mi@v1")
+      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image]).to match(/does not exist/) }
+    end
+
+    it "fails if machine image has no latest version for boot_image name@latest" do
+      create_machine_image_version_metal(project_id: project.id)
+      expect {
+        Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "test-mi@latest")
+      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image_version]).to match(/Version "latest" does not exist/) }
+    end
+
+    it "fails if machine image version has no metal record" do
+      miv = create_machine_image_version_metal(project_id: project.id).machine_image_version
       miv.metal.destroy
       expect {
-        Prog::Vm::Nexus.assemble("some_ssh key", project.id, machine_image_version_id: miv.id)
-      }.to raise_error RuntimeError, "No existing machine image version metal"
+        Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "test-mi@v1")
+      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image_version]).to match(/does not have an active metal/) }
     end
 
-    it "fails if boot_image is specified when using machine_image_version_id" do
-      miv = create_machine_image_version_metal
-      expect {
-        Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "ubuntu-jammy", machine_image_version_id: miv.id)
-      }.to raise_error RuntimeError, "Boot image cannot be specified when using machine image version"
-    end
-
-    it "fails if MachineImageVersionMetal with given machine_image_version_id is not enabled" do
-      miv = create_machine_image_version_metal
+    it "fails if machine image version metal is not enabled" do
+      miv = create_machine_image_version_metal(project_id: project.id)
       miv.update(enabled: false)
       expect {
-        Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: nil, machine_image_version_id: miv.id)
-      }.to raise_error RuntimeError, "machine image version #{miv.id} is not available"
+        Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "test-mi@v1")
+      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image_version]).to match(/does not have an active metal/) }
     end
 
     it "fails if given nic_id is not valid" do

--- a/spec/routes/api/cli/golden-files/help -r vm.txt
+++ b/spec/routes/api/cli/golden-files/help -r vm.txt
@@ -61,6 +61,7 @@ Options:
 
 Allowed Option Values:
     Boot Image: gpu-ubuntu-noble ubuntu-noble ubuntu-jammy debian-12 almalinux-9
+                machine-image-name@version machine-image-name@latest
     Size: standard-2 standard-4 standard-8 standard-16 standard-30 standard-60
           burstable-1 burstable-2
     Storage Size: 10 20 40 80 160 320 600 640 1200 2400

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -1153,6 +1153,7 @@ Options:
 
 Allowed Option Values:
     Boot Image: gpu-ubuntu-noble ubuntu-noble ubuntu-jammy debian-12 almalinux-9
+                machine-image-name@version machine-image-name@latest
     Size: standard-2 standard-4 standard-8 standard-16 standard-30 standard-60
           burstable-1 burstable-2
     Storage Size: 10 20 40 80 160 320 600 640 1200 2400

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create  -s bad "a a".txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create  -s bad "a a".txt
@@ -22,6 +22,7 @@ Options:
 
 Allowed Option Values:
     Boot Image: gpu-ubuntu-noble ubuntu-noble ubuntu-jammy debian-12 almalinux-9
+                machine-image-name@version machine-image-name@latest
     Size: standard-2 standard-4 standard-8 standard-16 standard-30 standard-60
           burstable-1 burstable-2
     Storage Size: 10 20 40 80 160 320 600 640 1200 2400

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create "# a".txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create "# a".txt
@@ -27,6 +27,7 @@ Options:
 
 Allowed Option Values:
     Boot Image: gpu-ubuntu-noble ubuntu-noble ubuntu-jammy debian-12 almalinux-9
+                machine-image-name@version machine-image-name@latest
     Size: standard-2 standard-4 standard-8 standard-16 standard-30 standard-60
           burstable-1 burstable-2
     Storage Size: 10 20 40 80 160 320 600 640 1200 2400

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create -S bad "a a".txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create -S bad "a a".txt
@@ -22,6 +22,7 @@ Options:
 
 Allowed Option Values:
     Boot Image: gpu-ubuntu-noble ubuntu-noble ubuntu-jammy debian-12 almalinux-9
+                machine-image-name@version machine-image-name@latest
     Size: standard-2 standard-4 standard-8 standard-16 standard-30 standard-60
           burstable-1 burstable-2
     Storage Size: 10 20 40 80 160 320 600 640 1200 2400

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create -b bad "a a".txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create -b bad "a a".txt
@@ -1,27 +1,3 @@
-! Invalid argument: -b bad
-
-Create a virtual machine
-
-Usage:
-    ubi vm location/vm-name create [options] public-key
-
-Examples:
-    ubi vm eu-central-h1/my-vm-name create "$(cat ~/.ssh/id_ed25519.pub)"
-    ubi vm eu-central-h1/my-vm-name create "$(cat ~/.ssh/authorized_keys)"
-    ubi vm eu-central-h1/my-vm-name create registered-ssh-public-key-name
-    ubi vm eu-central-h1/my-vm-name create -i "$(cat /path/to/init/script)" registered-ssh-public-key-name
-
-Options:
-    -6, --ipv6-only                  do not enable IPv4
-    -b, --boot-image=image_name      boot image
-    -i, --init-script=script         use given init script
-    -p, --private-subnet-id=ps-id    place VM into specific private subnet (also accepts ps-name)
-    -s, --size=size                  server size
-    -S, --storage-size=size          storage size
-    -u, --unix-user=username         username (default: ubi)
-
-Allowed Option Values:
-    Boot Image: gpu-ubuntu-noble ubuntu-noble ubuntu-jammy debian-12 almalinux-9
-    Size: standard-2 standard-4 standard-8 standard-16 standard-30 standard-60
-          burstable-1 burstable-2
-    Storage Size: 10 20 40 80 160 320 600 640 1200 2400
+! Unexpected response status: 400
+Details: Validation failed for following fields: boot_image
+  boot_image: "bad" is not a valid boot image name. Available boot image names are: ["gpu-ubuntu-noble", "ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"], or you can use machine-image-name@version, machine-image-name@latest

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create a.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create a.txt
@@ -27,6 +27,7 @@ Options:
 
 Allowed Option Values:
     Boot Image: gpu-ubuntu-noble ubuntu-noble ubuntu-jammy debian-12 almalinux-9
+                machine-image-name@version machine-image-name@latest
     Size: standard-2 standard-4 standard-8 standard-16 standard-30 standard-60
           burstable-1 burstable-2
     Storage Size: 10 20 40 80 160 320 600 640 1200 2400

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test2-vm create.txt
@@ -22,6 +22,7 @@ Options:
 
 Allowed Option Values:
     Boot Image: gpu-ubuntu-noble ubuntu-noble ubuntu-jammy debian-12 almalinux-9
+                machine-image-name@version machine-image-name@latest
     Size: standard-2 standard-4 standard-8 standard-16 standard-30 standard-60
           burstable-1 burstable-2
     Storage Size: 10 20 40 80 160 320 600 640 1200 2400

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Clover, "vm" do
           enable_ip4: true,
         }.to_json
 
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: boot_image", {"boot_image" => "\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"gpu-ubuntu-noble\", \"ubuntu-noble\", \"ubuntu-jammy\", \"debian-12\", \"almalinux-9\"]"})
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: boot_image", {"boot_image" => "\"invalid-boot-image\" is not a valid boot image name. Available boot image names are: [\"gpu-ubuntu-noble\", \"ubuntu-noble\", \"ubuntu-jammy\", \"debian-12\", \"almalinux-9\"], or you can use machine-image-name@version, machine-image-name@latest"})
       end
 
       it "invalid vm size" do


### PR DESCRIPTION
### Allow Vm::Nexus.assemble() to accept machine images by name 
Previously, machine images were passed via `machine_image_version_id`. However, in several use cases (including the HTTP API), we need to map a `name@version` string to a machine_image_version_id and perform validation. `Vm::Nexus.assemble()` is the natural place to handle this conversion and validation.

Also remove the direct `machine_image_version_id` argument, which becomes redundant as a result.

### Accept machine images when creating a VM via API/CLI
Update validation to accept `name@version`. Also, update help texts.

An example which creates a VM from version 0.2 of machine image mi01:

```
ubi vm eu-central-h1/vm1 create \
   -b mi01@2.0 \
   "$(cat ~/.ssh/id_rsa.pub)"
```

One could use `...@latest` to use the latest version of the image.