### PR TITLE
Run e2e provider cleanup as a separate job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -315,8 +315,21 @@ jobs:
       if: always()
       run: sudo systemctl stop cloudflared || true
 
+  cleanup-aws:
+    needs: [setup, e2e]
+    if: always() && contains(needs.setup.outputs.providers, 'aws')
+    runs-on: ubicloud-standard-4
+    timeout-minutes: 20
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+
+    - name: Download e2e logs
+      uses: actions/download-artifact@v7
+      with:
+        name: e2e-aws-${{ github.run_id }}-logs
+
     - name: Cleanup AWS resources
-      if: always() && matrix.provider == 'aws'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.E2E_AWS_ACCESS_KEY }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.E2E_AWS_SECRET_KEY }}
@@ -387,8 +400,21 @@ jobs:
           done
         done
 
+  cleanup-gcp:
+    needs: [setup, e2e]
+    if: always() && contains(needs.setup.outputs.providers, 'gcp')
+    runs-on: ubicloud-standard-4
+    timeout-minutes: 20
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+
+    - name: Download e2e logs
+      uses: actions/download-artifact@v7
+      with:
+        name: e2e-gcp-${{ github.run_id }}-logs
+
     - name: Cleanup GCP resources
-      if: always() && matrix.provider == 'gcp'
       uses: ./.github/actions/gcp-cleanup-e2e
       with:
         credentials-base64: ${{ secrets.E2E_GCP_CREDENTIALS_BASE64_JSON }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -319,6 +319,7 @@ jobs:
     needs: [setup, e2e]
     if: always() && contains(needs.setup.outputs.providers, 'aws')
     runs-on: ubicloud-standard-4
+    environment: E2E-aws
     timeout-minutes: 20
     steps:
     - name: Check out code
@@ -404,6 +405,7 @@ jobs:
     needs: [setup, e2e]
     if: always() && contains(needs.setup.outputs.providers, 'gcp')
     runs-on: ubicloud-standard-4
+    environment: E2E-gcp
     timeout-minutes: 20
     steps:
     - name: Check out code


### PR DESCRIPTION
## Summary

- Hoists the per-provider e2e cleanup out of the `e2e` matrix job into two top-level jobs (`cleanup-aws`, `cleanup-gcp`) that `need: [setup, e2e]` and gate on `always() && contains(needs.setup.outputs.providers, '<p>')`.
- Each cleanup job runs on its own `ubicloud-standard-4` with a fresh `timeout-minutes: 20`, checks out the repo, downloads the `e2e-<provider>-${{ github.run_id }}-logs` artifact, and runs the existing cleanup shell / composite action unchanged.
- The `Sleep 10 minutes after failed notification` step stays in the `e2e` job — its only job is keeping the SSH runner alive for oncall attach, and it no longer steals wall-clock from cleanup.

## Why

When a workflow is manually cancelled (or a scheduled run is superseded), GitHub sends SIGTERM to the runner with ~5 min grace before SIGKILL. That window is not enough for the in-job cleanup to serially delete ~30 GCP resources (instances → firewall policy associations → firewall policies → static IPs → subnets → VPCs → service accounts → GCS buckets) or the AWS side to terminate instances and tear down VPCs across two regions. Each cancellation leaked, and over ~9 days us-central1 saturated its 32-quota `STATIC_ADDRESSES` cap, blocking all new GCP runs.

Running cleanup as a separate job means cleanup gets its own runner lifetime, independent of whatever happened to the e2e runner.

I just drained the leak in `ubicloud-e2e` by hand (32→0 static IPs, 33→0 VPCs, 25→0 subnets, 16→0 service accounts, 40→0 buckets) so the next scheduled run will at least find quota.

## Test plan

- [ ] Trigger a manual run via `workflow_dispatch` (all providers) and confirm both `cleanup-aws` and `cleanup-gcp` run after `e2e` and find no resources.
- [ ] Trigger a manual run, cancel it mid-flight, and confirm the cleanup jobs still execute and successfully tear down whatever the e2e run created.
- [ ] Confirm `ubicloud-e2e` GCP project stays clean after a few scheduled runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)