### PR TITLE
Restrict runner host utilization to suitable locations

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -282,7 +282,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     end
 
     # check utilization, if it's high, wait for it to go down
-    family_utilization = VmHost.where(allocation_state: "accepting", arch:)
+    family_utilization = VmHost.where(allocation_state: "accepting", location_id: [Location::GITHUB_RUNNERS_ID, Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID], arch:)
       .select_group(:family)
       .select_append { round(sum(:used_cores) * 100.0 / sum(:total_cores), 2).cast(:float).as(:utilization) }
       .to_hash(:family, :utilization)


### PR DESCRIPTION
We compute VM host utilization for runners to drive concurrency decisions such as alien spilling or falling back from premium to standard families.

Previously, the calculation included every host, which produced inaccurate utilization values and led to suboptimal decisions: US hosts are rarely used for runners, so including them skewed the numbers. Restrict the query to the locations actually used by runners (GitHub Runners, Hetzner FSN1, and Hetzner HEL1).