### PR TITLE
Allow inspect_values_hash to work with non-column in values

### DIFF
--- a/lib/resource_methods.rb
+++ b/lib/resource_methods.rb
@@ -102,7 +102,7 @@ module ResourceMethods
         next if k == :id
 
         inspect_values[k] = if v
-          if (converter = INSPECT_CONVERTERS[sch[k][:db_type]])
+          if (converter = INSPECT_CONVERTERS[sch.dig(k, :db_type)])
             converter.call(v)
           else
             v


### PR DESCRIPTION
Should fix this nondeterministic test failure:

```
  1) CloverAdmin KubernetesEtcdBackup displays the KubernetesEtcBackup instance page correctly
     Failure/Error: if (converter = INSPECT_CONVERTERS[sch[k][:db_type]])

     NoMethodError:
       undefined method '[]' for nil
     # ./lib/resource_methods.rb:105:in 'block in ResourceMethods::InstanceMethods#inspect_values_hash'
     # ./lib/resource_methods.rb:101:in 'Hash#each'
     # ./lib/resource_methods.rb:101:in 'ResourceMethods::InstanceMethods#inspect_values_hash'
     # ./coverage/views/admin/object.erb.rb:47:in 'Tilt::CompiledTemplates#__tilt_2904'
     # ./clover_admin.rb:982:in 'block (4 levels) in <class:CloverAdmin>'
     # ./clover_admin.rb:981:in 'block (3 levels) in <class:CloverAdmin>'
     # ./clover_admin.rb:978:in 'block (2 levels) in <class:CloverAdmin>'
     # ./clover_admin.rb:951:in 'block in <class:CloverAdmin>'
     # ./clover.rb:1012:in 'block in <class:Clover>'
     # ./spec/routes/spec_helper.rb:64:in 'block (3 levels) in <top (required)>'
     # ./spec/routes/spec_helper.rb:63:in 'block (2 levels) in <top (required)>'
     # ./spec/routes/web/admin/model/kubernetes_etcd_backup_spec.rb:18:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:66:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:65:in 'block (2 levels) in <top (required)>'
```

It's probably also faster as it is one method call and not two.