### PR TITLE
PostgreSQL data center exclusion filter improvements 

### DIFF
--- a/model/postgres/metal/postgres_resource.rb
+++ b/model/postgres/metal/postgres_resource.rb
@@ -31,10 +31,11 @@ class PostgresResource < Sequel::Model
       return ServerExclusionFilters.new(exclude_host_ids: [], exclude_data_centers: [], exclude_availability_zones: [], availability_zone: nil) if Config.allow_unspread_servers
       return ServerExclusionFilters.new(exclude_host_ids: Array(representative_server.vm.vm_host_id), exclude_data_centers: [], exclude_availability_zones: [], availability_zone: nil) if location.provider == HostProvider::LEASEWEB_PROVIDER_NAME
 
+      active_vm_ids = servers.reject { |s| s.needs_recycling? || s.destroy_set? }.map(&:vm_id)
       exclude_data_centers = VmHost
         .where(data_center: VmHost
           .join(:vm, vm_host_id: :id)
-          .where(Sequel[:vm][:id] => servers_dataset.select(:vm_id))
+          .where(Sequel[:vm][:id] => active_vm_ids)
           .select(:data_center)
           .distinct)
         .select_map(:data_center)

--- a/model/postgres/metal/postgres_resource.rb
+++ b/model/postgres/metal/postgres_resource.rb
@@ -33,11 +33,9 @@ class PostgresResource < Sequel::Model
 
       active_vm_ids = servers.reject { |s| s.needs_recycling? || s.destroy_set? }.map(&:vm_id)
       exclude_data_centers = VmHost
-        .where(data_center: VmHost
-          .join(:vm, vm_host_id: :id)
-          .where(Sequel[:vm][:id] => active_vm_ids)
-          .select(:data_center)
-          .distinct)
+        .join(:vm, vm_host_id: :id)
+        .where(Sequel[:vm][:id] => active_vm_ids)
+        .distinct
         .select_map(:data_center)
 
       ServerExclusionFilters.new(exclude_host_ids: [], exclude_data_centers:, exclude_availability_zones: [], availability_zone: nil)

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -101,12 +101,12 @@ RSpec.describe PostgresResource do
     let(:vm1) { create_hosted_vm(project, private_subnet, "pg-vm-1") }
     let(:vm2) { create_hosted_vm(project, private_subnet, "pg-vm-2") }
     let(:ps1) {
-      PostgresServer.create(timeline:, resource_id: postgres_resource.id, vm_id: vm1.id,
-        is_representative: true, synchronization_status: "ready", timeline_access: "push", version: "16")
+      PostgresServer.create(timeline:, resource_id: postgres_resource.id, vm_id: vm1.id, is_representative: true,
+        synchronization_status: "ready", timeline_access: "push", version: postgres_resource.target_version)
     }
     let(:ps2) {
       PostgresServer.create(timeline:, resource_id: postgres_resource.id, vm_id: vm2.id,
-        synchronization_status: "ready", timeline_access: "push", version: "16")
+        synchronization_status: "ready", timeline_access: "fetch", version: postgres_resource.target_version)
     }
 
     it "provisions a new server without excluding hosts when Config.allow_unspread_servers is true for regular instances" do
@@ -124,20 +124,40 @@ RSpec.describe PostgresResource do
       expect(new_server.vm.strand.stack[0]["exclude_data_centers"]).to eq([])
     end
 
-    it "provisions a new server but excludes currently used data centers" do
-      allow(Config).to receive(:allow_unspread_servers).and_return(false)
-      ps1
-      ps2
-      vm_host_1 = create_vm_host
-      vm_host_1.update(data_center: "dc1")
-      vm1.update(vm_host_id: vm_host_1.id)
-      vm2.update(vm_host_id: vm_host_1.id)
+    describe "excludes only active server data centers" do
+      before do
+        allow(Config).to receive(:allow_unspread_servers).and_return(false)
+        ps1
+        ps2
+        vm_host_1 = create_vm_host
+        vm_host_1.update(data_center: "dc1")
+        vm_host_2 = create_vm_host
+        vm_host_2.update(data_center: "dc2")
+        vm1.update(vm_host_id: vm_host_1.id)
+        VmStorageVolume.create(vm_id: vm1.id, size_gib: postgres_resource.target_storage_size_gib, boot: false, disk_index: 0)
+        vm2.update(vm_host_id: vm_host_2.id)
+        VmStorageVolume.create(vm_id: vm2.id, size_gib: postgres_resource.target_storage_size_gib, boot: false, disk_index: 0)
+        allow(postgres_resource).to receive(:servers).and_return([ps1, ps2])
+      end
 
-      expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(exclude_data_centers: ["dc1"])).and_call_original
-      postgres_resource.provision_new_standby
-      expect(postgres_resource.reload.servers.count).to eq(3)
-      new_server = PostgresServer.exclude(id: [ps1.id, ps2.id]).order(:created_at).last
-      expect(new_server.vm.strand.stack[0]["exclude_data_centers"]).to eq(["dc1"])
+      it "excludes both data centers when both servers are active" do
+        expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(exclude_data_centers: contain_exactly("dc1", "dc2"))).and_call_original
+        postgres_resource.provision_new_standby
+      end
+
+      it "does not exclude data center of a server being recycled" do
+        Strand.create_with_id(ps2, prog: "Postgres::PostgresServerNexus", label: "wait")
+        ps2.incr_recycle
+        expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(exclude_data_centers: ["dc1"])).and_call_original
+        postgres_resource.provision_new_standby
+      end
+
+      it "does not exclude data center of a server being destroyed" do
+        Strand.create_with_id(ps2, prog: "Postgres::PostgresServerNexus", label: "wait")
+        ps2.incr_destroy
+        expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(exclude_data_centers: ["dc1"])).and_call_original
+        postgres_resource.provision_new_standby
+      end
     end
 
     describe "use_different_az excludes only active server AZs" do


### PR DESCRIPTION
**Exclude only active server data centers in metal exclusion filters**
Previously, metal_new_server_exclusion_filters excluded data centers of
all existing servers, including ones being recycled or destroyed. This
could prevent placing replacements in a data center that is about to
free up. Now we filter to active servers only, matching the behavior
already implemented for AWS and GCP providers.

**Simplify exclude_data_centers query in metal exclusion filters**
The previous query wrapped the join in a redundant outer subquery to
look up the same data_center column. Also, the distinct being in the
inner query causing us to miss some duplicates. Collapse it into a
single join + distinct, which deduplicates the result correctly and has
one fewer level of indirection.