### PR TITLE
Make local E2E test failures issue info pages 

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1083,22 +1083,24 @@ class CloverAdmin < Roda
         end
       end
 
-      r.post %w[pause unpause].freeze, :ubid_uuid do |action, strand_id|
+      r.post %w[pause unpause destroy].freeze, :ubid_uuid do |action, strand_id|
         unless (strand = strand_ds.with_pk(strand_id))
           flash["error"] = "Strand not found, it was probably already deleted"
           r.redirect "/local-e2e"
         end
 
-        raise "invalid strand" unless LOCAL_E2E_PROGS.include?(strand.prog.split("::").last)
+        prog = strand.prog.split("::").last
+        raise "invalid strand" unless LOCAL_E2E_PROGS.include?(prog) || prog == "LocalE2eLoop"
 
-        if action == "pause"
-          Semaphore.incr(strand.id, "pause")
-        else
+        case action
+        when "pause", "destroy"
+          Semaphore.incr(strand.id, action)
+        else # unpause
           Semaphore.where(strand_id: strand.id, name: "pause").destroy
           strand.this.update(schedule: Sequel::CURRENT_TIMESTAMP)
         end
 
-        flash["notice"] = "Strand #{strand.ubid} #{action}d"
+        flash["notice"] = "Strand #{strand.ubid} #{action}#{"e" if action == "destroy"}d"
         r.redirect "/local-e2e"
       end
     end

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1074,7 +1074,7 @@ class CloverAdmin < Roda
           else
             progs.map do |prog|
               Prog::Test::LocalE2eLoop.check_prog(prog)
-              Prog::Test.const_get(prog).assemble(provider:)
+              Prog::Test.const_get(prog).assemble(provider:, local_e2e: true)
             end
           end
 

--- a/config.rb
+++ b/config.rb
@@ -221,7 +221,7 @@ module Config
   optional :e2e_cache_proxy_download_url, string
 
   # Local e2e
-  optional :local_e2e_postgres_test_project_id, string
+  optional :local_e2e_postgres_test_project_id, uuid
 
   # Load Balancer
   optional :load_balancer_service_project_id, uuid

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -3,7 +3,7 @@
 require_relative "../../lib/util"
 
 class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
-  semaphore :pause
+  semaphore :pause, :destroy
 
   def self.assemble(provider: "metal")
     super(provider:, project_name: "Postgres-HA-Test-Project")
@@ -25,7 +25,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   label def test_postgres
     unless representative_server.run_query(test_queries_sql) == "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to run test queries"})
-      hop_destroy_postgres
+      hop_destroy
     end
 
     hop_trigger_failover
@@ -57,7 +57,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
 
     if Time.now.to_i >= deadline
       update_stack({"fail_message" => "Failover did not complete within 600 seconds"})
-      hop_destroy_postgres
+      hop_destroy
     end
 
     nap 10
@@ -74,7 +74,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
     Clog.emit("Running read queries after failover")
     unless representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to run read queries after failover"})
-      hop_destroy_postgres
+      hop_destroy
     end
 
     Clog.emit("Running write queries after failover")
@@ -82,10 +82,10 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
       update_stack({"fail_message" => "Failed to run write queries after failover"})
     end
 
-    hop_destroy_postgres
+    hop_destroy
   end
 
-  label def destroy_postgres
+  label def destroy
     postgres_resource.timeline.incr_destroy
     postgres_resource.incr_destroy
     hop_wait_resources_destroyed

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -5,8 +5,8 @@ require_relative "../../lib/util"
 class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   semaphore :pause, :destroy
 
-  def self.assemble(provider: "metal")
-    super(provider:, project_name: "Postgres-HA-Test-Project")
+  def self.assemble(provider: "metal", **)
+    super(provider:, project_name: "Postgres-HA-Test-Project", **)
   end
 
   label def start
@@ -85,7 +85,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
     hop_destroy
   end
 
-  label def destroy
+  label def destroy_postgres
     postgres_resource.timeline.incr_destroy
     postgres_resource.incr_destroy
     hop_wait_resources_destroyed
@@ -99,4 +99,5 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
 
   label :finish
   label :failed
+  label :destroy
 end

--- a/prog/test/local_e2e_loop.rb
+++ b/prog/test/local_e2e_loop.rb
@@ -41,7 +41,7 @@ class Prog::Test::LocalE2eLoop < Prog::Test::Base
   end
 
   label def start
-    st = Prog::Test.const_get(frame["progs"].first).assemble(**frame["prog_args"].transform_keys(&:to_sym))
+    st = Prog::Test.const_get(frame["progs"].first).assemble(local_e2e: true, **frame["prog_args"].transform_keys(&:to_sym))
     st.update(parent_id: strand.id)
     update_stack(
       "current_strand" => st.id,

--- a/prog/test/local_e2e_loop.rb
+++ b/prog/test/local_e2e_loop.rb
@@ -7,7 +7,7 @@ class Prog::Test::LocalE2eLoop < Prog::Test::Base
     UpgradePostgresResource
   ].freeze
 
-  semaphore :pause
+  semaphore :pause, :destroy
 
   def self.check_prog(prog)
     raise "invalid local E2E prog" unless ALLOWED_PROGS.include?(prog)
@@ -69,5 +69,9 @@ class Prog::Test::LocalE2eLoop < Prog::Test::Base
     else
       hop_start
     end
+  end
+
+  label def destroy
+    pop "destruction of local E2E loop prog requested"
   end
 end

--- a/prog/test/local_e2e_loop.rb
+++ b/prog/test/local_e2e_loop.rb
@@ -72,6 +72,6 @@ class Prog::Test::LocalE2eLoop < Prog::Test::Base
   end
 
   label def destroy
-    pop "destruction of local E2E loop prog requested"
+    reap { pop "destruction of local E2E loop prog requested" }
   end
 end

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -95,8 +95,12 @@ class Prog::Test::PostgresBase < Prog::Test::Base
 
   def destroy
     if frame["fail_message"] && frame["local_e2e"]
-      Prog::PageNexus.assemble("Local E2E Failure: #{self.class.name}", ["LocalE2eFailure", strand.ubid], strand.ubid, severity: "info")
-      nap 60 * 60 * 24 * 365
+      unless destroy_set?
+        Prog::PageNexus.assemble("Local E2E Failure: #{self.class.name}", ["LocalE2eFailure", strand.ubid], strand.ubid, severity: "info")
+        nap 60 * 60 * 24 * 365
+      end
+
+      Page.from_tag_parts("LocalE2eFailure", strand.ubid)&.incr_resolve
     end
 
     hop_destroy_postgres

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -85,7 +85,13 @@ class Prog::Test::PostgresBase < Prog::Test::Base
 
   def finish
     postgres_test_project.destroy unless Config.local_e2e_postgres_test_project_id
-    fail_test(frame["fail_message"]) if frame["fail_message"]
+    if (fail_message = frame["fail_message"])
+      if frame["local_e2e"]
+        pop fail_message
+      else
+        fail_test(fail_message)
+      end
+    end
     pop "Postgres tests are finished!"
   end
 

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Prog::Test::PostgresBase < Prog::Test::Base
-  def self.assemble(provider:, project_name:)
+  def self.assemble(provider:, project_name:, local_e2e: false)
     postgres_test_project = if Config.local_e2e_postgres_test_project_id
       Project.with_pk!(Config.local_e2e_postgres_test_project_id)
     else
@@ -14,7 +14,7 @@ class Prog::Test::PostgresBase < Prog::Test::Base
     Strand.create(
       prog: name.delete_prefix("Prog::"),
       label: "start",
-      stack: [{"provider" => provider, "postgres_test_project_id" => postgres_test_project.id}],
+      stack: [{"provider" => provider, "postgres_test_project_id" => postgres_test_project.id, "local_e2e" => local_e2e}],
     )
   end
 
@@ -91,5 +91,14 @@ class Prog::Test::PostgresBase < Prog::Test::Base
 
   def failed
     nap 15
+  end
+
+  def destroy
+    if frame["fail_message"] && frame["local_e2e"]
+      Prog::PageNexus.assemble("Local E2E Failure: #{self.class.name}", ["LocalE2eFailure", strand.ubid], strand.ubid, severity: "info")
+      nap 60 * 60 * 24 * 365
+    end
+
+    hop_destroy_postgres
   end
 end

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -3,7 +3,7 @@
 require_relative "../../lib/util"
 
 class Prog::Test::PostgresResource < Prog::Test::PostgresBase
-  semaphore :pause
+  semaphore :pause, :destroy
 
   def self.assemble(provider: "metal")
     super(provider:, project_name: "Postgres-Test-Project")
@@ -27,10 +27,10 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
       update_stack({"fail_message" => "Failed to run test queries"})
     end
 
-    hop_destroy_postgres
+    hop_destroy
   end
 
-  label def destroy_postgres
+  label def destroy
     postgres_resource.timeline.incr_destroy
     postgres_resource.incr_destroy
     hop_wait_resources_destroyed

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -5,8 +5,8 @@ require_relative "../../lib/util"
 class Prog::Test::PostgresResource < Prog::Test::PostgresBase
   semaphore :pause, :destroy
 
-  def self.assemble(provider: "metal")
-    super(provider:, project_name: "Postgres-Test-Project")
+  def self.assemble(provider: "metal", **)
+    super(provider:, project_name: "Postgres-Test-Project", **)
   end
 
   label def start
@@ -30,7 +30,7 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
     hop_destroy
   end
 
-  label def destroy
+  label def destroy_postgres
     postgres_resource.timeline.incr_destroy
     postgres_resource.incr_destroy
     hop_wait_resources_destroyed
@@ -44,4 +44,5 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
 
   label :finish
   label :failed
+  label :destroy
 end

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -5,8 +5,8 @@ require_relative "../../lib/util"
 class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   semaphore :pause, :destroy
 
-  def self.assemble(provider: "metal")
-    super(provider:, project_name: "Postgres-Upgrade-Test-Project")
+  def self.assemble(provider: "metal", **)
+    super(provider:, project_name: "Postgres-Upgrade-Test-Project", **)
   end
 
   label def start
@@ -197,7 +197,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
     hop_destroy
   end
 
-  label def destroy
+  label def destroy_postgres
     pre_upgrade_timeline.incr_destroy
     postgres_resource.timeline.incr_destroy
     read_replica.incr_destroy
@@ -213,6 +213,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
 
   label :finish
   label :failed
+  label :destroy
 
   def read_replica
     @read_replica ||= PostgresResource[frame["read_replica_id"]]

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -3,7 +3,7 @@
 require_relative "../../lib/util"
 
 class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
-  semaphore :pause
+  semaphore :pause, :destroy
 
   def self.assemble(provider: "metal")
     super(provider:, project_name: "Postgres-Upgrade-Test-Project")
@@ -25,7 +25,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
     Clog.emit("Testing Postgres before read replica creation")
     unless representative_server.run_query(test_queries_sql) == "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to run test queries before read replica"})
-      hop_destroy_postgres
+      hop_destroy
     end
 
     hop_create_read_replica
@@ -63,13 +63,13 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
     # Test primary
     unless representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to run read queries on primary before upgrade"})
-      hop_destroy_postgres
+      hop_destroy
     end
 
     # Test read replica
     unless read_replica.representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to run read queries on replica before upgrade"})
-      hop_destroy_postgres
+      hop_destroy
     end
 
     Clog.emit("Verified both primary and read replica are working correctly")
@@ -142,7 +142,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
       failed_servers.each do |server|
         Clog.emit("Failed server: #{server.ubid}, version=#{server.version}, state=#{server.strand.label}")
       end
-      hop_destroy_postgres
+      hop_destroy
     end
 
     nap 60
@@ -157,47 +157,47 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
     # Verify all servers are at version 18
     unless postgres_resource.servers.all? { |s| s.version == "18" }
       update_stack({"fail_message" => "Not all primary servers upgraded to version 18"})
-      hop_destroy_postgres
+      hop_destroy
     end
 
     unless read_replica.servers.all? { |s| s.version == "18" }
       update_stack({"fail_message" => "Not all replica servers upgraded to version 18"})
-      hop_destroy_postgres
+      hop_destroy
     end
 
     # Test read queries on primary (data should still be there)
     Clog.emit("Running read queries on primary after upgrade")
     unless representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to run read queries on primary after upgrade"})
-      hop_destroy_postgres
+      hop_destroy
     end
 
     # Test read queries on read replica
     Clog.emit("Running read queries on replica after upgrade")
     unless read_replica.representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to run read queries on replica after upgrade"})
-      hop_destroy_postgres
+      hop_destroy
     end
 
     # Test write queries on primary (should work on v18)
     Clog.emit("Running write queries on primary after upgrade")
     unless representative_server.run_query(test_queries_sql) == "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to run write queries after upgrade"})
-      hop_destroy_postgres
+      hop_destroy
     end
 
     # Verify replica can still read the new data
     Clog.emit("Verifying replica can read updated data")
     unless read_replica.representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
       update_stack({"fail_message" => "Failed to read updated data on replica after upgrade"})
-      hop_destroy_postgres
+      hop_destroy
     end
 
     Clog.emit("All upgrade tests passed successfully!")
-    hop_destroy_postgres
+    hop_destroy
   end
 
-  label def destroy_postgres
+  label def destroy
     pre_upgrade_timeline.incr_destroy
     postgres_resource.timeline.incr_destroy
     read_replica.incr_destroy

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Prog::Test::HaPostgresResource do
     end
   end
 
-  describe "#destroy" do
+  describe "#destroy_postgres" do
     before do
       pg_strand = Prog::Postgres::PostgresResourceNexus.assemble(project_id: pgr_test.frame["postgres_test_project_id"], location_id: Location::HETZNER_FSN1_ID, name: "test-pg", target_vm_size: "standard-2", target_storage_size_gib: 128, ha_type: "async")
       refresh_frame(pgr_test, new_values: {"postgres_resource_id" => pg_strand.id})
@@ -189,7 +189,7 @@ RSpec.describe Prog::Test::HaPostgresResource do
     end
 
     it "increments the destroy count and hops to wait_resources_destroyed" do
-      expect { pgr_test.destroy }.to hop("wait_resources_destroyed")
+      expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
       expect(@pg_strand.subject.destroy_set?).to be true
       expect(@pg_strand.subject.timeline.strand.semaphores.map(&:name)).to include("destroy")
     end

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Prog::Test::HaPostgresResource do
 
     it "fails if the postgres test fails" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("")
-      expect { pgr_test.test_postgres }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run test queries")
     end
@@ -141,7 +141,7 @@ RSpec.describe Prog::Test::HaPostgresResource do
 
     it "fails when the deadline passes without a new primary" do
       refresh_frame(pgr_test, new_values: {"failover_deadline" => Time.now.to_i - 1})
-      expect { pgr_test.wait_failover }.to hop("destroy_postgres")
+      expect { pgr_test.wait_failover }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to match(/Failover did not complete/)
     end
@@ -164,24 +164,24 @@ RSpec.describe Prog::Test::HaPostgresResource do
 
     it "fails if the postgres test fails" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("")
-      expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_after_failover }.to hop("destroy")
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run read queries after failover")
     end
 
-    it "hops to destroy_postgres if the standby does not exit read-only mode" do
+    it "hops to destroy if the standby does not exit read-only mode" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "")
-      expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_after_failover }.to hop("destroy")
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run write queries after failover")
     end
 
-    it "hops to destroy_postgres if the postgres test succeeds" do
+    it "hops to destroy if the postgres test succeeds" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1")
-      expect { pgr_test.test_postgres_after_failover }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_after_failover }.to hop("destroy")
       expect(frame_value(pgr_test, "fail_message")).to be_nil
     end
   end
 
-  describe "#destroy_postgres" do
+  describe "#destroy" do
     before do
       pg_strand = Prog::Postgres::PostgresResourceNexus.assemble(project_id: pgr_test.frame["postgres_test_project_id"], location_id: Location::HETZNER_FSN1_ID, name: "test-pg", target_vm_size: "standard-2", target_storage_size_gib: 128, ha_type: "async")
       refresh_frame(pgr_test, new_values: {"postgres_resource_id" => pg_strand.id})
@@ -189,7 +189,7 @@ RSpec.describe Prog::Test::HaPostgresResource do
     end
 
     it "increments the destroy count and hops to wait_resources_destroyed" do
-      expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
+      expect { pgr_test.destroy }.to hop("wait_resources_destroyed")
       expect(@pg_strand.subject.destroy_set?).to be true
       expect(@pg_strand.subject.timeline.strand.semaphores.map(&:name)).to include("destroy")
     end

--- a/spec/prog/test/local_e2e_loop_spec.rb
+++ b/spec/prog/test/local_e2e_loop_spec.rb
@@ -91,4 +91,10 @@ RSpec.describe Prog::Test::LocalE2eLoop do
       expect { lel.nap_between }.to hop("start")
     end
   end
+
+  describe "#destroy" do
+    it "exits" do
+      expect { lel.destroy }.to exit({"msg" => "destruction of local E2E loop prog requested"})
+    end
+  end
 end

--- a/spec/prog/test/local_e2e_loop_spec.rb
+++ b/spec/prog/test/local_e2e_loop_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Prog::Test::LocalE2eLoop do
       ).to eq [child.id, 1, %w[HaPostgresResource PostgresResource]]
       expect(child.prog).to eq "Test::PostgresResource"
       expect(child.stack[0]["provider"]).to eq "metal"
+      expect(child.stack[0]["local_e2e"]).to be true
     end
   end
 

--- a/spec/prog/test/local_e2e_loop_spec.rb
+++ b/spec/prog/test/local_e2e_loop_spec.rb
@@ -94,6 +94,18 @@ RSpec.describe Prog::Test::LocalE2eLoop do
   end
 
   describe "#destroy" do
+    it "reaps children before exiting" do
+      st = Strand.create(parent_id: lel_strand.id, prog: "Test", label: "hop_exit")
+      Semaphore.incr(lel_strand.id, "destroying")
+      lel_strand.update(label: "destroy")
+      lel_strand.run
+      expect(lel_strand.exists?).to be true
+
+      st.run
+      lel_strand.run
+      expect(lel_strand.exists?).to be false
+    end
+
     it "exits" do
       expect { lel.destroy }.to exit({"msg" => "destruction of local E2E loop prog requested"})
     end

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -113,8 +113,37 @@ RSpec.describe Prog::Test::PostgresResource do
   describe "#destroy" do
     before { setup_postgres_resource(with_server: true) }
 
+    it "hops to destroy postgres and does not page if no failure" do
+      expect { pgr_test.destroy }.to hop("destroy_postgres")
+      expect(Page.count).to eq 0
+    end
+
+    it "hops to destroy postgres and does not page if failure but not local e2e" do
+      refresh_frame(pgr_test, new_values: {"fail_message" => "Test failed"})
+      expect { pgr_test.destroy }.to hop("destroy_postgres")
+      expect(Page.count).to eq 0
+    end
+
+    it "hops to destroy postgres and does not page if local e2e but no failure" do
+      refresh_frame(pgr_test, new_values: {"local_e2e" => true})
+      expect { pgr_test.destroy }.to hop("destroy_postgres")
+      expect(Page.count).to eq 0
+    end
+
+    it "naps and pages if failure and local e2e" do
+      refresh_frame(pgr_test, new_values: {"fail_message" => "Test failed", "local_e2e" => true})
+      expect { pgr_test.destroy }.to nap(60 * 60 * 24 * 365)
+      pages = Page.all
+      expect(pages.size).to eq 1
+      expect(pages[0].severity).to eq "info"
+    end
+  end
+
+  describe "#destroy_postgres" do
+    before { setup_postgres_resource(with_server: true) }
+
     it "increments the destroy count and hops to wait_resources_destroyed" do
-      expect { pgr_test.destroy }.to hop("wait_resources_destroyed")
+      expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
       expect(Semaphore.where(strand_id: postgres_resource.id, name: "destroy").count).to eq(1)
       expect(Semaphore.where(strand_id: timeline.strand.id, name: "destroy").count).to eq(1)
     end
@@ -154,9 +183,7 @@ RSpec.describe Prog::Test::PostgresResource do
     end
 
     it "hops to failed if a failure happened" do
-      pgr_test.strand.stack.first["fail_message"] = "Test failed"
-      pgr_test.strand.modified!(:stack)
-      pgr_test.strand.save_changes
+      refresh_frame(pgr_test, new_values: {"fail_message" => "Test failed"})
       fresh_pgr_test = described_class.new(pgr_test.strand)
       expect { fresh_pgr_test.finish }.to hop("failed")
     end

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -197,6 +197,12 @@ RSpec.describe Prog::Test::PostgresResource do
         .and not_change { Project.select_order_map(:name) }
     end
 
+    it "exits if a failure happened and it is a local e2e strand" do
+      refresh_frame(pgr_test, new_values: {"fail_message" => "Test failed", "local_e2e" => true})
+      fresh_pgr_test = described_class.new(pgr_test.strand)
+      expect { fresh_pgr_test.finish }.to exit({"msg" => "Test failed"})
+    end
+
     it "hops to failed if a failure happened" do
       refresh_frame(pgr_test, new_values: {"fail_message" => "Test failed"})
       fresh_pgr_test = described_class.new(pgr_test.strand)

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -111,7 +111,10 @@ RSpec.describe Prog::Test::PostgresResource do
   end
 
   describe "#destroy" do
-    before { setup_postgres_resource(with_server: true) }
+    before do
+      setup_postgres_resource(with_server: true)
+      pgr_test.strand.update(label: "destroy")
+    end
 
     it "hops to destroy postgres and does not page if no failure" do
       expect { pgr_test.destroy }.to hop("destroy_postgres")
@@ -130,12 +133,24 @@ RSpec.describe Prog::Test::PostgresResource do
       expect(Page.count).to eq 0
     end
 
-    it "naps and pages if failure and local e2e" do
+    it "hops to destroy postgres and does not page if failure and local e2e but destroy semaphore set" do
+      refresh_frame(pgr_test, new_values: {"fail_message" => "Test failed", "local_e2e" => true})
+      pgr_test.incr_destroy
+      expect { pgr_test.destroy }.to hop("destroy_postgres")
+      expect(Page.count).to eq 0
+    end
+
+    it "naps and pages if failure and local e2e, but allows destruction if destroy semaphore set" do
       refresh_frame(pgr_test, new_values: {"fail_message" => "Test failed", "local_e2e" => true})
       expect { pgr_test.destroy }.to nap(60 * 60 * 24 * 365)
       pages = Page.all
       expect(pages.size).to eq 1
       expect(pages[0].severity).to eq "info"
+      expect(pages[0].reload.resolve_set?).to be false
+
+      pgr_test.incr_destroy
+      expect { pgr_test.destroy }.to hop("destroy_postgres")
+      expect(pages[0].reload.resolve_set?).to be true
     end
   end
 

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -101,20 +101,20 @@ RSpec.describe Prog::Test::PostgresResource do
 
     it "fails if the basic connectivity test fails" do
       expect(sshable).to receive(:_cmd).and_return("\n")
-      expect { pgr_test.test_postgres }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres }.to hop("destroy")
     end
 
-    it "hops to destroy_postgres if the basic connectivity test passes" do
+    it "hops to destroy if the basic connectivity test passes" do
       expect(sshable).to receive(:_cmd).and_return("DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1\n")
-      expect { pgr_test.test_postgres }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres }.to hop("destroy")
     end
   end
 
-  describe "#destroy_postgres" do
+  describe "#destroy" do
     before { setup_postgres_resource(with_server: true) }
 
     it "increments the destroy count and hops to wait_resources_destroyed" do
-      expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
+      expect { pgr_test.destroy }.to hop("wait_resources_destroyed")
       expect(Semaphore.where(strand_id: postgres_resource.id, name: "destroy").count).to eq(1)
       expect(Semaphore.where(strand_id: timeline.strand.id, name: "destroy").count).to eq(1)
     end

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
 
     it "fails if the postgres test fails" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("")
-      expect { pgr_test.test_postgres_before_read_replica }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_before_read_replica }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run test queries before read replica")
     end
@@ -141,7 +141,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
 
     it "fails if read queries on primary fail before upgrade" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("")
-      expect { pgr_test.test_postgres_with_read_replica }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_with_read_replica }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run read queries on primary before upgrade")
     end
@@ -149,7 +149,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     it "fails if read queries on replica fail before upgrade" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1")
       allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("")
-      expect { pgr_test.test_postgres_with_read_replica }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_with_read_replica }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run read queries on replica before upgrade")
     end
@@ -194,7 +194,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
 
     it "fails if any servers are in failed state" do
       pgr_test.postgres_resource.servers.first.strand.update(label: "failed")
-      expect { pgr_test.check_upgrade_progress }.to hop("destroy_postgres")
+      expect { pgr_test.check_upgrade_progress }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to eq("Upgrade failed: some servers are in failed state")
     end
@@ -303,21 +303,21 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
 
     it "fails if not all primary servers are at version 18" do
       pgr_test.postgres_resource.servers.first.update(version: "17")
-      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to eq("Not all primary servers upgraded to version 18")
     end
 
     it "fails if not all replica servers are at version 18" do
       pgr_test.read_replica.servers.first.update(version: "17")
-      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to eq("Not all replica servers upgraded to version 18")
     end
 
     it "fails if read queries on primary fail after upgrade" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("")
-      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run read queries on primary after upgrade")
     end
@@ -325,7 +325,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     it "fails if read queries on replica fail after upgrade" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1")
       allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("")
-      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run read queries on replica after upgrade")
     end
@@ -333,7 +333,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     it "fails if write queries on primary fail after upgrade" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "")
       allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1")
-      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run write queries after upgrade")
     end
@@ -341,21 +341,21 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     it "fails if replica cannot read updated data after upgrade" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1")
       allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "")
-      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to eq("Failed to read updated data on replica after upgrade")
     end
 
-    it "hops to destroy_postgres if all tests pass" do
+    it "hops to destroy if all tests pass" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1")
       allow(pgr_test.read_replica.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "4159.90\n415.99\n4.1")
-      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy_postgres")
+      expect { pgr_test.test_postgres_after_upgrade }.to hop("destroy")
       refresh_frame(pgr_test)
       expect(frame_value(pgr_test, "fail_message")).to be_nil
     end
   end
 
-  describe "#destroy_postgres" do
+  describe "#destroy" do
     before do
       pg_strand = Prog::Postgres::PostgresResourceNexus.assemble(project_id: pgr_test.frame["postgres_test_project_id"], location_id: Location::HETZNER_FSN1_ID, name: "test-pg", target_vm_size: "standard-2", target_storage_size_gib: 128, ha_type: "async", target_version: "17")
       replica_strand = Prog::Postgres::PostgresResourceNexus.assemble(project_id: pgr_test.frame["postgres_test_project_id"], location_id: Location::HETZNER_FSN1_ID, name: "test-pg-replica", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: pg_strand.id)
@@ -367,7 +367,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
 
     it "increments the destroy count and hops to wait_resources_destroyed" do
-      expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
+      expect { pgr_test.destroy }.to hop("wait_resources_destroyed")
       expect(@pg_strand.subject.destroy_set?).to be true
       expect(@replica_strand.subject.destroy_set?).to be true
       expect(@pre_upgrade_timeline.strand.reload.semaphores.map(&:name)).to include("destroy")

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
   end
 
-  describe "#destroy" do
+  describe "#destroy_postgres" do
     before do
       pg_strand = Prog::Postgres::PostgresResourceNexus.assemble(project_id: pgr_test.frame["postgres_test_project_id"], location_id: Location::HETZNER_FSN1_ID, name: "test-pg", target_vm_size: "standard-2", target_storage_size_gib: 128, ha_type: "async", target_version: "17")
       replica_strand = Prog::Postgres::PostgresResourceNexus.assemble(project_id: pgr_test.frame["postgres_test_project_id"], location_id: Location::HETZNER_FSN1_ID, name: "test-pg-replica", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: pg_strand.id)
@@ -367,7 +367,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
 
     it "increments the destroy count and hops to wait_resources_destroyed" do
-      expect { pgr_test.destroy }.to hop("wait_resources_destroyed")
+      expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
       expect(@pg_strand.subject.destroy_set?).to be true
       expect(@replica_strand.subject.destroy_set?).to be true
       expect(@pre_upgrade_timeline.strand.reload.semaphores.map(&:name)).to include("destroy")

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1464,8 +1464,8 @@ RSpec.describe CloverAdmin do
   describe "local E2E" do
     before do
       project = Project.create(name: "Postgres-Service-Project")
-      expect(Config).to receive(:postgres_service_project_id).and_return(project.id).at_least(:once)
-      expect(Config).to receive(:local_e2e_postgres_test_project_id).and_return(nil).at_least(:once)
+      allow(Config).to receive(:postgres_service_project_id).and_return(project.id).at_least(:once)
+      allow(Config).to receive(:local_e2e_postgres_test_project_id).and_return(nil).at_least(:once)
       click_link "Manage Local E2E"
     end
 
@@ -1476,14 +1476,14 @@ RSpec.describe CloverAdmin do
       local_e2e_path = page.current_path
       strand = Prog::Test::PostgresResource.assemble(provider: "metal")
       page.refresh
-      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", strand.ubid, '{"provider" => "metal"}', ""]
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", strand.ubid, '{"provider" => "metal"}', "", ""]
       click_link strand.ubid
       expect(page.title).to eq "Ubicloud Admin - Strand #{strand.ubid}"
 
       strand.run
       pg_ubid = UBID.to_ubid(strand.stack[0]["postgres_resource_id"])
       visit local_e2e_path
-      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "wait_postgres_resource", "0", strand.ubid, "{\"provider\" => \"metal\", \"postgres_resource\" => \"#{pg_ubid}\"}", ""]
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "wait_postgres_resource", "0", strand.ubid, "{\"provider\" => \"metal\", \"postgres_resource\" => \"#{pg_ubid}\"}", "", ""]
       click_link pg_ubid
       expect(page.title).to eq "Ubicloud Admin - PostgresResource #{pg_ubid}"
     end
@@ -1507,7 +1507,7 @@ RSpec.describe CloverAdmin do
 
       st = Strand.first(prog: "Test::PostgresResource")
       expect(page).to have_flash_notice("Started local E2E strand(s): #{st.ubid}")
-      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", st.ubid, '{"provider" => "metal"}', ""]
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", st.ubid, '{"provider" => "metal"}', "", ""]
     end
 
     it "allows creation of multiple strands" do
@@ -1520,8 +1520,8 @@ RSpec.describe CloverAdmin do
       pg_st = Strand.first(prog: "Test::PostgresResource")
       expect(page).to have_flash_notice("Started local E2E strand(s): #{pg_st.ubid} #{ha_pg_st.ubid}")
       expect(page.all(".local-e2e-table td").map(&:text)).to eq [
-        "Test::HaPostgresResource", "start", "0", ha_pg_st.ubid, '{"provider" => "metal"}', "",
-        "Test::PostgresResource", "start", "0", pg_st.ubid, '{"provider" => "metal"}', "",
+        "Test::HaPostgresResource", "start", "0", ha_pg_st.ubid, '{"provider" => "metal"}', "", "",
+        "Test::PostgresResource", "start", "0", pg_st.ubid, '{"provider" => "metal"}', "", "",
       ]
     end
 
@@ -1534,14 +1534,14 @@ RSpec.describe CloverAdmin do
 
       st = Strand.first(prog: "Test::LocalE2eLoop")
       expect(page).to have_flash_notice("Started local E2E strand(s): #{st.ubid}")
-      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::LocalE2eLoop", "start", "0", st.ubid, "{\"progs\" => [\"PostgresResource\", \"HaPostgresResource\"], \"prog_args\" => {\"provider\" => \"metal\"}}", ""]
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::LocalE2eLoop", "start", "0", st.ubid, "{\"progs\" => [\"PostgresResource\", \"HaPostgresResource\"], \"prog_args\" => {\"provider\" => \"metal\"}}", "", ""]
 
       st.run
       page.refresh
       child_ubid = st.children[0].ubid
       expect(page.all(".local-e2e-table td").map(&:text)).to eq [
-        "Test::LocalE2eLoop", "wait", "0", st.ubid, "{\"progs\" => [\"HaPostgresResource\", \"PostgresResource\"], \"prog_args\" => {\"provider\" => \"metal\"}, \"current_strand\" => \"#{child_ubid}\"}", "",
-        "Test::PostgresResource", "start", "0", child_ubid, "{\"provider\" => \"metal\"}", "",
+        "Test::LocalE2eLoop", "wait", "0", st.ubid, "{\"progs\" => [\"HaPostgresResource\", \"PostgresResource\"], \"prog_args\" => {\"provider\" => \"metal\"}, \"current_strand\" => \"#{child_ubid}\"}", "", "",
+        "Test::PostgresResource", "start", "0", child_ubid, "{\"provider\" => \"metal\"}", "", "",
       ]
     end
 
@@ -1569,6 +1569,29 @@ RSpec.describe CloverAdmin do
       st.destroy
       click_button "Pause"
       expect(page).to have_flash_error("Strand not found, it was probably already deleted")
+    end
+
+    it "allows destroying strands" do
+      check "PostgresResource"
+      select "metal"
+      click_button "Start Local E2E Strand"
+
+      click_button "Destroy"
+      st = Strand.first(prog: "Test::PostgresResource")
+      expect(page).to have_flash_notice("Strand #{st.ubid} destroyed")
+      expect(st.semaphores.map(&:name)).to eq ["destroy"]
+    end
+
+    it "allows destroying loop strand" do
+      check "PostgresResource"
+      select "metal"
+      check "Loop?"
+      click_button "Start Local E2E Strand"
+
+      click_button "Destroy"
+      st = Strand.first(prog: "Test::LocalE2eLoop")
+      expect(page).to have_flash_notice("Strand #{st.ubid} destroyed")
+      expect(st.semaphores.map(&:name)).to eq ["destroy"]
     end
   end
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1535,13 +1535,13 @@ RSpec.describe CloverAdmin do
 
       st = Strand.first(prog: "Test::LocalE2eLoop")
       expect(page).to have_flash_notice("Started local E2E strand(s): #{st.ubid}")
-      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::LocalE2eLoop", "start", "0", st.ubid, "{\"progs\" => [\"PostgresResource\", \"HaPostgresResource\"], \"prog_args\" => {\"provider\" => \"metal\"}}", "", ""]
+      expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::LocalE2eLoop", "start", "0", st.ubid, "{\"progs\" => [\"PostgresResource\", \"HaPostgresResource\"], \"prog_args\" => {\"provider\" => \"metal\"}, \"starts\" => 0, \"successes\" => 0, \"failures\" => 0}", "", ""]
 
       st.run
       page.refresh
       child_ubid = st.children[0].ubid
       expect(page.all(".local-e2e-table td").map(&:text)).to eq [
-        "Test::LocalE2eLoop", "wait", "0", st.ubid, "{\"progs\" => [\"HaPostgresResource\", \"PostgresResource\"], \"prog_args\" => {\"provider\" => \"metal\"}, \"current_strand\" => \"#{child_ubid}\"}", "", "",
+        "Test::LocalE2eLoop", "wait", "0", st.ubid, "{\"progs\" => [\"HaPostgresResource\", \"PostgresResource\"], \"prog_args\" => {\"provider\" => \"metal\"}, \"starts\" => 1, \"successes\" => 0, \"failures\" => 0, \"current_strand\" => \"#{child_ubid}\"}", "", "",
         "Test::PostgresResource", "start", "0", child_ubid, "{\"provider\" => \"metal\"}", "", "",
       ]
     end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1506,6 +1506,7 @@ RSpec.describe CloverAdmin do
       click_button "Start Local E2E Strand"
 
       st = Strand.first(prog: "Test::PostgresResource")
+      expect(st.stack[0]["local_e2e"]).to be true
       expect(page).to have_flash_notice("Started local E2E strand(s): #{st.ubid}")
       expect(page.all(".local-e2e-table td").map(&:text)).to eq ["Test::PostgresResource", "start", "0", st.ubid, '{"provider" => "metal"}', "", ""]
     end

--- a/views/admin/local_e2e.erb
+++ b/views/admin/local_e2e.erb
@@ -15,6 +15,8 @@
     table_form_button("Pause", action: "/local-e2e/pause/#{strand.ubid}", method: "post")
   end
 
+  h[:destroy] = table_form_button("Destroy", action: "/local-e2e/destroy/#{strand.ubid}", method: "post")
+
   h
 end %>
 

--- a/views/admin/local_e2e.erb
+++ b/views/admin/local_e2e.erb
@@ -4,7 +4,7 @@
   h = strand.values.slice(:prog, :label, :try)
   frame = strand.stack[0]
   h[:id] = strand.ubid
-  data = h[:data] = frame.slice("provider", "progs", "prog_args")
+  data = h[:data] = frame.slice("provider", "progs", "prog_args", "starts", "successes", "failures")
   data.compact!
   data["current_strand"] = UBID.to_ubid(frame["current_strand"]) if frame["current_strand"]
   data["postgres_resource"] = UBID.to_ubid(frame["postgres_resource_id"]) if frame["postgres_resource_id"]


### PR DESCRIPTION
This allows developers to investigate the local E2E failure to determine the root cause. After that, they can destroy the local E2E strand, and it will exit.

Additional changes:

* Allow destroying local E2E strands on admin site, in addition to pausing them
* Switch Config.local_e2e_postgres_test_project_id to uuid
* Fix local E2E loop strand to reap children before exiting
* Show starts, successes, and failures for local E2E loop strand on admin site

See commit messages for details.

After these changes, I think it's OK to start testing local E2E in staging.