### PR TITLE
Run pg-collect-metrics as ubi_monitoring

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -342,7 +342,7 @@ TIMER
     vm.sshable.write_file("/etc/systemd/system/postgres-metrics.timer", metrics_timer)
 
     vm.sshable.cmd("sudo mkdir -p /var/lib/node_exporter")
-    vm.sshable.cmd("sudo chown ubi:ubi /var/lib/node_exporter")
+    vm.sshable.cmd("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
 
     pg_metrics_service = <<SERVICE
 [Unit]
@@ -351,7 +351,13 @@ After=postgresql.service
 
 [Service]
 Type=oneshot
-User=ubi
+User=ubi_monitoring
+# group ubi: traverse /home/ubi (0750) to exec the script; ambient
+# capabilities are not in the effective set at execve time.
+SupplementaryGroups=ubi
+# read the postgres-owned pg_wal/archive_status directory without sudo
+AmbientCapabilities=CAP_DAC_READ_SEARCH
+NoNewPrivileges=true
 ExecStart=/home/ubi/postgres/bin/collect-pg-metrics #{postgres_server.version}
 StandardOutput=journal
 StandardError=journal
@@ -373,6 +379,11 @@ TIMER
     vm.sshable.write_file("/etc/systemd/system/pg-collect-metrics.timer", pg_metrics_timer)
 
     vm.sshable.cmd("sudo systemctl daemon-reload")
+    # The old User=ubi unit leaves its safe_write_to_file lock and possibly
+    # a stale tmp file owned ubi:ubi 0644, which the new user cannot write.
+    vm.sshable.cmd("sudo rm -f :lock_path :tmp_path",
+      lock_path: "/tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock",
+      tmp_path: "/var/lib/node_exporter/pg_metrics.prom.tmp")
 
     when_initial_provisioning_set? do
       vm.sshable.cmd("sudo systemctl enable --now postgres_exporter")

--- a/prog/rollout_semaphore.rb
+++ b/prog/rollout_semaphore.rb
@@ -10,7 +10,7 @@ class Prog::RolloutSemaphore < Prog::Base
     LoadBalancer => [:rewrite_dns_records, :refresh_cert, :update_load_balancer],
     Page => [:resolve, :retrigger],
     PostgresResource => [:refresh_dns_record, :refresh_certificates],
-    PostgresServer => [:install_rhizome, :configure, :refresh_walg_credentials],
+    PostgresServer => [:install_rhizome, :configure, :configure_metrics, :refresh_walg_credentials],
     Vm => [:update_firewall_rules, :restart],
     VmHost => [:patch],
   }.freeze.each_value(&:freeze)

--- a/rhizome/postgres/bin/collect-pg-metrics
+++ b/rhizome/postgres/bin/collect-pg-metrics
@@ -13,21 +13,21 @@ output_path = "/var/lib/node_exporter/pg_metrics.prom"
 lines = []
 
 # Archival backlog: count of WAL files pending archival
-backlog = r("sudo", "find", "/dat/#{version}/data/pg_wal/archive_status", "-name", "*.ready").count("\n")
+backlog = r("find", "/dat/#{version}/data/pg_wal/archive_status", "-name", "*.ready").count("\n")
 lines << "# HELP ubicloud_pg_archival_backlog Number of WAL files pending archival\n"
 lines << "# TYPE ubicloud_pg_archival_backlog gauge\n"
 lines << "ubicloud_pg_archival_backlog #{backlog}\n"
 
 # Current WAL LSN as integer bytes
-is_recovery = r("sudo", "-u", "postgres", "psql", "-t", "-A", "-c", "SELECT pg_is_in_recovery()").strip
+is_recovery = r("psql", "-U", "ubi_monitoring", "-d", "postgres", "-t", "-A", "-c", "SELECT pg_is_in_recovery()").strip
 lsn_func = if is_recovery == "t"
-  lsn = r("sudo", "-u", "postgres", "psql", "-t", "-A", "-c", "SELECT pg_last_wal_receive_lsn()").strip
+  lsn = r("psql", "-U", "ubi_monitoring", "-d", "postgres", "-t", "-A", "-c", "SELECT pg_last_wal_receive_lsn()").strip
   lsn.empty? ? "pg_last_wal_replay_lsn" : "pg_last_wal_receive_lsn"
 else
   "pg_current_wal_lsn"
 end
 
-lsn = r("sudo", "-u", "postgres", "psql", "-t", "-A", "-c", "SELECT #{lsn_func}()").strip
+lsn = r("psql", "-U", "ubi_monitoring", "-d", "postgres", "-t", "-A", "-c", "SELECT #{lsn_func}()").strip
 unless lsn.empty?
   high, low = lsn.split("/")
   lsn_bytes = high.to_i(16) << 32 | low.to_i(16)
@@ -38,7 +38,7 @@ end
 
 # Last replay timestamp (standbys/replicas only)
 if is_recovery == "t"
-  ts = r("sudo", "-u", "postgres", "psql", "-t", "-A", "-c", "SELECT extract(epoch FROM pg_last_xact_replay_timestamp())").strip
+  ts = r("psql", "-U", "ubi_monitoring", "-d", "postgres", "-t", "-A", "-c", "SELECT extract(epoch FROM pg_last_xact_replay_timestamp())").strip
   unless ts.empty?
     lines << "# HELP ubicloud_pg_last_xact_replay_timestamp_seconds Last transaction replay timestamp as Unix epoch\n"
     lines << "# TYPE ubicloud_pg_last_xact_replay_timestamp_seconds gauge\n"

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -708,10 +708,14 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.service > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.timer > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo mkdir -p /var/lib/node_exporter")
-      expect(sshable).to receive(:_cmd).with("sudo chown ubi:ubi /var/lib/node_exporter")
-      expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
+      expect(sshable).to receive(:_cmd).with("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
+      expect(sshable).to receive(:_cmd).with(
+        "sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null",
+        stdin: /User=ubi_monitoring.*SupplementaryGroups=ubi.*AmbientCapabilities=CAP_DAC_READ_SEARCH/m,
+      )
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
+      expect(sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now postgres-metrics.timer")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now pg-collect-metrics.timer")
 
@@ -748,10 +752,11 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.service > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.timer > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo mkdir -p /var/lib/node_exporter")
-      expect(sshable).to receive(:_cmd).with("sudo chown ubi:ubi /var/lib/node_exporter")
+      expect(sshable).to receive(:_cmd).with("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
+      expect(sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now postgres-metrics.timer")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now pg-collect-metrics.timer")
 
@@ -782,10 +787,11 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo mkdir -p /var/lib/node_exporter")
-      expect(standby_sshable).to receive(:_cmd).with("sudo chown ubi:ubi /var/lib/node_exporter")
+      expect(standby_sshable).to receive(:_cmd).with("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
+      expect(standby_sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
 
       expect { standby_nx.configure_metrics }.to hop("wait")
     end
@@ -815,10 +821,11 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.timer > /dev/null", stdin: /OnUnitActiveSec=15s/)
       expect(standby_sshable).to receive(:_cmd).with("sudo mkdir -p /var/lib/node_exporter")
-      expect(standby_sshable).to receive(:_cmd).with("sudo chown ubi:ubi /var/lib/node_exporter")
+      expect(standby_sshable).to receive(:_cmd).with("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
+      expect(standby_sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
 
       expect { standby_nx.configure_metrics }.to hop("wait")
     end
@@ -854,10 +861,11 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/postgres-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo mkdir -p /var/lib/node_exporter")
-      expect(standby_sshable).to receive(:_cmd).with("sudo chown ubi:ubi /var/lib/node_exporter")
+      expect(standby_sshable).to receive(:_cmd).with("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
+      expect(standby_sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
 
       expect { standby_nx.configure_metrics }.to hop("wait")
     end


### PR DESCRIPTION
Runs `pg-collect-metrics.service` as `ubi_monitoring` instead of `ubi` + `sudo -u postgres psql`, removing the last recurring superuser query on managed Postgres VMs. `CAP_DAC_READ_SEARCH` replaces `sudo find` for the archive_status backlog count; `SupplementaryGroups=ubi` is needed to exec the script since ambient capabilities are not effective at execve time. The stale lock and tmp files from the old unit are cleaned up, and `configure_metrics` joins the RolloutSemaphore allowlist so the new unit can reach existing servers.

Independent of #5424: the collector peer-auths by OS/DB name match. Rollout needs the `install_rhizome` and `configure_metrics` sweeps together — either half fails loudly without the other.

Tested with `spec/prog/postgres/postgres_server_nexus_spec.rb -e configure_metrics`; on a dev VM after a configure_metrics tick, the collector runs without permission errors, the LSN gauges in `pg_metrics.prom` advance, and `pg_stat_activity` shows it connecting as `ubi_monitoring`.
