### PR TITLE
Add require-e2e status check for rhizome PRs

### DIFF
--- a/.github/workflows/require_e2e.yml
+++ b/.github/workflows/require_e2e.yml
@@ -1,0 +1,97 @@
+name: Require E2E
+
+permissions:
+  contents: read
+  statuses: write
+  actions: read
+  pull-requests: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["E2E CI"]
+    types: [completed]
+
+jobs:
+  check:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Evaluate require-e2e and post commit status
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const headSha = context.eventName === 'pull_request'
+              ? context.payload.pull_request.head.sha
+              : context.payload.workflow_run.head_sha;
+
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: headSha,
+            });
+            const pr = prs.find(p => p.state === 'open');
+            if (!pr) {
+              core.info(`No open PR for ${headSha}; skipping`);
+              return;
+            }
+
+            const { data: cmp } = await github.rest.repos.compareCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: pr.base.sha,
+              head: headSha,
+            });
+            const watched = (f) =>
+              f.startsWith('rhizome/') ||
+              f === '.github/workflows/e2e.yml' ||
+              f === '.github/workflows/require_e2e.yml';
+            const rhizomeChanged = (cmp.files || []).some(f => watched(f.filename));
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            let state, description, targetUrl;
+
+            if (!rhizomeChanged) {
+              state = 'success';
+              description = 'No rhizome changes in PR';
+              targetUrl = runUrl;
+            } else {
+              const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'e2e.yml',
+                head_sha: headSha,
+              });
+              let okRun = null;
+              for (const run of runs.workflow_runs) {
+                if (run.status !== 'completed') continue;
+                const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                });
+                if (jobs.jobs.some(j => j.name === 'E2E - metal' && j.conclusion === 'success')) {
+                  okRun = run;
+                  break;
+                }
+              }
+              if (okRun) {
+                state = 'success';
+                description = 'E2E metal succeeded for this commit';
+                targetUrl = okRun.html_url;
+              } else {
+                state = 'failure';
+                description = 'E2E metal required: comment /run-e2e on the PR';
+                targetUrl = runUrl;
+              }
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: headSha,
+              state,
+              context: 'require-e2e',
+              description,
+              target_url: targetUrl,
+            });


### PR DESCRIPTION
GitHub branch protection cannot scope a required status check to specific paths, but we want every PR that touches the rhizome dataplane to prove an E2E run succeeded before it merges. The e2e workflow itself runs only on a 2-hour cron and on workflow_dispatch (notably via /run-e2e PR comments); running it unconditionally on every PR would tie up dedicated metal hardware.

This adds a require_e2e workflow that posts a commit status named require-e2e on the PR head SHA. It triggers both on pull_request and on completion of the E2E CI workflow_run, so the same logic runs whether the PR was just opened, was just pushed to, or had an e2e run finish for it (regardless of whether that run was started by /run-e2e, the GitHub UI, or cron).

The job uses actions/github-script to:

- find the open PR for the head SHA,
- diff base..head via repos.compareCommits (no checkout needed),
- if no rhizome/ files (or e2e workflow files) changed, post the status as success;
- otherwise list e2e.yml runs for the head SHA and look for one whose E2E - metal matrix job has conclusion success. The aws matrix job is intentionally not required - it is informational.

The Statuses API upserts by (sha, context), so subsequent triggers overwrite earlier results. Branch protection on main needs to be updated separately (in the GitHub UI) to require the require-e2e context after the workflow has run once on a sample PR so GitHub registers the context name.