### PR TITLE
Update to Ruby 4.0.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby 4.0.2
+ruby 4.0.3
 nodejs 24.12.0
 golang 1.24.0
 victoria-metrics v1.113.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci
 RUN npm run prod
 
 
-FROM docker.io/library/ruby:4.0.2-alpine3.23 AS bundler
+FROM docker.io/library/ruby:4.0.3-alpine3.23 AS bundler
 # Install build dependencies
 # - build-base, git, curl: To ensure certain gems can be compiled
 # - postgresql-dev: Required for postgresql gem
@@ -20,7 +20,7 @@ COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
 
-FROM docker.io/library/ruby:4.0.2-alpine3.23
+FROM docker.io/library/ruby:4.0.3-alpine3.23
 # Install runtime dependencies
 # - tzdata: The public-domain time zone database
 # - curl: Required for healthcheck and some basic operations

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 #
 # Update BUNDLED WITH version in Gemfile.lock to match bundler version that
 # ships with this Ruby version.
-ruby "4.0.2"
+ruby "4.0.3"
 
 gem "acme-client"
 gem "argon2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -513,7 +513,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-  ruby 4.0.2p0
+  ruby 4.0.3
 
 BUNDLED WITH
   4.0.6


### PR DESCRIPTION
The only change since 4.0.2 is a security fix for erb. In order for erb to be vulnerable, you have to be unmarshalling untrusted input and be using active_support or some other vulnerable library that can operate like a trampoline.