### PR TITLE
Switch DateTime.now to Time.now.utc

### DIFF
--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -664,10 +664,10 @@ class Clover
         authorize("Postgres:view", pg)
 
         start_time, end_time = typecast_params.str(%w[start end])
-        start_time ||= (DateTime.now.new_offset(0) - 30.0 / 1440).rfc3339
+        start_time ||= (Time.now.utc - 60 * 30).xmlschema
         start_time = Validation.validate_rfc3339_datetime_str(start_time, "start")
 
-        end_time ||= DateTime.now.new_offset(0).rfc3339
+        end_time ||= Time.now.utc.xmlschema
         end_time = Validation.validate_rfc3339_datetime_str(end_time, "end")
 
         start_ts = start_time.to_i

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -810,8 +810,8 @@ RSpec.describe Clover, "postgres" do
 
       it "fails when end timestamp is before start timestamp" do
         query_params = {
-          start: (DateTime.now.new_offset(0) - 1).rfc3339,
-          end: (DateTime.now.new_offset(0) - 2).rfc3339,
+          start: (Time.now.utc - 60 * 60 * 24).xmlschema,
+          end: (Time.now.utc - 60 * 60 * 24 * 2).xmlschema,
         }
 
         query_str = URI.encode_www_form(query_params)
@@ -822,8 +822,8 @@ RSpec.describe Clover, "postgres" do
 
       it "fails when time range is too large" do
         query_params = {
-          start: (DateTime.now.new_offset(0) - 32).rfc3339,
-          end: DateTime.now.new_offset(0).rfc3339,
+          start: (Time.now.utc - 60 * 60 * 24 * 32).xmlschema,
+          end: Time.now.utc.xmlschema,
         }
         query_str = URI.encode_www_form(query_params)
 
@@ -834,8 +834,8 @@ RSpec.describe Clover, "postgres" do
 
       it "fails when start timestamp is too old" do
         query_params = {
-          start: (DateTime.now.new_offset(0) - 32).rfc3339,
-          end: (DateTime.now.new_offset(0) - 31).rfc3339,
+          start: (Time.now.utc - 60 * 60 * 24 * 32).xmlschema,
+          end: (Time.now.utc - 60 * 60 * 24 * 31).xmlschema,
         }
         query_str = URI.encode_www_form(query_params)
 


### PR DESCRIPTION
Make appropriate adjustments, as Time operates in second units, while DateTime operates in day units.

DateTime has been officially deprecated since Ruby 3.0.

There are still a couple of DateTime callers in lib/validation.rb, but those uses cannot be replaced as simply as these.