### PR TITLE
Push postgres_exporter queries from control plane

### DIFF
--- a/config/postgres_exporter_queries.yml
+++ b/config/postgres_exporter_queries.yml
@@ -1,0 +1,168 @@
+# Low-cardinality custom queries for postgres_exporter
+#
+# NOTE: These queries use the SAME metric names as the original collectors,
+# but aggregate across all databases. The only difference is the absence of
+# per-database labels (datname, datid), making them drop-in replacements for
+# existing dashboards and alerts.
+
+pg_stat_activity:
+  query: |
+    SELECT
+      state,
+      COUNT(*) as count,
+      MAX(EXTRACT(EPOCH FROM now() - xact_start))::float AS max_tx_duration
+    FROM pg_stat_activity
+    WHERE pid <> pg_backend_pid()
+      AND datname IS NOT NULL
+      AND state IS NOT NULL
+    GROUP BY state
+  metrics:
+    - state:
+        usage: "LABEL"
+        description: "Connection state (active, idle, etc.)"
+    - count:
+        usage: "GAUGE"
+        description: "Number of connections in this state across all databases"
+    - max_tx_duration:
+        usage: "GAUGE"
+        description: "Maximum transaction duration in seconds across all databases"
+
+pg_stat_database:
+  query: |
+    SELECT
+      SUM(numbackends)::float as numbackends,
+      SUM(xact_commit)::float as xact_commit,
+      SUM(xact_rollback)::float as xact_rollback,
+      SUM(blks_read)::float as blks_read,
+      SUM(blks_hit)::float as blks_hit,
+      SUM(tup_returned)::float as tup_returned,
+      SUM(tup_fetched)::float as tup_fetched,
+      SUM(tup_inserted)::float as tup_inserted,
+      SUM(tup_updated)::float as tup_updated,
+      SUM(tup_deleted)::float as tup_deleted,
+      SUM(conflicts)::float as conflicts,
+      SUM(temp_files)::float as temp_files,
+      SUM(temp_bytes)::float as temp_bytes,
+      SUM(deadlocks)::float as deadlocks,
+      SUM(blk_read_time)::float as blk_read_time,
+      SUM(blk_write_time)::float as blk_write_time
+    FROM pg_stat_database
+    WHERE datname IS NOT NULL
+      AND datname NOT IN ('template0', 'template1')
+  metrics:
+    - numbackends:
+        usage: "GAUGE"
+        description: "Total number of backends across all databases"
+    - xact_commit:
+        usage: "COUNTER"
+        description: "Total committed transactions across all databases"
+    - xact_rollback:
+        usage: "COUNTER"
+        description: "Total rolled back transactions across all databases"
+    - blks_read:
+        usage: "COUNTER"
+        description: "Total disk blocks read across all databases"
+    - blks_hit:
+        usage: "COUNTER"
+        description: "Total buffer cache hits across all databases"
+    - tup_returned:
+        usage: "COUNTER"
+        description: "Total rows returned across all databases"
+    - tup_fetched:
+        usage: "COUNTER"
+        description: "Total rows fetched across all databases"
+    - tup_inserted:
+        usage: "COUNTER"
+        description: "Total rows inserted across all databases"
+    - tup_updated:
+        usage: "COUNTER"
+        description: "Total rows updated across all databases"
+    - tup_deleted:
+        usage: "COUNTER"
+        description: "Total rows deleted across all databases"
+    - conflicts:
+        usage: "COUNTER"
+        description: "Total query conflicts across all databases"
+    - temp_files:
+        usage: "COUNTER"
+        description: "Total temporary files created across all databases"
+    - temp_bytes:
+        usage: "COUNTER"
+        description: "Total temporary file bytes across all databases"
+    - deadlocks:
+        usage: "COUNTER"
+        description: "Total deadlocks across all databases"
+    - blk_read_time:
+        usage: "COUNTER"
+        description: "Total time spent reading blocks in milliseconds across all databases"
+    - blk_write_time:
+        usage: "COUNTER"
+        description: "Total time spent writing blocks in milliseconds across all databases"
+
+# Top 5 largest databases (this one keeps per-database labels)
+pg_database:
+  query: |
+    SELECT
+      datname,
+      pg_database_size(datname)::float as size_bytes
+    FROM pg_database
+    WHERE datallowconn = true
+      AND datistemplate = false
+      AND datname NOT IN ('template0', 'template1')
+    ORDER BY pg_database_size(datname) DESC
+    LIMIT 5
+  metrics:
+    - datname:
+        usage: "LABEL"
+        description: "Database name"
+    - size_bytes:
+        usage: "GAUGE"
+        description: "Database size in bytes"
+
+pg_locks:
+  query: |
+    SELECT
+      lower(mode) as mode,
+      COUNT(*)::float as count
+    FROM pg_locks
+    WHERE database IS NOT NULL
+    GROUP BY mode
+  metrics:
+    - mode:
+        usage: "LABEL"
+        description: "Lock mode"
+    - count:
+        usage: "GAUGE"
+        description: "Number of locks across all databases by mode"
+
+pg_stat_database_conflicts:
+  query: |
+    SELECT
+      SUM(confl_tablespace)::float as confl_tablespace,
+      SUM(confl_lock)::float as confl_lock,
+      SUM(confl_snapshot)::float as confl_snapshot,
+      SUM(confl_bufferpin)::float as confl_bufferpin,
+      SUM(confl_deadlock)::float as confl_deadlock,
+      SUM(COALESCE(confl_active_logicalslot, 0))::float as confl_active_logicalslot
+    FROM pg_stat_database_conflicts
+    WHERE datname IS NOT NULL
+      AND datname NOT IN ('template0', 'template1')
+  metrics:
+    - confl_tablespace:
+        usage: "COUNTER"
+        description: "Total queries canceled due to dropped tablespaces across all databases"
+    - confl_lock:
+        usage: "COUNTER"
+        description: "Total queries canceled due to lock timeouts across all databases"
+    - confl_snapshot:
+        usage: "COUNTER"
+        description: "Total queries canceled due to old snapshots across all databases"
+    - confl_bufferpin:
+        usage: "COUNTER"
+        description: "Total queries canceled due to pinned buffers across all databases"
+    - confl_deadlock:
+        usage: "COUNTER"
+        description: "Total queries canceled due to deadlocks across all databases"
+    - confl_active_logicalslot:
+        usage: "COUNTER"
+        description: "Total queries canceled due to active logical replication slots across all databases (PG 14+)"

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -253,6 +253,8 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   end
 
   label def configure_metrics
+    vm.sshable.cmd("sudo mkdir -p /usr/local/share/postgresql")
+    vm.sshable.write_file("/usr/local/share/postgresql/postgres_exporter_queries.yaml", postgres_exporter_queries_yaml)
     web_config = <<CONFIG
 tls_server_config:
   cert_file: /etc/ssl/certs/server.crt
@@ -920,6 +922,10 @@ SQL
 
   def update_stack_lsn(lsn)
     update_stack({"lsn" => lsn})
+  end
+
+  def postgres_exporter_queries_yaml
+    File.read("config/postgres_exporter_queries.yml")
   end
 
   def version

--- a/spec/config/postgres_exporter_queries_yml_spec.rb
+++ b/spec/config/postgres_exporter_queries_yml_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+# rubocop:disable RSpec/DescribeClass
+# There is no class in this case; the spec verifies a static config file.
+RSpec.describe "config/postgres_exporter_queries.yml" do
+  # rubocop:enable RSpec/DescribeClass
+  it "parses as YAML" do
+    expect { YAML.safe_load_file("config/postgres_exporter_queries.yml") }.not_to raise_error
+  end
+
+  it "is a non-empty mapping (top-level keys are query names)" do
+    parsed = YAML.safe_load_file("config/postgres_exporter_queries.yml")
+    expect(parsed).to be_a(Hash)
+    expect(parsed).not_to be_empty
+  end
+end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -568,11 +568,20 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
   end
 
+  describe "#postgres_exporter_queries_yaml" do
+    it "returns YAML containing all keys from config/postgres_exporter_queries.yml" do
+      expect(YAML.safe_load(nx.send(:postgres_exporter_queries_yaml)))
+        .to include(YAML.safe_load_file("config/postgres_exporter_queries.yml"))
+    end
+  end
+
   describe "#configure_metrics" do
     let(:metrics_config) { {interval: "30s", endpoints: ["https://localhost:9100/metrics"], metrics_dir: "/home/ubi/postgres/metrics"} }
 
     it "configures prometheus and metrics during initial provisioning" do
       nx.incr_initial_provisioning
+      expect(sshable).to receive(:_cmd).with("sudo mkdir -p /usr/local/share/postgresql")
+      expect(sshable).to receive(:_cmd).with("sudo tee /usr/local/share/postgresql/postgres_exporter_queries.yaml > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo -u prometheus tee /home/prometheus/web-config.yml > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo -u prometheus tee /home/prometheus/prometheus.yml > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now postgres_exporter")
@@ -610,6 +619,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
       nx.incr_initial_provisioning
       expect(nx.postgres_server.resource).to receive(:use_old_walg_command_set?).and_return(false)
+      expect(sshable).to receive(:_cmd).with("sudo mkdir -p /usr/local/share/postgresql")
+      expect(sshable).to receive(:_cmd).with("sudo tee /usr/local/share/postgresql/postgres_exporter_queries.yaml > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo -u prometheus tee /home/prometheus/web-config.yml > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo -u prometheus tee /home/prometheus/prometheus.yml > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now postgres_exporter")
@@ -643,6 +654,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       standby_sshable = standby_server.vm.sshable
 
       # Prometheus expectations
+      expect(standby_sshable).to receive(:_cmd).with("sudo mkdir -p /usr/local/share/postgresql")
+      expect(standby_sshable).to receive(:_cmd).with("sudo tee /usr/local/share/postgresql/postgres_exporter_queries.yaml > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo -u prometheus tee /home/prometheus/web-config.yml > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo -u prometheus tee /home/prometheus/prometheus.yml > /dev/null", stdin: /ubicloud_resource_role: standby/)
       expect(standby_sshable).to receive(:_cmd).with("sudo systemctl reload postgres_exporter || sudo systemctl restart postgres_exporter")
@@ -674,6 +687,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       standby_sshable = standby_server.vm.sshable
 
       # Prometheus expectations
+      expect(standby_sshable).to receive(:_cmd).with("sudo mkdir -p /usr/local/share/postgresql")
+      expect(standby_sshable).to receive(:_cmd).with("sudo tee /usr/local/share/postgresql/postgres_exporter_queries.yaml > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo -u prometheus tee /home/prometheus/web-config.yml > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo -u prometheus tee /home/prometheus/prometheus.yml > /dev/null", stdin: /ubicloud_resource_role: standby/)
       expect(standby_sshable).to receive(:_cmd).with("sudo systemctl reload postgres_exporter || sudo systemctl restart postgres_exporter")
@@ -711,6 +726,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       standby_sshable = standby_server.vm.sshable
 
       # Prometheus expectations
+      expect(standby_sshable).to receive(:_cmd).with("sudo mkdir -p /usr/local/share/postgresql")
+      expect(standby_sshable).to receive(:_cmd).with("sudo tee /usr/local/share/postgresql/postgres_exporter_queries.yaml > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo -u prometheus tee /home/prometheus/web-config.yml > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo -u prometheus tee /home/prometheus/prometheus.yml > /dev/null", stdin: /remote_write:.*url:.*metrics\.example\.com/m)
       expect(standby_sshable).to receive(:_cmd).with("sudo systemctl reload postgres_exporter || sudo systemctl restart postgres_exporter")


### PR DESCRIPTION
## Summary

- Move `postgres_exporter`'s custom queries file out of `postgres-vm-images` and into `config/postgres_exporter_queries.yaml` in this repo.
- Push the file to each Postgres server during `configure_metrics`, so query changes propagate via the existing `incr_configure_metrics` rollout channel — no VM image rebuild, no `postgres` restart. The existing reload-or-restart line at the end of the label picks up changes via `postgres_exporter` SIGHUP.
- Placement in the label is load-bearing: the write goes near the top so both the initial-provisioning path (which hops to `configure_logs`/`setup_hugepages` before reaching the bottom-of-label reload) and the steady-state path see the new file.
- The `postgres-vm-images` install of the same file stays as-is for now: freshly-built VMs need a working queries file before `configure_metrics` first runs. Removing the vm-images copy is a follow-up after fleet rollout — that follow-up will need explicit chmod handling because today `sudo tee` preserves the existing 0644 mode set by `setup_monitoring.sh`.
- A small `postgres_exporter_queries_yaml` helper is exposed so downstream forks can override it (e.g. via `Overrider`/`PrependMethods`-style mechanisms) and ship their own queries content without editing this base file.
- A YAML-parse smoke test in `spec/config/` catches accidental quote/indent/tab breakage before it can reach the fleet via `incr_configure_metrics`.

## Test plan

- [x] `bundle exec rspec spec/config/postgres_exporter_queries_yaml_spec.rb` — 2 examples, 0 failures
- [x] `bundle exec rspec spec/prog/postgres/postgres_server_nexus_spec.rb` — 174 examples, 0 failures (5 existing `#configure_metrics` examples updated to assert the new tee call; 1 new example pins the helper's return)
- [x] `bundle exec rspec spec/prog/postgres/ spec/model/postgres/` — all green
- [x] `bundle exec rubocop` on touched Ruby files — clean
- [ ] CI (full `rake coverage` + `rake frozen_spec`) — relying on CI as the authoritative gate; local `rake coverage` was flaky on both `main` and this branch with seed-dependent line/branch threshold misses on unrelated files