### PR TITLE
Revert "Clear restart state when recovering from postgres unavailability"

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -698,7 +698,6 @@ SQL
 
   label def unavailable
     when_lockout_set? do
-      clear_restart_state
       hop_lockout
     end
 
@@ -706,14 +705,12 @@ SQL
 
     when_configure_set? do
       decr_configure
-      clear_restart_state
       hop_configure
     end
 
     if available?
       decr_checkup
       decr_recycle_unavailable_server
-      clear_restart_state
       hop_wait
     end
 
@@ -945,9 +942,5 @@ SQL
     end
 
     false
-  end
-
-  def clear_restart_state
-    vm.sshable.d_clean("postgres_restart") if vm.sshable.d_check("postgres_restart") == "Succeeded"
   end
 end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1332,21 +1332,17 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   describe "#unavailable" do
     it "hops to configure if configure is set" do
       nx.incr_configure
-      expect(sshable).to receive(:d_check).with("postgres_restart").and_return("NotStarted")
       expect { nx.unavailable }.to hop("configure")
     end
 
     it "hops to lockout if lockout is set" do
       nx.incr_lockout
-      expect(sshable).to receive(:d_check).with("postgres_restart").and_return("NotStarted")
       expect { nx.unavailable }.to hop("lockout")
     end
 
     it "hops to wait if the server is available" do
       expect(nx).to receive(:available?).and_return(true)
       expect(nx).to receive(:decr_recycle_unavailable_server)
-      expect(sshable).to receive(:d_check).with("postgres_restart").and_return("Succeeded")
-      expect(sshable).to receive(:d_clean).with("postgres_restart")
       expect { nx.unavailable }.to hop("wait")
     end
 
@@ -1775,20 +1771,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx.strand).to receive(:modified!)
       nx.update_stack_lsn("update")
       expect(frame.first["lsn"]).to eq("update")
-    end
-  end
-
-  describe "#clear_restart_state" do
-    it "cleans up when restart state is Succeeded" do
-      expect(sshable).to receive(:d_check).with("postgres_restart").and_return("Succeeded")
-      expect(sshable).to receive(:d_clean).with("postgres_restart")
-      nx.clear_restart_state
-    end
-
-    it "does nothing when restart state is not Succeeded" do
-      expect(sshable).to receive(:d_check).with("postgres_restart").and_return("NotStarted")
-      expect(sshable).not_to receive(:d_clean)
-      nx.clear_restart_state
     end
   end
 


### PR DESCRIPTION
The clear_restart_state causes issues during unplanned failovers as the sshable call will fail.

This reverts commit e0d4509899f6a992fdf9d7491c8d3d0b678ee3d5.