### PR TITLE
Make metal bucket creation idempotent

### DIFF
--- a/model/postgres/metal/postgres_timeline.rb
+++ b/model/postgres/metal/postgres_timeline.rb
@@ -47,6 +47,8 @@ PGDATA=/dat/#{version}/data
 
     def metal_create_bucket
       blob_storage_client.create_bucket(ubid)
+    rescue RuntimeError => e
+      raise unless e.message.include?("BucketAlreadyOwnedByYou")
     end
 
     def metal_set_lifecycle_policy

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -320,6 +320,16 @@ PGDATA=/dat/17/data
       expect(postgres_timeline.create_bucket).to be(true)
     end
 
+    it "swallows BucketAlreadyOwnedByYou errors on bucket creation" do
+      expect(minio_client).to receive(:create_bucket).with(postgres_timeline.ubid).and_raise(RuntimeError.new("Error: <Code>BucketAlreadyOwnedByYou</Code>"))
+      expect { postgres_timeline.create_bucket }.not_to raise_error
+    end
+
+    it "re-raises other RuntimeErrors on bucket creation" do
+      expect(minio_client).to receive(:create_bucket).with(postgres_timeline.ubid).and_raise(RuntimeError.new("Error: something else"))
+      expect { postgres_timeline.create_bucket }.to raise_error(RuntimeError, /something else/)
+    end
+
     it "sets lifecycle policy" do
       expect(minio_client).to receive(:set_lifecycle_policy).with(postgres_timeline.ubid, postgres_timeline.ubid, 8).and_return(true)
       expect(postgres_timeline.set_lifecycle_policy).to be(true)


### PR DESCRIPTION
Minio returns BucketAlreadyOwnedByYou when the bucket already exists, which was raising a RuntimeError and failing setup_bucket on retries. Swallow that specific error so the strand step can re-enter safely, mirroring the existing AWS variant.