### PR TITLE
CreateVersionMetalFromUrl: bound the size of the downloaded image.

### DIFF
--- a/prog/machine_image/create_version_metal_from_url.rb
+++ b/prog/machine_image/create_version_metal_from_url.rb
@@ -5,7 +5,7 @@ require "json"
 class Prog::MachineImage::CreateVersionMetalFromUrl < Prog::Base
   subject_is :machine_image_version
 
-  def self.assemble(machine_image, version, url, sha256sum, store, set_as_latest: true)
+  def self.assemble(machine_image, version, url, sha256sum, store, set_as_latest: true, max_actual_size_mib: 10240)
     vbb = VhostBlockBackend
       .where(vm_host_id: VmHost.where(location_id: machine_image.location_id).select(:id))
       .where { version_code >= VhostBlockBackend::MIN_ARCHIVE_SUPPORT_VERSION }
@@ -36,6 +36,7 @@ class Prog::MachineImage::CreateVersionMetalFromUrl < Prog::Base
           "vm_host_id" => vbb.vm_host_id,
           "vhost_block_backend_version" => vbb.version,
           "set_as_latest" => set_as_latest,
+          "max_actual_size_mib" => max_actual_size_mib,
         }])
     end
   end
@@ -78,7 +79,10 @@ class Prog::MachineImage::CreateVersionMetalFromUrl < Prog::Base
       archive_size_mib: (frame["physical_size_bytes"]/1048576r).ceil,
     )
 
-    machine_image_version.update(actual_size_mib: (frame["logical_size_bytes"]/1048576r).ceil)
+    actual_size_mib = (frame["logical_size_bytes"]/1048576r).ceil
+    fail "Actual size of machine image version (#{actual_size_mib} MiB) exceeds the specified maximum (#{frame["max_actual_size_mib"]} MiB)" if actual_size_mib > frame["max_actual_size_mib"]
+
+    machine_image_version.update(actual_size_mib:)
 
     if frame["set_as_latest"]
       machine_image_version.machine_image.update(latest_version_id: machine_image_version.id)

--- a/spec/prog/machine_image/create_version_metal_from_url_spec.rb
+++ b/spec/prog/machine_image/create_version_metal_from_url_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Prog::MachineImage::CreateVersionMetalFromUrl do
         "vm_host_id" => vm_host.id,
         "vhost_block_backend_version" => vbb.version,
         "set_as_latest" => false,
+        "max_actual_size_mib" => 10240,
       }],
     )
   }
@@ -50,6 +51,14 @@ RSpec.describe Prog::MachineImage::CreateVersionMetalFromUrl do
       expect(strand.stack.first["vm_host_id"]).to eq(vm_host.id)
       expect(strand.stack.first["vhost_block_backend_version"]).to eq(vbb.version)
       expect(strand.stack.first["set_as_latest"]).to be true
+      expect(strand.stack.first["max_actual_size_mib"]).to eq(10240)
+    end
+
+    it "uses the provided max_actual_size_mib" do
+      create_vhost_block_backend(version: "v0.4.1", allocation_weight: 50, vm_host_id: vm_host.id)
+      strand = described_class.assemble(machine_image, "2.0", url, sha256sum, store, max_actual_size_mib: 5120)
+
+      expect(strand.stack.first["max_actual_size_mib"]).to eq(5120)
     end
 
     it "selects only from backends that support archive" do
@@ -140,6 +149,11 @@ RSpec.describe Prog::MachineImage::CreateVersionMetalFromUrl do
 
       machine_image.reload
       expect(machine_image.latest_version.id).to eq(mi_version_metal.id)
+    end
+
+    it "fails when actual size exceeds max_actual_size_mib" do
+      refresh_frame(prog, new_values: {"max_actual_size_mib" => 10})
+      expect { prog.finish }.to raise_error(RuntimeError, "Actual size of machine image version (20 MiB) exceeds the specified maximum (10 MiB)")
     end
   end
 


### PR DESCRIPTION
We use `CreateVersionMetalFromUrl` to create base machine images like ubuntu and debian. All regular VMs should be bootable from such machine images. Our smallest supported boot disk is 10G, so we should have a check when creating a machine image version from the URL to verify its size.

Distro Images we use in production has the following sizes (rounded up to the next GiB)

- ubuntu-jammy: 3G
- ubuntu-noble: 4G
- almalinux-8: 10G
- almalinux-9: 10G
- debian-12: 2G