### PR TITLE
postgres: verify wal-g auth before initialize_database_from_backup

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -166,6 +166,14 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   label def configure_walg_credentials
     postgres_server.attach_s3_policy_if_needed
     postgres_server.refresh_walg_credentials
+
+    # AttachRolePolicy is eventually consistent on AWS.
+    # Wait for wal-g to be able to connect to storage before moving.
+    unless walg_credentials_ready?
+      register_deadline("wait", 10 * 60)
+      nap 5
+    end
+
     hop_initialize_empty_database if postgres_server.primary?
     hop_initialize_database_from_backup
   end
@@ -933,6 +941,15 @@ SQL
 
   def version
     postgres_server.version
+  end
+
+  def walg_credentials_ready?
+    return true if postgres_server.timeline.blob_storage.nil?
+
+    vm.sshable.cmd("sudo -u postgres /usr/bin/wal-g st check read --config /etc/postgresql/wal-g.env")
+    true
+  rescue Sshable::SshError
+    false
   end
 
   def daemonized_restart

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -383,6 +383,26 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
       expect { standby_nx.configure_walg_credentials }.to hop("initialize_database_from_backup")
     end
+
+    it "runs a wal-g storage check when blob storage exists and hops once it succeeds" do
+      expect(server).to receive(:refresh_walg_credentials)
+      expect(server).to receive(:attach_s3_policy_if_needed)
+      expect(server.timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster))
+      expect(sshable).to receive(:_cmd).with("sudo -u postgres /usr/bin/wal-g st check read --config /etc/postgresql/wal-g.env")
+
+      expect { nx.configure_walg_credentials }.to hop("initialize_empty_database")
+    end
+
+    it "naps and registers a deadline when wal-g cannot authenticate yet" do
+      expect(server).to receive(:refresh_walg_credentials)
+      expect(server).to receive(:attach_s3_policy_if_needed)
+      expect(server.timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster))
+      expect(sshable).to receive(:_cmd).with("sudo -u postgres /usr/bin/wal-g st check read --config /etc/postgresql/wal-g.env")
+        .and_raise(Sshable::SshError.new("cmd", "", "NoCredentialProviders", 1, nil))
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60)
+
+      expect { nx.configure_walg_credentials }.to nap(5)
+    end
   end
 
   describe "#initialize_empty_database" do


### PR DESCRIPTION
AttachRolePolicy is eventually consistent, so the immediate hop from `configure_walg_credentials` into `initialize_database_from_backup` races IAM propagation and trips `PGInitializeDatabaseFromBackupFailed` before the policy reaches the EC2 instance's IMDS credentials.

We're seeing ~5% of E2E tests cause noisy alerts because of that.

Probe wal-g auth with `wal-g st check read` after attach + refresh; nap under a 10-minute deadline until the probe succeeds, then hop.
