### PR TITLE
Show family utilization and spilled vCPUs on runner usage page

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1189,6 +1189,13 @@ class CloverAdmin < Roda
         .reverse(:runner_vcpus, :vm_vcpus)
         .all
 
+      @family_utilization = VmHost.where(allocation_state: "accepting", location_id: [Location::GITHUB_RUNNERS_ID, Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID], arch: @arch)
+        .select_group(:family)
+        .select_append { round(sum(:used_cores) * 100.0 / sum(:total_cores), 2).cast(:float).as(:utilization) }
+        .to_hash(:family, :utilization)
+
+      @spilled_vcpus = Vm.where(arch: @arch, boot_image: Prog::Github::GithubRunnerNexus::AWS_AMI_VERSIONS).sum(:vcpus) || 0
+
       view("github_runner_usage")
     end
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1660,10 +1660,16 @@ RSpec.describe CloverAdmin do
     GithubRunner.create(installation_id:, repository_name:, label: "ubicloud-standard-4", allocated_at: Time.now, vm_id: create_vm(vcpus: 4, family: "premium").id)
     GithubRunner.create(installation_id:, repository_name:, label: "ubicloud-standard-8", allocated_at: Time.now, vm_id: create_vm(vcpus: 8, family: "m7a").id)
     GithubRunner.create(installation_id:, repository_name:, label: "ubicloud-standard-30")
+    create_vm_host(location_id: Location::GITHUB_RUNNERS_ID, family: "standard", used_cores: 12, total_cores: 48)
+    create_vm_host(location_id: Location::HETZNER_FSN1_ID, family: "premium", used_cores: 12, total_cores: 24)
+    create_vm(boot_image: Config.github_ubuntu_2204_x64_aws_ami_version, vcpus: 4)
+    create_vm(boot_image: Config.github_ubuntu_2404_x64_aws_ami_version, vcpus: 8)
+    create_vm(arch: "arm64", boot_image: Config.github_ubuntu_2404_arm64_aws_ami_version, vcpus: 16)
 
     click_link "GitHub Runner VM Usage"
     expect(page.title).to eq "Ubicloud Admin - GitHub Runner x64 VM Usage"
     expect(page).to have_link "Show arm64"
+    expect(page).to have_css("p", exact_text: "Utilization: standard: 25.0% , premium: 50.0% , spilled vcpus: 12")
     expect(page.all("#content td").map(&:text)).to eq [
       "TOTAL", "", "", "400",
       "2", "1", "1", "0", "1", "0",
@@ -1691,11 +1697,14 @@ RSpec.describe CloverAdmin do
     installation = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User", project_id: project.id)
     GithubRunner.create(installation_id: installation.id, repository_name: "test-repo", label: "ubicloud-arm")
     GithubRunner.create(installation_id: installation.id, repository_name: "test-repo", label: "ubicloud")
+    create_vm_host(arch: "arm64", location_id: Location::GITHUB_RUNNERS_ID, family: "standard", used_cores: 6, total_cores: 24)
+    create_vm(arch: "arm64", boot_image: Config.github_ubuntu_2204_arm64_aws_ami_version, vcpus: 8)
 
     click_link "Show arm64"
 
     expect(page.title).to eq "Ubicloud Admin - GitHub Runner arm64 VM Usage"
     expect(page).to have_link "Show x64"
+    expect(page).to have_css("p", exact_text: "Utilization: standard: 25.0% , spilled vcpus: 8")
     expect(page.all("#content td").map(&:text)).to eq [
       "TOTAL", "", "", "100",
       "1", "0", "0", "0", "0", "0",

--- a/views/admin/github_runner_usage.erb
+++ b/views/admin/github_runner_usage.erb
@@ -14,6 +14,10 @@ types.each do |type|
 end
 @data.prepend({name: "TOTAL", prem: "", spill: "", **total}) if @data.any? %>
 
+<% other_arch = (@arch == "x64") ? "arm64" : "x64" %>
+<a href="/github-runner-usage?arch=<%= other_arch %>">Show
+  <%= other_arch %></a>
+
 <p>
   <strong>Utilization:</strong>
   <%= "standard: #{@family_utilization["standard"] || 0}%" %>
@@ -23,10 +27,6 @@ end
 </p>
 
 <%== part("components/table", title: nil, table_class: "github-runner-usage-table", data: @data, use_admin_label: false) %>
-
-<% other_arch = (@arch == "x64") ? "arm64" : "x64" %>
-<h3><a href="/github-runner-usage?arch=<%= other_arch %>">Show
-    <%= other_arch %></a></h3>
 
 <h3>Columns</h3>
 <p><strong>prem:</strong>

--- a/views/admin/github_runner_usage.erb
+++ b/views/admin/github_runner_usage.erb
@@ -14,6 +14,14 @@ types.each do |type|
 end
 @data.prepend({name: "TOTAL", prem: "", spill: "", **total}) if @data.any? %>
 
+<p>
+  <strong>Utilization:</strong>
+  <%= "standard: #{@family_utilization["standard"] || 0}%" %>
+  <% if @arch == "x64" %>
+    <%= ", premium: #{@family_utilization["premium"] || 0}%" %><% end %>
+  <%= ", spilled vcpus: #{@spilled_vcpus}" %>
+</p>
+
 <%== part("components/table", title: nil, table_class: "github-runner-usage-table", data: @data, use_admin_label: false) %>
 
 <% other_arch = (@arch == "x64") ? "arm64" : "x64" %>


### PR DESCRIPTION
The admin GitHub Runner VM Usage page already shows per-installation allocation, but when triaging concurrency or spillover decisions we also need the inputs the allocator actually consults: per-family host utilization (used_cores / total_cores) and the total vCPUs of VMs spilled to AWS.