### PR TITLE
Add web UI for connecting Kubernetes to Postgres

### DIFF
--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -73,7 +73,14 @@ class Clover
         authorize("Firewall:edit", fw.id)
 
         cidrs = [kc_ps.net4.to_s, kc_ps.net6.to_s]
-        ranges = [Sequel.pg_range(5432..5432), Sequel.pg_range(6432..6432)]
+        ranges = [Sequel.pg_range(5432...5433), Sequel.pg_range(6432...6433)]
+
+        fw_rules = fw.firewall_rules_dataset
+          .where(cidr: cidrs, port_range: ranges)
+          .select_map([:cidr, :port_range])
+          .to_set do |cidr, port_range|
+            [cidr.to_s, port_range.begin, port_range.end]
+          end
 
         DB.transaction do
           kc_ps.connect_subnet(pg_ps)
@@ -82,12 +89,16 @@ class Clover
           fwrs = DB.ignore_duplicate_queries do
             ranges.flat_map do |range|
               cidrs.map do |cidr|
-                fw.insert_firewall_rule(cidr, range)
+                unless fw_rules.include?([cidr, range.begin, range.end])
+                  fw.insert_firewall_rule(cidr, range)
+                end
               end
             end
           end
-          fwr = fwrs.shift
-          audit_log(fwr, "create", fwrs << fw)
+          fwrs.compact!
+          if (fwr = fwrs.shift)
+            audit_log(fwr, "create", fwrs << fw)
+          end
         end
 
         flash["notice"] = "Connecting to #{pg.name}. Firewall rules will be updated in a few seconds."

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -49,7 +49,42 @@ class Clover
 
       r.rename kc, perm: "KubernetesCluster:edit", serializer: Serializers::KubernetesCluster, template_prefix: "kubernetes-cluster"
 
-      r.show_object(kc, actions: %w[overview nodepools settings], perm: "KubernetesCluster:view", template: "kubernetes-cluster/show")
+      r.show_object(kc, actions: %w[overview nodepools networking settings], perm: "KubernetesCluster:view", template: "kubernetes-cluster/show")
+
+      r.post "connect-postgres", :ubid_uuid do |pg_id|
+        authorize("KubernetesCluster:view", kc)
+        handle_validation_failure("kubernetes-cluster/show") { @page = "networking" }
+
+        pg = @project.postgres_resources_dataset.first(id: pg_id)
+        check_found_object(pg)
+        authorize("Postgres:view", pg)
+
+        kc_ps = kc.private_subnet
+        pg_ps = pg.private_subnet
+
+        authorize("PrivateSubnet:connect", kc_ps.id)
+
+        pg_ps.firewalls.each do |fw|
+          authorize("Firewall:edit", fw.id)
+        end
+
+        cidr = kc_ps.net4.to_s
+
+        DB.transaction do
+          kc_ps.connect_subnet(pg_ps)
+          audit_log(kc_ps, "connect", pg_ps)
+
+          pg_ps.firewalls.each do |fw|
+            fwr1 = fw.insert_firewall_rule(cidr, Sequel.pg_range(5432..5432))
+            audit_log(fwr1, "create", fw)
+            fwr2 = fw.insert_firewall_rule(cidr, Sequel.pg_range(6432..6432))
+            audit_log(fwr2, "create", fw)
+          end
+        end
+
+        flash["notice"] = "Connecting to #{pg.name}. Firewall rules will be updated in a few seconds."
+        r.redirect kc, "/networking"
+      end
 
       r.get "kubeconfig" do
         authorize("KubernetesCluster:edit", kc)

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -51,11 +51,11 @@ class Clover
 
       r.show_object(kc, actions: %w[overview nodepools networking settings], perm: "KubernetesCluster:view", template: "kubernetes-cluster/show")
 
-      r.post "connect-postgres", :ubid_uuid do |pg_id|
+      r.post web?, "connect-postgres", :ubid_uuid, :ubid_uuid do |pg_id, fw_id|
         authorize("KubernetesCluster:view", kc)
         handle_validation_failure("kubernetes-cluster/show") { @page = "networking" }
 
-        pg = @project.postgres_resources_dataset.first(id: pg_id)
+        pg = @project.postgres_resources_dataset.first(location_id: kc.location_id, id: pg_id)
         check_found_object(pg)
         authorize("Postgres:view", pg)
 
@@ -63,23 +63,31 @@ class Clover
         pg_ps = pg.private_subnet
 
         authorize("PrivateSubnet:connect", kc_ps.id)
+        authorize("PrivateSubnet:connect", pg_ps.id)
 
-        pg_ps.firewalls.each do |fw|
-          authorize("Firewall:edit", fw.id)
+        fw = pg_ps.firewalls_dataset.first(id: fw_id)
+        if fw.private_subnets_dataset.count > 1
+          flash["error"] = "Unable to connect to #{pg.name} as the requested firewall is used by other subnets."
+          r.redirect kc, "/networking"
         end
+        authorize("Firewall:edit", fw.id)
 
-        cidr = kc_ps.net4.to_s
+        cidrs = [kc_ps.net4.to_s, kc_ps.net6.to_s]
+        ranges = [Sequel.pg_range(5432..5432), Sequel.pg_range(6432..6432)]
 
         DB.transaction do
           kc_ps.connect_subnet(pg_ps)
           audit_log(kc_ps, "connect", pg_ps)
 
-          pg_ps.firewalls.each do |fw|
-            fwr1 = fw.insert_firewall_rule(cidr, Sequel.pg_range(5432..5432))
-            audit_log(fwr1, "create", fw)
-            fwr2 = fw.insert_firewall_rule(cidr, Sequel.pg_range(6432..6432))
-            audit_log(fwr2, "create", fw)
+          fwrs = DB.ignore_duplicate_queries do
+            ranges.flat_map do |range|
+              cidrs.map do |cidr|
+                fw.insert_firewall_rule(cidr, range)
+              end
+            end
           end
+          fwr = fwrs.shift
+          audit_log(fwr, "create", fwrs << fw)
         end
 
         flash["notice"] = "Connecting to #{pg.name}. Firewall rules will be updated in a few seconds."

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -828,6 +828,19 @@ RSpec.describe Clover, "Kubernetes" do
         expect(page).to have_button("Connect")
       end
 
+      it "does not shows connect button when all of the subnet's firewalls are connected to other subnets" do
+        ps = PrivateSubnet.create(net6: "1::0", net4: "128.0.0.1", name: "mysubnet2", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
+        ps.add_firewall(pg.private_subnet.firewalls.first)
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_no_button("Connect")
+      end
+
+      it "does not shows connect button when the postgres subnet does not have a firewall" do
+        pg.private_subnet.remove_all_firewalls
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_no_button("Connect")
+      end
+
       it "does not show connect button when user lacks PrivateSubnet:connect" do
         pg
         AccessControlEntry.dataset.destroy
@@ -938,10 +951,21 @@ RSpec.describe Clover, "Kubernetes" do
 
           pg_fw = pg_subnet.firewalls.first
           pg_fw.reload
-          kc_cidr = @kc_connectable.private_subnet.net4.to_s
+          kc_cidr4 = @kc_connectable.private_subnet.net4.to_s
+          kc_cidr6 = @kc_connectable.private_subnet.net6.to_s
           rule_summaries = pg_fw.firewall_rules.map { |r| [r.cidr.to_s, r.display_port_range] }
-          expect(rule_summaries).to include([kc_cidr, "5432"])
-          expect(rule_summaries).to include([kc_cidr, "6432"])
+          expect(rule_summaries).to include([kc_cidr4, "5432"])
+          expect(rule_summaries).to include([kc_cidr4, "6432"])
+          expect(rule_summaries).to include([kc_cidr6, "5432"])
+          expect(rule_summaries).to include([kc_cidr6, "6432"])
+        end
+
+        it "shows error if firewall used is associated with more than one subnet" do
+          visit "#{project.path}#{@kc_connectable.path}/networking"
+          ps = PrivateSubnet.create(net6: "1::0", net4: "128.0.0.1", name: "mysubnet2", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
+          ps.add_firewall(pg.private_subnet.firewalls.first)
+          click_button "Connect"
+          expect(page).to have_flash_error("Unable to connect to #{pg.name} as the requested firewall is used by other subnets.")
         end
 
         it "returns forbidden when user lacks KubernetesCluster:view" do

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -748,22 +748,23 @@ RSpec.describe Clover, "Kubernetes" do
         resource.reload
       }
 
-      it "can navigate to networking page via tab" do
+      before do
         kc
+      end
+
+      it "can navigate to networking page via tab" do
         visit "#{project.path}#{kc.path}"
         within("#kubernetes-cluster-submenu") { click_link "Networking" }
         expect(page.title).to eq("Ubicloud - #{kc.name}")
         expect(page).to have_content kc_ps.name
       end
 
-      it "shows private subnet with networking link when user has PrivateSubnet:edit" do
-        kc
+      it "shows private subnet with networking link when user has PrivateSubnet:view" do
         visit "#{project.path}#{kc.path}/networking"
         expect(page).to have_link(kc_ps.name, href: "#{project.path}#{kc_ps.path}/networking")
       end
 
-      it "shows private subnet without link when user lacks PrivateSubnet:edit" do
-        kc
+      it "shows private subnet without link when user lacks PrivateSubnet:view" do
         AccessControlEntry.dataset.destroy
         AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
 
@@ -772,8 +773,7 @@ RSpec.describe Clover, "Kubernetes" do
         expect(page).to have_no_link(kc_ps.name)
       end
 
-      it "shows attached firewall with networking link when user has Firewall:edit" do
-        kc
+      it "shows attached firewall with networking link when user has Firewall:view" do
         fw = Firewall.create(name: "kc-fw", description: "kc firewall", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
         fw.associate_with_private_subnet(kc_ps)
 
@@ -781,14 +781,12 @@ RSpec.describe Clover, "Kubernetes" do
         expect(page).to have_link(fw.name, href: "#{project.path}#{fw.path}/networking")
       end
 
-      it "shows attached firewall without link when user lacks Firewall:edit" do
-        kc
+      it "shows attached firewall without link when user lacks Firewall:view" do
         fw = Firewall.create(name: "kc-fw", description: "kc firewall", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
         fw.associate_with_private_subnet(kc_ps)
 
         AccessControlEntry.dataset.destroy
         AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
-        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:view"])
 
         visit "#{project.path}#{kc.path}/networking"
         expect(page).to have_content fw.name
@@ -802,14 +800,12 @@ RSpec.describe Clover, "Kubernetes" do
       end
 
       it "does not show postgres section when no postgres databases exist" do
-        kc
         visit "#{project.path}#{kc.path}/networking"
         expect(page).to have_no_content "PostgreSQL Databases"
       end
 
       it "shows postgres databases when user has Postgres:view" do
         pg
-        kc
         visit "#{project.path}#{kc.path}/networking"
         expect(page).to have_content "PostgreSQL Databases"
         expect(page).to have_content pg.name
@@ -818,7 +814,6 @@ RSpec.describe Clover, "Kubernetes" do
 
       it "does not show postgres databases when user lacks Postgres:view" do
         pg
-        kc
         AccessControlEntry.dataset.destroy
         AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
 
@@ -827,20 +822,18 @@ RSpec.describe Clover, "Kubernetes" do
         expect(page).to have_no_content pg.name
       end
 
-      it "shows connect button when subnets are not connected and user has all required permissions" do
+      it "shows connect button when subnets are not connected and user has admin permissions" do
         pg
-        kc
         visit "#{project.path}#{kc.path}/networking"
         expect(page).to have_button("Connect")
       end
 
       it "does not show connect button when user lacks PrivateSubnet:connect" do
         pg
-        kc
         AccessControlEntry.dataset.destroy
         AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
         AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
-        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:edit"])
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:view"])
 
         visit "#{project.path}#{kc.path}/networking"
         expect(page).to have_content pg.name
@@ -849,7 +842,6 @@ RSpec.describe Clover, "Kubernetes" do
 
       it "does not show connect button when user lacks Firewall:edit on postgres subnet firewalls" do
         pg
-        kc
         AccessControlEntry.dataset.destroy
         AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
         AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
@@ -858,6 +850,19 @@ RSpec.describe Clover, "Kubernetes" do
         visit "#{project.path}#{kc.path}/networking"
         expect(page).to have_content pg.name
         expect(page).to have_no_button("Connect")
+      end
+
+      it "shows connect button when user has all necessary permissions" do
+        pg
+        AccessControlEntry.dataset.destroy
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:connect"])
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:edit"])
+
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_content pg.name
+        expect(page).to have_button("Connect")
       end
 
       context "when subnets are already connected" do
@@ -881,11 +886,11 @@ RSpec.describe Clover, "Kubernetes" do
           expect(page).to have_link(pg_fw.name, href: "#{project.path}#{pg_fw.path}/networking")
         end
 
-        it "shows Connected status without links when user lacks PrivateSubnet:edit on postgres subnet" do
+        it "shows Connected status without links when user lacks PrivateSubnet:view on postgres subnet" do
           AccessControlEntry.dataset.destroy
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
-          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:edit"])
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:view"])
 
           visit "#{project.path}#{@kc_connected.path}/networking"
           expect(page).to have_content pg.name
@@ -893,11 +898,11 @@ RSpec.describe Clover, "Kubernetes" do
           expect(page).to have_no_link("Connected")
         end
 
-        it "shows Connected status without firewall links when user lacks Firewall:edit on postgres subnet firewalls" do
+        it "shows Connected status without firewall links when user lacks Firewall:view on postgres subnet firewalls" do
           AccessControlEntry.dataset.destroy
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
-          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:edit"])
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:view"])
 
           visit "#{project.path}#{@kc_connected.path}/networking"
           expect(page).to have_content pg.name
@@ -941,43 +946,43 @@ RSpec.describe Clover, "Kubernetes" do
 
         it "returns forbidden when user lacks KubernetesCluster:view" do
           visit "#{project.path}#{@kc_connectable.path}/networking"
-          _csrf = find("#form-connect-pg-#{pg.ubid} input[name='_csrf']", visible: false).value
           AccessControlEntry.dataset.destroy
-          page.driver.post "#{project.path}#{@kc_connectable.path}/connect-postgres/#{pg.ubid}", {_csrf:}
+          click_button "Connect"
           expect(page.status_code).to eq(403)
+          expect(page).to have_no_button("Connect")
         end
 
         it "returns forbidden when user lacks Postgres:view" do
           visit "#{project.path}#{@kc_connectable.path}/networking"
-          _csrf = find("#form-connect-pg-#{pg.ubid} input[name='_csrf']", visible: false).value
           AccessControlEntry.dataset.destroy
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:connect"])
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:edit"])
-          page.driver.post "#{project.path}#{@kc_connectable.path}/connect-postgres/#{pg.ubid}", {_csrf:}
+          click_button "Connect"
           expect(page.status_code).to eq(403)
+          expect(page).to have_no_button("Connect")
         end
 
         it "returns forbidden when user lacks PrivateSubnet:connect" do
           visit "#{project.path}#{@kc_connectable.path}/networking"
-          _csrf = find("#form-connect-pg-#{pg.ubid} input[name='_csrf']", visible: false).value
           AccessControlEntry.dataset.destroy
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:edit"])
-          page.driver.post "#{project.path}#{@kc_connectable.path}/connect-postgres/#{pg.ubid}", {_csrf:}
+          click_button "Connect"
           expect(page.status_code).to eq(403)
+          expect(page).to have_no_button("Connect")
         end
 
         it "returns forbidden when user lacks Firewall:edit on postgres subnet firewalls" do
           visit "#{project.path}#{@kc_connectable.path}/networking"
-          _csrf = find("#form-connect-pg-#{pg.ubid} input[name='_csrf']", visible: false).value
           AccessControlEntry.dataset.destroy
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
           AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:connect"])
-          page.driver.post "#{project.path}#{@kc_connectable.path}/connect-postgres/#{pg.ubid}", {_csrf:}
+          click_button "Connect"
           expect(page.status_code).to eq(403)
+          expect(page).to have_no_button("Connect")
         end
       end
     end

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -743,7 +743,7 @@ RSpec.describe Clover, "Kubernetes" do
       }
 
       let(:pg) {
-        resource = create_postgres_resource(project: project, location_id: Location::HETZNER_FSN1_ID)
+        resource = create_postgres_resource(project:, location_id: Location::HETZNER_FSN1_ID)
         resource.update(private_subnet_id: pg_subnet.id)
         resource.reload
       }
@@ -926,7 +926,7 @@ RSpec.describe Clover, "Kubernetes" do
           click_button "Connect"
 
           expect(page).to have_flash_notice("Connecting to #{pg.name}. Firewall rules will be updated in a few seconds.")
-          expect(page.current_path).to eq("#{project.path}#{@kc_connectable.path}/networking")
+          expect(page).to have_current_path("#{project.path}#{@kc_connectable.path}/networking", ignore_query: true)
 
           @kc_connectable.private_subnet.reload
           expect(@kc_connectable.private_subnet.connected_subnets.map(&:id)).to include pg_subnet.id

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -735,6 +735,253 @@ RSpec.describe Clover, "Kubernetes" do
       end
     end
 
+    describe "networking" do
+      let(:kc_ps) { kc.private_subnet }
+
+      let(:pg_subnet) {
+        Prog::Vnet::SubnetNexus.assemble(project.id, name: "pg-subnet", location_id: Location::HETZNER_FSN1_ID).subject
+      }
+
+      let(:pg) {
+        resource = create_postgres_resource(project: project, location_id: Location::HETZNER_FSN1_ID)
+        resource.update(private_subnet_id: pg_subnet.id)
+        resource.reload
+      }
+
+      it "can navigate to networking page via tab" do
+        kc
+        visit "#{project.path}#{kc.path}"
+        within("#kubernetes-cluster-submenu") { click_link "Networking" }
+        expect(page.title).to eq("Ubicloud - #{kc.name}")
+        expect(page).to have_content kc_ps.name
+      end
+
+      it "shows private subnet with networking link when user has PrivateSubnet:edit" do
+        kc
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_link(kc_ps.name, href: "#{project.path}#{kc_ps.path}/networking")
+      end
+
+      it "shows private subnet without link when user lacks PrivateSubnet:edit" do
+        kc
+        AccessControlEntry.dataset.destroy
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
+
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_content kc_ps.name
+        expect(page).to have_no_link(kc_ps.name)
+      end
+
+      it "shows attached firewall with networking link when user has Firewall:edit" do
+        kc
+        fw = Firewall.create(name: "kc-fw", description: "kc firewall", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
+        fw.associate_with_private_subnet(kc_ps)
+
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_link(fw.name, href: "#{project.path}#{fw.path}/networking")
+      end
+
+      it "shows attached firewall without link when user lacks Firewall:edit" do
+        kc
+        fw = Firewall.create(name: "kc-fw", description: "kc firewall", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
+        fw.associate_with_private_subnet(kc_ps)
+
+        AccessControlEntry.dataset.destroy
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:view"])
+
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_content fw.name
+        expect(page).to have_no_link(fw.name)
+      end
+
+      it "shows no firewall section content when no firewalls attached" do
+        kc.private_subnet.remove_all_firewalls
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_content "No firewall attached"
+      end
+
+      it "does not show postgres section when no postgres databases exist" do
+        kc
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_no_content "PostgreSQL Databases"
+      end
+
+      it "shows postgres databases when user has Postgres:view" do
+        pg
+        kc
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_content "PostgreSQL Databases"
+        expect(page).to have_content pg.name
+        expect(page).to have_content "Not connected"
+      end
+
+      it "does not show postgres databases when user lacks Postgres:view" do
+        pg
+        kc
+        AccessControlEntry.dataset.destroy
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
+
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_no_content "PostgreSQL Databases"
+        expect(page).to have_no_content pg.name
+      end
+
+      it "shows connect button when subnets are not connected and user has all required permissions" do
+        pg
+        kc
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_button("Connect")
+      end
+
+      it "does not show connect button when user lacks PrivateSubnet:connect" do
+        pg
+        kc
+        AccessControlEntry.dataset.destroy
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:edit"])
+
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_content pg.name
+        expect(page).to have_no_button("Connect")
+      end
+
+      it "does not show connect button when user lacks Firewall:edit on postgres subnet firewalls" do
+        pg
+        kc
+        AccessControlEntry.dataset.destroy
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:connect"])
+
+        visit "#{project.path}#{kc.path}/networking"
+        expect(page).to have_content pg.name
+        expect(page).to have_no_button("Connect")
+      end
+
+      context "when subnets are already connected" do
+        before do
+          @kc_connected = Prog::Kubernetes::KubernetesClusterNexus.assemble(
+            name: "kc-connected",
+            version: Option.kubernetes_versions.first,
+            project_id: project.id,
+            location_id: Location::HETZNER_FSN1_ID,
+          ).subject
+          pg
+          @kc_connected.private_subnet.connect_subnet(pg_subnet)
+        end
+
+        it "shows Connected status with links to postgres subnet and firewalls when user has all permissions" do
+          visit "#{project.path}#{@kc_connected.path}/networking"
+          expect(page).to have_content pg.name
+          expect(page).to have_link("Connected", href: "#{project.path}#{pg_subnet.path}/networking")
+
+          pg_fw = pg_subnet.firewalls.first
+          expect(page).to have_link(pg_fw.name, href: "#{project.path}#{pg_fw.path}/networking")
+        end
+
+        it "shows Connected status without links when user lacks PrivateSubnet:edit on postgres subnet" do
+          AccessControlEntry.dataset.destroy
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:edit"])
+
+          visit "#{project.path}#{@kc_connected.path}/networking"
+          expect(page).to have_content pg.name
+          expect(page).to have_content "Connected"
+          expect(page).to have_no_link("Connected")
+        end
+
+        it "shows Connected status without firewall links when user lacks Firewall:edit on postgres subnet firewalls" do
+          AccessControlEntry.dataset.destroy
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:edit"])
+
+          visit "#{project.path}#{@kc_connected.path}/networking"
+          expect(page).to have_content pg.name
+          expect(page).to have_link("Connected", href: "#{project.path}#{pg_subnet.path}/networking")
+          pg_fw = pg_subnet.firewalls.first
+          expect(page).to have_no_link(pg_fw.name)
+        end
+      end
+
+      context "when connecting postgres subnet" do
+        before do
+          @kc_connectable = Prog::Kubernetes::KubernetesClusterNexus.assemble(
+            name: "kc-connectable",
+            version: Option.kubernetes_versions.first,
+            project_id: project.id,
+            location_id: Location::HETZNER_FSN1_ID,
+          ).subject
+          pg
+        end
+
+        it "connects the private subnets and adds firewall rules when button is clicked" do
+          visit "#{project.path}#{@kc_connectable.path}/networking"
+          expect(page).to have_content pg.name
+          expect(page).to have_button("Connect")
+
+          click_button "Connect"
+
+          expect(page).to have_flash_notice("Connecting to #{pg.name}. Firewall rules will be updated in a few seconds.")
+          expect(page.current_path).to eq("#{project.path}#{@kc_connectable.path}/networking")
+
+          @kc_connectable.private_subnet.reload
+          expect(@kc_connectable.private_subnet.connected_subnets.map(&:id)).to include pg_subnet.id
+
+          pg_fw = pg_subnet.firewalls.first
+          pg_fw.reload
+          kc_cidr = @kc_connectable.private_subnet.net4.to_s
+          rule_summaries = pg_fw.firewall_rules.map { |r| [r.cidr.to_s, r.display_port_range] }
+          expect(rule_summaries).to include([kc_cidr, "5432"])
+          expect(rule_summaries).to include([kc_cidr, "6432"])
+        end
+
+        it "returns forbidden when user lacks KubernetesCluster:view" do
+          visit "#{project.path}#{@kc_connectable.path}/networking"
+          _csrf = find("#form-connect-pg-#{pg.ubid} input[name='_csrf']", visible: false).value
+          AccessControlEntry.dataset.destroy
+          page.driver.post "#{project.path}#{@kc_connectable.path}/connect-postgres/#{pg.ubid}", {_csrf:}
+          expect(page.status_code).to eq(403)
+        end
+
+        it "returns forbidden when user lacks Postgres:view" do
+          visit "#{project.path}#{@kc_connectable.path}/networking"
+          _csrf = find("#form-connect-pg-#{pg.ubid} input[name='_csrf']", visible: false).value
+          AccessControlEntry.dataset.destroy
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:connect"])
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:edit"])
+          page.driver.post "#{project.path}#{@kc_connectable.path}/connect-postgres/#{pg.ubid}", {_csrf:}
+          expect(page.status_code).to eq(403)
+        end
+
+        it "returns forbidden when user lacks PrivateSubnet:connect" do
+          visit "#{project.path}#{@kc_connectable.path}/networking"
+          _csrf = find("#form-connect-pg-#{pg.ubid} input[name='_csrf']", visible: false).value
+          AccessControlEntry.dataset.destroy
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Firewall:edit"])
+          page.driver.post "#{project.path}#{@kc_connectable.path}/connect-postgres/#{pg.ubid}", {_csrf:}
+          expect(page.status_code).to eq(403)
+        end
+
+        it "returns forbidden when user lacks Firewall:edit on postgres subnet firewalls" do
+          visit "#{project.path}#{@kc_connectable.path}/networking"
+          _csrf = find("#form-connect-pg-#{pg.ubid} input[name='_csrf']", visible: false).value
+          AccessControlEntry.dataset.destroy
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
+          AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:connect"])
+          page.driver.post "#{project.path}#{@kc_connectable.path}/connect-postgres/#{pg.ubid}", {_csrf:}
+          expect(page.status_code).to eq(403)
+        end
+      end
+    end
+
     describe "delete" do
       it "can delete kubernetes cluster" do
         visit "#{project.path}#{kc.path}"

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -941,10 +941,12 @@ RSpec.describe Clover, "Kubernetes" do
           expect(page).to have_content pg.name
           expect(page).to have_button("Connect")
 
+          expect(DB[:audit_log].count).to eq 0
           click_button "Connect"
 
           expect(page).to have_flash_notice("Connecting to #{pg.name}. Firewall rules will be updated in a few seconds.")
           expect(page).to have_current_path("#{project.path}#{@kc_connectable.path}/networking", ignore_query: true)
+          expect(DB[:audit_log].count).to eq 2
 
           @kc_connectable.private_subnet.reload
           expect(@kc_connectable.private_subnet.connected_subnets.map(&:id)).to include pg_subnet.id
@@ -958,6 +960,16 @@ RSpec.describe Clover, "Kubernetes" do
           expect(rule_summaries).to include([kc_cidr4, "6432"])
           expect(rule_summaries).to include([kc_cidr6, "5432"])
           expect(rule_summaries).to include([kc_cidr6, "6432"])
+
+          # Check that connection works even if some firewall rules already exist
+          path = page.current_path
+          click_link "Connected"
+          click_button "Disconnect"
+          expect(DB[:audit_log].count).to eq 3
+          visit path
+          click_button "Connect"
+          expect(page).to have_flash_notice("Connecting to #{pg.name}. Firewall rules will be updated in a few seconds.")
+          expect(DB[:audit_log].count).to eq 4
         end
 
         it "shows error if firewall used is associated with more than one subnet" do

--- a/views/kubernetes-cluster/networking.erb
+++ b/views/kubernetes-cluster/networking.erb
@@ -10,7 +10,7 @@ allow_ps_connect = has_permission?("PrivateSubnet:connect", kc_ps)
 pg_ds = dataset_authorize(project.postgres_resources_dataset.where(location_id:), "Postgres:view")
 pg_ps_ds = project.private_subnets_dataset.where(id: pg_ds.select(:private_subnet_id))
 
-pg_resources = pg_ds.order(:name).eager(private_subnet: :firewalls).all
+pg_resources = pg_ds.order(:name).eager(private_subnet: {firewalls: :private_subnets}).all
 
 kc_ps_connected_subnet_ids = kc_ps.connected_subnets.to_set(&:id)
 
@@ -108,8 +108,8 @@ pg_ps_fw_edit_ids = dataset_authorize(pg_ps_fw_ds, "Firewall:edit").select_set(:
                       <% end %>
                     </div>
                   <% end %>
-                <% elsif allow_ps_connect && pg_ps_connect_ids.include?(pg_ps.id) && pg_ps.firewalls.to_set(&:id) <= pg_ps_fw_edit_ids %>
-                  <% form(action: "#{kc_path}/connect-postgres/#{pg.ubid}", method: :post, id: "form-connect-pg-#{pg.ubid}") do %>
+                <% elsif allow_ps_connect && pg_ps_connect_ids.include?(pg_ps.id) && (fw = pg_ps.firewalls.find { pg_ps_fw_edit_ids.include?(it.id) && it.private_subnets.length == 1 }) %>
+                  <% form(action: "#{kc_path}/connect-postgres/#{pg.ubid}/#{fw.ubid}", method: :post, id: "form-connect-pg-#{pg.ubid}") do %>
                     <%== part("components/form/submit_button", text: "Connect") %>
                   <% end %>
                 <% end %>

--- a/views/kubernetes-cluster/networking.erb
+++ b/views/kubernetes-cluster/networking.erb
@@ -1,0 +1,121 @@
+<% kc_ps = @kc.private_subnet
+kc_path = path(@kc)
+
+kc_ps.firewalls(eager: :location)
+kc_ps_firewall_ids = kc_ps.firewalls.map(&:id)
+
+pg_resources = dataset_authorize(@project.postgres_resources_dataset, "Postgres:view").all
+kc_ps_connected_subnet_ids = kc_ps.connected_subnets.map(&:id).to_set
+
+pg_data = pg_resources.map do |pg|
+  pg_ps = pg.private_subnet
+  pg_ps.firewalls(eager: :location)
+  [pg, pg_ps]
+end
+
+pg_ps_ids = pg_data.map { |_, ps| ps.id }
+all_pg_fw_ids = pg_data.flat_map { |_, ps| ps.firewalls.map(&:id) }
+
+kc_ps_edit_ids, kc_fw_edit_ids, pg_ps_edit_ids, kc_ps_connect_ids, pg_fw_edit_ids =
+  DB.ignore_duplicate_queries do
+    [
+      dataset_authorize(@project.private_subnets_dataset.where(id: kc_ps.id), "PrivateSubnet:edit").select_set(:id),
+      dataset_authorize(@project.firewalls_dataset.where(id: kc_ps_firewall_ids), "Firewall:edit").select_set(:id),
+      dataset_authorize(@project.private_subnets_dataset.where(id: pg_ps_ids), "PrivateSubnet:edit").select_set(:id),
+      dataset_authorize(@project.private_subnets_dataset.where(id: kc_ps.id), "PrivateSubnet:connect").select_set(:id),
+      dataset_authorize(@project.firewalls_dataset.where(id: all_pg_fw_ids), "Firewall:edit").select_set(:id),
+    ]
+  end %>
+
+<div class="p-6 grid grid-cols-1 gap-6">
+  <%== part(
+    "components/table_card",
+    title: "Private Subnet",
+    headers: %w[Name],
+    empty_state: "No private subnet",
+    rows: [
+      [
+        [
+          kc_ps_edit_ids.include?(kc_ps.id) ? [kc_ps.name, {link: "#{path(kc_ps)}/networking"}] : kc_ps.name
+        ],
+        {id: "kc-ps-#{kc_ps.ubid}"}
+      ]
+    ]
+  ) %>
+
+  <%== part(
+    "components/table_card",
+    title: "Attached Firewalls",
+    headers: %w[Name Description],
+    empty_state: "No firewall attached",
+    rows:
+      kc_ps.firewalls.map do |fw|
+        [
+          [
+            kc_fw_edit_ids.include?(fw.id) ? [fw.name, {link: "#{path(fw)}/networking"}] : fw.name,
+            fw.description
+          ],
+          {id: "fw-#{fw.ubid}"}
+        ]
+      end
+  ) %>
+
+  <% unless pg_resources.empty? %>
+    <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
+      <div class="min-w-0 flex-1">
+        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+          PostgreSQL Databases
+        </h3>
+      </div>
+    </div>
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+      <table class="min-w-full divide-y divide-gray-300">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Status</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <% pg_data.each do |pg, pg_ps| %>
+            <%
+              connected = kc_ps_connected_subnet_ids.include?(pg_ps.id)
+              pg_ps_fw_ids = pg_ps.firewalls.map(&:id)
+              can_view_pg_ps = pg_ps_edit_ids.include?(pg_ps.id)
+              can_view_pg_fws = pg_ps_fw_ids.all? { |id| pg_fw_edit_ids.include?(id) }
+              can_connect = kc_ps_connect_ids.include?(kc_ps.id) && (pg_ps_fw_ids.empty? || pg_ps_fw_ids.all? { |id| pg_fw_edit_ids.include?(id) })
+            %>
+            <tr id="pg-row-<%= pg.ubid %>">
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                <%= pg.name %>
+              </td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                <% if connected && can_view_pg_ps %>
+                  <a href="<%= "#{path(pg_ps)}/networking" %>" class="text-orange-600 hover:text-orange-700">Connected</a>
+                <% elsif connected %>
+                  Connected
+                <% else %>
+                  Not connected
+                <% end %>
+              </td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-right">
+                <% if connected && can_view_pg_ps && can_view_pg_fws && !pg_ps_fw_ids.empty? %>
+                  <div class="flex gap-2 justify-end">
+                    <% pg_ps.firewalls.each do |fw| %>
+                      <%== part("components/button", text: fw.name, link: "#{path(fw)}/networking") %>
+                    <% end %>
+                  </div>
+                <% elsif !connected && can_connect %>
+                  <% form(action: "#{kc_path}/connect-postgres/#{pg.ubid}", method: :post, id: "form-connect-pg-#{pg.ubid}") do %>
+                    <%== part("components/form/submit_button", text: "Connect") %>
+                  <% end %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/views/kubernetes-cluster/networking.erb
+++ b/views/kubernetes-cluster/networking.erb
@@ -1,31 +1,29 @@
-<% kc_ps = @kc.private_subnet
-kc_path = path(@kc)
+<% kc = @kc
+project = @project
+location_id = kc.location_id
 
-kc_ps.firewalls(eager: :location)
-kc_ps_firewall_ids = kc_ps.firewalls.map(&:id)
+kc_ps = kc.private_subnet
+kc_path = path(kc)
 
-pg_resources = dataset_authorize(@project.postgres_resources_dataset, "Postgres:view").all
-kc_ps_connected_subnet_ids = kc_ps.connected_subnets.map(&:id).to_set
+allow_ps_connect = has_permission?("PrivateSubnet:connect", kc_ps)
 
-pg_data = pg_resources.map do |pg|
-  pg_ps = pg.private_subnet
-  pg_ps.firewalls(eager: :location)
-  [pg, pg_ps]
-end
+pg_ds = dataset_authorize(project.postgres_resources_dataset.where(location_id:), "Postgres:view")
+pg_ps_ds = project.private_subnets_dataset.where(id: pg_ds.select(:private_subnet_id))
 
-pg_ps_ids = pg_data.map { |_, ps| ps.id }
-all_pg_fw_ids = pg_data.flat_map { |_, ps| ps.firewalls.map(&:id) }
+pg_resources = pg_ds.order(:name).eager(private_subnet: :firewalls).all
 
-kc_ps_edit_ids, kc_fw_edit_ids, pg_ps_edit_ids, kc_ps_connect_ids, pg_fw_edit_ids =
-  DB.ignore_duplicate_queries do
-    [
-      dataset_authorize(@project.private_subnets_dataset.where(id: kc_ps.id), "PrivateSubnet:edit").select_set(:id),
-      dataset_authorize(@project.firewalls_dataset.where(id: kc_ps_firewall_ids), "Firewall:edit").select_set(:id),
-      dataset_authorize(@project.private_subnets_dataset.where(id: pg_ps_ids), "PrivateSubnet:edit").select_set(:id),
-      dataset_authorize(@project.private_subnets_dataset.where(id: kc_ps.id), "PrivateSubnet:connect").select_set(:id),
-      dataset_authorize(@project.firewalls_dataset.where(id: all_pg_fw_ids), "Firewall:edit").select_set(:id),
-    ]
-  end %>
+kc_ps_connected_subnet_ids = kc_ps.connected_subnets.to_set(&:id)
+
+kc_fw_view_ids = dataset_authorize(kc_ps.firewalls_dataset, "Firewall:view").select_set(:id)
+pg_ps_view_ids = dataset_authorize(pg_ps_ds, "PrivateSubnet:view").select_set(:id)
+pg_ps_connect_ids = dataset_authorize(pg_ps_ds, "PrivateSubnet:connect").select_set(:id)
+
+pg_ps_fw_ds = project.firewalls_dataset
+  .where(id: DB[:firewalls_private_subnets].where(private_subnet_id: pg_ps_ds.select(:id))
+  .select(:firewall_id))
+
+pg_ps_fw_view_ids = dataset_authorize(pg_ps_fw_ds, "Firewall:view").select_set(:id)
+pg_ps_fw_edit_ids = dataset_authorize(pg_ps_fw_ds, "Firewall:edit").select_set(:id) %>
 
 <div class="p-6 grid grid-cols-1 gap-6">
   <%== part(
@@ -36,7 +34,7 @@ kc_ps_edit_ids, kc_fw_edit_ids, pg_ps_edit_ids, kc_ps_connect_ids, pg_fw_edit_id
     rows: [
       [
         [
-          kc_ps_edit_ids.include?(kc_ps.id) ? [kc_ps.name, {link: "#{path(kc_ps)}/networking"}] : kc_ps.name
+          has_permission?("PrivateSubnet:view", kc_ps) ? [kc_ps.name, {link: "#{path(kc_ps)}/networking"}] : kc_ps.name
         ],
         {id: "kc-ps-#{kc_ps.ubid}"}
       ]
@@ -49,10 +47,10 @@ kc_ps_edit_ids, kc_fw_edit_ids, pg_ps_edit_ids, kc_ps_connect_ids, pg_fw_edit_id
     headers: %w[Name Description],
     empty_state: "No firewall attached",
     rows:
-      kc_ps.firewalls.map do |fw|
+      kc_ps.firewalls(eager: :location).map do |fw|
         [
           [
-            kc_fw_edit_ids.include?(fw.id) ? [fw.name, {link: "#{path(fw)}/networking"}] : fw.name,
+            kc_fw_view_ids.include?(fw.id) ? [fw.name, {link: "#{path(fw)}/networking"}] : fw.name,
             fw.description
           ],
           {id: "fw-#{fw.ubid}"}
@@ -78,35 +76,39 @@ kc_ps_edit_ids, kc_fw_edit_ids, pg_ps_edit_ids, kc_ps_connect_ids, pg_fw_edit_id
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
-          <% pg_data.each do |pg, pg_ps| %>
+          <% pg_resources.each do |pg| %>
             <%
+              pg_ps = pg.private_subnet
               connected = kc_ps_connected_subnet_ids.include?(pg_ps.id)
-              pg_ps_fw_ids = pg_ps.firewalls.map(&:id)
-              can_view_pg_ps = pg_ps_edit_ids.include?(pg_ps.id)
-              can_view_pg_fws = pg_ps_fw_ids.all? { |id| pg_fw_edit_ids.include?(id) }
-              can_connect = kc_ps_connect_ids.include?(kc_ps.id) && (pg_ps_fw_ids.empty? || pg_ps_fw_ids.all? { |id| pg_fw_edit_ids.include?(id) })
             %>
             <tr id="pg-row-<%= pg.ubid %>">
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
                 <%= pg.name %>
               </td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                <% if connected && can_view_pg_ps %>
-                  <a href="<%= "#{path(pg_ps)}/networking" %>" class="text-orange-600 hover:text-orange-700">Connected</a>
-                <% elsif connected %>
-                  Connected
+                <% if connected %>
+                  <% if pg_ps_view_ids.include?(pg_ps.id) %>
+                    <a href="<%= "#{path(pg_ps)}/networking" %>" class="text-orange-600 hover:text-orange-700">Connected</a>
+                  <% else %>
+                    Connected
+                  <% end %>
                 <% else %>
                   Not connected
                 <% end %>
               </td>
               <td class="whitespace-nowrap px-3 py-4 text-sm text-right">
-                <% if connected && can_view_pg_ps && can_view_pg_fws && !pg_ps_fw_ids.empty? %>
-                  <div class="flex gap-2 justify-end">
-                    <% pg_ps.firewalls.each do |fw| %>
-                      <%== part("components/button", text: fw.name, link: "#{path(fw)}/networking") %>
-                    <% end %>
-                  </div>
-                <% elsif !connected && can_connect %>
+                <% if connected %>
+                  <% pg_ps.firewalls.each do |fw| %>
+                    <div class="flex gap-2 justify-end">
+                      Firewall:
+                      <% if pg_ps_fw_view_ids.include?(fw.id)  %>
+                        <a href="<%= "#{path(fw)}/networking" %>" class="text-orange-600 hover:text-orange-700"><%= fw.name %></a>
+                      <% else %>
+                        <%= fw.name %>
+                      <% end %>
+                    </div>
+                  <% end %>
+                <% elsif allow_ps_connect && pg_ps_connect_ids.include?(pg_ps.id) && pg_ps.firewalls.to_set(&:id) <= pg_ps_fw_edit_ids %>
                   <% form(action: "#{kc_path}/connect-postgres/#{pg.ubid}", method: :post, id: "form-connect-pg-#{pg.ubid}") do %>
                     <%== part("components/form/submit_button", text: "Connect") %>
                   <% end %>

--- a/views/kubernetes-cluster/networking.erb
+++ b/views/kubernetes-cluster/networking.erb
@@ -76,6 +76,7 @@ pg_ps_fw_edit_ids = dataset_authorize(pg_ps_fw_ds, "Firewall:edit").select_set(:
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
+          <% show_connect_info = false %>
           <% pg_resources.each do |pg| %>
             <%
               pg_ps = pg.private_subnet
@@ -109,6 +110,7 @@ pg_ps_fw_edit_ids = dataset_authorize(pg_ps_fw_ds, "Firewall:edit").select_set(:
                     </div>
                   <% end %>
                 <% elsif allow_ps_connect && pg_ps_connect_ids.include?(pg_ps.id) && (fw = pg_ps.firewalls.find { pg_ps_fw_edit_ids.include?(it.id) && it.private_subnets.length == 1 }) %>
+                  <% show_connect_info = true %>
                   <% form(action: "#{kc_path}/connect-postgres/#{pg.ubid}/#{fw.ubid}", method: :post, id: "form-connect-pg-#{pg.ubid}") do %>
                     <%== part("components/form/submit_button", text: "Connect") %>
                   <% end %>
@@ -118,6 +120,19 @@ pg_ps_fw_edit_ids = dataset_authorize(pg_ps_fw_ds, "Firewall:edit").select_set(:
           <% end %>
         </tbody>
       </table>
+      <% if show_connect_info %>
+        <div class="px-4 py-5 sm:p-6">
+          <p class="text-sm text-gray-700">
+            Connecting this Kubernetes cluster to a PostgreSQL database will set
+            up a connection between the private subnets for the cluster and
+            database, and add firewall rules so the PostgreSQL database will
+            accept connections from the private IP addresses for the cluster.
+            For this to work correctly, you need to have the cluster
+            <a class="text-orange-600 hover:text-orange-700" href="https://www.ubicloud.com/docs/managed-postgresql/connection#private-dns">connect to the PostgreSQL database using the private DNS name</a>.
+          </p>
+        </div>
+      <% end %>
+
     </div>
   <% end %>
 </div>

--- a/views/kubernetes-cluster/show.erb
+++ b/views/kubernetes-cluster/show.erb
@@ -12,7 +12,3 @@
   breadcrumb_label: "Kubernetes Clusters",
   right_header: part("components/kubernetes_state_label", state: @kc.display_state, extra_class: "text-md")
 ) %>
-
-<div class="grid gap-6">
-  <!-- Danger Zone -->
-</div>

--- a/views/kubernetes-cluster/show.erb
+++ b/views/kubernetes-cluster/show.erb
@@ -5,6 +5,7 @@
   tabs: [
     ["Overview", "overview", "hero-squares-plus"],
     ["Nodepools", "nodepools", "hero-rectangle-group"],
+    ["Networking", "networking", "hero-globe-alt"],
     ["Settings", "settings", "hero-cog-8-tooth"]
   ],
   type: "kubernetes-cluster",


### PR DESCRIPTION
This handles the subnet connection and sets up the appropriate firewall rules, making things easier for users that use both kubernetes and postgres.

<img width="163" height="234" alt="localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_location_eu-central-h1_kubernetes-cluster_t_networking (1)" src="https://github.com/user-attachments/assets/14d58e14-a61b-48a9-82b7-bf5beabe8a97" />
<img width="163" height="234" alt="localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_location_eu-central-h1_kubernetes-cluster_t_networking" src="https://github.com/user-attachments/assets/829964aa-9b34-4c7c-aec2-f043e525a1ff" />

Initial work done by Claude, but I rewrote most of the logic in order to fix numerous problems and corner cases. See commit messages for details.