### PR TITLE
Add support for deleting multiple GitHub cache entries to web UI

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -62,3 +62,19 @@
     display: block;
   }
 }
+
+#cache-entries {
+  tr.cache-group {
+    position: relative;
+
+    label.cache-group-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      cursor: pointer;
+      z-index: 1;
+    }
+  }
+}

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -203,26 +203,21 @@ class Clover
               end
             end
 
-            r.on :ubid_uuid do |id|
+            r.is api?, :ubid_uuid do |id|
               entry = repository.cache_entries_dataset.with_pk(id)
               check_found_object(entry)
 
-              r.get api? do
+              r.get do
                 Serializers::GithubCacheEntry.serialize(entry, installation:, repository:)
               end
 
-              r.delete true do
+              r.delete do
                 DB.transaction do
                   entry.destroy
                   audit_log(entry, "destroy")
                 end
 
-                if web?
-                  flash["notice"] = "Cache '#{entry.key}' deleted."
-                  r.redirect @project, "/github/#{@installation.ubid}/cache"
-                else
-                  204
-                end
+                204
               end
             end
           end

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -139,7 +139,7 @@ class Clover
         view "github/cache"
       end
 
-      r.post web?, "cache" do
+      r.delete web?, "cache" do
         ubids = typecast_params.array(:ubid_uuid, "ubids") || []
         entries = @installation.cache_entries_dataset.where(Sequel[:github_cache_entry][:id] => ubids).all
 
@@ -147,15 +147,15 @@ class Clover
           no_audit_log
           flash["notice"] = "No cache entries selected for deletion"
         else
+          num_entries = entries.size
           DB.transaction do
             DB.ignore_duplicate_queries do
-              entries.each do |entry|
-                entry.destroy
-                audit_log(entry, "destroy")
-              end
+              entries.each(&:destroy)
             end
+            entry = entries.shift
+            audit_log(entry, "destroy", entries)
           end
-          flash["notice"] = "#{entries.count} cache entr#{entries.count == 1 ? "y" : "ies"} deleted"
+          flash["notice"] = "#{num_entries} cache entr#{(num_entries == 1) ? "y" : "ies"} deleted"
         end
 
         r.redirect @project, "/github/#{@installation.ubid}/cache"

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -139,6 +139,28 @@ class Clover
         view "github/cache"
       end
 
+      r.post web?, "cache" do
+        ubids = typecast_params.array(:ubid_uuid, "ubids") || []
+        entries = @installation.cache_entries_dataset.where(Sequel[:github_cache_entry][:id] => ubids).all
+
+        if entries.empty?
+          no_audit_log
+          flash["notice"] = "No cache entries selected for deletion"
+        else
+          DB.transaction do
+            DB.ignore_duplicate_queries do
+              entries.each do |entry|
+                entry.destroy
+                audit_log(entry, "destroy")
+              end
+            end
+          end
+          flash["notice"] = "#{entries.count} cache entr#{entries.count == 1 ? "y" : "ies"} deleted"
+        end
+
+        r.redirect @project, "/github/#{@installation.ubid}/cache"
+      end
+
       r.on "repository" do
         r.get api? do
           paginated_result(installation.repositories_dataset.order(:name), Serializers::GithubRepository, installation:)

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -158,7 +158,7 @@ class Clover
           flash["notice"] = "#{num_entries} cache entr#{(num_entries == 1) ? "y" : "ies"} deleted"
         end
 
-        r.redirect @project, "/github/#{@installation.ubid}/cache"
+        r.redirect @installation, "/cache"
       end
 
       r.on "repository" do

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -378,12 +378,12 @@ RSpec.describe Clover, "github" do
       expect(client).to receive(:delete_object).with(bucket: repository.bucket_name, key: entry.blob_key)
 
       visit "#{project.path}/github/#{installation.ubid}/cache"
-      _csrf = find("#delete-selected-form input[name='_csrf']", visible: false).value
-      page.driver.post "#{project.path}/github/#{installation.ubid}/cache", {ubids: [entry.ubid], _csrf:}
-      visit "#{project.path}/github/#{installation.ubid}/cache"
+      find("#entry-#{entry.ubid} input[type=checkbox]").check
+      click_button "Delete Selected Cache Entries"
 
+      expect(page.title).to eq "Ubicloud - Caches"
       expect(page).to have_flash_notice("1 cache entry deleted")
-      expect(GithubCacheEntry[entry.id]).to be_nil
+      expect(entry).not_to exist
     end
 
     it "can delete multiple cache entries" do
@@ -395,26 +395,25 @@ RSpec.describe Clover, "github" do
       allow(client).to receive(:delete_object)
 
       visit "#{project.path}/github/#{installation.ubid}/cache"
-      _csrf = find("#delete-selected-form input[name='_csrf']", visible: false).value
-      page.driver.post "#{project.path}/github/#{installation.ubid}/cache", {ubids: [entry1.ubid, entry2.ubid], _csrf:}
-      visit "#{project.path}/github/#{installation.ubid}/cache"
+      find("#entry-#{entry1.ubid} input[type=checkbox]").check
+      find("#entry-#{entry2.ubid} input[type=checkbox]").check
+      click_button "Delete Selected Cache Entries"
 
+      expect(page.title).to eq "Ubicloud - Caches"
       expect(page).to have_flash_notice("2 cache entries deleted")
-      expect(GithubCacheEntry[entry1.id]).to be_nil
-      expect(GithubCacheEntry[entry2.id]).to be_nil
-      expect(GithubCacheEntry[entry3.id]).not_to be_nil
-      expect(DB[:audit_log].where(action: "destroy").count).to eq(2)
+      expect(entry1).not_to exist
+      expect(entry2).not_to exist
+      expect(entry3).to exist
+      expect(DB[:audit_log].where(action: "destroy").count).to eq(1)
     end
 
     it "handles no cache entries selected for deletion" do
       create_cache_entry(key: "new-cache")
 
       visit "#{project.path}/github/#{installation.ubid}/cache"
-      _csrf = find("#delete-selected-form input[name='_csrf']", visible: false).value
-      page.driver.post "#{project.path}/github/#{installation.ubid}/cache", {_csrf:}
-      visit "#{project.path}/github/#{installation.ubid}/cache"
-
+      click_button "Delete Selected Cache Entries"
       expect(page).to have_flash_notice("No cache entries selected for deletion")
+      expect(page.title).to eq "Ubicloud - Caches"
     end
 
     it "can delete all cache entries for a repository" do

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -371,33 +371,50 @@ RSpec.describe Clover, "github" do
       expect(page).to have_content "3 hours ago"
     end
 
-    it "can delete cache entries" do
+    it "can delete a cache entry" do
       entry = create_cache_entry(key: "new-cache")
       client = instance_double(Aws::S3::Client)
       expect(Aws::S3::Client).to receive(:new).and_return(client)
       expect(client).to receive(:delete_object).with(bucket: repository.bucket_name, key: entry.blob_key)
 
       visit "#{project.path}/github/#{installation.ubid}/cache"
+      _csrf = find("#delete-selected-form input[name='_csrf']", visible: false).value
+      page.driver.post "#{project.path}/github/#{installation.ubid}/cache", {ubids: [entry.ubid], _csrf:}
+      visit "#{project.path}/github/#{installation.ubid}/cache"
 
-      expect(page.status_code).to eq(200)
-      expect(page).to have_content entry.key
-
-      find("#entry-#{entry.ubid} .delete-btn").click
-      expect(page).to have_flash_notice("Cache '#{entry.key}' deleted.")
+      expect(page).to have_flash_notice("1 cache entry deleted")
+      expect(GithubCacheEntry[entry.id]).to be_nil
     end
 
-    it "raises not found when cache entry not exists" do
-      entry = create_cache_entry(key: "new-cache")
+    it "can delete multiple cache entries" do
+      entry1 = create_cache_entry(key: "cache-1")
+      entry2 = create_cache_entry(key: "cache-2")
+      entry3 = create_cache_entry(key: "cache-3")
       client = instance_double(Aws::S3::Client)
-      expect(Aws::S3::Client).to receive(:new).and_return(client)
-      expect(client).to receive(:delete_object).with(bucket: repository.bucket_name, key: entry.blob_key)
+      allow(Aws::S3::Client).to receive(:new).and_return(client)
+      allow(client).to receive(:delete_object)
 
       visit "#{project.path}/github/#{installation.ubid}/cache"
-      entry_ubid = entry.ubid
-      entry.destroy
+      _csrf = find("#delete-selected-form input[name='_csrf']", visible: false).value
+      page.driver.post "#{project.path}/github/#{installation.ubid}/cache", {ubids: [entry1.ubid, entry2.ubid], _csrf:}
+      visit "#{project.path}/github/#{installation.ubid}/cache"
 
-      find("#entry-#{entry_ubid} .delete-btn").click
-      expect(page.status_code).to eq 404
+      expect(page).to have_flash_notice("2 cache entries deleted")
+      expect(GithubCacheEntry[entry1.id]).to be_nil
+      expect(GithubCacheEntry[entry2.id]).to be_nil
+      expect(GithubCacheEntry[entry3.id]).not_to be_nil
+      expect(DB[:audit_log].where(action: "destroy").count).to eq(2)
+    end
+
+    it "handles no cache entries selected for deletion" do
+      create_cache_entry(key: "new-cache")
+
+      visit "#{project.path}/github/#{installation.ubid}/cache"
+      _csrf = find("#delete-selected-form input[name='_csrf']", visible: false).value
+      page.driver.post "#{project.path}/github/#{installation.ubid}/cache", {_csrf:}
+      visit "#{project.path}/github/#{installation.ubid}/cache"
+
+      expect(page).to have_flash_notice("No cache entries selected for deletion")
     end
 
     it "can delete all cache entries for a repository" do

--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -4,6 +4,13 @@
 
 <div class="grid grid-cols-1 gap-6">
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <% if @entries_by_repo.count > 0 %>
+      <div class="px-4 py-3 flex justify-end">
+        <% form(action: "#{path(@installation)}/cache", method: :post, id: "delete-selected-form") do %>
+          <%== part("components/button", text: "Delete Selected Cache Entries", type: "danger", icon: "hero-trash") %>
+        <% end %>
+      </div>
+    <% end %>
     <div class="overflow-x-auto">
     <table class="min-w-full divide-y divide-gray-300">
       <tbody class="divide-y divide-gray-200 bg-white">
@@ -56,11 +63,7 @@
                   <% end %>
                 </td>
                 <td class="whitespace-nowrap py-3 pl-3 pr-4 text-sm text-right">
-                  <%== part(
-                    "components/delete_button",
-                    url: "#{path(@installation)}/repository/#{repository_id}/cache/#{entry.ubid}",
-                    text: ""
-                  ) %>
+                  <input type="checkbox" name="ubids[]" value="<%= entry.ubid %>" form="delete-selected-form" class="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600">
                 </td>
               </tr>
             <% end %>

--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -6,7 +6,7 @@
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <% if @entries_by_repo.count > 0 %>
       <div class="px-4 py-3 flex justify-end">
-        <% form(action: "#{path(@installation)}/cache", method: :post, id: "delete-selected-form") do %>
+        <% form(action: "#{path(@installation)}/cache/delete", method: :post, id: "delete-selected-form") do %>
           <%== part("components/button", text: "Delete Selected Cache Entries", type: "danger", icon: "hero-trash") %>
         <% end %>
       </div>

--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -12,12 +12,12 @@
       </div>
     <% end %>
     <div class="overflow-x-auto">
-    <table class="min-w-full divide-y divide-gray-300">
+    <table id="cache-entries" class="min-w-full divide-y divide-gray-300">
       <tbody class="divide-y divide-gray-200 bg-white">
         <% if @entries_by_repo.count > 0 %>
           <% @entries_by_repo.each do |repository_id, entries| %>
             <tr class="cache-group-row cursor-pointer group" data-repository="<%= repository_id %>">
-              <th scope="colgroup" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 w-full group-[.active]:bg-gray-50">
+              <th scope="colgroup" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 w-full group-[.active]:bg-gray-50" colspan="2">
                 <div class="flex">
                   <%== part("components/icon", name: "hero-chevron-right", classes: "w-5 h-5 group-[.active]:rotate-90") %>
                   <%= entries.first.repository.name %>
@@ -41,7 +41,11 @@
               </th>
             </tr>
             <% entries.each do |entry| %>
-              <tr id="entry-<%= entry.ubid %>" class="hidden cache-group-<%= repository_id %>">
+              <tr id="entry-<%= entry.ubid %>" class="hidden cache-group cache-group-<%= repository_id %>">
+                <td class="whitespace-nowrap py-3 pl-3 pr-4 text-sm text-right">
+                  <input type="checkbox" name="ubids[]" value="<%= entry.ubid %>" form="delete-selected-form" class="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600" id="delete-cache-entry-<%= entry.ubid %>">
+                  <label for="delete-cache-entry-<%= entry.ubid %>" class="cache-group-overlay"></label>
+                </td>
                 <td class="py-3 pl-4 pr-3 text-sm sm:pl-6 w-full" scope="row">
                   <div class="font-medium text-gray-900 break-all"><%= entry.key %></div>
                   <div class="mt-1 text-gray-500 text-xs ">created <span title="<%= entry.created_at.strftime("%Y-%m-%d %H:%M UTC") %>"><%= humanize_time(entry.created_at) %></span></div>
@@ -54,16 +58,13 @@
                     <%= humanize_size(entry.size) %>
                   </div>
                 </td>
-                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
+                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500" colspan="2">
                   <% if entry.last_accessed_at %>
                     <div>Last used</div>
                     <div title="<%= entry.last_accessed_at.strftime("%Y-%m-%d %H:%M UTC") %>"> <%= humanize_time(entry.last_accessed_at) %></div>
                   <% else %>
                     <div>Never used</div>
                   <% end %>
-                </td>
-                <td class="whitespace-nowrap py-3 pl-3 pr-4 text-sm text-right">
-                  <input type="checkbox" name="ubids[]" value="<%= entry.ubid %>" form="delete-selected-form" class="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600">
                 </td>
               </tr>
             <% end %>


### PR DESCRIPTION
Instead of a delete button per entry, this has a checkbox per entry,
and a single button at the top to delete selected cache entries.

<img width="163" height="92" alt="screenshot" src="https://github.com/user-attachments/assets/a50c8e78-1653-43f6-908f-4379b420075b" />
