### PR TITLE
Make per-server semaphore increments on PostgresResource greppable

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -344,7 +344,7 @@ class CloverAdmin < Roda
     },
     "PostgresResource" => {
       "restart" => object_action("Restart", flash: "Restart scheduled for PostgresResource") do |obj|
-        obj.server_incr("restart")
+        obj.incr_on_servers("incr_restart")
       end,
     },
     "PostgresServer" => {

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -233,10 +233,10 @@ class PostgresResource < Sequel::Model
     servers.any? { it.taking_over? }
   end
 
-  def server_incr(*semaphores)
+  def incr_on_servers(*semaphores)
     server_ids = servers.map(&:id)
-    semaphores.map do
-      Semaphore.incr(server_ids, it)
+    semaphores.each do |s|
+      Semaphore.incr(server_ids, s.delete_prefix("incr_"))
     end
   end
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -840,7 +840,7 @@ SQL
     case vm.sshable.d_check("promote_postgres")
     when "Succeeded"
       vm.sshable.d_clean("promote_postgres")
-      resource.server_incr("configure", "configure_metrics", "configure_logs")
+      resource.incr_on_servers("incr_configure", "incr_configure_metrics", "incr_configure_logs")
       hop_configure
     when "NotStarted", "Failed"
       vm.sshable.d_run("promote_postgres", "sudo", "postgres/bin/promote", postgres_server.version)
@@ -853,7 +853,7 @@ SQL
     if postgres_server.read_replica?
       resource.representative_server.update(is_representative: false)
       postgres_server.reload.update(is_representative: true, synchronization_status: "ready")
-      resource.server_incr("configure_metrics", "configure_logs")
+      resource.incr_on_servers("incr_configure_metrics", "incr_configure_logs")
       resource.incr_refresh_dns_record
       hop_configure
     end
@@ -865,7 +865,7 @@ SQL
       resource.representative_server.incr_destroy
       postgres_server.update(timeline_access: "push", is_representative: true, synchronization_status: "ready")
       resource.incr_refresh_dns_record
-      resource.server_incr("configure", "configure_metrics", "configure_logs", "restart")
+      resource.incr_on_servers("incr_configure", "incr_configure_metrics", "incr_configure_logs", "incr_restart")
       resource.servers.reject(&:primary?).each { it.update(synchronization_status: "catching_up") }
       hop_configure
     when "Failed"

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -146,7 +146,7 @@ class Clover
       r.post "restart" do
         authorize("Postgres:edit", pg)
         DB.transaction do
-          pg.server_incr("restart")
+          pg.incr_on_servers("incr_restart")
           audit_log(pg, "restart")
         end
 
@@ -258,7 +258,7 @@ class Clover
 
           DB.transaction do
             md = PostgresMetricDestination.create(postgres_resource_id: pg.id, url:, username:, password:)
-            pg.server_incr("configure_metrics")
+            pg.incr_on_servers("incr_configure_metrics")
             audit_log(md, "create", pg)
           end
 
@@ -276,7 +276,7 @@ class Clover
           if (md = pg.metric_destinations_dataset[id:])
             DB.transaction do
               md.destroy
-              pg.server_incr("configure_metrics")
+              pg.incr_on_servers("incr_configure_metrics")
               audit_log(md, "destroy")
             end
           else
@@ -330,7 +330,7 @@ class Clover
 
           ld = DB.transaction do
             ld = PostgresLogDestination.create(postgres_resource_id: pg.id, name:, type:, url:, options:)
-            pg.server_incr("configure_logs")
+            pg.incr_on_servers("incr_configure_logs")
             audit_log(ld, "create", pg)
             ld
           end
@@ -349,7 +349,7 @@ class Clover
           if (ld = pg.log_destinations_dataset[id:])
             DB.transaction do
               ld.destroy
-              pg.server_incr("configure_logs")
+              pg.incr_on_servers("incr_configure_logs")
               audit_log(ld, "destroy")
             end
           else
@@ -606,7 +606,7 @@ class Clover
               .exclude(cert_auth_users.contains([name]))
               .update(cert_auth_users: cert_auth_users.concat([name]))
             if n == 1
-              pg.server_incr("configure")
+              pg.incr_on_servers("incr_configure")
               audit_log(pg, "add_cert_auth_user")
               pg.refresh
             else
@@ -624,7 +624,7 @@ class Clover
               .where(cert_auth_users.contains([name]))
               .update(cert_auth_users: cert_auth_users - name)
             if n == 1
-              pg.server_incr("configure")
+              pg.incr_on_servers("incr_configure")
               audit_log(pg, "remove_cert_auth_user")
               pg.refresh
             else
@@ -782,7 +782,7 @@ class Clover
           old_pg_config = pg.user_config
           pg.update(user_config: pg_config, pgbouncer_user_config: pgbouncer_config)
 
-          pg.server_incr("configure")
+          pg.incr_on_servers("incr_configure")
 
           audit_log(pg, "update_config")
 


### PR DESCRIPTION
The helper fanning a semaphore increment out to every PostgresServer of a resource is genuinely useful. It batches all server ids into a single Semaphore.incr call per semaphore, avoiding N+1 queries when a resource has many servers. The downside is that it took bare names like "restart" and "configure", so a search for the canonical incr_<name> method missed these call sites.

Keep the batching, but pass the full "incr_<name>" string and strip the prefix internally, so grepping for incr_restart now finds every place it gets incremented.

We also rename the server_incr method to incr_on_servers, because old name reads like incrementing the servers themselves not the semaphores on the servers.