### PR TITLE
Add kubernetes v1 36

### DIFF
--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -339,7 +339,7 @@ class RegenScreenshots
 
     k8s_cluster = KubernetesCluster.create(
       name: "kubernetes-demo",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
       location_id: Location::HETZNER_FSN1_ID,
       target_node_size: "standard-2",

--- a/cli-commands/kc/post/create.rb
+++ b/cli-commands/kc/post/create.rb
@@ -9,7 +9,7 @@ UbiCli.on("kc").run_on("create") do
     on("-w", "--worker-node-count=count", Integer, "Worker node count")
     on("-z", "--worker-size=size", "Worker size")
   end
-  help_option_values("Version:", Option.kubernetes_versions)
+  help_option_values("Version:", Option.selectable_kubernetes_versions)
   help_option_values("Control Plane Node Count:", Option::KubernetesCPOptions.map(&:cp_node_count))
 
   run do |opts|

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -5,4 +5,4 @@
 - { name: postgres_ha,               images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_upgrade,          images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_firewall,         images: ["postgres-ubuntu-2204"] }
-- { name: kubernetes,                images: ["kubernetes-v1_34", "kubernetes-v1_35"]}
+- { name: kubernetes,                images: ["kubernetes-v1_35", "kubernetes-v1_36"]}

--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -57,7 +57,7 @@ class Clover
 
     options.add_option(name: "name")
     options.add_option(name: "location", values: Option.kubernetes_locations)
-    options.add_option(name: "version", values: Option.kubernetes_versions)
+    options.add_option(name: "version", values: Option.selectable_kubernetes_versions)
     options.add_option(name: "cp_nodes", values: Option::KubernetesCPOptions.map(&:cp_node_count), parent: "location")
     options.add_option(name: "worker_size", values: Option::VmSizes.select { it.visible && it.vcpus <= 16 }.map { it.display_name }, parent: "location") do |location, size|
       vm_size = Option::VmSizes.find { it.display_name == size && it.arch == "x64" }

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -18,6 +18,10 @@ module Option
     ["v1.36", "v1.35", "v1.34", "v1.33"].freeze
   end
 
+  def self.selectable_kubernetes_versions
+    kubernetes_versions.first(2)
+  end
+
   MACHINE_IMAGE_SEARCH_LOCATIONS = {
     Location::HETZNER_FSN1_ID => [Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID],
     Location::HETZNER_HEL1_ID => [Location::HETZNER_HEL1_ID, Location::HETZNER_FSN1_ID],

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -15,7 +15,7 @@ module Option
   end
 
   def self.kubernetes_versions
-    ["v1.35", "v1.34", "v1.33"].freeze
+    ["v1.36", "v1.35", "v1.34", "v1.33"].freeze
   end
 
   MACHINE_IMAGE_SEARCH_LOCATIONS = {
@@ -31,6 +31,7 @@ module Option
     {
       "v1.33" => "v1.34",
       "v1.34" => "v1.35",
+      "v1.35" => "v1.36",
     }.freeze[version]
   end
 

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -351,7 +351,7 @@ module Validation
   end
 
   def self.validate_kubernetes_version(version)
-    fail ValidationFailed.new({version: "Kubernetes version \"#{version}\" is not supported. Available versions: #{Option.kubernetes_versions.join(", ")}"}) unless Option.kubernetes_versions.include?(version)
+    fail ValidationFailed.new({version: "Kubernetes version \"#{version}\" is not supported. Available versions: #{Option.selectable_kubernetes_versions.join(", ")}"}) unless Option.selectable_kubernetes_versions.include?(version)
   end
 
   def self.validate_victoria_metrics_username(username)

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -258,6 +258,7 @@ class Prog::DownloadBootImage < Prog::Base
     "kubernetes-v1_35" => {
       "x64" => {
         "20260407.1.0" => "f1a985b5b977a054cb75a0fd4437cb16394fad9777e8fe9b09a4796cc1105cdd",
+        "20260508.1.0" => "343ffdc8b53863c1f553154dda37acfa653e5cc1e854161c5dc7cf12d6ce59dd",
       },
     },
     "kubernetes-v1_36" => {

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -260,6 +260,11 @@ class Prog::DownloadBootImage < Prog::Base
         "20260407.1.0" => "f1a985b5b977a054cb75a0fd4437cb16394fad9777e8fe9b09a4796cc1105cdd",
       },
     },
+    "kubernetes-v1_36" => {
+      "x64" => {
+        "20260508.1.0" => "821c03a5f7e7971c91b58839928a9fc799f790364048202586a1e9da8823c8c0",
+      },
+    },
     "gpu-ubuntu-noble" => {
       "x64" => {
         "20251017.1.0" => "b87829c6bc71718ff0dffe2948d2586ca7ff95a02dbb03f68d18ec8c223b312c",

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -3,7 +3,7 @@
 class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   subject_is :kubernetes_cluster
 
-  def self.assemble(name:, project_id:, location_id:, version: Option.kubernetes_versions.first, private_subnet_id: nil, cp_node_count: 3, target_node_size: "standard-2", target_node_storage_size_gib: nil)
+  def self.assemble(name:, project_id:, location_id:, version: Option.selectable_kubernetes_versions.first, private_subnet_id: nil, cp_node_count: 3, target_node_size: "standard-2", target_node_storage_size_gib: nil)
     DB.transaction do
       unless (project = Project[project_id])
         fail "No existing project"

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -25,7 +25,7 @@ class Prog::Test::Kubernetes < Prog::Test::Base
       name: "kubernetes-test-standard",
       project_id: frame["kubernetes_test_project_id"],
       location_id: Location::HETZNER_FSN1_ID,
-      version: Option.kubernetes_versions[1],
+      version: Option.selectable_kubernetes_versions[1],
       cp_node_count: 1,
     ).subject
     Prog::Kubernetes::KubernetesNodepoolNexus.assemble(

--- a/spec/lib/kubernetes/client_spec.rb
+++ b/spec/lib/kubernetes/client_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Kubernetes::Client do
   let(:kubernetes_cluster) {
     KubernetesCluster.create(
       name: "test",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
       private_subnet_id: private_subnet.id,
       location_id: Location::HETZNER_FSN1_ID,

--- a/spec/lib/option_spec.rb
+++ b/spec/lib/option_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Option do
     it "returns upgrade version for upgradeable version" do
       expect(described_class.kubernetes_upgrade_candidate("v1.33")).to eq("v1.34")
       expect(described_class.kubernetes_upgrade_candidate("v1.34")).to eq("v1.35")
+      expect(described_class.kubernetes_upgrade_candidate("v1.35")).to eq("v1.36")
     end
 
     it "returns nil for latest version" do

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -578,13 +578,14 @@ RSpec.describe Validation do
 
   describe "#validate_kubernetes_version" do
     it "valid versions" do
-      Option.kubernetes_versions.each do |version|
+      Option.selectable_kubernetes_versions.each do |version|
         expect(described_class.validate_kubernetes_version(version)).to be_nil
       end
     end
 
     it "invalid versions" do
-      ["v1.30", "v1.25", "invalid", "1.34"].each do |version|
+      unselectable = Option.kubernetes_versions - Option.selectable_kubernetes_versions
+      (["v1.30", "v1.25", "invalid", "1.34"] + unselectable).each do |version|
         expect { described_class.validate_kubernetes_version(version) }.to raise_error described_class::ValidationFailed
       end
     end

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe KubernetesCluster do
   subject(:kc) {
     Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "kc-name",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       location_id: Location::HETZNER_FSN1_ID,
       cp_node_count: 3,
       project_id: project.id,
@@ -117,8 +117,8 @@ RSpec.describe KubernetesCluster do
 
   describe "#available_upgrade_version" do
     it "returns upgrade version when available" do
-      kc.update(version: Option.kubernetes_versions[1])
-      expect(kc.available_upgrade_version).to eq(Option.kubernetes_versions.first)
+      kc.update(version: Option.selectable_kubernetes_versions[1])
+      expect(kc.available_upgrade_version).to eq(Option.selectable_kubernetes_versions.first)
     end
 
     it "returns nil when on latest version" do
@@ -236,7 +236,7 @@ RSpec.describe KubernetesCluster do
       expect(kc.valid?).to be false
       expect(kc.errors[:version]).to eq(["must be a valid Kubernetes version"])
 
-      kc.version = Option.kubernetes_versions.first
+      kc.version = Option.selectable_kubernetes_versions.first
       expect(kc.valid?).to be true
     end
 

--- a/spec/model/kubernetes/kubernetes_etcd_backup_spec.rb
+++ b/spec/model/kubernetes/kubernetes_etcd_backup_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe KubernetesEtcdBackup do
   let(:kc) {
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "test-cluster",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       location_id: location.id,
       project_id: project.id,
       private_subnet_id: private_subnet.id,

--- a/spec/model/kubernetes/kubernetes_node_spec.rb
+++ b/spec/model/kubernetes/kubernetes_node_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe KubernetesNode do
   let(:kc) {
     kc = KubernetesCluster.create(
       name: "kc-name",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       location_id: Location::HETZNER_FSN1_ID,
       cp_node_count: 1,
       project_id: project.id,

--- a/spec/prog/kubernetes/etcd_backup_nexus_spec.rb
+++ b/spec/prog/kubernetes/etcd_backup_nexus_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Prog::Kubernetes::EtcdBackupNexus do
     MinioCluster.create(project_id: project.id, location_id: location.id, name: "minio-cluster", admin_user: "admin", admin_password: "password", root_cert_1: "certs")
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "test",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       location_id: location.id,
       project_id: project.id,
       private_subnet_id: private_subnet.id,

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
   subject(:nx) {
     kc = described_class.assemble(
       name: "cluster",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
       location_id: Location::HETZNER_FSN1_ID,
       project_id: customer_project.id,
@@ -103,12 +103,12 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
     end
 
     it "creates a kubernetes cluster" do
-      st = described_class.assemble(name: "k8stest", version: Option.kubernetes_versions.first, private_subnet_id: subnet.id, project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3, target_node_size: "standard-8", target_node_storage_size_gib: 100)
+      st = described_class.assemble(name: "k8stest", version: Option.selectable_kubernetes_versions.first, private_subnet_id: subnet.id, project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3, target_node_size: "standard-8", target_node_storage_size_gib: 100)
 
       kc = st.subject
       expect(kc.name).to eq "k8stest"
       expect(kc.ubid).to start_with("kc")
-      expect(kc.version).to eq Option.kubernetes_versions.first
+      expect(kc.version).to eq Option.selectable_kubernetes_versions.first
       expect(kc.location_id).to eq Location::HETZNER_FSN1_ID
       expect(kc.cp_node_count).to eq 3
       expect(kc.private_subnet.id).to eq subnet.id
@@ -142,7 +142,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       st = described_class.assemble(name: "k8stest", project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3)
       kc = st.subject
 
-      expect(kc.version).to eq Option.kubernetes_versions.first
+      expect(kc.version).to eq Option.selectable_kubernetes_versions.first
       expect(kc.private_subnet.net4.to_s[-3..]).to eq "/16"
       expect(kc.private_subnet.name).to eq kc.ubid.to_s + "-subnet"
       expect(kc.private_subnet.firewalls.first.name).to eq kc.ubid.to_s + "-firewall"

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
   let(:kc) {
     kc = KubernetesCluster.create(
       name: "cluster",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
       private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
   let(:kc) {
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "k8scluster",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
       private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,
@@ -140,6 +140,13 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
     let(:first_node) { kn.nodes[0] }
     let(:second_node) { kn.nodes[1] }
     let(:client) { instance_double(Kubernetes::Client) }
+    let(:cluster_version) { Option.kubernetes_versions[0] }
+    let(:older_version) { Option.kubernetes_versions[1] }
+    let(:much_older_version) { Option.kubernetes_versions[2] }
+    let(:newer_version) {
+      major, minor = cluster_version.match(/^v(\d+)\.(\d+)$/).captures.map(&:to_i)
+      "v#{major}.#{minor + 1}"
+    }
 
     it "naps when cluster strand is in upgrade label" do
       kc.strand.update(label: "upgrade")
@@ -170,7 +177,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       end
 
       it "selects a node with minor version one less than the cluster's version" do
-        expect(client).to receive(:version).and_return(Option.kubernetes_versions.first, Option.kubernetes_versions[1])
+        expect(client).to receive(:version).and_return(cluster_version, older_version)
         expect { nx.upgrade }.to hop("wait_upgrade")
         st = Strand[prog: "Kubernetes::UpgradeKubernetesNode"]
         expect(st).not_to be_nil
@@ -178,12 +185,12 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       end
 
       it "hops to wait when all nodes are at the cluster's version" do
-        expect(client).to receive(:version).and_return(Option.kubernetes_versions.first, Option.kubernetes_versions.first)
+        expect(client).to receive(:version).and_return(cluster_version, cluster_version)
         expect { nx.upgrade }.to hop("wait")
       end
 
       it "does not select a node with minor version more than one less than the cluster's version" do
-        expect(client).to receive(:version).and_return(Option.kubernetes_versions.last, Option.kubernetes_versions.first)
+        expect(client).to receive(:version).and_return(much_older_version, cluster_version)
         expect { nx.upgrade }.to hop("wait")
       end
 
@@ -195,11 +202,11 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
         expect(page).not_to be_nil
         expect(page.summary).to eq "Invalid version format for #{first_node.name} of cluster #{kc.ubid}"
         expect(page.details["node_version"]).to eq "invalid"
-        expect(page.details["cluster_version"]).to eq Option.kubernetes_versions.first
+        expect(page.details["cluster_version"]).to eq Option.selectable_kubernetes_versions.first
       end
 
       it "selects the first node that is one minor version behind" do
-        expect(client).to receive(:version).and_return(Option.kubernetes_versions[1])
+        expect(client).to receive(:version).and_return(older_version)
         expect { nx.upgrade }.to hop("wait_upgrade")
         st = Strand[prog: "Kubernetes::UpgradeKubernetesNode"]
         expect(st).not_to be_nil
@@ -207,8 +214,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       end
 
       it "does not select a node with a higher minor version than the cluster" do
-        kc.update(version: Option.kubernetes_versions[1])
-        expect(client).to receive(:version).and_return(Option.kubernetes_versions.first, Option.kubernetes_versions.first)
+        expect(client).to receive(:version).and_return(newer_version, newer_version)
         expect { nx.upgrade }.to hop("wait")
       end
     end

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   let(:kubernetes_cluster) {
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "k8scluster",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
       private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,
@@ -35,7 +35,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       location_id: Location::HETZNER_FSN1_ID,
       size: "standard-4",
       storage_volumes: [{encrypted: true, size_gib: 40}],
-      boot_image: Option.kubernetes_versions.first,
+      boot_image: Option.selectable_kubernetes_versions.first,
       private_subnet_id: subnet.id,
       enable_ip4: true,
       kubernetes_cluster_id: kc.id,
@@ -106,7 +106,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(new_vm.sshable).not_to be_nil
       expect(new_vm.vcpus).to eq(4)
       expect(new_vm.strand.stack.first["storage_volumes"].first["size_gib"]).to eq(37)
-      expect(new_vm.boot_image).to eq("kubernetes-#{Option.kubernetes_versions.first.tr(".", "_")}")
+      expect(new_vm.boot_image).to eq("kubernetes-#{Option.selectable_kubernetes_versions.first.tr(".", "_")}")
     end
 
     it "creates a worker node and hops if a nodepool is given" do
@@ -122,7 +122,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(new_vm.sshable).not_to be_nil
       expect(new_vm.vcpus).to eq(8)
       expect(new_vm.strand.stack.first["storage_volumes"].first["size_gib"]).to eq(78)
-      expect(new_vm.boot_image).to eq("kubernetes-#{Option.kubernetes_versions.first.tr(".", "_")}")
+      expect(new_vm.boot_image).to eq("kubernetes-#{Option.selectable_kubernetes_versions.first.tr(".", "_")}")
     end
 
     it "assigns the default storage size if not specified" do

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
   let(:kubernetes_cluster) {
     kc = KubernetesCluster.create(
       name: "k8scluster",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
       private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Prog::Test::Kubernetes do
   let(:kubernetes_cluster) {
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "test-cluster",
-      version: Option.kubernetes_versions.last,
+      version: Option.selectable_kubernetes_versions.last,
       location_id: Location::HETZNER_FSN1_ID,
       project_id: kubernetes_test_project.id,
       private_subnet_id: private_subnet.id,
@@ -811,7 +811,7 @@ RSpec.describe Prog::Test::Kubernetes do
     end
 
     it "fails if no upgrade candidate is available" do
-      kubernetes_cluster.update(version: Option.kubernetes_versions.first)
+      kubernetes_cluster.update(version: Option.selectable_kubernetes_versions.first)
       expect { kubernetes_test.test_upgrade }.to hop("destroy_kubernetes")
       expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("No upgrade candidate available")
     end

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -372,7 +372,7 @@ Options:
     -z, --worker-size=size           Worker size
 
 Allowed Option Values:
-    Version: v1.36 v1.35 v1.34 v1.33
+    Version: v1.36 v1.35
     Control Plane Node Count: 1 3
 
 

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -372,7 +372,7 @@ Options:
     -z, --worker-size=size           Worker size
 
 Allowed Option Values:
-    Version: v1.35 v1.34 v1.33
+    Version: v1.36 v1.35 v1.34 v1.33
     Control Plane Node Count: 1 3
 
 

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create -c 1 -w bad.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create -c 1 -w bad.txt
@@ -12,5 +12,5 @@ Options:
     -z, --worker-size=size           Worker size
 
 Allowed Option Values:
-    Version: v1.36 v1.35 v1.34 v1.33
+    Version: v1.36 v1.35
     Control Plane Node Count: 1 3

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create -c 1 -w bad.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create -c 1 -w bad.txt
@@ -12,5 +12,5 @@ Options:
     -z, --worker-size=size           Worker size
 
 Allowed Option Values:
-    Version: v1.35 v1.34 v1.33
+    Version: v1.36 v1.35 v1.34 v1.33
     Control Plane Node Count: 1 3

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create -c a.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create -c a.txt
@@ -12,5 +12,5 @@ Options:
     -z, --worker-size=size           Worker size
 
 Allowed Option Values:
-    Version: v1.36 v1.35 v1.34 v1.33
+    Version: v1.36 v1.35
     Control Plane Node Count: 1 3

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create -c a.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create -c a.txt
@@ -12,5 +12,5 @@ Options:
     -z, --worker-size=size           Worker size
 
 Allowed Option Values:
-    Version: v1.35 v1.34 v1.33
+    Version: v1.36 v1.35 v1.34 v1.33
     Control Plane Node Count: 1 3

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create invalid.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create invalid.txt
@@ -12,5 +12,5 @@ Options:
     -z, --worker-size=size           Worker size
 
 Allowed Option Values:
-    Version: v1.36 v1.35 v1.34 v1.33
+    Version: v1.36 v1.35
     Control Plane Node Count: 1 3

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create invalid.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc create invalid.txt
@@ -12,5 +12,5 @@ Options:
     -z, --worker-size=size           Worker size
 
 Allowed Option Values:
-    Version: v1.35 v1.34 v1.33
+    Version: v1.36 v1.35 v1.34 v1.33
     Control Plane Node Count: 1 3

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -f node-size,version,nodepools,cp-vms.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -f node-size,version,nodepools,cp-vms.txt
@@ -1,5 +1,5 @@
 node-size: standard-2
-version: v1.34
+version: v1.35
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n id,name,node-count.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n id,name,node-count.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display-state: creating
 cp-node-count: 1
 node-size: standard-2
-version: v1.34
+version: v1.35
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n node-size,vms.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n node-size,vms.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display-state: creating
 cp-node-count: 1
 node-size: standard-2
-version: v1.34
+version: v1.35
 nodepool 1:
   node-size: standard-2
   vm 1:

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v id,name,state,location,size,unix-user,storage-size-gib.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v id,name,state,location,size,unix-user,storage-size-gib.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display-state: creating
 cp-node-count: 1
 node-size: standard-2
-version: v1.34
+version: v1.35
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v ip6,ip4-enabled,ip4.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v ip6,ip4-enabled,ip4.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display-state: creating
 cp-node-count: 1
 node-size: standard-2
-version: v1.34
+version: v1.35
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display-state: creating
 cp-node-count: 1
 node-size: standard-2
-version: v1.34
+version: v1.35
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc upgrade.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc upgrade.txt
@@ -1,1 +1,1 @@
-Scheduled version upgrade of Kubneretes cluster with id kcnzrctjjg4j4g6eqvdsvzthwp to version v1.35.
+Scheduled version upgrade of Kubneretes cluster with id kcnzrctjjg4j4g6eqvdsvzthwp to version v1.36.

--- a/spec/routes/api/cli/golden-files/kc kcnzrctjjg4j4g6eqvdsvzthwp show.txt
+++ b/spec/routes/api/cli/golden-files/kc kcnzrctjjg4j4g6eqvdsvzthwp show.txt
@@ -4,7 +4,7 @@ location: eu-central-h1
 display-state: creating
 cp-node-count: 1
 node-size: standard-2
-version: v1.34
+version: v1.35
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np

--- a/spec/routes/api/cli/golden-files/kc list -N.txt
+++ b/spec/routes/api/cli/golden-files/kc list -N.txt
@@ -1,1 +1,1 @@
-eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating  v1.34  1
+eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating  v1.35  1

--- a/spec/routes/api/cli/golden-files/kc list -l eu-central-h1.txt
+++ b/spec/routes/api/cli/golden-files/kc list -l eu-central-h1.txt
@@ -1,2 +1,2 @@
 location       name     id                          display-state  version  cp-node-count
-eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.34    1            
+eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.35    1            

--- a/spec/routes/api/cli/golden-files/kc list.txt
+++ b/spec/routes/api/cli/golden-files/kc list.txt
@@ -1,2 +1,2 @@
 location       name     id                          display-state  version  cp-node-count
-eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.34    1            
+eu-central-h1  test-kc  kcnzrctjjg4j4g6eqvdsvzthwp  creating       v1.35    1            

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Clover, "cli" do
     expect(Firewall).to receive(:generate_uuid).and_return("850f5687-1a76-8dfc-8949-a115826d20e7", "f26fd163-5a81-8dfc-a7f7-0802917b40c2", "0ec68714-d66c-81fc-ab4d-33235e8daea3")
     expect(FirewallRule).to receive(:generate_uuid).and_return("d5889073-4aed-89f8-8894-1c376ebea8f6", "0803b040-d565-81f8-b2ed-f4d28df19f7c", "753678ce-8c3c-8dfc-83ce-00abd4f0f3fe", "45b6f212-bedb-8dfc-b8f2-0bcbe963d5bb", "04dd799d-ef69-8dfc-b58a-1bef3dd69f86", "0acdc686-2462-85fc-9adb-cbd713cb33dd", "b62d8f1b-2c71-89fc-a087-fa4193dcd90b", "4fed0d91-99a9-8dfc-b392-36ad164bd580", "17bd4390-d26e-85fc-a2df-b22a6a0bb697", "32e35994-9dde-89fc-861a-44582c6528be", "ab1ceb1f-faec-81fc-8b4f-a17d15e17da0", "ffbcca2e-550e-81fc-a60d-b39e665c6aeb")
     expect(PrivateSubnet).to receive(:generate_ubid).and_return(UBID.parse("ps788q81w5w26h900k13ad8bkx"))
-    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.kubernetes_versions[1]}])
+    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.selectable_kubernetes_versions[1]}])
 
     expect(Vm).to receive(:generate_ubid).and_return(UBID.parse("vmgbbazmznfa0mp49nzh5v0z25"), UBID.parse("vmnwfmjk5k462kkzsfa4n1h4xm"))
     expect(Nic).to receive(:generate_ubid).and_return(UBID.parse("ncnqx1bbxgra7k8r9k9qwvspwd"), UBID.parse("nc1c3bggqpxt5kqqrdtkym1g03"))

--- a/spec/routes/api/cli/kc/create_spec.rb
+++ b/spec/routes/api/cli/kc/create_spec.rb
@@ -9,49 +9,50 @@ RSpec.describe Clover, "cli kc create" do
 
   it "creates kubernetes cluster with minimal options" do
     expect(KubernetesCluster.count).to eq 0
-    body = cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.kubernetes_versions.first}])
+    body = cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.selectable_kubernetes_versions.first}])
     expect(KubernetesCluster.count).to eq 1
     kc = KubernetesCluster.first
     expect(kc).to be_a KubernetesCluster
     expect(kc.name).to eq "test-kc"
-    expect(kc.version).to eq Option.kubernetes_versions.first
+    expect(kc.version).to eq Option.selectable_kubernetes_versions.first
     expect(body).to eq "Kubernetes cluster created with id: #{kc.ubid}\n"
   end
 
   it "creates kubernetes cluster without --cp-node-count" do
     expect(KubernetesCluster.count).to eq 0
-    body = cli(%W[kc eu-central-h1/test-kc create -z standard-2 -w 1 -v #{Option.kubernetes_versions.first}])
+    body = cli(%W[kc eu-central-h1/test-kc create -z standard-2 -w 1 -v #{Option.selectable_kubernetes_versions.first}])
     expect(KubernetesCluster.count).to eq 1
     kc = KubernetesCluster.first
     expect(kc).to be_a KubernetesCluster
     expect(kc.name).to eq "test-kc"
     expect(kc.cp_node_count).to eq 1
-    expect(kc.version).to eq Option.kubernetes_versions.first
+    expect(kc.version).to eq Option.selectable_kubernetes_versions.first
     expect(body).to eq "Kubernetes cluster created with id: #{kc.ubid}\n"
   end
 
   it "creates kubernetes cluster without --worker-node-count" do
     expect(KubernetesCluster.count).to eq 0
-    body = cli(%W[kc eu-central-h1/test-kc create -c 3 -z standard-2 -v #{Option.kubernetes_versions.first}])
+    body = cli(%W[kc eu-central-h1/test-kc create -c 3 -z standard-2 -v #{Option.selectable_kubernetes_versions.first}])
     expect(KubernetesCluster.count).to eq 1
     kc = KubernetesCluster.first
     expect(kc).to be_a KubernetesCluster
     expect(kc.name).to eq "test-kc"
     expect(kc.cp_node_count).to eq 3
     expect(kc.nodepools.sum(&:node_count)).to eq 1
-    expect(kc.version).to eq Option.kubernetes_versions.first
+    expect(kc.version).to eq Option.selectable_kubernetes_versions.first
     expect(body).to eq "Kubernetes cluster created with id: #{kc.ubid}\n"
   end
 
   it "creates kubernetes cluster with all options" do
+    version = Option.selectable_kubernetes_versions.last
     expect(KubernetesCluster.count).to eq 0
-    body = cli(%W[kc eu-central-h1/test-kc create -c 3 -w 2 -z standard-2 -v v1.33])
+    body = cli(%W[kc eu-central-h1/test-kc create -c 3 -w 2 -z standard-2 -v #{version}])
     expect(KubernetesCluster.count).to eq 1
     kc = KubernetesCluster.first
     expect(kc).to be_a KubernetesCluster
     expect(kc.name).to eq "test-kc"
     expect(kc.cp_node_count).to eq 3
-    expect(kc.version).to eq "v1.33"
+    expect(kc.version).to eq version
     expect(body).to eq "Kubernetes cluster created with id: #{kc.ubid}\n"
   end
 end

--- a/spec/routes/api/cli/kc/destroy_spec.rb
+++ b/spec/routes/api/cli/kc/destroy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Clover, "cli kc destroy" do
 
   it "destroys kubernetes cluster" do
     expect(KubernetesCluster.count).to eq 0
-    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.kubernetes_versions.first}])
+    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.selectable_kubernetes_versions.first}])
     expect(KubernetesCluster.count).to eq 1
     kc = KubernetesCluster.first
     expect(Semaphore.where(strand_id: kc.id, name: "destroy")).to be_empty

--- a/spec/routes/api/cli/kc/rename_spec.rb
+++ b/spec/routes/api/cli/kc/rename_spec.rb
@@ -5,7 +5,7 @@ require_relative "../spec_helper"
 RSpec.describe Clover, "cli kc rename" do
   it "renames kubernetes cluster" do
     expect(Config).to receive(:kubernetes_service_project_id).and_return(@project.id).at_least(:once)
-    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.kubernetes_versions.first}])
+    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.selectable_kubernetes_versions.first}])
     expect(cli(%W[kc eu-central-h1/test-kc rename new-name])).to eq "Kubernetes cluster renamed to new-name\n"
     expect(KubernetesCluster.select_order_map(:name)).to eq ["new-name"]
   end

--- a/spec/routes/api/cli/kc/upgrade_spec.rb
+++ b/spec/routes/api/cli/kc/upgrade_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Clover, "cli kc upgrade" do
   end
 
   it "upgrades cluster when upgrade is available" do
-    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.kubernetes_versions.last}])
+    cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.selectable_kubernetes_versions.last}])
 
     body = cli(%w[kc eu-central-h1/test-kc upgrade])
 

--- a/spec/routes/api/project/location/kubernetes_cluster_spec.rb
+++ b/spec/routes/api/project/location/kubernetes_cluster_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Clover, "kubernetes-cluster" do
   let(:kc) {
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "cluster",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
       project_id: project.id,
       private_subnet_id: subnet.id,
@@ -63,14 +63,15 @@ RSpec.describe Clover, "kubernetes-cluster" do
         expect(parsed_body["items"].length).to eq(1)
         expect(parsed_body["count"]).to eq(1)
         expect(parsed_body["items"][0]["name"]).to eq("cluster")
-        expect(parsed_body["items"][0]["version"]).to eq(Option.kubernetes_versions.first)
+        expect(parsed_body["items"][0]["version"]).to eq(Option.selectable_kubernetes_versions.first)
       end
     end
 
     describe "create" do
       it "success" do
+        version = Option.selectable_kubernetes_versions.last
         post "/project/#{project.ubid}/location/#{TEST_LOCATION}/kubernetes-cluster/test-cluster", {
-          version: "v1.33",
+          version:,
           worker_size: "standard-2",
           worker_nodes: 2,
           cp_nodes: 1,
@@ -78,7 +79,7 @@ RSpec.describe Clover, "kubernetes-cluster" do
 
         expect(last_response.status).to eq(200)
         expect(JSON.parse(last_response.body)["name"]).to eq("test-cluster")
-        expect(JSON.parse(last_response.body)["version"]).to eq("v1.33")
+        expect(JSON.parse(last_response.body)["version"]).to eq(version)
         expect(KubernetesCluster[name: "test-cluster"]).not_to be_nil
       end
 
@@ -181,12 +182,12 @@ RSpec.describe Clover, "kubernetes-cluster" do
 
     describe "upgrade" do
       it "upgrades cluster when upgrade is available" do
-        kc.update(version: Option.kubernetes_versions[1])
+        kc.update(version: Option.selectable_kubernetes_versions[1])
 
         post "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.ubid}/upgrade"
 
         expect(last_response.status).to eq(200)
-        expect(kc.reload.version).to eq(Option.kubernetes_versions.first)
+        expect(kc.reload.version).to eq(Option.selectable_kubernetes_versions.first)
         expect(SemSnap.new(kc.id).set?("upgrade")).to be true
         expect(SemSnap.new(kc.nodepools.first.id).set?("upgrade")).to be true
       end

--- a/spec/routes/web/admin/model/spec_helper.rb
+++ b/spec/routes/web/admin/model/spec_helper.rb
@@ -278,7 +278,7 @@ module AdminModelSpecHelper
         private_subnet_id: ps.id,
         location_id: Location::HETZNER_FSN1_ID,
         cp_node_count: 3,
-        version: Option.kubernetes_versions.first,
+        version: Option.selectable_kubernetes_versions.first,
         target_node_size: "standard-2",
       )
     end

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Clover, "Kubernetes" do
   let(:kc) do
     cluster = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "myk8s",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       project_id: project.id,
       private_subnet_id: PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "mysubnet", location_id: Location::HETZNER_FSN1_ID, project_id: project.id).id,
       location_id: Location::HETZNER_FSN1_ID,
@@ -45,7 +45,7 @@ RSpec.describe Clover, "Kubernetes" do
   let(:kc_no_perm) do
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "not-my-k8s",
-      version: Option.kubernetes_versions.first,
+      version: Option.selectable_kubernetes_versions.first,
       project_id: project_wo_permissions.id,
       private_subnet_id: PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "othersubnet", location_id: Location::HETZNER_FSN1_ID, project_id: project_wo_permissions.id).id,
       location_id: Location::HETZNER_FSN1_ID,
@@ -429,14 +429,14 @@ RSpec.describe Clover, "Kubernetes" do
 
     describe "upgrade" do
       it "shows upgrade button when upgrade is available and cluster is ready" do
-        kc.update(version: Option.kubernetes_versions[1])
+        kc.update(version: Option.selectable_kubernetes_versions[1])
         kc.strand.update(label: "wait")
         kc.nodepools.first.strand.update(label: "wait")
 
         visit "#{project.path}#{kc.path}/settings"
         expect(page).to have_content "Upgrade Cluster & Nodepool"
         expect(page).to have_content "can be upgraded to version"
-        expect(page).to have_content Option.kubernetes_versions.first
+        expect(page).to have_content Option.selectable_kubernetes_versions.first
         expect(page).to have_button "Upgrade"
       end
 
@@ -460,7 +460,7 @@ RSpec.describe Clover, "Kubernetes" do
       end
 
       it "shows not ready when upgrade is available but strands are busy" do
-        kc.update(version: Option.kubernetes_versions.last)
+        kc.update(version: Option.selectable_kubernetes_versions.last)
         kc.strand.update(label: "wait")
         kc.nodepools.first.strand.update(label: "bootstrap_worker_nodes")
 
@@ -475,19 +475,19 @@ RSpec.describe Clover, "Kubernetes" do
 
         visit "#{project.path}#{kc.path}/settings"
         expect(page).to have_content "Your cluster is up to date on version"
-        expect(page).to have_content Option.kubernetes_versions.first
+        expect(page).to have_content Option.selectable_kubernetes_versions.first
       end
 
       it "can upgrade kubernetes cluster" do
-        kc.update(version: Option.kubernetes_versions[1])
+        kc.update(version: Option.selectable_kubernetes_versions[1])
         kc.strand.update(label: "wait")
         kc.nodepools.first.strand.update(label: "wait")
 
         visit "#{project.path}#{kc.path}/settings"
         click_button "Upgrade"
 
-        expect(page).to have_flash_notice("myk8s will be upgraded to #{Option.kubernetes_versions.first}")
-        expect(kc.reload.version).to eq Option.kubernetes_versions.first
+        expect(page).to have_flash_notice("myk8s will be upgraded to #{Option.selectable_kubernetes_versions.first}")
+        expect(kc.reload.version).to eq Option.selectable_kubernetes_versions.first
         expect(SemSnap.new(kc.id).set?("upgrade")).to be true
       end
     end

--- a/spec/serializers/kubernetes_cluster_spec.rb
+++ b/spec/serializers/kubernetes_cluster_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Serializers::KubernetesCluster do
     it "serializes a KubernetesCluster without the detailed option" do
       project = Project.create(name: "default")
       subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
-      kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.kubernetes_versions.first, private_subnet_id: subnet.id).subject
+      kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.selectable_kubernetes_versions.first, private_subnet_id: subnet.id).subject
       kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
       KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
 
@@ -22,7 +22,7 @@ RSpec.describe Serializers::KubernetesCluster do
         display_state: "creating",
         cp_node_count: 3,
         node_size: "standard-2",
-        version: Option.kubernetes_versions.first,
+        version: Option.selectable_kubernetes_versions.first,
       }
 
       expect(described_class.serialize_internal(kc)).to eq(expected_result)
@@ -31,7 +31,7 @@ RSpec.describe Serializers::KubernetesCluster do
     it "serializes a KubernetesNodepool without the detailed option" do
       project = Project.create(name: "default")
       subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
-      kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.kubernetes_versions.first, private_subnet_id: subnet.id).subject
+      kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.selectable_kubernetes_versions.first, private_subnet_id: subnet.id).subject
       kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
       cp_vm = create_vm
       KubernetesNode.create(vm_id: cp_vm.id, kubernetes_cluster_id: kc.id)
@@ -44,7 +44,7 @@ RSpec.describe Serializers::KubernetesCluster do
         display_state: "creating",
         cp_node_count: 3,
         node_size: "standard-2",
-        version: Option.kubernetes_versions.first,
+        version: Option.selectable_kubernetes_versions.first,
         cp_vms: Serializers::Vm.serialize([cp_vm]),
         nodepools: Serializers::KubernetesNodepool.serialize([kn], {detailed: true}),
       }

--- a/spec/serializers/kubernetes_nodepool_spec.rb
+++ b/spec/serializers/kubernetes_nodepool_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Serializers::KubernetesNodepool do
       subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
       kc = KubernetesCluster.create(
         name: "cluster",
-        version: Option.kubernetes_versions.first,
+        version: Option.selectable_kubernetes_versions.first,
         cp_node_count: 3,
         private_subnet_id: subnet.id,
         location_id: Location::HETZNER_FSN1_ID,
@@ -37,7 +37,7 @@ RSpec.describe Serializers::KubernetesNodepool do
       subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
       kc = KubernetesCluster.create(
         name: "cluster",
-        version: Option.kubernetes_versions.first,
+        version: Option.selectable_kubernetes_versions.first,
         cp_node_count: 3,
         private_subnet_id: subnet.id,
         location_id: Location::HETZNER_FSN1_ID,


### PR DESCRIPTION
**Add kubernetes v1.36 image**

**Limit selectable Kubernetes versions in UI and CLI to top 2**

Add Option.selectable_kubernetes_versions returning the first 2 entriesof kubernetes_versions, and use it everywhere a user picks a version for a new cluster: the create-time Validation.validate_kubernetes_version, the web option tree, and the CLI help text. Model-level validation on KubernetesCluster still uses the full kubernetes_versions list, so existing clusters running an older but still-supported version (e.g. v1.33) continue to save without errors. As we add new versions, we constrain new cluster creation to the latest releases while keeping older versions valid for clusters already in the field.

**Update kubernetes v1.35 image**