### PR TITLE
Support K8s_POD_INDEX for worker partitioning

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -7,6 +7,9 @@ partition_number = ARGV[0]
 partition_number ||= if (match = /monitor\.(\d+)\z/.match(ENV["DYNO"] || ENV["PS"]))
   match[1] # Heroku/Foreman
 end
+partition_number ||= if (pod_index = ENV["K8S_POD_INDEX"])
+  (Integer(pod_index) + 1).to_s # Kubernetes StatefulSet (0-based)
+end
 
 # For simplicity, monitor always runs partitioned. Even if only running a single
 # process, in which case, the partition is the entire id space.

--- a/bin/respirate
+++ b/bin/respirate
@@ -7,6 +7,9 @@ partition_number = ARGV[0]
 partition_number ||= if (match = /respirate\.(\d+)\z/.match(ENV["DYNO"] || ENV["PS"]))
   match[1] # Heroku/Foreman
 end
+partition_number ||= if (pod_index = ENV["K8S_POD_INDEX"])
+  (Integer(pod_index) + 1).to_s # Kubernetes StatefulSet (0-based)
+end
 
 if partition_number
   partition_number = Integer(partition_number)


### PR DESCRIPTION
This can be used to determine partioning in kubernetes environments where the working is running as a statefulset. The environment variable can be set by referencing https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#ordinal-index via the downard API