### PR TITLE
Retry delete_object when deleting github cache entry if retryable error occurs

### DIFF
--- a/model/github/github_cache_entry.rb
+++ b/model/github/github_cache_entry.rb
@@ -48,10 +48,15 @@ class GithubCacheEntry < Sequel::Model
       end
     end
 
+    retries = 0
     begin
       repository.blob_storage_client.delete_object(bucket:, key:)
     rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::Unauthorized, Aws::S3::Errors::NoSuchBucket
       nil
+    rescue Aws::S3::Errors::InternalError => e
+      raise if retries > 3 || e.message != "We encountered an internal error. Please try again."
+      retries += 1
+      retry
     end
   end
 end

--- a/model/github/github_cache_entry.rb
+++ b/model/github/github_cache_entry.rb
@@ -33,6 +33,7 @@ class GithubCacheEntry < Sequel::Model
     end
   rescue Sequel::NoExistingObject
     # DELETE statement modified no rows due to filter
+    nil
   end
 
   def after_destroy
@@ -45,6 +46,7 @@ class GithubCacheEntry < Sequel::Model
       begin
         repository.blob_storage_client.abort_multipart_upload(bucket:, key:, upload_id:)
       rescue Aws::S3::Errors::NoSuchUpload, Aws::S3::Errors::NoSuchBucket
+        nil
       end
     end
 

--- a/spec/model/github/github_cache_entry_spec.rb
+++ b/spec/model/github/github_cache_entry_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe GithubCacheEntry do
       expect(client).to receive(:delete_object)
       entry.destroy
     end
+
+    it "retries if delete_object raises an error requesting retry" do
+      entry.update(committed_at: Time.now)
+      expect(client).to receive(:delete_object).and_raise(Aws::S3::Errors::InternalError.new(nil, "We encountered an internal error. Please try again."))
+      expect(client).to receive(:delete_object)
+      entry.destroy
+    end
+
+    it "raises if delete_object continually fails after retry" do
+      entry.update(committed_at: Time.now)
+      expect(client).to receive(:delete_object).and_raise(Aws::S3::Errors::InternalError.new(nil, "We encountered an internal error. Please try again.")).exactly(5).times
+      expect { entry.destroy }.to raise_error(Aws::S3::Errors::InternalError, "We encountered an internal error. Please try again.")
+    end
   end
 
   describe ".destroy_where" do


### PR DESCRIPTION
The error message in this case explicitly requests retrying.

This should hopefully fix a couple recent production exceptions, assuming retrying actually works.