### PR TITLE
Handle exception when GitHub Actions is disabled on a repository

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -178,6 +178,8 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     page_args = case e.message
     when /Repository level self-hosted runners are disabled/
       ["Repository level self-hosted runners are disabled on #{installation_ubid}", ["GithubSelfHostRunnersDisabled", installation_ubid]]
+    when /GitHub Actions is disabled on this repository/
+      ["GitHub Actions is disabled on #{installation_ubid}", ["GithubActionsDisabled", installation_ubid]]
     when /your IP address is not permitted to access this resource/
       ["The organization has an IP allow list enabled on #{installation_ubid}", ["GithubIPAllowlistEnabled", installation_ubid]]
     when /Resource not accessible by integration/

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -188,6 +188,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     end
 
     if page_args
+      Clog.emit("Matched a known GitHub API error", {matched_github_api_error: {error_message: e.message, label: github_runner.label, repository_name: github_runner.repository_name}})
       Prog::PageNexus.assemble(*page_args, installation_ubid, severity: "warning")
       github_runner.incr_destroy
       nap 0

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -752,6 +752,12 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(runner.destroy_set?).to be(true)
     end
 
+    it "destroys the runner if GitHub Actions are disabled" do
+      expect { nx.rescue_common_github_api_errors { raise Octokit::Error.new({body: "GitHub Actions is disabled on this repository"}) } }.to nap(0)
+        .and change { Page.count }.by(1)
+      expect(runner.destroy_set?).to be(true)
+    end
+
     it "destroys the runner if IP allowlist is enabled" do
       expect { nx.rescue_common_github_api_errors { raise Octokit::Error.new({body: "your IP address is not permitted to access this resource"}) } }.to nap(0)
         .and change { Page.count }.by(1)


### PR DESCRIPTION
- **Handle exception when GitHub Actions is disabled on a repository**

When a repository disables GitHub Actions entirely, the runner
registration call fails with "GitHub Actions is disabled on this
repository" rather than the existing "Repository level self-hosted
runners are disabled" message. Without a matching branch in
rescue_common_github_api_errors, the error raises multiple pages.

- **Log handled GitHub API error**

Since we trigger a single page for the installation, it's hard to say
which repositories have the issue.
