### PR TITLE
Pin third-party actions to commit SHAs

### DIFF
--- a/.github/actions/setup-clover/action.yml
+++ b/.github/actions/setup-clover/action.yml
@@ -29,7 +29,7 @@ runs:
         until pg_isready -q; do sleep 1; done
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
       with:
         ruby-version: .tool-versions
         bundler-cache: true
@@ -47,7 +47,7 @@ runs:
 
     - name: Set up Node.js
       if: ${{ inputs.setup-node == 'true' }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: "package.json"
         cache: "npm"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,14 +37,14 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -56,14 +56,14 @@ jobs:
 
       - name: Log in to Docker Hub
         if: ${{ env.PUSH_IMAGE == 'true' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload digest
         if: ${{ env.PUSH_IMAGE == 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ matrix.runner }}
           path: /tmp/digests/*
@@ -94,18 +94,18 @@ jobs:
       - docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: digests-*
           merge-multiple: true
           path: /tmp/digests
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -116,7 +116,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover
@@ -33,7 +33,7 @@ jobs:
       run: bundle exec rake linter:erb_formatter
 
     - name: Cache rubocop
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: /home/runner/.cache/rubocop_cache
         key: ${{ matrix.runs-on }}-rubocop-cache-${{ hashFiles('Gemfile.lock', '.rubocop.yml') }}
@@ -84,7 +84,7 @@ jobs:
 
     - name: Archive code coverage results
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: code-coverage-report-${{ matrix.runs-on }}
         path: coverage/

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -35,13 +35,13 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: 'cli/go.mod'
 
@@ -57,7 +57,7 @@ jobs:
       run: "cd cli && go fmt && git diff --stat --exit-code"
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
         version: v2.1.5
         working-directory: cli

--- a/.github/workflows/csi-build.yml
+++ b/.github/workflows/csi-build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubicloud-standard-2
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -65,10 +65,10 @@ jobs:
     runs-on: ubicloud-standard-8
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
         with:
           ruby-version: .tool-versions
 
@@ -80,11 +80,11 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -94,13 +94,13 @@ jobs:
 
       - name: Log in to Docker Hub
         if: ${{ env.PUSH_IMAGE == 'true' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: kubernetes/csi
           platforms: linux/amd64

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover
@@ -39,7 +39,7 @@ jobs:
 
     - name: Send notification if failed
       if: ${{ failure() && github.ref_name == 'main' }}
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         webhook: ${{ secrets.SLACK_WEBHOOK_PAGER_URL }}
         webhook-type: incoming-webhook

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,10 +59,10 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup SSH access
-      uses: ubicloud/ssh-runner@v2
+      uses: ubicloud/ssh-runner@b6ccad69f047c476b84a54a990f89b1ea5f2a828 # v2.0
       with:
         public-ssh-key: ${{ secrets.OPERATOR_SSH_PUBLIC_KEYS }}
         wait-minutes: 0
@@ -230,7 +230,7 @@ jobs:
 
     - name: Upload logs
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: e2e-${{ matrix.provider }}-${{ github.run_id }}-logs
         path: foreman.log
@@ -275,14 +275,14 @@ jobs:
 
     - name: Upload database dump
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: e2e-${{ matrix.provider }}-${{ github.run_id }}-db-dump
         path: clover_test_dump.sql
 
     - name: Send notification if failed
       if: ${{ failure() && github.ref_name == 'main' }}
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         webhook: ${{ secrets.SLACK_WEBHOOK_PAGER_URL }}
         webhook-type: incoming-webhook
@@ -323,10 +323,10 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Download e2e logs
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: e2e-aws-${{ github.run_id }}-logs
 
@@ -409,10 +409,10 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Download e2e logs
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: e2e-gcp-${{ github.run_id }}-logs
 

--- a/.github/workflows/kubernetes-csi-ci.yml
+++ b/.github/workflows/kubernetes-csi-ci.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Ruby for CSI gems
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
       env:
         BUNDLE_GEMFILE: kubernetes/csi/Gemfile
       with:

--- a/.github/workflows/monitor-ci.yml
+++ b/.github/workflows/monitor-ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover

--- a/.github/workflows/require_e2e.yml
+++ b/.github/workflows/require_e2e.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Evaluate require-e2e and post commit status
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const headSha = context.eventName === 'pull_request'

--- a/.github/workflows/respirate-ci.yml
+++ b/.github/workflows/respirate-ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover

--- a/.github/workflows/rhizome.yml
+++ b/.github/workflows/rhizome.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ${{matrix.runs-on}}
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/.github/workflows/trigger-e2e.yml
+++ b/.github/workflows/trigger-e2e.yml
@@ -15,7 +15,7 @@ jobs:
       runs-on: ubicloud
       steps:
         - name: Trigger E2E tests
-          uses: actions/github-script@v8
+          uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
           with:
             script: |
               // Check if the comment is from a contributor


### PR DESCRIPTION
Tags are mutable: if an action's repo is compromised, an attacker can repoint `@v6` to malicious code and every workflow consumes it on the next run. Pinning to a full-length commit SHA is the only immutable reference, and is the form GitHub recommends for third-party actions: https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

Dependabot's github-actions ecosystem (already configured) understands SHA pins with trailing version comments and will keep them current. While here, normalize `actions/download-artifact` to v8.0.1 across build.yml and e2e.yml; v8 reads v7 uploads, so it remains compatible with the `upload-artifact@v7` calls in place.