### PR TITLE
Avoid database error if there is an invoice in the future

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -131,8 +131,8 @@ class Project < Sequel::Model
   end
 
   def current_invoice(since: nil)
-    begin_time = since || invoices_dataset.get(:end_time) || Time.new(Time.now.year, Time.now.month, 1)
-    end_time = Time.now
+    end_time = Time.now.utc
+    begin_time = since || invoices_dataset.where(Sequel[:end_time] < end_time).get(:end_time) || Time.utc(end_time.year, end_time.month)
 
     if (invoice = InvoiceGenerator.new(begin_time, end_time, project_ids: [id]).run.first)
       return invoice
@@ -146,7 +146,7 @@ class Project < Sequel::Model
       "cost" => 0.0,
     }
 
-    Invoice.new(project_id: id, content:, begin_time:, end_time:, created_at: Time.now, status: "current")
+    Invoice.new(project_id: id, content:, begin_time:, end_time:, created_at: end_time, status: "current")
   end
 
   def current_resource_usage(resource_type)

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -142,6 +142,18 @@ RSpec.describe Project do
     end
   end
 
+  describe "#current_invoice" do
+    it "works even if most recent invoice end date is in the future" do
+      project = described_class.create(name: "dummy-name")
+      t = Time.now
+      expect(project.current_invoice).to be_a Invoice
+      Invoice.create(project_id: project.id, content: {}, begin_time: t, end_time: t + 86400, status: "current", invoice_number: "2")
+      expect(project.current_invoice).to be_a Invoice
+      Invoice.create(project_id: project.id, content: {}, begin_time: t, end_time: t - 86400, status: "current", invoice_number: "1", created_at: t - 1)
+      expect(project.current_invoice).to be_a Invoice
+    end
+  end
+
   it "sets and gets feature flags" do
     mod = Module.new
     described_class.feature_flag(:dummy_flag1, :dummy_flag2, into: mod)


### PR DESCRIPTION
We have had multiple production exceptions of the form:

```
PG::DataException
ERROR:  range lower bound must be less than or equal to range upper bound
CONTEXT:  unnamed portal parameter $1 = '...'
```

that have this code in the backtrace. One possible cause of this is an invoice with an end date in the future. I'm not sure this is the cause, and even if it is, maybe we should do something to prevent it.  However, this change should at least avoid the exception.

While here, remove redundant Time.now calls, and make sure the times are in UTC.