### PR TITLE
Add Postgres failure injection API for E2E tests

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -184,6 +184,9 @@ module Config
   optional :postgres_notification_email, string
   override :aws_postgres_iam_access, false, bool
 
+  # Testing
+  override :enable_failure_injection, false, bool
+
   # Logging
   optional :database_logger_level, string
   optional :ingest_key, string, clear: true

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -131,6 +131,9 @@ class Clover < Roda
     enable_cache_scope
     enable_premium
     enable_ssl
+    inject_failure_os_shutdown
+    inject_failure_pg_restart
+    inject_failure_pg_service_stop
     promote_read_replica
     recycle
     remove_account

--- a/helpers/postgres_failure_injection.rb
+++ b/helpers/postgres_failure_injection.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Clover
+  def postgres_inject_failure(pg, failure_type)
+    server = pg.representative_server
+    raise CloverError.new(400, "InvalidRequest", "No representative server found for this database") unless server
+
+    sshable = server.vm.sshable
+    # Audit the attempt before issuing the SSH command so the audit row survives
+    # even if the command (or the SSH connection) fails — the request itself
+    # is the auditable event.
+    audit_log(pg, "inject_failure_#{failure_type}")
+    case failure_type
+    when "pg_service_stop"
+      sshable.cmd("sudo pg_ctlcluster :version main stop -m smart", version: server.version)
+    when "os_shutdown"
+      begin
+        sshable.cmd("sudo shutdown -h now")
+      rescue *::Sshable::SSH_CONNECTION_ERRORS, ::Sshable::SshError
+        # Expected: SSH connection drops when the machine goes down.
+        nil
+      end
+    else # "pg_restart" — least consequential default; OpenAPI enum constrains failure_type to one of three values
+      sshable.cmd("sudo pg_ctlcluster :version main restart", version: server.version)
+    end
+
+    204
+  end
+end

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1576,6 +1576,39 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Firewall Rule
+  /project/{project_id}/location/{location}/postgres/{postgres_database_reference}/inject-failure:
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/postgres_database_reference'
+    post:
+      operationId: postPostgresInjectFailure
+      summary: Inject a failure into a running Postgres resource for testing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                failure_type:
+                  description: |
+                    Type of failure to inject. os_shutdown: graceful OS shutdown. pg_restart: restart the Postgres process only. pg_service_stop: stop the Postgres service (smart shutdown).
+                  type: string
+                  enum:
+                    - os_shutdown
+                    - pg_restart
+                    - pg_service_stop
+              additionalProperties: false
+              required:
+                - failure_type
+      responses:
+        '204':
+          description: Failure injected. Resource state will reflect the failure asynchronously.
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Postgres Database
   /project/{project_id}/location/{location}/postgres/{postgres_database_reference}/log-destination:
     parameters:
       - $ref: '#/components/parameters/location'

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -842,6 +842,16 @@ class Clover
           end
         end
       end
+
+      r.post api?, "inject-failure" do
+        unless Config.enable_failure_injection
+          no_authorization_needed
+          raise CloverError.new(403, "Forbidden", "Failure injection is not enabled for this deployment")
+        end
+        authorize("Postgres:edit", pg)
+
+        postgres_inject_failure(pg, typecast_params.nonempty_str!("failure_type"))
+      end
     end
   end
 end

--- a/spec/routes/api/project/location/postgres_inject_failure_spec.rb
+++ b/spec/routes/api/project/location/postgres_inject_failure_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require_relative "../../spec_helper"
+
+RSpec.describe Clover, "postgres inject-failure" do
+  let(:user) { create_account }
+  let(:project) { project_with_default_policy(user) }
+
+  before do
+    login_api
+    postgres_project = Project.create(name: "default")
+    allow(Config).to receive_messages(postgres_service_project_id: postgres_project.id, enable_failure_injection: true)
+  end
+
+  def create_pg(name)
+    Prog::Postgres::PostgresResourceNexus.assemble(
+      project_id: project.id,
+      location_id: Location::HETZNER_FSN1_ID,
+      name:,
+      target_vm_size: "standard-2",
+      target_storage_size_gib: 128,
+    ).subject
+  end
+
+  # Temporarily replaces _cmd on the SSH module for the duration of the block,
+  # restoring the original method in ensure to prevent leaking across examples.
+  def with_stub_sshable(cmds = [], raise_error: nil)
+    original = NetSsh::WarnUnsafe::Sshable.instance_method(:_cmd)
+    NetSsh::WarnUnsafe::Sshable.define_method(:_cmd) do |cmd, **|
+      cmds << cmd
+      raise raise_error if raise_error
+      ""
+    end
+    yield cmds
+  ensure
+    NetSsh::WarnUnsafe::Sshable.define_method(:_cmd, original)
+  end
+
+  def inject_failure_path(pg_or_name)
+    name_or_id = pg_or_name.is_a?(String) ? pg_or_name : pg_or_name.name
+    location = pg_or_name.respond_to?(:display_location) ? pg_or_name.display_location : "eu-central-h1"
+    "/project/#{project.ubid}/location/#{location}/postgres/#{name_or_id}/inject-failure"
+  end
+
+  describe "POST /project/:project_id/location/:location/postgres/:pg_name/inject-failure" do
+    it "returns 403 when failure injection is disabled" do
+      allow(Config).to receive(:enable_failure_injection).and_return(false)
+      pg = create_pg("test-pg-disabled")
+      post inject_failure_path(pg), {failure_type: "pg_restart"}.to_json
+      expect(last_response.status).to eq(403)
+      expect(JSON.parse(last_response.body).dig("error", "message")).to eq("Failure injection is not enabled for this deployment")
+    end
+
+    it "returns 404 for nonexistent postgres resource" do
+      post inject_failure_path("nonexistent"), {failure_type: "pg_restart"}.to_json
+      expect(last_response.status).to eq(404)
+    end
+
+    it "rejects missing failure_type at schema validation" do
+      pg = create_pg("test-pg-missing")
+      expect {
+        post inject_failure_path(pg), "{}"
+      }.to raise_error(Committee::InvalidRequest, /missing required parameters: failure_type/)
+    end
+
+    it "rejects invalid failure_type at schema validation" do
+      pg = create_pg("test-pg-invalid")
+      expect {
+        post inject_failure_path(pg), {failure_type: "invalid"}.to_json
+      }.to raise_error(Committee::InvalidRequest, /isn't part of the enum/)
+    end
+
+    it "injects pg_restart failure" do
+      pg = create_pg("test-pg-restart")
+      version = pg.representative_server.version
+      with_stub_sshable do |cmds|
+        post inject_failure_path(pg), {failure_type: "pg_restart"}.to_json
+        expect(last_response.status).to eq(204)
+        expect(last_response.body).to be_empty
+        expect(cmds).to include("sudo pg_ctlcluster #{version} main restart")
+      end
+    end
+
+    it "propagates SSH errors for pg_restart" do
+      pg = create_pg("test-pg-restart-fail")
+      with_stub_sshable(raise_error: Errno::ECONNREFUSED) do
+        expect {
+          post inject_failure_path(pg), {failure_type: "pg_restart"}.to_json
+        }.to raise_error(Errno::ECONNREFUSED)
+      end
+    end
+
+    it "handles SSH errors gracefully for os_shutdown" do
+      pg = create_pg("test-pg-shutdown")
+      with_stub_sshable(raise_error: Errno::ECONNRESET) do
+        post inject_failure_path(pg), {failure_type: "os_shutdown"}.to_json
+        expect(last_response.status).to eq(204)
+      end
+    end
+
+    it "injects pg_service_stop failure" do
+      pg = create_pg("test-pg-svc-stop")
+      version = pg.representative_server.version
+      with_stub_sshable do |cmds|
+        post inject_failure_path(pg), {failure_type: "pg_service_stop"}.to_json
+        expect(last_response.status).to eq(204)
+        expect(cmds).to include("sudo pg_ctlcluster #{version} main stop -m smart")
+      end
+    end
+
+    it "looks up postgres resource by UBID" do
+      pg = create_pg("test-pg-ubid")
+      with_stub_sshable do
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.ubid}/inject-failure",
+          {failure_type: "pg_restart"}.to_json
+        expect(last_response.status).to eq(204)
+      end
+    end
+
+    it "writes an audit_log entry tagged with the failure type" do
+      pg = create_pg("test-pg-audit")
+      with_stub_sshable do
+        expect {
+          post inject_failure_path(pg), {failure_type: "pg_restart"}.to_json
+        }.to change { DB[:audit_log].where(action: "inject_failure_pg_restart").count }.by(1)
+        expect(last_response.status).to eq(204)
+      end
+    end
+
+    it "returns 400 when the resource has no representative server" do
+      pg = create_pg("test-pg-no-server")
+      # Demote all servers so PostgresResource#representative_server returns nil.
+      # allow_any_instance_of doesn't work in frozen mode (the model class is frozen).
+      pg.servers_dataset.update(is_representative: false)
+      post inject_failure_path(pg), {failure_type: "pg_restart"}.to_json
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body).dig("error", "message"))
+        .to eq("No representative server found for this database")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

E2E tests of failover and recovery need a deterministic way to simulate failure of a running Postgres resource. This adds a POST endpoint:

```
/project/{project_id}/location/{location}/postgres/{postgres_database_reference}/inject-failure
```

accepting `failure_type` of:
- `pg_restart` — restart Postgres via `pg_ctlcluster`
- `pg_service_stop` — pg service graceful stop via `pg_ctlcluster ... stop -m smart`
- `os_shutdown` — `sudo shutdown -h now` (SSH connection drop is expected and swallowed)

API endpoint is disabled by default, need to be explicitly enabled in Test/Staging environments only