### PR TITLE
Fix PG IO throttle process classification

### DIFF
--- a/rhizome/postgres/lib/io_throttle.rb
+++ b/rhizome/postgres/lib/io_throttle.rb
@@ -79,7 +79,7 @@ class IoThrottle
 
   def find_immune_pids
     postmaster_pid = find_postmaster_pid
-    children = File.read("/proc/#{postmaster_pid}/task/#{postmaster_pid}/children").split.map { Integer(_1, 10) }
+    children = get_pid_children(postmaster_pid)
 
     immune_pids = [postmaster_pid]
     children.each do |pid|
@@ -101,6 +101,12 @@ class IoThrottle
     File.write("#{cgroup_path}/cgroup.procs", pid.to_s)
   rescue Errno::ESRCH
     # Process no longer exists
+  end
+
+  def get_pid_children(pid)
+    File.read("/proc/#{pid}/task/#{pid}/children").split.map { Integer(_1, 10) }
+  rescue Errno::ENOENT
+    []
   end
 
   private
@@ -156,13 +162,15 @@ class IoThrottle
       move_pid_to_cgroup(pid, @immune_cgroup)
     end
 
-    (get_cgroup_pids(@service_cgroup) + get_cgroup_pids(@immune_cgroup)).each do |pid|
+    # Only reclassify direct children of postmaster: these are the only processes that
+    # can end up in immune_cgroup incorrectly (via fork inheritance).
+    # Descendants of other immune backends (e.g., wal-g spawned by archiver)
+    # belong in immune_cgroup and are left alone.
+    postmaster_pid = immune_pids.first
+    postmaster_children = get_pid_children(postmaster_pid)
+    postmaster_children.each do |pid|
       next if immune_pids.include?(pid)
       move_pid_to_cgroup(pid, @throttled_cgroup)
-    end
-
-    get_cgroup_pids(@throttled_cgroup).each do |pid|
-      move_pid_to_cgroup(pid, @immune_cgroup) if immune_pids.include?(pid)
     end
 
     immune_pids

--- a/rhizome/postgres/spec/io_throttle_spec.rb
+++ b/rhizome/postgres/spec/io_throttle_spec.rb
@@ -183,8 +183,10 @@ RSpec.describe IoThrottle do
       ready_files = Array.new(150) { |i| "#{data_dir}/pg_wal/archive_status/#{i.to_s.rjust(8, "0")}.ready" }
       allow(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return(ready_files)
       allow(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
-      allow(throttle).to receive_messages(find_immune_pids: [], get_cgroup_pids: [])
+      allow(throttle).to receive(:find_immune_pids).and_return([1000])
+      allow(File).to receive(:read).with("/proc/1000/task/1000/children").and_return("")
 
+      allow(File).to receive(:write)
       # 150 files hits moderate tier (100+): 80% of baseline 100 MB/s = 80 MB/s
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=#{80 * 1024 * 1024}")
 
@@ -199,8 +201,10 @@ RSpec.describe IoThrottle do
       ready_files = Array.new(150) { |i| "#{data_dir}/pg_wal/archive_status/#{i.to_s.rjust(8, "0")}.ready" }
       allow(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return(ready_files)
       allow(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
-      allow(throttle_leaseweb).to receive_messages(find_immune_pids: [], get_cgroup_pids: [])
+      allow(throttle_leaseweb).to receive(:find_immune_pids).and_return([1000])
+      allow(File).to receive(:read).with("/proc/1000/task/1000/children").and_return("")
 
+      allow(File).to receive(:write)
       # 150 files hits moderate tier (100+): 80% of baseline 35 MB/s = 28 MB/s
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=#{28 * 1024 * 1024}")
 
@@ -211,9 +215,10 @@ RSpec.describe IoThrottle do
       expect(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return([])
       expect(throttle).to receive(:calculate_disk_usage_throttle).and_return(55)
       expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
-      expect(throttle).to receive(:find_immune_pids).and_return([])
-      expect(throttle).to receive(:get_cgroup_pids).and_return([]).at_least(:once)
+      expect(throttle).to receive(:find_immune_pids).and_return([1000])
+      allow(File).to receive(:read).with("/proc/1000/task/1000/children").and_return("")
 
+      allow(File).to receive(:write)
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=#{55 * 1024 * 1024}")
 
       throttle.run
@@ -225,9 +230,10 @@ RSpec.describe IoThrottle do
       # Archival: 80 MB/s, disk usage: 55 MB/s -> pick 55
       expect(throttle).to receive(:calculate_disk_usage_throttle).and_return(55)
       expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
-      expect(throttle).to receive(:find_immune_pids).and_return([])
-      expect(throttle).to receive(:get_cgroup_pids).and_return([]).at_least(:once)
+      expect(throttle).to receive(:find_immune_pids).and_return([1000])
+      allow(File).to receive(:read).with("/proc/1000/task/1000/children").and_return("")
 
+      allow(File).to receive(:write)
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=#{55 * 1024 * 1024}")
 
       throttle.run


### PR DESCRIPTION
Simplify throttled and immune process classification.  The reclassification from immune -> throttled existed to bring new backend processes into the throttled group, since they would spawn as immune as postmaster is immune.

Before this change, the descendents of the immune PIDs were not traversed.  For existing immune PIDs, while their children would spawn in the immune cgroup, they would get reclassified as throttled. This was detected by spotting a throttled wal-g process (archiver -> sh -> wal-g).

Interestingly, after correcting this on the problematic server, the WAL shipping speed did not improve. This is most likely because the throttle is only applied to disk write ops, which are minimal during wal-push.