### PR TITLE
Run Postgres VM monitoring as ubi_monitoring

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -342,7 +342,7 @@ TIMER
     vm.sshable.write_file("/etc/systemd/system/postgres-metrics.timer", metrics_timer)
 
     vm.sshable.cmd("sudo mkdir -p /var/lib/node_exporter")
-    vm.sshable.cmd("sudo chown ubi:ubi /var/lib/node_exporter")
+    vm.sshable.cmd("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
 
     pg_metrics_service = <<SERVICE
 [Unit]
@@ -351,7 +351,13 @@ After=postgresql.service
 
 [Service]
 Type=oneshot
-User=ubi
+User=ubi_monitoring
+# group ubi: traverse /home/ubi (0750) to exec the script; ambient
+# capabilities are not in the effective set at execve time.
+SupplementaryGroups=ubi
+# read the postgres-owned pg_wal/archive_status directory without sudo
+AmbientCapabilities=CAP_DAC_READ_SEARCH
+NoNewPrivileges=true
 ExecStart=/home/ubi/postgres/bin/collect-pg-metrics #{postgres_server.version}
 StandardOutput=journal
 StandardError=journal
@@ -373,6 +379,11 @@ TIMER
     vm.sshable.write_file("/etc/systemd/system/pg-collect-metrics.timer", pg_metrics_timer)
 
     vm.sshable.cmd("sudo systemctl daemon-reload")
+    # The old User=ubi unit leaves its safe_write_to_file lock and possibly
+    # a stale tmp file owned ubi:ubi 0644, which the new user cannot write.
+    vm.sshable.cmd("sudo rm -f :lock_path :tmp_path",
+      lock_path: "/tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock",
+      tmp_path: "/var/lib/node_exporter/pg_metrics.prom.tmp")
 
     when_initial_provisioning_set? do
       vm.sshable.cmd("sudo systemctl enable --now postgres_exporter")

--- a/prog/rollout_semaphore.rb
+++ b/prog/rollout_semaphore.rb
@@ -10,7 +10,7 @@ class Prog::RolloutSemaphore < Prog::Base
     LoadBalancer => [:rewrite_dns_records, :refresh_cert, :update_load_balancer],
     Page => [:resolve, :retrigger],
     PostgresResource => [:refresh_dns_record, :refresh_certificates],
-    PostgresServer => [:install_rhizome, :configure, :refresh_walg_credentials],
+    PostgresServer => [:install_rhizome, :configure, :configure_metrics, :refresh_walg_credentials],
     Vm => [:update_firewall_rules, :restart],
     VmHost => [:patch],
   }.freeze.each_value(&:freeze)

--- a/rhizome/postgres/bin/collect-pg-metrics
+++ b/rhizome/postgres/bin/collect-pg-metrics
@@ -13,21 +13,21 @@ output_path = "/var/lib/node_exporter/pg_metrics.prom"
 lines = []
 
 # Archival backlog: count of WAL files pending archival
-backlog = r("sudo", "find", "/dat/#{version}/data/pg_wal/archive_status", "-name", "*.ready").count("\n")
+backlog = r("find", "/dat/#{version}/data/pg_wal/archive_status", "-name", "*.ready").count("\n")
 lines << "# HELP ubicloud_pg_archival_backlog Number of WAL files pending archival\n"
 lines << "# TYPE ubicloud_pg_archival_backlog gauge\n"
 lines << "ubicloud_pg_archival_backlog #{backlog}\n"
 
 # Current WAL LSN as integer bytes
-is_recovery = r("sudo", "-u", "postgres", "psql", "-t", "-A", "-c", "SELECT pg_is_in_recovery()").strip
+is_recovery = r("psql", "-U", "ubi_monitoring", "-d", "ubi_admin", "-t", "-A", "-c", "SELECT pg_is_in_recovery()").strip
 lsn_func = if is_recovery == "t"
-  lsn = r("sudo", "-u", "postgres", "psql", "-t", "-A", "-c", "SELECT pg_last_wal_receive_lsn()").strip
+  lsn = r("psql", "-U", "ubi_monitoring", "-d", "ubi_admin", "-t", "-A", "-c", "SELECT pg_last_wal_receive_lsn()").strip
   lsn.empty? ? "pg_last_wal_replay_lsn" : "pg_last_wal_receive_lsn"
 else
   "pg_current_wal_lsn"
 end
 
-lsn = r("sudo", "-u", "postgres", "psql", "-t", "-A", "-c", "SELECT #{lsn_func}()").strip
+lsn = r("psql", "-U", "ubi_monitoring", "-d", "ubi_admin", "-t", "-A", "-c", "SELECT #{lsn_func}()").strip
 unless lsn.empty?
   high, low = lsn.split("/")
   lsn_bytes = high.to_i(16) << 32 | low.to_i(16)
@@ -38,7 +38,7 @@ end
 
 # Last replay timestamp (standbys/replicas only)
 if is_recovery == "t"
-  ts = r("sudo", "-u", "postgres", "psql", "-t", "-A", "-c", "SELECT extract(epoch FROM pg_last_xact_replay_timestamp())").strip
+  ts = r("psql", "-U", "ubi_monitoring", "-d", "ubi_admin", "-t", "-A", "-c", "SELECT extract(epoch FROM pg_last_xact_replay_timestamp())").strip
   unless ts.empty?
     lines << "# HELP ubicloud_pg_last_xact_replay_timestamp_seconds Last transaction replay timestamp as Unix epoch\n"
     lines << "# TYPE ubicloud_pg_last_xact_replay_timestamp_seconds gauge\n"

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -78,9 +78,11 @@ local   all             postgres                                peer map=system2
 local   all             pgbouncer                               peer map=system2pgbouncer
 
 # Allow connections from localhost with ubi_monitoring OS user as
-# ubi_monitoring database user. This will be used by postgres_exporter
-# to scrape metrics and expose them to prometheus.
-local   all             ubi_monitoring                          peer
+# ubi_monitoring database user (postgres_exporter and other on-box
+# collectors). The system2monitoring map also lets the SSH-tunnelled
+# control plane, which lands as OS user ubi, authenticate as
+# ubi_monitoring.
+local   all             ubi_monitoring                          peer map=system2monitoring
 
 # "local" is for Unix domain socket connections only
 # Use md5 authentication for all local connections to allow pgbouncer
@@ -134,6 +136,8 @@ pg_ident_entries = <<-PG_IDENT
 system2postgres       postgres                postgres
 system2pgbouncer      postgres                pgbouncer
 system2postgres       ubi                     postgres
+system2monitoring     ubi_monitoring          ubi_monitoring
+system2monitoring     ubi                     ubi_monitoring
 standby2replication   #{identity}             ubi_replication
 PG_IDENT
 safe_write_to_file("/etc/postgresql/#{v}/main/pg_ident.conf", pg_ident_entries)

--- a/rhizome/postgres/lib/postgres_lockout.rb
+++ b/rhizome/postgres/lib/postgres_lockout.rb
@@ -23,9 +23,10 @@ class PostgresLockout
 local   all             postgres                                peer map=system2postgres
 
 # Allow connections from localhost with ubi_monitoring OS user as
-# ubi_monitoring database user. This will be used by postgres_exporter
-# to scrape metrics and expose them to prometheus.
-local   all             ubi_monitoring                          peer
+# ubi_monitoring database user. Mirrors the system2monitoring map
+# from rhizome/postgres/bin/configure; pg_ident is not rewritten
+# during lockout, so the map still resolves.
+local   all             ubi_monitoring                          peer map=system2monitoring
 
 # Allow replication connection using special replication user for
 # HA standbys (SSL connections from ubi_replication user only)

--- a/rhizome/postgres/spec/postgres_lockout_spec.rb
+++ b/rhizome/postgres/spec/postgres_lockout_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe PostgresLockout do
 
       expect(config).to include("LOCKOUT MODE")
       expect(config).to include("local   all             postgres")
-      expect(config).to include("local   all             ubi_monitoring")
+      expect(config).to include("local   all             ubi_monitoring                          peer map=system2monitoring")
       expect(config).to include("hostssl replication     ubi_replication all")
       expect(config).to include("hostssl postgres        ubi_replication all")
     end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -708,10 +708,14 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.service > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.timer > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo mkdir -p /var/lib/node_exporter")
-      expect(sshable).to receive(:_cmd).with("sudo chown ubi:ubi /var/lib/node_exporter")
-      expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
+      expect(sshable).to receive(:_cmd).with("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
+      expect(sshable).to receive(:_cmd).with(
+        "sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null",
+        stdin: /User=ubi_monitoring.*SupplementaryGroups=ubi.*AmbientCapabilities=CAP_DAC_READ_SEARCH/m,
+      )
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
+      expect(sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now postgres-metrics.timer")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now pg-collect-metrics.timer")
 
@@ -748,10 +752,11 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.service > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.timer > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo mkdir -p /var/lib/node_exporter")
-      expect(sshable).to receive(:_cmd).with("sudo chown ubi:ubi /var/lib/node_exporter")
+      expect(sshable).to receive(:_cmd).with("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
+      expect(sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now postgres-metrics.timer")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now pg-collect-metrics.timer")
 
@@ -782,10 +787,11 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo mkdir -p /var/lib/node_exporter")
-      expect(standby_sshable).to receive(:_cmd).with("sudo chown ubi:ubi /var/lib/node_exporter")
+      expect(standby_sshable).to receive(:_cmd).with("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
+      expect(standby_sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
 
       expect { standby_nx.configure_metrics }.to hop("wait")
     end
@@ -815,10 +821,11 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.timer > /dev/null", stdin: /OnUnitActiveSec=15s/)
       expect(standby_sshable).to receive(:_cmd).with("sudo mkdir -p /var/lib/node_exporter")
-      expect(standby_sshable).to receive(:_cmd).with("sudo chown ubi:ubi /var/lib/node_exporter")
+      expect(standby_sshable).to receive(:_cmd).with("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
+      expect(standby_sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
 
       expect { standby_nx.configure_metrics }.to hop("wait")
     end
@@ -854,10 +861,11 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo mkdir -p /var/lib/node_exporter")
-      expect(standby_sshable).to receive(:_cmd).with("sudo chown ubi:ubi /var/lib/node_exporter")
+      expect(standby_sshable).to receive(:_cmd).with("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
+      expect(standby_sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
 
       expect { standby_nx.configure_metrics }.to hop("wait")
     end


### PR DESCRIPTION
Two commits moving Postgres VM monitoring auth off the superuser path.

**Add system2monitoring pg_ident map** — lets the SSH-tunnelled control plane (OS user `ubi`) peer-auth as `ubi_monitoring` on the local socket. The identity entry keeps postgres_exporter working, and `postgres_lockout.rb` is mirrored so the map applies while a lockout pg_hba is in effect. Additive: nothing consumes the new entry until the follow-up pulse change (#5423), and pg_hba/pg_ident only update on each server's next `configure` run.

**Run pg-collect-metrics as ubi_monitoring** — removes the last recurring superuser query on managed VMs (`sudo -u postgres psql` every 30s). `CAP_DAC_READ_SEARCH` replaces `sudo find` for the archive_status count; `SupplementaryGroups=ubi` is needed to exec the script since ambient capabilities are not effective at execve time. Stale lock/tmp files from the old unit are cleaned up, and `configure_metrics` joins the RolloutSemaphore allowlist so the new unit can reach existing servers. Independent of the map: the collector peer-auths by OS/DB name match.

Rollout: deploy, then sweep `install_rhizome` first, then `configure` and `configure_metrics` (either order). Torn script/unit halves fail loudly, so run the sweeps together.

Verified end-to-end on a freshly provisioned AWS server: the unit runs as `ubi_monitoring` with `status=0/SUCCESS`, the LSN gauge byte-math matches `pg_wal_lsn_diff(pg_current_wal_lsn(), '0/0')` exactly, gauges advance every tick, peer auth resolves as expected with and without the map, and `pg_stat_activity` shows no superuser session from the collector.
