### PR TITLE
Add feature flag to overwrite runner apt mirrors

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -246,6 +246,7 @@ class Project < Sequel::Model
     :vm_public_ssh_keys,
     :postgres_aws_use_different_azs_for_standbys,
     :cache_proxy_download_url,
+    :overwrite_runner_apt_sources,
   )
 end
 

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -423,6 +423,17 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       COMMAND
     end
 
+    if project.get_ff_overwrite_runner_apt_sources
+      command << NetSsh.command(<<~COMMAND)
+        sudo tee /etc/apt/apt-mirrors.txt > /dev/null <<MIRRORS
+        https://mirror.hetzner.com/ubuntu/packages/	priority:1
+        https://mirror.hetzner.com/ubuntu/security/	priority:2
+        https://archive.ubuntu.com/ubuntu/	priority:3
+        https://security.ubuntu.com/ubuntu/	priority:4
+        MIRRORS
+      COMMAND
+    end
+
     begin
       # Remove comments and empty lines before sending them to the machine
       vm.sshable.cmd("bash", stdin: NetSsh.combine(*command, joiner: "").gsub(/^(\s*# .*)?\n/, ""))

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -14,6 +14,7 @@ class Prog::Test::GithubRunner < Prog::Test::Base
     service_project = Project.create_with_id(Config.github_runner_service_project_id, name: "Github-Runner-Service-Project")
     Project.create_with_id(Config.vm_pool_project_id, name: "Vm-Pool-Service-Project")
     customer_project = Project.create(name: "Github-Runner-Customer-Project")
+    customer_project.set_ff_overwrite_runner_apt_sources(true)
 
     if provider == "aws"
       customer_project.set_ff_aws_alien_runners_ratio(1)

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -656,6 +656,28 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect { nx.setup_environment }.to hop("register_runner")
     end
 
+    it "hops to register_runner with overwriting apt mirrors" do
+      expect(vm).to receive(:runtime_token).and_return("my_token")
+      installation.update(use_docker_mirror: false, cache_enabled: false)
+      project.set_ff_overwrite_runner_apt_sources(true)
+      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND)
+        set -ueo pipefail
+        echo "image version: $ImageVersion"
+        sudo usermod -a -G sudo,adm runneradmin
+        jq '. += ['\\{\\"group\\":\\"Ubicloud\\ Managed\\ Runner\\",\\"detail\\":\\"Name:\\ #{runner.ubid}\\\\nLabel:\\ ubicloud-standard-4\\\\nVM\\ Family:\\ standard\\\\nArch:\\ x64\\\\nImage:\\ github-ubuntu-2204\\\\nVM\\ Host:\\ #{vm.vm_host.ubid}\\\\nVM\\ Pool:\\ \\\\nLocation:\\ hetzner-fsn1\\\\nDatacenter:\\ FSN1-DC8\\\\nProject:\\ #{project.ubid}\\\\nConsole\\ URL:\\ http://localhost:9292/project/#{project.ubid}/github\\"\\}']' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info > /dev/null
+        echo "UBICLOUD_RUNTIME_TOKEN="my_token"
+        UBICLOUD_CACHE_URL="http://localhost:9292"/runtime/github/" | sudo tee -a /etc/environment > /dev/null
+        sudo tee /etc/apt/apt-mirrors.txt > /dev/null <<MIRRORS
+        https://mirror.hetzner.com/ubuntu/packages/\tpriority:1
+        https://mirror.hetzner.com/ubuntu/security/\tpriority:2
+        https://archive.ubuntu.com/ubuntu/\tpriority:3
+        https://security.ubuntu.com/ubuntu/\tpriority:4
+        MIRRORS
+      COMMAND
+
+      expect { nx.setup_environment }.to hop("register_runner")
+    end
+
     it "naps if ssh authentication failed" do
       expect(vm).to receive(:runtime_token).and_return("my_token")
       expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"))]).at_least(:once)


### PR DESCRIPTION
Our runner images are built from GitHub's official runner image templates, which list the Azure mirror at priority 1 (followed by the canonical archive and security mirrors) because GitHub's hosted runners run on Azure. We inherit that ordering even though we don't run our runners on Azure, so we get no proximity benefit, and the Azure mirror has been increasingly unstable.

Add an `overwrite_runner_apt_sources` project feature flag that, when set, rewrites `/etc/apt/apt-mirrors.txt` during runner setup to use Hetzner's mirror and the canonical Ubuntu archive and security mirrors. Gating this behind a flag lets us roll it out per project before making it the default.

We will move it to image generation after we verify it.

Previous /etc/apt/apt-mirrors.txt

    http://azure.archive.ubuntu.com/ubuntu/ priority:1
    https://archive.ubuntu.com/ubuntu/      priority:2
    https://security.ubuntu.com/ubuntu/     priority:3
