### PR TITLE
Protect representative server from accidental destroys

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -82,9 +82,9 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
 
   def before_run
     when_destroy_set? do
-      is_destroying = ["destroy", nil].include?(resource&.strand&.label)
+      is_resource_destroying = resource.nil? || resource.destroy_set? || resource.destroying_set?
 
-      if is_destroying || !postgres_server.taking_over?
+      if is_resource_destroying || !postgres_server.taking_over?
         hop_destroy unless destroying_set?
       else
         Clog.emit("Postgres server deletion is cancelled, because it is in the process of taking over the primary role")

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -87,8 +87,6 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
       if is_destroying || !postgres_server.taking_over?
         if !%w[destroy wait_children_destroy destroy_vm_and_pg].include?(strand.label)
           hop_destroy
-        elsif strand.stack.count > 1
-          pop "operation is cancelled due to the destruction of the postgres server"
         end
       else
         Clog.emit("Postgres server deletion is cancelled, because it is in the process of taking over the primary role")

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -84,12 +84,13 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
     when_destroy_set? do
       is_resource_destroying = resource.nil? || resource.destroy_set? || resource.destroying_set?
 
-      if is_resource_destroying || !postgres_server.taking_over?
-        hop_destroy unless destroying_set?
-      else
+      if !is_resource_destroying && postgres_server.taking_over?
         Clog.emit("Postgres server deletion is cancelled, because it is in the process of taking over the primary role")
         decr_destroy
+        return
       end
+
+      hop_destroy unless destroying_set?
     end
   end
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -84,6 +84,12 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
     when_destroy_set? do
       is_resource_destroying = resource.nil? || resource.destroy_set? || resource.destroying_set?
 
+      if !is_resource_destroying && postgres_server.is_representative
+        Clog.emit("Postgres server deletion is cancelled, because it is the representative server of an alive resource; flip is_representative=false (via a proper failover) before destroying.", {ubid: postgres_server.ubid, resource_ubid: resource.ubid})
+        decr_destroy
+        return
+      end
+
       if !is_resource_destroying && postgres_server.taking_over?
         Clog.emit("Postgres server deletion is cancelled, because it is in the process of taking over the primary role")
         decr_destroy

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -85,9 +85,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
       is_destroying = ["destroy", nil].include?(resource&.strand&.label)
 
       if is_destroying || !postgres_server.taking_over?
-        if !%w[destroy wait_children_destroy destroy_vm_and_pg].include?(strand.label)
-          hop_destroy
-        end
+        hop_destroy unless destroying_set?
       else
         Clog.emit("Postgres server deletion is cancelled, because it is in the process of taking over the primary role")
         decr_destroy

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -160,17 +160,25 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.before_run }.to hop("destroy")
     end
 
-    it "does not hop to destroy if already destroying" do
+    it "cancels the destroy if the server is the representative of an alive resource" do
       nx.incr_destroy
-      nx.incr_destroying
       expect { nx.before_run }.not_to hop("destroy")
+      expect(Semaphore.where(strand_id: postgres_server.id, name: "destroy").count).to eq(0)
     end
 
     it "cancels the destroy if the server is picked up for take over" do
       nx.incr_destroy
+      postgres_server.update(is_representative: false)
       expect(nx.postgres_server).to receive(:taking_over?).and_return(true)
       expect { nx.before_run }.not_to hop("destroy")
       expect(Semaphore.where(strand_id: postgres_server.id, name: "destroy").count).to eq(0)
+    end
+
+    it "does not hop to destroy if already destroying" do
+      nx.incr_destroy
+      nx.incr_destroying
+      postgres_server.update(is_representative: false)
+      expect { nx.before_run }.not_to hop("destroy")
     end
   end
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -181,14 +181,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.before_run }.not_to hop("destroy")
       expect(Semaphore.where(strand_id: postgres_server.id, name: "destroy").count).to eq(0)
     end
-
-    it "pops additional operations from stack" do
-      postgres_server.resource.strand.update(label: "destroy")
-      nx.strand.update(label: "destroy", stack: [{"link" => ["Postgres::PostgresServerNexus", "wait"]}, {}])
-      fresh_nx = described_class.new(Strand[postgres_server.id])
-      fresh_nx.incr_destroy
-      expect { fresh_nx.before_run }.to hop("wait")
-    end
   end
 
   describe "#start" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -154,24 +154,10 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.before_run }.to hop("destroy")
     end
 
-    it "does not hop to destroy if already in the destroy state" do
+    it "does not hop to destroy if already destroying" do
       nx.incr_destroy
+      nx.incr_destroying
       postgres_server.resource.strand.destroy
-      nx.strand.update(label: "destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the wait_children_destroy state" do
-      nx.incr_destroy
-      postgres_server.resource.strand.destroy
-      nx.strand.update(label: "wait_children_destroy")
-      expect { nx.before_run }.not_to hop("destroy")
-    end
-
-    it "does not hop to destroy if already in the destroy_vm_and_pg state" do
-      nx.incr_destroy
-      postgres_server.resource.strand.destroy
-      nx.strand.update(label: "destroy_vm_and_pg")
       expect { nx.before_run }.not_to hop("destroy")
     end
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -148,16 +148,21 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   end
 
   describe "#before_run" do
-    it "hops to destroy when needed" do
+    it "hops to destroy when resource is gone" do
       nx.incr_destroy
       postgres_server.resource.destroy
+      expect { nx.before_run }.to hop("destroy")
+    end
+
+    it "hops to destroy when resource is destroying" do
+      nx.incr_destroy
+      postgres_server.resource.incr_destroying
       expect { nx.before_run }.to hop("destroy")
     end
 
     it "does not hop to destroy if already destroying" do
       nx.incr_destroy
       nx.incr_destroying
-      postgres_server.resource.strand.destroy
       expect { nx.before_run }.not_to hop("destroy")
     end
 


### PR DESCRIPTION
The last commit is for protecting representative server from accidental destroys. However we already have lots of logic in `before_run` run function and some of it is already obsolete. So the first 4 commits cleans it up. In the last commit, we had chance to combine two `!is_resource_destroying` checks into one parent if check, but I found this version to be easier to digest.