### PR TITLE
Fix screenshot regen script

### DIFF
--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -136,7 +136,6 @@ class RegenScreenshots
     resize(1400)
     click_link "Create PostgreSQL Database"
     screenshot "managed-postgresql/create-screenshot.png"
-    screenshot "quick-start/using-kamal-with-ubicloud-3-screenshot.png"
 
     pg_private_subnet = PrivateSubnet.create_with_id(UBID.parse("psdkk2ssb6cy4j31yx1cjn2jqm").to_uuid,
       project_id: project.id,
@@ -353,6 +352,7 @@ class RegenScreenshots
     ) do |kc|
       kc.id = UBID.parse(kc_ubid).to_uuid
     end
+    Strand.create_with_id(k8s_cluster.id, prog: "Kubernetes::KubernetesClusterNexus", label: "start")
 
     k8s_nodepool = KubernetesNodepool.create(
       name: "kubernetes-demo-np",
@@ -362,6 +362,7 @@ class RegenScreenshots
     ) do |kn|
       kn.id = UBID.parse(kn_ubid).to_uuid
     end
+    Strand.create_with_id(k8s_nodepool.id, prog: "Kubernetes::KubernetesNodeNexus", label: "start")
 
     services_lb = Prog::Vnet::LoadBalancerNexus.assemble(
       k8s_cluster.private_subnet_id,
@@ -455,6 +456,8 @@ class RegenScreenshots
     page.refresh
     page.evaluate_script("$('#user_policy_#{account2.ubid}').focus()")
     screenshot "security/users-2-screenshot.png"
+
+    DB[:access_tag].returning(:hyper_tag_id).insert(hyper_tag_id: account2.id, project_id: project.id)
 
     click_link "Access Control"
     access_control_path = page.current_path


### PR DESCRIPTION
We no longer have Kamal documentation, so there's no need to generate screenshots for it.

We also started requiring explicit approval of project invitations instead of auto-accepting them, so we need to accept the invitation before running the script.