### PR TITLE
Validation: use `match?` instead of `match` when match data is unused

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -68,12 +68,12 @@ module Validation
 
   def self.validate_name(name)
     msg = "Name must only contain lowercase letters, numbers, and hyphens and have max length 63."
-    fail ValidationFailed.new({name: msg}) unless name&.match(ALLOWED_NAME_PATTERN)
+    fail ValidationFailed.new({name: msg}) unless name&.match?(ALLOWED_NAME_PATTERN)
   end
 
   def self.validate_minio_username(username)
     msg = "Minio user must only contain lowercase letters, numbers, hyphens and underscore and cannot start with a number or hyphen. It also have max length of 32, min length of 3."
-    fail ValidationFailed.new({username: msg}) unless username&.match(ALLOWED_MINIO_USERNAME_PATTERN)
+    fail ValidationFailed.new({username: msg}) unless username&.match?(ALLOWED_MINIO_USERNAME_PATTERN)
   end
 
   def self.validate_minio_setup(storage_size_gib:, pool_count:, server_count:, drive_count:)
@@ -139,7 +139,7 @@ module Validation
 
   def self.validate_os_user_name(os_user_name)
     msg = "OS user name must only contain lowercase letters, numbers, hyphens and underscore and cannot start with a number or hyphen. It also have max length of 32."
-    fail ValidationFailed.new({user: msg}) unless os_user_name&.match(ALLOWED_OS_USER_NAME_PATTERN)
+    fail ValidationFailed.new({user: msg}) unless os_user_name&.match?(ALLOWED_OS_USER_NAME_PATTERN)
   end
 
   def self.validate_storage_volumes(storage_volumes, boot_disk_index)
@@ -250,11 +250,11 @@ module Validation
   end
 
   def self.validate_short_text(text, field_name)
-    fail ValidationFailed.new({field_name: "The #{field_name} must have max length 63 and only contain alphanumeric characters, hyphen, underscore, space, parantheses, exclamation, question mark and star."}) unless text.match(ALLOWED_SHORT_TEXT_PATTERN)
+    fail ValidationFailed.new({field_name: "The #{field_name} must have max length 63 and only contain alphanumeric characters, hyphen, underscore, space, parantheses, exclamation, question mark and star."}) unless text.match?(ALLOWED_SHORT_TEXT_PATTERN)
   end
 
   def self.validate_account_name(name)
-    fail ValidationFailed.new({name: "Name must only contain letters, numbers, spaces, and hyphens and have max length 63."}) unless name&.match(ALLOWED_ACCOUNT_NAME)
+    fail ValidationFailed.new({name: "Name must only contain letters, numbers, spaces, and hyphens and have max length 63."}) unless name&.match?(ALLOWED_ACCOUNT_NAME)
   end
 
   def self.validate_url(url)
@@ -327,7 +327,7 @@ module Validation
   end
 
   def self.validate_kubernetes_name(name)
-    fail ValidationFailed.new({name: "Kubernetes cluster name must only contain lowercase letters, numbers, and hyphens and have max length 40."}) unless name&.match(ALLOWED_KUBERNETES_NAME_PATTERN)
+    fail ValidationFailed.new({name: "Kubernetes cluster name must only contain lowercase letters, numbers, and hyphens and have max length 40."}) unless name&.match?(ALLOWED_KUBERNETES_NAME_PATTERN)
   end
 
   def self.validate_kubernetes_cp_node_count(count)
@@ -345,7 +345,7 @@ module Validation
 
   def self.validate_victoria_metrics_username(username)
     msg = "VictoriaMetrics user must only contain lowercase letters, numbers, hyphens and underscore and cannot start with a number or hyphen. It also has a max length of 32 and a min length of 3."
-    fail ValidationFailed.new({username: msg}) unless username&.match(ALLOWED_VICTORIA_METRICS_USERNAME_PATTERN)
+    fail ValidationFailed.new({username: msg}) unless username&.match?(ALLOWED_VICTORIA_METRICS_USERNAME_PATTERN)
   end
 
   def self.validate_victoria_metrics_storage_size(storage_size)


### PR DESCRIPTION
`match?` avoids allocating a MatchData object and is preferred when only a boolean check is needed.