### PR TITLE
Use UMI for vanilla boot images whenever available (2nd appoach)

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -53,12 +53,20 @@ class Prog::Vm::Nexus < Prog::Base
 
     Validation.validate_storage_volumes(storage_volumes, boot_disk_index)
 
+    metal_vm = location.provider_dispatcher_group_name == "metal"
+    boot_volume = storage_volumes[boot_disk_index]
+
     if boot_image.include?("@")
-      fail "Machine images are only supported for metal locations" unless location.provider_dispatcher_group_name == "metal"
+      fail "Machine images are only supported for metal locations" unless metal_vm
       image_name, image_version = boot_image.split("@", 2)
-      boot_volume = storage_volumes[boot_disk_index]
       machine_image_version = lookup_machine_image_version(project_id, location_id, image_name, image_version, boot_volume[:size_gib])
       boot_volume[:machine_image_version_id] = machine_image_version.id
+    elsif metal_vm && (mi_project_id = Config.machine_images_service_project_id)
+      # We want to eventually use machine images for base images. If a suitable
+      # machine image version isn't found, we'll fall back to using the
+      # boot_image as a name of a BootImage for now.
+      machine_image_version = lookup_machine_image_version(mi_project_id, location_id, boot_image, "latest", boot_volume[:size_gib], raise_on_invalid: false)
+      boot_volume[:machine_image_version_id] = machine_image_version&.id
     end
 
     ubid = Vm.generate_ubid
@@ -216,13 +224,14 @@ class Prog::Vm::Nexus < Prog::Base
     st
   end
 
-  def self.lookup_machine_image_version(project_id, location_id, name, version, vm_boot_disk_size_gib)
+  def self.lookup_machine_image_version(project_id, location_id, name, version, vm_boot_disk_size_gib, raise_on_invalid: true)
     search_ids = Option.machine_image_search_locations(location_id)
     mi = MachineImage
       .order(Sequel.function(:array_position, Sequel.pg_array(search_ids, :uuid), :location_id))
       .first(project_id:, location_id: search_ids, name:)
 
     unless mi
+      return nil unless raise_on_invalid
       search_locations = search_ids.map { |id| Location[id].display_name }.join(", ")
       fail Validation::ValidationFailed.new({machine_image: "Machine image with name \"#{name}\" does not exist in the specified project and any of the following locations: #{search_locations}"})
     end
@@ -233,9 +242,11 @@ class Prog::Vm::Nexus < Prog::Base
       MachineImageVersion.first(machine_image_id: mi.id, version:)
     end
 
-    fail Validation::ValidationFailed.new({machine_image_version: "Version \"#{version}\" does not exist for machine image \"#{name}\""}) unless miv
-    fail Validation::ValidationFailed.new({machine_image_version: "Machine image version \"#{version}\" does not have an active metal version"}) unless miv.metal&.enabled
-    fail Validation::ValidationFailed.new({machine_image_version: "Machine image version \"#{version}\" is larger than the VM boot disk size"}) if miv.actual_size_mib > vm_boot_disk_size_gib * 1024
+    if raise_on_invalid
+      fail Validation::ValidationFailed.new({machine_image_version: "Version \"#{version}\" does not exist for machine image \"#{name}\""}) unless miv
+      fail Validation::ValidationFailed.new({machine_image_version: "Machine image version \"#{version}\" does not have an active metal version"}) unless miv.metal&.enabled
+      fail Validation::ValidationFailed.new({machine_image_version: "Machine image version \"#{version}\" is larger than the VM boot disk size"}) if miv.actual_size_mib > vm_boot_disk_size_gib * 1024
+    end
 
     miv
   end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -190,11 +190,38 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(vm.vm_storage_volumes.first.machine_image_version_id).to eq(miv.id)
     end
 
+    it "falls back to using boot_image as a BootImage name if machine image lookup fails" do
+      mi_project = Project.create(name: "machine-images-service-project")
+      expect(Config).to receive(:machine_images_service_project_id).at_least(:once).and_return(mi_project.id)
+      vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "ubuntu-jammy", location_id: Location::HETZNER_FSN1_ID).subject
+      expect(vm.vm_storage_volumes.first.machine_image_version_id).to be_nil
+      expect(vm.boot_image).to eq("ubuntu-jammy")
+    end
+
+    it "falls back to using boot_image as a BootImage name if machine image doesn't have an active latest version" do
+      mi_project = Project.create(name: "machine-images-service-project")
+      expect(Config).to receive(:machine_images_service_project_id).at_least(:once).and_return(mi_project.id)
+      miv = create_machine_image_version_metal(project_id: mi_project.id, location_id: Location::HETZNER_FSN1_ID, name: "ubuntu-jammy").machine_image_version
+      miv.machine_image.update(latest_version_id: nil)
+      vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "ubuntu-jammy", location_id: Location::HETZNER_FSN1_ID).subject
+      expect(vm.vm_storage_volumes.first.machine_image_version_id).to be_nil
+      expect(vm.boot_image).to eq("ubuntu-jammy")
+    end
+
     it "uses the primary machine image location if it exists in both primary and fallback locations" do
       miv_primary = create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "some-mi-name", version: "20200202").machine_image_version
       create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_HEL1_ID, name: "some-mi-name", version: "20200202").machine_image_version
       vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "some-mi-name@20200202", location_id: Location::HETZNER_FSN1_ID).subject
       expect(vm.vm_storage_volumes.first.machine_image_version_id).to eq(miv_primary.id)
+    end
+
+    it "uses a machine image if a base boot image is requested and boot_image@latest exists in the machine images service project" do
+      mi_project = Project.create(name: "machine-images-service-project")
+      expect(Config).to receive(:machine_images_service_project_id).at_least(:once).and_return(mi_project.id)
+      miv = create_machine_image_version_metal(project_id: mi_project.id, location_id: Location::HETZNER_FSN1_ID, name: "ubuntu-jammy").machine_image_version
+      miv.machine_image.update(latest_version_id: miv.id)
+      vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "ubuntu-jammy", location_id: Location::HETZNER_FSN1_ID).subject
+      expect(vm.vm_storage_volumes.first.machine_image_version_id).to eq(miv.id)
     end
 
     it "fails if given nic_id is not valid" do


### PR DESCRIPTION
If `Config.machine_images_service_project_id` has boot_image@latest and validates, use it. Otherwise, fallback to regular BootImage.