### PR TITLE
Page on SSH down for 5m

### DIFF
--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -5,6 +5,10 @@ class MonitorableResource
   attr_accessor :monitor_job_started_at, :monitor_job_finished_at
   attr_writer :session
 
+  # Page after consecutive monitor session opens have failed for this long.
+  # Catches sshd outages while a strand is stuck retrying outside of `wait`.
+  OPEN_SESSION_FAILURE_PAGE_THRESHOLD = 5 * 60
+
   def initialize(resource)
     @resource = resource
     @session = nil
@@ -12,6 +16,8 @@ class MonitorableResource
     @pulse_check_started_at = Time.now
     @pulse_thread = nil
     @deleted = false
+    @open_session_failure_started_at = nil
+    @open_session_failure_paged = false
     if resource.is_a?(VmHost)
       @attached_resources = {}
       @attached_resources_mutex = Mutex.new
@@ -27,13 +33,22 @@ class MonitorableResource
   end
 
   def open_resource_session
-    return if @session && @pulse[:reading] == "up"
+    if @session && @pulse[:reading] == "up"
+      clear_open_session_failure
+      return
+    end
 
     @session = @resource.reload.init_health_monitor_session
   rescue Sequel::NoExistingObject
     Clog.emit("Resource is deleted.", {resource_deleted: {ubid: @resource.ubid}})
     @session = nil
     @deleted = true
+    clear_open_session_failure
+  rescue *Sshable::SSH_CONNECTION_ERRORS
+    record_open_session_failure
+    raise
+  else
+    clear_open_session_failure
   end
 
   def check_pulse
@@ -77,7 +92,15 @@ class MonitorableResource
         rescue
           nil
         end
-        @session.merge!(@resource.init_health_monitor_session)
+        begin
+          new_session = @resource.init_health_monitor_session
+        rescue *Sshable::SSH_CONNECTION_ERRORS
+          # Drop session so next monitor cycle reinits via open_resource_session,
+          # which tracks persistent failures.
+          @session = nil
+          raise
+        end
+        @session.merge!(new_session)
         retry
       end
 
@@ -123,5 +146,28 @@ class MonitorableResource
     end
 
     nil
+  end
+
+  private
+
+  def record_open_session_failure
+    @open_session_failure_started_at ||= Time.now
+    return if @open_session_failure_paged
+    elapsed = Time.now - @open_session_failure_started_at
+    return if elapsed < OPEN_SESSION_FAILURE_PAGE_THRESHOLD
+
+    Prog::PageNexus.assemble(
+      "#{@resource.ubid} sshable unreachable for #{elapsed.to_i}s",
+      ["SshableUnreachable", @resource.id],
+      @resource.ubid,
+    )
+    @open_session_failure_paged = true
+  end
+
+  def clear_open_session_failure
+    return unless @open_session_failure_started_at
+    Page.from_tag_parts("SshableUnreachable", @resource.id)&.incr_resolve if @open_session_failure_paged
+    @open_session_failure_started_at = nil
+    @open_session_failure_paged = false
   end
 end

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -444,7 +444,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
 
     if all_tried && unsupported_azs.size >= total_azs
       Clog.emit("all azs unsupported for instance type", {retry_different_az_unsupported: {vm:, error: e.class.name, message: e.message, unsupported_azs:}})
-      Prog::PageNexus.assemble("#{vm.name} instance type unsupported in all AZs", ["InstanceTypeUnsupported", vm.id], vm.ubid, severity: "error")
+      Prog::PageNexus.assemble("#{vm.name} instance type unsupported in all AZs", ["InstanceTypeUnsupported", vm.id], vm.ubid)
       update_stack({"unsupported_azs" => unsupported_azs, "exclude_availability_zones" => []})
       nap 60 * 60
     elsif all_tried

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -63,6 +63,76 @@ RSpec.describe MonitorableResource do
       expect(postgres_server).to receive(:reload).and_raise(StandardError)
       expect { r_w_event_loop.open_resource_session }.to raise_error(StandardError)
     end
+
+    describe "ssh failure tracking" do
+      let(:now) { Time.now }
+
+      before do
+        allow(Time).to receive(:now).and_return(now)
+      end
+
+      it "re-raises Sequel::DatabaseDisconnectError without paging" do
+        expect(postgres_server).to receive(:reload).and_raise(Sequel::DatabaseDisconnectError).twice
+        expect { r_w_event_loop.open_resource_session }.to raise_error(Sequel::DatabaseDisconnectError)
+        allow(Time).to receive(:now).and_return(now + described_class::OPEN_SESSION_FAILURE_PAGE_THRESHOLD + 1)
+        expect { r_w_event_loop.open_resource_session }.to raise_error(Sequel::DatabaseDisconnectError)
+        expect(Page.from_tag_parts("SshableUnreachable", postgres_server.id)).to be_nil
+      end
+
+      it "does not page if failure has not persisted past the threshold" do
+        expect(postgres_server).to receive(:init_health_monitor_session).and_raise(IOError).twice
+        expect { r_w_event_loop.open_resource_session }.to raise_error(IOError)
+        allow(Time).to receive(:now).and_return(now + described_class::OPEN_SESSION_FAILURE_PAGE_THRESHOLD - 1)
+        expect { r_w_event_loop.open_resource_session }.to raise_error(IOError)
+        expect(Page.from_tag_parts("SshableUnreachable", postgres_server.id)).to be_nil
+      end
+
+      it "pages once threshold is exceeded, suppresses re-page, and resolves on recovery" do
+        expect(postgres_server).to receive(:init_health_monitor_session).and_raise(IOError).exactly(3).times
+        expect { r_w_event_loop.open_resource_session }.to raise_error(IOError)
+
+        past = now + described_class::OPEN_SESSION_FAILURE_PAGE_THRESHOLD + 1
+        allow(Time).to receive(:now).and_return(past)
+        expect { r_w_event_loop.open_resource_session }.to raise_error(IOError)
+        page = Page.from_tag_parts("SshableUnreachable", postgres_server.id)
+        expect(page.summary).to start_with("#{postgres_server.ubid} sshable unreachable for ")
+        expect(page.severity).to eq("error")
+        summary = page.summary
+
+        allow(Time).to receive(:now).and_return(past + 10)
+        expect { r_w_event_loop.open_resource_session }.to raise_error(IOError)
+        expect(page.reload.summary).to eq(summary)
+
+        expect(postgres_server).to receive(:init_health_monitor_session).and_return("session")
+        r_w_event_loop.open_resource_session
+        expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
+      end
+
+      it "tolerates the page being absent on recovery" do
+        expect(postgres_server).to receive(:init_health_monitor_session).and_raise(IOError).twice
+        expect { r_w_event_loop.open_resource_session }.to raise_error(IOError)
+        allow(Time).to receive(:now).and_return(now + described_class::OPEN_SESSION_FAILURE_PAGE_THRESHOLD + 1)
+        expect { r_w_event_loop.open_resource_session }.to raise_error(IOError)
+        Page.from_tag_parts("SshableUnreachable", postgres_server.id).destroy
+        expect(postgres_server).to receive(:init_health_monitor_session).and_return("session")
+        expect { r_w_event_loop.open_resource_session }.not_to raise_error
+      end
+
+      it "clears tracking on success without raising or resolving a page" do
+        expect(postgres_server).to receive(:init_health_monitor_session).and_raise(IOError).ordered
+        expect(postgres_server).to receive(:init_health_monitor_session).and_return("session").ordered
+        expect { r_w_event_loop.open_resource_session }.to raise_error(IOError)
+        r_w_event_loop.open_resource_session
+        expect(Page.from_tag_parts("SshableUnreachable", postgres_server.id)).to be_nil
+      end
+
+      it "clears tracking when resource is deleted" do
+        expect(postgres_server).to receive(:init_health_monitor_session).and_raise(IOError)
+        expect { r_w_event_loop.open_resource_session }.to raise_error(IOError)
+        postgres_server.destroy
+        expect { r_w_event_loop.open_resource_session }.to change(r_w_event_loop, :deleted).from(false).to(true)
+      end
+    end
   end
 
   describe "#check_pulse" do
@@ -287,6 +357,31 @@ RSpec.describe MonitorableResource do
         expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 1})
         r_w_event_loop.check_pulse
       end
+    end
+  end
+
+  describe "#check_pulse stale retry init failure" do
+    let(:session) { {ssh_session: Net::SSH::Connection::Session.allocate, last_pulse: Time.now - 10} }
+    let(:ex) { IOError.new("closed stream") }
+
+    before do
+      r_without_event_loop.instance_variable_set(:@session, session)
+    end
+
+    it "drops the session so next cycle reinits on ssh connection error" do
+      expect(vm_host).to receive(:check_pulse).and_raise(ex)
+      expect(session[:ssh_session]).to receive(:shutdown!)
+      expect(vm_host).to receive(:init_health_monitor_session).and_raise(Net::SSH::Disconnect)
+      expect { r_without_event_loop.check_pulse }.to raise_error(Net::SSH::Disconnect)
+      expect(r_without_event_loop.instance_variable_get(:@session)).to be_nil
+    end
+
+    it "lets non-ssh exceptions propagate without dropping the session" do
+      expect(vm_host).to receive(:check_pulse).and_raise(ex)
+      expect(session[:ssh_session]).to receive(:shutdown!)
+      expect(vm_host).to receive(:init_health_monitor_session).and_raise(Sequel::DatabaseDisconnectError)
+      expect { r_without_event_loop.check_pulse }.to raise_error(Sequel::DatabaseDisconnectError)
+      expect(r_without_event_loop.instance_variable_get(:@session)).to eq(session)
     end
   end
 end

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -515,7 +515,7 @@ usermod -L ubuntu
       it "pages and naps 1 hour when all AZs are unsupported" do
         refresh_frame(nx, new_values: {"unsupported_azs" => ["b", "c", "d", "e", "f"]})
         expect(Clog).to receive(:emit).with("all azs unsupported for instance type", instance_of(Hash))
-        expect(Prog::PageNexus).to receive(:assemble).with("#{vm.name} instance type unsupported in all AZs", ["InstanceTypeUnsupported", vm.id], vm.ubid, severity: "error")
+        expect(Prog::PageNexus).to receive(:assemble).with("#{vm.name} instance type unsupported in all AZs", ["InstanceTypeUnsupported", vm.id], vm.ubid)
         expect { nx.create_instance }.to nap(60 * 60)
         expect(st.stack.last["unsupported_azs"]).to eq(["b", "c", "d", "e", "f", "a"])
         expect(st.stack.last["exclude_availability_zones"]).to eq([])


### PR DESCRIPTION
Existing incr_checkup escalation only fires when strand is in wait, so the host stayed unreachable with no page until an operator noticed

Track consecutive open_resource_session failures in MonitorableResource, paging after five minutes of continuous failure regardless of strand state. The tracking covers every monitored resource type