### PR TITLE
Drop superuser from the Postgres health pulse

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -464,7 +464,7 @@ class PostgresServer < Sequel::Model
 
   def check_pulse(session:, previous_pulse:)
     reading = begin
-      session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, port: 5432, database: "postgres", user: "postgres", connect_timeout: 4, keep_reference: false)
+      session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, port: 5432, database: "postgres", user: "ubi_monitoring", connect_timeout: 4, keep_reference: false)
       last_known_lsn = session[:db_connection].get(last_lsn_expression.as(:lsn))
       "up"
     rescue

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -908,7 +908,7 @@ RSpec.describe PostgresServer do
   it "passes hardcoded port and database to Sequel.connect when opening a fresh db_connection" do
     db = instance_double(Sequel::Postgres::Database)
     expect(Sequel).to receive(:connect).with(
-      hash_including(host: postgres_server.health_monitor_socket_path, port: 5432, database: "postgres", user: "postgres"),
+      hash_including(host: postgres_server.health_monitor_socket_path, port: 5432, database: "postgres", user: "ubi_monitoring"),
     ).and_return(db)
     expect(db).to receive(:get).and_raise(Sequel::DatabaseConnectionError)
 


### PR DESCRIPTION
Switches `PostgresServer#check_pulse` from the `postgres` superuser to `ubi_monitoring`. The pulse runs one `pg_monitor`-readable LSN expression per tick, so it does not need superuser.

The prerequisite from #5424 has landed and rolled out. The `system2monitoring` map (`ubi` -> `ubi_monitoring`) is in `pg_hba`/`pg_ident` as of 8908e06d7, with the mirror in `postgres_lockout.rb` so it also applies under a lockout, and the fleet-wide `install_rhizome` + `configure` sweep is complete. The pulse arrives as OS user `ubi` and now peer-authenticates as `ubi_monitoring` everywhere.

Beyond dropping the privilege, this keeps the pulse alive through a disk full event: `disk-full-check` terminates every backend except `ubi_replication` and `ubi_monitoring` when it flips the cluster to read-only, so the pulse was being cut off as `postgres` exactly when `last_known_lsn` matters most.

Rebased on main. `spec/model/postgres/postgres_server_spec.rb` passes (218 examples, 0 failures); after convergence the pulse session appears as `ubi_monitoring` in `pg_stat_activity` and `last_known_lsn` keeps advancing.

Note for review: this is the first consumer of the `ubi` -> `ubi_monitoring` map line (#5424's collector runs as OS user `ubi_monitoring` and matches the other line), so it is worth confirming on one converged server of each shape before merge:

```sh
sudo -u ubi psql -h /var/run/postgresql -U ubi_monitoring -d postgres -c "SELECT pg_current_wal_lsn()"
```
