### PR TITLE
Check Postgres DNS records every 5 minutes

### DIFF
--- a/lib/dns_checker.rb
+++ b/lib/dns_checker.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "resolv"
+
+module DnsChecker
+  IN = Resolv::DNS::Resource::IN
+
+  TYPE_MAP = {
+    A: IN::A,
+    AAAA: IN::AAAA,
+    CNAME: IN::CNAME,
+  }.freeze
+
+  def self.open(nameservers)
+    Resolv::DNS.open(nameserver: nameservers, search: [].freeze, ndots: 1) do |resolver|
+      resolver.timeouts = [1, 2, 3].freeze
+      checker = Checker.new(resolver)
+      yield checker
+      return checker.failures
+    end
+  end
+
+  class Checker
+    attr_reader :failures
+
+    def initialize(resolver)
+      @resolver = resolver
+      @failures = []
+    end
+
+    def check(type, record_name, expected_value)
+      typeclass = TYPE_MAP.fetch(type)
+      resource = @resolver.getresource(record_name, typeclass)
+      actual_value = ((type == :CNAME) ? resource.name : resource.address).to_s
+    rescue Resolv::ResolvError => e
+      # Deliberately avoid Util.exception_to_hash here, as backtrace is not helpful
+      @failures << {type:, record_name:, expected_value:, exception: "#{e.class}: #{e.message}"}
+    else
+      unless expected_value == actual_value
+        @failures << {type:, record_name:, expected_value:, actual_value:}
+      end
+    end
+  end
+end

--- a/loader.rb
+++ b/loader.rb
@@ -229,6 +229,7 @@ def clover_freeze
   [
     Authorization,
     Authorization::Unauthorized,
+    DnsChecker::Checker,
     HealthMonitorMethods,
     Hosting,
     Minio,

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -167,6 +167,31 @@ class PostgresResource < Sequel::Model
     maintenance_window_start_at.nil? || (Time.now.utc.hour - maintenance_window_start_at) % 24 < MAINTENANCE_DURATION_IN_HOURS
   end
 
+  # Returns array of any DNS record lookup failures
+  def check_all_dns_records
+    return [].freeze unless dns_zone && (vm = representative_server&.vm)
+
+    record_name = hostname
+    nameservers = dns_zone.dns_servers(eager: :vms).flat_map { it.vms.map(&:ip4_string) }
+
+    DnsChecker.open(nameservers) do |dns|
+      if location.aws?
+        dns.check(:CNAME, record_name, vm.aws_instance.ipv4_dns_name + ".")
+      else
+        dns.check(:A, record_name, vm.ip4_string)
+
+        if created_at >= PostgresResource::AAAA_CUTOFF ||
+            !dns_zone.records_dataset.where(type: "AAAA", name: record_name + ".").empty?
+          dns.check(:AAAA, record_name, vm.ip6_string)
+        end
+
+        record_name = "private.#{record_name}"
+        dns.check(:A, record_name, vm.private_ipv4_string)
+        dns.check(:AAAA, record_name, vm.private_ipv6_string)
+      end
+    end
+  end
+
   # This may return nil if the customer has destroyed the firewall or
   # detached it from the private subnet.
   def customer_firewall

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -150,6 +150,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         dns_zone.insert_record(record_name:, type: "A", ttl: 10, data: vm.private_ipv4_string)
         dns_zone.insert_record(record_name:, type: "AAAA", ttl: 10, data: vm.private_ipv6_string)
       end
+
+      update_stack("dns_refreshed_at" => Time.now.to_i)
     end
 
     when_initial_provisioning_set? do
@@ -304,7 +306,9 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       decr_update_firewall_rules
     end
 
-    nap 30
+    check_all_dns_records
+
+    nap(60 * 5)
   end
 
   label def destroy
@@ -356,5 +360,21 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       issuer_cert:,
       issuer_key:,
     ).map(&:to_pem)
+  end
+
+  def check_all_dns_records
+    return unless postgres_resource.dns_zone
+
+    # Give DNS servers time to apply recent DNS changes
+    return if frame["dns_refreshed_at"]&.>(Time.now.to_i - 150)
+
+    dns_failures = postgres_resource.check_all_dns_records
+    dns_tag = ["PostgreSQL-DNS-Record-Failure", postgres_resource.ubid]
+
+    if dns_failures.empty?
+      Page.from_tag_parts(*dns_tag)&.incr_resolve
+    else
+      Prog::PageNexus.assemble("PostgreSQL DNS record lookup failure", dns_tag, postgres_resource.ubid, extra_data: {dns_failures:})
+    end
   end
 end

--- a/spec/lib/dns_checker_spec.rb
+++ b/spec/lib/dns_checker_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "resolv"
+
+RSpec.describe DnsChecker do
+  it ".open returns DNS CNAME record lookup failures" do
+    expect(described_class.open(["127.0.0.1"]) do
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::CNAME)
+        .and_return(Resolv::DNS::Resource::IN::CNAME.new("actual-val"))
+      it.check(:CNAME, "rec", "expect-val")
+    end).to eq [{actual_value: "actual-val", expected_value: "expect-val", record_name: "rec", type: :CNAME}]
+  end
+
+  it ".open returns DNS A record lookup failures" do
+    expect(described_class.open(["127.0.0.1"]) do
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::A)
+        .and_return(Resolv::DNS::Resource::IN::A.new(Resolv::IPv4.new("\x0a\x00\x00\x01")))
+      it.check(:A, "rec", "127.0.0.1")
+    end).to eq [{actual_value: "10.0.0.1", expected_value: "127.0.0.1", record_name: "rec", type: :A}]
+  end
+
+  it ".open returns DNS AAAA record lookup failures" do
+    expect(described_class.open(["127.0.0.1"]) do
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::AAAA)
+        .and_return(Resolv::DNS::Resource::IN::AAAA.new(Resolv::IPv6.new("\xfe\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02")))
+      it.check(:AAAA, "rec", "fe80::1")
+    end).to eq [{actual_value: "fe80::2", expected_value: "fe80::1", record_name: "rec", type: :AAAA}]
+  end
+
+  it ".open returns empty array if there are no failures" do
+    expect(described_class.open(["127.0.0.1"]) do
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::CNAME)
+        .and_return(Resolv::DNS::Resource::IN::CNAME.new("expect-val"))
+      it.check(:CNAME, "rec", "expect-val")
+
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::A)
+        .and_return(Resolv::DNS::Resource::IN::A.new(Resolv::IPv4.new("\x7f\x00\x00\x01")))
+      it.check(:A, "rec", "127.0.0.1")
+
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::AAAA)
+        .and_return(Resolv::DNS::Resource::IN::AAAA.new(Resolv::IPv6.new("\xfe\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01")))
+      it.check(:AAAA, "rec", "fe80::1")
+    end).to eq []
+  end
+
+  it ".open returns exceptions as failures" do
+    expect(described_class.open(["127.0.0.1"]) do
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::CNAME)
+        .and_raise(Resolv::ResolvError.new("foo"))
+      it.check(:CNAME, "rec", "expect-val")
+    end).to eq [{exception: "Resolv::ResolvError: foo", expected_value: "expect-val", record_name: "rec", type: :CNAME}]
+  end
+end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -633,6 +633,97 @@ RSpec.describe PostgresResource do
     expect(postgres_resource.target_server_count).to eq(3)
   end
 
+  describe "check_all_dns_records" do
+    let(:dns_zone) { DnsZone.create(project_id: project.id, name: "pg.example.com") }
+
+    it "returns empty array if the resource does not have a DNS zone" do
+      expect(postgres_resource.check_all_dns_records).to eq []
+    end
+
+    it "returns empty array if the resource does not have a representative_server" do
+      expect(Config).to receive(:postgres_service_project_id).and_return(project.id)
+      expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com")
+      dns_zone
+      expect(postgres_resource.check_all_dns_records).to eq []
+    end
+
+    context "with DNS zone" do
+      before do
+        allow(Config).to receive_messages(postgres_service_project_id: project.id, postgres_service_hostname: "pg.example.com")
+        dns_zone
+        vm = create_hosted_vm(project, private_subnet, "pg-vm")
+        PostgresServer.create(timeline:, resource_id: postgres_resource.id, vm_id: vm.id, is_representative: true, synchronization_status: "ready", timeline_access: "push", version: "17")
+      end
+
+      it "resolves using the expected DNS servers" do
+        expect(DnsChecker).to receive(:open).with(contain_exactly("10.0.1.1", "10.0.2.2", "10.1.1.1", "10.1.2.2"))
+        2.times do
+          server = DnsServer.create(name: "ns#{it}.ubicloud.com")
+          dns_zone.add_dns_server(server)
+          vm1 = create_vm(name: "vm#{it}1")
+          vm2 = create_vm(name: "vm#{it}2")
+          add_ipv4_to_vm(vm1, "10.#{it}.1.1")
+          add_ipv4_to_vm(vm2, "10.#{it}.2.2")
+          server.add_vm(vm1)
+          server.add_vm(vm2)
+        end
+        postgres_resource.check_all_dns_records
+      end
+
+      context "with representative server" do
+        let(:checker) { DnsChecker::Checker.new(nil) }
+
+        before do
+          # Currently not needed for these specs, but in case an actual nameserver IP is needed later:
+          # server = DnsServer.create(name: "ns#{it}.ubicloud.com")
+          # dns_zone.add_dns_server(server)
+          # vm = create_vm(name: "vm1")
+          # add_ipv4_to_vm(vm, "10.0.1.1")
+          # server.add_vm(vm)
+          expect(DnsChecker::Checker).to receive(:new).and_return(checker)
+          add_ipv4_to_vm(postgres_resource.representative_server.vm, "10.1.2.3")
+          postgres_resource.representative_server.vm.update(ephemeral_net6: "fe80::/80")
+        end
+
+        it "resolves CNAME record for AWS databases" do
+          location = Location.create(display_name: "a1", name: "a1", ui_name: "a1", visible: true, provider: "aws")
+          postgres_resource.update(location_id: location.id)
+          AwsInstance.create_with_id(postgres_resource.representative_server.vm.id, ipv4_dns_name: "foo")
+          expect(checker).to receive(:check).with(:CNAME, postgres_resource.hostname, "foo.")
+          expect(postgres_resource.check_all_dns_records).to eq []
+        end
+
+        it "resolves A and AAAA records for metal databases" do
+          expect(checker).to receive(:check).with(:A, postgres_resource.hostname, "10.1.2.3")
+          expect(checker).to receive(:check).with(:AAAA, postgres_resource.hostname, "fe80::2")
+          expect(checker).to receive(:check).with(:A, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv4_string)
+          expect(checker).to receive(:check).with(:AAAA, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv6_string)
+          expect(postgres_resource.check_all_dns_records).to eq []
+        end
+
+        it "does not attempt to resolve AAAA public record for old metal databases lacking one" do
+          postgres_resource.update(created_at: Time.utc(2025))
+          expect(checker).to receive(:check).with(:A, postgres_resource.hostname, "10.1.2.3")
+          expect(checker).to receive(:check).with(:A, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv4_string)
+          expect(checker).to receive(:check).with(:AAAA, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv6_string)
+          expect(postgres_resource.check_all_dns_records).to eq []
+        end
+
+        it "returns failures" do
+          location = Location.create(display_name: "a1", name: "a1", ui_name: "a1", visible: true, provider: "aws")
+          postgres_resource.update(location_id: location.id)
+          AwsInstance.create_with_id(postgres_resource.representative_server.vm.id, ipv4_dns_name: "foo")
+          expect(checker).to receive(:check) do |type, record_name, expected_value|
+            checker.failures << {type:, record_name:, expected_value:, actual_value: "bar."}
+          end
+          expect(postgres_resource.check_all_dns_records).to eq [
+            {type: :CNAME, record_name: postgres_resource.hostname, expected_value: "foo.", actual_value: "bar."},
+          ]
+        end
+      end
+    end
+  end
+
   describe "#ongoing_failover?" do
     def create_server_with_strand(label:)
       vm = create_hosted_vm(project, private_subnet, "pg-vm-#{SecureRandom.hex(4)}")

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -275,6 +275,8 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
         ["AAAA", "#{name}.pg.example.com.", "2::1"],
         ["AAAA", "private.#{name}.pg.example.com.", "::1"],
       ]
+
+      expect(nx.strand.stack[0]["dns_refreshed_at"]).to be_within(2).of(Time.now.to_i)
     end
 
     it "does not create public AAAA record for older resources" do
@@ -577,15 +579,66 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
     it "calls set_firewall_rules method of the postgres resource when update_firewall_rules is set" do
       nx.incr_update_firewall_rules
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(300)
       expect(Semaphore.where(strand_id: st.id, name: "update_firewall_rules")).to be_empty
     end
 
     it "calls handle_storage_auto_scale when check_disk_usage is set and decrements the semaphore" do
       nx.incr_check_disk_usage
       expect(nx.postgres_resource).to receive(:handle_storage_auto_scale)
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(300)
       expect(Semaphore.where(strand_id: st.id, name: "check_disk_usage")).to be_empty
+    end
+
+    context "with dns zone and representative server" do
+      let(:checker) { DnsChecker::Checker.new(nil) }
+      let(:location) { Location[Location::HETZNER_FSN1_ID] }
+      let(:timeline) { create_postgres_timeline(location_id:) }
+
+      before do
+        allow(Config).to receive_messages(postgres_service_project_id: project.id, postgres_service_hostname: "pg.example.com")
+        DnsZone.create(project_id: project.id, name: "pg.example.com")
+        allow(DnsChecker::Checker).to receive(:new).and_return(checker)
+      end
+
+      it "does not checks dns records if they were recently updated" do
+        refresh_frame(nx, new_values: {"dns_refreshed_at" => (Time.now - 60).to_i})
+        expect { nx.wait }.to nap(300)
+      end
+
+      it "checks dns records and does nothing if they match" do
+        expect(checker).to receive(:check).with(:A, postgres_resource.hostname, postgres_resource.representative_server.vm.ip4_string)
+        expect(checker).to receive(:check).with(:AAAA, postgres_resource.hostname, postgres_resource.representative_server.vm.ip6_string)
+        expect(checker).to receive(:check).with(:A, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv4_string)
+        expect(checker).to receive(:check).with(:AAAA, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv6_string)
+        expect { nx.wait }.to nap(300)
+        expect(Page.all).to eq []
+      end
+
+      it "checks dns records and pages if they don't match" do
+        expect(checker).to receive(:check).with(:A, postgres_resource.hostname, postgres_resource.representative_server.vm.ip4_string).twice
+        expect(checker).to receive(:check).with(:AAAA, postgres_resource.hostname, postgres_resource.representative_server.vm.ip6_string).twice
+        expect(checker).to receive(:check).with(:A, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv4_string).twice
+        expect(checker).to receive(:check).with(:AAAA, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv6_string).twice
+        checker.failures << {type: :A, record_name: postgres_resource.hostname, expected_value: postgres_resource.representative_server.vm.ip4_string, actual_value: "1.2.3.4"}
+        expect { nx.wait }.to nap(300)
+        expect(Page.count).to eq 1
+        page = Page.first
+        expect(page.summary).to eq "PostgreSQL DNS record lookup failure"
+        expect(page.details).to eq({
+          "dns_failures" => [{
+            "type" => "A",
+            "record_name" => postgres_resource.hostname,
+            "actual_value" => "1.2.3.4",
+            "expected_value" => postgres_resource.representative_server.vm.ip4_string,
+          }],
+          "related_resources" => [postgres_resource.ubid],
+        })
+
+        checker.failures.clear
+        expect { nx.wait }.to nap(300)
+          .and change { Semaphore.where(strand_id: page.id, name: "resolve").count }.from(0).to(1)
+      end
     end
   end
 
@@ -596,7 +649,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
     it "buds ConvergePostgresResource prog if needs_convergence? is true" do
       postgres_server.incr_recycle
-      expect { nx.wait }.to nap(30)
+      expect { nx.wait }.to nap(300)
       expect(st.children_dataset.where(prog: "Postgres::ConvergePostgresResource").first).to exist
     end
   end

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -124,6 +124,8 @@ module ThawedMock
   allow_mocking(Clog, :emit, :write)
   allow_mocking(CloudflareClient, :new)
   allow_mocking(Clover, :ips_v4, :call, :authorized_project)
+  allow_mocking(DnsChecker, :open)
+  allow_mocking(DnsChecker::Checker, :new)
   allow_mocking(EmailRenderer, :sendmail)
   allow_mocking(Hosting::Apis, :pull_data_center, :pull_ips, :reimage_server, :hardware_reset_server, :set_server_name)
   allow_mocking(InvoiceGenerator, :new)


### PR DESCRIPTION
Instead of napping for 30 seconds at the wait label, check the DNS records and nap for 5 minutes.  If any expected DNS records do not match, and we didn't change DNS records recently, page. If all DNS records are present, resolve the page.

I'm separating this from #5365 as I would like to merge that first and test it in staging an production before merging this.