### PR TITLE
Support UDP for firewall rules

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -52,7 +52,7 @@
   #custom-ports, #subnet-source, #custom-source {
     display: none;
   }
-  &:has(#port_type option[value=custom]:checked) #custom-ports {
+  &:has(#port_type option[value^=custom]:checked) #custom-ports {
     display: block;
   }
   &:has(#source_type option[value^=subnet]:checked) #subnet-source {

--- a/cli-commands/fw/post/add-rule.rb
+++ b/cli-commands/fw/post/add-rule.rb
@@ -6,6 +6,7 @@ UbiCli.on("fw").run_on("add-rule") do
   options("ubi fw (location/fw-name | fw-id) add-rule [options] (cidr | ps-id | ps-name)", key: :fw_add_rule) do
     on("-s", "--start-port=port", Integer, "starting (or only) port to allow (default: 0)")
     on("-e", "--end-port=port", Integer, "ending port to allow (default: 65535)")
+    on("-p", "--protocol=protocol", "protocol to allow (tcp or udp, default: tcp)")
     on("-d", "--description=desc", "description of rule")
   end
 

--- a/cli-commands/fw/post/modify-rule.rb
+++ b/cli-commands/fw/post/modify-rule.rb
@@ -7,6 +7,7 @@ UbiCli.on("fw").run_on("modify-rule") do
     on("-c", "--cidr=ip-range", "IPv4 or IPv6 range to allow")
     on("-s", "--start-port=port", Integer, "starting (or only) port to allow (default: 0)")
     on("-e", "--end-port=port", Integer, "ending port to allow (default: 65535)")
+    on("-p", "--protocol=protocol", "protocol to allow (tcp or udp)")
     on("-d", "--description=desc", "description of rule")
   end
 
@@ -15,7 +16,7 @@ UbiCli.on("fw").run_on("modify-rule") do
   run do |rule_id, opts, cmd|
     opts = underscore_keys(opts[:fw_modify_rule])
     if opts.empty?
-      raise Rodish::CommandFailure.new("Must provide at least one option (-c, -s, -e, or -d)", cmd)
+      raise Rodish::CommandFailure.new("Must provide at least one option (-c, -s, -e, -p, or -d)", cmd)
     end
     id = sdk_object.modify_rule(rule_id, **opts)[:id]
     response("Modified firewall rule with id: #{id}")

--- a/helpers/firewall.rb
+++ b/helpers/firewall.rb
@@ -33,9 +33,12 @@ class Clover
       else
         FirewallRule.cidr_for_source_type(source_type)
       end
+
+      protocol = typecast_params.nonempty_str("protocol")
     else
       cidr = typecast_params.str!("cidr")
       port_range = typecast_params.str("port_range")
+      protocol = typecast_params.str("protocol")
     end
 
     unless cidr.include?(".") || cidr.include?(":")
@@ -59,9 +62,10 @@ class Clover
     cidrs ||= [Validation.validate_cidr(cidr)]
     port_range = Validation.validate_port_range(port_range)
     pg_range = Sequel.pg_range(port_range.first..port_range.last)
+    protocol = Validation.validate_protocol(protocol)
     description = typecast_params.str("description")&.strip
 
-    [cidrs, pg_range, description]
+    [cidrs, pg_range, protocol, description]
   end
 
   def firewall_post(firewall_name)

--- a/helpers/firewall.rb
+++ b/helpers/firewall.rb
@@ -16,9 +16,11 @@ class Clover
 
   def firewall_rule_params
     if web?
-      port_range = if (range = FirewallRule.range_for_port_type(typecast_params.nonempty_str("port_type")))
+      port_type = typecast_params.nonempty_str("port_type")
+      port_range = if (protocol, range = FirewallRule.protocol_and_range_for_port_type(port_type))
         "#{range.begin}..#{range.end - 1}"
       else
+        protocol = "udp" if port_type == "custom_udp"
         start_port = typecast_params.Integer!("start_port")
         end_port = typecast_params.Integer("end_port") || start_port
         "#{start_port}..#{end_port}"
@@ -33,8 +35,6 @@ class Clover
       else
         FirewallRule.cidr_for_source_type(source_type)
       end
-
-      protocol = typecast_params.nonempty_str("protocol")
     else
       cidr = typecast_params.str!("cidr")
       port_range = typecast_params.str("port_range")

--- a/helpers/model_hiding.rb
+++ b/helpers/model_hiding.rb
@@ -17,7 +17,7 @@ class Clover < Roda
         ::ActionTag => [:options_for_project],
         ::ApiKey => [:create_inference_api_key, :create_personal_access_token, :project_id_for_personal_access_token],
         ::DiscountCode => [:first],
-        ::FirewallRule => [:cidr_for_source_type, :range_for_port_type, :port_options, :source_options],
+        ::FirewallRule => [:cidr_for_source_type, :protocol_and_range_for_port_type, :port_options, :source_options],
         ::GithubInstallation => [:with_github_installation_id],
         ::GithubRepository => [:cache_size_limit],
         ::InferenceEndpoint => [:is_public],

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -217,6 +217,15 @@ module Validation
     fail ValidationFailed.new({cidr: "Invalid CIDR"})
   end
 
+  ALLOWED_PROTOCOLS = %w[tcp udp].freeze
+
+  def self.validate_protocol(protocol)
+    return "tcp" if protocol.nil?
+    protocol = protocol.downcase
+    fail ValidationFailed.new({protocol: "Invalid protocol, must be tcp or udp"}) unless ALLOWED_PROTOCOLS.include?(protocol)
+    protocol
+  end
+
   def self.validate_port_range(port_range)
     return [0, 65535] if port_range.nil?
 

--- a/model/firewall.rb
+++ b/model/firewall.rb
@@ -28,8 +28,8 @@ class Firewall < Sequel::Model
     update_private_subnet_firewall_rules
   end
 
-  def insert_firewall_rule(cidr, port_range, description: nil)
-    fwr = add_firewall_rule(cidr:, port_range:, description:)
+  def insert_firewall_rule(cidr, port_range, protocol: "tcp", description: nil)
+    fwr = add_firewall_rule(cidr:, port_range:, protocol:, description:)
     update_private_subnet_firewall_rules
     fwr
   end

--- a/model/firewall_rule.rb
+++ b/model/firewall_rule.rb
@@ -30,6 +30,10 @@ class FirewallRule < Sequel::Model
     DISPLAY_PORT_NAMES[port_range&.to_range] || display_port_range
   end
 
+  def web_display_protocol_and_port_range
+    "#{protocol.upcase}: #{web_display_port_range}"
+  end
+
   def <=>(other)
     (cidr.version <=> other.cidr.version).nonzero? ||
       (cidr.network.addr <=> other.cidr.network.addr).nonzero? ||
@@ -68,6 +72,11 @@ class FirewallRule < Sequel::Model
   PORT_OPTIONS.freeze.each(&:freeze)
   def self.port_options
     PORT_OPTIONS
+  end
+
+  PROTOCOL_OPTIONS = [["tcp", "TCP"], ["udp", "UDP"]].freeze
+  def self.protocol_options
+    PROTOCOL_OPTIONS
   end
 
   # This is used for mapping IP address ranges to displayed names in the UI.

--- a/model/firewall_rule.rb
+++ b/model/firewall_rule.rb
@@ -27,11 +27,7 @@ class FirewallRule < Sequel::Model
   end
 
   def web_display_port_range
-    DISPLAY_PORT_NAMES[port_range&.to_range] || display_port_range
-  end
-
-  def web_display_protocol_and_port_range
-    "#{protocol.upcase}: #{web_display_port_range}"
+    DISPLAY_PORT_NAMES.dig(protocol, port_range&.to_range) || "#{protocol.upcase}: #{display_port_range}"
   end
 
   def <=>(other)
@@ -45,39 +41,58 @@ class FirewallRule < Sequel::Model
 
   # This is used for mapping port ranges to displayed names in the UI.
   DISPLAY_PORT_NAMES = {
-    (22...23) => "SSH",
-    (443...444) => "HTTPS",
-    (5432...5433) => "PostgreSQL",
-    (6432...6433) => "pgBouncer",
-    (0...65536) => "All",
-  }.freeze
+    "tcp" => {
+      (22...23) => "SSH",
+      (443...444) => "HTTPS",
+      (5432...5433) => "PostgreSQL",
+      (6432...6433) => "pgBouncer",
+      (0...65536) => "All TCP",
+      nil => "All TCP",
+    },
+    "udp" => {
+      (0...65536) => "All UDP",
+      nil => "All UDP",
+    },
+  }.freeze.each_value(&:freeze)
 
   # This is used for mapping port ranges to select option values in the UI.
-  PORT_TYPES = DISPLAY_PORT_NAMES.transform_values(&:downcase)
-  PORT_TYPES.default = "custom"
-  PORT_TYPES.freeze
+  PORT_TYPES = DISPLAY_PORT_NAMES.to_h do |protocol, ports|
+    ports = ports.dup
+    ports.delete(nil)
+    ports = ports.transform_values { it.downcase.tr(" ", "_") }
+    ports.default = "custom_#{protocol}"
+    [protocol, ports]
+  end.freeze.each_value(&:freeze)
   def port_type
-    PORT_TYPES[port_range.to_range]
+    PORT_TYPES.dig(protocol, port_range.to_range)
   end
 
   # This maps from select option values in the UI to port ranges. It is used during
   # form submissions to determine the underlying port range to use.
-  PORT_RANGES = PORT_TYPES.invert.freeze
-  def self.range_for_port_type(type)
+  PORT_RANGES = {}
+  PORT_TYPES.each do |protocol, ports|
+    ports.each do |k, v|
+      PORT_RANGES[v] = [protocol, k]
+    end
+  end
+  PORT_RANGES.freeze.each_value(&:freeze)
+  def self.protocol_and_range_for_port_type(type)
     PORT_RANGES[type]
   end
 
   # This lists all allowed port select option values and text to display in the UI.
-  PORT_OPTIONS = PORT_TYPES.values.zip(DISPLAY_PORT_NAMES.values)
-  PORT_OPTIONS << ["custom", "Custom"]
+  PORT_OPTIONS = []
+  DISPLAY_PORT_NAMES.each_value do
+    it.each do |k, v|
+      next unless k
+      PORT_OPTIONS << [v.downcase.tr(" ", "_").freeze, v]
+    end
+  end
+  PORT_OPTIONS << ["custom_tcp", "Custom TCP"]
+  PORT_OPTIONS << ["custom_udp", "Custom UDP"]
   PORT_OPTIONS.freeze.each(&:freeze)
   def self.port_options
     PORT_OPTIONS
-  end
-
-  PROTOCOL_OPTIONS = [["tcp", "TCP"], ["udp", "UDP"]].freeze
-  def self.protocol_options
-    PROTOCOL_OPTIONS
   end
 
   # This is used for mapping IP address ranges to displayed names in the UI.

--- a/model/firewall_rule.rb
+++ b/model/firewall_rule.rb
@@ -38,6 +38,7 @@ class FirewallRule < Sequel::Model
     (cidr.version <=> other.cidr.version).nonzero? ||
       (cidr.network.addr <=> other.cidr.network.addr).nonzero? ||
       (cidr.netmask.mask <=> other.cidr.netmask.mask).nonzero? ||
+      (protocol <=> other.protocol).nonzero? ||
       (port_range.begin <=> other.port_range.begin).nonzero? ||
       port_range.end <=> other.port_range.end
   end

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -506,6 +506,9 @@ paths:
                 port_range:
                   description: Port range to allow
                   type: string
+                protocol:
+                  description: Protocol to allow (tcp or udp, default tcp)
+                  type: string
                 description:
                   description: Description to use for the firewall rule
                   type: string
@@ -3028,6 +3031,9 @@ components:
             port_range:
               description: Port range of the firewall rule
               type: string
+            protocol:
+              description: Protocol of the firewall rule (tcp or udp)
+              type: string
             description:
               description: Description of the firewall rule
               type: string
@@ -3039,12 +3045,26 @@ components:
             port_range:
               description: Port range of the firewall rule
               type: string
+            protocol:
+              description: Protocol of the firewall rule (tcp or udp)
+              type: string
             description:
               description: Description of the firewall rule
               type: string
           additionalProperties: false
           required:
             - port_range
+        - type: object
+          properties:
+            protocol:
+              description: Protocol of the firewall rule (tcp or udp)
+              type: string
+            description:
+              description: Description of the firewall rule
+              type: string
+          additionalProperties: false
+          required:
+            - protocol
         - type: object
           properties:
             description:
@@ -3280,6 +3300,12 @@ components:
         port_range:
           description: Port range of the firewall rule
           type: string
+        protocol:
+          description: Protocol of the firewall rule (tcp or udp)
+          type: string
+          enum:
+            - tcp
+            - udp
         description:
           description: Description of the firewall rule
           type: string
@@ -3288,6 +3314,7 @@ components:
         - cidr
         - id
         - port_range
+        - protocol
         - description
     SshPublicKey:
       type: object

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -125,13 +125,13 @@ class Clover
               @page = "firewall_rule"
             end
 
-            cidrs, pg_range, description = firewall_rule_params
+            cidrs, pg_range, protocol, description = firewall_rule_params
             description = nil if description&.empty?
 
             DB.transaction do
               DB.ignore_duplicate_queries do
                 cidrs.map! do |cidr|
-                  firewall_rule = firewall.insert_firewall_rule(cidr, pg_range, description:)
+                  firewall_rule = firewall.insert_firewall_rule(cidr, pg_range, protocol:, description:)
                   audit_log(firewall_rule, "create", firewall)
                   firewall_rule
                 end
@@ -158,28 +158,32 @@ class Clover
 
             current_cidr = firewall_rule.cidr.to_s
             current_port_range = firewall_rule.display_port_range
+            current_protocol = firewall_rule.protocol
 
             if web?
-              cidrs, pg_range, description = firewall_rule_params
+              cidrs, pg_range, protocol, description = firewall_rule_params
               cidr = cidrs[0].to_s
               description = nil if description == ""
             else
-              cidr, port_range, description = typecast_params.str(%w[cidr port_range description])
+              cidr, port_range, protocol, description = typecast_params.str(%w[cidr port_range protocol description])
               cidr = Validation.validate_cidr(cidr).to_s if cidr
 
               if port_range
                 port_range = Validation.validate_port_range(port_range)
                 pg_range = Sequel.pg_range(port_range.first..port_range.last)
               end
+
+              protocol = Validation.validate_protocol(protocol) if protocol
             end
 
             firewall_rule.cidr = cidr if cidr
             firewall_rule.port_range = pg_range if pg_range
+            firewall_rule.protocol = protocol if protocol
             firewall_rule.description = description.strip if description
 
             DB.transaction do
               firewall_rule.save_changes
-              if current_cidr != firewall_rule.cidr.to_s || current_port_range != firewall_rule.display_port_range
+              if current_cidr != firewall_rule.cidr.to_s || current_port_range != firewall_rule.display_port_range || current_protocol != firewall_rule.protocol
                 firewall.update_private_subnet_firewall_rules
               end
               audit_log(firewall_rule, "update")

--- a/sdk/ruby/lib/ubicloud/model/firewall.rb
+++ b/sdk/ruby/lib/ubicloud/model/firewall.rb
@@ -18,10 +18,12 @@ module Ubicloud
     # * If only +start_port+ is given, only that single port is allowed.
     # * If only +end_port+ is given, all ports up to that end port are allowed.
     # * If neither +start_port+ and +end_port+ are given, all ports are allowed.
+    # * +protocol+ can be "tcp" (default) or "udp".
     #
     # Returns a hash for the firewall rule.
-    def add_rule(cidr, start_port: nil, end_port: nil, description: nil)
+    def add_rule(cidr, start_port: nil, end_port: nil, protocol: nil, description: nil)
       hash = {cidr:, port_range: "#{start_port || 0}..#{end_port || start_port || 65535}"}
+      hash[:protocol] = protocol if protocol
       hash[:description] = description if description
       rule = adapter.post(_path("/firewall-rule"), **hash)
 
@@ -36,12 +38,13 @@ module Ubicloud
     # * If only +start_port+ is given, the rule is updated to allow only that single port.
     # * If only +end_port+ is given, the rule is updated to allow all ports up to that port.
     # * If neither +start_port+ and +end_port+ are given, the port range is left unchanged.
+    # * +protocol+ can be "tcp" or "udp".
     #
     # Returns a hash for the updated firewall rule.
-    def modify_rule(rule_id, cidr: nil, start_port: nil, end_port: nil, description: nil)
+    def modify_rule(rule_id, cidr: nil, start_port: nil, end_port: nil, protocol: nil, description: nil)
       check_no_slash(rule_id, "invalid rule id format")
 
-      hash = {cidr:, description:}
+      hash = {cidr:, protocol:, description:}
       hash.compact!
       if start_port || end_port
         hash[:port_range] = "#{start_port || 0}..#{end_port || start_port}"

--- a/serializers/firewall_rule.rb
+++ b/serializers/firewall_rule.rb
@@ -6,6 +6,7 @@ class Serializers::FirewallRule < Serializers::Base
       id: firewall_rule.ubid,
       cidr: firewall_rule.cidr,
       port_range: firewall_rule.display_port_range,
+      protocol: firewall_rule.protocol,
       description: firewall_rule.description || "",
     }
   end

--- a/spec/model/firewall_rule_spec.rb
+++ b/spec/model/firewall_rule_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FirewallRule do
     expect(fw_rule.ip6?).to be false
   end
 
-  it "<=> sorts by family, ip address (numerically), netmask, starting port, and ending port" do
+  it "<=> sorts by family, ip address (numerically), netmask, protocol, starting port, and ending port" do
     fws = []
     fws << (fw1 = described_class.create(cidr: "1.2.3.4/31", port_range: (22...32), firewall_id: fw.id))
     fws << (fw2 = described_class.create(cidr: "1.2.3.4/31", port_range: (22...31), firewall_id: fw.id))
@@ -27,5 +27,7 @@ RSpec.describe FirewallRule do
     expect(fws.sort).to eq [fw4, fw3, fw2, fw1, fw5]
     fws << (fw6 = described_class.create(cidr: "::/0", port_range: (21...33), firewall_id: fw.id))
     expect(fws.sort).to eq [fw4, fw3, fw2, fw1, fw5, fw6]
+    fws << (fw7 = described_class.create(cidr: "1.2.3.4/31", port_range: (22...31), protocol: "udp", firewall_id: fw.id))
+    expect(fws.sort).to eq [fw4, fw3, fw2, fw1, fw7, fw5, fw6]
   end
 end

--- a/spec/model/firewall_rule_spec.rb
+++ b/spec/model/firewall_rule_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe FirewallRule do
     Firewall.create(location_id: Location::HETZNER_FSN1_ID, project_id: Project.create(name: "test").id)
   }
 
+  it "#display_port_range handles nil port range" do
+    expect(described_class.new.display_port_range).to eq "0..65535"
+  end
+
   it "returns ip6? properly" do
     fw_rule = described_class.create(cidr: "::/0", firewall_id: fw.id)
     expect(fw_rule.ip6?).to be true

--- a/spec/routes/api/cli/fw/add-rule_spec.rb
+++ b/spec/routes/api/cli/fw/add-rule_spec.rb
@@ -75,6 +75,18 @@ RSpec.describe Clover, "cli fw add-rule" do
     expect(fwr2.firewall_id).to eq @fw.id
   end
 
+  it "supports -p option to set protocol" do
+    expect(FirewallRule.count).to eq 0
+    body = cli(%W[fw eu-central-h1/test-fw add-rule -s 53 -p udp 1.2.3.0/24])
+    expect(FirewallRule.count).to eq 1
+    fwr = FirewallRule.first
+    expect(body).to eq "Added firewall rule with id: #{fwr.ubid}\n"
+    expect(fwr.cidr.to_s).to eq "1.2.3.0/24"
+    expect(fwr.port_range.to_range).to eq(53...54)
+    expect(fwr.protocol).to eq "udp"
+    expect(fwr.firewall_id).to eq @fw.id
+  end
+
   it "adds rule to firewall using subnet id" do
     expect(FirewallRule.count).to eq 0
     cli(%W[ps eu-central-h1/test-ps create -f test-fw])

--- a/spec/routes/api/cli/fw/modify-rule_spec.rb
+++ b/spec/routes/api/cli/fw/modify-rule_spec.rb
@@ -53,4 +53,13 @@ RSpec.describe Clover, "cli fw modify-rule" do
     expect(@fwr.port_range.to_range).to eq(0...65536)
     expect(@fwr.description).to eq "my-desc"
   end
+
+  it "can modify protocol with -p" do
+    body = cli(%W[fw eu-central-h1/test-fw modify-rule -p udp #{@fwr.ubid}])
+    expect(body).to eq "Modified firewall rule with id: #{@fwr.ubid}\n"
+    @fwr.reload
+    expect(@fwr.cidr.to_s).to eq "1.2.3.0/24"
+    expect(@fwr.port_range.to_range).to eq(0...65536)
+    expect(@fwr.protocol).to eq "udp"
+  end
 end

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default add-rule -e a 10.10.10.0.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default add-rule -e a 10.10.10.0.txt
@@ -8,4 +8,5 @@ Usage:
 Options:
     -s, --start-port=port            starting (or only) port to allow (default: 0)
     -e, --end-port=port              ending port to allow (default: 65535)
+    -p, --protocol=protocol          protocol to allow (tcp or udp, default: tcp)
     -d, --description=desc           description of rule

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default add-rule -s a 10.10.10.0.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default add-rule -s a 10.10.10.0.txt
@@ -8,4 +8,5 @@ Usage:
 Options:
     -s, --start-port=port            starting (or only) port to allow (default: 0)
     -e, --end-port=port              ending port to allow (default: 65535)
+    -p, --protocol=protocol          protocol to allow (tcp or udp, default: tcp)
     -d, --description=desc           description of rule

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default modify-rule fra7jvrz94be7qy8qrq8n1jrp1.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default modify-rule fra7jvrz94be7qy8qrq8n1jrp1.txt
@@ -1,4 +1,4 @@
-! Must provide at least one option (-c, -s, -e, or -d)
+! Must provide at least one option (-c, -s, -e, -p, or -d)
 
 Modify a firewall rule
 
@@ -9,4 +9,5 @@ Options:
     -c, --cidr=ip-range              IPv4 or IPv6 range to allow
     -s, --start-port=port            starting (or only) port to allow (default: 0)
     -e, --end-port=port              ending port to allow (default: 65535)
+    -p, --protocol=protocol          protocol to allow (tcp or udp)
     -d, --description=desc           description of rule

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -169,6 +169,7 @@ Usage:
 Options:
     -s, --start-port=port            starting (or only) port to allow (default: 0)
     -e, --end-port=port              ending port to allow (default: 65535)
+    -p, --protocol=protocol          protocol to allow (tcp or udp, default: tcp)
     -d, --description=desc           description of rule
 
 
@@ -217,6 +218,7 @@ Options:
     -c, --cidr=ip-range              IPv4 or IPv6 range to allow
     -s, --start-port=port            starting (or only) port to allow (default: 0)
     -e, --end-port=port              ending port to allow (default: 65535)
+    -p, --protocol=protocol          protocol to allow (tcp or udp)
     -d, --description=desc           description of rule
 
 

--- a/spec/routes/api/project/firewall_rule_spec.rb
+++ b/spec/routes/api/project/firewall_rule_spec.rb
@@ -101,6 +101,46 @@ RSpec.describe Clover, "firewall" do
       expect(rule.description).to eq "fw rd"
     end
 
+    it "create udp firewall rule" do
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule", {
+        cidr: "0.0.0.0/0",
+        port_range: "53",
+        protocol: "udp",
+      }.to_json
+
+      expect(last_response.status).to eq(200)
+      rule = FirewallRule.first
+      expect(rule.cidr.to_s).to eq "0.0.0.0/0"
+      expect(rule.port_range.to_range).to eq 53...54
+      expect(rule.protocol).to eq "udp"
+    end
+
+    it "can modify protocol to udp" do
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule", {
+        cidr: "0.0.0.0/1",
+        port_range: "53",
+      }.to_json
+      rule = FirewallRule.first
+      expect(rule.protocol).to eq "tcp"
+
+      patch "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule/#{rule.ubid}", {
+        protocol: "udp",
+      }.to_json
+
+      expect(last_response.status).to eq(200)
+      rule.reload
+      expect(rule.protocol).to eq "udp"
+    end
+
+    it "fails with invalid protocol" do
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule", {
+        cidr: "0.0.0.0/0",
+        protocol: "icmp",
+      }.to_json
+
+      expect(last_response).to have_api_error(400, "Validation failed for following fields: protocol")
+    end
+
     it "firewall rule delete" do
       delete "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/firewall-rule/#{firewall_rule.ubid}"
       expect(last_response.status).to eq(204)
@@ -120,6 +160,7 @@ RSpec.describe Clover, "firewall" do
         "id" => firewall_rule.ubid,
         "cidr" => firewall_rule.cidr.to_s,
         "port_range" => "80..5432",
+        "protocol" => "tcp",
         "description" => "fwrd",
       )
     end

--- a/spec/routes/web/firewall_spec.rb
+++ b/spec/routes/web/firewall_spec.rb
@@ -296,40 +296,80 @@ RSpec.describe Clover, "firewall" do
     end
 
     describe "rules" do
-      it "can add using custom address and port" do
-        visit "#{project.path}#{firewall.path}/networking"
-        click_link "Add Firewall Rule"
+      %w[TCP UDP].each do |protocol|
+        it "can add using custom address and #{protocol} port" do
+          visit "#{project.path}#{firewall.path}/networking"
+          click_link "Add Firewall Rule"
 
-        within("#port-type") { select "Custom" }
-        fill_in "Start Port", with: "80"
-        fill_in "End Port (optional)", with: "82"
-        within("#source-type") { select "Custom" }
-        fill_in "Source IP Address Range (CIDR)", with: "1.1.1.1"
-        click_button "Add Firewall Rule"
+          within("#port-type") { select "Custom #{protocol}" }
+          fill_in "Start Port", with: "80"
+          fill_in "End Port (optional)", with: "82"
+          within("#source-type") { select "Custom" }
+          fill_in "Source IP Address Range (CIDR)", with: "1.1.1.1"
+          click_button "Add Firewall Rule"
 
-        expect(page.title).to eq("Ubicloud - #{firewall.name}")
-        expect(page).to have_flash_notice("Firewall rule is created")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["1.1.1.1", "TCP: 80..82", "", "", ""]
+          expect(page.title).to eq("Ubicloud - #{firewall.name}")
+          expect(page).to have_flash_notice("Firewall rule is created")
+          expect(page.all("#firewall-rules td").map(&:text)).to eq ["1.1.1.1", "#{protocol}: 80..82", "", "", ""]
 
-        expect(firewall.firewall_rules_dataset.count).to eq(1)
-        rule = firewall.firewall_rules_dataset.first
-        expect(rule.firewall_id).to eq firewall.id
-        expect(rule.cidr.to_s).to eq "1.1.1.1/32"
-        expect(rule.port_range.to_range).to eq 80...83
-        expect(rule.description).to be_nil
+          expect(firewall.firewall_rules_dataset.count).to eq(1)
+          rule = firewall.firewall_rules_dataset.first
+          expect(rule.firewall_id).to eq firewall.id
+          expect(rule.cidr.to_s).to eq "1.1.1.1/32"
+          expect(rule.port_range.to_range).to eq 80...83
+          expect(rule.protocol).to eq protocol.downcase
+          expect(rule.description).to be_nil
 
-        find("#edit-#{rule.ubid}").click
-        fill_in "Source IP Address Range (CIDR)", with: "1234::5678/128"
-        click_button "Edit Firewall Rule"
-        expect(page).to have_flash_notice("Firewall rule updated")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["1234::5678", "TCP: 80..82", "", "", ""]
+          find("#edit-#{rule.ubid}").click
+          fill_in "Source IP Address Range (CIDR)", with: "1234::5678/128"
+          click_button "Edit Firewall Rule"
+          expect(page).to have_flash_notice("Firewall rule updated")
+          expect(page.all("#firewall-rules td").map(&:text)).to eq ["1234::5678", "#{protocol}: 80..82", "", "", ""]
 
-        expect(firewall.firewall_rules_dataset.count).to eq(1)
-        rule = firewall.firewall_rules_dataset.first
-        expect(rule.firewall_id).to eq firewall.id
-        expect(rule.cidr.to_s).to eq "1234::5678/128"
-        expect(rule.port_range.to_range).to eq 80...83
-        expect(rule.description).to be_nil
+          expect(firewall.firewall_rules_dataset.count).to eq(1)
+          rule = firewall.firewall_rules_dataset.first
+          expect(rule.firewall_id).to eq firewall.id
+          expect(rule.cidr.to_s).to eq "1234::5678/128"
+          expect(rule.port_range.to_range).to eq 80...83
+          expect(rule.protocol).to eq protocol.downcase
+          expect(rule.description).to be_nil
+        end
+
+        it "can add using custom address and all #{protocol} ports" do
+          visit "#{project.path}#{firewall.path}/networking"
+          click_link "Add Firewall Rule"
+
+          within("#port-type") { select "All #{protocol}" }
+          within("#source-type") { select "Custom" }
+          fill_in "Source IP Address Range (CIDR)", with: "1.1.1.1"
+          click_button "Add Firewall Rule"
+
+          expect(page.title).to eq("Ubicloud - #{firewall.name}")
+          expect(page).to have_flash_notice("Firewall rule is created")
+          expect(page.all("#firewall-rules td").map(&:text)).to eq ["1.1.1.1", "All #{protocol}", "", "", ""]
+
+          expect(firewall.firewall_rules_dataset.count).to eq(1)
+          rule = firewall.firewall_rules_dataset.first
+          expect(rule.firewall_id).to eq firewall.id
+          expect(rule.cidr.to_s).to eq "1.1.1.1/32"
+          expect(rule.port_range.to_range).to eq 0...65536
+          expect(rule.protocol).to eq protocol.downcase
+          expect(rule.description).to be_nil
+
+          find("#edit-#{rule.ubid}").click
+          fill_in "Source IP Address Range (CIDR)", with: "1234::5678/128"
+          click_button "Edit Firewall Rule"
+          expect(page).to have_flash_notice("Firewall rule updated")
+          expect(page.all("#firewall-rules td").map(&:text)).to eq ["1234::5678", "All #{protocol}", "", "", ""]
+
+          expect(firewall.firewall_rules_dataset.count).to eq(1)
+          rule = firewall.firewall_rules_dataset.first
+          expect(rule.firewall_id).to eq firewall.id
+          expect(rule.cidr.to_s).to eq "1234::5678/128"
+          expect(rule.port_range.to_range).to eq 0...65536
+          expect(rule.protocol).to eq protocol.downcase
+          expect(rule.description).to be_nil
+        end
       end
 
       it "can add with description" do
@@ -342,7 +382,7 @@ RSpec.describe Clover, "firewall" do
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
         expect(page).to have_flash_notice("Firewall rule is created")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv6", "TCP: SSH", "my desc", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv6", "SSH", "my desc", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -354,7 +394,7 @@ RSpec.describe Clover, "firewall" do
         find("#edit-#{rule.ubid}").click
         click_button "Edit Firewall Rule"
         expect(page).to have_flash_notice("Firewall rule updated")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv6", "TCP: SSH", "my desc", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv6", "SSH", "my desc", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -376,7 +416,7 @@ RSpec.describe Clover, "firewall" do
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
         expect(page).to have_flash_notice("Firewall rule is created")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv4 Subnet: dummy-ps-1", "TCP: HTTPS", "my desc", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv4 Subnet: dummy-ps-1", "HTTPS", "my desc", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -388,7 +428,7 @@ RSpec.describe Clover, "firewall" do
         find("#edit-#{rule.ubid}").click
         click_button "Edit Firewall Rule"
         expect(page).to have_flash_notice("Firewall rule updated")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv4 Subnet: dummy-ps-1", "TCP: HTTPS", "my desc", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv4 Subnet: dummy-ps-1", "HTTPS", "my desc", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -409,7 +449,7 @@ RSpec.describe Clover, "firewall" do
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
         expect(page).to have_flash_notice("Firewall rule is created")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv6 Subnet: dummy-ps-1", "TCP: PostgreSQL", "", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv6 Subnet: dummy-ps-1", "PostgreSQL", "", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -421,7 +461,7 @@ RSpec.describe Clover, "firewall" do
         find("#edit-#{rule.ubid}").click
         click_button "Edit Firewall Rule"
         expect(page).to have_flash_notice("Firewall rule updated")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv6 Subnet: dummy-ps-1", "TCP: PostgreSQL", "", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv6 Subnet: dummy-ps-1", "PostgreSQL", "", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -434,7 +474,7 @@ RSpec.describe Clover, "firewall" do
       it "can not add rule when it is invalid" do
         visit "#{project.path}#{firewall.path}/firewall-rule"
 
-        within("#port-type") { select "Custom" }
+        within("#port-type") { select "Custom TCP" }
         fill_in "Start Port", with: "80"
         within("#source-type") { select "Custom" }
         fill_in "Source IP Address Range (CIDR)", with: "invalid"
@@ -456,8 +496,7 @@ RSpec.describe Clover, "firewall" do
       it "can add udp rule" do
         visit "#{project.path}#{firewall.path}/firewall-rule"
 
-        select "UDP"
-        within("#port-type") { select "Custom" }
+        within("#port-type") { select "Custom UDP" }
         fill_in "Start Port", with: "53"
         within("#source-type") { select "All IPv4" }
         click_button "Add Firewall Rule"
@@ -494,7 +533,7 @@ RSpec.describe Clover, "firewall" do
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
         expect(page).to have_flash_notice("Firewall rule updated")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv4", "TCP: pgBouncer", "my desc", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv4", "pgBouncer", "my desc", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule.refresh
@@ -510,7 +549,7 @@ RSpec.describe Clover, "firewall" do
         visit "#{project.path}#{firewall.path}/networking"
         find("#edit-#{rule.ubid}").click
 
-        select "UDP"
+        select "Custom UDP"
         within("#source-type") { select "All IPv4" }
         click_button "Edit Firewall Rule"
 
@@ -552,7 +591,7 @@ RSpec.describe Clover, "firewall" do
         firewall.insert_firewall_rule("1.0.0.0/8", nil)
 
         visit "#{project.path}#{firewall.path}/networking"
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["1.0.0.0/8", "TCP: 0..65535", "", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["1.0.0.0/8", "All TCP", "", "", ""]
       end
 
       it "does not show actions that require edit permissions" do

--- a/spec/routes/web/firewall_spec.rb
+++ b/spec/routes/web/firewall_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe Clover, "firewall" do
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
         expect(page).to have_flash_notice("Firewall rule is created")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["1.1.1.1", "80..82", "", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["1.1.1.1", "TCP: 80..82", "", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -322,7 +322,7 @@ RSpec.describe Clover, "firewall" do
         fill_in "Source IP Address Range (CIDR)", with: "1234::5678/128"
         click_button "Edit Firewall Rule"
         expect(page).to have_flash_notice("Firewall rule updated")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["1234::5678", "80..82", "", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["1234::5678", "TCP: 80..82", "", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -342,7 +342,7 @@ RSpec.describe Clover, "firewall" do
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
         expect(page).to have_flash_notice("Firewall rule is created")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv6", "SSH", "my desc", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv6", "TCP: SSH", "my desc", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -354,7 +354,7 @@ RSpec.describe Clover, "firewall" do
         find("#edit-#{rule.ubid}").click
         click_button "Edit Firewall Rule"
         expect(page).to have_flash_notice("Firewall rule updated")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv6", "SSH", "my desc", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv6", "TCP: SSH", "my desc", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -376,7 +376,7 @@ RSpec.describe Clover, "firewall" do
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
         expect(page).to have_flash_notice("Firewall rule is created")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv4 Subnet: dummy-ps-1", "HTTPS", "my desc", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv4 Subnet: dummy-ps-1", "TCP: HTTPS", "my desc", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -388,7 +388,7 @@ RSpec.describe Clover, "firewall" do
         find("#edit-#{rule.ubid}").click
         click_button "Edit Firewall Rule"
         expect(page).to have_flash_notice("Firewall rule updated")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv4 Subnet: dummy-ps-1", "HTTPS", "my desc", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv4 Subnet: dummy-ps-1", "TCP: HTTPS", "my desc", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -409,7 +409,7 @@ RSpec.describe Clover, "firewall" do
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
         expect(page).to have_flash_notice("Firewall rule is created")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv6 Subnet: dummy-ps-1", "PostgreSQL", "", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv6 Subnet: dummy-ps-1", "TCP: PostgreSQL", "", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -421,7 +421,7 @@ RSpec.describe Clover, "firewall" do
         find("#edit-#{rule.ubid}").click
         click_button "Edit Firewall Rule"
         expect(page).to have_flash_notice("Firewall rule updated")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv6 Subnet: dummy-ps-1", "PostgreSQL", "", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["IPv6 Subnet: dummy-ps-1", "TCP: PostgreSQL", "", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule = firewall.firewall_rules_dataset.first
@@ -453,6 +453,26 @@ RSpec.describe Clover, "firewall" do
         expect(firewall.firewall_rules_dataset.count).to eq(0)
       end
 
+      it "can add udp rule" do
+        visit "#{project.path}#{firewall.path}/firewall-rule"
+
+        select "UDP"
+        within("#port-type") { select "Custom" }
+        fill_in "Start Port", with: "53"
+        within("#source-type") { select "All IPv4" }
+        click_button "Add Firewall Rule"
+
+        expect(page.title).to eq("Ubicloud - #{firewall.name}")
+        expect(page).to have_flash_notice("Firewall rule is created")
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv4", "UDP: 53", "", "", ""]
+
+        expect(firewall.firewall_rules_dataset.count).to eq(1)
+        rule = firewall.firewall_rules_dataset.first
+        expect(rule.cidr.to_s).to eq "0.0.0.0/0"
+        expect(rule.port_range.to_range).to eq 53...54
+        expect(rule.protocol).to eq "udp"
+      end
+
       it "can edit rule" do
         firewall.insert_firewall_rule("1.0.0.0/8", Sequel.pg_range(80..80))
         rule = firewall.firewall_rules_dataset.first
@@ -474,13 +494,32 @@ RSpec.describe Clover, "firewall" do
 
         expect(page.title).to eq("Ubicloud - #{firewall.name}")
         expect(page).to have_flash_notice("Firewall rule updated")
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv4", "pgBouncer", "my desc", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv4", "TCP: pgBouncer", "my desc", "", ""]
 
         expect(firewall.firewall_rules_dataset.count).to eq(1)
         rule.refresh
         expect(rule.cidr.to_s).to eq "0.0.0.0/0"
         expect(rule.port_range.to_range).to eq 6432...6433
         expect(rule.description).to eq "my desc"
+      end
+
+      it "can edit rule to change protocol to udp" do
+        firewall.insert_firewall_rule("1.0.0.0/8", Sequel.pg_range(53..53))
+        rule = firewall.firewall_rules_dataset.first
+
+        visit "#{project.path}#{firewall.path}/networking"
+        find("#edit-#{rule.ubid}").click
+
+        select "UDP"
+        within("#source-type") { select "All IPv4" }
+        click_button "Edit Firewall Rule"
+
+        expect(page.title).to eq("Ubicloud - #{firewall.name}")
+        expect(page).to have_flash_notice("Firewall rule updated")
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["All IPv4", "UDP: 53", "", "", ""]
+
+        rule.refresh
+        expect(rule.protocol).to eq "udp"
       end
 
       it "can delete rule" do
@@ -513,7 +552,7 @@ RSpec.describe Clover, "firewall" do
         firewall.insert_firewall_rule("1.0.0.0/8", nil)
 
         visit "#{project.path}#{firewall.path}/networking"
-        expect(page.all("#firewall-rules td").map(&:text)).to eq ["1.0.0.0/8", "0..65535", "", "", ""]
+        expect(page.all("#firewall-rules td").map(&:text)).to eq ["1.0.0.0/8", "TCP: 0..65535", "", "", ""]
       end
 
       it "does not show actions that require edit permissions" do

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -745,10 +745,10 @@ RSpec.describe Clover, "vm" do
         visit "#{project.path}#{vm.path}"
         within("#vm-submenu") { click_link "Networking" }
         expect(page.all("#vm-firewall-rules td").map(&:text)).to eq [
-          "default-eu-central-h1-default", "0.0.0.0/0", "0..65535",
-          "default-eu-central-h1-default", "0.0.0.0/0", "0..65535",
-          "default-eu-central-h1-default", "::/0", "0..65535",
-          "default-eu-central-h1-default", "::/0", "0..65535",
+          "default-eu-central-h1-default", "0.0.0.0/0", "TCP 0..65535",
+          "default-eu-central-h1-default", "0.0.0.0/0", "UDP 0..65535",
+          "default-eu-central-h1-default", "::/0", "TCP 0..65535",
+          "default-eu-central-h1-default", "::/0", "UDP 0..65535",
         ]
         page.all("#vm-firewall-rules td a").first.click
         expect(page.title).to eq "Ubicloud - default-eu-central-h1-default"
@@ -758,10 +758,10 @@ RSpec.describe Clover, "vm" do
         AccessControlEntry.create(project_id: project_wo_permissions.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Vm:view"])
         visit "#{project_wo_permissions.path}#{vm_wo_permission.path}/networking"
         expect(page.all("#vm-firewall-rules td").map(&:text)).to eq [
-          "default-eu-central-h1-default", "0.0.0.0/0", "0..65535",
-          "default-eu-central-h1-default", "0.0.0.0/0", "0..65535",
-          "default-eu-central-h1-default", "::/0", "0..65535",
-          "default-eu-central-h1-default", "::/0", "0..65535",
+          "default-eu-central-h1-default", "0.0.0.0/0", "TCP 0..65535",
+          "default-eu-central-h1-default", "0.0.0.0/0", "UDP 0..65535",
+          "default-eu-central-h1-default", "::/0", "TCP 0..65535",
+          "default-eu-central-h1-default", "::/0", "UDP 0..65535",
         ]
         expect(page.all("#vm-firewall-rules td a").to_a).to eq []
       end

--- a/views/networking/firewall/firewall_rule.erb
+++ b/views/networking/firewall/firewall_rule.erb
@@ -36,6 +36,18 @@
   <div>
     <% form(action:, method: :post, class: "gap-6", id: "firewall-rule-form") do %>
       <div class="mb-2">
+        <%== part(
+          "components/form/select",
+          label: "Protocol",
+          name: "protocol",
+          placeholder: "",
+          attributes: {required: true},
+          selected: fwr ? fwr.protocol : "tcp",
+          options: FirewallRule.protocol_options
+        ) %>
+      </div>
+
+      <div class="mb-2">
         <div id="port-type">
           <%== part(
             "components/form/select",

--- a/views/networking/firewall/firewall_rule.erb
+++ b/views/networking/firewall/firewall_rule.erb
@@ -36,18 +36,6 @@
   <div>
     <% form(action:, method: :post, class: "gap-6", id: "firewall-rule-form") do %>
       <div class="mb-2">
-        <%== part(
-          "components/form/select",
-          label: "Protocol",
-          name: "protocol",
-          placeholder: "",
-          attributes: {required: true},
-          selected: fwr ? fwr.protocol : "tcp",
-          options: FirewallRule.protocol_options
-        ) %>
-      </div>
-
-      <div class="mb-2">
         <div id="port-type">
           <%== part(
             "components/form/select",

--- a/views/networking/firewall/networking.erb
+++ b/views/networking/firewall/networking.erb
@@ -54,7 +54,7 @@ edit_perm = has_permission?("Firewall:edit", @firewall) %>
           <% ubid = fwr.ubid %>
           <tr>
             <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 break-all" scope="row"><%= fwr.web_display_cidr(ps_map) %></td>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr.web_display_port_range %></td>
+            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr.web_display_protocol_and_port_range %></td>
             <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 break-all" scope="row"><%= fwr.description %></td>
             <% if edit_perm %>
               <td

--- a/views/networking/firewall/networking.erb
+++ b/views/networking/firewall/networking.erb
@@ -36,7 +36,7 @@ edit_perm = has_permission?("Firewall:edit", @firewall) %>
     <% end %>
   </div>
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
-    <div class="overflow-x-auto">
+    <div class="overflow-auto">
     <table class="min-w-full divide-y divide-gray-300" id="firewall-rules">
       <thead class="bg-gray-50">
         <tr>

--- a/views/networking/firewall/networking.erb
+++ b/views/networking/firewall/networking.erb
@@ -54,7 +54,7 @@ edit_perm = has_permission?("Firewall:edit", @firewall) %>
           <% ubid = fwr.ubid %>
           <tr>
             <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 break-all" scope="row"><%= fwr.web_display_cidr(ps_map) %></td>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr.web_display_protocol_and_port_range %></td>
+            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr.web_display_port_range %></td>
             <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 break-all" scope="row"><%= fwr.description %></td>
             <% if edit_perm %>
               <td

--- a/views/vm/networking.erb
+++ b/views/vm/networking.erb
@@ -16,7 +16,7 @@ viewable_fws =
         view_perm = viewable_fws.include?(fw.ubid)
         fw.firewall_rules.map do |fwr|
           [
-            [[fw.name, view_perm ? { link: path(fw)} : {}], fwr.cidr, fwr.display_port_range],
+            [[fw.name, view_perm ? { link: path(fw)} : {}], fwr.cidr, "#{fwr.protocol.upcase} #{fwr.display_port_range}"],
             { id: "firewall-rule-#{fwr.ubid}" }
           ]
         end


### PR DESCRIPTION
This was already supported internally, but there was no user accessible
way to use UDP rules.  This adds UDP firewall rule support to the Web
UI, API, and CLI.

<img width="163" height="168" alt="localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_location_eu-central-h1_firewall_t_firewall-rule (1)" src="https://github.com/user-attachments/assets/aa439b79-f7d8-46ed-8037-1bbff3458195" />
<img width="163" height="168" alt="localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_location_eu-central-h1_firewall_t_firewall-rule" src="https://github.com/user-attachments/assets/01ecbad6-15c1-44fa-bdf7-6fd8afdeedb3" />
<img width="163" height="168" alt="localhost_3000_project_pjkvsq7s5e5a7mjtsdjvetweyk_location_eu-central-h1_firewall_t_networking" src="https://github.com/user-attachments/assets/95d299e8-1db4-48e8-a8e8-6d35f80cb454" />


See commit messages for details.