### PR TITLE
Recreate AWS runner VM after Server.InternalError on launch

### DIFF
--- a/model/github/github_runner.rb
+++ b/model/github/github_runner.rb
@@ -10,7 +10,7 @@ class GithubRunner < Sequel::Model
   one_through_one :project, join_table: :github_installation, left_key: :id, left_primary_key: :installation_id, read_only: true
 
   plugin ResourceMethods, redacted_columns: :workflow_job
-  plugin SemaphoreMethods, :destroy, :skip_deregistration, :not_upgrade_premium, :spill_over
+  plugin SemaphoreMethods, :destroy, :skip_deregistration, :not_upgrade_premium, :spill_over, :spare_runner_provisioned
   include HealthMonitorMethods
 
   NOT_VM_ALLOCATED_RUNNER_LABELS = %w[start wait_concurrency_limit apply_custom_label_quota].freeze
@@ -61,7 +61,9 @@ class GithubRunner < Sequel::Model
     Clog.emit(message, {message => values})
   end
 
-  def provision_spare_runner
+  def provision_spare_runner(force: false)
+    return if !force && spare_runner_provisioned_set?
+    incr_spare_runner_provisioned
     Prog::Github::GithubRunnerNexus.assemble(installation, repository_name:, label:).subject
   end
 

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -241,9 +241,10 @@ class Prog::Vm::Aws::Nexus < Prog::Base
     state = instance_response&.dig(:state, :name)
 
     if state == "terminated" && instance_response.dig(:state_reason, :code) == "Server.InternalError" && is_runner? && (runner = GithubRunner[vm_id: vm.id])
-      Clog.emit("aws internal error on launch", {aws_internal_error_on_launch: {vm:, message: instance_response.dig(:state_reason, :message)}})
-      runner.provision_spare_runner
-      runner.incr_destroy
+      if runner.provision_spare_runner
+        Clog.emit("aws internal error on launch", {aws_internal_error_on_launch: {vm:, message: instance_response.dig(:state_reason, :message)}})
+        runner.incr_destroy
+      end
       nap 60 * 60
     end
 

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -236,11 +236,18 @@ class Prog::Vm::Aws::Nexus < Prog::Base
   end
 
   label def wait_instance_created
-    unless (reservation = client.describe_instances({filters: [{name: "instance-id", values: [aws_instance.instance_id]}, {name: "tag:Ubicloud", values: [Config.provider_resource_tag_value]}]}).reservations.first) &&
-        (instance_response = reservation.instances.first) &&
-        instance_response.dig(:state, :name) == "running"
-      nap 1
+    reservation = client.describe_instances({filters: [{name: "instance-id", values: [aws_instance.instance_id]}, {name: "tag:Ubicloud", values: [Config.provider_resource_tag_value]}]}).reservations.first
+    instance_response = reservation&.instances&.first
+    state = instance_response&.dig(:state, :name)
+
+    if state == "terminated" && instance_response.dig(:state_reason, :code) == "Server.InternalError" && is_runner? && (runner = GithubRunner[vm_id: vm.id])
+      Clog.emit("aws internal error on launch", {aws_internal_error_on_launch: {vm:, message: instance_response.dig(:state_reason, :message)}})
+      runner.provision_spare_runner
+      runner.incr_destroy
+      nap 60 * 60
     end
+
+    nap 1 unless state == "running"
     public_ipv4 = instance_response.dig(:network_interfaces, 0, :association, :public_ip)
     public_ipv6 = instance_response.dig(:network_interfaces, 0, :ipv_6_addresses, 0, :ipv_6_address)
     AssignedVmAddress.create(dst_vm_id: vm.id, ip: public_ipv4)

--- a/spec/model/github/github_runner_spec.rb
+++ b/spec/model/github/github_runner_spec.rb
@@ -123,13 +123,34 @@ RSpec.describe GithubRunner do
     })
   end
 
-  it "provisions a spare runner" do
+  it "provisions a spare runner and increments the spare_runner_provisioned semaphore" do
+    Strand.create_with_id(github_runner, prog: "Github::GithubRunnerNexus", label: "start")
+
     spare_runner = github_runner.provision_spare_runner
 
     expect(spare_runner).to be_a(described_class)
     expect(spare_runner.installation_id).to eq(github_runner.installation_id)
     expect(spare_runner.repository_name).to eq(github_runner.repository_name)
     expect(spare_runner.label).to eq(github_runner.label)
+    expect(github_runner.reload.spare_runner_provisioned_set?).to be(true)
+  end
+
+  it "does not provision another spare runner once one has been provisioned" do
+    Strand.create_with_id(github_runner, prog: "Github::GithubRunnerNexus", label: "start")
+    github_runner.incr_spare_runner_provisioned
+
+    expect {
+      expect(github_runner.provision_spare_runner).to be_nil
+    }.not_to change(described_class, :count)
+  end
+
+  it "provisions a spare runner regardless of the semaphore when force is true" do
+    Strand.create_with_id(github_runner, prog: "Github::GithubRunnerNexus", label: "start")
+    github_runner.incr_spare_runner_provisioned
+
+    expect {
+      expect(github_runner.provision_spare_runner(force: true)).to be_a(described_class)
+    }.to change(described_class, :count).from(1).to(2)
   end
 
   it "initiates a new health monitor session" do

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -706,8 +706,20 @@ usermod -L ubuntu
       client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "terminated"}, state_reason: {code: "Server.InternalError", message: "Server.InternalError: Internal error on launch"}}]}])
       expect(Clog).to receive(:emit).with("aws internal error on launch", instance_of(Hash)).and_call_original
       expect { nx.wait_instance_created }.to nap(60 * 60)
-        .and change(GithubRunner, :count).by(1)
+        .and change(GithubRunner, :count).from(1).to(2)
         .and change { runner.reload.destroy_set? }.from(false).to(true)
+    end
+
+    it "does not provision another spare runner if one was already provisioned" do
+      vm.update(unix_user: "runneradmin")
+      installation = GithubInstallation.create(name: "ubicloud", type: "Organization", installation_id: 123, project_id: vm.project_id)
+      runner = GithubRunner.create(label: "ubicloud-standard-2", repository_name: "ubicloud/test", installation_id: installation.id, vm_id: vm.id)
+      Strand.create_with_id(runner, prog: "Github::GithubRunnerNexus", label: "start")
+      runner.incr_spare_runner_provisioned
+      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "terminated"}, state_reason: {code: "Server.InternalError", message: "Server.InternalError: Internal error on launch"}}]}])
+      expect { nx.wait_instance_created }.to nap(60 * 60)
+        .and not_change(GithubRunner, :count)
+        .and not_change { runner.reload.destroy_set? }
     end
 
     it "naps without recreating when the instance is terminated due to a non-internal-error reason" do

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -697,6 +697,39 @@ usermod -L ubuntu
       client.stub_responses(:describe_instances, reservations: [])
       expect { nx.wait_instance_created }.to nap(1)
     end
+
+    it "provisions a spare runner and destroys the runner when the instance is terminated due to AWS internal error" do
+      vm.update(unix_user: "runneradmin")
+      installation = GithubInstallation.create(name: "ubicloud", type: "Organization", installation_id: 123, project_id: vm.project_id)
+      runner = GithubRunner.create(label: "ubicloud-standard-2", repository_name: "ubicloud/test", installation_id: installation.id, vm_id: vm.id)
+      Strand.create_with_id(runner, prog: "Github::GithubRunnerNexus", label: "start")
+      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "terminated"}, state_reason: {code: "Server.InternalError", message: "Server.InternalError: Internal error on launch"}}]}])
+      expect(Clog).to receive(:emit).with("aws internal error on launch", instance_of(Hash)).and_call_original
+      expect { nx.wait_instance_created }.to nap(60 * 60)
+        .and change(GithubRunner, :count).by(1)
+        .and change { runner.reload.destroy_set? }.from(false).to(true)
+    end
+
+    it "naps without recreating when the instance is terminated due to a non-internal-error reason" do
+      vm.update(unix_user: "runneradmin")
+      installation = GithubInstallation.create(name: "ubicloud", type: "Organization", installation_id: 123, project_id: vm.project_id)
+      GithubRunner.create(label: "ubicloud-standard-2", repository_name: "ubicloud/test", installation_id: installation.id, vm_id: vm.id)
+      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "terminated"}, state_reason: {code: "Client.UserInitiatedShutdown", message: "User initiated shutdown"}}]}])
+      expect { nx.wait_instance_created }.to nap(1)
+        .and not_change(GithubRunner, :count)
+    end
+
+    it "naps without recreating when the instance is terminated due to internal error but the vm is not a runner" do
+      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "terminated"}, state_reason: {code: "Server.InternalError", message: "Server.InternalError: Internal error on launch"}}]}])
+      expect { nx.wait_instance_created }.to nap(1)
+    end
+
+    it "naps without recreating when the instance is terminated due to internal error but no GithubRunner record exists" do
+      vm.update(unix_user: "runneradmin")
+      client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "terminated"}, state_reason: {code: "Server.InternalError", message: "Server.InternalError: Internal error on launch"}}]}])
+      expect { nx.wait_instance_created }.to nap(1)
+        .and not_change(GithubRunner, :count)
+    end
   end
 
   describe "#wait_instance_created", "without sshable" do


### PR DESCRIPTION
EC2 occasionally terminates a fresh runner instance with state reason Server.InternalError ("Internal error on launch"). The strand then sits in wait_instance_created until its deadline trips, leaving the GitHub job waiting on a runner that will never come up.

Detect the terminated+InternalError combination for runner VMs that still have a GithubRunner record, provision a spare runner, mark the failed runner for destroy, and nap. This mirrors the recovery path already used for InsufficientInstanceCapacity in create_instance.