### PR TITLE
Start logging CLI commands

### DIFF
--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -64,6 +64,10 @@ class UbiCli
   end
 
   def self.process(argv, env)
+    logged_argv = argv[0...25].map { |s| (s.bytesize > 25) ? [s.bytesize, s[0...5], s[-5...-1]] : s }
+    logged_argv << argv.length if argv.length > 25
+    Clog.emit("cli command", cli_command: {argv: logged_argv, project: env["clover.project_ubid"]})
+
     super
   rescue Ubicloud::Error => e
     status = e.code

--- a/spec/routes/api/cli/options_spec.rb
+++ b/spec/routes/api/cli/options_spec.rb
@@ -21,4 +21,33 @@ RSpec.describe Clover, "cli" do
     expect(cli(%w[version], env: {"HTTP_X_UBI_VERSION" => "bad"})).to eq "unknown\n"
     expect(cli(%w[version], env: {})).to eq "unknown\n"
   end
+
+  it "logs CLI commands" do
+    expect(Clog).to receive(:emit).with("cli command", cli_command: {argv: %w[version], project: @project.ubid})
+    expect(cli(%w[version])).to match(/\A\d+\.\d+\.\d+\n\z/)
+  end
+
+  it "truncates long cli command arguments" do
+    expect(Clog).to receive(:emit).with("cli command", cli_command: {argv: ["version", [26, "aaaaa", "aaaa"]], project: @project.ubid})
+    expect(cli(["version", "a" * 26], status: 400)).to eq <<~END
+       ! Invalid number of arguments for version subcommand (requires: 0, given: 1)
+
+       Display CLI program version
+
+       Usage:
+           ubi version
+    END
+  end
+
+  it "truncates long cli command argument lists" do
+    expect(Clog).to receive(:emit).with("cli command", cli_command: {argv: ["version"] + ["a"] * 24 + [26], project: @project.ubid})
+    expect(cli(["version"] + ["a"] * 25, status: 400)).to eq <<~END
+       ! Invalid number of arguments for version subcommand (requires: 0, given: 25)
+
+       Display CLI program version
+
+       Usage:
+           ubi version
+    END
+  end
 end


### PR DESCRIPTION
This truncates large CLI arguments (over 25 bytes) to the first 5 and last 5 characters. It also only logs the first 25 arguments.