### PR TITLE
Add visible_postgres_locations feature flag for postgres-only visibility

### DIFF
--- a/model/location.rb
+++ b/model/location.rb
@@ -34,10 +34,10 @@ class Location < Sequel::Model
     end
   end
 
-  def self.postgres_locations(project_ff_visible_locations = nil)
+  def self.postgres_locations(visible_gcp_names = nil)
     where(name: ["hetzner-fsn1", "leaseweb-wdc02"])
       .or(provider: "aws", project_id: nil)
-      .or(provider: "gcp", project_id: nil, name: project_ff_visible_locations || [])
+      .or(provider: "gcp", project_id: nil, name: visible_gcp_names || [])
       .all
   end
 

--- a/model/location.rb
+++ b/model/location.rb
@@ -35,7 +35,7 @@ class Location < Sequel::Model
   end
 
   def self.postgres_locations(visible_gcp_names = nil)
-    where(name: ["hetzner-fsn1", "leaseweb-wdc02"])
+    where(project_id: nil, name: ["hetzner-fsn1", "leaseweb-wdc02"])
       .or(provider: "aws", project_id: nil)
       .or(provider: "gcp", project_id: nil, name: visible_gcp_names || [])
       .all

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -567,7 +567,7 @@ class PostgresResource < Sequel::Model
   end
 
   def self.postgres_locations(project)
-    Location.postgres_locations(project.get_ff_visible_locations) + project.locations
+    Location.postgres_locations(project.get_ff_visible_postgres_locations) + project.locations
   end
 
   module HaType

--- a/model/project.rb
+++ b/model/project.rb
@@ -251,6 +251,7 @@ class Project < Sequel::Model
     :skip_runner_pool,
     :spill_to_alien_runners,
     :visible_locations,
+    :visible_postgres_locations,
     :vm_public_ssh_keys,
     :postgres_aws_use_different_azs_for_standbys,
     :cache_proxy_download_url,

--- a/spec/model/location_spec.rb
+++ b/spec/model/location_spec.rb
@@ -85,6 +85,13 @@ RSpec.describe Location do
       expect(names).not_to include("my-aws")
     end
 
+    it "excludes a project-owned location even if its name matches a public metal location" do
+      described_class.create(name: "hetzner-fsn1", display_name: "shadow-hetzner-fsn1", ui_name: "shadow-hetzner-fsn1", visible: true, provider: "hetzner", project_id: p1_id)
+      locations = described_class.postgres_locations
+      expect(locations.count { it.name == "hetzner-fsn1" }).to eq(1)
+      expect(locations.find { it.name == "hetzner-fsn1" }.project_id).to be_nil
+    end
+
     it "includes AWS public locations regardless of array (bypass preserved)" do
       expect(described_class[name: "us-east-1"].visible).to be(false)
       names_nil = described_class.postgres_locations.map(&:name)

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -1216,25 +1216,25 @@ RSpec.describe PostgresResource do
   end
 
   describe ".postgres_locations" do
-    it "includes gcp-us-central1 when project has it in visible_locations" do
-      project.set_ff_visible_locations(["gcp-us-central1"])
+    it "includes gcp-us-central1 when project has it in visible_postgres_locations" do
+      project.set_ff_visible_postgres_locations(["gcp-us-central1"])
       names = described_class.postgres_locations(project).map(&:name)
       expect(names).to include("gcp-us-central1")
     end
 
-    it "excludes gcp-us-central1 when project has no visible_locations flag" do
-      expect(project.get_ff_visible_locations).to be_nil
+    it "excludes gcp-us-central1 when project has no visible_postgres_locations flag" do
+      expect(project.get_ff_visible_postgres_locations).to be_nil
       names = described_class.postgres_locations(project).map(&:name)
       expect(names).not_to include("gcp-us-central1")
     end
 
-    it "excludes gcp-us-central1 when project's visible_locations is []" do
-      project.set_ff_visible_locations([])
+    it "excludes gcp-us-central1 when project's visible_postgres_locations is []" do
+      project.set_ff_visible_postgres_locations([])
       names = described_class.postgres_locations(project).map(&:name)
       expect(names).not_to include("gcp-us-central1")
     end
 
-    it "includes AWS public regions regardless of visible_locations" do
+    it "includes AWS public regions regardless of visible_postgres_locations" do
       names = described_class.postgres_locations(project).map(&:name)
       expect(names).to include("us-east-1", "us-west-2")
     end


### PR DESCRIPTION
Add visible_postgres_locations feature flag for postgres-only visibility

Until now, the visible_locations feature flag was shared between the
VM create form and the Postgres create form. Setting
visible_locations=["gcp-us-central1"] for the GCP postgres rollout
also unlocked the GCP location in the VM page, where VM-on-GCP isn't
a tested/supported product. This let users provision plain VMs in
GCP, which is not the intent of the rollout.

Introduce a separate visible_postgres_locations flag that gates only
the Postgres surface:

- visible_locations: continues to unlock invisible public locations
  for the VM create form (Option.locations) and any other surface
  that reads it.
- visible_postgres_locations: now the only flag PostgresResource
  consumes when computing the Postgres create form's location set
  (PostgresResource.postgres_locations).

To enable the Postgres GCP rollout without exposing the location in
the VM page, set ff_visible_postgres_locations=["gcp-us-central1"]
and leave ff_visible_locations unset (or unset gcp-us-central1 from
it). To make a location visible in both pages, set it in both
flags.