### PR TITLE
Fix AWS VPC destruction without security_group_id

### DIFF
--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -172,6 +172,7 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
     private_subnet.remove_all_firewalls
 
     hop_finish unless private_subnet_aws_resource
+    hop_delete_vpc unless private_subnet_aws_resource.security_group_id
 
     begin
       ignore_invalid_id do

--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -297,6 +297,12 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
       expect { nx.destroy }.to hop("finish")
     end
 
+    it "hops to delete_vpc if aws resource does not have security_group_id" do
+      aws_resource.update(security_group_id: nil)
+      nx.private_subnet.reload
+      expect { nx.destroy }.to hop("delete_vpc")
+    end
+
     it "deletes the security group and hops to delete_internet_gateway" do
       client.stub_responses(:delete_security_group)
       expect(client).to receive(:delete_security_group).with({group_id: "sg-0123456789abcdefg"}).and_call_original


### PR DESCRIPTION
If the AWS VPC has incr_destroy called after start and before wait_vpc_created, it will not have a security_group_id, and destroy will continually fail with:

```
Aws::EC2::Errors::MissingParameter
The request must contain the parameter groupName or groupId
```

If a security_group_id is not present, there shouldn't be any internet gateways (created in create_route_table) or subnets (created in create_az_subnets), but there could potentially be a vpc, so hop to delete_vpc.

It's possible that a similar issue occurs in delete_internet_gateway if the AWS VPC had incr_destroy called before reaching create_route_table.