### PR TITLE
Add AWS instance type fallback for Postgres servers

### DIFF
--- a/cli-commands/pg/post/list-servers.rb
+++ b/cli-commands/pg/post/list-servers.rb
@@ -11,6 +11,6 @@ UbiCli.on("pg").run_on("list-servers") do
 
   run do |opts|
     servers = sdk_object.servers
-    response(format_rows(%i[id role state synchronization_status vm], servers, headers: opts[key][:"no-headers"] != false))
+    response(format_rows(%i[id role state synchronization_status vm vm_size], servers, headers: opts[key][:"no-headers"] != false))
   end
 end

--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -67,7 +67,7 @@ class Clover
   end
 
   def postgres_list(tags_param: nil)
-    dataset = dataset_authorize(@project.postgres_resources_dataset.eager(:timeline, representative_server: [:strand, vm: :vm_storage_volumes]), "Postgres:view").eager(:semaphores, :location, strand: :children)
+    dataset = dataset_authorize(@project.postgres_resources_dataset.eager(:timeline, representative_server: [:semaphores, :strand, vm: :vm_storage_volumes]), "Postgres:view").eager(:semaphores, :location, strand: :children)
 
     if tags_param
       tags_param = tags_param.split(",")

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -104,6 +104,7 @@ module Option
 
   AWS_FAMILY_OPTIONS = AWS_FAMILY_VM_CONFIG.keys.freeze
   GCP_FAMILY_OPTIONS = ["c4a-standard", "c4a-highmem"].freeze
+
   non_storage_optimized_vm_storage_size_options = {1 => [59], 2 => [118], 4 => [237], 8 => [474], 16 => [950], 32 => [1900], 48 => [2850], 64 => [3800], 96 => [5700], 128 => [7600], 192 => [11400]}
   AWS_STORAGE_SIZE_OPTIONS = {
     "c6gd" => non_storage_optimized_vm_storage_size_options,
@@ -406,6 +407,25 @@ module Option
     ["burstable-1", POSTGRES_SIZE_OPTIONS["hobby-1"]],
     ["burstable-2", POSTGRES_SIZE_OPTIONS["hobby-2"]],
   ].to_h).freeze
+
+  POSTGRES_FAMILY_FALLBACK_CHAINS = [
+    ["c6gd", "c7gd", "c8gd"],
+    ["c6id", "c8id"],
+    ["m6id", "m8id"],
+    ["m6gd", "m7gd", "m8gd"],
+    ["r6gd", "r7gd", "r8gd"],
+    ["r6id", "r8id"],
+  ].freeze
+
+  def self.postgres_fallback_candidates(family)
+    chain = POSTGRES_FAMILY_FALLBACK_CHAINS.find { it.include?(family) }
+    chain ? chain - [family] : []
+  end
+
+  def self.postgres_family_rank(family)
+    chain = POSTGRES_FAMILY_FALLBACK_CHAINS.find { it.include?(family) }
+    chain ? chain.index(family) : -1
+  end
 
   POSTGRES_STORAGE_SIZE_OPTIONS = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096].freeze
 

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -268,6 +268,15 @@ class PostgresResource < Sequel::Model
     !needs_convergence? && !PostgresTimeline.earliest_restore_time(timeline).nil?
   end
 
+  def update_target_sizes_with_replicas(target_vm_size:, target_storage_size_gib:, **extra)
+    target_vm_size_changing = self.target_vm_size != target_vm_size
+    update(target_vm_size:, target_storage_size_gib:, **extra)
+    read_replicas_dataset.update(target_vm_size:, target_storage_size_gib:)
+    return unless target_vm_size_changing
+    servers.each(&:decr_ignore_instance_size_mismatch)
+    read_replicas.each { |rr| rr.servers.each(&:decr_ignore_instance_size_mismatch) }
+  end
+
   def handle_storage_auto_scale
     begin
       disk_usage_percent = representative_server.vm.sshable.cmd("df --output=pcent /dat | tail -n 1").strip.delete("%").to_i
@@ -322,8 +331,7 @@ class PostgresResource < Sequel::Model
         target_storage_size_gib = next_option["storage_size"]
 
         unless storage_auto_scale_canceled_set?
-          update(target_vm_size:, target_storage_size_gib:)
-          read_replicas_dataset.update(target_vm_size:, target_storage_size_gib:)
+          update_target_sizes_with_replicas(target_vm_size:, target_storage_size_gib:)
         end
       end
 
@@ -377,8 +385,7 @@ class PostgresResource < Sequel::Model
       return false unless can_cancel_storage_auto_scale?
 
       current_storage_size_gib = representative_server.storage_size_gib
-      update(target_vm_size: vm_size, target_storage_size_gib: current_storage_size_gib)
-      read_replicas_dataset.update(target_vm_size: vm_size, target_storage_size_gib: current_storage_size_gib)
+      update_target_sizes_with_replicas(target_vm_size: vm_size, target_storage_size_gib: current_storage_size_gib)
 
       incr_storage_auto_scale_canceled
 

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -18,7 +18,7 @@ class PostgresServer < Sequel::Model
     :restart, :configure, :fence, :unfence, :planned_take_over, :unplanned_take_over, :configure_metrics,
     :destroy, :recycle, :recycle_lagging_read_replica, :recycle_unavailable_server, :recycle_by_user_request,
     :promote_read_replica, :refresh_walg_credentials, :configure_s3_new_timeline, :lockout, :use_physical_slot,
-    :configure_logs
+    :configure_logs, :ignore_instance_size_mismatch
   include HealthMonitorMethods
   include MetricsTargetMethods
 
@@ -218,9 +218,20 @@ class PostgresServer < Sequel::Model
     vm.vm_storage_volumes.reject(&:boot).sum(&:size_gib)
   end
 
+  def fallback_active?
+    ignore_instance_size_mismatch_set?
+  end
+
+  def fallback_eligible?
+    return false unless vm.location.aws?
+    return false unless resource.project.get_ff_postgres_instance_type_fallback
+    return false if recycle_by_user_request_set?
+    true
+  end
+
   def needs_recycling?
     recycle_requested = recycle_set? || recycle_lagging_read_replica_set? || recycle_unavailable_server_set? || recycle_by_user_request_set?
-    instance_size_mismatch = vm.display_size.gsub("burstable", "hobby") != resource.target_vm_size || storage_size_gib != resource.target_storage_size_gib
+    instance_size_mismatch = (vm.display_size.gsub("burstable", "hobby") != resource.target_vm_size && !ignore_instance_size_mismatch_set?) || storage_size_gib != resource.target_storage_size_gib
     version_mismatch = version != resource.target_version
 
     recycle_requested || instance_size_mismatch || version_mismatch
@@ -271,7 +282,14 @@ class PostgresServer < Sequel::Model
 
     target = candidates
       .map { {server: it, lsn: it.current_lsn} }
-      .max_by { [(it[:server].physical_slot_ready_id == resource.representative_server.id) ? 1 : 0, lsn2int(it[:lsn])] }
+      # Priority: slot-readiness (safe to promote) > lsn (minimize data loss)
+      # > intended type (post-failover stability) > family rank (prefer newer).
+      .max_by {
+        slot_score = (it[:server].physical_slot_ready_id == resource.representative_server.id) ? 1 : 0
+        type_score = it[:server].fallback_active? ? 0 : 1
+        rank_score = Option.postgres_family_rank(it[:server].vm.family)
+        [slot_score, lsn2int(it[:lsn]), type_score, rank_score]
+      }
 
     return nil if target.nil?
 

--- a/model/project.rb
+++ b/model/project.rb
@@ -254,6 +254,7 @@ class Project < Sequel::Model
     :visible_postgres_locations,
     :vm_public_ssh_keys,
     :postgres_aws_use_different_azs_for_standbys,
+    :postgres_instance_type_fallback,
     :cache_proxy_download_url,
     :overwrite_runner_apt_sources,
   )

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -3613,6 +3613,9 @@ components:
           description: Parent Postgres database
           type: string
           nullable: true
+        fallback_active:
+          description: Whether the primary server is running on a fallback instance type
+          type: boolean
         tags:
           description: Tags of the Postgres database
           type: array
@@ -3637,6 +3640,7 @@ components:
         - vm_size
         - maintenance_window_start_at
         - read_replica
+        - fallback_active
         - tags
         - created_at
     PostgresDatabaseLogEntry:
@@ -3778,6 +3782,12 @@ components:
           enum:
             - ready
             - catching_up
+        vm_size:
+          description: Actual VM size of the server
+          type: string
+        fallback_active:
+          description: Whether the server is running on a fallback instance type
+          type: boolean
         vm:
           $ref: '#/components/schemas/Vm'
       additionalProperties: false

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -136,7 +136,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
     # ready and recent servers (in that order)
     servers_to_keep = postgres_resource.servers
       .reject { it.is_representative || it.needs_recycling? || it.version != postgres_resource.target_version }
-      .sort_by { [(it.strand.label == "wait") ? 0 : 1, Time.now - it.created_at] }
+      .sort_by { [(it.strand.label == "wait") ? 0 : 1, it.fallback_active? ? 1 : 0, -Option.postgres_family_rank(it.vm.family), Time.now - it.created_at] }
       .take(postgres_resource.target_standby_count) + [postgres_resource.representative_server]
     servers_to_destroy = (postgres_resource.servers - servers_to_keep)
     servers_to_destroy.each(&:incr_destroy)

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -424,7 +424,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
 
   # Two-tier AZ exclusion: unsupported_azs (permanent, from multi-AZ constraints
   # and Unsupported errors) and exclude_availability_zones (transient, InsufficientCapacity only).
-  # All unsupported: page + 1hr nap. All tried: clear transient, wait 5min.
+  # All unsupported: try family fallback, else page + 1hr nap. All tried: try family fallback, else reset transient + 5min.
   def retry_in_different_az(e, az_failure_type)
     unsupported_azs = frame["unsupported_azs"] || []
     exclude_availability_zones = frame["exclude_availability_zones"] || []
@@ -442,6 +442,11 @@ class Prog::Vm::Aws::Nexus < Prog::Base
     total_azs = nic.private_subnet.private_subnet_aws_resource.aws_subnets.count
     all_tried = (unsupported_azs + exclude_availability_zones).uniq.size >= total_azs
 
+    if all_tried && try_postgres_family_fallback
+      update_stack({"unsupported_azs" => [], "exclude_availability_zones" => []})
+      nap 0
+    end
+
     if all_tried && unsupported_azs.size >= total_azs
       Clog.emit("all azs unsupported for instance type", {retry_different_az_unsupported: {vm:, error: e.class.name, message: e.message, unsupported_azs:}})
       Prog::PageNexus.assemble("#{vm.name} instance type unsupported in all AZs", ["InstanceTypeUnsupported", vm.id], vm.ubid)
@@ -457,6 +462,27 @@ class Prog::Vm::Aws::Nexus < Prog::Base
       nic.incr_destroy
       hop_wait_old_nic_deleted
     end
+  end
+
+  def try_postgres_family_fallback
+    ps = PostgresServer[vm_id: vm.id]
+    return false unless ps&.fallback_eligible?
+
+    candidates = Option.postgres_fallback_candidates(vm.family)
+    return false if candidates.empty?
+
+    option_tree, parents = PostgresResource.generate_postgres_options(ps.resource.project, flavor: ps.resource.flavor, location: ps.resource.location)
+    allowed_families = OptionTreeGenerator.generate_allowed_options("family", option_tree, parents).map { it["family"] }.uniq
+
+    next_family = candidates.find { |f| allowed_families.include?(f) }
+    return false unless next_family
+
+    Clog.emit("postgres az exhausted, trying fallback family", {postgres_family_fallback: {vm:, from: vm.family, to: next_family}})
+    DB.transaction do
+      vm.update(family: next_family)
+      ps.incr_ignore_instance_size_mismatch unless ps.ignore_instance_size_mismatch_set?
+    end
+    true
   end
 
   def ignore_invalid_entity

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -102,8 +102,7 @@ class Clover
         Validation.validate_vcpu_quota(@project, "PostgresVCpu", requested_postgres_vcpu_count - current_postgres_vcpu_count)
 
         DB.transaction do
-          pg.update(target_vm_size: requested_parsed_size.name, target_storage_size_gib:, ha_type:, tags:)
-          pg.read_replicas_dataset.update(target_vm_size: requested_parsed_size.name, target_storage_size_gib:)
+          pg.update_target_sizes_with_replicas(target_vm_size: requested_parsed_size.name, target_storage_size_gib:, ha_type:, tags:)
 
           # Updating target_vm_size and target_storage_size_gib might undo what
           # we did in auto-scaling, so we are decrementing related semaphores

--- a/serializers/postgres.rb
+++ b/serializers/postgres.rb
@@ -20,6 +20,7 @@ class Serializers::Postgres < Serializers::Base
       maintenance_window_start_at: pg.maintenance_window_start_at,
       read_replica: !!pg.read_replica?,
       parent: pg.parent&.path,
+      fallback_active: pg.representative_server.fallback_active?,
       tags: pg.tags || [],
       created_at: pg.created_at.iso8601,
     }

--- a/serializers/postgres_server.rb
+++ b/serializers/postgres_server.rb
@@ -7,6 +7,8 @@ class Serializers::PostgresServer < Serializers::Base
       role: server.is_representative ? "primary" : "standby",
       state: server.display_state,
       synchronization_status: server.synchronization_status,
+      vm_size: server.vm.display_size,
+      fallback_active: server.fallback_active?,
       vm: Serializers::Vm.serialize(server.vm),
     }
   end

--- a/spec/lib/option_spec.rb
+++ b/spec/lib/option_spec.rb
@@ -63,6 +63,60 @@ RSpec.describe Option do
     end
   end
 
+  describe "POSTGRES_FAMILY_FALLBACK_CHAINS" do
+    it "matches the derivation from POSTGRES_SIZE_OPTIONS" do
+      derived = (Option::POSTGRES_SIZE_OPTIONS.values.map(&:family).uniq & Option::AWS_FAMILY_OPTIONS)
+        .group_by { it.sub(/\d+/, "") }
+        .values
+        .map { |chain| chain.sort_by { it[/\d+/].to_i } }
+        .reject { |chain| chain.size < 2 }
+      expect(Option::POSTGRES_FAMILY_FALLBACK_CHAINS).to eq(derived)
+    end
+  end
+
+  describe ".postgres_fallback_candidates" do
+    it "returns the older family for the newest in a 2-element chain" do
+      expect(described_class.postgres_fallback_candidates("m8id")).to eq(["m6id"])
+    end
+
+    it "returns the newer family for the oldest in a 2-element chain" do
+      expect(described_class.postgres_fallback_candidates("m6id")).to eq(["m8id"])
+    end
+
+    it "returns all older alternatives for the newest in a 3-element chain" do
+      expect(described_class.postgres_fallback_candidates("c8gd")).to eq(["c6gd", "c7gd"])
+    end
+
+    it "returns all newer alternatives for the oldest in a 3-element chain" do
+      expect(described_class.postgres_fallback_candidates("c6gd")).to eq(["c7gd", "c8gd"])
+    end
+
+    it "returns older alternatives first then newer for a mid-chain family" do
+      expect(described_class.postgres_fallback_candidates("c7gd")).to eq(["c6gd", "c8gd"])
+    end
+
+    it "returns empty list for a family not in any chain" do
+      expect(described_class.postgres_fallback_candidates("standard")).to eq([])
+    end
+  end
+
+  describe ".postgres_family_rank" do
+    it "returns the chain index for a 2-element chain" do
+      expect(described_class.postgres_family_rank("m6id")).to eq(0)
+      expect(described_class.postgres_family_rank("m8id")).to eq(1)
+    end
+
+    it "returns the chain index for a 3-element chain" do
+      expect(described_class.postgres_family_rank("c6gd")).to eq(0)
+      expect(described_class.postgres_family_rank("c7gd")).to eq(1)
+      expect(described_class.postgres_family_rank("c8gd")).to eq(2)
+    end
+
+    it "returns -1 for a family not in any chain" do
+      expect(described_class.postgres_family_rank("standard")).to eq(-1)
+    end
+  end
+
   describe "#kubernetes_upgrade_candidate" do
     it "returns upgrade version for upgradeable version" do
       expect(described_class.kubernetes_upgrade_candidate("v1.33")).to eq("v1.34")

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -93,6 +93,47 @@ RSpec.describe PostgresResource do
     expect(postgres_resource.client_ca_certificates).to be_nil
   end
 
+  describe "#update_target_sizes_with_replicas" do
+    let(:replica) {
+      described_class.create(
+        name: "pg-replica", superuser_password: "dummy-password", ha_type: "none",
+        target_version: "17", location_id:, project_id: project.id, user_config: {},
+        pgbouncer_user_config: {}, target_vm_size: "standard-2", target_storage_size_gib: 64,
+        parent_id: postgres_resource.id,
+      )
+    }
+
+    before { allow(postgres_resource).to receive(:read_replicas).and_return([replica]) }
+
+    it "updates self and each read replica" do
+      postgres_resource.update_target_sizes_with_replicas(target_vm_size: "standard-8", target_storage_size_gib: 256, ha_type: "async")
+
+      expect(postgres_resource.reload).to have_attributes(target_vm_size: "standard-8", target_storage_size_gib: 256, ha_type: "async")
+      expect(replica.reload).to have_attributes(target_vm_size: "standard-8", target_storage_size_gib: 256)
+    end
+
+    it "clears ignore_instance_size_mismatch on all servers when target_vm_size changes" do
+      parent_server = instance_double(PostgresServer)
+      replica_server = instance_double(PostgresServer)
+      allow(postgres_resource).to receive(:servers).and_return([parent_server])
+      allow(replica).to receive(:servers).and_return([replica_server])
+
+      expect(parent_server).to receive(:decr_ignore_instance_size_mismatch)
+      expect(replica_server).to receive(:decr_ignore_instance_size_mismatch)
+
+      postgres_resource.update_target_sizes_with_replicas(target_vm_size: "standard-8", target_storage_size_gib: 256)
+    end
+
+    it "does not clear ignore_instance_size_mismatch when target_vm_size does not change" do
+      parent_server = instance_double(PostgresServer)
+      allow(postgres_resource).to receive(:servers).and_return([parent_server])
+
+      expect(parent_server).not_to receive(:decr_ignore_instance_size_mismatch)
+
+      postgres_resource.update_target_sizes_with_replicas(target_vm_size: postgres_resource.target_vm_size, target_storage_size_gib: 256)
+    end
+  end
+
   describe "#provision_new_standby" do
     before do
       allow(Config).to receive(:postgres_service_project_id).and_return(project.id)

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -219,15 +219,91 @@ RSpec.describe PostgresServer do
     expect(postgres_server).not_to be_read_replica
   end
 
+  describe "#fallback_active?" do
+    before { Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait") }
+
+    it "is false when the ignore_instance_size_mismatch semaphore is not set" do
+      expect(postgres_server).not_to be_fallback_active
+    end
+
+    it "is true when the ignore_instance_size_mismatch semaphore is set" do
+      postgres_server.incr_ignore_instance_size_mismatch
+      expect(postgres_server).to be_fallback_active
+    end
+  end
+
+  describe "#fallback_eligible?" do
+    let(:aws_vm) { instance_double(Vm, location: instance_double(Location, aws?: true)) }
+    let(:metal_vm) { instance_double(Vm, location: instance_double(Location, aws?: false)) }
+
+    it "is false when the vm is not on AWS" do
+      allow(postgres_server).to receive(:vm).and_return(metal_vm)
+      expect(postgres_server).not_to be_fallback_eligible
+    end
+
+    it "is false when the project feature flag is off" do
+      allow(postgres_server).to receive(:vm).and_return(aws_vm)
+      allow(resource).to receive(:project).and_return(instance_double(Project, get_ff_postgres_instance_type_fallback: false))
+      expect(postgres_server).not_to be_fallback_eligible
+    end
+
+    it "is false when recycle_by_user_request is set" do
+      Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
+      allow(postgres_server).to receive(:vm).and_return(aws_vm)
+      allow(resource).to receive(:project).and_return(instance_double(Project, get_ff_postgres_instance_type_fallback: true))
+      postgres_server.incr_recycle_by_user_request
+      expect(postgres_server).not_to be_fallback_eligible
+    end
+
+    it "is true when AWS, flag is on, and no user recycle is set" do
+      allow(postgres_server).to receive(:vm).and_return(aws_vm)
+      allow(resource).to receive(:project).and_return(instance_double(Project, get_ff_postgres_instance_type_fallback: true))
+      expect(postgres_server).to be_fallback_eligible
+    end
+  end
+
+  describe "#needs_recycling?" do
+    before do
+      Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
+      allow(postgres_server).to receive(:vm).and_return(instance_double(Vm, display_size: "r6gd.large", vm_storage_volumes: []))
+      allow(resource).to receive_messages(target_vm_size: "r6gd.large", target_storage_size_gib: 0, target_version: postgres_server.version)
+    end
+
+    it "does not recycle on instance size mismatch when ignore_instance_size_mismatch is set" do
+      allow(resource).to receive(:target_vm_size).and_return("r8gd.large")
+      postgres_server.incr_ignore_instance_size_mismatch
+      expect(postgres_server.needs_recycling?).to be false
+    end
+
+    it "recycles on instance size mismatch when ignore_instance_size_mismatch is not set" do
+      allow(resource).to receive(:target_vm_size).and_return("r8gd.large")
+      expect(postgres_server.needs_recycling?).to be true
+    end
+
+    it "recycles on storage size mismatch even when ignore_instance_size_mismatch is set" do
+      allow(resource).to receive(:target_storage_size_gib).and_return(100)
+      postgres_server.incr_ignore_instance_size_mismatch
+      expect(postgres_server.needs_recycling?).to be true
+    end
+
+    it "translates burstable to hobby when comparing vm.display_size to resource.target_vm_size" do
+      allow(postgres_server).to receive(:vm).and_return(instance_double(Vm, display_size: "burstable-2", vm_storage_volumes: []))
+      allow(resource).to receive(:target_vm_size).and_return("hobby-2")
+      expect(postgres_server.needs_recycling?).to be false
+    end
+  end
+
   describe "#failover_target" do
+    let(:standby_vm) { instance_double(Vm, family: "standard", display_size: "standard-4") }
+
     before do
       postgres_server.is_representative = true
       allow(postgres_server).to receive(:read_replica?).and_return(false)
       allow(resource).to receive(:servers).and_return([
         postgres_server,
-        instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, strand: instance_double(Strand, label: "wait_catch_up"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready"),
-        instance_double(described_class, ubid: "pgubidstandby2", is_representative: false, current_lsn: "1/5", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready"),
-        instance_double(described_class, ubid: "pgubidstandby3", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready"),
+        instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, strand: instance_double(Strand, label: "wait_catch_up"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: standby_vm),
+        instance_double(described_class, ubid: "pgubidstandby2", is_representative: false, current_lsn: "1/5", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: standby_vm),
+        instance_double(described_class, ubid: "pgubidstandby3", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: standby_vm),
       ])
     end
 
@@ -242,7 +318,7 @@ RSpec.describe PostgresServer do
       expect(standby_server).to receive(:resource).at_least(:once).and_return(resource)
       expect(standby_server).to receive(:is_representative).and_return(false).at_least(:once)
       expect(standby_server).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
-      expect(standby_server).to receive(:vm).and_return(instance_double(Vm, display_size: "standard-4", sshable: Sshable.new))
+      expect(standby_server).to receive(:vm).and_return(instance_double(Vm, display_size: "standard-4", sshable: Sshable.new)).at_least(:once)
 
       expect(resource).to receive(:servers).and_return([postgres_server, standby_server]).at_least(:once)
       expect(resource).to receive(:target_vm_size).and_return("standard-2")
@@ -281,7 +357,7 @@ RSpec.describe PostgresServer do
     it "returns standby with physical_slot_ready_id nil as fallback for unplanned failover" do
       allow(resource).to receive(:servers).and_return([
         postgres_server,
-        instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: nil, synchronization_status: "ready"),
+        instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: nil, synchronization_status: "ready", fallback_active?: false, vm: standby_vm),
       ])
       expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
       expect(postgres_server.failover_target.ubid).to eq("pgubidstandby1")
@@ -296,7 +372,7 @@ RSpec.describe PostgresServer do
     end
 
     it "returns nil for planned failover when logical slots not synced on standby" do
-      standby = instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready")
+      standby = instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: standby_vm)
       expect(resource).to receive(:servers).and_return([postgres_server, standby]).at_least(:once)
       expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
       expect(postgres_server).to receive(:unsynced_logical_failover_slots).with(standby).and_return(["slot1"])
@@ -304,7 +380,7 @@ RSpec.describe PostgresServer do
     end
 
     it "returns standby for planned failover when logical slots are synced" do
-      standby = instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready")
+      standby = instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: standby_vm)
       expect(resource).to receive(:servers).and_return([postgres_server, standby]).at_least(:once)
       expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
       expect(postgres_server).to receive(:unsynced_logical_failover_slots).with(standby).and_return([])
@@ -314,11 +390,47 @@ RSpec.describe PostgresServer do
     it "prefers standby with physical_slot_ready_id set over higher lsn without" do
       allow(resource).to receive(:servers).and_return([
         postgres_server,
-        instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/5", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready"),
-        instance_double(described_class, ubid: "pgubidstandby2", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: nil, synchronization_status: "ready"),
+        instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/5", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: standby_vm),
+        instance_double(described_class, ubid: "pgubidstandby2", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: nil, synchronization_status: "ready", fallback_active?: false, vm: standby_vm),
       ])
       expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
       expect(postgres_server.failover_target.ubid).to eq("pgubidstandby1")
+    end
+
+    it "prefers higher lsn over intended-type when both slot-ready" do
+      fallback_vm = instance_double(Vm, family: "r6gd", display_size: "r6gd.large")
+      intended_vm = instance_double(Vm, family: "r8gd", display_size: "r8gd.large")
+      allow(resource).to receive(:servers).and_return([
+        postgres_server,
+        instance_double(described_class, ubid: "pgFallbackHighLsn", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: true, vm: fallback_vm),
+        instance_double(described_class, ubid: "pgIntendedLowLsn", is_representative: false, current_lsn: "1/5", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: intended_vm),
+      ])
+      expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
+      expect(postgres_server.failover_target.ubid).to eq("pgFallbackHighLsn")
+    end
+
+    it "prefers intended-type over family rank at equal lsn" do
+      intended_vm = instance_double(Vm, family: "r6gd", display_size: "r6gd.large")
+      fallback_vm = instance_double(Vm, family: "r8gd", display_size: "r8gd.large")
+      allow(resource).to receive(:servers).and_return([
+        postgres_server,
+        instance_double(described_class, ubid: "pgIntendedOld", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: intended_vm),
+        instance_double(described_class, ubid: "pgFallbackNew", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: true, vm: fallback_vm),
+      ])
+      expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
+      expect(postgres_server.failover_target.ubid).to eq("pgIntendedOld")
+    end
+
+    it "prefers newer family rank as final tiebreaker at equal lsn and intended-type" do
+      new_vm = instance_double(Vm, family: "r8gd", display_size: "r8gd.large")
+      old_vm = instance_double(Vm, family: "r6gd", display_size: "r6gd.large")
+      allow(resource).to receive(:servers).and_return([
+        postgres_server,
+        instance_double(described_class, ubid: "pgNewerFamily", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: new_vm),
+        instance_double(described_class, ubid: "pgOlderFamily", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: old_vm),
+      ])
+      expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
+      expect(postgres_server.failover_target.ubid).to eq("pgNewerFamily")
     end
   end
 
@@ -376,15 +488,17 @@ RSpec.describe PostgresServer do
   end
 
   describe "#failover_target read_replica" do
+    let(:replica_vm) { instance_double(Vm, family: "standard", display_size: "standard-4") }
+
     before do
       expect(postgres_server).to receive(:is_representative).and_return(true)
       allow(postgres_server).to receive(:read_replica?).and_return(true)
 
       allow(resource).to receive(:servers).and_return([
         postgres_server,
-        instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, strand: instance_double(Strand, label: "wait_catch_up"), needs_recycling?: false, read_replica?: true, physical_slot_ready_id: nil, synchronization_status: "ready"),
-        instance_double(described_class, ubid: "pgubidstandby2", is_representative: false, current_lsn: "1/5", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: true, physical_slot_ready_id: nil, synchronization_status: "ready"),
-        instance_double(described_class, ubid: "pgubidstandby3", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: true, physical_slot_ready_id: nil, synchronization_status: "ready"),
+        instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, strand: instance_double(Strand, label: "wait_catch_up"), needs_recycling?: false, read_replica?: true, physical_slot_ready_id: nil, synchronization_status: "ready", fallback_active?: false, vm: replica_vm),
+        instance_double(described_class, ubid: "pgubidstandby2", is_representative: false, current_lsn: "1/5", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: true, physical_slot_ready_id: nil, synchronization_status: "ready", fallback_active?: false, vm: replica_vm),
+        instance_double(described_class, ubid: "pgubidstandby3", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: true, physical_slot_ready_id: nil, synchronization_status: "ready", fallback_active?: false, vm: replica_vm),
       ])
     end
 
@@ -397,7 +511,7 @@ RSpec.describe PostgresServer do
       replica_server = described_class.new { it.id = "c068cac7-ed45-82db-bf38-a003582b36ef" }
       expect(replica_server).to receive(:resource).at_least(:once).and_return(resource)
       expect(replica_server).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
-      expect(replica_server).to receive(:vm).and_return(instance_double(Vm, display_size: "standard-4"))
+      expect(replica_server).to receive(:vm).and_return(instance_double(Vm, display_size: "standard-4")).at_least(:once)
       expect(resource).to receive(:servers).and_return([postgres_server, replica_server]).at_least(:once)
       expect(resource).to receive(:target_vm_size).and_return("standard-2")
       expect(postgres_server.failover_target).to be_nil
@@ -410,7 +524,7 @@ RSpec.describe PostgresServer do
     it "returns the replica even if physical_slot_ready_id is nil" do
       allow(resource).to receive(:servers).and_return([
         postgres_server,
-        instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: true, physical_slot_ready_id: nil, synchronization_status: "ready"),
+        instance_double(described_class, ubid: "pgubidstandby1", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: false, read_replica?: true, physical_slot_ready_id: nil, synchronization_status: "ready", fallback_active?: false, vm: replica_vm),
       ])
       expect(postgres_server.failover_target.ubid).to eq("pgubidstandby1")
     end

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -615,6 +615,37 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect(servers_to_destroy_ids).to contain_exactly(recycling_server.id, unavailable_server.id, extra_server.id)
     end
 
+    it "prefers servers on intended type when picking which standbys to keep" do
+      create_server(is_representative: true)
+      on_intended = create_server
+      fallback = create_server
+      on_intended.update(created_at: Time.now - 120)
+      fallback.update(created_at: Time.now)
+      # Change vm.family so display_size diverges from resource.target_vm_size,
+      # mimicking a server that has fallen back to a different family.
+      fallback.vm.update(family: "m6a")
+
+      expect { nx.prune_servers }.to hop("wait_prune_servers")
+
+      expect(fallback.reload.destroy_set?).to be true
+      expect(on_intended.reload.destroy_set?).to be false
+    end
+
+    it "factors fallback_active? into the sort when both standbys survive needs_recycling?" do
+      pg.update(ha_type: PostgresResource::HaType::ASYNC)
+      create_server(is_representative: true)
+      on_intended = create_server
+      fallback = create_server
+      fallback.vm.update(family: "m6a")
+      # Semaphore makes the fallback pass needs_recycling? so the sort sees both.
+      fallback.incr_ignore_instance_size_mismatch
+
+      expect { nx.prune_servers }.to hop("wait_prune_servers")
+
+      expect(fallback.reload.destroy_set?).to be true
+      expect(on_intended.reload.destroy_set?).to be false
+    end
+
     it "destroys servers with older versions" do
       old_server = create_server(version: "16")
       new_server = create_server(version: "17", is_representative: true)

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -584,6 +584,76 @@ usermod -L ubuntu
     it "raises on invalid az_failure_type" do
       expect { nx.retry_in_different_az(RuntimeError.new("test"), :bogus) }.to raise_error("unexpected az_failure_type: bogus")
     end
+
+    describe "when postgres family fallback engages" do
+      let(:nic) { vm.nics.first }
+
+      before do
+        nic.nic_aws_resource.update(subnet_az: "a")
+        refresh_frame(nx, new_values: {"unsupported_azs" => ["b", "c", "d", "e", "f"]})
+        client.stub_responses(:run_instances, Aws::EC2::Errors::Unsupported.new(nil, "Instance type not supported"))
+      end
+
+      it "invokes try_postgres_family_fallback, clears both AZ sets, and naps 0" do
+        expect(nx).to receive(:try_postgres_family_fallback).and_return(true)
+        expect { nx.create_instance }.to nap(0)
+        expect(st.stack.last["unsupported_azs"]).to eq([])
+        expect(st.stack.last["exclude_availability_zones"]).to eq([])
+      end
+    end
+  end
+
+  describe "#try_postgres_family_fallback" do
+    it "returns false when there is no postgres_server for the vm" do
+      expect(nx.try_postgres_family_fallback).to be false
+    end
+
+    it "returns false when the postgres_server is not fallback eligible" do
+      ps = instance_double(PostgresServer, fallback_eligible?: false)
+      allow(PostgresServer).to receive(:[]).with(vm_id: vm.id).and_return(ps)
+      expect(nx.try_postgres_family_fallback).to be false
+    end
+
+    it "returns false when no fallback candidate has a matching postgres size option" do
+      vm.update(family: "standard")
+      ps = instance_double(PostgresServer, fallback_eligible?: true)
+      allow(PostgresServer).to receive(:[]).with(vm_id: vm.id).and_return(ps)
+      expect(nx.try_postgres_family_fallback).to be false
+    end
+
+    it "skips chain entries whose project feature flag is disabled and lands on the next enabled one" do
+      # vm starts on m6gd; chain is [m6gd, m7gd, m8gd]. m7gd needs ff_enable_m7gd
+      # (off by default), so the fallback skips it and lands on m8gd (unconditional).
+      ps = instance_double(PostgresServer, fallback_eligible?: true, resource: instance_double(PostgresResource, project:, flavor: "standard", location:), ignore_instance_size_mismatch_set?: false)
+      allow(PostgresServer).to receive(:[]).with(vm_id: vm.id).and_return(ps)
+      expect(ps).to receive(:incr_ignore_instance_size_mismatch)
+      expect { nx.try_postgres_family_fallback }.to change { vm.reload.family }.from("m6gd").to("m8gd")
+    end
+
+    it "picks an earlier chain entry when its feature flag is enabled" do
+      project.set_ff_enable_m7gd(true)
+      ps = instance_double(PostgresServer, fallback_eligible?: true, resource: instance_double(PostgresResource, project:, flavor: "standard", location:), ignore_instance_size_mismatch_set?: false)
+      allow(PostgresServer).to receive(:[]).with(vm_id: vm.id).and_return(ps)
+      expect(ps).to receive(:incr_ignore_instance_size_mismatch)
+      expect { nx.try_postgres_family_fallback }.to change { vm.reload.family }.from("m6gd").to("m7gd")
+    end
+
+    it "does not incr ignore_instance_size_mismatch when already set" do
+      ps = instance_double(PostgresServer, fallback_eligible?: true, resource: instance_double(PostgresResource, project:, flavor: "standard", location:), ignore_instance_size_mismatch_set?: true)
+      allow(PostgresServer).to receive(:[]).with(vm_id: vm.id).and_return(ps)
+      expect(ps).not_to receive(:incr_ignore_instance_size_mismatch)
+      nx.try_postgres_family_fallback
+    end
+
+    it "returns false when no chain candidate is allowed by the option tree" do
+      # r-family chain members all require per-family feature flags; with none
+      # enabled the option tree excludes them, so no candidate is allowed.
+      vm.update(family: "r6gd")
+      ps = instance_double(PostgresServer, fallback_eligible?: true, resource: instance_double(PostgresResource, project:, flavor: "standard", location:), ignore_instance_size_mismatch_set?: false)
+      allow(PostgresServer).to receive(:[]).with(vm_id: vm.id).and_return(ps)
+      expect(ps).not_to receive(:incr_ignore_instance_size_mismatch)
+      expect(nx.try_postgres_family_fallback).to be false
+    end
   end
 
   describe "#wait_instance_created" do

--- a/spec/routes/api/cli/pg/list-servers_spec.rb
+++ b/spec/routes/api/cli/pg/list-servers_spec.rb
@@ -14,5 +14,6 @@ RSpec.describe Clover, "cli pg list-servers" do
     result = cli(%w[pg eu-central-h1/test-pg list-servers -N])
     expect(result).to include(server.ubid)
     expect(result).to include("primary")
+    expect(result).to include(server.vm.display_size)
   end
 end

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -379,6 +379,18 @@ RSpec.describe Clover, "postgres" do
         expect(page).to have_content "64.0 GB is used (50.0%)"
       end
 
+      it "annotates the CPU subtext when the representative is on a fallback type" do
+        pg.update(target_vm_size: "r8gd.large")
+        pg.representative_server.incr_ignore_instance_size_mismatch
+        visit "#{project.path}#{pg.path}/overview"
+        expect(page).to have_content("Fallback from r8gd.large")
+      end
+
+      it "does not annotate the CPU subtext when the representative is on its intended type" do
+        visit "#{project.path}#{pg.path}/overview"
+        expect(page).to have_no_content("Fallback from")
+      end
+
       it "shows the disk usage in red if usage is high" do
         pg
 

--- a/spec/serializers/postgres_server_spec.rb
+++ b/spec/serializers/postgres_server_spec.rb
@@ -64,4 +64,20 @@ RSpec.describe Serializers::PostgresServer do
     expect(data[0][:role]).to eq("primary")
     expect(data[1][:role]).to eq("standby")
   end
+
+  it "exposes vm_size and fallback_active false when the ignore_instance_size_mismatch semaphore is not set" do
+    server = create_server
+    data = described_class.serialize(server)
+
+    expect(data[:vm_size]).to eq(server.vm.display_size)
+    expect(data[:fallback_active]).to be false
+  end
+
+  it "exposes fallback_active true when the ignore_instance_size_mismatch semaphore is set" do
+    server = create_server
+    server.incr_ignore_instance_size_mismatch
+    data = described_class.serialize(server)
+
+    expect(data[:fallback_active]).to be true
+  end
 end

--- a/spec/serializers/postgres_spec.rb
+++ b/spec/serializers/postgres_spec.rb
@@ -84,4 +84,29 @@ RSpec.describe Serializers::Postgres do
     data = described_class.serialize(pg)
     expect(data[:target_server_count]).to eq(pg.target_server_count)
   end
+
+  it "exposes fallback_active false when the representative is on its intended type" do
+    create_representative_server(primary: true)
+    data = described_class.serialize(pg)
+    expect(data[:fallback_active]).to be false
+  end
+
+  it "exposes fallback_active true when the representative is on a fallback type" do
+    server = create_representative_server(primary: true)
+    server.incr_ignore_instance_size_mismatch
+    data = described_class.serialize(pg)
+    expect(data[:fallback_active]).to be true
+  end
+
+  it "ignores standby fallback state since fallback_active reflects only the primary" do
+    create_representative_server(primary: true)
+    standby_vm = create_hosted_vm(project, private_subnet, "pg-standby-vm")
+    PostgresServer.create(
+      timeline:, resource_id: pg.id, vm_id: standby_vm.id,
+      is_representative: false, synchronization_status: "ready",
+      timeline_access: "fetch", version: "17",
+    )
+    data = described_class.serialize(pg)
+    expect(data[:fallback_active]).to be false
+  end
 end

--- a/views/postgres/overview.erb
+++ b/views/postgres/overview.erb
@@ -26,15 +26,20 @@ vm = @pg.representative_server.vm
     end
 
     ha_option = Option::POSTGRES_HA_OPTIONS[@pg.ha_type]
-    
+
     location_details, provider = if vm.aws_instance
       [vm.aws_instance.az_id, "AWS"]
     else
       [@pg.location.ui_name, @pg.location.provider.capitalize]
     end
+    fallback_type_subtext = if @pg.representative_server.fallback_active?
+      "<br><span class=\"text-amber-600 text-sm\">Fallback from #{h(@pg.target_vm_size)}</span>"
+    else
+      ""
+    end
 
     [
-      ["hero-cpu-chip", @pg.vm_size, "#{vm.vcpus} vCPU, #{vm.memory_gib} GB RAM"],
+      ["hero-cpu-chip", @pg.vm_size, "#{h("#{vm.vcpus} vCPU, #{vm.memory_gib} GB RAM")}#{fallback_type_subtext}"],
       ["hero-circle-stack", "#{@pg.representative_server.storage_size_gib} GB", disk_usage_subtext],
       ["hero-square-2-stack-modified", ha_option.description, ""],
       ["hero-map-pin", @pg.location.display_name, h("#{location_details} (#{provider})")],


### PR DESCRIPTION
When an AWS instance type (e.g., `r8gd`) is unavailable across all AZs, fall back to a compatible alternative from a predefined chain (e.g., `r6gd`). Controlled by project feature flag `postgres_instance_type_fallback`.

Key changes:
- Add `:ignore_instance_size_mismatch` semaphore to `postgres_server`, set by the AWS prog on fallback and cleared on resource `target_vm_size` change
- Fallback triggers after AZ exhaustion in `retry_in_different_az`; `vm.update(family:)` and the semaphore increment run in a single `DB.transaction`
- `POSTGRES_FAMILY_FALLBACK_CHAINS` stores chains oldest-to-newest; `postgres_fallback_candidates` walks both directions for availability, `postgres_family_rank` derives preference. Pinned by a spec against a derivation from POSTGRES_SIZE_OPTIONS
- `try_postgres_family_fallback` intersects fallback candidates with families allowed by the resource's option tree (project / flavor / location)
- `needs_recycling?` suppresses `vm.display_size` vs `resource.target_vm_size` mismatch while the semaphore is set; storage and version mismatches still recycle
- `update_target_sizes_with_replicas` wraps the resource and read-replica updates and clears the semaphore on every server when `target_vm_size` changes
- `failover_target` scoring: slot-ready > LSN > intended-type > family rank
- `prune_servers` tiebreaks by intended-type and family rank
- API exposes `fallback_active` on the resource and `vm_size` / `on_intended_type` per server; `ubi pg list-servers` shows a `vm_size` column; overview annotates the CPU subtext when the primary is on a fallback type