### PR TITLE
Fix issues with Postgres health monitor unix socket connection

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "base64"
+require "tmpdir"
 require "uri"
 require_relative "../../model"
 require_relative "../../lib/net_ssh"
@@ -307,7 +308,7 @@ class PostgresServer < Sequel::Model
 
   def init_health_monitor_session
     FileUtils.rm_rf(health_monitor_socket_path)
-    FileUtils.mkdir_p(health_monitor_socket_path)
+    FileUtils.mkdir_p(health_monitor_socket_path, mode: 0o700)
 
     ssh_session = vm.sshable.start_fresh_session
     ssh_session.forward.local_socket(File.join(health_monitor_socket_path, ".s.PGSQL.5432"), "/var/run/postgresql/.s.PGSQL.5432")
@@ -326,7 +327,7 @@ class PostgresServer < Sequel::Model
 
   def check_pulse(session:, previous_pulse:)
     reading = begin
-      session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, user: "postgres", connect_timeout: 4, keep_reference: false)
+      session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, port: 5432, database: "postgres", user: "postgres", connect_timeout: 4, keep_reference: false)
       last_known_lsn = session[:db_connection].get(Sequel.function(lsn_function_name).as(:lsn))
       "up"
     rescue
@@ -362,7 +363,7 @@ class PostgresServer < Sequel::Model
   end
 
   def health_monitor_socket_path
-    @health_monitor_socket_path ||= File.join(Dir.pwd, "var", "health_monitor_sockets", "pg_#{vm.ip6}")
+    @health_monitor_socket_path ||= File.join(Dir.tmpdir, "ubi-hm", "pg_#{ubid}")
   end
 
   def lsn2int(lsn)

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -502,6 +502,21 @@ RSpec.describe PostgresServer do
     expect(session).to receive(:forward).and_return(forward)
     expect(postgres_server.vm.sshable).to receive(:start_fresh_session).and_return(session)
     postgres_server.init_health_monitor_session
+    expect(File.stat(postgres_server.health_monitor_socket_path).mode & 0o777).to eq(0o700)
+  end
+
+  it "passes hardcoded port and database to Sequel.connect when opening a fresh db_connection" do
+    db = instance_double(Sequel::Postgres::Database)
+    expect(Sequel).to receive(:connect).with(
+      hash_including(host: postgres_server.health_monitor_socket_path, port: 5432, database: "postgres", user: "postgres"),
+    ).and_return(db)
+    expect(db).to receive(:get).and_raise(Sequel::DatabaseConnectionError)
+    expect(postgres_server).to receive(:primary?).and_return(false)
+    expect(postgres_server).to receive(:standby?).and_return(false)
+
+    session = {ssh_session: Net::SSH::Connection::Session.allocate, db_connection: nil}
+    pulse = {reading: "down", reading_rpt: 1, reading_chg: Time.now}
+    postgres_server.check_pulse(session:, previous_pulse: pulse)
   end
 
   it "initiates a new metrics export session" do


### PR DESCRIPTION
* health_monitor_socket_path joined Dir.pwd, "var",
  "health_monitor_sockets", and "pg_#{vm.ip6}", producing a path that
  can exceed the unix socket address-length limit. Switch to
  Dir.tmpdir + ubi-hm + pg_<ubid>, which is consistently short and
  removes the dependency on the process working directory. Create the
  directory with mode 0700 since /tmp is world-traversable; otherwise
  any local UID could connect to the forwarded socket and reach the
  remote postgres as the monitor's role.

* Sequel.connect inherited PGPORT and PGDATABASE from the environment.
  libpq derives the socket filename from the port (.s.PGSQL.<port>),
  so any non-default PGPORT made it look for a file that doesn't
  exist; PGDATABASE similarly steered the connection to whatever db
  was named in env. Pass port: 5432 and database: "postgres"
  explicitly.