### PR TITLE
Fix a nondeterministic spec failure

### DIFF
--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -209,16 +209,24 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     it "falls back to using boot_image as a BootImage name if machine image lookup fails" do
       mi_project = Project.create(name: "machine-images-service-project")
       expect(Config).to receive(:machine_images_service_project_id).at_least(:once).and_return(mi_project.id)
-      expect(Clog).to receive(:emit).with("No suitable machine image version found for boot image, falling back to using boot image as BootImage name", {
-        base_machine_image_version_not_found: {
-          boot_image: "ubuntu-jammy",
-          location_id: Location::HETZNER_FSN1_ID,
-          error: {machine_image: "Machine image with name \"ubuntu-jammy\" does not exist in the specified project and any of the following locations: eu-central-h1, eu-north-h1"},
-        },
-      }).and_call_original
+      emit_args = []
+      expect(Clog).to receive(:emit).at_least(:once).and_wrap_original do |m, *args|
+        emit_args << args.map(&:dup)
+        m.call(*args)
+      end
       vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "ubuntu-jammy", location_id: Location::HETZNER_FSN1_ID).subject
       expect(vm.vm_storage_volumes.first.machine_image_version_id).to be_nil
       expect(vm.boot_image).to eq("ubuntu-jammy")
+      expect(emit_args).to include([
+        "No suitable machine image version found for boot image, falling back to using boot image as BootImage name",
+        {
+          base_machine_image_version_not_found: {
+            boot_image: "ubuntu-jammy",
+            location_id: Location::HETZNER_FSN1_ID,
+            error: {machine_image: "Machine image with name \"ubuntu-jammy\" does not exist in the specified project and any of the following locations: eu-central-h1, eu-north-h1"},
+          },
+        },
+      ])
     end
 
     it "falls back to using boot_image as a BootImage name if machine images service project is not configured" do


### PR DESCRIPTION
This spec failure happens when Prog::Vnet::SubnetNexus.random_private_ipv4 ends up picking a banned IP address during one of the iterations.

I'm not sure if this is the best way to fix it. Other places that indirectly call Prog::Vnet::SubnetNexus.random_private_ipv4 and also expect certain Clog.emit calls are likely at risk for the same issue. I'm not sure how many times that happens in our specs. The approach taken is to allow for multiple emit calls, and only check that one of them matches the expected call.

CI Failure showing issue:

```
  1) Prog::Vm::Metal::Nexus.assemble falls back to using boot_image as a BootImage name if machine image lookup fails
     Failure/Error: mock.send(method, *a, **kw, &b)

       #<Object:0x0000ffc276ae4370> received :emit with unexpected arguments
         expected: ("No suitable machine image version found for boot image, falling back to using boot image as BootImage name", {base_machine_image_version_not_found: {boot_image: "ubuntu-jammy", error: {machine_image: "Machine i...owing locations: eu-central-h1, eu-north-h1"}, location_id: "caa7a807-36c5-8420-a75c-f906839dad71"}})
              got: ("Selected IPv4 subnet 172.17.58.128/26 is banned")
       Diff:
       @@ -1,7 +1 @@
       -["No suitable machine image version found for boot image, falling back to using boot image as BootImage name",
       - {base_machine_image_version_not_found:
       -   {boot_image: "ubuntu-jammy",
       -    error:
       -     {machine_image:
       -       "Machine image with name \"ubuntu-jammy\" does not exist in the specified project and any of the following locations: eu-central-h1, eu-north-h1"},
       -    location_id: "caa7a807-36c5-8420-a75c-f906839dad71"}}]
       +["Selected IPv4 subnet 172.17.58.128/26 is banned"]
     # ./spec/thawed_mock.rb:24:in 'block (2 levels) in allow_mocking'
     # ./prog/vnet/subnet_nexus.rb:125:in 'Prog::Vnet::SubnetNexus._random_private_ipv4'
     # ./prog/vnet/subnet_nexus.rb:105:in 'block in Prog::Vnet::SubnetNexus.random_private_ipv4'
     # ./prog/vnet/subnet_nexus.rb:136:in 'block (2 levels) in Prog::Vnet::SubnetNexus.until_random_ip'
     # ./prog/vnet/subnet_nexus.rb:135:in 'Integer#times'
     # ./prog/vnet/subnet_nexus.rb:135:in 'block in Prog::Vnet::SubnetNexus.until_random_ip'
     # ./db.rb:45:in 'ignore_duplicate_queries'
     # ./prog/vnet/subnet_nexus.rb:134:in 'Prog::Vnet::SubnetNexus.until_random_ip'
     # ./prog/vnet/subnet_nexus.rb:105:in 'Prog::Vnet::SubnetNexus.random_private_ipv4'
     # ./spec/thawed_mock.rb:20:in 'Method#call'
     # ./spec/thawed_mock.rb:20:in 'block (2 levels) in allow_mocking'
     # ./spec/thawed_mock.rb:24:in 'block (2 levels) in allow_mocking'
     # ./prog/vnet/subnet_nexus.rb:25:in 'Prog::Vnet::SubnetNexus.assemble'
     # ./spec/thawed_mock.rb:20:in 'Method#call'
     # ./spec/thawed_mock.rb:20:in 'block (2 levels) in allow_mocking'
     # ./spec/thawed_mock.rb:24:in 'block (2 levels) in allow_mocking'
     # ./model/project.rb:198:in 'Project#default_private_subnet'
     # ./prog/vm/nexus.rb:104:in 'block in Prog::Vm::Nexus.assemble'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.103.0/lib/sequel/database/transactions.rb:264:in 'Sequel::Database#_transaction'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.103.0/lib/sequel/database/transactions.rb:239:in 'block in Sequel::Database#transaction'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.103.0/lib/sequel/connection_pool/timed_queue.rb:87:in 'Sequel::TimedQueueConnectionPool#hold'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.103.0/lib/sequel/database/connecting.rb:283:in 'Sequel::Database#synchronize'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.103.0/lib/sequel/database/transactions.rb:197:in 'Sequel::Database#transaction'
     # ./prog/vm/nexus.rb:78:in 'Prog::Vm::Nexus.assemble'
     # ./spec/thawed_mock.rb:20:in 'Method#call'
     # ./spec/thawed_mock.rb:20:in 'block (2 levels) in allow_mocking'
     # ./spec/thawed_mock.rb:24:in 'block (2 levels) in allow_mocking'
     # ./spec/prog/vm/metal/nexus_spec.rb:219:in 'block (3 levels) in <top (required)>'
```