### PR TITLE
Replace Digest with OpenSSL::Digest

### DIFF
--- a/lib/minio/header_signer.rb
+++ b/lib/minio/header_signer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "digest"
 require "openssl"
 
 # This is a ruby implementation of the AWS Signature Version 4 signing process.
@@ -136,10 +135,7 @@ class Minio::HeaderSigner
   end
 
   def sha256_hash(data)
-    # Ensure data is not nil, default to an empty string if it is
-    data ||= ""
-    # Compute SHA-256 hash
-    Digest::SHA256.hexdigest(data)
+    OpenSSL::Digest::SHA256.hexdigest(data || "")
   end
 
   def hmac_hash(key, data, hexdigest = false)
@@ -157,6 +153,6 @@ class Minio::HeaderSigner
   end
 
   def md5sum_hash(data)
-    Base64.strict_encode64(Digest::MD5.digest(data))
+    Base64.strict_encode64(OpenSSL::Digest::MD5.digest(data))
   end
 end

--- a/lib/victoria_metrics/client.rb
+++ b/lib/victoria_metrics/client.rb
@@ -3,7 +3,7 @@
 require "excon"
 require "json"
 require "base64"
-require "digest"
+require "openssl"
 require "zlib"
 
 class VictoriaMetrics::Client

--- a/prog/ai/inference_router_replica_nexus.rb
+++ b/prog/ai/inference_router_replica_nexus.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "digest"
+require "openssl"
 require "excon"
 require "forwardable"
 
@@ -268,7 +268,7 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
           api_keys: it.api_keys
             .select { |k| k.used_for == "inference_endpoint" && k.is_valid }
             .sort_by { |k| k.id }
-            .map { |k| Digest::SHA2.hexdigest(k.key) },
+            .map { |k| OpenSSL::Digest::SHA256.hexdigest(k.key) },
         }
     end
 
@@ -303,7 +303,7 @@ class Prog::Ai::InferenceRouterReplicaNexus < Prog::Base
     }
     new_config = new_config.merge(JSON.parse(File.read("config/inference_router_config.json")))
     new_config_json = JSON.generate(new_config)
-    new_md5 = Digest::MD5.hexdigest(new_config_json)
+    new_md5 = OpenSSL::Digest::MD5.hexdigest(new_config_json)
     config_path = "/ir/workdir/config.json"
     current_md5 = vm.sshable.cmd("md5sum :config_path | awk '{ print $1 }'", config_path:).strip
     if current_md5 != new_md5

--- a/prog/ai/inference_router_target_nexus.rb
+++ b/prog/ai/inference_router_target_nexus.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "digest"
 require "json"
 require "forwardable"
 

--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -2,7 +2,7 @@
 
 require "rubygems/package"
 require "stringio"
-require "digest/sha2"
+require "openssl"
 
 class Prog::InstallRhizome < Prog::Base
   subject_is :sshable
@@ -30,7 +30,7 @@ class Prog::InstallRhizome < Prog::Base
             end
           end
 
-          file_hash_map[file] = Digest::SHA384.file(full_path).hexdigest unless SKIP_VALIDATION.include?(file)
+          file_hash_map[file] = OpenSSL::Digest::SHA384.file(full_path).hexdigest unless SKIP_VALIDATION.include?(file)
         else
           # :nocov:
           fail "BUG"
@@ -39,7 +39,7 @@ class Prog::InstallRhizome < Prog::Base
       end
 
       hashes_json = JSON.generate(file_hash_map.sort.to_h)
-      digest = Digest::SHA256.hexdigest(hashes_json)[0, 24]
+      digest = OpenSSL::Digest::SHA256.hexdigest(hashes_json)[0, 24]
       update_stack({"rhizome_digest" => digest})
       writer.add_file("hashes.json", 0o100755) do |tf|
         tf.write hashes_json

--- a/rhizome/common/bin/validate
+++ b/rhizome/common/bin/validate
@@ -2,14 +2,14 @@
 # frozen_string_literal: true
 
 require "json"
-require "digest/sha2"
+require "openssl"
 
 hashes = JSON.load_file("hashes.json")
 
 violations = []
 
 hashes.each do |filename, expected_hash|
-  calculated_hash = Digest::SHA384.file(filename).hexdigest
+  calculated_hash = OpenSSL::Digest::SHA384.file(filename).hexdigest
   next if calculated_hash == expected_hash
 
   violations << {name: filename, expected: expected_hash, calculated: calculated_hash}

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -3,7 +3,7 @@
 require "bundler/setup"
 require "open3"
 require "shellwords"
-require "digest"
+require "openssl"
 
 class CommandFail < RuntimeError
   attr_reader :stdout, :stderr
@@ -63,7 +63,7 @@ def safe_write_to_file(filename, content = nil)
   raise ArgumentError, "must provide either content or block" if (content.nil? && !block_given?) || (!content.nil? && block_given?)
 
   temp_filename = filename + ".tmp"
-  lock_filename = "/tmp/#{Digest::SHA256.hexdigest(temp_filename)}.lock"
+  lock_filename = "/tmp/#{OpenSSL::Digest::SHA256.hexdigest(temp_filename)}.lock"
   File.open(lock_filename, File::RDWR | File::CREAT) do |lock_file|
     lock_file.flock(File::LOCK_EX)
     if block_given?

--- a/rhizome/host/lib/boot_image.rb
+++ b/rhizome/host/lib/boot_image.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "digest"
 require "fileutils"
 require "uri"
 require_relative "../../common/lib/arch"

--- a/rhizome/kubernetes/bin/backup-etcd
+++ b/rhizome/kubernetes/bin/backup-etcd
@@ -4,7 +4,7 @@
 require_relative "../../common/lib/util"
 require "fileutils"
 require "json"
-require "digest"
+require "openssl"
 require "tempfile"
 
 input = JSON.parse($stdin.read)
@@ -18,7 +18,7 @@ unless File.exist?(MC_PATH)
   Tempfile.create("mc") do |tmp_mc|
     r(*%W[curl -sL #{MC_RELEASE_URL} -o #{tmp_mc.path}])
 
-    actual_hash = Digest::SHA256.file(tmp_mc.path).hexdigest
+    actual_hash = OpenSSL::Digest::SHA256.file(tmp_mc.path).hexdigest
 
     if actual_hash != EXPECTED_HASH
       puts "Error: mc binary hash mismatch. Expected #{EXPECTED_HASH}, got #{actual_hash}"


### PR DESCRIPTION
OpenSSL::Digest is faster, and much faster for SHA256.

```ruby
require 'digest'
require 'openssl'
require 'benchmark/ips'

s = File.binread("/dev/random", 100_000_000)
%i[MD5 SHA256 SHA384].each do |hash_type|
  puts
  o = OpenSSL::Digest.const_get(hash_type)
  d = Digest.const_get(hash_type)
  Benchmark.ips do |x|
    x.report("#{hash_type} digest"){d.hexdigest(s)}
    x.report("#{hash_type} openssl"){o.hexdigest(s)}
  end
end
```

Results:

```
ruby 4.0.3 (2026-04-21 revision 85ddef263a) +PRISM [x86_64-linux]
Warming up --------------------------------------
          MD5 digest     1.000 i/100ms
         MD5 openssl     1.000 i/100ms
Calculating -------------------------------------
          MD5 digest      9.072 (± 0.0%) i/s  (110.23 ms/i) -     46.000 in   5.071053s
         MD5 openssl      9.840 (± 0.0%) i/s  (101.63 ms/i) -     50.000 in   5.081802s

ruby 4.0.3 (2026-04-21 revision 85ddef263a) +PRISM [x86_64-linux]
Warming up --------------------------------------
       SHA256 digest     1.000 i/100ms
      SHA256 openssl     2.000 i/100ms
Calculating -------------------------------------
       SHA256 digest      3.451 (± 0.0%) i/s  (289.78 ms/i) -     18.000 in   5.217338s
      SHA256 openssl     22.528 (± 0.0%) i/s   (44.39 ms/i) -    114.000 in   5.060939s

ruby 4.0.3 (2026-04-21 revision 85ddef263a) +PRISM [x86_64-linux]
Warming up --------------------------------------
       SHA384 digest     1.000 i/100ms
      SHA384 openssl     1.000 i/100ms
Calculating -------------------------------------
       SHA384 digest      5.144 (± 0.0%) i/s  (194.41 ms/i) -     26.000 in   5.055356s
      SHA384 openssl      9.460 (± 0.0%) i/s  (105.71 ms/i) -     48.000 in   5.075217s
```