### PR TITLE
Run kubeadm upgrade apply during cluster upgrades

### DIFF
--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -110,6 +110,15 @@ class KubernetesCluster < Sequel::Model
     [extra_ports, missing_ports]
   end
 
+  def kubeadm_recorded_version
+    raw = client.kubectl("-n kube-system get cm kubeadm-config -o jsonpath='{.data.ClusterConfiguration}'")
+    YAML.safe_load(raw)["kubernetesVersion"]
+  end
+
+  def kubeadm_recorded_minor_version
+    kubeadm_recorded_version&.[](/^v\d+\.\d+/)
+  end
+
   def cluster_health_report
     return unless connectivity_check_target
 

--- a/prog/kubernetes/upgrade_kubernetes_node.rb
+++ b/prog/kubernetes/upgrade_kubernetes_node.rb
@@ -7,6 +7,10 @@ class Prog::Kubernetes::UpgradeKubernetesNode < Prog::Base
     @old_node ||= KubernetesNode[frame.fetch("old_node_id")]
   end
 
+  def new_node
+    @new_node ||= KubernetesNode[frame.fetch("new_node_id")]
+  end
+
   def kubernetes_nodepool
     @kubernetes_nodepool ||= KubernetesNodepool[frame.fetch("nodepool_id", nil)]
   end
@@ -40,7 +44,30 @@ class Prog::Kubernetes::UpgradeKubernetesNode < Prog::Base
       # However, the strand has only has a single child created in start.
       update_stack({"new_node_id" => node_id})
 
+      hop_upgrade_kubeadm
+    end
+  end
+
+  label def upgrade_kubeadm
+    hop_drain_old_node if kubernetes_nodepool
+    hop_drain_old_node if kubernetes_cluster.kubeadm_recorded_minor_version == kubernetes_cluster.version
+
+    state = new_node.vm.sshable.d_check("kubeadm_upgrade_apply")
+    case state
+    when "Succeeded"
       hop_drain_old_node
+    when "NotStarted"
+      new_node.vm.sshable.d_run(
+        "kubeadm_upgrade_apply",
+        "bash", "-c",
+        "sudo kubeadm upgrade apply --yes $(kubeadm version -o short)",
+      )
+      nap 30
+    when "InProgress"
+      nap 30
+    else
+      Clog.emit((state == "Failed") ? "could not run kubeadm upgrade apply" : "got unknown state from daemonizer2 check: #{state}")
+      nap 65536
     end
   end
 

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -44,6 +44,32 @@ RSpec.describe KubernetesCluster do
     expect(kc.display_state).to eq "deleting"
   end
 
+  describe "#kubeadm_recorded_version" do
+    let(:ssh_session) { Net::SSH::Connection::Session.allocate }
+    let(:client) { Kubernetes::Client.new(kc, ssh_session) }
+
+    before { expect(kc).to receive(:client).and_return(client) }
+
+    it "returns the kubernetesVersion field from the kubeadm-config ConfigMap" do
+      cluster_config = "apiServer: {}\nkubernetesVersion: v1.34.0\n"
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new(cluster_config, 0)
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf -n kube-system get cm kubeadm-config -o jsonpath='{.data.ClusterConfiguration}'").and_return(response)
+      expect(kc.kubeadm_recorded_version).to eq("v1.34.0")
+    end
+  end
+
+  describe "#kubeadm_recorded_minor_version" do
+    it "extracts the major.minor portion of the recorded version" do
+      expect(kc).to receive(:kubeadm_recorded_version).and_return("v1.34.5")
+      expect(kc.kubeadm_recorded_minor_version).to eq("v1.34")
+    end
+
+    it "returns nil when the recorded version is missing" do
+      expect(kc).to receive(:kubeadm_recorded_version).and_return(nil)
+      expect(kc.kubeadm_recorded_minor_version).to be_nil
+    end
+  end
+
   it "initiates a new health monitor session" do
     sshable = Sshable.new
     expect(kc).to receive(:sshable).and_return(sshable)

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -5,7 +5,7 @@ require_relative "../../model/spec_helper"
 RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
   subject(:prog) { described_class.new(st) }
 
-  let(:st) { Strand.create(prog: "Kubernetes::UpgradeKubernetesNode", label: "start") }
+  let(:st) { Strand.create(prog: "Kubernetes::UpgradeKubernetesNode", label: "start", stack: [{"subject_id" => kubernetes_cluster.id}]) }
 
   let(:project) {
     Project.create(name: "default")
@@ -37,7 +37,6 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
 
   before do
     allow(Config).to receive(:kubernetes_service_project_id).and_return(Project.create(name: "UbicloudKubernetesService").id)
-    allow(prog).to receive(:kubernetes_cluster).and_return(kubernetes_cluster)
   end
 
   describe "#before_run" do
@@ -46,17 +45,17 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
     end
 
     it "exits when kubernetes cluster is deleted and has no children itself" do
-      st.update(prog: "Kubernetes::UpgradeKubernetesNode", label: "somestep", stack: [{}])
+      st.update(label: "somestep")
       prog.before_run # Nothing happens
 
-      kubernetes_cluster.strand.label = "destroy"
+      prog.kubernetes_cluster.strand.update(label: "destroy")
       expect { prog.before_run }.to exit({"msg" => "upgrade cancelled"})
     end
 
     it "donates when kubernetes cluster is deleted and but has a child" do
-      st.update(prog: "Kubernetes::UpgradeKubernetesNode", label: "somestep", stack: [{}])
+      st.update(label: "somestep")
       Strand.create(parent_id: st.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
-      kubernetes_cluster.strand.label = "destroy"
+      prog.kubernetes_cluster.strand.update(label: "destroy")
       expect { prog.before_run }.to nap(120)
     end
   end
@@ -75,16 +74,72 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
 
   describe "#wait_new_node" do
     it "donates if there are sub-programs running" do
-      st.update(prog: "Kubernetes::UpgradeKubernetesNode", label: "wait_new_node", stack: [{}])
+      st.update(label: "wait_new_node")
       Strand.create(parent_id: st.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
       expect { prog.wait_new_node }.to nap(120)
     end
 
-    it "hops to drain_old_node if there are no sub-programs running" do
-      st.update(prog: "Kubernetes::UpgradeKubernetesNode", label: "wait_new_node", stack: [{}])
+    it "hops to upgrade_kubeadm if there are no sub-programs running" do
+      st.update(label: "wait_new_node")
       Strand.create(parent_id: st.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{}], exitval: {"node_id" => "12345"})
-      expect { prog.wait_new_node }.to hop("drain_old_node")
+      expect { prog.wait_new_node }.to hop("upgrade_kubeadm")
       expect(prog.strand.stack.first["new_node_id"]).to eq "12345"
+    end
+  end
+
+  describe "#upgrade_kubeadm" do
+    let(:new_node) { KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kubernetes_cluster.id) }
+
+    before do
+      Sshable.create_with_id(new_node.vm.id)
+      st.update(stack: [{"subject_id" => kubernetes_cluster.id, "new_node_id" => new_node.id, "old_node_id" => "old"}])
+    end
+
+    it "skips kubeadm upgrade for worker (nodepool) replacements" do
+      st.update(stack: [{"subject_id" => kubernetes_cluster.id, "new_node_id" => new_node.id, "old_node_id" => "old", "nodepool_id" => kubernetes_nodepool.id}])
+      expect(prog.new_node.vm.sshable).not_to receive(:d_check)
+      expect { prog.upgrade_kubeadm }.to hop("drain_old_node")
+    end
+
+    it "skips kubeadm upgrade when the cluster is already recorded at the target version" do
+      expect(prog.kubernetes_cluster).to receive(:kubeadm_recorded_minor_version).at_least(:once).and_return(prog.kubernetes_cluster.version)
+      expect(prog.new_node.vm.sshable).not_to receive(:d_check)
+      expect { prog.upgrade_kubeadm }.to hop("drain_old_node")
+    end
+
+    context "when the ConfigMap is behind the cluster version" do
+      before do
+        expect(prog.kubernetes_cluster).to receive(:kubeadm_recorded_minor_version).at_least(:once).and_return("v1.99")
+      end
+
+      it "starts kubeadm upgrade apply on the new node when not started yet" do
+        expect(prog.new_node.vm.sshable).to receive(:d_check).with("kubeadm_upgrade_apply").and_return("NotStarted")
+        expect(prog.new_node.vm.sshable).to receive(:d_run).with(
+          "kubeadm_upgrade_apply", "bash", "-c",
+          "sudo kubeadm upgrade apply --yes $(kubeadm version -o short)",
+        )
+        expect { prog.upgrade_kubeadm }.to nap(30)
+      end
+
+      it "naps while the upgrade is in progress" do
+        expect(prog.new_node.vm.sshable).to receive(:d_check).with("kubeadm_upgrade_apply").and_return("InProgress")
+        expect { prog.upgrade_kubeadm }.to nap(30)
+      end
+
+      it "hops to drain_old_node when the upgrade succeeded" do
+        expect(prog.new_node.vm.sshable).to receive(:d_check).with("kubeadm_upgrade_apply").and_return("Succeeded")
+        expect { prog.upgrade_kubeadm }.to hop("drain_old_node")
+      end
+
+      it "logs and naps long when the upgrade failed" do
+        expect(prog.new_node.vm.sshable).to receive(:d_check).with("kubeadm_upgrade_apply").and_return("Failed")
+        expect { prog.upgrade_kubeadm }.to nap(65536)
+      end
+
+      it "naps long for an unknown daemonizer state" do
+        expect(prog.new_node.vm.sshable).to receive(:d_check).with("kubeadm_upgrade_apply").and_return("Whatever")
+        expect { prog.upgrade_kubeadm }.to nap(65536)
+      end
     end
   end
 


### PR DESCRIPTION
Replacing CP nodes during an upgrade only swapped kubelet binaries: the kubeadm-config ConfigMap kept its original kubernetesVersion, so new VMs joining the control plane rendered apiserver/controller-mgr/ scheduler/etcd static pods at the *old* version (kubeadm join reads image tags from the ConfigMap, not from its own binary). kube-proxy and CoreDNS likewise stayed at the init-time version. The drift silently violated the version-skew policy for one cycle and tripped the kubeadm preflight check on the next minor upgrade.

Adds an upgrade_kubeadm label between wait_new_node and drain_old_node that runs `kubeadm upgrade apply --yes $(kubeadm version -o short)` on the freshly-joined CP node via daemonizer. The label is skipped for worker replacements and for any iteration where the ConfigMap's recorded minor version already matches the cluster's target, so it executes at most once per upgrade campaign — the moment after the first new CP VM joins. That single run bumps the ConfigMap, re-renders the local static pods at the new version, and rolls kube-proxy and CoreDNS, so subsequent CP replacements come up correctly from the start.

Adds KubernetesCluster#kubeadm_recorded_version and kubeadm_recorded_minor_version for the staleness check.