### PR TITLE
Paginate GCP CRM list_tag_* calls in prog/vnet/gcp

### DIFF
--- a/prog/vnet/gcp/subnet_nexus.rb
+++ b/prog/vnet/gcp/subnet_nexus.rb
@@ -238,8 +238,9 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
     tag_key = lookup_tag_key
     return unless tag_key
 
-    resp = credential.crm_client.list_tag_values(parent: tag_key.name)
-    subnet_tv = resp.tag_values&.find { |v| v.short_name == TAG_VALUE }
+    subnet_tv = credential.crm_client
+      .fetch_all(items: :tag_values) { |token, s| s.list_tag_values(parent: tag_key.name, page_token: token) }
+      .find { |v| v.short_name == TAG_VALUE }
     credential.crm_client.delete_tag_value(subnet_tv.name) if subnet_tv
 
     # Per-subnet tag key. Always delete it when the subnet is destroyed.
@@ -326,8 +327,9 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   end
 
   def lookup_tag_key
-    resp = credential.crm_client.list_tag_keys(parent: tag_key_parent)
-    resp.tag_keys&.find { |tk| tk.short_name == tag_key_short_name }
+    credential.crm_client
+      .fetch_all(items: :tag_keys) { |token, s| s.list_tag_keys(parent: tag_key_parent, page_token: token) }
+      .find { |tk| tk.short_name == tag_key_short_name }
   end
 
   def ensure_tag_value(parent_tag_key_name, short_name)
@@ -386,8 +388,9 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   end
 
   def lookup_tag_value_name(parent_tag_key_name, short_name)
-    resp = credential.crm_client.list_tag_values(parent: parent_tag_key_name)
-    resp.tag_values&.find { |v| v.short_name == short_name }&.name
+    credential.crm_client
+      .fetch_all(items: :tag_values) { |token, s| s.list_tag_values(parent: parent_tag_key_name, page_token: token) }
+      .find { |v| v.short_name == short_name }&.name
   end
 
   # Extracts the v2 error `status` field (e.g. "FAILED_PRECONDITION") from a

--- a/prog/vnet/gcp/update_firewall_rules.rb
+++ b/prog/vnet/gcp/update_firewall_rules.rb
@@ -69,14 +69,17 @@ class Prog::Vnet::Gcp::UpdateFirewallRules < Prog::Base
     # Stale-binding cleanup uses the list because a transiently-stale
     # entry only means we skip a delete that a subsequent run will
     # catch. That's harmless, unlike skipping a create.
-    existing = regional_crm_client.list_tag_bindings(parent: resource).tag_bindings || [].freeze
     desired_set = desired_tag_values.to_set
-    stale_bindings = existing.reject { |b| desired_set.include?(b.tag_value_namespaced_name) }
-    stale_bindings.each do |binding|
-      regional_crm_client.delete_tag_binding(binding.name)
-    rescue Google::Apis::ClientError => e
-      raise unless e.status_code == 404
-    end
+    regional_crm_client
+      .fetch_all(items: :tag_bindings) { |token, s| s.list_tag_bindings(parent: resource, page_token: token) }
+      .each do |binding|
+        next if desired_set.include?(binding.tag_value_namespaced_name)
+        begin
+          regional_crm_client.delete_tag_binding(binding.name)
+        rescue Google::Apis::ClientError => e
+          raise unless e.status_code == 404
+        end
+      end
 
     pop "firewall rule is added"
   end

--- a/prog/vnet/gcp/vpc_nexus.rb
+++ b/prog/vnet/gcp/vpc_nexus.rb
@@ -203,12 +203,13 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
   label def enumerate_destroy_state
     network_self_link = gcp_vpc.network_self_link
     pending_tag_key_names = if network_self_link
-      resp = credential.crm_client.list_tag_keys(parent: "projects/#{gcp_project_id}")
-      resp.tag_keys&.select do |tk|
-        tk.short_name.start_with?("ubicloud-fw-") &&
-          tk.purpose == "GCE_FIREWALL" &&
-          tk.purpose_data&.dig("network") == network_self_link
-      end&.map(&:name) || [].freeze
+      credential.crm_client
+        .fetch_all(items: :tag_keys) { |token, s| s.list_tag_keys(parent: "projects/#{gcp_project_id}", page_token: token) }
+        .select { |tk|
+          tk.short_name.start_with?("ubicloud-fw-") &&
+            tk.purpose == "GCE_FIREWALL" &&
+            tk.purpose_data&.dig("network") == network_self_link
+        }.map(&:name)
     else
       [].freeze
     end
@@ -343,8 +344,9 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
     end
 
     tk_name = pending_tk.first
-    resp = credential.crm_client.list_tag_values(parent: tk_name)
-    tv_names = resp.tag_values&.map(&:name) || [].freeze
+    tv_names = credential.crm_client
+      .fetch_all(items: :tag_values) { |token, s| s.list_tag_values(parent: tk_name, page_token: token) }
+      .map(&:name)
     update_stack({"pending_tag_value_names" => tv_names})
     hop_delete_firewall_tag_values
   end

--- a/prog/vnet/gcp/vpc_update_firewall_rules.rb
+++ b/prog/vnet/gcp/vpc_update_firewall_rules.rb
@@ -119,8 +119,9 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
   end
 
   def lookup_tag_key_name(short_name)
-    resp = credential.crm_client.list_tag_keys(parent: tag_key_parent)
-    resp.tag_keys&.find { |tk| tk.short_name == short_name }&.name
+    credential.crm_client
+      .fetch_all(items: :tag_keys) { |token, s| s.list_tag_keys(parent: tag_key_parent, page_token: token) }
+      .find { |tk| tk.short_name == short_name }&.name
   end
 
   def lookup_tag_key_name!(short_name, label = "created but name not found")
@@ -162,8 +163,9 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
   end
 
   def lookup_tag_value_name(tag_key_name, short_name)
-    resp = credential.crm_client.list_tag_values(parent: tag_key_name)
-    resp.tag_values&.find { |v| v.short_name == short_name }&.name
+    credential.crm_client
+      .fetch_all(items: :tag_values) { |token, s| s.list_tag_values(parent: tag_key_name, page_token: token) }
+      .find { |v| v.short_name == short_name }&.name
   end
 
   def lookup_tag_value_name!(tag_key_name, short_name, label = "created but name not found")
@@ -271,12 +273,13 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
 
     vpc_network_link = gcp_network_self_link_with_id
 
-    resp = credential.crm_client.list_tag_keys(parent: tag_key_parent)
-    fw_tag_keys = resp.tag_keys&.select { |tk|
-      tk.short_name.start_with?("ubicloud-fw-") &&
-        tk.purpose == "GCE_FIREWALL" &&
-        tk.purpose_data&.dig("network") == vpc_network_link
-    } || [].freeze
+    fw_tag_keys = credential.crm_client
+      .fetch_all(items: :tag_keys) { |token, s| s.list_tag_keys(parent: tag_key_parent, page_token: token) }
+      .select { |tk|
+        tk.short_name.start_with?("ubicloud-fw-") &&
+          tk.purpose == "GCE_FIREWALL" &&
+          tk.purpose_data&.dig("network") == vpc_network_link
+      }
 
     # Pair each non-active candidate tag key with its parsed firewall UUID.
     # Malformed ubids yield nil and are always treated as orphaned.

--- a/spec/prog/vnet/gcp/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_spec.rb
@@ -166,6 +166,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
 
     before do
       allow(nx.send(:credential)).to receive(:crm_client).and_return(crm_client)
+      stub_fetch_all_via_list(crm_client)
     end
 
     it "creates tag key and tag value, stores in frame, and hops to create_subnet_allow_rules" do
@@ -450,6 +451,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
 
     before do
       allow(nx.send(:credential)).to receive(:crm_client).and_return(crm_client)
+      stub_fetch_all_via_list(crm_client)
       # Default: no tag key found (skip tag cleanup)
       allow(crm_client).to receive(:list_tag_keys).and_return(
         Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(tag_keys: []),
@@ -489,7 +491,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
       subnet_tv = Google::Apis::CloudresourcemanagerV3::TagValue.new(
         name: "tagValues/222", short_name: "active",
       )
-      expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111")
+      expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111", page_token: nil)
         .and_return(
           Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(tag_values: [subnet_tv]),
         )
@@ -811,6 +813,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
 
     before do
       allow(nx.send(:credential)).to receive(:crm_client).and_return(crm_client)
+      stub_fetch_all_via_list(crm_client)
     end
 
     describe "#tag_key_short_name" do
@@ -829,9 +832,25 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
       it "returns nil when tag_values is nil in the response" do
         resp = Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new
         expect(crm_client).to receive(:list_tag_values)
-          .with(parent: "tagKeys/123").and_return(resp)
+          .with(parent: "tagKeys/123", page_token: nil).and_return(resp)
 
         expect(nx.send(:lookup_tag_value_name, "tagKeys/123", "active")).to be_nil
+      end
+
+      it "paginates list_tag_values to find the target on a later page" do
+        page1 = Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(
+          tag_values: [Google::Apis::CloudresourcemanagerV3::TagValue.new(name: "tagValues/p1", short_name: "stale")],
+          next_page_token: "tv-tok",
+        )
+        page2 = Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(
+          tag_values: [Google::Apis::CloudresourcemanagerV3::TagValue.new(name: "tagValues/page2", short_name: "active")],
+        )
+        expect(crm_client).to receive(:list_tag_values)
+          .with(parent: "tagKeys/123", page_token: nil).ordered.and_return(page1)
+        expect(crm_client).to receive(:list_tag_values)
+          .with(parent: "tagKeys/123", page_token: "tv-tok").ordered.and_return(page2)
+
+        expect(nx.send(:lookup_tag_value_name, "tagKeys/123", "active")).to eq("tagValues/page2")
       end
     end
 
@@ -840,6 +859,32 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         resp = Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(tag_keys: [])
         expect(crm_client).to receive(:list_tag_keys).and_return(resp)
         expect(crm_client).not_to receive(:list_tag_values)
+
+        nx.send(:delete_subnet_tag_resources)
+      end
+
+      it "paginates list_tag_values to find subnet tag value on page 2" do
+        tag_key = Google::Apis::CloudresourcemanagerV3::TagKey.new(
+          name: "tagKeys/111", short_name: "ubicloud-subnet-#{ps.ubid}",
+        )
+        expect(crm_client).to receive(:list_tag_keys).and_return(
+          Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(tag_keys: [tag_key]),
+        )
+
+        page1 = Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(
+          tag_values: [Google::Apis::CloudresourcemanagerV3::TagValue.new(name: "tagValues/other", short_name: "stale")],
+          next_page_token: "del-tok",
+        )
+        page2 = Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(
+          tag_values: [Google::Apis::CloudresourcemanagerV3::TagValue.new(name: "tagValues/active-on-page-2", short_name: "active")],
+        )
+        expect(crm_client).to receive(:list_tag_values)
+          .with(parent: "tagKeys/111", page_token: nil).ordered.and_return(page1)
+        expect(crm_client).to receive(:list_tag_values)
+          .with(parent: "tagKeys/111", page_token: "del-tok").ordered.and_return(page2)
+
+        expect(crm_client).to receive(:delete_tag_value).with("tagValues/active-on-page-2")
+        expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111")
 
         nx.send(:delete_subnet_tag_resources)
       end
@@ -855,7 +900,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         other_tv = Google::Apis::CloudresourcemanagerV3::TagValue.new(
           name: "tagValues/333", short_name: "other",
         )
-        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111")
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111", page_token: nil)
           .and_return(
             Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(tag_values: [other_tv]),
           )
@@ -873,7 +918,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
           Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(tag_keys: [tag_key]),
         )
 
-        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111")
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111", page_token: nil)
           .and_return(
             Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new,
           )
@@ -894,7 +939,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         subnet_tv = Google::Apis::CloudresourcemanagerV3::TagValue.new(
           name: "tagValues/222", short_name: "active",
         )
-        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111")
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111", page_token: nil)
           .and_return(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(tag_values: [subnet_tv]))
         body = {error: {code: 400, status: "FAILED_PRECONDITION", message: "Cannot delete tag value still attached to resources"}}.to_json
         expect(crm_client).to receive(:delete_tag_value).with("tagValues/222")
@@ -911,7 +956,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
           Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(tag_keys: [tag_key]),
         )
 
-        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111")
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111", page_token: nil)
           .and_return(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new)
         body = {error: {code: 400, status: "FAILED_PRECONDITION", message: "Tag key has children"}}.to_json
         expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111")
@@ -1035,6 +1080,26 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         )
 
         expect(nx.send(:ensure_tag_key)).to eq("tagKeys/existing")
+      end
+
+      it "paginates list_tag_keys to find target on page 2 after ALREADY_EXISTS" do
+        error = Google::Apis::CloudresourcemanagerV3::Status.new(code: 6, message: "tag key already exists")
+        op = Google::Apis::CloudresourcemanagerV3::Operation.new(done: true, error:)
+        expect(crm_client).to receive(:create_tag_key).and_return(op)
+
+        page1 = Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(
+          tag_keys: [Google::Apis::CloudresourcemanagerV3::TagKey.new(name: "tagKeys/other", short_name: "ubicloud-subnet-other")],
+          next_page_token: "subnet-tok",
+        )
+        page2 = Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(
+          tag_keys: [Google::Apis::CloudresourcemanagerV3::TagKey.new(name: "tagKeys/page2", short_name: "ubicloud-subnet-#{ps.ubid}")],
+        )
+        expect(crm_client).to receive(:list_tag_keys)
+          .with(parent: "projects/test-gcp-project", page_token: nil).ordered.and_return(page1)
+        expect(crm_client).to receive(:list_tag_keys)
+          .with(parent: "projects/test-gcp-project", page_token: "subnet-tok").ordered.and_return(page2)
+
+        expect(nx.send(:ensure_tag_key)).to eq("tagKeys/page2")
       end
 
       it "raises when response has no name and lookup returns nil" do
@@ -1164,7 +1229,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
       it "falls back to lookup when operation response has no name" do
         op = Google::Apis::CloudresourcemanagerV3::Operation.new(done: true, response: nil)
         expect(crm_client).to receive(:create_tag_value).and_return(op)
-        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123").and_return(
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123", page_token: nil).and_return(
           Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(
             tag_values: [Google::Apis::CloudresourcemanagerV3::TagValue.new(name: "tagValues/fallback", short_name: "active")],
           ),
@@ -1176,7 +1241,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
       it "handles 409 conflict by looking up existing tag value" do
         expect(crm_client).to receive(:create_tag_value)
           .and_raise(Google::Apis::ClientError.new("conflict", status_code: 409))
-        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123").and_return(
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123", page_token: nil).and_return(
           Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(
             tag_values: [Google::Apis::CloudresourcemanagerV3::TagValue.new(name: "tagValues/existing", short_name: "active")],
           ),
@@ -1189,7 +1254,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         error = Google::Apis::CloudresourcemanagerV3::Status.new(code: 6, message: "tag value already exists")
         op = Google::Apis::CloudresourcemanagerV3::Operation.new(done: true, error:)
         expect(crm_client).to receive(:create_tag_value).and_return(op)
-        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123").and_return(
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123", page_token: nil).and_return(
           Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(
             tag_values: [Google::Apis::CloudresourcemanagerV3::TagValue.new(name: "tagValues/existing", short_name: "active")],
           ),
@@ -1201,7 +1266,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
       it "raises when response nil and lookup returns nil" do
         op = Google::Apis::CloudresourcemanagerV3::Operation.new(done: true, response: nil)
         expect(crm_client).to receive(:create_tag_value).and_return(op)
-        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123").and_return(
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123", page_token: nil).and_return(
           Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(tag_values: []),
         )
 
@@ -1211,7 +1276,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
       it "raises when 409 conflict and lookup returns nil" do
         expect(crm_client).to receive(:create_tag_value)
           .and_raise(Google::Apis::ClientError.new("conflict", status_code: 409))
-        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123").and_return(
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123", page_token: nil).and_return(
           Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(tag_values: []),
         )
 
@@ -1222,7 +1287,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         error = Google::Apis::CloudresourcemanagerV3::Status.new(code: 6, message: "tag value already exists")
         op = Google::Apis::CloudresourcemanagerV3::Operation.new(done: true, error:)
         expect(crm_client).to receive(:create_tag_value).and_return(op)
-        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123").and_return(
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123", page_token: nil).and_return(
           Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(tag_values: []),
         )
 
@@ -1301,7 +1366,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
           done: true, name: "operations/tv-no-name-nil", response: nil,
         )
         expect(crm_client).to receive(:get_operation).with("operations/tv-no-name-nil").and_return(no_name_op)
-        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123").and_return(
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/123", page_token: nil).and_return(
           Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(tag_values: []),
         )
 

--- a/spec/prog/vnet/gcp/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/gcp/update_firewall_rules_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Prog::Vnet::Gcp::UpdateFirewallRules do
     allow(nx.send(:credential)).to receive(:regional_crm_client).and_return(regional_crm_client)
     allow(crm_client).to receive(:get_project).and_return(project_obj)
     allow(compute_client).to receive(:get).and_return(instance_obj)
+    stub_fetch_all_via_list(regional_crm_client)
   end
 
   describe "#before_run" do
@@ -108,7 +109,7 @@ RSpec.describe Prog::Vnet::Gcp::UpdateFirewallRules do
       fw_rule
       # No CRM list_tag_keys / list_tag_values stubs: the VM side now
       # constructs namespaced names directly from ubids.
-      empty_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse, tag_bindings: [])
+      empty_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse, tag_bindings: [], next_page_token: nil)
       binding_op = instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "bind-op", error: nil)
       allow(regional_crm_client).to receive_messages(list_tag_bindings: empty_bindings, create_tag_binding: binding_op)
     end
@@ -122,6 +123,17 @@ RSpec.describe Prog::Vnet::Gcp::UpdateFirewallRules do
 
       expect { nx.update_firewall_rules }.to hop("wait_sshable", "Vm::Gcp::Nexus")
       expect(bound).to contain_exactly(fw_tag_value_name, subnet_tag_value_name)
+    end
+
+    it "handles nil tag_bindings in list response without iterating" do
+      nil_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse,
+        tag_bindings: nil, next_page_token: nil)
+      expect(regional_crm_client).to receive(:list_tag_bindings).and_return(nil_bindings)
+      expect(regional_crm_client).not_to receive(:delete_tag_binding)
+      expect(regional_crm_client).to receive(:create_tag_binding).twice
+        .and_return(instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "bind-op", error: nil))
+
+      expect { nx.update_firewall_rules }.to hop("wait_sshable", "Vm::Gcp::Nexus")
     end
 
     it "does not create any tag keys or values (VpcNexus owns that)" do
@@ -165,14 +177,40 @@ RSpec.describe Prog::Vnet::Gcp::UpdateFirewallRules do
       expect(bound).to contain_exactly(fw_tag_value_name, firewall2_tag, subnet_tag_value_name)
     end
 
+    it "paginates list_tag_bindings and deletes stale bindings discovered on later pages" do
+      page1_stale = instance_double(Google::Apis::CloudresourcemanagerV3::TagBinding,
+        name: "tagBindings/p1-stale", tag_value_namespaced_name: "tagValues/old-page1")
+      page2_stale = instance_double(Google::Apis::CloudresourcemanagerV3::TagBinding,
+        name: "tagBindings/p2-stale", tag_value_namespaced_name: "tagValues/old-page2")
+      page1_resp = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse,
+        tag_bindings: [page1_stale], next_page_token: "tb-tok")
+      page2_resp = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse,
+        tag_bindings: [page2_stale], next_page_token: nil)
+      expect(regional_crm_client).to receive(:list_tag_bindings)
+        .with(parent: instance_of(String), page_token: nil).ordered.and_return(page1_resp)
+      expect(regional_crm_client).to receive(:list_tag_bindings)
+        .with(parent: instance_of(String), page_token: "tb-tok").ordered.and_return(page2_resp)
+
+      unbind_op = instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "unbind-op", error: nil)
+      expect(regional_crm_client).to receive(:delete_tag_binding).with("tagBindings/p1-stale").and_return(unbind_op)
+      expect(regional_crm_client).to receive(:delete_tag_binding).with("tagBindings/p2-stale").and_return(unbind_op)
+      bound = []
+      expect(regional_crm_client).to receive(:create_tag_binding).twice do |binding|
+        bound << binding.tag_value_namespaced_name
+        instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "bind-op", error: nil)
+      end
+
+      expect { nx.update_firewall_rules }.to hop("wait_sshable", "Vm::Gcp::Nexus")
+      expect(bound).to contain_exactly(fw_tag_value_name, subnet_tag_value_name)
+    end
+
     it "unbinds stale tags from firewalls no longer attached" do
       stale_binding = instance_double(Google::Apis::CloudresourcemanagerV3::TagBinding,
         name: "tagBindings/stale-1", tag_value_namespaced_name: "tagValues/old-fw-tv")
       active_binding = instance_double(Google::Apis::CloudresourcemanagerV3::TagBinding,
         name: "tagBindings/active-1", tag_value_namespaced_name: fw_tag_value_name)
 
-      existing_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse,
-        tag_bindings: [stale_binding, active_binding])
+      existing_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse, tag_bindings: [stale_binding, active_binding], next_page_token: nil)
       expect(regional_crm_client).to receive(:list_tag_bindings).and_return(existing_bindings)
 
       unbind_op = instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "unbind-op", error: nil)
@@ -196,8 +234,7 @@ RSpec.describe Prog::Vnet::Gcp::UpdateFirewallRules do
     it "creates new tag bindings before deleting stale ones" do
       stale_binding = instance_double(Google::Apis::CloudresourcemanagerV3::TagBinding,
         name: "tagBindings/stale-1", tag_value_namespaced_name: "tagValues/old-fw-tv")
-      existing_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse,
-        tag_bindings: [stale_binding])
+      existing_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse, tag_bindings: [stale_binding], next_page_token: nil)
       expect(regional_crm_client).to receive(:list_tag_bindings).and_return(existing_bindings)
 
       unbind_op = instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "unbind-op", error: nil)
@@ -308,8 +345,7 @@ RSpec.describe Prog::Vnet::Gcp::UpdateFirewallRules do
         name: "tagBindings/existing-1", tag_value_namespaced_name: fw_tag_value_name)
       subnet_binding = instance_double(Google::Apis::CloudresourcemanagerV3::TagBinding,
         name: "tagBindings/existing-2", tag_value_namespaced_name: subnet_tag_value_name)
-      existing_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse,
-        tag_bindings: [existing_binding, subnet_binding])
+      existing_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse, tag_bindings: [existing_binding, subnet_binding], next_page_token: nil)
       # GCP's 409 response is the only durable signal that a binding is
       # already persisted; we hammer create on every iteration and let
       # GCP arbitrate.
@@ -324,8 +360,7 @@ RSpec.describe Prog::Vnet::Gcp::UpdateFirewallRules do
     it "handles unbind 404 gracefully" do
       stale_binding = instance_double(Google::Apis::CloudresourcemanagerV3::TagBinding,
         name: "tagBindings/stale-1", tag_value_namespaced_name: "tagValues/old")
-      existing_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse,
-        tag_bindings: [stale_binding])
+      existing_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse, tag_bindings: [stale_binding], next_page_token: nil)
       expect(regional_crm_client).to receive(:list_tag_bindings).and_return(existing_bindings)
       expect(regional_crm_client).to receive(:delete_tag_binding)
         .and_raise(Google::Apis::ClientError.new("not found", status_code: 404))
@@ -342,8 +377,7 @@ RSpec.describe Prog::Vnet::Gcp::UpdateFirewallRules do
     it "re-raises non-404 errors during stale binding unbind" do
       stale_binding = instance_double(Google::Apis::CloudresourcemanagerV3::TagBinding,
         name: "tagBindings/stale-1", tag_value_namespaced_name: "tagValues/old")
-      existing_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse,
-        tag_bindings: [stale_binding])
+      existing_bindings = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagBindingsResponse, tag_bindings: [stale_binding], next_page_token: nil)
       expect(regional_crm_client).to receive(:list_tag_bindings).and_return(existing_bindings)
       expect(regional_crm_client).to receive(:delete_tag_binding)
         .and_raise(Google::Apis::ClientError.new("forbidden", status_code: 403))

--- a/spec/prog/vnet/gcp/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_nexus_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
     allow(Google::Apis::CloudresourcemanagerV3::CloudResourceManagerService).to receive(:new).and_return(crm_client)
     allow(crm_client).to receive(:authorization=)
     allow(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(nil)
+    stub_fetch_all_via_list(crm_client)
   end
 
   describe ".assemble" do
@@ -657,7 +658,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
         purpose_data: {"network" => "https://www.googleapis.com/compute/v1/projects/test-gcp-project/global/networks/99999"})
       nil_purpose_data = make_tag_key("tagKeys/444", "ubicloud-fw-nilpd", purpose_data: nil)
 
-      expect(crm_client).to receive(:list_tag_keys).with(parent: "projects/test-gcp-project").and_return(
+      expect(crm_client).to receive(:list_tag_keys).with(parent: "projects/test-gcp-project", page_token: nil).and_return(
         Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(
           tag_keys: [matching, wrong_prefix, wrong_purpose, wrong_network, nil_purpose_data],
         ),
@@ -719,6 +720,28 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
 
       expect { nx.enumerate_destroy_state }.to hop("delete_firewall_tag_values_start")
       expect(st.stack.first["pending_tag_key_names"]).to eq([])
+    end
+
+    it "paginates list_tag_keys and collects matching tag keys from every page" do
+      page1_match = make_tag_key("tagKeys/page1-match", "ubicloud-fw-page1")
+      page1_skip = make_tag_key("tagKeys/page1-skip", "other-tag")
+      page2_match = make_tag_key("tagKeys/page2-match", "ubicloud-fw-page2")
+
+      page1 = Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(
+        tag_keys: [page1_match, page1_skip], next_page_token: "destroy-tok",
+      )
+      page2 = Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(
+        tag_keys: [page2_match],
+      )
+      expect(crm_client).to receive(:list_tag_keys)
+        .with(parent: "projects/test-gcp-project", page_token: nil).ordered.and_return(page1)
+      expect(crm_client).to receive(:list_tag_keys)
+        .with(parent: "projects/test-gcp-project", page_token: "destroy-tok").ordered.and_return(page2)
+      expect(nfp_client).to receive(:get).and_raise(Google::Cloud::NotFoundError.new("gone"))
+
+      expect { nx.enumerate_destroy_state }.to hop("delete_firewall_tag_values_start")
+      expect(st.stack.first["pending_tag_key_names"])
+        .to contain_exactly("tagKeys/page1-match", "tagKeys/page2-match")
     end
   end
 
@@ -926,7 +949,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
 
     it "populates pending_tag_value_names and hops to delete_firewall_tag_values" do
       refresh_frame(nx, new_values: {"pending_tag_key_names" => ["tagKeys/999"]})
-      expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/999").and_return(
+      expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/999", page_token: nil).and_return(
         Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(
           tag_values: [
             Google::Apis::CloudresourcemanagerV3::TagValue.new(name: "tagValues/1"),
@@ -941,12 +964,33 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
 
     it "handles nil tag_values (empty pending list)" do
       refresh_frame(nx, new_values: {"pending_tag_key_names" => ["tagKeys/999"]})
-      expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/999").and_return(
+      expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/999", page_token: nil).and_return(
         Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new,
       )
 
       expect { nx.delete_firewall_tag_values_start }.to hop("delete_firewall_tag_values")
       expect(st.stack.first["pending_tag_value_names"]).to eq([])
+    end
+
+    it "paginates list_tag_values and collects every tag value across pages" do
+      refresh_frame(nx, new_values: {"pending_tag_key_names" => ["tagKeys/999"]})
+      page1 = Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(
+        tag_values: [Google::Apis::CloudresourcemanagerV3::TagValue.new(name: "tagValues/p1")],
+        next_page_token: "tv-tok",
+      )
+      page2 = Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(
+        tag_values: [
+          Google::Apis::CloudresourcemanagerV3::TagValue.new(name: "tagValues/p2-a"),
+          Google::Apis::CloudresourcemanagerV3::TagValue.new(name: "tagValues/p2-b"),
+        ],
+      )
+      expect(crm_client).to receive(:list_tag_values)
+        .with(parent: "tagKeys/999", page_token: nil).ordered.and_return(page1)
+      expect(crm_client).to receive(:list_tag_values)
+        .with(parent: "tagKeys/999", page_token: "tv-tok").ordered.and_return(page2)
+
+      expect { nx.delete_firewall_tag_values_start }.to hop("delete_firewall_tag_values")
+      expect(st.stack.first["pending_tag_value_names"]).to eq(["tagValues/p1", "tagValues/p2-a", "tagValues/p2-b"])
     end
   end
 

--- a/spec/prog/vnet/gcp/vpc_update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_update_firewall_rules_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       network_firewall_policies_client: nfp_client,
       crm_client:,
     )
+    stub_fetch_all_via_list(crm_client)
   end
 
   describe "#before_run" do
@@ -109,7 +110,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       empty_policy = v1::FirewallPolicy.new(rules: [])
       allow(nfp_client).to receive_messages(get: empty_policy, add_rule: lro_op)
 
-      empty_tk_list = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [])
+      empty_tk_list = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [], next_page_token: nil)
       allow(crm_client).to receive_messages(
         create_tag_key: crm_done_op,
         get_operation: crm_done_op,
@@ -241,7 +242,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         .and_raise(Google::Apis::ClientError.new("conflict", status_code: 409))
       tk = instance_double(Google::Apis::CloudresourcemanagerV3::TagKey,
         short_name: "ubicloud-fw-#{firewall.ubid}", name: "tagKeys/existing-1")
-      tk_list = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [tk])
+      tk_list = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [tk], next_page_token: nil)
       expect(crm_client).to receive(:list_tag_keys).and_return(tk_list)
 
       expect(nx.send(:ensure_firewall_tag_key, firewall)).to eq("tagKeys/existing-1")
@@ -253,10 +254,36 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       expect(crm_client).to receive(:create_tag_key).and_return(op)
       tk = instance_double(Google::Apis::CloudresourcemanagerV3::TagKey,
         short_name: "ubicloud-fw-#{firewall.ubid}", name: "tagKeys/existing-lro-1")
-      tk_list = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [tk])
+      tk_list = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [tk], next_page_token: nil)
       expect(crm_client).to receive(:list_tag_keys).and_return(tk_list)
 
       expect(nx.send(:ensure_firewall_tag_key, firewall)).to eq("tagKeys/existing-lro-1")
+    end
+
+    # Regression: GCP CRM list_tag_keys returns at most 100 entries per page.
+    # Once a project accumulates >100 tag keys, the target tag key for an
+    # ALREADY_EXISTS retry can land on page 2; without pagination the lookup
+    # falls back to "conflict but not found", the strand label rolls back the
+    # cleared pending op, and the prog re-polls forever (HA test hang
+    # observed 2026-05-07).
+    it "paginates list_tag_keys to find target on page 2 after ALREADY_EXISTS" do
+      error = instance_double(Google::Apis::CloudresourcemanagerV3::Status, code: 6, message: "tag key already exists")
+      op = instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "op-1", error:)
+      expect(crm_client).to receive(:create_tag_key).and_return(op)
+      filler = instance_double(Google::Apis::CloudresourcemanagerV3::TagKey,
+        short_name: "ubicloud-fw-other", name: "tagKeys/other")
+      target = instance_double(Google::Apis::CloudresourcemanagerV3::TagKey,
+        short_name: "ubicloud-fw-#{firewall.ubid}", name: "tagKeys/page2-target")
+      page1 = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse,
+        tag_keys: [filler], next_page_token: "tok-2")
+      page2 = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse,
+        tag_keys: [target], next_page_token: nil)
+      expect(crm_client).to receive(:list_tag_keys)
+        .with(parent: "projects/test-gcp-project", page_token: nil).ordered.and_return(page1)
+      expect(crm_client).to receive(:list_tag_keys)
+        .with(parent: "projects/test-gcp-project", page_token: "tok-2").ordered.and_return(page2)
+
+      expect(nx.send(:ensure_firewall_tag_key, firewall)).to eq("tagKeys/page2-target")
     end
 
     it "re-raises non-ALREADY_EXISTS LRO errors" do
@@ -282,7 +309,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       tk = instance_double(Google::Apis::CloudresourcemanagerV3::TagKey,
         short_name: "ubicloud-fw-#{firewall.ubid}", name: "tagKeys/lookup-1")
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [tk]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [tk], next_page_token: nil),
       )
 
       expect(nx.send(:ensure_firewall_tag_key, firewall)).to eq("tagKeys/lookup-1")
@@ -292,7 +319,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       op = instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "op-1", response: nil, error: nil)
       expect(crm_client).to receive(:create_tag_key).and_return(op)
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: []),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [], next_page_token: nil),
       )
 
       expect { nx.send(:ensure_firewall_tag_key, firewall) }.to raise_error(/created but name not found/)
@@ -302,7 +329,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       expect(crm_client).to receive(:create_tag_key)
         .and_raise(Google::Apis::ClientError.new("conflict", status_code: 409))
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: nil),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: nil, next_page_token: nil),
       )
 
       expect { nx.send(:ensure_firewall_tag_key, firewall) }.to raise_error(/conflict but not found/)
@@ -356,7 +383,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       tk = instance_double(Google::Apis::CloudresourcemanagerV3::TagKey,
         short_name: "ubicloud-fw-#{firewall.ubid}", name: "tagKeys/poll-1")
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [tk]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [tk], next_page_token: nil),
       )
 
       expect(nx.send(:ensure_firewall_tag_key, firewall)).to eq("tagKeys/poll-1")
@@ -377,7 +404,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       expect(crm_client).to receive(:create_tag_value).and_return(op)
       tv = instance_double(Google::Apis::CloudresourcemanagerV3::TagValue, short_name: "active", name: "tagValues/lookup-1")
       expect(crm_client).to receive(:list_tag_values).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [tv]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [tv], next_page_token: nil),
       )
 
       expect(nx.send(:ensure_tag_value, "tagKeys/123", "active")).to eq("tagValues/lookup-1")
@@ -387,7 +414,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       op = instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "op-1", response: nil, error: nil)
       expect(crm_client).to receive(:create_tag_value).and_return(op)
       expect(crm_client).to receive(:list_tag_values).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: nil),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: nil, next_page_token: nil),
       )
 
       expect { nx.send(:ensure_tag_value, "tagKeys/123", "active") }.to raise_error(/created but name not found/)
@@ -398,7 +425,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         .and_raise(Google::Apis::ClientError.new("conflict", status_code: 409))
       tv = instance_double(Google::Apis::CloudresourcemanagerV3::TagValue, short_name: "active", name: "tagValues/existing-1")
       expect(crm_client).to receive(:list_tag_values).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [tv]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [tv], next_page_token: nil),
       )
 
       expect(nx.send(:ensure_tag_value, "tagKeys/123", "active")).to eq("tagValues/existing-1")
@@ -408,7 +435,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       expect(crm_client).to receive(:create_tag_value)
         .and_raise(Google::Apis::ClientError.new("conflict", status_code: 409))
       expect(crm_client).to receive(:list_tag_values).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: nil),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: nil, next_page_token: nil),
       )
 
       expect { nx.send(:ensure_tag_value, "tagKeys/123", "active") }.to raise_error(/conflict but not found/)
@@ -427,10 +454,28 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       expect(crm_client).to receive(:create_tag_value).and_return(op)
       tv = instance_double(Google::Apis::CloudresourcemanagerV3::TagValue, short_name: "active", name: "tagValues/existing-lro-1")
       expect(crm_client).to receive(:list_tag_values).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [tv]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [tv], next_page_token: nil),
       )
 
       expect(nx.send(:ensure_tag_value, "tagKeys/123", "active")).to eq("tagValues/existing-lro-1")
+    end
+
+    it "paginates list_tag_values to find target on page 2 after ALREADY_EXISTS" do
+      error = instance_double(Google::Apis::CloudresourcemanagerV3::Status, code: 6, message: "already exists")
+      op = instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "op-1", error:)
+      expect(crm_client).to receive(:create_tag_value).and_return(op)
+      filler = instance_double(Google::Apis::CloudresourcemanagerV3::TagValue, short_name: "stale", name: "tagValues/stale")
+      target = instance_double(Google::Apis::CloudresourcemanagerV3::TagValue, short_name: "active", name: "tagValues/page2")
+      page1 = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse,
+        tag_values: [filler], next_page_token: "tv-tok-2")
+      page2 = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse,
+        tag_values: [target], next_page_token: nil)
+      expect(crm_client).to receive(:list_tag_values)
+        .with(parent: "tagKeys/123", page_token: nil).ordered.and_return(page1)
+      expect(crm_client).to receive(:list_tag_values)
+        .with(parent: "tagKeys/123", page_token: "tv-tok-2").ordered.and_return(page2)
+
+      expect(nx.send(:ensure_tag_value, "tagKeys/123", "active")).to eq("tagValues/page2")
     end
 
     it "re-raises non-ALREADY_EXISTS LRO errors" do
@@ -509,7 +554,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       expect(crm_client).to receive(:get_operation).with("operations/tv-no-name").and_return(no_name_op)
       tv = instance_double(Google::Apis::CloudresourcemanagerV3::TagValue, short_name: "active", name: "tagValues/fallback-1")
       expect(crm_client).to receive(:list_tag_values).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [tv]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [tv], next_page_token: nil),
       )
 
       expect(nx.send(:ensure_tag_value, "tagKeys/123", "active")).to eq("tagValues/fallback-1")
@@ -776,12 +821,12 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         short_name: "ubicloud-fw-#{orphan_fw_ubid}", name: orphan_tag_key_name,
         purpose: "GCE_FIREWALL", purpose_data: vpc_purpose_data)
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [orphan_tk]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [orphan_tk], next_page_token: nil),
       )
       orphan_tv = instance_double(Google::Apis::CloudresourcemanagerV3::TagValue,
         short_name: "active", name: orphan_tag_value_name)
-      expect(crm_client).to receive(:list_tag_values).with(parent: orphan_tag_key_name).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [orphan_tv]),
+      expect(crm_client).to receive(:list_tag_values).with(parent: orphan_tag_key_name, page_token: nil).and_return(
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [orphan_tv], next_page_token: nil),
       )
       rule = v1::FirewallPolicyRule.new(
         priority: 10005, action: "allow",
@@ -801,7 +846,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         short_name: "ubicloud-fw-#{firewall.ubid}", name: "tagKeys/active-1",
         purpose: "GCE_FIREWALL", purpose_data: vpc_purpose_data)
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [active_tk]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [active_tk], next_page_token: nil),
       )
       expect(nfp_client).not_to receive(:get)
       expect(crm_client).not_to receive(:delete_tag_key)
@@ -820,7 +865,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         short_name: "ubicloud-fw-#{other_fw.ubid}", name: "tagKeys/cross-1",
         purpose: "GCE_FIREWALL", purpose_data: vpc_purpose_data)
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [tk]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [tk], next_page_token: nil),
       )
       expect(nfp_client).not_to receive(:get)
       expect(crm_client).not_to receive(:delete_tag_key)
@@ -840,7 +885,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         short_name: "ubicloud-fw-#{vm_fw.ubid}", name: "tagKeys/vm-attached",
         purpose: "GCE_FIREWALL", purpose_data: vpc_purpose_data)
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [tk]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [tk], next_page_token: nil),
       )
       expect(nfp_client).not_to receive(:get)
       expect(crm_client).not_to receive(:delete_tag_key)
@@ -854,7 +899,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         purpose: "GCE_FIREWALL",
         purpose_data: {"network" => "https://www.googleapis.com/compute/v1/projects/test-gcp-project/global/networks/9999999999"})
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [other_tk]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [other_tk], next_page_token: nil),
       )
       expect(nfp_client).not_to receive(:get)
       expect(crm_client).not_to receive(:delete_tag_key)
@@ -867,7 +912,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         short_name: "ubicloud-fw-#{orphan_fw_ubid}", name: orphan_tag_key_name,
         purpose: "GCE_FIREWALL", purpose_data: nil)
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [nil_pd]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [nil_pd], next_page_token: nil),
       )
       expect(nfp_client).not_to receive(:get)
 
@@ -878,7 +923,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       non_fw = instance_double(Google::Apis::CloudresourcemanagerV3::TagKey,
         short_name: "ubicloud-fw-weird", name: "tagKeys/other-1", purpose: nil)
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [non_fw]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [non_fw], next_page_token: nil),
       )
       expect(nfp_client).not_to receive(:get)
 
@@ -889,7 +934,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       subnet_tk = instance_double(Google::Apis::CloudresourcemanagerV3::TagKey,
         short_name: "ubicloud-subnet-x", name: "tagKeys/subnet-1", purpose: "GCE_FIREWALL")
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [subnet_tk]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [subnet_tk], next_page_token: nil),
       )
       expect(nfp_client).not_to receive(:get)
 
@@ -898,7 +943,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
 
     it "returns early when no tag keys exist" do
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: nil),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: nil, next_page_token: nil),
       )
       expect(nfp_client).not_to receive(:get)
 
@@ -910,10 +955,10 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         short_name: "ubicloud-fw-#{orphan_fw_ubid}", name: orphan_tag_key_name,
         purpose: "GCE_FIREWALL", purpose_data: vpc_purpose_data)
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [orphan_tk]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [orphan_tk], next_page_token: nil),
       )
-      expect(crm_client).to receive(:list_tag_values).with(parent: orphan_tag_key_name).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: nil),
+      expect(crm_client).to receive(:list_tag_values).with(parent: orphan_tag_key_name, page_token: nil).and_return(
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: nil, next_page_token: nil),
       )
       expect(nfp_client).not_to receive(:get)
       expect(crm_client).not_to receive(:delete_tag_value)
@@ -927,12 +972,12 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         short_name: "ubicloud-fw-#{orphan_fw_ubid}", name: orphan_tag_key_name,
         purpose: "GCE_FIREWALL", purpose_data: vpc_purpose_data)
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [orphan_tk]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [orphan_tk], next_page_token: nil),
       )
       orphan_tv = instance_double(Google::Apis::CloudresourcemanagerV3::TagValue,
         short_name: "active", name: orphan_tag_value_name)
-      expect(crm_client).to receive(:list_tag_values).with(parent: orphan_tag_key_name).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [orphan_tv]),
+      expect(crm_client).to receive(:list_tag_values).with(parent: orphan_tag_key_name, page_token: nil).and_return(
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [orphan_tv], next_page_token: nil),
       )
       deny_rule = v1::FirewallPolicyRule.new(
         priority: 10005, action: "deny",
@@ -951,12 +996,12 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         short_name: "ubicloud-fw-#{orphan_fw_ubid}", name: orphan_tag_key_name,
         purpose: "GCE_FIREWALL", purpose_data: vpc_purpose_data)
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [orphan_tk]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [orphan_tk], next_page_token: nil),
       )
       orphan_tv = instance_double(Google::Apis::CloudresourcemanagerV3::TagValue,
         short_name: "active", name: orphan_tag_value_name)
-      expect(crm_client).to receive(:list_tag_values).with(parent: orphan_tag_key_name).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [orphan_tv]),
+      expect(crm_client).to receive(:list_tag_values).with(parent: orphan_tag_key_name, page_token: nil).and_return(
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [orphan_tv], next_page_token: nil),
       )
       unrelated_rule = v1::FirewallPolicyRule.new(
         priority: 10005, action: "allow",
@@ -975,7 +1020,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         short_name: "ubicloud-fw-#{orphan_fw_ubid}", name: orphan_tag_key_name,
         purpose: "GCE_FIREWALL", purpose_data: vpc_purpose_data)
       expect(crm_client).to receive(:list_tag_keys).and_return(
-        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [orphan_tk]),
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [orphan_tk], next_page_token: nil),
       )
       expect(crm_client).to receive(:list_tag_values)
         .and_raise(Google::Apis::ClientError.new("forbidden", status_code: 403))
@@ -987,6 +1032,30 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       expect(crm_client).to receive(:list_tag_keys).and_raise(Google::Cloud::Error.new("error"))
 
       expect { nx.send(:cleanup_orphaned_firewall_rules) }.to raise_error(Google::Cloud::Error)
+    end
+
+    it "paginates list_tag_keys and includes orphan candidates from later pages" do
+      page1_tk = instance_double(Google::Apis::CloudresourcemanagerV3::TagKey,
+        short_name: "ubicloud-fw-#{firewall.ubid}", name: "tagKeys/active-1",
+        purpose: "GCE_FIREWALL", purpose_data: vpc_purpose_data)
+      page2_tk = instance_double(Google::Apis::CloudresourcemanagerV3::TagKey,
+        short_name: "ubicloud-fw-#{orphan_fw_ubid}", name: orphan_tag_key_name,
+        purpose: "GCE_FIREWALL", purpose_data: vpc_purpose_data)
+      page1 = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse,
+        tag_keys: [page1_tk], next_page_token: "orphan-tok-2")
+      page2 = instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse,
+        tag_keys: [page2_tk], next_page_token: nil)
+      expect(crm_client).to receive(:list_tag_keys)
+        .with(parent: "projects/test-gcp-project", page_token: nil).ordered.and_return(page1)
+      expect(crm_client).to receive(:list_tag_keys)
+        .with(parent: "projects/test-gcp-project", page_token: "orphan-tok-2").ordered.and_return(page2)
+      expect(crm_client).to receive(:list_tag_values).with(parent: orphan_tag_key_name, page_token: nil).and_return(
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: nil, next_page_token: nil),
+      )
+      # Active tag key (page 1) is NOT deleted; only the orphan from page 2 is.
+      expect(crm_client).to receive(:delete_tag_key).with(orphan_tag_key_name)
+
+      nx.send(:cleanup_orphaned_firewall_rules)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -360,6 +360,27 @@ RSpec.configure do |config|
       AssignedVmAddress.create(ip: ipv4, address_id: addr.id, dst_vm_id: vm.id)
     end
 
+    # Stubs Google::Apis::Core::BaseService#fetch_all on a doubled CRM-like
+    # client so existing list_tag_keys / list_tag_values / list_tag_bindings
+    # stubs continue to work after callers were switched to fetch_all. The
+    # returned Enumerator paginates by invoking the caller's block (which in
+    # turn calls the doubled list_* method whose stubs the spec defines), and
+    # short-circuits when the consumer breaks (so .find still avoids fetching
+    # later pages when a match lands on the first page).
+    def stub_fetch_all_via_list(client)
+      allow(client).to receive(:fetch_all) do |items:, &block|
+        Enumerator.new do |yielder|
+          page_token = nil
+          loop do
+            resp = block.call(page_token, client)
+            resp.send(items)&.each(&yielder)
+            page_token = resp.next_page_token
+            break if page_token.to_s.empty?
+          end
+        end
+      end
+    end
+
     def refresh_frame(prog, new_frame: nil, new_values: nil, parent_values: nil)
       st = prog.strand
       fail "cannot pass both new_frame and new_values" if new_frame && new_values


### PR DESCRIPTION
## Summary

Fixes a 65+ minute HA e2e hang observed live on 2026-05-07 (runner 46.4.203.232). All nine `list_tag_keys` / `list_tag_values` / `list_tag_bindings` call sites in `prog/vnet/gcp/` now paginate via the SDK's existing `Google::Apis::Core::BaseService#fetch_all` instead of reading only the first 100-entry page.

## How the hang happened

`Test::HaPostgresResource.wait_postgres_resource` was stuck for 65+ minutes. Walking the dependency chain top-down:

```
Test::HaPostgresResource.wait_postgres_resource (waiting)
  PostgresResource pg8nhxvvpagj0h... at PostgresResourceNexus.start
  → PostgresServerNexus.start naps until VM strand is "wait"
  → Vm::Gcp::Nexus.start naps until subnet strand is "wait"
  → Vnet::Gcp::SubnetNexus at wait_vpc_ready (subnet blocked)
  → Vnet::Gcp::VpcNexus at update_firewall_rules (the actual hang)
```

The VPC's child `Vnet::Gcp::VpcUpdateFirewallRules.update_firewall_rules` strand had `pending_tag_key_crm_op` set since 12:05:02. Querying that LRO directly:

```ruby
op = cred.crm_client.get_operation("operations/rctk.global.6695305035193437870")
op.done?  # => true
op.error  # => code=6 ALREADY_EXISTS, "TagKey with short name 'ubicloud-fw-fw0r6x...' already exists"
```

The op IS done. The matching tag key DOES exist as `tagKeys/281483491297593`. But the project held **133 tag keys total**, and `lookup_tag_key_name` issued a single `list_tag_keys(parent: ...)` call which returned 100 of them — the target was on page 2.

## The infinite loop

1. Strand re-enters with `pending_tag_key_crm_op` set.
2. `get_operation` returns `done?=true` with `code=6 ALREADY_EXISTS`.
3. `update_stack` clears `pending_tag_key_crm_op` (in the same `DB.transaction` as the rest of the strand label body).
4. `raise CrmOperationError(code: 6)`.
5. Outer rescue in `ensure_firewall_tag_key` catches code 6, calls `lookup_tag_key_name(short_name)`.
6. `lookup_tag_key_name` calls `list_tag_keys(parent: ...)`. One page, 100 of 133. Target on page 2. Returns `nil`.
7. `lookup_tag_key_name!` raises `"Tag key ... conflict but not found on lookup"`.
8. The unhandled raise propagates out of the strand label.
9. The label body is a `DB.transaction`, so it rolls back — **including the `update_stack` that cleared `pending_tag_key_crm_op`**.
10. Strand re-enters, schedule fires ~5s later, **GOTO step 1**.

Hot retry forever, never makes progress. Same shape applies (less commonly) to tag values under a single tag key and to tag bindings on a single resource.

## Fix

Use the SDK's `BaseService#fetch_all`, which returns a `PagedResults` Enumerable that lazily fetches pages and short-circuits when the consumer breaks. So `.find` stops at the matching page exactly like a hand-rolled retry loop would, and `.select` / `.each` / `.map` iterate every page. The block form `{ |token, s| s.list_*(parent: ..., page_token: token) }` is the SDK's documented usage.

Sites updated:

| File | Function | Pattern |
|---|---|---|
| `vpc_update_firewall_rules.rb` | `lookup_tag_key_name` | find-first (the hang) |
| `vpc_update_firewall_rules.rb` | `lookup_tag_value_name` | find-first |
| `vpc_update_firewall_rules.rb` | `cleanup_orphaned_firewall_rules` | select-all |
| `subnet_nexus.rb` | `lookup_tag_key` | find-first |
| `subnet_nexus.rb` | `lookup_tag_value_name` | find-first |
| `subnet_nexus.rb` | `delete_subnet_tag_resources` | find-first |
| `vpc_nexus.rb` | `enumerate_destroy_state` | select-and-map |
| `vpc_nexus.rb` | `delete_firewall_tag_values_start` | map-all |
| `update_firewall_rules.rb` | stale-binding cleanup | each-with-side-effect |

Specs gain a per-helper "page 2" regression case using two `.ordered` `list_*` expectations with distinct `page_token` values, so a future regression to the single-page form would fail the second-page expectation. A focused regression spec drives `ensure_firewall_tag_key` end-to-end with ALREADY_EXISTS plus a 2-page `list_tag_keys`, asserting the target on page 2 is recovered without the "conflict but not found" raise.

To keep the existing ~100 `list_*` spec stubs working unchanged, a small `stub_fetch_all_via_list` helper in `spec_helper.rb` stubs `fetch_all` on a doubled CRM service to return an Enumerator that internally calls the same `list_*` method the spec already stubs. The Enumerator stays lazy enough that `.find` still short-circuits without invoking page-2 stubs.

## Test plan

- [x] `cberp` (full parallel suite + coverage): 6358 examples, 0 failures, 100% line + branch coverage.
- [x] Rubocop clean.
- [x] Codex adversarial review on the staged diff — verdict `ship`, no findings.
- [ ] e2e on the previously-hung HA runner reaches `Test::HaPostgresResource.test_postgres` past `wait_postgres_resource`.

## Out of scope

- Orphan-tag-key cleanup of the live `ubicloud-e2e` project (filed as a separate follow-up walk issue, branch `cleanup-orphan-firewall-tag-keys-script` already in flight).
- Compute API `list_addresses` and friends — never used as listing in this codebase, always `get`-by-name.
- AWS-side pagination — different SDK, audited separately and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)