### PR TITLE
Add hugepage utilization to runner usage page in admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1193,8 +1193,9 @@ class CloverAdmin < Roda
 
       @family_utilization = VmHost.where(allocation_state: "accepting", location_id: [Location::GITHUB_RUNNERS_ID, Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID], arch: @arch)
         .select_group(:family)
-        .select_append { round(sum(:used_cores) * 100.0 / sum(:total_cores), 2).cast(:float).as(:utilization) }
-        .to_hash(:family, :utilization)
+        .select_append { round(sum(:used_cores) * 100.0 / sum(:total_cores), 2).cast(:float).as(:vcpu_util) }
+        .select_append { round(sum(:used_hugepages_1g) * 100.0 / sum(:total_hugepages_1g), 2).cast(:float).as(:hugepage_util) }
+        .to_hash(:family, [:vcpu_util, :hugepage_util])
 
       @spilled_vcpus = Vm.where(arch: @arch, boot_image: Prog::Github::GithubRunnerNexus::AWS_AMI_VERSIONS).sum(:vcpus) || 0
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1693,7 +1693,7 @@ RSpec.describe CloverAdmin do
     click_link "GitHub Runner VM Usage"
     expect(page.title).to eq "Ubicloud Admin - GitHub Runner x64 VM Usage"
     expect(page).to have_link "Show arm64"
-    expect(page).to have_css("p", exact_text: "Utilization: standard: 25.0% , premium: 50.0% , spilled vcpus: 12")
+    expect(page).to have_css("p", exact_text: "standard: vcpu 25.0%, hugepage 4.27%, spilled vcpus 12 - premium: vcpu 50.0%, hugepage 4.27%")
     expect(page.all("#content td").map(&:text)).to eq [
       "TOTAL", "", "", "400",
       "2", "1", "1", "0", "1", "0",
@@ -1728,7 +1728,7 @@ RSpec.describe CloverAdmin do
 
     expect(page.title).to eq "Ubicloud Admin - GitHub Runner arm64 VM Usage"
     expect(page).to have_link "Show x64"
-    expect(page).to have_css("p", exact_text: "Utilization: standard: 25.0% , spilled vcpus: 8")
+    expect(page).to have_css("p", exact_text: "standard: vcpu 25.0%, hugepage 4.27%, spilled vcpus 8")
     expect(page.all("#content td").map(&:text)).to eq [
       "TOTAL", "", "", "100",
       "1", "0", "0", "0", "0", "0",

--- a/views/admin/github_runner_usage.erb
+++ b/views/admin/github_runner_usage.erb
@@ -19,11 +19,13 @@ end
   <%= other_arch %></a>
 
 <p>
-  <strong>Utilization:</strong>
-  <%= "standard: #{@family_utilization["standard"] || 0}%" %>
+  <strong>standard:</strong>
+  <%= "vcpu #{@family_utilization.dig("standard", 0) || 0}%, hugepage #{@family_utilization.dig("standard", 1) || 0}%, spilled vcpus #{@spilled_vcpus}" %>
   <% if @arch == "x64" %>
-    <%= ", premium: #{@family_utilization["premium"] || 0}%" %><% end %>
-  <%= ", spilled vcpus: #{@spilled_vcpus}" %>
+    -
+    <strong>premium:</strong>
+    <%= "vcpu #{@family_utilization.dig("premium", 0) || 0}%, hugepage #{@family_utilization.dig("premium", 1) || 0}%" %>
+  <% end %>
 </p>
 
 <%== part("components/table", title: nil, table_class: "github-runner-usage-table", data: @data, use_admin_label: false) %>


### PR DESCRIPTION
Since new VM hosts have more vCPUs than available hugepages, hugepages have become our new bottleneck for VM allocation. It's useful to see hugepage utilization alongside vCPU utilization.