### PR TITLE
Exclude serializable transaction isolation from standby user config

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -134,7 +134,7 @@ class PostgresServer < Sequel::Model
 
     {
       configs:,
-      user_config: resource.user_config,
+      user_config:,
       pgbouncer_user_config: resource.pgbouncer_user_config,
       physical_slots: caught_up_standbys&.map(&:ubid),
       private_subnets: vm.private_subnets.map {
@@ -151,6 +151,14 @@ class PostgresServer < Sequel::Model
       disk_throughput_baseline_mbps:,
       strict_overcommit: !resource.skip_strict_memory_overcommit_set?,
     }
+  end
+
+  def user_config
+    config = resource.user_config
+    if !primary? && config["default_transaction_isolation"]&.include?("serializable")
+      config = config.merge("default_transaction_isolation" => "repeatable read")
+    end
+    config
   end
 
   def disk_throughput_baseline_mbps

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -167,6 +167,24 @@ RSpec.describe PostgresServer do
       resource.incr_skip_strict_memory_overcommit
       expect(postgres_server.configure_hash[:strict_overcommit]).to be false
     end
+
+    it "downgrades serializable default_transaction_isolation to repeatable read on standbys" do
+      resource.update(user_config: {"default_transaction_isolation" => "serializable", "max_connections" => "100"})
+      expect(postgres_server.configure_hash[:user_config]["default_transaction_isolation"]).to eq("serializable")
+      postgres_server.timeline_access = "fetch"
+      expect(postgres_server).to receive(:doing_pitr?).and_return(false).at_least(:once)
+      allow(resource).to receive(:replication_connection_string).and_return("postgres://ubi_replication@host")
+      expect(postgres_server.configure_hash[:user_config]["default_transaction_isolation"]).to eq("repeatable read")
+      expect(postgres_server.configure_hash[:user_config]).to include("max_connections" => "100")
+    end
+
+    it "keeps non-serializable default_transaction_isolation on standbys" do
+      resource.update(user_config: {"default_transaction_isolation" => "repeatable read"})
+      postgres_server.timeline_access = "fetch"
+      expect(postgres_server).to receive(:doing_pitr?).and_return(false).at_least(:once)
+      allow(resource).to receive(:replication_connection_string).and_return("postgres://ubi_replication@host")
+      expect(postgres_server.configure_hash[:user_config]).to have_key("default_transaction_isolation")
+    end
   end
 
   describe "#trigger_failover" do


### PR DESCRIPTION
PostgreSQL hot standbys do not support serializable isolation and will error on every transaction if default_transaction_isolation is set to serializable. Set it to `repeatable read` instead.