### PR TITLE
Skip sshable-unreachable pages for GitHub runners

### DIFF
--- a/lib/health_monitor_methods.rb
+++ b/lib/health_monitor_methods.rb
@@ -12,4 +12,8 @@ module HealthMonitorMethods
   def needs_event_loop_for_pulse_check?
     false
   end
+
+  def page_on_sshable_failure?
+    true
+  end
 end

--- a/lib/monitor_resource_stub.rb
+++ b/lib/monitor_resource_stub.rb
@@ -49,6 +49,10 @@ class MonitorResourceStub
     @need_event_loop
   end
 
+  def page_on_sshable_failure?
+    true
+  end
+
   def check_pulse(session:, previous_pulse:)
     @pulse_count += 1
     sleep(0.1 + rand)

--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -151,6 +151,7 @@ class MonitorableResource
   private
 
   def record_open_session_failure
+    return unless @resource.page_on_sshable_failure?
     @open_session_failure_started_at ||= Time.now
     return if @open_session_failure_paged
     elapsed = Time.now - @open_session_failure_started_at

--- a/model/github/github_runner.rb
+++ b/model/github/github_runner.rb
@@ -81,6 +81,10 @@ class GithubRunner < Sequel::Model
     aggregate_readings(previous_pulse:, reading:, data: {available_memory:})
   end
 
+  def page_on_sshable_failure?
+    false
+  end
+
   def custom_label
     GithubCustomLabel.first(name: actual_label, installation_id:)
   end

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -126,6 +126,15 @@ RSpec.describe MonitorableResource do
         expect(Page.from_tag_parts("SshableUnreachable", postgres_server.id)).to be_nil
       end
 
+      it "does not page if resource opts out via page_on_sshable_failure?" do
+        allow(postgres_server).to receive(:page_on_sshable_failure?).and_return(false)
+        expect(postgres_server).to receive(:init_health_monitor_session).and_raise(IOError).twice
+        expect { r_w_event_loop.open_resource_session }.to raise_error(IOError)
+        allow(Time).to receive(:now).and_return(now + described_class::OPEN_SESSION_FAILURE_PAGE_THRESHOLD + 1)
+        expect { r_w_event_loop.open_resource_session }.to raise_error(IOError)
+        expect(Page.from_tag_parts("SshableUnreachable", postgres_server.id)).to be_nil
+      end
+
       it "clears tracking when resource is deleted" do
         expect(postgres_server).to receive(:init_health_monitor_session).and_raise(IOError)
         expect { r_w_event_loop.open_resource_session }.to raise_error(IOError)

--- a/spec/model/github/github_runner_spec.rb
+++ b/spec/model/github/github_runner_spec.rb
@@ -137,6 +137,10 @@ RSpec.describe GithubRunner do
     github_runner.init_health_monitor_session
   end
 
+  it "does not page on sshable failure" do
+    expect(github_runner.page_on_sshable_failure?).to be false
+  end
+
   it "checks pulse" do
     session = {
       ssh_session: Net::SSH::Connection::Session.allocate,


### PR DESCRIPTION
Customer workloads can easily break SSH on a runner (firewall rules, shutting down sshd, saturating the box), which would otherwise wake on-call for a condition we cannot act on. Add a page_on_sshable_failure? predicate to HealthMonitorMethods, default true, and override it to false on GithubRunner so MonitorableResource skips Prog::PageNexus assembly when the open-session failure threshold is exceeded.