### PR TITLE
Skip cryptswap setup when swap is a swapfile

### DIFF
--- a/rhizome/host/lib/crypt_swap_setup.rb
+++ b/rhizome/host/lib/crypt_swap_setup.rb
@@ -25,6 +25,13 @@ module CryptSwapSetup
     fail "No swap entry found in /etc/fstab" unless swap_line_idx
 
     swap_real = resolve_swap_device(fstab[swap_line_idx])
+
+    # dm-crypt needs a block device; we can't encrypt a swapfile in place.
+    unless File.blockdev?(swap_real)
+      puts "swap is a file (#{swap_real}), not a block device; skipping cryptswap setup"
+      return
+    end
+
     by_id = persistent_device_id(swap_real, device_node: true)
 
     r "swapoff", swap_real

--- a/rhizome/host/spec/crypt_swap_setup_spec.rb
+++ b/rhizome/host/spec/crypt_swap_setup_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe CryptSwapSetup do
     it "configures encrypted swap" do
       expect(File).to receive(:read).with(CryptSwapSetup::FSTAB).and_return(fstab.dup)
       expect(File).to receive(:realpath).with("/dev/disk/by-uuid/4c4fe278-d132-4136-8073-b1242eacf5eb").and_return("/dev/nvme0n1p2")
+      expect(File).to receive(:blockdev?).with("/dev/nvme0n1p2").and_return(true)
 
       expect(Dir).to receive(:[]).with("/dev/disk/by-id/*").and_return(["/dev/disk/by-id/nvme-eui.12345678", "/dev/disk/by-id/wwn-0x87654321"])
       expect(File).to receive(:realpath).with("/dev/disk/by-id/nvme-eui.12345678").and_return("/dev/nvme0n1p2")
@@ -44,6 +45,18 @@ RSpec.describe CryptSwapSetup do
       expect(described_class).to receive(:r).with("swapon", "-a")
 
       described_class.run
+    end
+
+    it "skips cryptswap setup when swap is a swapfile" do
+      swapfile_fstab = <<~FSTAB
+            UUID=52ad6a6b-7eae-4ebe-ae19-6aab35d7f2fa / ext4 defaults 0 0
+            /swap.img none swap sw 0 0
+      FSTAB
+      expect(File).to receive(:read).with(CryptSwapSetup::FSTAB).and_return(swapfile_fstab.dup)
+      expect(File).to receive(:realpath).with("/swap.img").and_return("/swap.img")
+      expect(File).to receive(:blockdev?).with("/swap.img").and_return(false)
+
+      expect { described_class.run }.to output(/skipping cryptswap setup/).to_stdout
     end
   end
 end


### PR DESCRIPTION
prep_host crashed on hosts where /etc/fstab pointed swap at a swapfile instead of a partition, since dm-crypt needs a block device. Log and skip in that case so prep can finish; the operator can decide what to do with the swapfile.