### PR TITLE
Add VmStorageVolume#restart_daemon

### DIFF
--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -90,6 +90,21 @@ class VmStorageVolume < Sequel::Model
       stdin: key_encryption_key_1.secret_key_material_hash.to_json,
     )
   end
+
+  def restart_daemon
+    fail "restart_daemon only supported for vm storage volumes with vhost block backend" unless vhost_block_backend
+    fail "restart_daemon requires an encrypted vm storage volume" unless key_encryption_key_1
+    fail "VM must be stopped before restarting the vhost backend daemon" unless ["stopped", "stopped by admin"].include?(vm.display_state)
+
+    vm.vm_host.sshable.cmd(
+      "sudo host/bin/storage-restart-daemon :vm_name :storage_device :disk_index :vhost_block_backend_version",
+      vm_name: vm.inhost_name,
+      storage_device: storage_device.name,
+      disk_index:,
+      vhost_block_backend_version: vhost_block_backend.version,
+      stdin: key_encryption_key_1.secret_key_material_hash.to_json,
+    )
+  end
 end
 
 # Table: vm_storage_volume

--- a/rhizome/host/bin/storage-restart-daemon
+++ b/rhizome/host/bin/storage-restart-daemon
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require_relative "../lib/storage_volume"
+
+unless ARGV.length == 4
+  puts "usage: storage-restart-daemon vm_name storage_device_name disk_index ubiblk_version"
+  exit 1
+end
+vm_name, device, disk_index, vhost_block_backend_version = ARGV
+
+key_wrapping_secrets = JSON.parse($stdin.read)
+
+unless key_wrapping_secrets["key"]
+  puts "expected key in stdin payload"
+  exit 1
+end
+
+StorageVolume.new(
+  vm_name,
+  {
+    "disk_index" => disk_index,
+    "storage_device" => device,
+    "encrypted" => true,
+    "vhost_block_backend_version" => vhost_block_backend_version,
+  },
+).vhost_backend_start(key_wrapping_secrets)

--- a/spec/model/vm_storage_volume_spec.rb
+++ b/spec/model/vm_storage_volume_spec.rb
@@ -160,4 +160,53 @@ RSpec.describe VmStorageVolume do
       expect { volume.dump_metadata }.to raise_error(RuntimeError, "dump_metadata only supported for vm storage volumes with vhost block backend version v0.4.0+")
     end
   end
+
+  describe "#restart_daemon" do
+    let(:vbb) { VhostBlockBackend.create(version_code: 400, allocation_weight: 100, vm_host_id: vm_host.id) }
+    let(:vm) {
+      project = Project.create(name: "test-project")
+      vm_host = create_vm_host
+      storage_device = StorageDevice.create(vm_host_id: vm_host.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100)
+      vm = Prog::Vm::Nexus.assemble("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7", project.id).subject
+      vm.vm_storage_volumes.first.update(vhost_block_backend_id: vbb.id, vring_workers: 2, storage_device_id: storage_device.id)
+      vm.update(vm_host_id: vm_host.id)
+      vm.strand.update(label: "stopped")
+      vm
+    }
+    let(:volume) { vm.vm_storage_volumes.first }
+
+    it "runs storage-restart-daemon command with the kek as stdin" do
+      expect(volume.vm.vm_host.sshable).to receive(:_cmd).with(
+        "sudo host/bin/storage-restart-daemon #{vm.inhost_name} DEFAULT 0 v0.4.0",
+        stdin: volume.key_encryption_key_1.secret_key_material_hash.to_json,
+      ).and_return("")
+
+      volume.restart_daemon
+    end
+
+    it "accepts a VM stopped by admin" do
+      vm.strand.update(label: "stopped_by_admin")
+      expect(volume.vm.vm_host.sshable).to receive(:_cmd).with(
+        "sudo host/bin/storage-restart-daemon #{vm.inhost_name} DEFAULT 0 v0.4.0",
+        stdin: volume.key_encryption_key_1.secret_key_material_hash.to_json,
+      ).and_return("")
+
+      volume.restart_daemon
+    end
+
+    it "fails when VM is not stopped" do
+      vm.strand.update(label: "wait")
+      expect { volume.restart_daemon }.to raise_error(RuntimeError, "VM must be stopped before restarting the vhost backend daemon")
+    end
+
+    it "fails when volume is not encrypted" do
+      volume.update(key_encryption_key_1: nil)
+      expect { volume.restart_daemon }.to raise_error(RuntimeError, "restart_daemon requires an encrypted vm storage volume")
+    end
+
+    it "fails when volume does not have a vhost block backend" do
+      volume.update(vhost_block_backend_id: nil, vring_workers: nil)
+      expect { volume.restart_daemon }.to raise_error(RuntimeError, "restart_daemon only supported for vm storage volumes with vhost block backend")
+    end
+  end
 end


### PR DESCRIPTION
### Rhizome: Add host/bin/storage-restart-daemon 

Add `host/bin/storage-restart-daemon` which restarts the systemd unit of a ubiblk disk while providing the KEK via pipe.

An example usecase is when a UMI backed volume has failed because of ongoing object store issues, and we want to retry after the object store issues have been resolved.

An example invocation:

```
host/bin/storage-restart-daemon vm123456 DEFAULT 1 v0.4.0
```

Positional args:
- vm name
- storage device name
- disk index
- ubiblk version

Stdin: key-encryption-key json required to decrypt disk's secrets.

### Add VmStorageVolume#restart_daemon 

Restart the storage daemon of a volume. The daemon can fail to fetch remote stripes when the remote object storage is unavailable; this lets us retry everything again once the remote object storage is back.

To use this, operator will need to incr_stop the VM, restart storage, and then incr_start the VM. We can automate this flow in a separate change.