### PR TITLE
add storage volume dump metadata

### DIFF
--- a/model/vhost_block_backend.rb
+++ b/model/vhost_block_backend.rb
@@ -4,6 +4,7 @@ require_relative "../model"
 
 class VhostBlockBackend < Sequel::Model
   MIN_ARCHIVE_SUPPORT_VERSION = 401
+  MIN_DUMP_METADATA_SUPPORT_VERSION = 400
 
   plugin ResourceMethods, etc_type: true
 
@@ -17,6 +18,10 @@ class VhostBlockBackend < Sequel::Model
   def version=(version_str)
     v = Gem::Version.new(version_str.delete_prefix("v")).segments
     self.version_code = v[0] * 10000 + v[1] * 100 + v[2]
+  end
+
+  def supports_dump_metadata?
+    version_code >= MIN_DUMP_METADATA_SUPPORT_VERSION
   end
 end
 

--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -76,6 +76,20 @@ class VmStorageVolume < Sequel::Model
     stripes = rpc(command: "status").dig("status", "stripes")
     stripes.fetch("fetched") == stripes.fetch("source")
   end
+
+  def dump_metadata
+    fail "dump_metadata only supported for vm storage volumes with vhost block backend version v0.4.0+" unless vhost_block_backend&.supports_dump_metadata?
+    fail "dump_metadata requires an encrypted vm storage volume" unless key_encryption_key_1
+
+    vm.vm_host.sshable.cmd(
+      "sudo host/bin/storage-dump-metadata :vm_name :storage_device :disk_index :vhost_block_backend_version",
+      vm_name: vm.inhost_name,
+      storage_device: storage_device.name,
+      disk_index:,
+      vhost_block_backend_version:,
+      stdin: key_encryption_key_1.secret_key_material_hash.to_json,
+    )
+  end
 end
 
 # Table: vm_storage_volume

--- a/rhizome/host/bin/storage-dump-metadata
+++ b/rhizome/host/bin/storage-dump-metadata
@@ -1,0 +1,28 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require_relative "../lib/storage_volume"
+
+unless ARGV.length == 4
+  puts "usage: storage-dump-metadata vm_name storage_device_name disk_index ubiblk_version"
+  exit 1
+end
+vm_name, device, disk_index, vhost_block_backend_version = ARGV
+
+key_wrapping_secrets = JSON.parse($stdin.read)
+
+unless key_wrapping_secrets["key"]
+  puts "expected key in stdin payload"
+  exit 1
+end
+
+StorageVolume.new(
+  vm_name,
+  {
+    "disk_index" => disk_index,
+    "storage_device" => device,
+    "encrypted" => true,
+    "vhost_block_backend_version" => vhost_block_backend_version,
+  },
+).dump_metadata(key_wrapping_secrets)

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -483,6 +483,21 @@ class StorageVolume
     end
   end
 
+  def dump_metadata(key_wrapping_secrets)
+    fail "vhost block backend version #{@vhost_backend_version} does not support dump-metadata" unless @vhost_backend_version && vhost_backend.config_v2?
+
+    run_with_kek_pipe(
+      [
+        "sudo", "-u", @vm_name,
+        vhost_backend.dump_metadata_path,
+        "--config", sp.vhost_backend_config,
+      ],
+      kek_pipe: sp.kek_pipe,
+      kek_content: vhost_backend_kek(key_wrapping_secrets),
+      owner: @vm_name,
+    )
+  end
+
   def stop_service_if_loaded(name)
     r "systemctl", "stop", name
   rescue CommandFail => e

--- a/rhizome/host/lib/vhost_block_backend.rb
+++ b/rhizome/host/lib/vhost_block_backend.rb
@@ -60,6 +60,10 @@ class VhostBlockBackend
     "#{dir}/archive"
   end
 
+  def dump_metadata_path
+    "#{dir}/dump-metadata"
+  end
+
   def download
     temp_tarball = "/tmp/vhost-backend-#{@version}.tar.gz"
     puts "Downloading ubiblk package from #{url}"

--- a/spec/model/vm_storage_volume_spec.rb
+++ b/spec/model/vm_storage_volume_spec.rb
@@ -116,4 +116,48 @@ RSpec.describe VmStorageVolume do
       expect(vol.caught_up?).to be false
     end
   end
+
+  describe "#dump_metadata" do
+    let(:vbb) { VhostBlockBackend.create(version_code: 400, allocation_weight: 100, vm_host_id: vm_host.id) }
+    let(:kek) { StorageKeyEncryptionKey.create_random(auth_data: "aad") }
+    let(:volume) do
+      described_class.create(
+        vm:,
+        disk_index: 1,
+        storage_device: default_storage_device,
+        vhost_block_backend_id: vbb.id,
+        key_encryption_key_1: kek,
+        boot: false,
+        size_gib: 10,
+        vring_workers: 1,
+      )
+    end
+
+    it "runs storage-dump-metadata command and returns stdout" do
+      expect(volume.vm.vm_host.sshable).to receive(:_cmd).with(
+        "sudo host/bin/storage-dump-metadata #{vm.inhost_name} DEFAULT 1 v0.4.0",
+        stdin: kek.secret_key_material_hash.to_json,
+      ).and_return("metadata")
+
+      expect(volume.dump_metadata).to eq("metadata")
+    end
+
+    it "fails when vhost block backend does not support dump_metadata" do
+      vbb.update(version_code: 301)
+
+      expect { volume.dump_metadata }.to raise_error(RuntimeError, "dump_metadata only supported for vm storage volumes with vhost block backend version v0.4.0+")
+    end
+
+    it "fails when volume is not encrypted" do
+      volume.update(key_encryption_key_1: nil)
+
+      expect { volume.dump_metadata }.to raise_error(RuntimeError, "dump_metadata requires an encrypted vm storage volume")
+    end
+
+    it "fails when volume does not have a vhost block backend" do
+      volume.update(vhost_block_backend_id: nil, vring_workers: nil)
+
+      expect { volume.dump_metadata }.to raise_error(RuntimeError, "dump_metadata only supported for vm storage volumes with vhost block backend version v0.4.0+")
+    end
+  end
 end


### PR DESCRIPTION
### Rhizome: add storage volume dump metadata 

Add `host/bin/dump-metadata` which calls the dump-metadata utility for a storage volume. This is useful for investigating the metadata of a storage volume: which stripe indexes exist in the source, which indexes have been fetched, and which indexes have data written to.

An example invocation:

```
host/bin/storage-dump-metadata vm123456 DEFAULT 1 v0.4.0
```

Positional args:
- vm name
- storage device name
- disk index
- ubiblk version

Stdin: key-encryption-key json required to decrypt disk's metadata

### Clover: Add storage volume dump metadata 

Adds `VmStorageVolume#dump_metadata`, which calls the corresponding executable on the rhizome side. This is useful when investigating metadata of a storage volume.

This is supported by ubiblk v0.4.0+.

An example output is:

```
data file: /var/storage/vm96zvkp/0/disk.raw (10737418240 bytes)
source: raw (path: /var/storage/images/ubuntu-noble-20250502.1.raw,
size: 3758096384 bytes)
metadata version: 2.0
stripe size: 1048576 bytes
fetched stripes: 0, 5-12, 111, 113, 125, 241, ...
written stripes: 0, 5, 6, 12, 111, 113, 125, 241-285, ...
has-source stripes: 0-3583
```