### PR TITLE
Minor k8s improvements

### DIFF
--- a/lib/kubernetes/client.rb
+++ b/lib/kubernetes/client.rb
@@ -31,7 +31,7 @@ class Kubernetes::Client
   end
 
   def kubectl(cmd, **)
-    output = @session.exec!(NetSsh.combine("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf", cmd), **)
+    output = @session.exec!(NetSsh.combine("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s", cmd), **)
     raise output if output.exitstatus != 0
 
     output

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -363,6 +363,11 @@ module Validation
     fail ValidationFailed.new({version: "Kubernetes version \"#{version}\" is not supported. Available versions: #{Option.selectable_kubernetes_versions.join(", ")}"}) unless Option.selectable_kubernetes_versions.include?(version)
   end
 
+  def self.validate_kubernetes_location(location_id)
+    return if Option.kubernetes_locations.any? { it.id == location_id }
+    fail ValidationFailed.new({location: "Kubernetes clusters are not supported in this location. Available locations: #{Option.kubernetes_locations.map(&:display_name).join(", ")}"})
+  end
+
   def self.validate_victoria_metrics_username(username)
     msg = "VictoriaMetrics user must only contain lowercase letters, numbers, hyphens and underscore and cannot start with a number or hyphen. It also has a max length of 32 and a min length of 3."
     fail ValidationFailed.new({username: msg}) unless username&.match?(ALLOWED_VICTORIA_METRICS_USERNAME_PATTERN)

--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -187,6 +187,10 @@ class Sshable < Sequel::Model
     cmd("common/bin/daemonizer2 restart :unit_name", unit_name:)
   end
 
+  def d_logs(unit_name)
+    cmd("sudo journalctl -u :unit_name --no-pager", unit_name:)
+  end
+
   # A huge number of settings are needed to isolate net-ssh from the
   # host system and provide some anti-hanging assurance (keepalive,
   # timeout).

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -241,7 +241,6 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
 
   label def sync_kubernetes_services
     decr_sync_kubernetes_services
-    # TODO: timeout or other logic to avoid apoptosis should be added
     kubernetes_cluster.client.sync_kubernetes_services
     hop_wait
   end

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -12,6 +12,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       Validation.validate_kubernetes_version(version)
       Validation.validate_kubernetes_name(name)
       Validation.validate_kubernetes_cp_node_count(cp_node_count)
+      Validation.validate_kubernetes_location(location_id)
 
       ubid = KubernetesCluster.generate_ubid
       subnet = if private_subnet_id
@@ -46,9 +47,6 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
           {cidr: subnet.net6.to_s, port_range: Sequel.pg_range(10250..10250)},
         ],
       )
-
-      # TODO: Validate location
-      # TODO: Validate node count
 
       id = ubid.to_uuid
       KubernetesCluster.create_with_id(id, name:, version:, cp_node_count:, location_id:, target_node_size:, target_node_storage_size_gib:, project_id: project.id, private_subnet_id: subnet.id)

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -40,6 +40,8 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
   end
 
   label def start
+    register_deadline(nil, 20 * 60)
+
     name, vm_size, storage_size_gib = if kubernetes_nodepool
       ["#{kubernetes_nodepool.ubid}-#{SecureRandom.alphanumeric(5).downcase}",
         kubernetes_nodepool.target_node_size,
@@ -131,8 +133,10 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
   end
 
   label def init_cluster
-    case vm.sshable.d_check("init_kubernetes_cluster")
+    state = vm.sshable.d_check("init_kubernetes_cluster")
+    case state
     when "Succeeded"
+      Page.from_tag_parts("KubernetesNodeInitClusterFailed", node.ubid)&.incr_resolve
       hop_install_cni
     when "NotStarted"
       params = {
@@ -151,17 +155,24 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     when "InProgress"
       nap 10
     when "Failed"
-      Clog.emit("INIT CLUSTER FAILED")
-      nap 65536
-      # TODO: register deadline
+      Clog.emit("init kubernetes cluster failed", {logs: vm.sshable.d_logs("init_kubernetes_cluster")})
+      Prog::PageNexus.assemble(
+        "init kubernetes cluster failed on node #{node.ubid}",
+        ["KubernetesNodeInitClusterFailed", node.ubid],
+        [node.ubid, kubernetes_cluster.ubid],
+      )
+      nap 30
+    else
+      Clog.emit("got unknown state from daemonizer2 check: #{state}")
+      nap 30
     end
-
-    nap 65536
   end
 
   label def join_control_plane
-    case vm.sshable.d_check("join_control_plane")
+    state = vm.sshable.d_check("join_control_plane")
+    case state
     when "Succeeded"
+      Page.from_tag_parts("KubernetesNodeJoinControlPlaneFailed", node.ubid)&.incr_resolve
       hop_install_cni
     when "NotStarted"
       cp_sshable = kubernetes_cluster.sshable
@@ -180,17 +191,24 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     when "InProgress"
       nap 10
     when "Failed"
-      # TODO: Create a page
-      Clog.emit("JOIN CP NODE TO CLUSTER FAILED")
-      nap 65536
+      Clog.emit("join cp node to cluster failed", {logs: vm.sshable.d_logs("join_control_plane")})
+      Prog::PageNexus.assemble(
+        "join cp node to cluster failed on node #{node.ubid}",
+        ["KubernetesNodeJoinControlPlaneFailed", node.ubid],
+        [node.ubid, kubernetes_cluster.ubid],
+      )
+      nap 30
+    else
+      Clog.emit("got unknown state from daemonizer2 check: #{state}")
+      nap 30
     end
-
-    nap 65536
   end
 
   label def join_worker
-    case vm.sshable.d_check("join_worker")
+    state = vm.sshable.d_check("join_worker")
+    case state
     when "Succeeded"
+      Page.from_tag_parts("KubernetesNodeJoinWorkerFailed", node.ubid)&.incr_resolve
       hop_install_cni
     when "NotStarted"
       cp_sshable = kubernetes_cluster.sshable
@@ -208,12 +226,17 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     when "InProgress"
       nap 10
     when "Failed"
-      # TODO: Create a page
-      Clog.emit("JOIN WORKER NODE TO CLUSTER FAILED")
-      nap 65536
+      Clog.emit("join worker node to cluster failed", {logs: vm.sshable.d_logs("join_worker")})
+      Prog::PageNexus.assemble(
+        "join worker node to cluster failed on node #{node.ubid}",
+        ["KubernetesNodeJoinWorkerFailed", node.ubid],
+        [node.ubid, kubernetes_cluster.ubid],
+      )
+      nap 30
+    else
+      Clog.emit("got unknown state from daemonizer2 check: #{state}")
+      nap 30
     end
-
-    nap 65536
   end
 
   label def install_cni

--- a/spec/lib/kubernetes/client_spec.rb
+++ b/spec/lib/kubernetes/client_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe Kubernetes::Client do
   describe "kubectl" do
     it "runs kubectl command in the right format" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_return(response)
       expect { kubernetes_client.kubectl("get nodes") }.not_to raise_error
     end
 
@@ -208,7 +208,7 @@ RSpec.describe Kubernetes::Client do
 
     it "raises an error" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("error happened", 1)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_return(response)
       expect { kubernetes_client.kubectl("get nodes") }.to raise_error(RuntimeError, "error happened")
     end
   end
@@ -216,7 +216,7 @@ RSpec.describe Kubernetes::Client do
   describe "version" do
     it "runs a version command on kubectl" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Client Version: v1.33.0\nKustomize Version: v5.6.0", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf version --client").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s version --client").and_return(response)
       expect(kubernetes_client.version).to eq("v1.33")
     end
   end
@@ -224,7 +224,7 @@ RSpec.describe Kubernetes::Client do
   describe "delete_node" do
     it "deletes a node" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("node deleted", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf delete node asdf").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete node asdf").and_return(response)
       kubernetes_client.delete_node("asdf")
     end
   end
@@ -232,13 +232,13 @@ RSpec.describe Kubernetes::Client do
   describe "get_csr" do
     it "returns the pending csr name for the node" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("csr-abc123\n", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get csr --sort-by=.metadata.creationTimestamp | awk /Pending/' && /kubelet-serving/ && /'my-node'/ {print $1}' | tail -1").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get csr --sort-by=.metadata.creationTimestamp | awk /Pending/' && /kubelet-serving/ && /'my-node'/ {print $1}' | tail -1").and_return(response)
       expect(kubernetes_client.get_csr("my-node", csr_status: "Pending")).to eq("csr-abc123")
     end
 
     it "returns the approved csr name for the node" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("csr-xyz789\n", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get csr --sort-by=.metadata.creationTimestamp | awk /Approved/' && /kubelet-serving/ && /'my-node'/ {print $1}' | tail -1").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get csr --sort-by=.metadata.creationTimestamp | awk /Approved/' && /kubelet-serving/ && /'my-node'/ {print $1}' | tail -1").and_return(response)
       expect(kubernetes_client.get_csr("my-node", csr_status: "Approved")).to eq("csr-xyz789")
     end
   end
@@ -246,7 +246,7 @@ RSpec.describe Kubernetes::Client do
   describe "approve_csr" do
     it "approves the given csr" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("approved", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf certificate approve csr-abc123").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s certificate approve csr-abc123").and_return(response)
       kubernetes_client.approve_csr("csr-abc123")
     end
   end
@@ -260,7 +260,7 @@ RSpec.describe Kubernetes::Client do
         },
       }
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("node deleted", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf -n default patch service test-svc --type=merge -p \\{\\\"status\\\":\\{\\\"loadBalancer\\\":\\{\\\"ingress\\\":\\[\\{\\\"hostname\\\":\\\"asdf.com\\\"\\}\\]\\}\\}\\} --subresource=status").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s -n default patch service test-svc --type=merge -p \\{\\\"status\\\":\\{\\\"loadBalancer\\\":\\{\\\"ingress\\\":\\[\\{\\\"hostname\\\":\\\"asdf.com\\\"\\}\\]\\}\\}\\} --subresource=status").and_return(response)
       kubernetes_client.set_load_balancer_hostname(svc, "asdf.com")
     end
   end
@@ -273,7 +273,7 @@ RSpec.describe Kubernetes::Client do
         "items" => ["metadata" => {"name" => "svc", "namespace" => "default", "creationTimestamp" => "2024-01-03T00:00:00Z"}],
       }.to_json
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(@response, 0)
-      allow(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
+      allow(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
       expect(kubernetes_client.instance_variable_get(:@kubernetes_cluster)).to receive(:reload).at_least(:once)
       expect(kubernetes_client.instance_variable_get(:@load_balancer)).to receive(:reload).at_least(:once)
     end
@@ -283,7 +283,7 @@ RSpec.describe Kubernetes::Client do
         "items" => [],
       }.to_json
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(response, 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
       expect(kubernetes_client.any_lb_services_modified?).to be(true)
     end
 
@@ -321,7 +321,7 @@ RSpec.describe Kubernetes::Client do
         ],
       }.to_json
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(response, 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
 
       allow(kubernetes_cluster).to receive_messages(
         vm_diff_for_lb: [[], []],
@@ -341,7 +341,7 @@ RSpec.describe Kubernetes::Client do
         ],
       }.to_json
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(@response, 0)
-      allow(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
+      allow(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
     end
 
     it "reconciles with pre existing lb with not ready loadbalancer" do
@@ -375,7 +375,7 @@ RSpec.describe Kubernetes::Client do
       session = Net::SSH::Connection::Session.allocate
       kubernetes_client = described_class.new(instance_double(KubernetesCluster, services_lb: nil), session)
       response = Net::SSH::Connection::Session::StringWithExitstatus.new({"items" => [{}]}.to_json, 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
       expect { kubernetes_client.sync_kubernetes_services }.to raise_error("services load balancer does not exist.")
     end
   end

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -591,6 +591,18 @@ RSpec.describe Validation do
     end
   end
 
+  describe "#validate_kubernetes_location" do
+    it "accepts kubernetes-supported locations" do
+      Option.kubernetes_locations.each do |location|
+        expect(described_class.validate_kubernetes_location(location.id)).to be_nil
+      end
+    end
+
+    it "rejects locations that do not support kubernetes" do
+      expect { described_class.validate_kubernetes_location(Location::HETZNER_HEL1_ID) }.to raise_error described_class::ValidationFailed
+    end
+  end
+
   describe "#validate_private_location_name" do
     it "validates aws region names" do
       expect { described_class.validate_provider_location_name("aws", "us-west-2") }.not_to raise_error

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe KubernetesCluster do
     it "returns the kubernetesVersion field from the kubeadm-config ConfigMap" do
       cluster_config = "apiServer: {}\nkubernetesVersion: v1.34.0\n"
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(cluster_config, 0)
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf -n kube-system get cm kubeadm-config -o jsonpath='{.data.ClusterConfiguration}'").and_return(response)
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s -n kube-system get cm kubeadm-config -o jsonpath='{.data.ClusterConfiguration}'").and_return(response)
       expect(kc.kubeadm_recorded_version).to eq("v1.34.0")
     end
   end
@@ -150,8 +150,8 @@ RSpec.describe KubernetesCluster do
       LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 80, dst_port: 30000)
       lb_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate({"items" => []}), 0)
       pv_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate({"items" => []}), 0)
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(lb_response).ordered
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv -ojson").and_return(pv_response).ordered
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(lb_response).ordered
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(pv_response).ordered
 
       expect(kc.check_pulse(session:, previous_pulse: down_pulse)[:reading]).to eq("up")
       expect(kc.reload.sync_kubernetes_services_set?).to be true
@@ -160,14 +160,14 @@ RSpec.describe KubernetesCluster do
     it "checks pulse on with no changes to the internal services" do
       lb_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate({"items" => []}), 0)
       pv_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate({"items" => []}), 0)
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(lb_response).ordered
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv -ojson").and_return(pv_response).ordered
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(lb_response).ordered
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(pv_response).ordered
 
       expect(kc.check_pulse(session:, previous_pulse: up_pulse)[:reading]).to eq("up")
     end
 
     it "checks pulse and fails" do
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_raise(Sshable::SshError)
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_raise(Sshable::SshError)
       expect(kc.check_pulse(session:, previous_pulse: down_pulse)[:reading]).to eq("down")
     end
 
@@ -180,8 +180,8 @@ RSpec.describe KubernetesCluster do
 
       lb_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate({"items" => []}), 0)
       pv_response = Net::SSH::Connection::Session::StringWithExitstatus.new(pv_json, 0)
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(lb_response).ordered
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv -ojson").and_return(pv_response).ordered
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(lb_response).ordered
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(pv_response).ordered
       expect(kc.check_pulse(session:, previous_pulse: up_pulse)[:reading]).to eq("down")
 
       page = Page.from_tag_parts("KubernetesClusterPVMigrationStuck", kc.id)
@@ -198,8 +198,8 @@ RSpec.describe KubernetesCluster do
 
       lb_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate({"items" => []}), 0)
       pv_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate({"items" => []}), 0)
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(lb_response).ordered
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv -ojson").and_return(pv_response).ordered
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(lb_response).ordered
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(pv_response).ordered
 
       expect(kc.check_pulse(session:, previous_pulse: up_pulse)[:reading]).to eq("up")
       page = Page.from_tag_parts("KubernetesClusterPVMigrationStuck", kc.id)
@@ -329,7 +329,7 @@ RSpec.describe KubernetesCluster do
 
   describe "#cluster_health_report" do
     def stub_kubectl(session, command, return_value)
-      cmd = "sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf #{command}"
+      cmd = "sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s #{command}"
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(return_value, 0)
       expect(session).to receive(:_exec!).with(cmd).and_return(response)
     end
@@ -457,20 +457,20 @@ RSpec.describe KubernetesCluster do
 
     it "returns true when every functional node has Ready=True" do
       body = JSON.generate("items" => [{"metadata" => {"name" => node.name}, "status" => {"conditions" => [{"type" => "Ready", "status" => "True"}]}}])
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
       expect(kc.reload.all_functional_nodes_ready?).to be true
     end
 
     it "returns false when a functional node reports Ready=False" do
       body = JSON.generate("items" => [{"metadata" => {"name" => node.name}, "status" => {"conditions" => [{"type" => "Ready", "status" => "False"}]}}])
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
       expect(kc.reload.all_functional_nodes_ready?).to be false
     end
 
     it "returns false when a functional node is missing from the API response" do
       node
       body = JSON.generate("items" => [])
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
       expect(kc.reload.all_functional_nodes_ready?).to be false
     end
   end

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -299,5 +299,10 @@ LOCK
       expect(sa).to receive(:_cmd).with("common/bin/daemonizer2 run test_unit sudo\\ host/bin/setup-vm\\ prep\\ test_unit", stdin: stdin_data, log: true)
       sa.d_run(unit_name, run_command, stdin: stdin_data)
     end
+
+    it "calls cmd with the correct journalctl command for the unit" do
+      expect(sa).to receive(:_cmd).with("sudo journalctl -u test_unit --no-pager")
+      sa.d_logs(unit_name)
+    end
   end
 end

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -95,6 +95,10 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
         described_class.assemble(name: "somename", project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 2, private_subnet_id: subnet.id)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: control_plane_node_count"
 
+      expect {
+        described_class.assemble(name: "somename", project_id: customer_project.id, location_id: Location::HETZNER_HEL1_ID, cp_node_count: 3, private_subnet_id: subnet.id)
+      }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: location"
+
       p = Project.create(name: "another")
       subnet.update(project_id: p.id)
       expect {

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -657,7 +657,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       client = Kubernetes::Client.new(kubernetes_cluster, session)
       expect(kubernetes_cluster).to receive(:client).and_return(client)
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f kubernetes/manifests/ubicsi").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s apply -f kubernetes/manifests/ubicsi").and_return(response)
       expect { nx.install_csi }.to hop("wait")
     end
   end
@@ -681,7 +681,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       namespace: kube-system
       YAML
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(get_cm, 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf -n kube-system get cm coredns -oyaml").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s -n kube-system get cm coredns -oyaml").and_return(response)
       expect { nx.sync_internal_dns_config }.to hop("wait")
     end
 
@@ -772,7 +772,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       YAML
 
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(get_cm, 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf -n kube-system get cm coredns -oyaml").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s -n kube-system get cm coredns -oyaml").and_return(response)
       expect(sshable).to receive(:_cmd).with("sudo kubectl --kubeconfig /etc/kubernetes/admin.conf replace -f -", stdin: replace_cm)
       expect { nx.sync_internal_dns_config }.to hop("wait")
     end
@@ -812,7 +812,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       YAML
 
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(invalid_corefile, 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf -n kube-system get cm coredns -oyaml").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s -n kube-system get cm coredns -oyaml").and_return(response)
       expect { nx.sync_internal_dns_config }.to raise_error(RuntimeError, "Kubernetes block not found.")
     end
 
@@ -835,7 +835,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       YAML
 
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(broken_corefile, 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf -n kube-system get cm coredns -oyaml").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s -n kube-system get cm coredns -oyaml").and_return(response)
       expect { nx.sync_internal_dns_config }.to raise_error(RuntimeError, "Closing brace not found.")
     end
   end

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -192,13 +192,13 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       va_list = {"items" => [{
         "spec" => {"nodeName" => nx.kubernetes_node.name, "attacher" => "csi.ubicloud.com"},
       }]}
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get volumeattachments -ojson").and_return(success_response.replace(JSON.generate(va_list)))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get volumeattachments -ojson").and_return(success_response.replace(JSON.generate(va_list)))
       expect { nx.wait_for_detach }.to nap(5)
     end
 
     it "hops to wait_for_copy when no VolumeAttachments reference this node" do
       va_list = {"items" => []}
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get volumeattachments -ojson").and_return(success_response.replace(JSON.generate(va_list)))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get volumeattachments -ojson").and_return(success_response.replace(JSON.generate(va_list)))
       expect { nx.wait_for_detach }.to hop("wait_for_copy")
     end
 
@@ -206,7 +206,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       va_list = {"items" => [{
         "spec" => {"nodeName" => nx.kubernetes_node.name, "attacher" => "other-csi-driver"},
       }]}
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get volumeattachments -ojson").and_return(success_response.replace(JSON.generate(va_list)))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get volumeattachments -ojson").and_return(success_response.replace(JSON.generate(va_list)))
       expect { nx.wait_for_detach }.to hop("wait_for_copy")
     end
 
@@ -214,7 +214,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       va_list = {"items" => [{
         "spec" => {"nodeName" => "other-node", "attacher" => "csi.ubicloud.com"},
       }]}
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get volumeattachments -ojson").and_return(success_response.replace(JSON.generate(va_list)))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get volumeattachments -ojson").and_return(success_response.replace(JSON.generate(va_list)))
       expect { nx.wait_for_detach }.to hop("wait_for_copy")
     end
   end
@@ -236,13 +236,13 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
           "nodeAffinity" => {"required" => {"nodeSelectorTerms" => [{"matchExpressions" => [{"values" => [nx.kubernetes_node.name]}]}]}},
         },
       }]}
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv -ojson").and_return(success_response.replace(JSON.generate(pv_list)))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(success_response.replace(JSON.generate(pv_list)))
       expect { nx.wait_for_copy }.to nap(15)
     end
 
     it "hops to remove_node_from_cluster when no PVs reference this node" do
       pv_list = {"items" => []}
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv -ojson").and_return(success_response.replace(JSON.generate(pv_list)))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(success_response.replace(JSON.generate(pv_list)))
       expect { nx.wait_for_copy }.to hop("remove_node_from_cluster")
     end
 
@@ -251,7 +251,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
         "metadata" => {"annotations" => {"csi.ubicloud.com/old-pvc-object" => "some-data"}},
         "spec" => {"nodeAffinity" => {"required" => {"nodeSelectorTerms" => [{"matchExpressions" => [{"values" => ["other-node"]}]}]}}},
       }]}
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv -ojson").and_return(success_response.replace(JSON.generate(pv_list)))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(success_response.replace(JSON.generate(pv_list)))
       expect { nx.wait_for_copy }.to hop("remove_node_from_cluster")
     end
 
@@ -263,7 +263,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
           "nodeAffinity" => {"required" => {"nodeSelectorTerms" => [{"matchExpressions" => [{"values" => [nx.kubernetes_node.name]}]}]}},
         },
       }]}
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv -ojson").and_return(success_response.replace(JSON.generate(pv_list)))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(success_response.replace(JSON.generate(pv_list)))
       expect { nx.wait_for_copy }.to hop("remove_node_from_cluster")
     end
   end
@@ -297,14 +297,14 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       nx.kubernetes_node.update(kubernetes_nodepool_id: kn.id)
       expect(node_sshable).to receive(:_cmd).with("sudo kubeadm reset --force")
       expect(cluster.services_lb).to receive(:detach_vm).with(nx.kubernetes_node.vm)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf delete node vm").and_return(success_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete node vm").and_return(success_response)
       expect { nx.remove_node_from_cluster }.to hop("destroy")
     end
 
     it "runs kubeadm reset and remove cluster node from api_server_lb and deletes the node from cluster" do
       expect(node_sshable).to receive(:_cmd).with("sudo kubeadm reset --force")
       expect(cluster.api_server_lb).to receive(:detach_vm).with(nx.kubernetes_node.vm)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf delete node vm").and_return(success_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete node vm").and_return(success_response)
       expect { nx.remove_node_from_cluster }.to hop("destroy")
     end
   end

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -402,22 +402,22 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     end
 
     it "naps if no pending or approved csr exists yet" do
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get csr --sort-by=.metadata.creationTimestamp | awk /Approved/' && /kubelet-serving/ && /'test-vm'/ {print $1}' | tail -1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("\n", 0))
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get csr --sort-by=.metadata.creationTimestamp | awk /Pending/' && /kubelet-serving/ && /'test-vm'/ {print $1}' | tail -1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("\n", 0))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get csr --sort-by=.metadata.creationTimestamp | awk /Approved/' && /kubelet-serving/ && /'test-vm'/ {print $1}' | tail -1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("\n", 0))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get csr --sort-by=.metadata.creationTimestamp | awk /Pending/' && /kubelet-serving/ && /'test-vm'/ {print $1}' | tail -1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("\n", 0))
       expect { prog.approve_new_csr }.to nap(5)
     end
 
     it "skips approve if the csr is already approved" do
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get csr --sort-by=.metadata.creationTimestamp | awk /Approved/' && /kubelet-serving/ && /'test-vm'/ {print $1}' | tail -1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("csr-abc123\n", 0))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get csr --sort-by=.metadata.creationTimestamp | awk /Approved/' && /kubelet-serving/ && /'test-vm'/ {print $1}' | tail -1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("csr-abc123\n", 0))
       expect { prog.approve_new_csr }.to exit({node_id: prog.node.id})
       expect(kubernetes_cluster.reload.sync_internal_dns_config_set?).to be true
       expect(kubernetes_cluster.reload.sync_worker_mesh_set?).to be true
     end
 
     it "approves the csr when it is pending" do
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get csr --sort-by=.metadata.creationTimestamp | awk /Approved/' && /kubelet-serving/ && /'test-vm'/ {print $1}' | tail -1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("\n", 0))
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get csr --sort-by=.metadata.creationTimestamp | awk /Pending/' && /kubelet-serving/ && /'test-vm'/ {print $1}' | tail -1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("csr-abc123\n", 0))
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf certificate approve csr-abc123").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("approved", 0))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get csr --sort-by=.metadata.creationTimestamp | awk /Approved/' && /kubelet-serving/ && /'test-vm'/ {print $1}' | tail -1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("\n", 0))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get csr --sort-by=.metadata.creationTimestamp | awk /Pending/' && /kubelet-serving/ && /'test-vm'/ {print $1}' | tail -1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("csr-abc123\n", 0))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s certificate approve csr-abc123").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("approved", 0))
       expect { prog.approve_new_csr }.to exit({node_id: prog.node.id})
       expect(kubernetes_cluster.reload.sync_internal_dns_config_set?).to be true
       expect(kubernetes_cluster.reload.sync_worker_mesh_set?).to be true

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -98,6 +98,8 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(kubernetes_cluster.nodes.count).to eq(2)
 
       expect { prog.start }.to hop("bootstrap_rhizome")
+      expect(prog.strand.stack.first["deadline_target"]).to be_nil
+      expect(Time.parse(prog.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 20 * 60)
       kubernetes_cluster.reload
 
       expect(kubernetes_cluster.nodes.count).to eq(3)
@@ -222,19 +224,30 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect { prog.init_cluster }.to nap(10)
     end
 
-    it "naps and does nothing (for now) if the init_cluster script is failed" do
+    it "pages and naps if the init_cluster script is failed" do
       expect(prog.vm.sshable).to receive(:d_check).with("init_kubernetes_cluster").and_return("Failed")
-      expect { prog.init_cluster }.to nap(65536)
+      expect(prog.vm.sshable).to receive(:d_logs).with("init_kubernetes_cluster").and_return("error logs")
+      expect { prog.init_cluster }.to nap(30)
+      expect(Page.from_tag_parts("KubernetesNodeInitClusterFailed", prog.node.ubid)).not_to be_nil
     end
 
-    it "pops if the init_cluster script is successful" do
+    it "resolves any open page and hops if the init_cluster script is successful" do
+      Prog::PageNexus.assemble("existing", ["KubernetesNodeInitClusterFailed", prog.node.ubid], prog.node.ubid)
+      expect(prog.vm.sshable).to receive(:d_check).with("init_kubernetes_cluster").and_return("Succeeded")
+      expect { prog.init_cluster }.to hop("install_cni")
+      page = Page.from_tag_parts("KubernetesNodeInitClusterFailed", prog.node.ubid)
+      expect(page.resolve_set?).to be true
+    end
+
+    it "hops if the init_cluster script is successful and no page exists" do
+      expect(Page.from_tag_parts("KubernetesNodeInitClusterFailed", prog.node.ubid)).to be_nil
       expect(prog.vm.sshable).to receive(:d_check).with("init_kubernetes_cluster").and_return("Succeeded")
       expect { prog.init_cluster }.to hop("install_cni")
     end
 
-    it "naps forever if the daemonizer check returns something unknown" do
+    it "naps if the daemonizer check returns something unknown" do
       expect(prog.vm.sshable).to receive(:d_check).with("init_kubernetes_cluster").and_return("Unknown")
-      expect { prog.init_cluster }.to nap(65536)
+      expect { prog.init_cluster }.to nap(30)
     end
   end
 
@@ -263,19 +276,30 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect { prog.join_control_plane }.to nap(10)
     end
 
-    it "naps and does nothing (for now) if the join_control_plane script is failed" do
+    it "pages and naps if the join_control_plane script is failed" do
       expect(prog.vm.sshable).to receive(:d_check).with("join_control_plane").and_return("Failed")
-      expect { prog.join_control_plane }.to nap(65536)
+      expect(prog.vm.sshable).to receive(:d_logs).with("join_control_plane").and_return("error logs")
+      expect { prog.join_control_plane }.to nap(30)
+      expect(Page.from_tag_parts("KubernetesNodeJoinControlPlaneFailed", prog.node.ubid)).not_to be_nil
     end
 
-    it "pops if the join_control_plane script is successful" do
+    it "resolves any open page and hops if the join_control_plane script is successful" do
+      Prog::PageNexus.assemble("existing", ["KubernetesNodeJoinControlPlaneFailed", prog.node.ubid], prog.node.ubid)
+      expect(prog.vm.sshable).to receive(:d_check).with("join_control_plane").and_return("Succeeded")
+      expect { prog.join_control_plane }.to hop("install_cni")
+      page = Page.from_tag_parts("KubernetesNodeJoinControlPlaneFailed", prog.node.ubid)
+      expect(page.resolve_set?).to be true
+    end
+
+    it "hops if the join_control_plane script is successful and no page exists" do
+      expect(Page.from_tag_parts("KubernetesNodeJoinControlPlaneFailed", prog.node.ubid)).to be_nil
       expect(prog.vm.sshable).to receive(:d_check).with("join_control_plane").and_return("Succeeded")
       expect { prog.join_control_plane }.to hop("install_cni")
     end
 
-    it "naps forever if the daemonizer check returns something unknown" do
+    it "naps if the daemonizer check returns something unknown" do
       expect(prog.vm.sshable).to receive(:d_check).with("join_control_plane").and_return("Unknown")
-      expect { prog.join_control_plane }.to nap(65536)
+      expect { prog.join_control_plane }.to nap(30)
     end
   end
 
@@ -306,19 +330,30 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect { prog.join_worker }.to nap(10)
     end
 
-    it "naps and does nothing (for now) if the join-worker-node script is failed" do
+    it "pages and naps if the join-worker-node script is failed" do
       expect(prog.vm.sshable).to receive(:d_check).with("join_worker").and_return("Failed")
-      expect { prog.join_worker }.to nap(65536)
+      expect(prog.vm.sshable).to receive(:d_logs).with("join_worker").and_return("error logs")
+      expect { prog.join_worker }.to nap(30)
+      expect(Page.from_tag_parts("KubernetesNodeJoinWorkerFailed", prog.node.ubid)).not_to be_nil
     end
 
-    it "pops if the join-worker-node script is successful" do
+    it "resolves any open page and hops if the join-worker-node script is successful" do
+      Prog::PageNexus.assemble("existing", ["KubernetesNodeJoinWorkerFailed", prog.node.ubid], prog.node.ubid)
+      expect(prog.vm.sshable).to receive(:d_check).with("join_worker").and_return("Succeeded")
+      expect { prog.join_worker }.to hop("install_cni")
+      page = Page.from_tag_parts("KubernetesNodeJoinWorkerFailed", prog.node.ubid)
+      expect(page.resolve_set?).to be true
+    end
+
+    it "hops if the join-worker-node script is successful and no page exists" do
+      expect(Page.from_tag_parts("KubernetesNodeJoinWorkerFailed", prog.node.ubid)).to be_nil
       expect(prog.vm.sshable).to receive(:d_check).with("join_worker").and_return("Succeeded")
       expect { prog.join_worker }.to hop("install_cni")
     end
 
-    it "naps for a long time if the daemonizer check returns something unknown" do
+    it "naps if the daemonizer check returns something unknown" do
       expect(prog.vm.sshable).to receive(:d_check).with("join_worker").and_return("Unknown")
-      expect { prog.join_worker }.to nap(65536)
+      expect { prog.join_worker }.to nap(30)
     end
   end
 

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -114,13 +114,13 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
 
     it "naps if the new node is not yet Ready" do
       body = JSON.generate("items" => [{"metadata" => {"name" => new_node.name}, "status" => {"conditions" => [{"type" => "Ready", "status" => "False"}]}}])
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
       expect { prog.wait_node_ready }.to nap(10)
     end
 
     it "hops to upgrade_kubeadm once every functional node is Ready" do
       body = JSON.generate("items" => [{"metadata" => {"name" => new_node.name}, "status" => {"conditions" => [{"type" => "Ready", "status" => "True"}]}}])
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
       expect { prog.wait_node_ready }.to hop("upgrade_kubeadm")
     end
   end

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -152,13 +152,13 @@ RSpec.describe Prog::Test::Kubernetes do
       KubernetesNode.create(vm_id: create_vm(name: "kngp6bg8qmx61gd46vk8cvdv6m-d2h94").id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id)
 
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("NAME                               STATUS   ROLES           AGE     VERSION\nkcz70f4yk68e0ne5n6s938pmb2-ut4i8   Ready    control-plane   7m47s   v1.34.0\nkngp6bg8qmx61gd46vk8cvdv6m-d2h94   Ready    <none>          3m48s   v1.34.0", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_return(response)
 
       expect { kubernetes_test.test_nodes }.to hop("test_csi")
     end
 
     it "fails and hops to destroy_kubernetes with fail message" do
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes").and_raise("cluster issue")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_raise("cluster issue")
       expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "Failed to run test kubectl command: cluster issue"})
 
       expect { kubernetes_test.test_nodes }.to hop("destroy_kubernetes")
@@ -169,7 +169,7 @@ RSpec.describe Prog::Test::Kubernetes do
       KubernetesNode.create(vm_id: create_vm(name: "kngp6bg8qmx61gd46vk8cvdv6m-d2h94").id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id)
 
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("NAME                               STATUS   ROLES           AGE     VERSION\nkcz70f4yk68e0ne5n6s938pmb2-ut4i8   Ready    control-plane   7m47s   v1.34.0\n", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_return(response)
 
       expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "node kngp6bg8qmx61gd46vk8cvdv6m-d2h94 not found in cluster"})
 
@@ -197,13 +197,13 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "waits for the stateful pod to become running" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.status.phase}").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.status.phase}").and_return(response)
       expect { kubernetes_test.wait_for_statefulset }.to hop("test_lsblk")
     end
 
     it "naps if pod is not running yet" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.status.phase}").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.status.phase}").and_return(response)
       expect { kubernetes_test.wait_for_statefulset }.to nap(5)
     end
   end
@@ -215,21 +215,21 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "fails if the expected mount does not appear in lsblk output" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("no-data", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- lsblk").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- lsblk").and_return(response)
       expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "No /etc/data mount found in lsblk output"})
       expect { kubernetes_test.test_lsblk }.to hop("destroy_kubernetes")
     end
 
     it "fails if expected mount is not found for data volume" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINTS\nvda 252:0 0 40G 0 disk\n|-vda1 252:1 0 39.9G 0 part /etc/resolv.conf\n| /etc/hosts\n| /etc/data", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- lsblk").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- lsblk").and_return(response)
       expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "/etc/data is mounted incorrectly: | /etc/data"})
       expect { kubernetes_test.test_lsblk }.to hop("destroy_kubernetes")
     end
 
     it "hops to test_data_write if lsblk output is ok" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINTS\nloop3 7:3 0 5G 0 loop /etc/data\nvda 252:0 0 40G 0 disk\n|-vda1 252:1 0 39.9G 0 part /etc/resolv.conf\n| /etc/hosts\n|-vda14 252:14 0 4M 0 part", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- lsblk").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- lsblk").and_return(response)
       expect { kubernetes_test.test_lsblk }.to hop("test_data_write")
     end
   end
@@ -292,7 +292,7 @@ RSpec.describe Prog::Test::Kubernetes do
       (1..3).each do |i|
         expect(sshable).to receive(:_cmd).with("cat /dev/shm/csi_data_write_#{i}.hash").and_return("hash#{i}")
         read_response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
-        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(read_response)
+        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(read_response)
         expect(sshable).to receive(:d_clean).with("csi_data_write_#{i}")
       end
       expect(kubernetes_test).to receive(:update_stack).with({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
@@ -302,7 +302,7 @@ RSpec.describe Prog::Test::Kubernetes do
     it "fails on the first file if write and read hashes don't match" do
       expect(sshable).to receive(:_cmd).with("cat /dev/shm/csi_data_write_1.hash").and_return("hash1")
       read_response = Net::SSH::Connection::Session::StringWithExitstatus.new("wrong_hash", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-1\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(read_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-1\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(read_response)
       expect(sshable).to receive(:d_clean).with("csi_data_write_1")
       expect { kubernetes_test.verify_data_write }.to hop("destroy_kubernetes")
       expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("wrong read hash for random-data-1, expected: hash1, got: wrong_hash")
@@ -321,11 +321,11 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "cordons the node, deletes the pod and hops to verify_data_after_migration" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("w1-node", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf cordon w1-node").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf uncordon w2-node").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf delete pod ubuntu-statefulset-0 --wait=false").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s cordon w1-node").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s uncordon w2-node").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete pod ubuntu-statefulset-0 --wait=false").and_return(response)
       expect { kubernetes_test.test_pod_data_migration }.to hop("verify_data_after_migration")
     end
   end
@@ -338,9 +338,9 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "naps until the pod is running" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv,pvc")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv,pvc")
       expect { kubernetes_test.verify_data_after_migration }.to nap(5)
     end
 
@@ -348,7 +348,7 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(kubernetes_test).to receive(:pod_status).and_return("Running")
       (1..3).each do |i|
         response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
-        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
+        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
       end
       expect(kubernetes_test).to receive(:increment_migration_number)
       expect { kubernetes_test.verify_data_after_migration }.to hop("test_pod_data_migration")
@@ -359,7 +359,7 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(kubernetes_test).to receive(:pod_status).and_return("Running")
       (1..3).each do |i|
         response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
-        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
+        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
       end
       expect { kubernetes_test.verify_data_after_migration }.to hop("test_normal_pod_restart")
     end
@@ -372,10 +372,10 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "saves the current node and deletes the pod and hops to verify_normal_pod_restart" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("nodename", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
       expect(kubernetes_test).to receive(:update_stack).with({"normal_pod_restart_test_node" => "nodename"})
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf delete pod ubuntu-statefulset-0 --wait=false").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete pod ubuntu-statefulset-0 --wait=false").and_return(response)
       expect { kubernetes_test.test_normal_pod_restart }.to hop("verify_normal_pod_restart")
     end
   end
@@ -387,17 +387,17 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "waits until pod is runnning" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv,pvc")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv,pvc")
       expect { kubernetes_test.verify_normal_pod_restart }.to nap(5)
     end
 
     it "verifies mount and hops to destroy kubernetes" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("nodename", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
       expect(kubernetes_test.strand).to receive(:stack).and_return([{"normal_pod_restart_test_node" => "nodename"}])
       expect(kubernetes_test).to receive(:verify_mount)
       expect { kubernetes_test.verify_normal_pod_restart }.to hop("test_rsync_retry")
@@ -405,9 +405,9 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "finds a mismatch in node name" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("othernode", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
       expect(kubernetes_test.strand).to receive(:stack).and_return([{"normal_pod_restart_test_node" => "nodename"}])
       expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "unexpected pod node change after restart, expected: nodename, got: othernode"})
       expect { kubernetes_test.verify_normal_pod_restart }.to hop("destroy_kubernetes")
@@ -415,9 +415,9 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "fails when verifying the mount" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("nodename", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
       expect(kubernetes_test.strand).to receive(:stack).and_return([{"normal_pod_restart_test_node" => "nodename"}])
       expect(kubernetes_test).to receive(:verify_mount).and_raise("some error")
       expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "some error"})
@@ -436,13 +436,13 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "uncordons nodes, cordons pod node, triggers migration and hops to kill_rsync_process" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf uncordon w1-node").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf uncordon w2-node").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s uncordon w1-node").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s uncordon w2-node").and_return(response)
 
       pod_node_response = Net::SSH::Connection::Session::StringWithExitstatus.new("w1-node", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_node_response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf cordon w1-node").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf delete pod ubuntu-statefulset-0 --wait=false").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_node_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s cordon w1-node").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete pod ubuntu-statefulset-0 --wait=false").and_return(response)
 
       expect { kubernetes_test.test_rsync_retry }.to hop("kill_rsync_process")
       expect(kubernetes_test.strand.stack.first["rsync_retry_source_node"]).to eq("w1-node")
@@ -464,14 +464,14 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "naps if pod is not yet scheduled" do
       pod_response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
       expect { kubernetes_test.kill_rsync_process }.to nap(1)
     end
 
     it "naps if rsync has not started yet" do
       expect(target_node.vm).to receive(:sshable).and_return(sshable).at_least(:once)
       pod_response = Net::SSH::Connection::Session::StringWithExitstatus.new("w2-node", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
       expect(sshable).to receive(:_cmd).with("pgrep rsync || true").and_return("")
       expect { kubernetes_test.kill_rsync_process }.to nap(1)
     end
@@ -479,7 +479,7 @@ RSpec.describe Prog::Test::Kubernetes do
     it "kills rsync and hops to verify_rsync_retry" do
       expect(target_node.vm).to receive(:sshable).and_return(sshable).at_least(:once)
       pod_response = Net::SSH::Connection::Session::StringWithExitstatus.new("w2-node", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
       expect(sshable).to receive(:_cmd).with("pgrep rsync || true").and_return("12345 rsync -az /var/lib/ubicsi/vol.img")
       expect(sshable).to receive(:_cmd).with("sudo pkill -9 rsync")
       expect { kubernetes_test.kill_rsync_process }.to hop("verify_rsync_retry")
@@ -493,9 +493,9 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "naps until pod is running" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv,pvc")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv,pvc")
       expect { kubernetes_test.verify_rsync_retry }.to nap(5)
     end
 
@@ -504,7 +504,7 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(kubernetes_test).to receive(:pod_status).and_return("Running")
       (1..3).each do |i|
         response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
-        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
+        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
       end
       expect { kubernetes_test.verify_rsync_retry }.to hop("test_chained_migration")
     end
@@ -522,14 +522,14 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "uncordons all, cordons pod node, deletes pod and hops to cordon_chained_target" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf uncordon w1-node").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf uncordon w2-node").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf uncordon w3-node").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s uncordon w1-node").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s uncordon w2-node").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s uncordon w3-node").and_return(response)
 
       pod_response = Net::SSH::Connection::Session::StringWithExitstatus.new("w1-node", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf cordon w1-node").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf delete pod ubuntu-statefulset-0 --wait=false").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s cordon w1-node").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete pod ubuntu-statefulset-0 --wait=false").and_return(response)
 
       expect { kubernetes_test.test_chained_migration }.to hop("cordon_chained_target")
       expect(kubernetes_test.strand.stack.first["chained_migration_source_node"]).to eq("w1-node")
@@ -551,14 +551,14 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "naps if pod is not yet scheduled" do
       pod_response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
       expect { kubernetes_test.cordon_chained_target }.to nap(1)
     end
 
     it "naps if rsync has not started on target node" do
       expect(target_node.vm).to receive(:sshable).and_return(sshable).at_least(:once)
       pod_response = Net::SSH::Connection::Session::StringWithExitstatus.new("w2-node", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
       expect(sshable).to receive(:_cmd).with("pgrep rsync || true").and_return("")
       expect { kubernetes_test.cordon_chained_target }.to nap(1)
     end
@@ -566,11 +566,11 @@ RSpec.describe Prog::Test::Kubernetes do
     it "cordons the rsync target, deletes pod and hops to verify_chained_migration" do
       expect(target_node.vm).to receive(:sshable).and_return(sshable).at_least(:once)
       pod_response = Net::SSH::Connection::Session::StringWithExitstatus.new("w2-node", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(pod_response)
       expect(sshable).to receive(:_cmd).with("pgrep rsync || true").and_return("12345 rsync -az /var/lib/ubicsi/vol.img")
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf cordon w2-node").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf delete pod ubuntu-statefulset-0 --wait=false").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s cordon w2-node").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete pod ubuntu-statefulset-0 --wait=false").and_return(response)
       expect { kubernetes_test.cordon_chained_target }.to hop("verify_chained_migration")
     end
   end
@@ -582,9 +582,9 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "naps until pod is running" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv,pvc")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv,pvc")
       expect { kubernetes_test.verify_chained_migration }.to nap(5)
     end
 
@@ -593,7 +593,7 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(kubernetes_test).to receive(:pod_status).and_return("Running")
       (1..3).each do |i|
         response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
-        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
+        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
       end
       expect { kubernetes_test.verify_chained_migration }.to hop("test_node_not_deleted_during_copy")
     end
@@ -611,11 +611,11 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "uncordons all nodes, retires the pod node and hops to verify_node_not_deleted_during_copy" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf uncordon w1-node").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf uncordon w2-node").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s uncordon w1-node").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s uncordon w2-node").and_return(response)
 
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("w1-node", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
 
       pod_node = kubernetes_test.kubernetes_cluster.nodepools.first.nodes.find { |n| n.name == "w1-node" }
 
@@ -647,10 +647,10 @@ RSpec.describe Prog::Test::Kubernetes do
         },
       }]}
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(pv_list), 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv -ojson").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(response)
 
       get_node_response = Net::SSH::Connection::Session::StringWithExitstatus.new("w1-node", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get node w1-node").and_return(get_node_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get node w1-node").and_return(get_node_response)
 
       expect { kubernetes_test.verify_node_not_deleted_during_copy }.to nap(15)
     end
@@ -667,9 +667,9 @@ RSpec.describe Prog::Test::Kubernetes do
         },
       }]}
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(pv_list), 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv -ojson").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(response)
 
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get node w1-node").and_raise("not found")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get node w1-node").and_raise("not found")
 
       expect { kubernetes_test.verify_node_not_deleted_during_copy }.to hop("destroy_kubernetes")
       expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("Node w1-node was removed while CSI data copy was still in progress: not found")
@@ -681,7 +681,7 @@ RSpec.describe Prog::Test::Kubernetes do
 
       pv_list = {"items" => []}
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(pv_list), 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv -ojson").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(response)
 
       expect { kubernetes_test.verify_node_not_deleted_during_copy }.to nap(15)
     end
@@ -694,19 +694,19 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "naps until pod is running" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv,pvc")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv,pvc")
       expect { kubernetes_test.verify_data_after_drain }.to nap(5)
     end
 
     it "verifies all data hashes and hops to test_reboot_nftables" do
       kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
       (1..3).each do |i|
         response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
-        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
+        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
       end
       expect { kubernetes_test.verify_data_after_drain }.to hop("test_reboot_nftables")
     end
@@ -868,10 +868,10 @@ RSpec.describe Prog::Test::Kubernetes do
         ],
       }
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(nodes_json), 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -o json").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -o json").and_return(response)
 
       response_raw = Net::SSH::Connection::Session::StringWithExitstatus.new("nodes_raw", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes").and_return(response_raw)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_return(response_raw)
 
       expect { kubernetes_test.wait_for_upgrade }.to hop("destroy_kubernetes")
       expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("Not all 3 nodes upgraded to #{kubernetes_cluster.version}:\nnodes_raw")
@@ -888,10 +888,10 @@ RSpec.describe Prog::Test::Kubernetes do
         ],
       }
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(nodes_json), 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -o json").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -o json").and_return(response)
 
       response_raw = Net::SSH::Connection::Session::StringWithExitstatus.new("nodes_raw", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes").and_return(response_raw)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_return(response_raw)
 
       expect { kubernetes_test.wait_for_upgrade }.to hop("destroy_kubernetes")
       expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("Not all 1 nodes upgraded to #{kubernetes_cluster.version}:\nnodes_raw")
@@ -905,7 +905,7 @@ RSpec.describe Prog::Test::Kubernetes do
         "items" => [{"status" => {"nodeInfo" => {"kubeletVersion" => "#{kubernetes_cluster.version}.0"}}}] * 3,
       }
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(nodes_json), 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -o json").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -o json").and_return(response)
 
       expect { kubernetes_test.wait_for_upgrade }.to hop("verify_data_after_upgrade")
     end
@@ -918,19 +918,19 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "naps until pod is running" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pv,pvc")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv,pvc")
       expect { kubernetes_test.verify_data_after_upgrade }.to nap(5)
     end
 
     it "verifies all data hashes and hops to destroy_kubernetes" do
       kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
       (1..3).each do |i|
         response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
-        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
+        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
       end
       expect { kubernetes_test.verify_data_after_upgrade }.to hop("destroy_kubernetes")
     end
@@ -938,9 +938,9 @@ RSpec.describe Prog::Test::Kubernetes do
     it "sets fail_message and hops to destroy_kubernetes if a hash is wrong" do
       kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("corrupted_hash", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-1\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-1\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
 
       expect { kubernetes_test.verify_data_after_upgrade }.to hop("destroy_kubernetes")
       expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("data hash changed after upgrade for random-data-1, expected: hash1, got: corrupted_hash")
@@ -1080,7 +1080,7 @@ RSpec.describe Prog::Test::Kubernetes do
       kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       (1..3).each do |i|
         response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
-        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
+        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
       end
       kubernetes_test.verify_data_hashes("migration")
     end
@@ -1088,7 +1088,7 @@ RSpec.describe Prog::Test::Kubernetes do
     it "sets fail_message when a hash does not match" do
       kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("wronghash", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-1\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-1\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
       expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "data hash changed after migration for random-data-1, expected: hash1, got: wronghash"})
       expect { kubernetes_test.verify_data_hashes("migration") }.to hop("destroy_kubernetes")
     end


### PR DESCRIPTION
**Validate kubernetes cluster location in assemble**

Previously KubernetesClusterNexus.assemble accepted any visible project location, even ones not in Option.kubernetes_locations. The UI option tree restricted the choice, but the API layer did not, so an API caller could create a cluster in an unsupported location.

Add Validation.validate_kubernetes_location and call it from assemble alongside the other input validations.

**Register deadline and journalctl-log daemonizer failures in node provision**

Adds a 30 minute deadline at the start of ProvisionKubernetesNode and refactors init_cluster, join_control_plane, and join_worker to follow the upgrade_kubernetes_node daemonizer pattern. On Failed state, each emits the unit's journalctl output via a new Sshable#d_logs helper.

**Cap kubectl request time at 30s to avoid strand apoptosis**

Kubernetes::Client#kubectl used session.exec! directly with no timeout, so a slow or unreachable API server in sync_kubernetes_services could hang past the strand's apoptosis deadline. Pass --request-timeout=30s to every kubectl invocation to bound each call.