### PR TITLE
Avoid nondeterminstic failure in admin web specs

### DIFF
--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2252,7 +2252,7 @@ RSpec.describe CloverAdmin do
   end
 
   describe "admin authentication audit log" do
-    def insert_account_audit_log(account_id: DB[:admin_account].get(:id), message: "login", metadata: {"ip" => "127.0.0.1"}, at: Sequel::CURRENT_TIMESTAMP)
+    def insert_account_audit_log(account_id: DB[:admin_account].where(login: "admin").get(:id), message: "login", metadata: {"ip" => "127.0.0.1"}, at: Sequel::CURRENT_TIMESTAMP)
       DB[:admin_account_authentication_audit_log].returning(:id).insert(
         account_id:,
         message:,


### PR DESCRIPTION
Previously, if there were multiple admin accounts (as there are in the "can filter by account login and ubid" spec), which account id was used was nondeterministic.