### PR TITLE
Add ability to check DNS records for a Postgres resource

### DIFF
--- a/lib/dns_checker.rb
+++ b/lib/dns_checker.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "resolv"
+
+module DnsChecker
+  IN = Resolv::DNS::Resource::IN
+
+  TYPE_MAP = {
+    A: IN::A,
+    AAAA: IN::AAAA,
+    CNAME: IN::CNAME,
+  }.freeze
+
+  def self.open(nameservers)
+    Resolv::DNS.open(nameserver: nameservers, search: [].freeze, ndots: 1) do |resolver|
+      resolver.timeouts = [1, 2, 3].freeze
+      checker = Checker.new(resolver)
+      yield checker
+      return checker.failures
+    end
+  end
+
+  class Checker
+    attr_reader :failures
+
+    def initialize(resolver)
+      @resolver = resolver
+      @failures = []
+    end
+
+    def check(type, record_name, expected_value)
+      typeclass = TYPE_MAP.fetch(type)
+      resource = @resolver.getresource(record_name, typeclass)
+      actual_value = ((type == :CNAME) ? resource.name : resource.address).to_s
+    rescue Resolv::ResolvError => e
+      # Deliberately avoid Util.exception_to_hash here, as backtrace is not helpful
+      @failures << {type:, record_name:, expected_value:, exception: "#{e.class}: #{e.message}"}
+    else
+      unless expected_value == actual_value
+        @failures << {type:, record_name:, expected_value:, actual_value:}
+      end
+    end
+  end
+end

--- a/lib/dns_checker.rb
+++ b/lib/dns_checker.rb
@@ -12,9 +12,9 @@ module DnsChecker
   }.freeze
 
   def self.open(nameservers)
-    Resolv::DNS.open(nameserver: nameservers, search: [].freeze, ndots: 1) do |resolver|
-      resolver.timeouts = [1, 2, 3].freeze
-      checker = Checker.new(resolver)
+    Resolv::DNS.open(nameserver: nameservers, search: [].freeze, ndots: 1) do
+      it.timeouts = [1, 2, 3].freeze
+      checker = Checker.new(it)
       yield checker
       return checker.failures
     end

--- a/loader.rb
+++ b/loader.rb
@@ -236,6 +236,7 @@ def clover_freeze
   [
     Authorization,
     Authorization::Unauthorized,
+    DnsChecker::Checker,
     HealthMonitorMethods,
     Hosting,
     Minio,

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -204,6 +204,30 @@ class PostgresResource < Sequel::Model
     maintenance_window_start_at.nil? || (Time.now.utc.hour - maintenance_window_start_at) % 24 < MAINTENANCE_DURATION_IN_HOURS
   end
 
+  # Returns array of any DNS record lookup failures
+  def check_all_dns_records
+    return [].freeze unless dns_zone && (vm = representative_server&.vm)
+
+    record_name = hostname
+    nameservers = dns_zone.dns_servers(eager: :vms).flat_map { it.vms.map(&:ip4_string) }
+
+    DnsChecker.open(nameservers) do |dns|
+      if location.aws?
+        dns.check(:CNAME, record_name, vm.aws_instance.ipv4_dns_name + ".")
+      else
+        dns.check(:A, record_name, vm.ip4_string)
+
+        unless dns_zone.records_dataset.where(type: "AAAA", name: record_name + ".").empty?
+          dns.check(:AAAA, record_name, vm.ip6_string)
+        end
+
+        record_name = "private.#{record_name}"
+        dns.check(:A, record_name, vm.private_ipv4_string)
+        dns.check(:AAAA, record_name, vm.private_ipv6_string)
+      end
+    end
+  end
+
   # This may return nil if the customer has destroyed the firewall or
   # detached it from the private subnet.
   def customer_firewall

--- a/spec/lib/dns_checker_spec.rb
+++ b/spec/lib/dns_checker_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "resolv"
+
+RSpec.describe DnsChecker do
+  it ".open returns DNS CNAME record lookup failures" do
+    expect(described_class.open(["127.0.0.1"]) do
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::CNAME)
+        .and_return(Resolv::DNS::Resource::IN::CNAME.new("actual-val"))
+      it.check(:CNAME, "rec", "expect-val")
+    end).to eq [{actual_value: "actual-val", expected_value: "expect-val", record_name: "rec", type: :CNAME}]
+  end
+
+  it ".open returns DNS A record lookup failures" do
+    expect(described_class.open(["127.0.0.1"]) do
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::A)
+        .and_return(Resolv::DNS::Resource::IN::A.new(Resolv::IPv4.new("\x0a\x00\x00\x01")))
+      it.check(:A, "rec", "127.0.0.1")
+    end).to eq [{actual_value: "10.0.0.1", expected_value: "127.0.0.1", record_name: "rec", type: :A}]
+  end
+
+  it ".open returns DNS AAAA record lookup failures" do
+    expect(described_class.open(["127.0.0.1"]) do
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::AAAA)
+        .and_return(Resolv::DNS::Resource::IN::AAAA.new(Resolv::IPv6.new("\xfe\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02")))
+      it.check(:AAAA, "rec", "fe80::1")
+    end).to eq [{actual_value: "fe80::2", expected_value: "fe80::1", record_name: "rec", type: :AAAA}]
+  end
+
+  it ".open returns empty array if there are no failures" do
+    expect(described_class.open(["127.0.0.1"]) do
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::CNAME)
+        .and_return(Resolv::DNS::Resource::IN::CNAME.new("expect-val"))
+      it.check(:CNAME, "rec", "expect-val")
+
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::A)
+        .and_return(Resolv::DNS::Resource::IN::A.new(Resolv::IPv4.new("\x7f\x00\x00\x01")))
+      it.check(:A, "rec", "127.0.0.1")
+
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::AAAA)
+        .and_return(Resolv::DNS::Resource::IN::AAAA.new(Resolv::IPv6.new("\xfe\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01")))
+      it.check(:AAAA, "rec", "fe80::1")
+    end).to eq []
+  end
+
+  it ".open returns exceptions as failures" do
+    expect(described_class.open(["127.0.0.1"]) do
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::CNAME)
+        .and_raise(Resolv::ResolvError.new("foo"))
+      it.check(:CNAME, "rec", "expect-val")
+    end).to eq [{exception: "Resolv::ResolvError: foo", expected_value: "expect-val", record_name: "rec", type: :CNAME}]
+  end
+end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -759,6 +759,100 @@ RSpec.describe PostgresResource do
     expect(postgres_resource.target_server_count).to eq(3)
   end
 
+  describe "check_all_dns_records" do
+    let(:dns_zone) { DnsZone.create(project_id: project.id, name: "pg.example.com") }
+
+    it "returns empty array if the resource does not have a DNS zone" do
+      expect(postgres_resource.check_all_dns_records).to eq []
+    end
+
+    it "returns empty array if the resource does not have a representative_server" do
+      expect(Config).to receive(:postgres_service_project_id).and_return(project.id)
+      expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com")
+      dns_zone
+      expect(postgres_resource.check_all_dns_records).to eq []
+    end
+
+    context "with DNS zone" do
+      before do
+        allow(Config).to receive_messages(postgres_service_project_id: project.id, postgres_service_hostname: "pg.example.com")
+        dns_zone
+        vm = create_hosted_vm(project, private_subnet, "pg-vm")
+        PostgresServer.create(timeline:, resource_id: postgres_resource.id, vm_id: vm.id, is_representative: true, synchronization_status: "ready", timeline_access: "push", version: "17")
+      end
+
+      it "resolves using the expected DNS servers" do
+        expect(DnsChecker).to receive(:open).with(contain_exactly("10.0.1.1", "10.0.2.2", "10.1.1.1", "10.1.2.2"))
+        2.times do
+          server = DnsServer.create(name: "ns#{it}.ubicloud.com")
+          dns_zone.add_dns_server(server)
+          vm1 = create_vm(name: "vm#{it}1")
+          vm2 = create_vm(name: "vm#{it}2")
+          add_ipv4_to_vm(vm1, "10.#{it}.1.1")
+          add_ipv4_to_vm(vm2, "10.#{it}.2.2")
+          server.add_vm(vm1)
+          server.add_vm(vm2)
+        end
+        postgres_resource.check_all_dns_records
+      end
+
+      context "with representative server" do
+        let(:checker) { DnsChecker::Checker.new(nil) }
+
+        before do
+          # Currently not needed for these specs, but in case an actual nameserver IP is needed later:
+          # server = DnsServer.create(name: "ns#{it}.ubicloud.com")
+          # dns_zone.add_dns_server(server)
+          # vm = create_vm(name: "vm1")
+          # add_ipv4_to_vm(vm, "10.0.1.1")
+          # server.add_vm(vm)
+          expect(DnsChecker::Checker).to receive(:new).and_return(checker)
+          add_ipv4_to_vm(postgres_resource.representative_server.vm, "10.1.2.3")
+          postgres_resource.representative_server.vm.update(ephemeral_net6: "fe80::/80")
+        end
+
+        it "resolves CNAME record for AWS databases" do
+          location = Location.create(display_name: "a1", name: "a1", ui_name: "a1", visible: true, provider: "aws")
+          postgres_resource.update(location_id: location.id)
+          AwsInstance.create_with_id(postgres_resource.representative_server.vm.id, ipv4_dns_name: "foo")
+          expect(checker).to receive(:check).with(:CNAME, postgres_resource.hostname, "foo.")
+          expect(postgres_resource.check_all_dns_records).to eq []
+        end
+
+        it "resolves A and AAAA records for metal databases" do
+          # AAAA not added by default, need to add it
+          postgres_resource.dns_zone.insert_record(type: "AAAA", record_name: postgres_resource.hostname, data: "fe80::2", ttl: 30)
+
+          expect(checker).to receive(:check).with(:A, postgres_resource.hostname, "10.1.2.3")
+          expect(checker).to receive(:check).with(:AAAA, postgres_resource.hostname, "fe80::2")
+          expect(checker).to receive(:check).with(:A, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv4_string)
+          expect(checker).to receive(:check).with(:AAAA, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv6_string)
+          expect(postgres_resource.check_all_dns_records).to eq []
+        end
+
+        it "does not attempt to resolve AAAA public record for old metal databases lacking one" do
+          postgres_resource.update(created_at: Time.utc(2025))
+          expect(checker).to receive(:check).with(:A, postgres_resource.hostname, "10.1.2.3")
+          expect(checker).to receive(:check).with(:A, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv4_string)
+          expect(checker).to receive(:check).with(:AAAA, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv6_string)
+          expect(postgres_resource.check_all_dns_records).to eq []
+        end
+
+        it "returns failures" do
+          location = Location.create(display_name: "a1", name: "a1", ui_name: "a1", visible: true, provider: "aws")
+          postgres_resource.update(location_id: location.id)
+          AwsInstance.create_with_id(postgres_resource.representative_server.vm.id, ipv4_dns_name: "foo")
+          expect(checker).to receive(:check) do |type, record_name, expected_value|
+            checker.failures << {type:, record_name:, expected_value:, actual_value: "bar."}
+          end
+          expect(postgres_resource.check_all_dns_records).to eq [
+            {type: :CNAME, record_name: postgres_resource.hostname, expected_value: "foo.", actual_value: "bar."},
+          ]
+        end
+      end
+    end
+  end
+
   describe "#ongoing_failover?" do
     def create_server_with_strand(label:)
       vm = create_hosted_vm(project, private_subnet, "pg-vm-#{SecureRandom.hex(4)}")

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -122,6 +122,8 @@ module ThawedMock
   allow_mocking(Clog, :emit, :write)
   allow_mocking(CloudflareClient, :new)
   allow_mocking(Clover, :ips_v4, :call, :authorized_project)
+  allow_mocking(DnsChecker, :open)
+  allow_mocking(DnsChecker::Checker, :new)
   allow_mocking(EmailRenderer, :sendmail)
   allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reimage_server, :hardware_reset_server, :set_server_name)
   allow_mocking(InvoiceGenerator, :new)


### PR DESCRIPTION
This adds a DnsChecker class that can do general DNS checking, and adds PostgresResource#check_all_dns_records to handle checks for an individual database.