### PR TITLE
Daily CI: increase timeout to 35 minutes

### DIFF
--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     name: Daily CI
     runs-on: ubicloud-standard-8
-    timeout-minutes: 25
+    timeout-minutes: 35
 
     steps:
     - name: Check out code


### PR DESCRIPTION
The previous timeout was 25 minutes. Recent changes increased the Daily CI runtime and it sometimes takes slightly more than 25 minutes and causes timeouts.

An example timeout:
https://github.com/ubicloud/ubicloud/actions/runs/25728887948