### PR TITLE
Allow customizing author name in outgoing emails

### DIFF
--- a/lib/email_renderer.rb
+++ b/lib/email_renderer.rb
@@ -10,7 +10,7 @@ class EmailRenderer < Roda
   plugin :mailer, terminal: true
 
   route do |r|
-    r.mail "" do |receiver, subject, greeting: nil, body: nil, button_title: nil, button_link: nil, cc: nil, bcc: nil, attachments: []|
+    r.mail "" do |receiver, subject, greeting: nil, body: nil, button_title: nil, button_link: nil, author_name: "Ubicloud", cc: nil, bcc: nil, attachments: []|
       no_mail! if Array(receiver).compact.empty?
       from Config.mail_from
       to receiver
@@ -25,7 +25,7 @@ class EmailRenderer < Roda
       text_part "#{greeting}\n#{Array(body).join("\n")}\n#{button_link}"
 
       html_part(
-        part("email/layout", subject:, greeting:, body:, button_title:, button_link:),
+        part("email/layout", subject:, greeting:, body:, button_title:, button_link:, author_name:),
         "Content-Type" => "text/html; charset=UTF-8",
       )
     end

--- a/spec/lib/util_spec.rb
+++ b/spec/lib/util_spec.rb
@@ -38,6 +38,20 @@ RSpec.describe Util do
     end
   end
 
+  describe "#send_email" do
+    it "renders 'Ubicloud' as the author name by default" do
+      described_class.send_email("user@example.com", "Hello", greeting: "Hi", body: "Welcome")
+      expect(Mail::TestMailer.deliveries.length).to eq 1
+      expect(Mail::TestMailer.deliveries.first.html_part.body.to_s).to include("Regards,").and include("Ubicloud")
+    end
+
+    it "renders a custom author name when provided" do
+      described_class.send_email("user@example.com", "Hello", greeting: "Hi", body: "Welcome", author_name: "The Ubicloud Team")
+      expect(Mail::TestMailer.deliveries.length).to eq 1
+      expect(Mail::TestMailer.deliveries.first.html_part.body.to_s).to include("The Ubicloud Team")
+    end
+  end
+
   describe "#parse_key" do
     it "can parse an elliptic key" do
       expect(described_class.parse_key(Clec::Cert::EC_KEY_PEM)).to be_instance_of OpenSSL::PKey::EC

--- a/views/email/layout.erb
+++ b/views/email/layout.erb
@@ -1,4 +1,4 @@
-<%# locals: (subject:, greeting:, body:, button_title:, button_link:) %><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+<%# locals: (subject:, greeting:, body:, button_title:, button_link:,author_name:) %><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
@@ -36,7 +36,7 @@
                       <% end %>
                       <p>
                         Regards,<br>
-                        Ubicloud
+                        <%= author_name %>
                       </p>
 
                       <% if button_link %>


### PR DESCRIPTION
The email layout previously hard-coded "Ubicloud" in the closing "Regards," signature. Some categories of email (billing, security notices, team-specific notifications) read more naturally when signed by a more specific author. Add an `author_name` keyword argument to the email renderer's mail route, defaulting to "Ubicloud" so existing callers are unaffected.