### PR TITLE
Track in-progress boot image download size

### DIFF
--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -304,6 +304,11 @@ class Prog::DownloadBootImage < Prog::Base
     client.get_presigned_url("GET", Config.ubicloud_images_bucket_name, key, 60 * 60).to_s
   end
 
+  def image_size_gib(suffix: nil)
+    image_size_bytes = sshable.cmd("stat -c %s :image_path", image_path: "#{image.path}#{suffix}").to_i
+    (image_size_bytes / 1024.0**3).ceil
+  end
+
   label def start
     register_deadline(nil, 24 * 60 * 60)
 
@@ -347,19 +352,20 @@ class Prog::DownloadBootImage < Prog::Base
         image.destroy
         pop "operation cancelled"
       end
+    when "InProgress"
+      update_stack({"current_size_gib" => image_size_gib(suffix: ".tmp")})
     end
 
     nap 15
   end
 
   label def update_available_storage_space
-    image_size_bytes = sshable.cmd("stat -c %s :image_path", image_path: image.path).to_i
-    fail "Downloaded boot image has zero size" unless image_size_bytes > 0
-    image_size_gib = (image_size_bytes / 1024.0**3).ceil
+    size_gib = image_size_gib
+    fail "Downloaded boot image has zero size" unless size_gib > 0
     StorageDevice.where(vm_host_id: vm_host.id, name: "DEFAULT").update(
-      available_storage_gib: Sequel[:available_storage_gib] - image_size_gib,
+      available_storage_gib: Sequel[:available_storage_gib] - size_gib,
     )
-    image.update(size_gib: image_size_gib)
+    image.update(size_gib:)
     hop_activate_boot_image
   end
 

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -222,8 +222,16 @@ RSpec.describe Prog::DownloadBootImage do
       expect { dbi.download }.to nap(15)
     end
 
-    it "waits for the download to complete" do
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check download_my-image_20230303").and_return("InProgess")
+    it "updates current size while the download is in progress" do
+      BootImage.create(vm_host_id: vm_host.id, name: "my-image", version: "20230303", size_gib: 0)
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check download_my-image_20230303").and_return("InProgress")
+      expect(sshable).to receive(:_cmd).with("stat -c %s /var/storage/images/my-image-20230303.raw.tmp").and_return("2361393152")
+      expect { dbi.download }.to nap(15)
+        .and change { dbi.strand.stack.first["current_size_gib"] }.from(nil).to(3)
+    end
+
+    it "naps if unknown state" do
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check download_my-image_20230303").and_return("Unknown")
       expect { dbi.download }.to nap(15)
     end
 


### PR DESCRIPTION
Stash the current on-disk size on the strand stack each tick the daemonizer reports "InProgress", so the admin panel can show how many GiB have landed so far.