### PR TITLE
Allocator: remove the unused os_filter

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Scheduling::Allocator
-  def self.allocate(vm, storage_volumes, distinct_storage_devices: false, gpu_count: 0, gpu_device: nil, allocation_state_filter: ["accepting"], host_filter: [], host_exclusion_filter: [], location_filter: [], location_preference: [], family_filter: [], os_filter: nil, data_center_exclusion_filter: [])
+  def self.allocate(vm, storage_volumes, distinct_storage_devices: false, gpu_count: 0, gpu_device: nil, allocation_state_filter: ["accepting"], host_filter: [], host_exclusion_filter: [], location_filter: [], location_preference: [], family_filter: [], data_center_exclusion_filter: [])
     requires_track_written = storage_volumes.any? { it["track_written"] }
     uses_machine_image = storage_volumes.any? { it["machine_image_version_id"] }
     if requires_track_written || uses_machine_image
@@ -32,7 +32,6 @@ module Scheduling::Allocator
       Option::VmFamilies.find { it.name == vm.family }&.require_shared_slice || false,
       vm.project.get_ff_allocator_diagnostics || false,
       family_filter,
-      os_filter,
       minimum_vhost_block_backend_version,
     )
     allocation = Allocation.best_allocation(request)
@@ -67,7 +66,6 @@ module Scheduling::Allocator
     :require_shared_slice,
     :diagnostics,
     :family_filter,
-    :os_filter,
     :minimum_vhost_block_backend_version,
   ) do
     def initialize(*args)
@@ -245,9 +243,6 @@ module Scheduling::Allocator
       ds = ds.where(allocation_state: request.allocation_state_filter) unless request.allocation_state_filter.empty?
       ds = ds.where(Sequel[:vm_host][:family] => request.family_filter) unless request.family_filter.empty?
       ds = ds.exclude { Sequel.function(:coalesce, num_gpus, 0) > 0 } unless request.gpu_count > 0 || request.host_filter.any?
-
-      # Temporary while testing CloudHypervisor 46 rollout
-      ds = ds.where(Sequel[:vm_host][:os_version] => request.os_filter) if request.os_filter
 
       if request.minimum_vhost_block_backend_version
         ds = ds.where(

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Al do
 
   # Creates a Request object with the given parameters
   #
-  def create_req(vm, storage_volumes, target_host_utilization: 0.55, distinct_storage_devices: false, gpu_count: 0, gpu_device: nil, allocation_state_filter: ["accepting"], host_filter: [], host_exclusion_filter: [], data_center_exclusion_filter: [], location_filter: [], location_preference: [], use_slices: true, require_shared_slice: false, diagnostics: false, family_filter: [], os_filter: nil, minimum_vhost_block_backend_version: nil)
+  def create_req(vm, storage_volumes, target_host_utilization: 0.55, distinct_storage_devices: false, gpu_count: 0, gpu_device: nil, allocation_state_filter: ["accepting"], host_filter: [], host_exclusion_filter: [], data_center_exclusion_filter: [], location_filter: [], location_preference: [], use_slices: true, require_shared_slice: false, diagnostics: false, family_filter: [], minimum_vhost_block_backend_version: nil)
     Al::Request.new(
       vm.id,
       vm.vcpus,
@@ -41,7 +41,6 @@ RSpec.describe Al do
       require_shared_slice,
       diagnostics,
       family_filter,
-      os_filter,
       minimum_vhost_block_backend_version,
     )
   end
@@ -300,23 +299,6 @@ RSpec.describe Al do
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
       req.family_filter = ["premium"]
-      cand = Al::Allocation.candidate_hosts(req)
-
-      expect(cand.size).to eq(1)
-      expect(cand.first[:vm_host_id]).to eq(vmh1.id)
-    end
-
-    it "applies os filter" do
-      vmh1 = create_vm_host(family: "standard", os_version: "ubuntu-24.04", total_cpus: 10, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
-      vmh2 = create_vm_host(family: "standard", os_version: "ubuntu-22.04", total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
-      StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
-      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
-      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
-
-      req.os_filter = "ubuntu-24.04"
       cand = Al::Allocation.candidate_hosts(req)
 
       expect(cand.size).to eq(1)


### PR DESCRIPTION
A code comment said this was a temporary knob while rolling out cloud-hypervisor 46.