### PR TITLE
Allow VM creation to find machine images in fallback locations

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -18,6 +18,15 @@ module Option
     ["v1.35", "v1.34", "v1.33"].freeze
   end
 
+  MACHINE_IMAGE_SEARCH_LOCATIONS = {
+    Location::HETZNER_FSN1_ID => [Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID],
+    Location::HETZNER_HEL1_ID => [Location::HETZNER_HEL1_ID, Location::HETZNER_FSN1_ID],
+  }.each_value(&:freeze).freeze
+
+  def self.machine_image_search_locations(location_id)
+    MACHINE_IMAGE_SEARCH_LOCATIONS.fetch(location_id, [location_id])
+  end
+
   def self.families
     Option::VmFamilies.select { it.visible }
   end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -217,8 +217,15 @@ class Prog::Vm::Nexus < Prog::Base
   end
 
   def self.lookup_machine_image_version(project_id, location_id, name, version, vm_boot_disk_size_gib)
-    mi = MachineImage.first(project_id:, location_id:, name:)
-    fail Validation::ValidationFailed.new({machine_image: "Machine image with name \"#{name}\" does not exist in the specified project and location"}) unless mi
+    search_ids = Option.machine_image_search_locations(location_id)
+    mi = MachineImage
+      .order(Sequel.function(:array_position, Sequel.pg_array(search_ids, :uuid), :location_id))
+      .first(project_id:, location_id: search_ids, name:)
+
+    unless mi
+      search_locations = search_ids.map { |id| Location[id].display_name }.join(", ")
+      fail Validation::ValidationFailed.new({machine_image: "Machine image with name \"#{name}\" does not exist in the specified project and any of the following locations: #{search_locations}"})
+    end
 
     miv = if version == "latest"
       mi.latest_version

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -128,7 +128,9 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     it "fails if machine image name does not exist in project/location" do
       expect {
         Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "missing-mi@v1")
-      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image]).to match(/does not exist/) }
+      }.to raise_error(Validation::ValidationFailed) { |e|
+        expect(e.details[:machine_image]).to eq("Machine image with name \"missing-mi\" does not exist in the specified project and any of the following locations: eu-central-h1, eu-north-h1")
+      }
     end
 
     it "fails if machine image has no latest version for boot_image name@latest" do
@@ -174,6 +176,25 @@ RSpec.describe Prog::Vm::Metal::Nexus do
           boot_disk_index: 1,
         )
       }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image_version]).to match(/is larger than the VM boot disk size/) }
+    end
+
+    it "uses a machine image in hetzner-hel1 if it doesn't exist in hetzner-fsn1" do
+      miv = create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_HEL1_ID, name: "some-mi-name", version: "20200202").machine_image_version
+      vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "some-mi-name@20200202", location_id: Location::HETZNER_FSN1_ID).subject
+      expect(vm.vm_storage_volumes.first.machine_image_version_id).to eq(miv.id)
+    end
+
+    it "uses a machine image in hetzner-fsn1 if it doesn't exist in hetzner-hel1" do
+      miv = create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "some-mi-name", version: "20200202").machine_image_version
+      vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "some-mi-name@20200202", location_id: Location::HETZNER_HEL1_ID).subject
+      expect(vm.vm_storage_volumes.first.machine_image_version_id).to eq(miv.id)
+    end
+
+    it "uses the primary machine image location if it exists in both primary and fallback locations" do
+      miv_primary = create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "some-mi-name", version: "20200202").machine_image_version
+      create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_HEL1_ID, name: "some-mi-name", version: "20200202").machine_image_version
+      vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "some-mi-name@20200202", location_id: Location::HETZNER_FSN1_ID).subject
+      expect(vm.vm_storage_volumes.first.machine_image_version_id).to eq(miv_primary.id)
     end
 
     it "fails if given nic_id is not valid" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -301,10 +301,10 @@ RSpec.configure do |config|
       vm
     end
 
-    def create_machine_image_version_metal(project_id: nil, machine_image_id: nil, machine_image_store_id: nil, version: "v1", location_id: Location::HETZNER_FSN1_ID, store_prefix: "prefix/path")
+    def create_machine_image_version_metal(project_id: nil, machine_image_id: nil, machine_image_store_id: nil, name: "test-mi", version: "v1", location_id: Location::HETZNER_FSN1_ID, store_prefix: "prefix/path")
       project_id ||= Project.create(name: "miv-metal-project").id
       machine_image_store_id ||= MachineImageStore.create(project_id:, location_id:, provider: "r2", region: "auto", endpoint: "https://r2.cloudflare.com/", bucket: "test-bucket", access_key: "ak", secret_key: "sk").id
-      machine_image_id ||= MachineImage.create(name: "test-mi", project_id:, arch: "x64", location_id:).id
+      machine_image_id ||= MachineImage.create(name:, project_id:, arch: "x64", location_id:).id
       miv = MachineImageVersion.create(machine_image_id:, version:, actual_size_mib: 5 * 1024)
       archive_kek = StorageKeyEncryptionKey.create_random(auth_data: "auth_data")
       MachineImageVersionMetal.create_with_id(miv, archive_kek_id: archive_kek.id, store_id: machine_image_store_id, store_prefix:, enabled: true, archive_size_mib: 1024)


### PR DESCRIPTION
We use the same object store region for all EU VM locations, so storing a separate copy of each machine image per location is redundant. Allow HETZNER_FSN1 and HETZNER_HEL1 VMs to use machine images from either location.