### PR TITLE
Avoid nondetermistic coverage failure in Page::Client#initialize

### DIFF
--- a/spec/model/page_spec.rb
+++ b/spec/model/page_spec.rb
@@ -8,6 +8,12 @@ require "pagerduty"
 RSpec.describe Page do
   subject(:p) { described_class.create(tag: "dummy-tag") }
 
+  if Config.unfrozen_test?
+    after do
+      described_class.instance_variable_set(:@client, nil)
+    end
+  end
+
   describe ".group_by_vm_host" do
     it "groups pages by the VmHost they are related to" do
       expect(described_class.group_by_vm_host).to eq({})


### PR DESCRIPTION
Unset the Page `@client` instance variable when running unfrozen tests, to ensure initialize is called multiple times, some with Config.pagerduty_key set and some without.