### PR TITLE
Make postgres backup taking more robust and intuitive

### DIFF
--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -23,7 +23,7 @@ class PostgresTimeline < Sequel::Model
     return false if blob_storage.nil?
     return false if leader.nil?
 
-    status = leader.vm.sshable.cmd("common/bin/daemonizer --check take_postgres_backup")
+    status = leader.vm.sshable.d_check("take_postgres_backup")
     return true if ["Failed", "NotStarted"].include?(status)
     return true if status == "Succeeded" && (latest_backup_started_at.nil? || latest_backup_started_at < Time.now - 60 * 60 * backup_period_hours)
 

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -31,18 +31,16 @@ class PostgresTimeline < Sequel::Model
   end
 
   def backups
-    return [] if blob_storage.nil?
+    return @backups if @backups
+    return @backups = [] if blob_storage.nil?
 
-    begin
-      list_objects("basebackups_005/", delimiter: "/")
-        .select { it.key.end_with?("backup_stop_sentinel.json") }
-    rescue => ex
-      recoverable_errors = ["The AWS Access Key Id you provided does not exist in our records.", "The specified bucket does not exist", "AccessDenied", "No route to host", "Connection refused"]
-      Clog.emit("Backup fetch exception", Util.exception_to_hash(ex))
-      return [] if recoverable_errors.any? { ex.message.include?(it) }
+    @backups = list_objects("basebackups_005/", delimiter: "/").select { it.key.end_with?("backup_stop_sentinel.json") }
+  rescue => ex
+    recoverable_errors = ["The AWS Access Key Id you provided does not exist in our records.", "The specified bucket does not exist", "AccessDenied", "No route to host", "Connection refused"]
+    Clog.emit("Backup fetch exception", Util.exception_to_hash(ex))
+    raise unless recoverable_errors.any? { ex.message.include?(it) }
 
-      raise
-    end
+    @backups = []
   end
 
   def latest_backup_label_before_target(target:)

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -22,12 +22,9 @@ class PostgresTimeline < Sequel::Model
   def need_backup?
     return false if blob_storage.nil?
     return false if leader.nil?
+    return false if latest_backup_started_at && latest_backup_started_at > Time.now - 60 * 60 * backup_period_hours
 
-    status = leader.vm.sshable.d_check("take_postgres_backup")
-    return true if ["Failed", "NotStarted"].include?(status)
-    return true if status == "Succeeded" && (latest_backup_started_at.nil? || latest_backup_started_at < Time.now - 60 * 60 * backup_period_hours)
-
-    false
+    leader.vm.sshable.d_check("take_postgres_backup") != "InProgress"
   end
 
   def backups

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -64,20 +64,24 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
       hop_destroy
     end
 
-    nap 20 * 60 if postgres_timeline.blob_storage.nil?
-
-    if postgres_timeline.need_backup?
-      hop_take_backup
-    end
+    hop_take_backup if postgres_timeline.need_backup?
 
     nap 20 * 60
   end
 
   label def take_backup
-    postgres_timeline.leader.vm.sshable.d_run("take_postgres_backup", "sudo", "postgres/bin/take-backup", postgres_timeline.leader.version)
-    postgres_timeline.update(latest_backup_started_at: Time.now)
-
-    hop_wait
+    sshable = postgres_timeline.leader.vm.sshable
+    case sshable.d_check("take_postgres_backup")
+    when "Succeeded"
+      sshable.d_clean("take_postgres_backup")
+      hop_wait
+    when "InProgress"
+      nap 60
+    else # "Failed", "NotStarted"
+      sshable.d_run("take_postgres_backup", "sudo", "postgres/bin/take-backup", postgres_timeline.leader.version)
+      postgres_timeline.update(latest_backup_started_at: Time.now)
+      nap 60
+    end
   end
 
   label def destroy

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -28,7 +28,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
 
     latest_backup_completed_at = postgres_timeline.backups.map(&:last_modified).max
     if postgres_timeline.leader && (latest_backup_completed_at.nil? || latest_backup_completed_at < Time.now - 2 * 24 * 60 * 60)
-      Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", ["MissingBackup", postgres_timeline.id], postgres_timeline.ubid)
+      Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", ["MissingBackup", postgres_timeline.id], postgres_timeline.ubid, severity: "warning")
     else
       Page.from_tag_parts("MissingBackup", postgres_timeline.id)&.incr_resolve
     end

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -78,8 +78,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
     # the state to database. Since backup taking is an expensive operation,
     # we check if backup is truly needed.
     if postgres_timeline.need_backup?
-      d_command = NetSsh.command("sudo postgres/bin/take-backup :version", version: postgres_timeline.leader.version)
-      postgres_timeline.leader.vm.sshable.cmd("common/bin/daemonizer :d_command take_postgres_backup", d_command:)
+      postgres_timeline.leader.vm.sshable.d_run("take_postgres_backup", "sudo", "postgres/bin/take-backup", postgres_timeline.leader.version)
       postgres_timeline.latest_backup_started_at = Time.now
       postgres_timeline.save_changes
     end

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -28,7 +28,8 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
 
     latest_backup_completed_at = postgres_timeline.backups.map(&:last_modified).max
     if postgres_timeline.leader && (latest_backup_completed_at.nil? || latest_backup_completed_at < Time.now - 2 * 24 * 60 * 60)
-      Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", ["MissingBackup", postgres_timeline.id], postgres_timeline.ubid, severity: "warning")
+      severity = (latest_backup_completed_at && latest_backup_completed_at < Time.now - 3 * 24 * 60 * 60) ? "error" : "warning"
+      Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", ["MissingBackup", postgres_timeline.id], postgres_timeline.ubid, severity:)
     else
       Page.from_tag_parts("MissingBackup", postgres_timeline.id)&.incr_resolve
     end

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -24,11 +24,10 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   def before_run
     super
 
-    # For the purpose of missing backup pages, we act like the very first backup
-    # is taken at the creation, which ensures that we would get a page if and only
-    # if no backup is taken for 2 days.
-    latest_backup_completed_at = postgres_timeline.backups.map(&:last_modified).max || postgres_timeline.created_at
-    if postgres_timeline.leader && latest_backup_completed_at < Time.now - 2 * 24 * 60 * 60 # 2 days
+    return if postgres_timeline.created_at > Time.now - 6 * 60 * 60
+
+    latest_backup_completed_at = postgres_timeline.backups.map(&:last_modified).max
+    if postgres_timeline.leader && (latest_backup_completed_at.nil? || latest_backup_completed_at < Time.now - 2 * 24 * 60 * 60)
       Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", ["MissingBackup", postgres_timeline.id], postgres_timeline.ubid)
     else
       Page.from_tag_parts("MissingBackup", postgres_timeline.id)&.incr_resolve

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -21,6 +21,20 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
     end
   end
 
+  def before_run
+    super
+
+    # For the purpose of missing backup pages, we act like the very first backup
+    # is taken at the creation, which ensures that we would get a page if and only
+    # if no backup is taken for 2 days.
+    latest_backup_completed_at = postgres_timeline.backups.map(&:last_modified).max || postgres_timeline.created_at
+    if postgres_timeline.leader && latest_backup_completed_at < Time.now - 2 * 24 * 60 * 60 # 2 days
+      Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", ["MissingBackup", postgres_timeline.id], postgres_timeline.ubid)
+    else
+      Page.from_tag_parts("MissingBackup", postgres_timeline.id)&.incr_resolve
+    end
+  end
+
   label def start
     if postgres_timeline.blob_storage
       postgres_timeline.setup_blob_storage
@@ -46,23 +60,12 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
 
   label def wait
     dependent = PostgresServer[timeline_id: postgres_timeline.id]
-    backups = postgres_timeline.backups
-    if dependent.nil? && backups.empty? && Time.now - postgres_timeline.created_at > 10 * 24 * 60 * 60
+    if dependent.nil? && postgres_timeline.backups.empty? && Time.now - postgres_timeline.created_at > 10 * 24 * 60 * 60
       Clog.emit("Self-destructing timeline as no leader or backups are present and it is older than 10 days", postgres_timeline)
       hop_destroy
     end
 
     nap 20 * 60 if postgres_timeline.blob_storage.nil?
-
-    # For the purpose of missing backup pages, we act like the very first backup
-    # is taken at the creation, which ensures that we would get a page if and only
-    # if no backup is taken for 2 days.
-    latest_backup_completed_at = backups.map(&:last_modified).max || postgres_timeline.created_at
-    if postgres_timeline.leader && latest_backup_completed_at < Time.now - 2 * 24 * 60 * 60 # 2 days
-      Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", ["MissingBackup", postgres_timeline.id], postgres_timeline.ubid)
-    else
-      Page.from_tag_parts("MissingBackup", postgres_timeline.id)&.incr_resolve
-    end
 
     if postgres_timeline.need_backup?
       hop_take_backup

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -74,14 +74,8 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   end
 
   label def take_backup
-    # It is possible that we already started backup but crashed before saving
-    # the state to database. Since backup taking is an expensive operation,
-    # we check if backup is truly needed.
-    if postgres_timeline.need_backup?
-      postgres_timeline.leader.vm.sshable.d_run("take_postgres_backup", "sudo", "postgres/bin/take-backup", postgres_timeline.leader.version)
-      postgres_timeline.latest_backup_started_at = Time.now
-      postgres_timeline.save_changes
-    end
+    postgres_timeline.leader.vm.sshable.d_run("take_postgres_backup", "sudo", "postgres/bin/take-backup", postgres_timeline.leader.version)
+    postgres_timeline.update(latest_backup_started_at: Time.now)
 
     hop_wait
   end

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -126,32 +126,32 @@ PGDATA=/dat/17/data
       expect(postgres_timeline.need_backup?).to be(false)
     end
 
-    it "returns true as backup needed if there is no backup process or the last backup failed" do
+    it "returns true if no backup has been started yet" do
       expect(postgres_timeline).to receive(:blob_storage).and_return("dummy-blob-storage").twice
       expect(sshable).to receive(:_cmd).and_return("NotStarted", "Failed")
       expect(postgres_timeline.need_backup?).to be(true)
       expect(postgres_timeline.need_backup?).to be(true)
     end
 
-    it "returns true as backup needed if previous backup started more than a day ago and is succeeded" do
+    it "returns true if the previous backup is older than backup_period_hours" do
       expect(postgres_timeline).to receive(:blob_storage).and_return("dummy-blob-storage").twice
       expect(postgres_timeline).to receive(:latest_backup_started_at).and_return(Time.now - 60 * 60 * 25).exactly(4).times
-      expect(sshable).to receive(:_cmd).and_return("Succeeded").twice
+      expect(sshable).to receive(:_cmd).and_return("NotStarted")
       expect(postgres_timeline.need_backup?).to be(true)
       postgres_timeline.update(backup_period_hours: 30)
       expect(postgres_timeline.need_backup?).to be(false)
     end
 
-    it "returns false as backup needed if previous backup started less than a day ago" do
+    it "returns false if the previous backup is within backup_period_hours" do
       expect(postgres_timeline).to receive(:blob_storage).and_return("dummy-blob-storage").twice
       expect(postgres_timeline).to receive(:latest_backup_started_at).and_return(Time.now - 60 * 60 * 23).exactly(4).times
-      expect(sshable).to receive(:_cmd).and_return("Succeeded").twice
+      expect(sshable).to receive(:_cmd).and_return("NotStarted")
       expect(postgres_timeline.need_backup?).to be(false)
       postgres_timeline.update(backup_period_hours: 12)
       expect(postgres_timeline.need_backup?).to be(true)
     end
 
-    it "returns false as backup needed if previous backup started is in progress" do
+    it "returns false if a backup is currently in progress" do
       expect(postgres_timeline).to receive(:blob_storage).and_return("dummy-blob-storage")
       expect(sshable).to receive(:_cmd).and_return("InProgress")
       expect(postgres_timeline.need_backup?).to be(false)

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -352,17 +352,32 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       expect(Page.count).to eq(0)
     end
 
-    it "creates a missing backup page if last completed backup is older than 2 days" do
+    it "creates a warning missing backup page if last completed backup is between 2 and 3 days old" do
       create_minio_cluster
       resource = create_postgres_resource(project:, location_id:)
       create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
       postgres_timeline.update(created_at: Time.now - 3 * 24 * 60 * 60)
 
-      backup = backup_fixture(days_ago: 3)
+      backup = backup_fixture(days_ago: 2.5)
       mock_minio_client(list_objects: [backup])
 
       nx.before_run
       expect(Page.count).to eq(1)
+      expect(Page.first.severity).to eq("warning")
+    end
+
+    it "escalates to an error missing backup page if last completed backup is older than 3 days" do
+      create_minio_cluster
+      resource = create_postgres_resource(project:, location_id:)
+      create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
+      postgres_timeline.update(created_at: Time.now - 4 * 24 * 60 * 60)
+
+      backup = backup_fixture(days_ago: 4)
+      mock_minio_client(list_objects: [backup])
+
+      nx.before_run
+      expect(Page.count).to eq(1)
+      expect(Page.first.severity).to eq("error")
     end
 
     it "resolves the missing page if last completed backup is more recent than 2 days" do

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -413,22 +413,9 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       server
     end
 
-    it "hops to wait if backup is not needed" do
-      # Set latest_backup_started_at to recent so "Succeeded" makes need_backup? return false
-      postgres_timeline.update(latest_backup_started_at: Time.now)
-
-      # need_backup? calls sshable.cmd once, returns "Succeeded" so need_backup? is false
-      expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("Succeeded")
-
-      expect { nx.take_backup }.to hop("wait")
-    end
-
-    it "takes backup if it is needed" do
-      # need_backup? is called once (returns true because NotStarted),
-      # then cmd is called to run the backup
+    it "takes backup and hops to wait" do
       sshable = nx.postgres_timeline.leader.vm.sshable
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("NotStarted").ordered
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17", {log: true, stdin: nil}).ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17", {log: true, stdin: nil})
 
       expect { nx.take_backup }.to hop("wait")
       expect(postgres_timeline.reload.latest_backup_started_at).not_to be_nil

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -336,7 +336,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       resource = create_postgres_resource(project:, location_id:)
       create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
 
-      expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer --check take_postgres_backup").and_return("NotStarted")
+      expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("NotStarted")
 
       expect { nx.wait }.to hop("take_backup")
     end
@@ -348,7 +348,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       # Set latest_backup_started_at to avoid need_backup? returning true due to nil check
       postgres_timeline.update(latest_backup_started_at: Time.now)
 
-      expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer --check take_postgres_backup").and_return("Succeeded")
+      expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("Succeeded")
 
       expect { nx.wait }.to nap(20 * 60)
     end
@@ -418,7 +418,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       postgres_timeline.update(latest_backup_started_at: Time.now)
 
       # need_backup? calls sshable.cmd once, returns "Succeeded" so need_backup? is false
-      expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer --check take_postgres_backup").and_return("Succeeded")
+      expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("Succeeded")
 
       expect { nx.take_backup }.to hop("wait")
     end
@@ -427,8 +427,8 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       # need_backup? is called once (returns true because NotStarted),
       # then cmd is called to run the backup
       sshable = nx.postgres_timeline.leader.vm.sshable
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check take_postgres_backup").and_return("NotStarted").ordered
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer sudo\\ postgres/bin/take-backup\\ 17 take_postgres_backup").ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("NotStarted").ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17", {log: true, stdin: nil}).ordered
 
       expect { nx.take_backup }.to hop("wait")
       expect(postgres_timeline.reload.latest_backup_started_at).not_to be_nil

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -355,10 +355,20 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
   end
 
   describe "#before_run" do
+    it "skips check if timeline is within the grace period" do
+      create_minio_cluster
+      resource = create_postgres_resource(project:, location_id:)
+      create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
+
+      nx.before_run
+      expect(Page.count).to eq(0)
+    end
+
     it "creates a missing backup page if last completed backup is older than 2 days" do
       create_minio_cluster
       resource = create_postgres_resource(project:, location_id:)
       create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
+      postgres_timeline.update(created_at: Time.now - 3 * 24 * 60 * 60)
 
       backup = backup_fixture(days_ago: 3)
       mock_minio_client(list_objects: [backup])
@@ -371,6 +381,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       create_minio_cluster
       resource = create_postgres_resource(project:, location_id:)
       create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
+      postgres_timeline.update(created_at: Time.now - 7 * 60 * 60)
 
       backup = backup_fixture(days_ago: 1)
       mock_minio_client(list_objects: [backup])

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -308,15 +308,6 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
   end
 
   describe "#wait" do
-    it "naps if blob storage is not configured" do
-      # No minio cluster exists for the timeline's location, so blob_storage is nil
-      resource = create_postgres_resource(project:, location_id:)
-      create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
-
-      expect(nx.postgres_timeline.blob_storage).to be_nil
-      expect { nx.wait }.to nap(20 * 60)
-    end
-
     it "self-destructs if there's no leader, no backups and the timeline is old enough" do
       create_minio_cluster
       resource = create_postgres_resource(project:, location_id:)
@@ -345,10 +336,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       create_minio_cluster
       resource = create_postgres_resource(project:, location_id:)
       create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
-      # Set latest_backup_started_at to avoid need_backup? returning true due to nil check
       postgres_timeline.update(latest_backup_started_at: Time.now)
-
-      expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("Succeeded")
 
       expect { nx.wait }.to nap(20 * 60)
     end
@@ -413,12 +401,36 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       server
     end
 
-    it "takes backup and hops to wait" do
+    it "cleans up and hops to wait if the backup is successful" do
       sshable = nx.postgres_timeline.leader.vm.sshable
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17", {log: true, stdin: nil})
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("Succeeded").ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 clean take_postgres_backup").ordered
 
       expect { nx.take_backup }.to hop("wait")
+    end
+
+    it "naps if a backup is already in progress" do
+      sshable = nx.postgres_timeline.leader.vm.sshable
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("InProgress")
+
+      expect { nx.take_backup }.to nap(60)
+    end
+
+    it "starts the backup and naps when the unit has not started" do
+      sshable = nx.postgres_timeline.leader.vm.sshable
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("NotStarted").ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17", {log: true, stdin: nil}).ordered
+
+      expect { nx.take_backup }.to nap(60)
       expect(postgres_timeline.reload.latest_backup_started_at).not_to be_nil
+    end
+
+    it "retries when the previous backup failed" do
+      sshable = nx.postgres_timeline.leader.vm.sshable
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("Failed").ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17", {log: true, stdin: nil}).ordered
+
+      expect { nx.take_backup }.to nap(60)
     end
   end
 

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -336,48 +336,9 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       resource = create_postgres_resource(project:, location_id:)
       create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
 
-      backup = backup_fixture(days_ago: 3)
-      mock_minio_client(list_objects: [backup])
-
       expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer --check take_postgres_backup").and_return("NotStarted")
 
       expect { nx.wait }.to hop("take_backup")
-    end
-
-    it "creates a missing backup page if last completed backup is older than 2 days" do
-      create_minio_cluster
-      resource = create_postgres_resource(project:, location_id:)
-      create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
-      # Set latest_backup_started_at to avoid need_backup? returning true due to nil check
-      postgres_timeline.update(latest_backup_started_at: Time.now)
-
-      backup = backup_fixture(days_ago: 3)
-      mock_minio_client(list_objects: [backup])
-
-      expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer --check take_postgres_backup").and_return("Succeeded")
-
-      expect { nx.wait }.to nap(20 * 60)
-      expect(Page.active.count).to eq(1)
-    end
-
-    it "resolves the missing page if last completed backup is more recent than 2 days" do
-      create_minio_cluster
-      resource = create_postgres_resource(project:, location_id:)
-      create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
-      # Set latest_backup_started_at to avoid need_backup? returning true due to nil check
-      postgres_timeline.update(latest_backup_started_at: Time.now)
-
-      backup = backup_fixture(days_ago: 1)
-      mock_minio_client(list_objects: [backup])
-
-      expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer --check take_postgres_backup").and_return("Succeeded")
-
-      # Create a real Page with the "MissingBackup" tag and its Strand (needed for semaphores)
-      page = Page.create(tag: Page.generate_tag(["MissingBackup", postgres_timeline.id]), summary: "Missing backup")
-      Strand.create_with_id(page, prog: "PageNexus", label: "wait")
-
-      expect { nx.wait }.to nap(20 * 60)
-      expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
     end
 
     it "naps if there is nothing to do" do
@@ -387,12 +348,47 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       # Set latest_backup_started_at to avoid need_backup? returning true due to nil check
       postgres_timeline.update(latest_backup_started_at: Time.now)
 
-      backup = backup_fixture(days_ago: 1)
-      mock_minio_client(list_objects: [backup])
-
       expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("common/bin/daemonizer --check take_postgres_backup").and_return("Succeeded")
 
       expect { nx.wait }.to nap(20 * 60)
+    end
+  end
+
+  describe "#before_run" do
+    it "creates a missing backup page if last completed backup is older than 2 days" do
+      create_minio_cluster
+      resource = create_postgres_resource(project:, location_id:)
+      create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
+
+      backup = backup_fixture(days_ago: 3)
+      mock_minio_client(list_objects: [backup])
+
+      nx.before_run
+      expect(Page.count).to eq(1)
+    end
+
+    it "resolves the missing page if last completed backup is more recent than 2 days" do
+      create_minio_cluster
+      resource = create_postgres_resource(project:, location_id:)
+      create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
+
+      backup = backup_fixture(days_ago: 1)
+      mock_minio_client(list_objects: [backup])
+
+      page = Page.create(tag: Page.generate_tag(["MissingBackup", postgres_timeline.id]), summary: "Missing backup")
+      Strand.create_with_id(page, prog: "PageNexus", label: "wait")
+
+      nx.before_run
+      expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
+    end
+
+    it "does not create a page if there is no leader" do
+      create_minio_cluster
+      postgres_timeline.update(created_at: Time.now - 3 * 24 * 60 * 60)
+      mock_minio_client(list_objects: [])
+
+      nx.before_run
+      expect(Page.count).to eq(0)
     end
   end
 


### PR DESCRIPTION
This PR includes several commits to make backup taking more straightforward and intuitive. I'll also open another PR to ensure we would automatically take backup after scale down (if necessary). This is also preparation for that. 