### PR TITLE
Remove unused require_relative lines

### DIFF
--- a/db.rb
+++ b/db.rb
@@ -4,7 +4,6 @@ require "netaddr"
 require "sequel/core"
 require_relative "config"
 require_relative "lib/util"
-require_relative "lib/clog"
 if Config.clover_database_rds_iam_auth_enabled
   require "pg/aws_rds_iam"
   driver_options = {aws_rds_iam_auth_token_generator: "default"}

--- a/model/github/github_runner.rb
+++ b/model/github/github_runner.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../../model"
-require_relative "../../lib/net_ssh"
 
 class GithubRunner < Sequel::Model
   one_to_one :strand, key: :id

--- a/model/load_balancer_vm_port.rb
+++ b/model/load_balancer_vm_port.rb
@@ -1,7 +1,6 @@
 #  frozen_string_literal: true
 
 require_relative "../model"
-require_relative "../lib/net_ssh"
 
 class LoadBalancerVmPort < Sequel::Model
   many_to_one :load_balancer_vm, read_only: true

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../../model"
-require_relative "../../lib/net_ssh"
 
 class MinioServer < Sequel::Model
   one_to_one :strand, key: :id, read_only: true

--- a/model/storage_device.rb
+++ b/model/storage_device.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../model"
-require_relative "../lib/system_parser"
 
 class StorageDevice < Sequel::Model
   many_to_one :vm_host, read_only: true

--- a/prog/ai/inference_endpoint_nexus.rb
+++ b/prog/ai/inference_endpoint_nexus.rb
@@ -2,8 +2,6 @@
 
 require "forwardable"
 
-require_relative "../../lib/util"
-
 class Prog::Ai::InferenceEndpointNexus < Prog::Base
   subject_is :inference_endpoint
 

--- a/prog/ai/inference_router_nexus.rb
+++ b/prog/ai/inference_router_nexus.rb
@@ -2,8 +2,6 @@
 
 require "forwardable"
 
-require_relative "../../lib/util"
-
 class Prog::Ai::InferenceRouterNexus < Prog::Base
   subject_is :inference_router
 

--- a/prog/ai/inference_router_target_nexus.rb
+++ b/prog/ai/inference_router_target_nexus.rb
@@ -3,8 +3,6 @@
 require "json"
 require "forwardable"
 
-require_relative "../../lib/util"
-
 class Prog::Ai::InferenceRouterTargetNexus < Prog::Base
   subject_is :inference_router_target
 

--- a/prog/dns_zone/dns_zone_nexus.rb
+++ b/prog/dns_zone/dns_zone_nexus.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/util"
-
 class Prog::DnsZone::DnsZoneNexus < Prog::Base
   subject_is :dns_zone
 

--- a/prog/github/destroy_github_installation.rb
+++ b/prog/github/destroy_github_installation.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/util"
-
 class Prog::Github::DestroyGithubInstallation < Prog::Base
   subject_is :github_installation
 

--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/util"
-
 class Prog::Github::GithubRepositoryNexus < Prog::Base
   subject_is :github_repository
 

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/net_ssh"
-
 class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
   subject_is :kubernetes_cluster
 

--- a/prog/minio/minio_pool_nexus.rb
+++ b/prog/minio/minio_pool_nexus.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/util"
-
 class Prog::Minio::MinioPoolNexus < Prog::Base
   subject_is :minio_pool
 

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/util"
-
 class Prog::Postgres::ConvergePostgresResource < Prog::Base
   subject_is :postgres_resource
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -2,8 +2,6 @@
 
 require "forwardable"
 
-require_relative "../../lib/util"
-
 class Prog::Postgres::PostgresServerNexus < Prog::Base
   subject_is :postgres_server
 

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/util"
-
 class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   semaphore :pause, :destroy
 

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/util"
-
 class Prog::Test::Kubernetes < Prog::Test::Base
   MIGRATION_TRIES = 1
 

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/util"
-
 class Prog::Test::PostgresResource < Prog::Test::PostgresBase
   semaphore :pause, :destroy
 

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/util"
-
 class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   semaphore :pause, :destroy
 

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/net_ssh"
-
 class Prog::Test::VmGroup < Prog::Test::Base
   def self.assemble(boot_images:, test_reboot: true, verify_host_capacity: true)
     Strand.create(

--- a/prog/vm/update_ipv6.rb
+++ b/prog/vm/update_ipv6.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/util"
-
 class Prog::Vm::UpdateIpv6 < Prog::Base
   subject_is :vm
 

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/net_ssh"
-
 class Prog::Vm::VmPool < Prog::Base
   subject_is :vm_pool
 

--- a/rhizome/host/lib/spdk_rpc.rb
+++ b/rhizome/host/lib/spdk_rpc.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "spdk_path"
-
 class SpdkRpc
   def initialize(socket_path, timeout = 5, response_size_limit = 1048576)
     @socket_path = socket_path

--- a/spec/lib/ssh_key_spec.rb
+++ b/spec/lib/ssh_key_spec.rb
@@ -3,8 +3,6 @@
 require "open3"
 require "tmpdir"
 
-require_relative "../../lib/net_ssh"
-
 RSpec.describe SshKey do
   it "can generate an ed25519 key that loads successfully" do
     # Catenate a few simple tests together for speedup.

--- a/spec/model/oidc_provider_spec.rb
+++ b/spec/model/oidc_provider_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "spec_helper"
-require_relative "../../model/address"
 
 RSpec.describe OidcProvider do
   let(:registration_body) do


### PR DESCRIPTION
Loading these modules has no effect on the importing file — neither the named constants (Util, NetSsh, Clog, SystemParser, etc.) nor any top-level methods they define are referenced. They snuck in as copy-paste leftovers and as files outgrew the symbols they originally used.

Detected by scanning every Ruby file for require_relative whose target's defined constants do not appear anywhere in the importer (excluding files that define top-level methods, where the import is likely intentional).