### PR TITLE
Send email change verification to new address

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -711,7 +711,7 @@ class Clover < Roda
     verify_login_change_view { view "auth/verify_login_change", "Verify Email Change" }
     send_verify_login_change_email do |new_login|
       user = Account[account_id]
-      Util.send_email(email_to, "Please Verify New Email Address for Ubicloud",
+      Util.send_email(new_login, "Please Verify New Email Address for Ubicloud",
         greeting: "Hello #{user.name},",
         body: ["We received a request to change your account email to '#{new_login}'. To verify new email, click the button below.",
           "If you did not initiate this request, no action is needed. Current email address can be used to login your account.",

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -429,7 +429,9 @@ RSpec.describe Clover, "auth" do
 
         expect(page).to have_flash_notice("An email has been sent to you with a link to verify your login change")
         expect(Mail::TestMailer.deliveries.length).to eq 1
-        verify_link = Mail::TestMailer.deliveries.first.html_part.body.match(/(\/verify-login-change.+?)"/)[1]
+        mail = Mail::TestMailer.deliveries.first
+        expect(mail.to).to eq [new_email]
+        verify_link = mail.html_part.body.match(/(\/verify-login-change.+?)"/)[1]
 
         click_button "Log out" unless logged_in
         visit verify_link


### PR DESCRIPTION
When a user requests to change their login email, the verification link was being sent to the old address. This allowed anyone to change to any email address without receiving the verification link, making impersonation attacks easier. The verification link should be sent to the new email address instead.