### PR TITLE
Fix IPv6 pod egress on hosts with non-/64 delegations

### DIFF
--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -225,7 +225,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
   "name": "ubicni-network",
   "type": "ubicni",
   "ranges":{
-      "subnet_ipv6": "#{NetAddr::IPv6Net.new(vm.ephemeral_net6.network, NetAddr::Mask128.new(80))}",
+      "subnet_ipv6": "#{NetAddr::IPv6Net.new(vm.ephemeral_net6.network, NetAddr::Mask128.new(vm.ephemeral_net6.netmask.prefix_len + 1))}",
       "subnet_ula_ipv6": "#{vm.nics.first.private_ipv6}",
       "subnet_ipv4": "#{vm.nics.first.private_ipv4}"
   }

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -323,15 +323,38 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   end
 
   describe "#install_cni" do
-    it "configures ubicni" do
-      sshable = Sshable.new
-      expect(prog.vm).to receive(:sshable).and_return(sshable)
-      expect(prog.node.vm).to receive_messages(
-        nics: [instance_double(Nic, private_ipv4: "10.0.0.37", private_ipv6: "0::1")],
-        ephemeral_net6: NetAddr::IPv6Net.new(NetAddr::IPv6.parse("2001:db8::"), NetAddr::Mask128.new(64)),
-      )
+    it "configures ubicni with the VM's ephemeral prefix" do
+      expected_config = <<~CONFIG
+        {
+          "cniVersion": "1.0.0",
+          "name": "ubicni-network",
+          "type": "ubicni",
+          "ranges":{
+              "subnet_ipv6": "2001:db8:85a3:73f2:1c4a::/80",
+              "subnet_ula_ipv6": "fd40:1a0a:8d48:182a::/79",
+              "subnet_ipv4": "172.19.145.64/26"
+          }
+        }
+      CONFIG
+      expect(prog.vm.sshable).to receive(:_cmd).with("sudo tee /etc/cni/net.d/ubicni-config.json", stdin: expected_config)
+      expect { prog.install_cni }.to hop("approve_new_csr")
+    end
 
-      expect(sshable).to receive(:_cmd).with("sudo tee /etc/cni/net.d/ubicni-config.json", stdin: /"type": "ubicni"/)
+    it "uses the VM's actual ephemeral prefix on hosts with narrow delegations" do
+      prog.vm.update(ephemeral_net6: "2607:f5b7:9:1a:0:355c::/95")
+      expected_config = <<~CONFIG
+        {
+          "cniVersion": "1.0.0",
+          "name": "ubicni-network",
+          "type": "ubicni",
+          "ranges":{
+              "subnet_ipv6": "2607:f5b7:9:1a:0:355c:0:0/96",
+              "subnet_ula_ipv6": "fd40:1a0a:8d48:182a::/79",
+              "subnet_ipv4": "172.19.145.64/26"
+          }
+        }
+      CONFIG
+      expect(prog.vm.sshable).to receive(:_cmd).with("sudo tee /etc/cni/net.d/ubicni-config.json", stdin: expected_config)
       expect { prog.install_cni }.to hop("approve_new_csr")
     end
   end


### PR DESCRIPTION
The CNI config for subnet_ipv6 was hardcoded to widen vm.ephemeral_net6 to a /80 via NetAddr::IPv6Net.new(vm.ephemeral_net6.network, Mask128.new(80)). This worked by accident on hosts with /64 delegations (where VMs get /79 slices — a /79 covers a /80), but broke on hosts with /80 delegations (where VMs get /95 slices).

On a /80 host the widening produced the entire host /80 as the pod subnet, while the nft pod_access table correctly used the VM's actual /95 allocation. Pods assigned addresses outside that /95 but inside the /80 were dropped by nft's default-drop forward chain. IPv4 and ULA worked because they use separate, correctly-scoped allocations.

The fix uses vm.ephemeral_net6 directly so the CNI pod range always matches the nft rules — /79 on /64 hosts, /95 on /80 hosts, or whatever the allocator returns.