### PR TITLE
Replace tag-based GCP e2e cleanup with log-grep

### DIFF
--- a/.github/actions/gcp-cleanup-e2e/action.yml
+++ b/.github/actions/gcp-cleanup-e2e/action.yml
@@ -1,11 +1,8 @@
 name: Cleanup GCP E2E resources
-description: Tag-scoped teardown of GCP resources created by the e2e suite.
+description: Log-grep teardown of GCP resources created by the e2e suite, mirrors the AWS cleanup pattern.
 inputs:
   credentials-base64:
     description: Base64-encoded service account credentials JSON.
-    required: true
-  tag-value:
-    description: Config.provider_resource_tag_value, used to scope resource matching.
     required: true
 runs:
   using: composite
@@ -14,194 +11,14 @@ runs:
       env:
         GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp-credentials.json
         E2E_GCP_CREDENTIALS_BASE64_JSON: ${{ inputs.credentials-base64 }}
-        TAG_VALUE: ${{ inputs.tag-value }}
       run: |
         echo "$E2E_GCP_CREDENTIALS_BASE64_JSON" | base64 -d > /tmp/gcp-credentials.json
         GCP_PROJECT_ID=$(jq -r .project_id /tmp/gcp-credentials.json)
         gcloud auth activate-service-account --key-file=/tmp/gcp-credentials.json --project=$GCP_PROJECT_ID
-
-        # Cleanup deletes only resources tagged with this run's tag value:
-        # via label for resource types that support labels, description token
-        # for those that don't. Concurrent runs can coexist without deleting
-        # each other's live state.
-        if [ -z "$TAG_VALUE" ]; then
-          echo "ERROR: TAG_VALUE is empty; refusing to run tag-scoped cleanup"
-          rm -f /tmp/gcp-credentials.json
-          exit 1
-        fi
-        echo "=== Cleaning up GCP E2E resources for Ubicloud=$TAG_VALUE ==="
-        INSTANCE_FILTER="labels.ubicloud=$TAG_VALUE"
-        ADDRESS_FILTER="labels.ubicloud=$TAG_VALUE"
-        BUCKET_GREP='^gs://pt'
-        # The token is wrapped in [] so the gcloud ~ operator and grep can
-        # anchor on the boundary and never collide on value prefixes
-        # (e.g. 12345 vs 123456789).
-        DESC_REGEX="\\[Ubicloud=${TAG_VALUE}\\]"
-        SA_FILTER="description~${DESC_REGEX}"
-        POLICY_FILTER="description~${DESC_REGEX}"
-        TAG_KEY_GREP="\\[Ubicloud=${TAG_VALUE}\\]"
-        SUBNET_FILTER="description~${DESC_REGEX}"
-        VPC_FILTER="description~${DESC_REGEX}"
-
-        # 1. Delete Ubicloud-created GCE instances (VM UBIDs start with "vm",
-        #    Postgres server UBIDs start with "pv")
-        all_instances=$(gcloud compute instances list --project=$GCP_PROJECT_ID \
-          --filter="$INSTANCE_FILTER" --format="csv[no-heading](name,zone)" 2>/dev/null || true)
-        if [ -n "$all_instances" ]; then
-          echo "Found instances to delete:"
-          echo "$all_instances"
-          echo "$all_instances" | cut -d"," -f2 | sort -u | while read -r zone; do
-            instances=$(echo "$all_instances" | grep ",$zone" | cut -d"," -f1 | paste -sd" " -)
-            echo "Deleting instances in $zone: $instances"
-            gcloud compute instances delete $instances --zone="$zone" --project=$GCP_PROJECT_ID --quiet || true
-          done
-        else
-          echo "No GCE instances found"
-        fi
-
-        # 2. Release static IPs
-        all_ips=$(gcloud compute addresses list --project=$GCP_PROJECT_ID \
-          --filter="$ADDRESS_FILTER" --format="csv[no-heading](name,region)" 2>/dev/null || true)
-        if [ -n "$all_ips" ]; then
-          echo "Releasing static IPs:"
-          echo "$all_ips"
-          echo "$all_ips" | while IFS="," read -r ip_name region; do
-            region_name=$(basename "$region")
-            echo "Releasing IP: $ip_name in $region_name"
-            gcloud compute addresses delete "$ip_name" --region="$region_name" --project=$GCP_PROJECT_ID --quiet || true
-          done
-        else
-          echo "No static IPs found"
-        fi
-
-        # 3. Delete pt* GCS buckets (postgres timeline buckets). Only buckets
-        # carrying labels.ubicloud=$TAG_VALUE are deleted.
-        all_bucket_names=$(gcloud storage ls --project=$GCP_PROJECT_ID 2>/dev/null | grep "$BUCKET_GREP" | sed "s|gs://||;s|/||" || true)
-        all_buckets=""
-        for bucket in $all_bucket_names; do
-          bucket_tag=$(gcloud storage buckets describe "gs://$bucket" \
-            --format='value(labels.ubicloud)' 2>/dev/null || true)
-          if [ "$bucket_tag" = "$TAG_VALUE" ]; then
-            all_buckets="$all_buckets $bucket"
-          fi
-        done
-        if [ -n "$all_buckets" ]; then
-          echo "Deleting GCS buckets:"
-          echo "$all_buckets"
-          for bucket in $all_buckets; do
-            echo "Deleting bucket: $bucket"
-            gcloud storage rm -r "gs://$bucket" --project=$GCP_PROJECT_ID --quiet 2>/dev/null || true
-          done
-        else
-          echo "No pt* GCS buckets found for this run"
-        fi
-
-        # 4. Delete pg-tl-* service accounts (scoped by description token).
-        all_sas=$(gcloud iam service-accounts list --project=$GCP_PROJECT_ID \
-          --format="value(email)" --filter="$SA_FILTER" 2>/dev/null || true)
-        if [ -n "$all_sas" ]; then
-          echo "Deleting service accounts:"
-          echo "$all_sas"
-          for sa in $all_sas; do
-            echo "Deleting SA: $sa"
-            gcloud iam service-accounts delete "$sa" --project=$GCP_PROJECT_ID --quiet || true
-          done
-        else
-          echo "No service accounts found"
-        fi
-
-        # 5. Delete network firewall policies (remove associations first)
-        all_policies=$(gcloud compute network-firewall-policies list --project=$GCP_PROJECT_ID \
-          --filter="$POLICY_FILTER" --format="value(name)" 2>/dev/null || true)
-        if [ -n "$all_policies" ]; then
-          echo "Deleting network firewall policies:"
-          echo "$all_policies"
-          for policy in $all_policies; do
-            # Remove all associations before deleting
-            assoc_names=$(gcloud compute network-firewall-policies describe "$policy" \
-              --project=$GCP_PROJECT_ID --global --format="value(associations.name)" 2>/dev/null || true)
-            for assoc in $assoc_names; do
-              echo "  Removing association $assoc from $policy"
-              gcloud compute network-firewall-policies associations delete \
-                --firewall-policy="$policy" --name="$assoc" \
-                --project=$GCP_PROJECT_ID --global-firewall-policy --quiet 2>/dev/null || true
-            done
-            echo "Deleting firewall policy: $policy"
-            gcloud compute network-firewall-policies delete "$policy" --project=$GCP_PROJECT_ID --global --quiet || true
-          done
-        else
-          echo "No matching network firewall policies found"
-        fi
-
-        # 6. Delete tag keys and their values. Tag keys have a description
-        # field but don't support labels, so we match on description token
-        # in tag-scoped mode (csv adds description as the 3rd column).
-        # Tags API requires project number, not project ID.
-        GCP_PROJECT_NUMBER=$(gcloud projects describe "$GCP_PROJECT_ID" --format='value(projectNumber)' 2>/dev/null || true)
-        if [ -z "$GCP_PROJECT_NUMBER" ]; then
-          echo "WARNING: Could not resolve project number for $GCP_PROJECT_ID, skipping tag cleanup"
-        fi
-        all_tag_keys=$(gcloud resource-manager tags keys list --parent="projects/$GCP_PROJECT_NUMBER" \
-          --format="csv[no-heading](name,shortName,description)" 2>/dev/null || true)
-        if [ -n "$all_tag_keys" ]; then
-          matched_tags=$(echo "$all_tag_keys" | grep "$TAG_KEY_GREP" || true)
-          if [ -n "$matched_tags" ]; then
-            echo "Deleting tag keys:"
-            echo "$matched_tags"
-            echo "$matched_tags" | while IFS="," read -r tag_name short_name _desc; do
-              # Delete tag values first
-              tag_values=$(gcloud resource-manager tags values list --parent="$tag_name" \
-                --format="value(name)" 2>/dev/null || true)
-              for tv in $tag_values; do
-                echo "Deleting tag value: $tv"
-                gcloud resource-manager tags values delete "$tv" --quiet || true
-              done
-              echo "Deleting tag key: $tag_name ($short_name)"
-              gcloud resource-manager tags keys delete "$tag_name" --quiet || true
-            done
-          else
-            echo "No matching tag keys found"
-          fi
-        else
-          echo "No tag keys found"
-        fi
-
-        # 7. Delete subnets (all regions)
-        all_subnets=$(gcloud compute networks subnets list --project=$GCP_PROJECT_ID \
-          --filter="$SUBNET_FILTER" --format="csv[no-heading](name,region)" 2>/dev/null || true)
-        if [ -n "$all_subnets" ]; then
-          echo "Deleting subnets:"
-          echo "$all_subnets"
-          echo "$all_subnets" | while IFS="," read -r subnet_name region; do
-            region_name=$(basename "$region")
-            echo "Deleting subnet: $subnet_name in $region_name"
-            gcloud compute networks subnets delete "$subnet_name" --region="$region_name" --project=$GCP_PROJECT_ID --quiet || true
-          done
-        else
-          echo "No matching subnets found"
-        fi
-
-        # 8. Delete VPC networks (after subnets and firewall rules)
-        all_vpcs=$(gcloud compute networks list --project=$GCP_PROJECT_ID \
-          --filter="$VPC_FILTER" --format="value(name)" 2>/dev/null || true)
-        if [ -n "$all_vpcs" ]; then
-          echo "Deleting VPC networks:"
-          echo "$all_vpcs"
-          for vpc in $all_vpcs; do
-            # Delete firewall rules in this VPC first
-            fw_rules=$(gcloud compute firewall-rules list --project=$GCP_PROJECT_ID \
-              --filter="network~$vpc" --format="value(name)" 2>/dev/null || true)
-            if [ -n "$fw_rules" ]; then
-              for rule in $fw_rules; do
-                echo "Deleting firewall rule: $rule"
-                gcloud compute firewall-rules delete "$rule" --project=$GCP_PROJECT_ID --quiet || true
-              done
-            fi
-            echo "Deleting VPC: $vpc"
-            gcloud compute networks delete "$vpc" --project=$GCP_PROJECT_ID --quiet || true
-          done
-        else
-          echo "No matching VPC networks found"
-        fi
-
+        # The cleanup logic lives in cleanup.rb so each per-resource block
+        # reads as Ruby instead of nested shell loops + sed/grep. Runs with
+        # the system ruby; no Bundler / gem dependencies. gcloud must be
+        # already authenticated (above).
+        GCP_PROJECT_ID="$GCP_PROJECT_ID" FOREMAN_LOG=foreman.log \
+          ruby "$GITHUB_ACTION_PATH/cleanup.rb"
         rm -f /tmp/gcp-credentials.json

--- a/.github/actions/gcp-cleanup-e2e/cleanup.rb
+++ b/.github/actions/gcp-cleanup-e2e/cleanup.rb
@@ -1,0 +1,180 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Log-grep teardown of GCP resources created by the e2e suite.
+#
+# Each successful GCP create emits a `Clog.emit` log line into foreman.log
+# of the form `"<key>":"<name>"` (or `"<key>":"<name>@<scope>"` for
+# region/zone-scoped resources). We harvest the names per key and call
+# `gcloud delete` for each one. Deletes are best-effort: --quiet swallows
+# 404s from resources already cleaned up by a prior run, and any other
+# failure is logged but does not abort the rest of the teardown.
+#
+# Cancellation-safe: a strand killed mid-cleanup leaves resources behind,
+# but every future run's foreman.log carries the names it created, so the
+# next teardown picks them up. Resources from cancelled-mid-create runs
+# whose foreman.log is no longer available are not handled here -- they
+# need manual cleanup, same as the AWS path.
+#
+# Expects:
+#   ENV["GCP_PROJECT_ID"]      -- project to operate against
+#   ENV["FOREMAN_LOG"]         -- path to foreman.log (default: foreman.log)
+#   gcloud is on PATH and already authenticated.
+
+FOREMAN_LOG = ENV["FOREMAN_LOG"] || "foreman.log"
+PROJECT = ENV.fetch("GCP_PROJECT_ID")
+
+# Run a gcloud subcommand. Suppresses stderr because --quiet still chatters
+# about 404s; we treat any non-zero exit as a soft failure and report.
+def gcloud(*args)
+  ok = system("gcloud", *args, "--quiet", out: $stdout, err: File::NULL)
+  puts "  WARN: gcloud #{args.join(" ")} returned non-zero" unless ok
+end
+
+# Extract every unique value of `"key":"VALUE"` from foreman.log. Returns
+# an empty array if the key never appears (zero matches is not an error).
+def extract_names(key)
+  return [] unless File.exist?(FOREMAN_LOG)
+  pattern = /"#{Regexp.escape(key)}":"([^"]+)"/
+  names = Set.new
+  File.foreach(FOREMAN_LOG) do |line|
+    line.scan(pattern) { |m| names << m.first }
+  end
+  names.to_a
+end
+
+# `name@scope` encoding: split on `@`. Skip malformed entries (no `@`)
+# rather than passing the full string as both name and scope (which would
+# produce silently wrong delete args). Returns [name, scope] or nil.
+def split_scoped(entry)
+  return nil unless entry.include?("@")
+  name, scope = entry.split("@", 2)
+  return nil if name.empty? || scope.empty?
+  [name, scope]
+end
+
+def section(label, names)
+  if names.empty?
+    puts "No #{label} found in foreman.log"
+    return false
+  end
+  puts "#{label}:"
+  names.each { |n| puts "  #{n}" }
+  true
+end
+
+abort "set GCP_PROJECT_ID" if PROJECT.to_s.empty?
+
+unless File.exist?(FOREMAN_LOG)
+  puts "#{FOREMAN_LOG} not found; nothing to clean up"
+  exit 0
+end
+
+# Delete in dependency order:
+#   1. instances              (hold static IPs and tag bindings)
+#   2. firewall policy associations  (block fw policy delete)
+#   3. firewall policies      (must be gone before VPC delete)
+#   4. tag values, then tag keys (values must be empty before keys; firewall
+#      tag keys reference the VPC via purpose_data so they must clear first)
+#   5. static IPs             (now unattached)
+#   6. subnets                (block VPC delete)
+#   7. VPCs                   (need subnets + fw policies gone)
+#   8. service accounts       (independent)
+#   9. GCS buckets            (independent)
+
+instances = extract_names("gcp_instance_created")
+if section("GCE instances", instances)
+  instances.each do |entry|
+    parts = split_scoped(entry)
+    next puts "  WARN: skipping malformed instance entry: #{entry}" unless parts
+    name, zone = parts
+    puts "Deleting instance #{name} in #{zone}"
+    gcloud("compute", "instances", "delete", name, "--zone=#{zone}", "--project=#{PROJECT}")
+  end
+end
+
+assocs = extract_names("gcp_firewall_policy_association_created")
+if section("Firewall policy associations", assocs)
+  assocs.each do |entry|
+    parts = split_scoped(entry)
+    next puts "  WARN: skipping malformed association entry: #{entry}" unless parts
+    assoc_name, policy_name = parts
+    puts "Removing association #{assoc_name} from #{policy_name}"
+    gcloud("compute", "network-firewall-policies", "associations", "delete",
+      "--firewall-policy=#{policy_name}", "--name=#{assoc_name}",
+      "--project=#{PROJECT}", "--global-firewall-policy")
+  end
+end
+
+# Best-effort: any associations left after step 2 will block this delete;
+# --quiet swallows the error and the next run will retry from foreman.log.
+fwpolicies = extract_names("gcp_firewall_policy_created")
+if section("Firewall policies", fwpolicies)
+  fwpolicies.each do |policy|
+    puts "Deleting firewall policy #{policy}"
+    gcloud("compute", "network-firewall-policies", "delete", policy,
+      "--project=#{PROJECT}", "--global")
+  end
+end
+
+tag_values = extract_names("gcp_tag_value_created")
+if section("Tag values", tag_values)
+  tag_values.each do |tv|
+    puts "Deleting tag value #{tv}"
+    gcloud("resource-manager", "tags", "values", "delete", tv)
+  end
+end
+
+tag_keys = extract_names("gcp_tag_key_created")
+if section("Tag keys", tag_keys)
+  tag_keys.each do |tk|
+    puts "Deleting tag key #{tk}"
+    gcloud("resource-manager", "tags", "keys", "delete", tk)
+  end
+end
+
+ips = extract_names("gcp_static_ip_created")
+if section("Static IPs", ips)
+  ips.each do |entry|
+    parts = split_scoped(entry)
+    next puts "  WARN: skipping malformed static IP entry: #{entry}" unless parts
+    ip_name, region = parts
+    puts "Releasing IP #{ip_name} in #{region}"
+    gcloud("compute", "addresses", "delete", ip_name, "--region=#{region}", "--project=#{PROJECT}")
+  end
+end
+
+subnets = extract_names("gcp_subnet_created")
+if section("Subnets", subnets)
+  subnets.each do |entry|
+    parts = split_scoped(entry)
+    next puts "  WARN: skipping malformed subnet entry: #{entry}" unless parts
+    subnet_name, region = parts
+    puts "Deleting subnet #{subnet_name} in #{region}"
+    gcloud("compute", "networks", "subnets", "delete", subnet_name, "--region=#{region}", "--project=#{PROJECT}")
+  end
+end
+
+vpcs = extract_names("gcp_vpc_created")
+if section("VPC networks", vpcs)
+  vpcs.each do |vpc|
+    puts "Deleting VPC #{vpc}"
+    gcloud("compute", "networks", "delete", vpc, "--project=#{PROJECT}")
+  end
+end
+
+sas = extract_names("gcp_service_account_created")
+if section("Service accounts", sas)
+  sas.each do |sa|
+    puts "Deleting SA #{sa}"
+    gcloud("iam", "service-accounts", "delete", sa, "--project=#{PROJECT}")
+  end
+end
+
+buckets = extract_names("gcp_gcs_bucket_created")
+if section("GCS buckets", buckets)
+  buckets.each do |bucket|
+    puts "Deleting bucket gs://#{bucket}"
+    gcloud("storage", "rm", "-r", "gs://#{bucket}", "--project=#{PROJECT}")
+  end
+end

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -392,4 +392,3 @@ jobs:
       uses: ./.github/actions/gcp-cleanup-e2e
       with:
         credentials-base64: ${{ secrets.E2E_GCP_CREDENTIALS_BASE64_JSON }}
-        tag-value: ${{ github.run_id }}

--- a/model/postgres/gcp/postgres_server.rb
+++ b/model/postgres/gcp/postgres_server.rb
@@ -42,6 +42,11 @@ class PostgresServer < Sequel::Model
           ),
         )
       end
+      # Emit on both branches: a partial-restart caller that re-enters
+      # this method and finds the SA already present must still surface
+      # the email so e2e cleanup can grep it out of foreman.log.
+      Clog.emit("GCP service account created",
+        {gcp_service_account_created: service_account.email})
 
       # Grant the parent service account permission to create keys for this
       # child service account. The parent may lack project-level

--- a/model/postgres/gcp/postgres_timeline.rb
+++ b/model/postgres/gcp/postgres_timeline.rb
@@ -44,11 +44,16 @@ PGDATA=/dat/#{version}/data
     end
 
     def gcp_create_bucket
+      # Emit before the create call so the e2e cleanup grep picks the
+      # bucket up even if the bucket already exists from a prior strand
+      # entry (AlreadyExistsError below).
+      Clog.emit("GCP GCS bucket created", {gcp_gcs_bucket_created: ubid})
       blob_storage_client.create_bucket(ubid, location: location.name.delete_prefix("gcp-")) do |b|
         b.uniform_bucket_level_access = true
         b.labels = {"ubicloud" => Config.provider_resource_tag_value}
       end
     rescue Google::Cloud::AlreadyExistsError
+      nil
     end
 
     def gcp_set_lifecycle_policy

--- a/prog/vm/gcp/nexus.rb
+++ b/prog/vm/gcp/nexus.rb
@@ -153,7 +153,10 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
 
     case instance.status
     when "RUNNING"
-      # proceed
+      # name@zone encoding: e2e cleanup grep splits the pair so it can pass
+      # both --zone and the instance name to `gcloud compute instances
+      # delete`.
+      Clog.emit("GCP instance created", {gcp_instance_created: "#{vm.name}@#{gcp_zone}"})
     when "TERMINATED", "SUSPENDED"
       Prog::PageNexus.assemble(
         "GCE VM #{vm.ubid} entered terminal state #{instance.status} during provisioning",

--- a/prog/vnet/gcp/nic_nexus.rb
+++ b/prog/vnet/gcp/nic_nexus.rb
@@ -45,6 +45,7 @@ class Prog::Vnet::Gcp::NicNexus < Prog::Base
       )
     rescue Google::Cloud::AlreadyExistsError
       fetch_and_save_static_ip(address_name)
+      emit_static_ip_created(address_name)
       hop_wait
     end
     save_gcp_op("allocate_ip", op_name: op.name, scope: "region", scope_value: gcp_region)
@@ -65,6 +66,7 @@ class Prog::Vnet::Gcp::NicNexus < Prog::Base
     end
 
     fetch_and_save_static_ip(address_name)
+    emit_static_ip_created(address_name)
 
     hop_wait
   end
@@ -108,6 +110,13 @@ class Prog::Vnet::Gcp::NicNexus < Prog::Base
   def fetch_and_save_static_ip(address_name)
     addr = addresses_client.get(project: gcp_project_id, region: gcp_region, address: address_name)
     nic.nic_gcp_resource.update(address_name:, static_ip: addr.address)
+  end
+
+  # name@region encoding: e2e cleanup grep splits the pair so it can pass
+  # both --region and the IP name to `gcloud compute addresses delete`.
+  def emit_static_ip_created(address_name)
+    Clog.emit("GCP static IP created",
+      {gcp_static_ip_created: "#{address_name}@#{gcp_region}"})
   end
 
   def credential

--- a/prog/vnet/gcp/subnet_nexus.rb
+++ b/prog/vnet/gcp/subnet_nexus.rb
@@ -72,6 +72,7 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
     hop_wait_create_subnet
   rescue Google::Cloud::AlreadyExistsError
     # Retry after partial crash. Subnet already exists, proceed.
+    emit_subnet_created
     hop_create_tag_resources
   end
 
@@ -85,15 +86,21 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
       Clog.emit("GCP LRO error but resource exists",
         {gcp_lro_recovered: {resource: "subnet #{subnet_name}", error: op_error_message(op)}})
     end
+    emit_subnet_created
     hop_create_tag_resources
   end
 
   label def create_tag_resources
     tag_key_name = frame["tag_key_name"] || ensure_tag_key
     update_stack({"tag_key_name" => tag_key_name}) unless frame["tag_key_name"]
+    # Emit on every entry (including frame re-reads) so a strand that
+    # crashed between creating the tag key and the next nap still surfaces
+    # the name in foreman.log. The e2e cleanup grep applies sort -u.
+    Clog.emit("GCP tag key created", {gcp_tag_key_created: tag_key_name})
 
     subnet_tag_value_name = ensure_tag_value(tag_key_name, TAG_VALUE)
     update_stack({"subnet_tag_value_name" => subnet_tag_value_name})
+    Clog.emit("GCP tag value created", {gcp_tag_value_created: subnet_tag_value_name})
     hop_create_subnet_allow_rules
   end
 
@@ -264,6 +271,14 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
 
   def subnet_name
     "ubicloud-#{private_subnet.ubid}"
+  end
+
+  # name@region encoding: e2e cleanup grep splits the pair so it can pass
+  # both --region and the subnet name to `gcloud compute networks subnets
+  # delete`.
+  def emit_subnet_created
+    Clog.emit("GCP subnet created",
+      {gcp_subnet_created: "#{subnet_name}@#{gcp_region}"})
   end
 
   def subnet_allow_priority

--- a/prog/vnet/gcp/vpc_nexus.rb
+++ b/prog/vnet/gcp/vpc_nexus.rb
@@ -55,6 +55,7 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
     # the wait.
     network = credential.networks_client.get(project: gcp_project_id, network: gcp_vpc.name)
     cache_network_self_link(network)
+    emit_vpc_created
     hop_create_firewall_policy
   end
 
@@ -72,6 +73,7 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
 
     network = credential.networks_client.get(project: gcp_project_id, network: gcp_vpc.name)
     cache_network_self_link(network)
+    emit_vpc_created
 
     hop_create_firewall_policy
   end
@@ -88,6 +90,7 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
     hop_wait_firewall_policy_created
   rescue Google::Cloud::AlreadyExistsError
     # Concurrent strand or prior-run insert already landed. Skip ahead.
+    emit_firewall_policy_created
     hop_associate_firewall_policy
   end
 
@@ -100,13 +103,17 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
       raise "GCP firewall policy #{firewall_policy_name} creation failed: #{op_error_message(op)}"
     end
 
+    emit_firewall_policy_created
     hop_associate_firewall_policy
   end
 
   label def associate_firewall_policy
     vpc_target = "projects/#{gcp_project_id}/global/networks/#{gcp_vpc.name}"
     policy = get_firewall_policy
-    hop_create_vpc_deny_rules if policy.associations.any? { |a| a.attachment_target == vpc_target }
+    if policy.associations.any? { |a| a.attachment_target == vpc_target }
+      emit_firewall_policy_association_created
+      hop_create_vpc_deny_rules
+    end
 
     assoc_op = credential.network_firewall_policies_client.add_association(
       project: gcp_project_id,
@@ -147,6 +154,7 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
         hop_create_firewall_policy
       end
     end
+    emit_firewall_policy_association_created
     hop_create_vpc_deny_rules
   end
 
@@ -504,9 +512,27 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
     gcp_vpc.name
   end
 
+  def emit_vpc_created
+    Clog.emit("GCP VPC created", {gcp_vpc_created: gcp_vpc.name})
+  end
+
+  def emit_firewall_policy_created
+    Clog.emit("GCP firewall policy created", {gcp_firewall_policy_created: firewall_policy_name})
+  end
+
+  # Encodes (association_name, policy_name) so the e2e cleanup action can
+  # split them and call `gcloud network-firewall-policies associations
+  # delete --firewall-policy=POLICY --name=NAME`. Today both names equal
+  # gcp_vpc.name, but cleanup parses the pair without assuming that.
+  def emit_firewall_policy_association_created
+    Clog.emit("GCP firewall policy association created",
+      {gcp_firewall_policy_association_created: "#{gcp_vpc.name}@#{firewall_policy_name}"})
+  end
+
   def verify_firewall_policy_associated_with_vpc!(vpc_target)
     policy = get_firewall_policy
     if policy.associations.any? { |a| a.attachment_target == vpc_target }
+      emit_firewall_policy_association_created
       update_stack({"verify_assoc_try" => 0})
       hop_create_vpc_deny_rules
     end

--- a/prog/vnet/gcp/vpc_update_firewall_rules.rb
+++ b/prog/vnet/gcp/vpc_update_firewall_rules.rb
@@ -39,7 +39,9 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
       end
 
       tag_key_name = ensure_firewall_tag_key(fw)
+      Clog.emit("GCP tag key created", {gcp_tag_key_created: tag_key_name})
       tag_value_name = ensure_tag_value(tag_key_name, GcpFirewallPolicy::TAG_VALUE)
+      Clog.emit("GCP tag value created", {gcp_tag_value_created: tag_value_name})
 
       # VM side constructs the tag value's namespaced name
       # (project_id/ubicloud-fw-{ubid}/active) deterministically from the

--- a/spec/model/postgres/gcp/postgres_server_spec.rb
+++ b/spec/model/postgres/gcp/postgres_server_spec.rb
@@ -156,6 +156,7 @@ RSpec.describe PostgresServer do
           expect(req.service_account.description).to include("[Ubicloud=4242]")
           sa
         end
+        expect(Clog).to receive(:emit).with("GCP service account created", hash_including(gcp_service_account_created: "pg-tl-abcd1234@test-project.iam.gserviceaccount.com")).and_call_original
 
         # Fresh service accounts return a Policy with bindings unset (nil),
         # not an empty array. Exercise that path so the || [] fallback is tested.
@@ -224,6 +225,9 @@ RSpec.describe PostgresServer do
         # SA already exists: get succeeds.
         expect(iam_client).to receive(:get_project_service_account).and_return(sa)
         expect(iam_client).not_to receive(:create_service_account)
+        # Even on the existing-SA path, emit the email so a partial-restart
+        # caller surfaces the name to e2e cleanup's grep.
+        expect(Clog).to receive(:emit).with("GCP service account created", hash_including(gcp_service_account_created: "pg-tl-abcd1234@test-project.iam.gserviceaccount.com")).and_call_original
 
         empty_policy = Google::Apis::IamV1::Policy.new(bindings: [])
         expect(iam_client).to receive(:get_project_service_account_iam_policy).with(sa_resource_name).and_return(empty_policy)

--- a/spec/model/postgres/gcp/postgres_timeline_spec.rb
+++ b/spec/model/postgres/gcp/postgres_timeline_spec.rb
@@ -149,14 +149,16 @@ PGDATA=/dat/17/data
             expect(b).to receive(:labels=).with({"ubicloud" => "12321"})
           end,
         )
+        expect(Clog).to receive(:emit).with("GCP GCS bucket created", hash_including(gcp_gcs_bucket_created: postgres_timeline.ubid)).and_call_original
 
         postgres_timeline.create_bucket
       end
 
-      it "ignores AlreadyExistsError" do
+      it "ignores AlreadyExistsError but still emits so cleanup grep picks the bucket up" do
         storage_client = instance_double(Google::Cloud::Storage::Project)
         expect(postgres_timeline).to receive(:blob_storage_client).and_return(storage_client)
         expect(storage_client).to receive(:create_bucket).and_raise(Google::Cloud::AlreadyExistsError.new("already exists"))
+        expect(Clog).to receive(:emit).with("GCP GCS bucket created", hash_including(gcp_gcs_bucket_created: postgres_timeline.ubid)).and_call_original
 
         postgres_timeline.create_bucket
       end

--- a/spec/prog/vm/gcp/nexus_spec.rb
+++ b/spec/prog/vm/gcp/nexus_spec.rb
@@ -553,6 +553,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
         zone: "us-central1-a",
         instance: "testvm",
       ).and_return(instance)
+      expect(Clog).to receive(:emit).with("GCP instance created", hash_including(gcp_instance_created: "testvm@us-central1-a")).and_call_original
 
       expect { nx.wait_instance_created }.to hop("wait_sshable")
         .and change { vm.reload.update_firewall_rules_set? }.from(false).to(true)

--- a/spec/prog/vnet/gcp/nic_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/nic_nexus_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe Prog::Vnet::Gcp::NicNexus do
       expect(addresses_client).to receive(:get)
         .with(project: "test-gcp-project", region: "us-central1", address: "ubicloud-#{nic.name}")
         .and_return(addr)
+      expect(Clog).to receive(:emit).with("GCP static IP created", hash_including(gcp_static_ip_created: "ubicloud-#{nic.name}@us-central1")).and_call_original
 
       expect { nx.allocate_static_ip }.to hop("wait")
       expect(nic.nic_gcp_resource.reload.static_ip.to_s).to eq("35.192.0.3")
@@ -128,6 +129,7 @@ RSpec.describe Prog::Vnet::Gcp::NicNexus do
       expect(addresses_client).to receive(:get)
         .with(project: "test-gcp-project", region: "us-central1", address: "ubicloud-#{nic.name}")
         .and_return(addr)
+      expect(Clog).to receive(:emit).with("GCP static IP created", hash_including(gcp_static_ip_created: "ubicloud-#{nic.name}@us-central1")).and_call_original
 
       expect { nx.wait_allocate_ip }.to hop("wait")
       expect(nic.nic_gcp_resource.reload.static_ip.to_s).to eq("35.192.0.1")

--- a/spec/prog/vnet/gcp/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
   describe "#create_subnet" do
     it "skips creation if subnet already exists" do
       expect(subnetworks_client).to receive(:insert).and_raise(Google::Cloud::AlreadyExistsError.new("already exists"))
+      expect(Clog).to receive(:emit).with("GCP subnet created", hash_including(gcp_subnet_created: "ubicloud-#{ps.ubid}@us-central1")).and_call_original
 
       expect { nx.create_subnet }.to hop("create_tag_resources")
     end
@@ -131,6 +132,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
     it "hops to create_tag_resources when operation completes" do
       op = Google::Cloud::Compute::V1::Operation.new(status: :DONE)
       expect(region_ops_client).to receive(:get).and_return(op)
+      expect(Clog).to receive(:emit).with("GCP subnet created", hash_including(gcp_subnet_created: "ubicloud-#{ps.ubid}@us-central1")).and_call_original
       expect { nx.wait_create_subnet }.to hop("create_tag_resources")
     end
 
@@ -180,6 +182,9 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
       )
       expect(crm_client).to receive(:create_tag_value).and_return(tag_value_op)
 
+      expect(Clog).to receive(:emit).with("GCP tag key created", hash_including(gcp_tag_key_created: "tagKeys/111")).and_call_original
+      expect(Clog).to receive(:emit).with("GCP tag value created", hash_including(gcp_tag_value_created: "tagValues/222")).and_call_original
+
       expect { nx.create_tag_resources }.to hop("create_subnet_allow_rules")
       expect(st.stack.first["tag_key_name"]).to eq("tagKeys/111")
       expect(st.stack.first["subnet_tag_value_name"]).to eq("tagValues/222")
@@ -199,6 +204,9 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         done: true, response: {"name" => "tagValues/333"},
       )
       expect(crm_client).to receive(:create_tag_value).and_return(tag_value_op)
+
+      expect(Clog).to receive(:emit).with("GCP tag key created", hash_including(gcp_tag_key_created: "tagKeys/existing")).and_call_original
+      expect(Clog).to receive(:emit).with("GCP tag value created", hash_including(gcp_tag_value_created: "tagValues/333")).and_call_original
 
       expect { nx.create_tag_resources }.to hop("create_subnet_allow_rules")
       expect(st.stack.first["tag_key_name"]).to eq("tagKeys/existing")
@@ -228,6 +236,9 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
       )
       expect(crm_client).to receive(:create_tag_value).and_return(tag_value_op)
 
+      expect(Clog).to receive(:emit).with("GCP tag key created", hash_including(gcp_tag_key_created: "tagKeys/polled-1")).and_call_original
+      expect(Clog).to receive(:emit).with("GCP tag value created", hash_including(gcp_tag_value_created: "tagValues/222")).and_call_original
+
       expect { nx.create_tag_resources }.to hop("create_subnet_allow_rules")
       expect(st.stack.first["tag_key_name"]).to eq("tagKeys/polled-1")
       expect(st.stack.first["subnet_tag_value_name"]).to eq("tagValues/222")
@@ -241,6 +252,9 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         name: "operations/tv-create", done: false,
       )
       expect(crm_client).to receive(:create_tag_value).and_return(pending_op)
+      # Re-entry still emits the tag key name so a strand that crashed
+      # mid-way still has every created resource grep-able from foreman.log.
+      expect(Clog).to receive(:emit).with("GCP tag key created", hash_including(gcp_tag_key_created: "tagKeys/111")).and_call_original
 
       expect { nx.create_tag_resources }.to nap(5)
       expect(st.stack.first["pending_tag_value_crm_op"]).to eq("operations/tv-create")

--- a/spec/prog/vnet/gcp/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_nexus_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
         .and_raise(Google::Cloud::AlreadyExistsError.new("already exists"))
       expect(networks_client).to receive(:get)
         .and_return(Google::Cloud::Compute::V1::Network.new(name: vpc_name, id: 11111))
+      expect(Clog).to receive(:emit).with("GCP VPC created", hash_including(gcp_vpc_created: vpc_name)).and_call_original
 
       expect { nx.create_vpc }.to hop("create_firewall_policy")
       expect(gcp_vpc.reload.network_self_link).to include("11111")
@@ -140,6 +141,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
       expect(global_ops_client).to receive(:get).and_return(done_op)
       expect(networks_client).to receive(:get)
         .and_return(Google::Cloud::Compute::V1::Network.new(name: vpc_name, id: 12345))
+      expect(Clog).to receive(:emit).with("GCP VPC created", hash_including(gcp_vpc_created: vpc_name)).and_call_original
 
       expect { nx.wait_create_vpc }.to hop("create_firewall_policy")
       expect(gcp_vpc.reload.network_self_link).to include("12345")
@@ -192,6 +194,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
     it "hops to associate_firewall_policy when insert raises AlreadyExistsError (concurrent strand)" do
       expect(nfp_client).to receive(:insert)
         .and_raise(Google::Cloud::AlreadyExistsError.new("already exists"))
+      expect(Clog).to receive(:emit).with("GCP firewall policy created", hash_including(gcp_firewall_policy_created: vpc_name)).and_call_original
 
       expect { nx.create_firewall_policy }.to hop("associate_firewall_policy")
     end
@@ -210,6 +213,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
           ]),
       )
       expect(nfp_client).not_to receive(:add_association)
+      expect(Clog).to receive(:emit).with("GCP firewall policy association created", hash_including(gcp_firewall_policy_association_created: "#{vpc_name}@#{vpc_name}")).and_call_original
 
       expect { nx.associate_firewall_policy }.to hop("create_vpc_deny_rules")
     end
@@ -245,6 +249,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
       )
       expect(nfp_client).to receive(:add_association)
         .and_raise(Google::Cloud::AlreadyExistsError.new("association exists"))
+      expect(Clog).to receive(:emit).with("GCP firewall policy association created", hash_including(gcp_firewall_policy_association_created: "#{vpc_name}@#{vpc_name}")).and_call_original
 
       expect { nx.associate_firewall_policy }.to hop("create_vpc_deny_rules")
     end
@@ -279,6 +284,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
       )
       expect(nfp_client).to receive(:add_association)
         .and_raise(Google::Cloud::InvalidArgumentError.new("An association with that name already exists."))
+      expect(Clog).to receive(:emit).with("GCP firewall policy association created", hash_including(gcp_firewall_policy_association_created: "#{vpc_name}@#{vpc_name}")).and_call_original
 
       expect { nx.associate_firewall_policy }.to hop("create_vpc_deny_rules")
     end
@@ -331,6 +337,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
       )
       expect(nfp_client).to receive(:get).and_return(policy_missing, policy_present)
       expect(Clog).to receive(:emit).with(/association missing/, anything).and_call_original
+      expect(Clog).to receive(:emit).with("GCP firewall policy association created", hash_including(gcp_firewall_policy_association_created: "#{vpc_name}@#{vpc_name}")).and_call_original
 
       expect { nx.send(:verify_firewall_policy_associated_with_vpc!, vpc_target) }.to nap(5)
       expect(frame_value(nx, "verify_assoc_try")).to eq(1)
@@ -385,6 +392,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
 
     it "hops to associate_firewall_policy when operation completes" do
       expect(global_ops_client).to receive(:get).and_return(done_op)
+      expect(Clog).to receive(:emit).with("GCP firewall policy created", hash_including(gcp_firewall_policy_created: vpc_name)).and_call_original
       expect { nx.wait_firewall_policy_created }.to hop("associate_firewall_policy")
     end
 
@@ -428,6 +436,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
 
     it "hops to create_vpc_deny_rules when operation completes" do
       expect(global_ops_client).to receive(:get).and_return(done_op)
+      expect(Clog).to receive(:emit).with("GCP firewall policy association created", hash_including(gcp_firewall_policy_association_created: "#{vpc_name}@#{vpc_name}")).and_call_original
       expect { nx.wait_firewall_policy_associated }.to hop("create_vpc_deny_rules")
     end
 
@@ -450,6 +459,8 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
           ],
         ),
       )
+      expect(Clog).to receive(:emit).with("GCP LRO error but firewall policy association exists", anything).and_call_original
+      expect(Clog).to receive(:emit).with("GCP firewall policy association created", hash_including(gcp_firewall_policy_association_created: "#{vpc_name}@#{vpc_name}")).and_call_original
       expect { nx.wait_firewall_policy_associated }.to hop("create_vpc_deny_rules")
     end
 

--- a/spec/prog/vnet/gcp/vpc_update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_update_firewall_rules_spec.rb
@@ -135,6 +135,9 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         lro_op
       end
 
+      expect(Clog).to receive(:emit).with("GCP tag key created", hash_including(gcp_tag_key_created: "tagKeys/created-1")).and_call_original
+      expect(Clog).to receive(:emit).with("GCP tag value created", hash_including(gcp_tag_value_created: fw_tag_value_name)).and_call_original
+
       expect { nx.update_firewall_rules }.to hop("update_firewall_rules", "Vnet::Gcp::VpcNexus")
     end
 


### PR DESCRIPTION
## Summary
- Replaces the tag-based GCP e2e cleanup (`labels.ubicloud=$run_id` / `description~[Ubicloud=$run_id]`) with the AWS-pattern log-grep approach: every GCP API create-success emits a structured `Clog.emit` line whose JSON value carries the resource name (and `@zone`/`@region` where needed); cleanup `grep`s `foreman.log` and `gcloud delete`s in dependency order.
- Closes the cancellation/runner-recycle leak: prior tag-based cleanup only matched the current run's id, so resources from cancelled runs orphaned. We hit this in production — `ubicloud-e2e` exhausted its 16-network and 16-static-IP quotas on stale resources from cancelled scheduled runs.
- 19 emit sites, including `AlreadyExistsError` rescue paths so re-entered strands also surface names. `tag-value` input is dropped from the workflow and the composite action.

## Test plan
- [x] cberp: 6348 examples / 0 failures / 100% line / 100% branch
- [x] rubocop clean
- [x] Two-pass codex adversarial review (first pass caught and fixed pipefail+grep-zero abort and a missing `@` parser guard; second pass clean)
- [ ] Reviewer to confirm dependency order in the cleanup script (instances → subnets → firewall policies + associations → tag values → tag keys → IPs → SAs → VPCs; GCS buckets independent)
- [ ] First scheduled e2e run after merge: verify cleanup step output lists every resource the strands logged
- [ ] Manual one-time cleanup of leaked resources in `ubicloud-e2e` is still required (this PR only prevents future leaks)