### PR TITLE
Postgres timeline wait for walg creds

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -496,6 +496,15 @@ class PostgresServer < Sequel::Model
     vm.sshable.cmd("sudo systemctl restart wal-g") unless resource.use_old_walg_command_set?
   end
 
+  def walg_credentials_ready?
+    return true if timeline.blob_storage.nil?
+
+    vm.sshable.cmd("sudo -u postgres /usr/bin/wal-g st check read --config /etc/postgresql/wal-g.env")
+    true
+  rescue Sshable::SshError
+    false
+  end
+
   def install_rhizome(install_specs: false)
     Strand.create(prog: "InstallRhizome", label: "start", stack: [{subject_id: vm.id, target_folder: "postgres", install_specs:}])
   end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -170,7 +170,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
 
     # AttachRolePolicy is eventually consistent on AWS.
     # Wait for wal-g to be able to connect to storage before moving.
-    unless walg_credentials_ready?
+    unless postgres_server.walg_credentials_ready?
       register_deadline("wait", 10 * 60)
       nap 5
     end
@@ -941,15 +941,6 @@ SQL
 
   def version
     postgres_server.version
-  end
-
-  def walg_credentials_ready?
-    return true if postgres_server.timeline.blob_storage.nil?
-
-    vm.sshable.cmd("sudo -u postgres /usr/bin/wal-g st check read --config /etc/postgresql/wal-g.env")
-    true
-  rescue Sshable::SshError
-    false
   end
 
   def daemonized_restart

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -39,7 +39,8 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   end
 
   label def wait_leader
-    nap 5 if postgres_timeline.leader.nil? || postgres_timeline.leader.strand.label != "wait"
+    leader = postgres_timeline.leader
+    nap 5 if leader.nil? || leader.strand.label != "wait" || !leader.walg_credentials_ready?
     hop_wait
   end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -696,6 +696,26 @@ RSpec.describe PostgresServer do
     end
   end
 
+  describe "#walg_credentials_ready?" do
+    it "returns true without ssh when timeline has no blob storage" do
+      expect(postgres_server.timeline.blob_storage).to be_nil
+      expect(postgres_server.vm.sshable).not_to receive(:_cmd)
+      expect(postgres_server.walg_credentials_ready?).to be true
+    end
+
+    it "runs wal-g st check read and returns true on success" do
+      expect(timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster))
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo -u postgres /usr/bin/wal-g st check read --config /etc/postgresql/wal-g.env")
+      expect(postgres_server.walg_credentials_ready?).to be true
+    end
+
+    it "returns false when ssh check raises" do
+      expect(timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster))
+      expect(postgres_server.vm.sshable).to receive(:_cmd).and_raise(Sshable::SshError.new("cmd", "", "denied", 1, nil))
+      expect(postgres_server.walg_credentials_ready?).to be false
+    end
+  end
+
   describe "#install_rhizome" do
     it "has a shortcut to install Rhizome" do
       st = postgres_server.install_rhizome

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -286,12 +286,24 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       expect { nx.wait_leader }.to nap(5)
     end
 
-    it "hops if leader is ready" do
+    it "hops if leader is ready and wal-g credentials work" do
       create_minio_cluster
       resource = create_postgres_resource(project:, location_id:)
-      create_postgres_server(resource:, timeline: postgres_timeline).strand.update(label: "wait")
+      server = create_postgres_server(resource:, timeline: postgres_timeline)
+      server.strand.update(label: "wait")
+      expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).with("sudo -u postgres /usr/bin/wal-g st check read --config /etc/postgresql/wal-g.env")
 
       expect { nx.wait_leader }.to hop("wait")
+    end
+
+    it "naps if leader is in wait but wal-g credentials haven't propagated yet" do
+      create_minio_cluster
+      resource = create_postgres_resource(project:, location_id:)
+      server = create_postgres_server(resource:, timeline: postgres_timeline)
+      server.strand.update(label: "wait")
+      expect(nx.postgres_timeline.leader.vm.sshable).to receive(:_cmd).and_raise(Sshable::SshError.new("cmd", "", "denied", 1, nil))
+
+      expect { nx.wait_leader }.to nap(5)
     end
   end
 


### PR DESCRIPTION
## Move walg_credentials_ready? to PostgresServer
The probe that asks wal-g whether its current credentials can talk to
the configured blob storage is a property of the server, not of the
nexus driving it: it only needs the timeline (for blob_storage) and
the server's vm.sshable, both of which the PostgresServer model
already exposes. Keeping it on the prog forced callers from outside
the server-nexus instance to either go through that strand or
duplicate the SSH call.

Lift it onto PostgresServer with the same body and the same
Sshable::SshError swallowing semantics so existing callers
(configure_walg_credentials in PostgresServerNexus) behave
identically, and so the timeline nexus can call it on the leader in
a follow-up commit.

## Wait for wal-g credentials before hopping to wait
PostgresTimelineNexus#wait_leader hopped to `wait` as soon as the
leader strand reached `wait`, which immediately kicked off
take_backup on the new timeline. On GCP, switch_to_new_timeline
writes wal-g.env with the new bucket prefix synchronously, but the
service account that backs that bucket is created later (by
attach_s3_policy_if_needed via the configure_s3_new_timeline
semaphore), and a fresh service account's objectAdmin binding on
its bucket takes several minutes to propagate. During that window
every take_backup invocation crashes in ~1 s with HTTP 403
(storage.objects.create denied). The strand's tight wait ->
take_backup loop occasionally catches a momentary daemonizer
InProgress between d_run and the unit-failure, falls through
need_backup?, and naps 20 * 60 in PostgresTimelineNexus#wait. Two
consecutive 20-minute naps before IAM converges is the 20-40 minute
stall observed on the first backup of every postgres upgrade on
GCP. AWS does not hit this because AttachRolePolicy on an existing
instance-attached role propagates in ~30 s rather than minutes.

Gate wait_leader's hop_wait on leader.walg_credentials_ready?.
While IAM has not converged, the timeline strand naps 10 s instead
of starting backups that are doomed to fail.