### PR TITLE
Don't restart new primary after failover

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -865,7 +865,7 @@ SQL
       resource.representative_server.incr_destroy
       postgres_server.update(timeline_access: "push", is_representative: true, synchronization_status: "ready")
       resource.incr_refresh_dns_record
-      resource.server_incr("configure", "configure_metrics", "configure_logs", "restart")
+      resource.server_incr("configure", "configure_metrics", "configure_logs")
       resource.servers.reject(&:primary?).each { it.update(synchronization_status: "catching_up") }
       hop_configure
     when "Failed"

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1525,7 +1525,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       [postgres_server, standby].each do |server|
         expect(Semaphore.where(strand_id: server.id, name: "configure").count).to eq(1)
         expect(Semaphore.where(strand_id: server.id, name: "configure_metrics").count).to eq(1)
-        expect(Semaphore.where(strand_id: server.id, name: "restart").count).to eq(1)
       end
     end
 
@@ -1557,7 +1556,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       [postgres_server, standby].each do |server|
         expect(Semaphore.where(strand_id: server.id, name: "configure").count).to eq(1)
         expect(Semaphore.where(strand_id: server.id, name: "configure_metrics").count).to eq(1)
-        expect(Semaphore.where(strand_id: server.id, name: "restart").count).to eq(1)
       end
 
       expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)


### PR DESCRIPTION
In the past, we used to not set `archive_mode` to `on` for standbys, so after failover, we had to restart the new primary to set `archive_mode` to `on` (because `archive_mode` is one of the parameters that requires a restart). Now, we set `archive_mode` to `on` unconditionally, so we don't need to restart the new primary after failovers anymore.