### PR TITLE
Use fast shutdown when fencing primary

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -730,8 +730,8 @@ SQL
     # to avoid stopping all workloads for a long shutdown checkpoint.
     postgres_server.run_query("CHECKPOINT; CHECKPOINT; CHECKPOINT;")
     postgres_server.vm.sshable.cmd("sudo postgres/bin/lockout :version", version:)
-    postgres_server.vm.sshable.cmd("sudo pg_ctlcluster :version main stop -m smart", version:)
     postgres_server.vm.sshable.cmd("sudo systemctl stop postgres-metrics.timer")
+    postgres_server.vm.sshable.cmd("sudo pg_ctlcluster :version main stop -m fast", version:)
 
     hop_wait_in_fence
   end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1249,8 +1249,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx).to receive(:decr_fence)
       expect(server).to receive(:_run_query).with("CHECKPOINT; CHECKPOINT; CHECKPOINT;")
       expect(sshable).to receive(:_cmd).with("sudo postgres/bin/lockout 17")
-      expect(sshable).to receive(:_cmd).with("sudo pg_ctlcluster 17 main stop -m smart")
       expect(sshable).to receive(:_cmd).with("sudo systemctl stop postgres-metrics.timer")
+      expect(sshable).to receive(:_cmd).with("sudo pg_ctlcluster 17 main stop -m fast")
       expect { nx.fence }.to hop("wait_in_fence")
     end
 


### PR DESCRIPTION
lockout-hba already terminates non-replication backends, so smart's wait-for-clients phase only stalls on stragglers; fast SIGTERMs them

Failover slots stay synced regardless. Walsenders aren't told to finish until after checkpointer completes the shutdown checkpoint[^1], and WalSndDone then only exits once standby's flush LSN catches up to sentPtr[^2]. Slot advances are WAL-logged and ship before that exit

[^1]: https://github.com/postgres/postgres/blob/122adefc94a4dc4e97b4fd5c3328e7dc5b58ebd0/src/backend/postmaster/postmaster.c#L3794-L3812
[^2]: https://github.com/postgres/postgres/blob/122adefc94a4dc4e97b4fd5c3328e7dc5b58ebd0/src/backend/replication/walsender.c#L3528-L3546