### PR TITLE
Wait for new node Ready before kubeadm upgrade apply

### DIFF
--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -189,6 +189,16 @@ class KubernetesCluster < Sequel::Model
     functional_nodes + nodepools.flat_map(&:functional_nodes)
   end
 
+  def all_functional_nodes_ready?
+    nodes_by_name = JSON.parse(client.kubectl("get nodes -ojson"))
+      .fetch("items")
+      .to_h { [it.dig("metadata", "name"), it] }
+    all_functional_nodes.all? do |fn|
+      conditions = nodes_by_name[fn.name]&.dig("status", "conditions") || []
+      conditions.any? { it["type"] == "Ready" && it["status"] == "True" }
+    end
+  end
+
   def worker_vms
     nodepools.flat_map(&:vms)
   end

--- a/prog/kubernetes/upgrade_kubernetes_node.rb
+++ b/prog/kubernetes/upgrade_kubernetes_node.rb
@@ -46,8 +46,15 @@ class Prog::Kubernetes::UpgradeKubernetesNode < Prog::Base
       # However, the strand has only has a single child created in start.
       update_stack({"new_node_id" => node_id})
 
-      hop_upgrade_kubeadm
+      hop_wait_node_ready
     end
+  end
+
+  label def wait_node_ready
+    # kubeadm upgrade apply has a ControlPlaneNodesReady preflight that
+    # fails if any control-plane node is NotReady.
+    nap 10 unless kubernetes_cluster.all_functional_nodes_ready?
+    hop_upgrade_kubeadm
   end
 
   label def upgrade_kubeadm

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe KubernetesCluster do
   let(:private_subnet) { PrivateSubnet.create(project_id: project.id, name: "test", location_id: Location::HETZNER_FSN1_ID, net6: "fe80::/64", net4: "192.168.0.0/24") }
 
   before {
-    expect(Config).to receive(:kubernetes_service_project_id).and_return(project.id).twice
+    allow(Config).to receive(:kubernetes_service_project_id).and_return(project.id)
   }
 
   it "displays location properly" do
@@ -430,6 +430,48 @@ RSpec.describe KubernetesCluster do
     it "returns all worker vms in the cluster" do
       expect(kc).to receive(:nodepools).and_return([instance_double(KubernetesNodepool, vms: [3, 4]), instance_double(KubernetesNodepool, vms: [5, 6])])
       expect(kc.worker_vms).to eq([3, 4, 5, 6])
+    end
+  end
+
+  describe "#all_functional_nodes_ready?" do
+    let(:ssh_session) { Net::SSH::Connection::Session.allocate }
+    let(:client) { Kubernetes::Client.new(kc, ssh_session) }
+    let(:node) {
+      Prog::Kubernetes::KubernetesNodeNexus.assemble(
+        project.id,
+        sshable_unix_user: "ubi",
+        name: "#{kc.ubid}-#{SecureRandom.alphanumeric(5).downcase}",
+        location_id: kc.location_id,
+        size: kc.target_node_size,
+        storage_volumes: [{encrypted: true, size_gib: 40}],
+        boot_image: "kubernetes-#{kc.version.tr(".", "_")}",
+        private_subnet_id: kc.private_subnet_id,
+        enable_ip4: true,
+        kubernetes_cluster_id: kc.id,
+      ).subject
+    }
+
+    before do
+      expect(kc).to receive(:client).and_return(client)
+    end
+
+    it "returns true when every functional node has Ready=True" do
+      body = JSON.generate("items" => [{"metadata" => {"name" => node.name}, "status" => {"conditions" => [{"type" => "Ready", "status" => "True"}]}}])
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
+      expect(kc.reload.all_functional_nodes_ready?).to be true
+    end
+
+    it "returns false when a functional node reports Ready=False" do
+      body = JSON.generate("items" => [{"metadata" => {"name" => node.name}, "status" => {"conditions" => [{"type" => "Ready", "status" => "False"}]}}])
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
+      expect(kc.reload.all_functional_nodes_ready?).to be false
+    end
+
+    it "returns false when a functional node is missing from the API response" do
+      node
+      body = JSON.generate("items" => [])
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
+      expect(kc.reload.all_functional_nodes_ready?).to be false
     end
   end
 end

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -81,11 +81,47 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
       expect { prog.wait_new_node }.to nap(120)
     end
 
-    it "hops to upgrade_kubeadm if there are no sub-programs running" do
+    it "hops to wait_node_ready if there are no sub-programs running" do
       st.update(label: "wait_new_node")
       Strand.create(parent_id: st.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{}], exitval: {"node_id" => "12345"})
-      expect { prog.wait_new_node }.to hop("upgrade_kubeadm")
+      expect { prog.wait_new_node }.to hop("wait_node_ready")
       expect(prog.strand.stack.first["new_node_id"]).to eq "12345"
+    end
+  end
+
+  describe "#wait_node_ready" do
+    let(:session) { Net::SSH::Connection::Session.allocate }
+    let(:new_node) {
+      Firewall.create(name: "#{kubernetes_cluster.ubid}-cp-vm-firewall", project_id: Config.kubernetes_service_project_id, location_id: kubernetes_cluster.location_id)
+      Prog::Kubernetes::KubernetesNodeNexus.assemble(
+        Config.kubernetes_service_project_id,
+        sshable_unix_user: "ubi",
+        name: "#{kubernetes_cluster.ubid}-#{SecureRandom.alphanumeric(5).downcase}",
+        location_id: kubernetes_cluster.location_id,
+        size: kubernetes_cluster.target_node_size,
+        storage_volumes: [{encrypted: true, size_gib: 40}],
+        boot_image: "kubernetes-#{kubernetes_cluster.version.tr(".", "_")}",
+        private_subnet_id: kubernetes_cluster.private_subnet_id,
+        enable_ip4: true,
+        kubernetes_cluster_id: kubernetes_cluster.id,
+      ).subject
+    }
+
+    before do
+      st.update(stack: [{"subject_id" => kubernetes_cluster.id, "new_node_id" => new_node.id, "old_node_id" => "old"}])
+      expect(prog.kubernetes_cluster.sshable).to receive(:connect).and_return(session)
+    end
+
+    it "naps if the new node is not yet Ready" do
+      body = JSON.generate("items" => [{"metadata" => {"name" => new_node.name}, "status" => {"conditions" => [{"type" => "Ready", "status" => "False"}]}}])
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
+      expect { prog.wait_node_ready }.to nap(10)
+    end
+
+    it "hops to upgrade_kubeadm once every functional node is Ready" do
+      body = JSON.generate("items" => [{"metadata" => {"name" => new_node.name}, "status" => {"conditions" => [{"type" => "Ready", "status" => "True"}]}}])
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
+      expect { prog.wait_node_ready }.to hop("upgrade_kubeadm")
     end
   end
 


### PR DESCRIPTION
After CSR approval the kubelet still needs a moment to register the new node as Ready, and kubeadm upgrade apply's ControlPlaneNodesReady preflight fails if any control-plane node is NotReady. Add a wait_node_ready label between wait_new_node and upgrade_kubeadm that naps until every functional node reports Ready=True.