### PR TITLE
Support semaphore rollouts via control plane

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1152,12 +1152,13 @@ class CloverAdmin < Roda
         st = if prog == "RolloutSemaphore"
           klass, semaphore = typecast_params.nonempty_str!(%w[class semaphore])
           gap = typecast_params.pos_int!("gap")
+          increment = typecast_params.bool!("increment")
           unless semaphore_classes.map(&:name).include?(klass) &&
               (klass = Object.const_get(klass)).semaphore_names.include?(semaphore.to_sym)
             flash["error"] = "invalid semaphore for class"
             r.redirect "/rollouts"
           end
-          Prog.const_get(prog).assemble(semaphore:, ids: klass.select_map(:id), gap:)
+          Prog.const_get(prog).assemble(semaphore:, ids: klass.select_map(:id), gap:, increment:)
         else
           Prog.const_get(prog).assemble
         end

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -923,7 +923,7 @@ class CloverAdmin < Roda
     matched_path = r.matched_path
     semaphores = allowed_semaphores = %w[pause unpause destroy].freeze
     semaphores += additional_semaphores.values.flatten unless additional_semaphores.empty?
-    r.post semaphores, :ubid_uuid do |action, strand_id|
+    r.post :ubid_uuid, semaphores do |strand_id, action|
       unless (strand = strand_ds.with_pk(strand_id))
         flash["error"] = "Strand not found, it was probably already deleted"
         r.redirect matched_path

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -186,15 +186,23 @@ class CloverAdmin < Roda
     "%02d:%02d:%02d" % [h, m, s]
   end
 
-  def available_classes
+  def _classes
     classes = []
     Sequel::Model.subclasses.each do |c|
-      classes << c if c < ResourceMethods::InstanceMethods
+      classes << c if yield c
       c.subclasses.each do |sc|
-        classes << sc if sc < ResourceMethods::InstanceMethods
+        classes << sc if yield sc
       end
     end
     classes.sort_by!(&:name)
+  end
+
+  def available_classes
+    _classes { it < ResourceMethods::InstanceMethods }
+  end
+
+  def semaphore_classes
+    _classes { it.respond_to?(:semaphore_names) }
   end
 
   skip_webauthn_requirement = Config.development? && Config.clover_admin_development_no_webauthn?
@@ -539,6 +547,7 @@ class CloverAdmin < Roda
 
   ROLLOUT_PROGS = %w[
     RolloutRhizome
+    RolloutSemaphore
   ].freeze
 
   LOCAL_E2E_PROGS = Prog::Test::LocalE2eLoop::ALLOWED_PROGS
@@ -1134,19 +1143,27 @@ class CloverAdmin < Roda
     r.on "rollouts" do
       strand_ds = Strand.where(prog: ROLLOUT_PROGS)
 
-      r.is do
-        r.get do
-          @strands = strand_ds.order(:prog, :id).eager(:semaphores).all
-          view("rollouts")
+      r.get true do
+        @strands = strand_ds.order(:prog, :id).eager(:semaphores).all
+        view("rollouts")
+      end
+
+      r.post "start", ROLLOUT_PROGS do |prog|
+        st = if prog == "RolloutSemaphore"
+          klass, semaphore = typecast_params.nonempty_str!(%w[class semaphore])
+          gap = typecast_params.pos_int!("gap")
+          unless semaphore_classes.map(&:name).include?(klass) &&
+              (klass = Object.const_get(klass)).semaphore_names.include?(semaphore.to_sym)
+            flash["error"] = "invalid semaphore for class"
+            r.redirect "/rollouts"
+          end
+          Prog.const_get(prog).assemble(semaphore:, ids: klass.select_map(:id), gap:)
+        else
+          Prog.const_get(prog).assemble
         end
 
-        r.post do
-          prog = typecast_params.nonempty_str("prog")
-          raise "invalid prog" unless ROLLOUT_PROGS.include?(prog)
-          st = Prog.const_get(prog).assemble
-          flash["notice"] = "Started rollout strand: #{st.ubid}"
-          r.redirect
-        end
+        flash["notice"] = "Started rollout strand: #{st.ubid}"
+        r.redirect "/rollouts"
       end
 
       strand_semaphore_action(strand_ds, ROLLOUT_PROGS,

--- a/prog/rollout_semaphore.rb
+++ b/prog/rollout_semaphore.rb
@@ -11,7 +11,9 @@ class Prog::RolloutSemaphore < Prog::Base
   # initial_range: The range of records to use the initial gap. By default, this
   #                will be 10% of the total records, but the number will be clamped
   #                to this range.
-  def self.assemble(semaphore:, ids:, gap: 60, initial_gap: gap * 5, initial_range: 2..15)
+  # increment: If true (the default), increments the semaphore. Otherwise, decrements
+  #            the semaphore.
+  def self.assemble(semaphore:, ids:, gap: 60, initial_gap: gap * 5, initial_range: 2..15, increment: true)
     classes = ids.map { UBID.class_for_ubid(UBID.to_ubid(it)) }
     classes.uniq!
     classes.delete_if { it.semaphore_names.include?(semaphore.to_sym) }
@@ -34,6 +36,7 @@ class Prog::RolloutSemaphore < Prog::Base
         "remaining" => ids,
         "completed" => [],
         "next_increment_time" => Time.now.to_i,
+        "increment" => increment,
       }],
     )
   end
@@ -53,7 +56,11 @@ class Prog::RolloutSemaphore < Prog::Base
     time_left = time_int - now
     nap(time_left) if time_left > 0
 
-    Semaphore.incr(next_id, frame.fetch("semaphore"))
+    if frame["increment"]
+      Semaphore.incr(next_id, frame.fetch("semaphore"))
+    else
+      Semaphore.where(strand_id: next_id, name: frame.fetch("semaphore")).destroy
+    end
 
     completed = frame.fetch("completed")
     completed << next_id

--- a/prog/rollout_semaphore.rb
+++ b/prog/rollout_semaphore.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class Prog::RolloutSemaphore < Prog::Base
+  semaphore :pause, :destroy
+
+  # semaphore: Name of semaphore to increment.
+  # ids: Array of object ids to increment semaphore on.
+  # gap: The number of seconds between objects when rolling out the remaining records.
+  # initial_gap: The number of seconds between objects when rolling out the
+  #              initial records.
+  # initial_range: The range of records to use the initial gap. By default, this
+  #                will be 10% of the total records, but the number will be clamped
+  #                to this range.
+  def self.assemble(semaphore:, ids:, gap: 60, initial_gap: gap * 5, initial_range: 2..15)
+    classes = ids.map { UBID.class_for_ubid(UBID.to_ubid(it)) }
+    classes.uniq!
+    classes.delete_if { it.semaphore_names.include?(semaphore.to_sym) }
+    unless classes.empty?
+      raise "Some classes do not support semaphores: #{classes.join(", ")}"
+    end
+
+    gap = gap.clamp(5, 3600)
+    initial_gap = initial_gap.clamp(5, 86400)
+    initial_num = (ids.size / 10).clamp(initial_range)
+
+    Strand.create(
+      prog: "RolloutSemaphore",
+      label: "start",
+      stack: [{
+        "semaphore" => semaphore,
+        "gap" => gap,
+        "initial_gap" => initial_gap,
+        "initial_num" => initial_num,
+        "remaining" => ids,
+        "completed" => [],
+        "next_increment_time" => Time.now.to_i,
+      }],
+    )
+  end
+
+  label def start
+    when_pause_set? do
+      nap 60 * 60
+    end
+
+    remaining = frame.fetch("remaining")
+    unless (next_id = remaining.shift)
+      hop_destroy
+    end
+
+    time_int = frame.fetch("next_increment_time")
+    now = Time.now.to_i
+    time_left = time_int - now
+    nap(time_left) if time_left > 0
+
+    Semaphore.incr(next_id, frame.fetch("semaphore"))
+
+    completed = frame.fetch("completed")
+    completed << next_id
+    nap_time = frame.fetch((completed.size >= frame["initial_num"]) ? "gap" : "initial_gap")
+    update_stack(
+      "remaining" => remaining,
+      "completed" => completed,
+      "next_increment_time" => now + nap_time,
+    )
+
+    nap(nap_time)
+  end
+
+  label def destroy
+    when_destroy_set? do
+      pop("rollout completed")
+    end
+
+    nap(60 * 60 * 24 * 365)
+  end
+end

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -34,8 +34,8 @@ input[type=submit] {
   #ubid_form & { font-size: 0.9em; }
 }
 
-#start-local-e2e > div {
-  margin-top: 10px;
+#start-local-e2e, #start-rollout {
+  > div { margin-top: 10px; }
 }
 span.label {
   display: block;

--- a/spec/prog/rollout_semaphore_spec.rb
+++ b/spec/prog/rollout_semaphore_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Prog::RolloutSemaphore do
       expect(frame["initial_num"]).to eq(2)
       expect(frame["remaining"]).to eq(page_ids)
       expect(frame["next_increment_time"]).to be_within(5).of(Time.now.to_i)
+      expect(frame["increment"]).to be true
     end
 
     it "raises for invalid semaphore" do
@@ -41,6 +42,14 @@ RSpec.describe Prog::RolloutSemaphore do
     it "increments semaphore on next object and naps" do
       expect { nx.start }.to nap(295...305)
         .and change { pages.first.reload.resolve_set? }.from(false).to(true)
+      expect(st.reload.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
+    end
+
+    it "decrements semaphore on next object and naps if increment is not true" do
+      pages.first.incr_resolve
+      refresh_frame(nx, new_values: {"increment" => false})
+      expect { nx.start }.to nap(295...305)
+        .and change { pages.first.reload.resolve_set? }.from(true).to(false)
       expect(st.reload.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
     end
 

--- a/spec/prog/rollout_semaphore_spec.rb
+++ b/spec/prog/rollout_semaphore_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Prog::RolloutSemaphore do
     end
 
     it "raises for invalid semaphore" do
-      expect { described_class.assemble(semaphore: "bad", ids: page_ids) }.to raise_error(RuntimeError)
+      expect { described_class.assemble(semaphore: "bad", ids: page_ids) }.to raise_error(RuntimeError, "Some classes do not support semaphores: Page")
     end
   end
 

--- a/spec/prog/rollout_semaphore_spec.rb
+++ b/spec/prog/rollout_semaphore_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::RolloutSemaphore do
+  subject(:nx) { described_class.new(st) }
+
+  let(:st) { described_class.assemble(semaphore: "resolve", ids: page_ids) }
+  let(:pages) { Array.new(3) { Prog::PageNexus.assemble("test", ["test", it], []).subject } }
+  let(:page_ids) { pages.map(&:id) }
+
+  def reload_frame
+    st.reload.stack.first
+  end
+
+  describe ".assemble" do
+    it "creates strand with objects to rollout semaphore to" do
+      expect(st.label).to eq("start")
+      expect(st.prog).to eq("RolloutSemaphore")
+
+      frame = st.stack.first
+      expect(frame["semaphore"]).to eq("resolve")
+      expect(frame["gap"]).to eq(60)
+      expect(frame["initial_gap"]).to eq(300)
+      expect(frame["initial_num"]).to eq(2)
+      expect(frame["remaining"]).to eq(page_ids)
+      expect(frame["next_increment_time"]).to be_within(5).of(Time.now.to_i)
+    end
+
+    it "raises for invalid semaphore" do
+      expect { described_class.assemble(semaphore: "bad", ids: page_ids) }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe "#start" do
+    it "naps when pause semaphore is set" do
+      nx.incr_pause
+      expect { nx.start }.to nap(60 * 60)
+    end
+
+    it "increments semaphore on next object and naps" do
+      expect { nx.start }.to nap(295...305)
+        .and change { pages.first.reload.resolve_set? }.from(false).to(true)
+      expect(st.reload.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
+    end
+
+    it "hops to destroy if there are no objects remaining" do
+      refresh_frame(nx, new_values: {"remaining" => []})
+      expect { nx.start }.to hop("destroy")
+    end
+
+    it "naps using regular gap after passing the initial number of records" do
+      refresh_frame(nx, new_values: {"initial_num" => 0})
+      expect { nx.start }.to nap(55...65)
+        .and change { pages.first.reload.resolve_set? }.from(false).to(true)
+      expect(st.reload.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 60)
+    end
+
+    it "naps if not yet at the next increment time" do
+      refresh_frame(nx, new_values: {"next_increment_time" => Time.now.to_i + 10})
+      expect { nx.start }.to nap(5...15)
+    end
+  end
+
+  describe "#destroy" do
+    it "exits if destroy semaphore is set" do
+      nx.incr_destroy
+      expect { nx.destroy }.to exit("msg" => "rollout completed")
+    end
+
+    it "naps otherwise" do
+      expect { nx.destroy }.to nap(60 * 60 * 24 * 365)
+    end
+  end
+end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1613,7 +1613,7 @@ RSpec.describe CloverAdmin do
       expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", st.ubid, "{}", "", "", ""]
     end
 
-    it "allows creation of semaphore rollout strands" do
+    it "allows creation of semaphore increment rollout strands" do
       select "Page"
       fill_in "Semaphore", with: "bad"
       click_button "Start Semaphore Rollout"
@@ -1627,16 +1627,40 @@ RSpec.describe CloverAdmin do
       click_button "Start Semaphore Rollout"
 
       st = Strand.first(prog: "RolloutSemaphore")
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{}", "", "", ""]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{}", "", "", "increment resolve"]
       expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
 
       expect(st.stack[0]["semaphore"]).to eq "resolve"
       expect(st.stack[0]["remaining"]).to eq [page_st.id]
       expect(st.stack[0]["gap"]).to eq 90
+      expect(st.stack[0]["increment"]).to be true
 
       st.run
       page.refresh
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{\"remaining\" => 0, \"completed\" => 1}", "", "", ""]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{\"remaining\" => 0, \"completed\" => 1}", "", "", "increment resolve"]
+    end
+
+    it "allows creation of semaphore decrement rollout strands" do
+      page_st = Prog::PageNexus.assemble("some problem", %w[a], nil)
+
+      select "Page"
+      fill_in "Semaphore", with: "resolve"
+      fill_in "Gap (seconds)", with: "90"
+      choose "Decrement"
+      click_button "Start Semaphore Rollout"
+
+      st = Strand.first(prog: "RolloutSemaphore")
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{}", "", "", "decrement resolve"]
+      expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
+
+      expect(st.stack[0]["semaphore"]).to eq "resolve"
+      expect(st.stack[0]["remaining"]).to eq [page_st.id]
+      expect(st.stack[0]["gap"]).to eq 90
+      expect(st.stack[0]["increment"]).to be false
+
+      st.run
+      page.refresh
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{\"remaining\" => 0, \"completed\" => 1}", "", "", "decrement resolve"]
     end
 
     it "allows pausing and unpausing strands" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1605,23 +1605,43 @@ RSpec.describe CloverAdmin do
       expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "wait_initial_rhizome_install", "0", strand.ubid, "{}", "", "", ""]
     end
 
-    it "allows creation of rollout strands" do
-      rollouts_path = page.current_path
-      expect { click_button "Start Rollout" }.to raise_error(RuntimeError)
-
-      visit rollouts_path
-      select "RolloutRhizome"
-      click_button "Start Rollout"
+    it "allows creation of rhizome rollout strands" do
+      click_button "Start Rhizome Rollout"
 
       st = Strand.first(prog: "RolloutRhizome")
       expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
       expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", st.ubid, "{}", "", "", ""]
     end
 
+    it "allows creation of semaphore rollout strands" do
+      select "Page"
+      fill_in "Semaphore", with: "bad"
+      click_button "Start Semaphore Rollout"
+      expect(page).to have_flash_error("invalid semaphore for class")
+
+      page_st = Prog::PageNexus.assemble("some problem", %w[a], nil)
+
+      select "Page"
+      fill_in "Semaphore", with: "resolve"
+      fill_in "Gap (seconds)", with: "90"
+      click_button "Start Semaphore Rollout"
+
+      st = Strand.first(prog: "RolloutSemaphore")
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{}", "", "", ""]
+      expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
+
+      expect(st.stack[0]["semaphore"]).to eq "resolve"
+      expect(st.stack[0]["remaining"]).to eq [page_st.id]
+      expect(st.stack[0]["gap"]).to eq 90
+
+      st.run
+      page.refresh
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{\"remaining\" => 0, \"completed\" => 1}", "", "", ""]
+    end
+
     it "allows pausing and unpausing strands" do
       rollouts_path = page.current_path
-      select "RolloutRhizome"
-      click_button "Start Rollout"
+      click_button "Start Rhizome Rollout"
 
       click_button "Pause"
       st = Strand.first(prog: "RolloutRhizome")
@@ -1641,8 +1661,7 @@ RSpec.describe CloverAdmin do
     end
 
     it "allows destroying strands" do
-      select "RolloutRhizome"
-      click_button "Start Rollout"
+      click_button "Start Rhizome Rollout"
 
       click_button "Destroy"
       st = Strand.first(prog: "RolloutRhizome")
@@ -1651,8 +1670,7 @@ RSpec.describe CloverAdmin do
     end
 
     it "allows marking RolloutRhizome strands as having working GitHub Runners" do
-      select "RolloutRhizome"
-      click_button "Start Rollout"
+      click_button "Start Rhizome Rollout"
 
       st = Strand.first(prog: "RolloutRhizome")
       st.stack[0]["monitor_github_runners_until"] = Time.now.to_i

--- a/views/admin/local_e2e.erb
+++ b/views/admin/local_e2e.erb
@@ -10,12 +10,12 @@
   data["postgres_resource"] = UBID.to_ubid(frame["postgres_resource_id"]) if frame["postgres_resource_id"]
 
   h[:pause] = if strand.semaphores.find { it.name == "pause" }
-    table_form_button("Unpause", action: "/local-e2e/unpause/#{strand.ubid}", method: "post")
+    table_form_button("Unpause", action: "/local-e2e/#{strand.ubid}/unpause", method: "post")
   else
-    table_form_button("Pause", action: "/local-e2e/pause/#{strand.ubid}", method: "post")
+    table_form_button("Pause", action: "/local-e2e/#{strand.ubid}/pause", method: "post")
   end
 
-  h[:destroy] = table_form_button("Destroy", action: "/local-e2e/destroy/#{strand.ubid}", method: "post")
+  h[:destroy] = table_form_button("Destroy", action: "/local-e2e/#{strand.ubid}/destroy", method: "post")
 
   h
 end %>

--- a/views/admin/rollouts.erb
+++ b/views/admin/rollouts.erb
@@ -26,6 +26,8 @@
 
   h[:action] = if time
     table_form_button("Github Runners Work", action: "/rollouts/github_runners_work/#{strand.ubid}", method: "post")
+  elsif strand.prog == "RolloutSemaphore"
+    "#{frame["increment"] ? "increment" : "decrement"} #{frame["semaphore"]}"
   end
 
   h
@@ -43,4 +45,5 @@ end %>
   <%== f.input(:select, key: :class, label: "Class", required: true, add_blank: true, options: semaphore_classes) %>
   <%== f.input(:text, key: :semaphore, label: "Semaphore", required: true) %>
   <%== f.input(:number, key: :gap, label: "Gap (seconds)", required: true, attr: {min: 5, max: 3600}, value: 60) %>
+  <%== f.input(:radioset, key: :increment, required: true, options: [["Increment", true], ["Decrement", false]], value: true) %>
 <% end %>

--- a/views/admin/rollouts.erb
+++ b/views/admin/rollouts.erb
@@ -11,7 +11,7 @@
       data["monitor_github_runners_until"] = Time.at(time).utc.strftime("%F %T UTC")
     end
   else
-    data["remaining"] = frame["remaining_host_ids"]&.size
+    data["remaining"] = (frame["remaining_host_ids"] || frame["remaining"])&.size
     data["completed"] = frame["completed"]&.size
   end
   data.compact!
@@ -33,8 +33,14 @@ end %>
 
 <%== part("components/table", title: "Active Rollouts", table_class: "rollouts-table", data:) %>
 
-<h2>Start Rollout</h2>
+<h2>Start Rhizome Rollout</h2>
 
-<% form({method: "post", id: "start-rollout"}, button: "Start Rollout") do |f| %>
-  <%== f.input(:select, key: :prog, label: "Prog", options: ROLLOUT_PROGS, add_blank: true, required: true) %>
+<%== form({action: "/rollouts/start/RolloutRhizome", method: "post"}, button: "Start Rhizome Rollout") %>
+
+<h2>Start Semaphore Rollout</h2>
+
+<% form({action: "/rollouts/start/RolloutSemaphore", method: "post", id: "start-local-e2e"}, button: "Start Semaphore Rollout", wrapper: :div) do |f| %>
+  <%== f.input(:select, key: :class, label: "Class", required: true, add_blank: true, options: semaphore_classes) %>
+  <%== f.input(:text, key: :semaphore, label: "Semaphore", required: true) %>
+  <%== f.input(:number, key: :gap, label: "Gap (seconds)", required: true, attr: {min: 5, max: 3600}, value: 60) %>
 <% end %>

--- a/views/admin/rollouts.erb
+++ b/views/admin/rollouts.erb
@@ -17,15 +17,15 @@
   data.compact!
 
   h[:pause] = if strand.semaphores.find { it.name == "pause" }
-    table_form_button("Unpause", action: "/rollouts/unpause/#{strand.ubid}", method: "post")
+    table_form_button("Unpause", action: "/rollouts/#{strand.ubid}/unpause", method: "post")
   else
-    table_form_button("Pause", action: "/rollouts/pause/#{strand.ubid}", method: "post")
+    table_form_button("Pause", action: "/rollouts/#{strand.ubid}/pause", method: "post")
   end
 
-  h[:destroy] = table_form_button("Destroy", action: "/rollouts/destroy/#{strand.ubid}", method: "post")
+  h[:destroy] = table_form_button("Destroy", action: "/rollouts/#{strand.ubid}/destroy", method: "post")
 
   h[:action] = if time
-    table_form_button("Github Runners Work", action: "/rollouts/github_runners_work/#{strand.ubid}", method: "post")
+    table_form_button("Github Runners Work", action: "/rollouts/#{strand.ubid}/github_runners_work", method: "post")
   elsif strand.prog == "RolloutSemaphore"
     "#{frame["increment"] ? "increment" : "decrement"} #{frame["semaphore"]}"
   end


### PR DESCRIPTION
This is similar to rhizome rollouts, but instead of rolling out rhizome to VmHosts, this rolls out a specific semaphore. Implementation wise, it's much simpler, since it only waits an amount of time between each semaphore increment (though with a larger gap for the initial members than subsequent members).

This also allows monitoring semaphore rollouts via the admin UI, as well as starting simple semaphore rollouts (rolling out a semaphore for all objects of a given class).