### PR TITLE
Validate VM boot disk size when using a machine image

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -25,12 +25,6 @@ class Prog::Vm::Nexus < Prog::Base
       fail "No existing location in project"
     end
 
-    if boot_image.include?("@")
-      fail "Machine images are only supported for metal locations" unless location.provider_dispatcher_group_name == "metal"
-      image_name, image_version = boot_image.split("@", 2)
-      machine_image_version = lookup_machine_image_version(project_id, location_id, image_name, image_version)
-    end
-
     vm_size = Validation.validate_vm_size(size, arch)
     Validation.validate_billing_rate("VmVCpu", vm_size.family, location.name)
 
@@ -49,7 +43,6 @@ class Prog::Vm::Nexus < Prog::Base
           volume[:size_gib] <= Config.machine_image_max_size_gib
       end
       volume[:boot] = disk_index == boot_disk_index
-      volume[:machine_image_version_id] = machine_image_version.id if volume[:boot] && machine_image_version
 
       if volume[:read_only]
         volume[:size_gib] = 0
@@ -59,6 +52,14 @@ class Prog::Vm::Nexus < Prog::Base
     end
 
     Validation.validate_storage_volumes(storage_volumes, boot_disk_index)
+
+    if boot_image.include?("@")
+      fail "Machine images are only supported for metal locations" unless location.provider_dispatcher_group_name == "metal"
+      image_name, image_version = boot_image.split("@", 2)
+      boot_volume = storage_volumes[boot_disk_index]
+      machine_image_version = lookup_machine_image_version(project_id, location_id, image_name, image_version, boot_volume[:size_gib])
+      boot_volume[:machine_image_version_id] = machine_image_version.id
+    end
 
     ubid = Vm.generate_ubid
     name ||= Vm.ubid_to_name(ubid)
@@ -198,7 +199,7 @@ class Prog::Vm::Nexus < Prog::Base
     st
   end
 
-  def self.lookup_machine_image_version(project_id, location_id, name, version)
+  def self.lookup_machine_image_version(project_id, location_id, name, version, vm_boot_disk_size_gib)
     mi = MachineImage.first(project_id:, location_id:, name:)
     fail Validation::ValidationFailed.new({machine_image: "Machine image with name \"#{name}\" does not exist in the specified project and location"}) unless mi
 
@@ -210,6 +211,7 @@ class Prog::Vm::Nexus < Prog::Base
 
     fail Validation::ValidationFailed.new({machine_image_version: "Version \"#{version}\" does not exist for machine image \"#{name}\""}) unless miv
     fail Validation::ValidationFailed.new({machine_image_version: "Machine image version \"#{version}\" does not have an active metal version"}) unless miv.metal&.enabled
+    fail Validation::ValidationFailed.new({machine_image_version: "Machine image version \"#{version}\" is larger than the VM boot disk size"}) if miv.actual_size_mib > vm_boot_disk_size_gib * 1024
 
     miv
   end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -154,6 +154,28 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image_version]).to match(/does not have an active metal/) }
     end
 
+    it "fails if machine image version size exceeds VM boot disk size" do
+      miv = create_machine_image_version_metal(project_id: project.id).machine_image_version
+      miv.update(actual_size_mib: 21 * 1024)
+      expect {
+        Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "test-mi@v1", storage_volumes: [{size_gib: 20}])
+      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image_version]).to match(/is larger than the VM boot disk size/) }
+    end
+
+    it "fails if machine image version size exceeds the selected boot disk size for non-default boot_disk_index" do
+      miv = create_machine_image_version_metal(project_id: project.id).machine_image_version
+      miv.update(actual_size_mib: 21 * 1024)
+      expect {
+        Prog::Vm::Nexus.assemble(
+          "some_ssh key",
+          project.id,
+          boot_image: "test-mi@v1",
+          storage_volumes: [{size_gib: 30}, {size_gib: 20}],
+          boot_disk_index: 1,
+        )
+      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image_version]).to match(/is larger than the VM boot disk size/) }
+    end
+
     it "fails if given nic_id is not valid" do
       expect {
         Prog::Vm::Nexus.assemble("some_ssh key", project.id, nic_id: "0a9a166c-e7e7-4447-ab29-7ea442b5bb0e")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -281,7 +281,7 @@ RSpec.configure do |config|
       project_id ||= Project.create(name: "miv-metal-project").id
       machine_image_store_id ||= MachineImageStore.create(project_id:, location_id:, provider: "r2", region: "auto", endpoint: "https://r2.cloudflare.com/", bucket: "test-bucket", access_key: "ak", secret_key: "sk").id
       machine_image_id ||= MachineImage.create(name: "test-mi", project_id:, arch: "x64", location_id:).id
-      miv = MachineImageVersion.create(machine_image_id:, version:)
+      miv = MachineImageVersion.create(machine_image_id:, version:, actual_size_mib: 5 * 1024)
       archive_kek = StorageKeyEncryptionKey.create_random(auth_data: "auth_data")
       MachineImageVersionMetal.create_with_id(miv, archive_kek_id: archive_kek.id, store_id: machine_image_store_id, store_prefix:, enabled: true, archive_size_mib: 1024)
     end


### PR DESCRIPTION
The VM’s boot disk size must be greater than or equal to the machine image’s `actual_size_mib`. Otherwise, the storage daemon will fail to start.