### PR TITLE
Identify omniauth account by identity, not email

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -625,15 +625,14 @@ class Clover < Roda
     end
 
     before_omniauth_callback_route do
-      account = Account[account_from_omniauth&.[](:id)]
       if authenticated?
-        unless account && account.id == scope.current_account.id
+        unless (account = Account[account_from_omniauth&.[](:id)]) && account.id == scope.current_account.id
           provider_name = scope.omniauth_provider_name(omniauth_provider)
           flash["error"] = "Your account's email address is different from the email address associated with the #{provider_name} account."
           add_audit_log(session_value, :connect_provider_failure, {"reason" => "different email", "provider" => provider_name})
           redirect "/account/login-method"
         end
-      elsif account && account.identities_dataset.where(provider: omniauth_provider).empty?
+      elsif omniauth_identity.nil? && Account[account_from_omniauth&.[](:id)]
         provider_name = scope.omniauth_provider_name(omniauth_provider)
         add_audit_log(account_session_value, :login_failure, {"reason" => "unlinked existing account", "provider" => provider_name})
         flash["error"] = "There is already an account with this email address, and it has not been linked to the #{provider_name} account.

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -1167,6 +1167,21 @@ RSpec.describe Clover, "auth" do
       expect(audit_log_hash).to eq({"login" => ip_hash("via" => "Google")})
     end
 
+    it "can login existing account after its email has been changed" do
+      mock_provider(:google)
+      account = create_account
+      account.add_identity(provider: "google", uid: "123456790")
+      account.update(email: "renamed@example.com")
+      account.projects.first.update(name: "Renamed")
+      create_account("user@example.com")
+
+      visit "/login"
+      click_button "Google"
+
+      expect(page.title).to eq("Ubicloud - Renamed Dashboard")
+      expect(audit_log_hash).to eq({"login" => ip_hash("via" => "Google")})
+    end
+
     it "can not login existing account before linking it" do
       mock_provider(:github)
       create_account


### PR DESCRIPTION
The omniauth callback hook looked up the existing account by the email returned from the provider. When an identity row already existed for the (provider, uid) pair, rodauth's flow looked up the account by identity, but the hook's email-based lookup ran first and gated whether to show the "unlinked existing account" error. Two problems followed.

First, an account whose Ubicloud email had been changed could no longer log in via a previously-linked provider when another account claimed the old email: the email lookup matched the unrelated account, the unrelated account had no identity for this provider, and the hook blocked the login despite a valid identity pointing at the original account.

Second, providers such as GitHub allow users to change the email on their side. The previous check only blocked login when the matched account had no identity for the provider at all. If the account was already linked to the provider via a different uid, the elsif fell through, rodauth's auto-link created a new identity for the attacker's uid against the victim's account, and the attacker logged in as the victim.

Switch the logged-out branch to gate on identity presence: only block when no identity exists yet for (provider, uid) and the provider's email matches some Ubicloud account. When an identity does exist, let rodauth resolve the account by identity regardless of email, which preserves login after a Ubicloud-side email change.

Note that `Account[account_from_omniauth&.[](:id)]` appears in both branches but cannot be hoisted into a shared local. Calling `account_from_omniauth` has the side effect of assigning rodauth's `@account`. If the logged-out branch invoked it unconditionally and the provider's email matched a different Ubicloud account, rodauth's subsequent `unless account` check in `_handle_omniauth_callback` would short-circuit, skip the identity-based lookup, and the user would be logged in as the email-matched account instead of the identity-linked one. Keeping the call inside the `omniauth_identity.nil?` short-circuit preserves rodauth's identity resolution path.