### PR TITLE
Include us-east-1 in e2e AWS cleanup region loop

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -328,7 +328,7 @@ jobs:
         fi
         echo "Found instances in logs: $log_instance_ids"
 
-        for region in eu-central-1 us-west-2; do
+        for region in eu-central-1 us-east-1 us-west-2; do
           echo "Cleaning up resources in $region"
 
           # Find instances that exist in this region (filter doesn't error for non-existent IDs)


### PR DESCRIPTION
## Summary

- The AWS cleanup step iterated `eu-central-1 us-west-2` only, but the e2e suite also provisions resources in `us-east-1` via the HA Postgres test (`prog/test/ha_postgres_resource.rb` passes `aws_location_name: "us-east-1"`).
- Every HA-Postgres e2e run — successful or not — left its us-east-1 VPC, subnets, instances, EIPs, and IAM instance profile behind, because no cleanup pass ever visited that region.
- This is a separate failure mode from PR #5446 (which fixes cleanup being killed by cancellation). It applies even to runs that completed fully.

## Why this matters

us-east-1 has a default per-region VPC quota of 5. With 1 leaked VPC per HA-Postgres run and zero cleanup, four runs is enough to saturate the region. I just hand-deleted the leak — us-east-1 went from 4/5 to 0/5 VPCs — so we have headroom now, but without this fix it'll re-saturate within days.

## Test plan

- [ ] Run an HA-Postgres e2e (`workflow_dispatch` with `postgres_ha`) and confirm the cleanup step's `Cleaning up resources in us-east-1` line appears and finds the test's instance.
- [ ] Confirm post-run that the us-east-1 VPC + subnets + EIP allocated for the HA test are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)