### PR TITLE
Add support for managing rollouts via the control plane and admin site

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -526,6 +526,10 @@ class CloverAdmin < Roda
     ["VmHost", :boot_images] => "vm_host",
   }.freeze
 
+  ROLLOUT_PROGS = %w[
+    RolloutRhizome
+  ].freeze
+
   LOCAL_E2E_PROGS = Prog::Test::LocalE2eLoop::ALLOWED_PROGS
   LOCAL_E2E_PROVIDERS = %w[
     aws
@@ -894,26 +898,40 @@ class CloverAdmin < Roda
     end
   end
 
-  def strand_semaphore_action(strand_ds, allowed_progs)
+  def strand_semaphore_action(strand_ds, allowed_progs, additional_semaphores: {}.freeze)
     r = request
     matched_path = r.matched_path
-    r.post %w[pause unpause destroy].freeze, :ubid_uuid do |action, strand_id|
+    semaphores = allowed_semaphores = %w[pause unpause destroy].freeze
+    semaphores += additional_semaphores.values.flatten unless additional_semaphores.empty?
+    r.post semaphores, :ubid_uuid do |action, strand_id|
       unless (strand = strand_ds.with_pk(strand_id))
         flash["error"] = "Strand not found, it was probably already deleted"
         r.redirect matched_path
       end
 
-      raise "invalid strand" unless allowed_progs.include?(strand.prog.split("::").last)
-
-      case action
-      when "pause", "destroy"
-        Semaphore.incr(strand.id, action)
-      else # unpause
-        Semaphore.where(strand_id: strand.id, name: "pause").destroy
-        strand.this.update(schedule: Sequel::CURRENT_TIMESTAMP)
+      prog = strand.prog.split("::").last
+      if (!additional_semaphores[prog]&.include?(action) && !allowed_semaphores.include?(action)) ||
+          !allowed_progs.include?(prog)
+        raise "invalid strand"
       end
 
-      flash["notice"] = "Strand #{strand.ubid} #{action}#{"e" if action == "destroy"}d"
+      case action
+      when "unpause"
+        Semaphore.where(strand_id: strand.id, name: "pause").destroy
+        strand.this.update(schedule: Sequel::CURRENT_TIMESTAMP)
+      else
+        Semaphore.incr(strand.id, action)
+      end
+
+      flash_action = case action
+      when "destroy"
+        "destroyed"
+      when "pause", "unpause"
+        action + "d"
+      else
+        "updated"
+      end
+      flash["notice"] = "Strand #{strand.ubid} #{flash_action}"
       r.redirect matched_path
     end
   end
@@ -1100,6 +1118,28 @@ class CloverAdmin < Roda
         **args,
       )
       view("authentication_audit_log")
+    end
+
+    r.on "rollouts" do
+      strand_ds = Strand.where(Sequel.like(:prog, ROLLOUT_PROGS))
+
+      r.is do
+        r.get do
+          @strands = strand_ds.order(:prog, :id).eager(:semaphores).all
+          view("rollouts")
+        end
+
+        r.post do
+          prog = typecast_params.nonempty_str("prog")
+          raise "invalid prog" unless ROLLOUT_PROGS.include?(prog)
+          st = Prog.const_get(prog).assemble
+          flash["notice"] = "Started rollout strand: #{st.ubid}"
+          r.redirect
+        end
+      end
+
+      strand_semaphore_action(strand_ds, ROLLOUT_PROGS,
+        additional_semaphores: {"RolloutRhizome" => %w[github_runners_work]})
     end
 
     r.on "local-e2e" do

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1121,7 +1121,7 @@ class CloverAdmin < Roda
     end
 
     r.on "rollouts" do
-      strand_ds = Strand.where(Sequel.like(:prog, ROLLOUT_PROGS))
+      strand_ds = Strand.where(prog: ROLLOUT_PROGS)
 
       r.is do
         r.get do

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -894,6 +894,30 @@ class CloverAdmin < Roda
     end
   end
 
+  def strand_semaphore_action(strand_ds, allowed_progs)
+    r = request
+    matched_path = r.matched_path
+    r.post %w[pause unpause destroy].freeze, :ubid_uuid do |action, strand_id|
+      unless (strand = strand_ds.with_pk(strand_id))
+        flash["error"] = "Strand not found, it was probably already deleted"
+        r.redirect matched_path
+      end
+
+      raise "invalid strand" unless allowed_progs.include?(strand.prog.split("::").last)
+
+      case action
+      when "pause", "destroy"
+        Semaphore.incr(strand.id, action)
+      else # unpause
+        Semaphore.where(strand_id: strand.id, name: "pause").destroy
+        strand.this.update(schedule: Sequel::CURRENT_TIMESTAMP)
+      end
+
+      flash["notice"] = "Strand #{strand.ubid} #{action}#{"e" if action == "destroy"}d"
+      r.redirect matched_path
+    end
+  end
+
   route do |r|
     r.public
     check_csrf!
@@ -1106,26 +1130,7 @@ class CloverAdmin < Roda
         end
       end
 
-      r.post %w[pause unpause destroy].freeze, :ubid_uuid do |action, strand_id|
-        unless (strand = strand_ds.with_pk(strand_id))
-          flash["error"] = "Strand not found, it was probably already deleted"
-          r.redirect "/local-e2e"
-        end
-
-        prog = strand.prog.split("::").last
-        raise "invalid strand" unless LOCAL_E2E_PROGS.include?(prog) || prog == "LocalE2eLoop"
-
-        case action
-        when "pause", "destroy"
-          Semaphore.incr(strand.id, action)
-        else # unpause
-          Semaphore.where(strand_id: strand.id, name: "pause").destroy
-          strand.this.update(schedule: Sequel::CURRENT_TIMESTAMP)
-        end
-
-        flash["notice"] = "Strand #{strand.ubid} #{action}#{"e" if action == "destroy"}d"
-        r.redirect "/local-e2e"
-      end
+      strand_semaphore_action(strand_ds, LOCAL_E2E_PROGS + ["LocalE2eLoop"])
     end
 
     r.get "admin-list" do

--- a/config.rb
+++ b/config.rb
@@ -226,6 +226,9 @@ module Config
   # Local e2e
   optional :local_e2e_postgres_test_project_id, uuid
 
+  # Rollouts
+  optional :rollouts_project_id, uuid
+
   # Load Balancer
   optional :load_balancer_service_project_id, uuid
   optional :load_balancer_service_hostname, string

--- a/prog/rollout_rhizome.rb
+++ b/prog/rollout_rhizome.rb
@@ -4,7 +4,10 @@ class Prog::RolloutRhizome < Prog::Base
   semaphore :pause, :github_runners_work, :destroy
 
   def self.assemble(vm_project_id: Config.rollouts_project_id)
-    vm_host_ds = VmHost.order(Sequel.function(:random))
+    vm_host_ds = VmHost
+      .order(Sequel.function(:random))
+      .where(allocation_state: "accepting")
+      .where { total_cores >= used_cores + 4 }
 
     initial_host_ids = [
       vm_host_ds.where(location_id: Location::HETZNER_FSN1_ID).get(:id),

--- a/prog/rollout_rhizome.rb
+++ b/prog/rollout_rhizome.rb
@@ -109,7 +109,7 @@ class Prog::RolloutRhizome < Prog::Base
 
   label def destroy_vms_on_initial_hosts
     Semaphore.incr(initial_vm_ids, "destroy")
-    delete_from_stack("initial_vm_ids", "initial_vms_private_key")
+    delete_from_stack("initial_vm_ids", "initial_vms_keypair")
 
     if frame["initial_github_runner_host_ids"].empty?
       update_stack("next_runner_time" => Time.now.to_i)

--- a/prog/rollout_rhizome.rb
+++ b/prog/rollout_rhizome.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+class Prog::RolloutRhizome < Prog::Base
+  semaphore :pause, :github_runners_work, :destroy
+
+  def self.assemble(vm_project_id: Config.rollouts_project_id)
+    vm_host_ds = VmHost.order(Sequel.function(:random))
+
+    initial_host_ids = [
+      vm_host_ds.where(location_id: Location::HETZNER_FSN1_ID).get(:id),
+      vm_host_ds.where(location_id: Location::LEASEWEB_WDC02_ID).get(:id),
+    ]
+    initial_host_ids.compact!
+
+    initial_github_runner_host_ds = vm_host_ds
+      .where(location_id: Location::GITHUB_RUNNERS_ID)
+      .limit(2)
+
+    initial_github_runner_host_ids = DB.ignore_duplicate_queries do
+      %w[x64 arm64].flat_map do |arch|
+        initial_github_runner_host_ds
+          .where(arch:)
+          .select_map(:id)
+      end
+    end
+
+    location_ids = [
+      Location::HETZNER_FSN1_ID,
+      Location::HETZNER_HEL1_ID,
+      Location::GITHUB_RUNNERS_ID,
+      Location::LEASEWEB_WDC02_ID,
+    ]
+
+    remaining_host_ids = VmHost
+      .order(:created_at)
+      .exclude(id: initial_host_ids + initial_github_runner_host_ids)
+      .where(location_id: location_ids)
+      .select_map(:id)
+
+    Strand.create(
+      prog: "RolloutRhizome",
+      label: "start",
+      stack: [{
+        "vm_project_id" => vm_project_id,
+        "initial_host_ids" => initial_host_ids,
+        "initial_github_runner_host_ids" => initial_github_runner_host_ids,
+        "remaining_host_ids" => remaining_host_ids,
+        "completed" => [],
+      }],
+    )
+  end
+
+  def before_run
+    when_pause_set? do
+      nap 60 * 60
+    end
+    super
+  end
+
+  label def start
+    initial_host_ids.each { install_rhizome(it) }
+    hop_wait_initial_rhizome_install
+  end
+
+  label def wait_initial_rhizome_install
+    reap(:setup_vms_on_initial_hosts)
+  end
+
+  label def setup_vms_on_initial_hosts
+    ssh_key = SshKey.generate
+    vm_strands = VmHost.where(id: initial_host_ids).all.map do |vm_host|
+      Prog::Vm::Nexus.assemble(
+        ssh_key.public_key,
+        vm_project_id,
+        name: vm_host.ubid,
+        unix_user: "rhizome",
+        force_host_id: vm_host.id,
+        location_id: vm_host.location_id,
+      )
+    end
+    update_stack(
+      "initial_vm_ids" => vm_strands.map(&:id),
+      "initial_vms_keypair" => Base64.strict_encode64(ssh_key.keypair),
+    )
+    hop_wait_vms_on_initial_hosts
+  end
+
+  label def wait_vms_on_initial_hosts
+    nap 30 unless Strand.where(id: initial_vm_ids, label: "wait").count == initial_vm_ids.size
+    hop_check_vms_on_initial_hosts
+  end
+
+  label def check_vms_on_initial_hosts
+    Vm.eager(:location).where(id: initial_vm_ids).all do
+      # id is used for ubid in a Clog.emit call
+      sshable = Sshable.new_with_id(
+        host: it.ip6_string,
+        raw_private_key_1: SshKey.from_binary(Base64.strict_decode64(frame.fetch("initial_vms_keypair"))).keypair,
+        unix_user: "rhizome",
+      )
+      sshable.cmd("sudo apt update && sudo apt install -y fio")
+      sshable.cmd("fio --version")
+    end
+    hop_destroy_vms_on_initial_hosts
+  end
+
+  label def destroy_vms_on_initial_hosts
+    Semaphore.incr(initial_vm_ids, "destroy")
+    delete_from_stack("initial_vm_ids", "initial_vms_private_key")
+
+    if frame["initial_github_runner_host_ids"].empty?
+      update_stack("next_runner_time" => Time.now.to_i)
+      hop_rollout_next
+    else
+      hop_install_on_initial_github_runners_hosts
+    end
+  end
+
+  label def install_on_initial_github_runners_hosts
+    frame.fetch("initial_github_runner_host_ids").each { install_rhizome(it) }
+    update_stack("monitor_github_runners_until" => Time.now.to_i + 45 * 60)
+    hop_wait_initial_github_runners_rhizome_install
+  end
+
+  label def wait_initial_github_runners_rhizome_install
+    reap(:monitor_github_runners)
+  end
+
+  label def monitor_github_runners
+    nap_until(frame["monitor_github_runners_until"])
+
+    when_github_runners_work_set? do
+      update_stack("next_runner_time" => Time.now.to_i)
+      hop_rollout_next
+    end
+
+    nap(60 * 60)
+  end
+
+  label def wait
+    reaper = lambda do |child|
+      update_stack(
+        "next_runner_time" => Time.now.to_i + 30,
+        "completed" => (frame.fetch("completed") << child.stack.first["subject_id"]),
+      )
+    end
+
+    reap(:rollout_next, reaper:)
+  end
+
+  label def rollout_next
+    nap_until(frame["next_runner_time"])
+
+    unless (next_vm_host_id = remaining_host_ids.shift)
+      hop_destroy
+    end
+
+    install_rhizome(next_vm_host_id)
+    update_stack("remaining_host_ids" => remaining_host_ids)
+    hop_wait
+  end
+
+  label def destroy
+    when_destroy_set? do
+      pop("rollout completed")
+    end
+
+    nap(60 * 60 * 24 * 365)
+  end
+
+  def nap_until(time_int)
+    now = Time.now.to_i
+    time_left = time_int - now
+    nap(time_left) if time_left > 0
+  end
+
+  def vm_project_id
+    frame.fetch("vm_project_id")
+  end
+
+  def initial_host_ids
+    frame.fetch("initial_host_ids")
+  end
+
+  def initial_vm_ids
+    frame.fetch("initial_vm_ids")
+  end
+
+  def remaining_host_ids
+    frame.fetch("remaining_host_ids")
+  end
+
+  def install_rhizome(vm_host_id)
+    bud Prog::InstallRhizome, {"subject_id" => vm_host_id, "target_folder" => "host"}
+  end
+end

--- a/spec/prog/rollout_rhizome_spec.rb
+++ b/spec/prog/rollout_rhizome_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Prog::RolloutRhizome do
     it "checks vms and hops" do
       # Setup vms
       expect { nx.setup_vms_on_initial_hosts }.to hop("wait_vms_on_initial_hosts")
-      nx.instance_variable_set(:@frame, nil)
+      refresh_frame(nx)
 
       ips = Vm.eager(:location).all.map { it.ip6_string }
       ssh_key = SshKey.from_binary(Base64.strict_decode64(st.stack[0]["initial_vms_keypair"]))
@@ -153,13 +153,13 @@ RSpec.describe Prog::RolloutRhizome do
     it "destroys vms and hops" do
       # Setup vms
       expect { nx.setup_vms_on_initial_hosts }.to hop("wait_vms_on_initial_hosts")
-      nx.instance_variable_set(:@frame, nil)
+      refresh_frame(nx)
 
       initial_vm_ids = st.stack[0]["initial_vm_ids"]
       expect { nx.destroy_vms_on_initial_hosts }.to hop("install_on_initial_github_runners_hosts")
         .and change { Semaphore.where(strand_id: initial_vm_ids, name: "destroy").count }.from(0).to(2)
       expect(st.reload.stack[0].has_key?("initial_vm_ids")).to be false
-      expect(st.stack[0].has_key?("initial_vms_private_key")).to be false
+      expect(st.stack[0].has_key?("initial_vms_keypair")).to be false
     end
 
     it "skips github runner testing if there are no github runners" do

--- a/spec/prog/rollout_rhizome_spec.rb
+++ b/spec/prog/rollout_rhizome_spec.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::RolloutRhizome do
+  subject(:nx) { described_class.new(st) }
+
+  let(:st) {
+    vm_hosts
+    described_class.assemble(vm_project_id: project_id)
+  }
+  let(:project_id) { Project.create(name: "RolloutRhizomeTest").id }
+
+  let(:fsn1_host) { create_vm_host(created_at: Time.utc(2024, 1, 1), location_id: Location::HETZNER_FSN1_ID) }
+  let(:hel1_host) { create_vm_host(created_at: Time.utc(2024, 1, 2), location_id: Location::HETZNER_HEL1_ID) }
+  let(:wdc2_host) { create_vm_host(created_at: Time.utc(2024, 1, 3), location_id: Location::LEASEWEB_WDC02_ID) }
+  let(:ghr_hosts) {
+    [
+      create_vm_host(created_at: Time.utc(2024, 1, 4), arch: "arm64", location_id: Location::GITHUB_RUNNERS_ID),
+      create_vm_host(created_at: Time.utc(2024, 1, 5), arch: "arm64", location_id: Location::GITHUB_RUNNERS_ID),
+      create_vm_host(created_at: Time.utc(2024, 1, 6), location_id: Location::GITHUB_RUNNERS_ID),
+      create_vm_host(created_at: Time.utc(2024, 1, 7), location_id: Location::GITHUB_RUNNERS_ID),
+      create_vm_host(created_at: Time.utc(2024, 1, 8), location_id: Location::GITHUB_RUNNERS_ID),
+    ]
+  }
+  let(:vm_hosts) {
+    [
+      fsn1_host,
+      hel1_host,
+      wdc2_host,
+      *ghr_hosts,
+    ]
+  }
+
+  def reload_frame
+    st.reload.stack.first
+  end
+
+  describe ".assemble" do
+    it "creates strand with hosts to rollout to" do
+      expect(st.label).to eq("start")
+      expect(st.prog).to eq("RolloutRhizome")
+
+      frame = st.stack.first
+      expect(frame["vm_project_id"]).to eq(project_id)
+      expect(frame["initial_host_ids"]).to eq([fsn1_host.id, wdc2_host.id])
+      expect(frame["completed"]).to eq([])
+
+      remaining_host_ids = frame["remaining_host_ids"]
+      expect(remaining_host_ids).to include(hel1_host.id)
+      expect(remaining_host_ids.size).to eq 2
+      remaining_host_ids.delete(hel1_host.id)
+
+      expect(ghr_hosts.map(&:id).sort!).to eq((frame["initial_github_runner_host_ids"] << remaining_host_ids.first).sort!)
+    end
+
+    it "respects Config.rollouts_project_id" do
+      expect(Config).to receive(:rollouts_project_id).and_return(project_id)
+      st = described_class.assemble
+      expect(st.label).to eq("start")
+      expect(st.prog).to eq("RolloutRhizome")
+
+      frame = st.stack.first
+      expect(frame["vm_project_id"]).to eq(project_id)
+      expect(frame["initial_host_ids"]).to eq([])
+      expect(frame["initial_github_runner_host_ids"]).to eq([])
+      expect(frame["remaining_host_ids"]).to eq([])
+      expect(frame["completed"]).to eq([])
+    end
+  end
+
+  describe "#before_run" do
+    it "naps when pause semaphore is set" do
+      nx.incr_pause
+      expect { nx.before_run }.to nap(60 * 60)
+    end
+  end
+
+  describe "#start" do
+    it "creates InstallRhizome strands and hops" do
+      ds = Strand.where(prog: "InstallRhizome", label: "start")
+      expect { nx.start }.to hop("wait_initial_rhizome_install")
+        .and change { ds.count }.from(0).to(2)
+      subject_ids = ds.select_map(:stack).map { it[0]["subject_id"] }
+      expect(subject_ids.sort!).to eq([fsn1_host.id, wdc2_host.id].sort!)
+    end
+  end
+
+  describe "#wait_initial_rhizome_install" do
+    it "naps if there are child strands" do
+      Strand.create(prog: "InstallRhizome", label: "start", parent_id: st.id, lease: Time.now + 100)
+      expect { nx.wait_initial_rhizome_install }.to nap(120)
+    end
+
+    it "hops if there are no child strands" do
+      expect { nx.wait_initial_rhizome_install }.to hop("setup_vms_on_initial_hosts")
+    end
+  end
+
+  describe "#setup_vms_on_initial_hosts" do
+    it "creates vms and hops" do
+      strand_ds = Strand.where(prog: "Vm::Metal::Nexus", label: "start")
+      expect { nx.setup_vms_on_initial_hosts }.to hop("wait_vms_on_initial_hosts")
+        .and change { Vm.count }.from(0).to(2)
+        .and change { strand_ds.count }.from(0).to(2)
+      SshKey.from_binary(Base64.strict_decode64(st.stack[0]["initial_vms_keypair"]))
+      expect(Vm.select_order_map(:id)).to eq st.stack[0]["initial_vm_ids"].sort!
+    end
+  end
+
+  describe "#wait_vms_on_initial_hosts" do
+    before do
+      refresh_frame(nx, new_values: {"initial_vm_ids" => Array.new(2) { Prog::Vm::Nexus.assemble("a a", project_id).id }})
+    end
+
+    it "naps if all expected vm strands are not in wait state" do
+      expect { nx.wait_vms_on_initial_hosts }.to nap(30)
+    end
+
+    it "hops if all expected vm strands are in wait state" do
+      Strand.where(prog: "Vm::Metal::Nexus", label: "start").update(label: "wait")
+      expect { nx.wait_vms_on_initial_hosts }.to hop("check_vms_on_initial_hosts")
+    end
+  end
+
+  describe "#check_vms_on_initial_hosts" do
+    it "checks vms and hops" do
+      # Setup vms
+      expect { nx.setup_vms_on_initial_hosts }.to hop("wait_vms_on_initial_hosts")
+      nx.instance_variable_set(:@frame, nil)
+
+      ips = Vm.eager(:location).all.map { it.ip6_string }
+      ssh_key = SshKey.from_binary(Base64.strict_decode64(st.stack[0]["initial_vms_keypair"]))
+
+      called = 0
+      expect(Sshable).to receive(:new_with_id) do |host:, raw_private_key_1:, unix_user:|
+        expect(ips).to include(host)
+        expect(raw_private_key_1).to eq ssh_key.keypair
+        expect(unix_user).to eq "rhizome"
+        sshable = Sshable.new
+        expect(sshable).to receive(:_cmd).with("sudo apt update && sudo apt install -y fio")
+        expect(sshable).to receive(:_cmd).with("fio --version")
+        called += 1
+        sshable
+      end.twice
+
+      expect { nx.check_vms_on_initial_hosts }.to hop("destroy_vms_on_initial_hosts")
+        .and change { called }.from(0).to(2)
+    end
+  end
+
+  describe "#destroy_vms_on_initial_hosts" do
+    it "destroys vms and hops" do
+      # Setup vms
+      expect { nx.setup_vms_on_initial_hosts }.to hop("wait_vms_on_initial_hosts")
+      nx.instance_variable_set(:@frame, nil)
+
+      initial_vm_ids = st.stack[0]["initial_vm_ids"]
+      expect { nx.destroy_vms_on_initial_hosts }.to hop("install_on_initial_github_runners_hosts")
+        .and change { Semaphore.where(strand_id: initial_vm_ids, name: "destroy").count }.from(0).to(2)
+      expect(st.reload.stack[0].has_key?("initial_vm_ids")).to be false
+      expect(st.stack[0].has_key?("initial_vms_private_key")).to be false
+    end
+
+    it "skips github runner testing if there are no github runners" do
+      refresh_frame(nx, new_values: {"initial_github_runner_host_ids" => [], "initial_vm_ids" => []})
+      expect { nx.destroy_vms_on_initial_hosts }.to hop("rollout_next")
+      expect(st.reload.stack[0]["next_runner_time"]).to be_within(5).of(Time.now.to_i)
+    end
+  end
+
+  describe "#install_on_initial_github_runners_hosts" do
+    it "creates InstallRhizome strands and hops" do
+      ds = Strand.where(prog: "InstallRhizome", label: "start")
+      expect { nx.install_on_initial_github_runners_hosts }.to hop("wait_initial_github_runners_rhizome_install")
+        .and change { ds.count }.from(0).to(4)
+      ghr_ids = ghr_hosts.map(&:id)
+      ds.select_map(:stack).each do
+        expect(ghr_ids).to include(it[0]["subject_id"])
+      end
+      expect(st.reload.stack[0]["monitor_github_runners_until"]).to be_within(5).of(Time.now.to_i + 45 * 60)
+    end
+  end
+
+  describe "#wait_initial_github_runners_rhizome_install" do
+    it "naps if there are child strands" do
+      Strand.create(prog: "InstallRhizome", label: "start", parent_id: st.id, lease: Time.now + 100)
+      expect { nx.wait_initial_github_runners_rhizome_install }.to nap(120)
+    end
+
+    it "hops if there are no child strands" do
+      expect { nx.wait_initial_github_runners_rhizome_install }.to hop("monitor_github_runners")
+    end
+  end
+
+  describe "#monitor_github_runners" do
+    it "naps if we haven't monitored github runners long enough" do
+      refresh_frame(nx, new_values: {"monitor_github_runners_until" => Time.now.to_i + 10})
+      expect { nx.monitor_github_runners }.to nap(5...15)
+    end
+
+    it "hops if github_runners_work semaphore is set" do
+      refresh_frame(nx, new_values: {"monitor_github_runners_until" => Time.now.to_i - 10})
+      nx.incr_github_runners_work
+      expect { nx.monitor_github_runners }.to hop("rollout_next")
+      expect(st.reload.stack[0]["next_runner_time"]).to be_within(5).of(Time.now.to_i)
+    end
+
+    it "naps otherwise" do
+      refresh_frame(nx, new_values: {"monitor_github_runners_until" => Time.now.to_i - 10})
+      expect { nx.monitor_github_runners }.to nap(60 * 60)
+    end
+  end
+
+  describe "#wait" do
+    it "naps if there are running child strands" do
+      Strand.create(prog: "InstallRhizome", label: "start", parent_id: st.id, lease: Time.now + 100)
+      expect { nx.wait_initial_github_runners_rhizome_install }.to nap(120)
+    end
+
+    it "hops if there are no running child strands" do
+      vm_host_id = VmHost.generate_uuid
+      Strand.create(prog: "InstallRhizome", label: "start", parent_id: st.id, exitval: {msg: "installed rhizome"}, stack: [{"subject_id" => vm_host_id}])
+      expect { nx.wait }.to hop("rollout_next")
+      expect(st.reload.stack[0]["next_runner_time"]).to be_within(5).of(Time.now.to_i + 30)
+      expect(st.stack[0]["completed"]).to eq [vm_host_id]
+    end
+  end
+
+  describe "#rollout_next" do
+    it "pops if there are no remaining hosts" do
+      refresh_frame(nx, new_values: {"next_runner_time" => Time.now.to_i - 10, "remaining_host_ids" => []})
+      expect { nx.rollout_next }.to hop("destroy")
+    end
+
+    it "naps if it is not yet next_runner_time" do
+      refresh_frame(nx, new_values: {"next_runner_time" => Time.now.to_i + 10})
+      expect { nx.rollout_next }.to nap(5...15)
+    end
+
+    it "creates InstallRhizome strand and hops" do
+      refresh_frame(nx, new_values: {"next_runner_time" => Time.now.to_i - 10})
+      ds = Strand.where(prog: "InstallRhizome", label: "start")
+      next_host_id = st.stack[0]["remaining_host_ids"].first
+      expect { nx.rollout_next }.to hop("wait")
+        .and change { ds.count }.from(0).to(1)
+        .and change { st.reload.stack[0]["remaining_host_ids"].size }.from(2).to(1)
+      expect(ds.get(:stack)[0]["subject_id"]).to eq next_host_id
+    end
+  end
+
+  describe "#destroy" do
+    it "exits if destroy semaphore is set" do
+      nx.incr_destroy
+      expect { nx.destroy }.to exit("msg" => "rollout completed")
+    end
+
+    it "naps otherwise" do
+      expect { nx.destroy }.to nap(60 * 60 * 24 * 365)
+    end
+  end
+end

--- a/spec/prog/rollout_rhizome_spec.rb
+++ b/spec/prog/rollout_rhizome_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Prog::RolloutRhizome do
   describe "#wait" do
     it "naps if there are running child strands" do
       Strand.create(prog: "InstallRhizome", label: "start", parent_id: st.id, lease: Time.now + 100)
-      expect { nx.wait_initial_github_runners_rhizome_install }.to nap(120)
+      expect { nx.wait }.to nap(120)
     end
 
     it "hops if there are no running child strands" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1543,6 +1543,90 @@ RSpec.describe CloverAdmin do
     expect(created_at_cell).to have_content(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/)
   end
 
+  describe "rollouts" do
+    before do
+      project = Project.create(name: "Rollout-Project")
+      allow(Config).to receive(:rollouts_project_id).and_return(project.id).at_least(:once)
+      click_link "Manage Rollouts"
+    end
+
+    it "shows strand status" do
+      expect(page.title).to eq "Ubicloud Admin - Manage Rollouts"
+      expect(page).to have_content("No data available for Active Rollouts")
+
+      rollouts_path = page.current_path
+      strand = Prog::RolloutRhizome.assemble
+      page.refresh
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", strand.ubid, "{}", "", "", ""]
+      click_link strand.ubid
+      expect(page.title).to eq "Ubicloud Admin - Strand #{strand.ubid}"
+
+      strand.run
+      visit rollouts_path
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "wait_initial_rhizome_install", "0", strand.ubid, "{}", "", "", ""]
+    end
+
+    it "allows creation of rollout strands" do
+      rollouts_path = page.current_path
+      expect { click_button "Start Rollout" }.to raise_error(RuntimeError)
+
+      visit rollouts_path
+      select "RolloutRhizome"
+      click_button "Start Rollout"
+
+      st = Strand.first(prog: "RolloutRhizome")
+      expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", st.ubid, "{}", "", "", ""]
+    end
+
+    it "allows pausing and unpausing strands" do
+      rollouts_path = page.current_path
+      select "RolloutRhizome"
+      click_button "Start Rollout"
+
+      click_button "Pause"
+      st = Strand.first(prog: "RolloutRhizome")
+      expect(page).to have_flash_notice("Strand #{st.ubid} paused")
+      expect(st.semaphores.map(&:name)).to eq ["pause"]
+
+      st.this.update(schedule: "2100-01-01")
+      click_button "Unpause"
+      expect(page).to have_flash_notice("Strand #{st.ubid} unpaused")
+      expect(st.semaphores(reload: true)).to eq []
+      expect(st.this.get(:schedule)).to be_within(10).of(Time.now)
+
+      visit rollouts_path
+      st.destroy
+      click_button "Pause"
+      expect(page).to have_flash_error("Strand not found, it was probably already deleted")
+    end
+
+    it "allows destroying strands" do
+      select "RolloutRhizome"
+      click_button "Start Rollout"
+
+      click_button "Destroy"
+      st = Strand.first(prog: "RolloutRhizome")
+      expect(page).to have_flash_notice("Strand #{st.ubid} destroyed")
+      expect(st.semaphores.map(&:name)).to eq ["destroy"]
+    end
+
+    it "allows marking RolloutRhizome strands as having working GitHub Runners" do
+      select "RolloutRhizome"
+      click_button "Start Rollout"
+
+      st = Strand.first(prog: "RolloutRhizome")
+      st.stack[0]["monitor_github_runners_until"] = Time.now.to_i
+      st.modified!(:stack)
+      st.save_changes
+      page.refresh
+
+      click_button "Github Runners Work"
+      expect(page).to have_flash_notice("Strand #{st.ubid} updated")
+      expect(st.semaphores.map(&:name)).to eq ["github_runners_work"]
+    end
+  end
+
   describe "local E2E" do
     before do
       project = Project.create(name: "Postgres-Service-Project")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -233,7 +233,7 @@ RSpec.configure do |config|
       false
     rescue Prog::Base::Nap => nap
       @nap = nap
-      expected_seconds.nil? || nap.seconds == expected_seconds
+      expected_seconds.nil? || expected_seconds === nap.seconds
     end
 
     failure_message do

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -85,7 +85,7 @@ module ThawedMock
   allow_mocking(Project, :[], :order_by)
   allow_mocking(Semaphore, :where, :create, :incr)
   allow_mocking(SshPublicKey, :generate_uuid)
-  allow_mocking(Sshable, :create_with_id, :repl?)
+  allow_mocking(Sshable, :create_with_id, :repl?, :new_with_id)
   allow_mocking(StorageKeyEncryptionKey, :create)
   allow_mocking(Strand, :create, :create_with_id)
   allow_mocking(UsageAlert, :where)

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -55,6 +55,7 @@
       <a href="/authentication-audit-log">View Authentication Audit Logs</a> |
       <a href="/authentication-audit-log/admin">View Admin Authentication Audit Logs</a>
     </li>
+    <li><a href="/rollouts">Manage Rollouts</a></li>
     <li><a href="/local-e2e">Manage Local E2E</a></li>
     <li><a href="/admin-list">View Admin List</a></li>
     <li><a href="/autoforme/Strand/search/1?<%= to_query_string(prog: "Vm::Metal::Nexus", label: "unavailable") %>">Show Unavailable VMs</a></li>

--- a/views/admin/rollouts.erb
+++ b/views/admin/rollouts.erb
@@ -1,0 +1,40 @@
+<% @page_title = "Manage Rollouts" %>
+
+<% data = @strands.map do |strand|
+  h = strand.values.slice(:prog, :label, :try)
+  h[:id] = strand.ubid
+  frame = strand.stack[0]
+  data = h[:data] = {}
+
+  if frame["completed"].empty?
+    if (time = frame["monitor_github_runners_until"])
+      data["monitor_github_runners_until"] = Time.at(time).utc.strftime("%F %T UTC")
+    end
+  else
+    data["remaining"] = frame["remaining_host_ids"]&.size
+    data["completed"] = frame["completed"]&.size
+  end
+  data.compact!
+
+  h[:pause] = if strand.semaphores.find { it.name == "pause" }
+    table_form_button("Unpause", action: "/rollouts/unpause/#{strand.ubid}", method: "post")
+  else
+    table_form_button("Pause", action: "/rollouts/pause/#{strand.ubid}", method: "post")
+  end
+
+  h[:destroy] = table_form_button("Destroy", action: "/rollouts/destroy/#{strand.ubid}", method: "post")
+
+  h[:action] = if time
+    table_form_button("Github Runners Work", action: "/rollouts/github_runners_work/#{strand.ubid}", method: "post")
+  end
+
+  h
+end %>
+
+<%== part("components/table", title: "Active Rollouts", table_class: "rollouts-table", data:) %>
+
+<h2>Start Rollout</h2>
+
+<% form({method: "post", id: "start-rollout"}, button: "Start Rollout") do |f| %>
+  <%== f.input(:select, key: :prog, label: "Prog", options: ROLLOUT_PROGS, add_blank: true, required: true) %>
+<% end %>


### PR DESCRIPTION
This adds a RolloutRhizome prog, which follows the standard practice we use for rhizome rollouts. This is mostly automated, but it does require the operator monitoring GitHub runners and explicitly marking that there are no problems noted before a general rollout takes place.

It also adds a UI to the admin site to start the prog and monitor it's progress.

I tested this in my dev environment, but as that has only a single host, it's not a great test.