### PR TITLE
Add deadlines for configure_metrics/logs re-runs

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -642,11 +642,13 @@ SQL
 
     when_configure_metrics_set? do
       decr_configure_metrics
+      register_deadline("wait", 3 * 60)
       hop_configure_metrics
     end
 
     when_configure_logs_set? do
       decr_configure_logs
+      register_deadline("wait", 3 * 60)
       hop_configure_logs
     end
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1222,6 +1222,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "hops to configure_metrics if configure_metrics is set" do
       nx.incr_configure_metrics
+      expect(nx).to receive(:register_deadline).with("wait", 3 * 60)
       expect { nx.wait }.to hop("configure_metrics")
     end
 
@@ -1233,6 +1234,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "hops to configure_logs if configure_logs is set" do
       nx.incr_configure_logs
+      expect(nx).to receive(:register_deadline).with("wait", 3 * 60)
       expect { nx.wait }.to hop("configure_logs")
     end
 


### PR DESCRIPTION
The `wait` label re-triggers `configure_metrics` and `configure_logs` via
the `when_configure_metrics_set?` and `when_configure_logs_set?` blocks
without registering a deadline. If either label fails repeatedly (SSH
errors, persistently failing `d_run`, etc.) the strand reruns it forever
and no `Page` is ever created.

Re-trigger sites today:
- Metric destination add/delete: `pg.server_incr("configure_metrics")` in `routes/project/location/postgres.rb`
- `promote_read_replica` and `taking_over` paths in this same file

This matches the precedent set by `when_promote_read_replica_set?` just below the two affected blocks and registers a 3-minute deadline on `"wait"` before each hop. If the label doesn't return to `wait` within the budget, `Strand#unsynchronized_run` assembles the standard `["Deadline", strand_id, prog, "wait"]` page.

3 minutes was chosen because both labels are short — file writes, `systemctl reload/restart`, and (for `configure_logs`) a single `d_run`. The existing `complete_restart` deadline a few lines above is 2 minutes for a similar shape of work.

### Out of scope, but flagged

The same gap exists for `when_refresh_certificates_set?`, `when_update_superuser_password_set?`, and `when_configure_set?` in `wait` — none of them register a deadline before hopping. Happy to follow up in a separate PR if maintainers agree the same pattern applies.