### PR TITLE
Do not show page ubid on the admin homepage

### DIFF
--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -757,16 +757,16 @@ RSpec.describe CloverAdmin do
     page.refresh
     expect(page).to have_content "Active Pages"
     expect(page_data).to eq [
-      ["", page1.ubid, "some problem", "{\"related_resources\" => []}"],
+      ["", "some problem", "{\"related_resources\" => []}"],
     ]
-    click_link page1.ubid
+    click_link page1.summary
     expect(page.title).to eq "Ubicloud Admin - Page #{page1.ubid}"
 
-    page2 = Prog::PageNexus.assemble("another problem", %w[b], vm_pool.ubid).subject
+    Prog::PageNexus.assemble("another problem", %w[b], vm_pool.ubid).subject
     visit "/"
     expect(page_data).to eq [
-      ["", page1.ubid, "some problem", "{\"related_resources\" => []}"],
-      [page2.ubid, "another problem", "{\"related_resources\" => [\"#{vm_pool.ubid}\"]}"],
+      ["", "some problem", "{\"related_resources\" => []}"],
+      ["another problem", "{\"related_resources\" => [\"#{vm_pool.ubid}\"]}"],
     ]
     click_link vm_pool.ubid
     expect(page.title).to eq "Ubicloud Admin - VmPool #{vm_pool.ubid}"
@@ -775,12 +775,12 @@ RSpec.describe CloverAdmin do
     pj = Project.create(name: "test")
     vm = Prog::Vm::Nexus.assemble("a a", pj.id).subject
     vm.update(vm_host_id: vmh.id)
-    page3 = Prog::PageNexus.assemble("third problem", %w[c], vm.ubid).subject
+    Prog::PageNexus.assemble("third problem", %w[c], vm.ubid).subject
     visit "/"
     expect(page_data).to eq [
-      [vmh.ubid, page3.ubid, "third problem", "{\"related_resources\" => [\"#{vm.ubid}\"]}"],
-      ["", page1.ubid, "some problem", "{\"related_resources\" => []}"],
-      [page2.ubid, "another problem", "{\"related_resources\" => [\"#{vm_pool.ubid}\"]}"],
+      [vmh.ubid, "third problem", "{\"related_resources\" => [\"#{vm.ubid}\"]}"],
+      ["", "some problem", "{\"related_resources\" => []}"],
+      ["another problem", "{\"related_resources\" => [\"#{vm_pool.ubid}\"]}"],
     ]
 
     click_link vmh.ubid

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CloverAdmin do
   def page_data
     page.all(".page-table tbody tr").map do
       tds = it.all("td").map(&:text)
-      tds.delete_at(-3)
+      tds.delete_at(-4)
       tds
     end
   end
@@ -757,7 +757,7 @@ RSpec.describe CloverAdmin do
     page.refresh
     expect(page).to have_content "Active Pages"
     expect(page_data).to eq [
-      ["", "some problem", "{\"related_resources\" => []}"],
+      ["", "some problem", "[]", "{}"],
     ]
     click_link page1.summary
     expect(page.title).to eq "Ubicloud Admin - Page #{page1.ubid}"
@@ -765,8 +765,8 @@ RSpec.describe CloverAdmin do
     Prog::PageNexus.assemble("another problem", %w[b], vm_pool.ubid).subject
     visit "/"
     expect(page_data).to eq [
-      ["", "some problem", "{\"related_resources\" => []}"],
-      ["another problem", "{\"related_resources\" => [\"#{vm_pool.ubid}\"]}"],
+      ["", "some problem", "[]", "{}"],
+      ["another problem", "[\"#{vm_pool.ubid}\"]", "{}"],
     ]
     click_link vm_pool.ubid
     expect(page.title).to eq "Ubicloud Admin - VmPool #{vm_pool.ubid}"
@@ -778,9 +778,9 @@ RSpec.describe CloverAdmin do
     Prog::PageNexus.assemble("third problem", %w[c], vm.ubid).subject
     visit "/"
     expect(page_data).to eq [
-      [vmh.ubid, "third problem", "{\"related_resources\" => [\"#{vm.ubid}\"]}"],
-      ["", "some problem", "{\"related_resources\" => []}"],
-      ["another problem", "{\"related_resources\" => [\"#{vm_pool.ubid}\"]}"],
+      [vmh.ubid, "third problem", "[\"#{vm.ubid}\"]", "{}"],
+      ["", "some problem", "[]", "{}"],
+      ["another problem", "[\"#{vm_pool.ubid}\"]", "{}"],
     ]
 
     click_link vmh.ubid

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -7,7 +7,6 @@
       <thead>
         <tr>
           <th>Root Resource</th>
-          <th>UBID</th>
           <th>Created At</th>
           <th>Summary</th>
           <th>Details</th>
@@ -25,9 +24,8 @@
                   <% end%>
                 </td>
               <% end %>
-              <td><a href="/model/Page/<%= page.ubid %>"><%= page.ubid %></a></td>
               <td><%= page.created_at.strftime("%F %T") %></td>
-              <td><%= page.summary %></td>
+              <td><a href="/model/Page/<%= page.ubid %>"><%= page.summary %></a></td>
               <td><%== linkify_ubids(page.details) %></td>
             </tr>
           <% end %>

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -9,12 +9,14 @@
           <th>Root Resource</th>
           <th>Created At</th>
           <th>Summary</th>
+          <th>Resources</th>
           <th>Details</th>
         </tr>
       </thead>
       <tbody>
         <% @grouped_pages.sort_by { |k,| k || "z" }.each do |root_resource_id, pages| %>
           <% pages.each_with_index do |page, index| %>
+            <% resources = page.details.delete("related_resources") %>
             <tr>
               <% if index == 0 %>
                 <td rowspan="<%= pages.size %>">
@@ -26,6 +28,7 @@
               <% end %>
               <td><%= page.created_at.strftime("%F %T") %></td>
               <td><a href="/model/Page/<%= page.ubid %>"><%= page.summary %></a></td>
+              <td><%== linkify_ubids(resources) %></td>
               <td><%== linkify_ubids(page.details) %></td>
             </tr>
           <% end %>


### PR DESCRIPTION
- Do not show page ubid on the admin homepage
Nobody needs to see the ubid of a page, there's no need for an extra
column for it.

- Show related resources of a page as a column
The related resource is one of the most useful pieces of data in a
page's details. Showing it as a dedicated column makes the layout
cleaner and easier to scan.


| Before | After |
|--------|-------|
| <img width="2734" height="1162" alt="CleanShot 2026-05-08 at 14 01 24@2x" src="https://github.com/user-attachments/assets/6b3efe2f-cb8f-4b76-956f-d2d2e7bad27d" /> | <img width="2662" height="1086" alt="CleanShot 2026-05-08 at 14 02 27@2x" src="https://github.com/user-attachments/assets/417d22a9-6a13-4c85-8c47-26f337d2f294" /> |