### PR TITLE
Add Config.e2e_aws_assume_role

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -220,6 +220,7 @@ module Config
   override :is_e2e, false, bool
   optional :e2e_aws_access_key, string, clear: true
   optional :e2e_aws_secret_key, string, clear: true
+  optional :e2e_aws_assume_role, string
   optional :e2e_gcp_credentials_base64_json, string, clear: true
   optional :e2e_cache_proxy_download_url, string
 

--- a/prog/test/base.rb
+++ b/prog/test/base.rb
@@ -20,4 +20,21 @@ class Prog::Test::Base < Prog::Base
       project_id: parsed["project_id"],
       service_account_email: parsed["client_email"])
   end
+
+  # Prefer IAM assume-role auth when Config.e2e_aws_assume_role is set,
+  # otherwise fall back to static access_key/secret_key
+  def self.ensure_aws_e2e_credential(location)
+    return if LocationCredentialAws[location.id]
+    assume_role = Config.e2e_aws_assume_role
+    access_key = Config.e2e_aws_access_key
+    secret_key = Config.e2e_aws_secret_key
+    if assume_role && (access_key || secret_key)
+      raise "e2e_aws_assume_role cannot be combined with e2e_aws_access_key/e2e_aws_secret_key"
+    end
+    if assume_role
+      LocationCredentialAws.create_with_id(location, assume_role:)
+    else
+      LocationCredentialAws.create_with_id(location, access_key:, secret_key:)
+    end
+  end
 end

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -19,7 +19,7 @@ class Prog::Test::GithubRunner < Prog::Test::Base
     if provider == "aws"
       customer_project.set_ff_aws_alien_runners_ratio(1)
       location = Location.create_with_id(Config.github_runner_aws_location_id, name: "eu-central-1", provider: "aws", project_id: service_project.id, display_name: "aws-e2e", ui_name: "aws-e2e", visible: true)
-      LocationCredentialAws.create_with_id(location.id, access_key: Config.e2e_aws_access_key, secret_key: Config.e2e_aws_secret_key)
+      Prog::Test::Base.ensure_aws_e2e_credential(location)
     end
 
     if (url = Config.e2e_cache_proxy_download_url) && !url.empty?

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -28,8 +28,7 @@ class Prog::Test::PostgresBase < Prog::Test::Base
     case provider
     when "aws"
       location = Location[provider: "aws", project_id: Config.local_e2e_postgres_test_project_id, name: aws_location_name]
-      location.location_credential_aws ||
-        LocationCredentialAws.create_with_id(location, access_key: Config.e2e_aws_access_key, secret_key: Config.e2e_aws_secret_key)
+      Prog::Test::Base.ensure_aws_e2e_credential(location)
       family = "m8gd"
       vcpus = 2
       [location.id, Option.aws_instance_type_name(family, vcpus), Option::AWS_STORAGE_SIZE_OPTIONS[family][vcpus].first.to_i]

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Prog::Test::GithubRunner do
     it "assemble with aws provider" do
       location_id = "5f0db214-de30-8420-8a11-98014b01c5b5"
       expect(Config).to receive(:github_runner_aws_location_id).and_return(location_id)
+      expect(Config).to receive(:e2e_aws_assume_role).and_return(nil)
       expect(Config).to receive(:e2e_aws_access_key).and_return("access_key")
       expect(Config).to receive(:e2e_aws_secret_key).and_return("secret_key")
       expect(Config).to receive(:e2e_cache_proxy_download_url).and_return("http://example.com/cache-proxy")
@@ -26,6 +27,18 @@ RSpec.describe Prog::Test::GithubRunner do
       expect(Location[location_id]).not_to be_nil
       expect(LocationCredentialAws[location_id].access_key).to eq("access_key")
       expect(GithubInstallation.first.project.get_ff_cache_proxy_download_url).to eq({"x64" => "http://example.com/cache-proxy"})
+    end
+
+    it "assemble with aws provider using assume_role" do
+      location_id = "5f0db214-de30-8420-8a11-98014b01c5b5"
+      expect(Config).to receive(:github_runner_aws_location_id).and_return(location_id)
+      expect(Config).to receive(:e2e_aws_assume_role).and_return("arn:aws:iam::123:role/e2e").at_least(:once)
+      expect(Config).to receive(:e2e_aws_access_key).and_return(nil)
+      expect(Config).to receive(:e2e_aws_secret_key).and_return(nil)
+      expect(Config).to receive(:e2e_cache_proxy_download_url).and_return("")
+      described_class.assemble([], provider: "aws")
+      expect(LocationCredentialAws[location_id].assume_role).to eq("arn:aws:iam::123:role/e2e")
+      expect(LocationCredentialAws[location_id].access_key).to be_nil
     end
 
     it "assembles labels based on test case names" do
@@ -36,6 +49,7 @@ RSpec.describe Prog::Test::GithubRunner do
     it "includes arm64 labels for aws provider" do
       location_id = "5f0db214-de30-8420-8a11-98014b01c5b5"
       expect(Config).to receive(:github_runner_aws_location_id).and_return(location_id)
+      expect(Config).to receive(:e2e_aws_assume_role).and_return(nil)
       expect(Config).to receive(:e2e_aws_access_key).and_return("access_key")
       expect(Config).to receive(:e2e_aws_secret_key).and_return("secret_key")
       expect(Config).to receive(:e2e_cache_proxy_download_url).and_return("")

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Prog::Test::HaPostgresResource do
     end
 
     it "creates a postgres resource on aws and hops to wait_postgres_resource" do
+      expect(Config).to receive(:e2e_aws_assume_role).and_return(nil)
       expect(Config).to receive(:e2e_aws_access_key).and_return("access_key")
       expect(Config).to receive(:e2e_aws_secret_key).and_return("secret_key")
       allow(Aws::Credentials).to receive(:new).and_return(Aws::Credentials.new("access_key", "secret_key"))

--- a/spec/prog/test/postgres_firewall_spec.rb
+++ b/spec/prog/test/postgres_firewall_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Prog::Test::PostgresFirewall do
     end
 
     it "creates resource on aws and hops to wait_postgres_resource" do
+      expect(Config).to receive(:e2e_aws_assume_role).and_return(nil)
       expect(Config).to receive(:e2e_aws_access_key).and_return("access_key")
       expect(Config).to receive(:e2e_aws_secret_key).and_return("secret_key")
       aws_strand = described_class.assemble(provider: "aws")

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Prog::Test::PostgresResource do
     end
 
     it "creates resource on aws and hops to wait_postgres_resource" do
+      expect(Config).to receive(:e2e_aws_assume_role).and_return(nil)
       expect(Config).to receive(:e2e_aws_access_key).and_return("access_key")
       expect(Config).to receive(:e2e_aws_secret_key).and_return("secret_key")
       aws_strand = described_class.assemble(provider: "aws")
@@ -75,6 +76,30 @@ RSpec.describe Prog::Test::PostgresResource do
       LocationAz.create(location_id: location.id, az: "a", zone_id: "usw2-az1")
       expect { aws_pgr_test.start }.to hop("wait_postgres_resource")
       expect(LocationCredentialAws[location.id].access_key).to eq("access_key")
+    end
+
+    it "creates resource on aws using assume_role and hops to wait_postgres_resource" do
+      expect(Config).to receive(:e2e_aws_assume_role).and_return("arn:aws:iam::123:role/e2e").at_least(:once)
+      expect(Config).to receive(:e2e_aws_access_key).and_return(nil)
+      expect(Config).to receive(:e2e_aws_secret_key).and_return(nil)
+      aws_strand = described_class.assemble(provider: "aws")
+      aws_pgr_test = described_class.new(aws_strand)
+      location = Location[provider: "aws", project_id: nil, name: "us-west-2"]
+      LocationAz.create(location_id: location.id, az: "a", zone_id: "usw2-az1")
+      expect { aws_pgr_test.start }.to hop("wait_postgres_resource")
+      expect(LocationCredentialAws[location.id].assume_role).to eq("arn:aws:iam::123:role/e2e")
+      expect(LocationCredentialAws[location.id].access_key).to be_nil
+    end
+
+    it "fails when both assume_role and access_key are configured" do
+      expect(Config).to receive(:e2e_aws_assume_role).and_return("arn:aws:iam::123:role/e2e")
+      expect(Config).to receive(:e2e_aws_access_key).and_return("access_key")
+      expect(Config).to receive(:e2e_aws_secret_key).and_return(nil)
+      aws_strand = described_class.assemble(provider: "aws")
+      aws_pgr_test = described_class.new(aws_strand)
+      location = Location[provider: "aws", project_id: nil, name: "us-west-2"]
+      LocationAz.create(location_id: location.id, az: "a", zone_id: "usw2-az1")
+      expect { aws_pgr_test.start }.to raise_error(/cannot be combined/)
     end
 
     it "skips aws credential creation when credential already exists" do

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
 
     it "creates a postgres resource on aws and hops to wait_postgres_resource" do
+      expect(Config).to receive(:e2e_aws_assume_role).and_return(nil)
       expect(Config).to receive(:e2e_aws_access_key).and_return("access_key")
       expect(Config).to receive(:e2e_aws_secret_key).and_return("secret_key")
       allow(Aws::Credentials).to receive(:new).and_return(Aws::Credentials.new("access_key", "secret_key"))
@@ -121,6 +122,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
 
     it "creates resource on aws and hops to wait_postgres_resource" do
+      expect(Config).to receive(:e2e_aws_assume_role).and_return(nil)
       expect(Config).to receive(:e2e_aws_access_key).and_return("access_key")
       expect(Config).to receive(:e2e_aws_secret_key).and_return("secret_key")
       aws_strand = described_class.assemble(provider: "aws")


### PR DESCRIPTION
Allows running test progs with IAM auth instead of access key/secret