### PR TITLE
disk-full-check: add storage threshold tiers and fix restart on systemd clusters

### DIFF
--- a/rhizome/postgres/bin/disk-full-check
+++ b/rhizome/postgres/bin/disk-full-check
@@ -45,7 +45,13 @@ elif test "$bavailable" -lt "$readonly_threshold"; then
     touch "$DAT/disk-full-read-only-pending-restart-$1"
     pg_ctlcluster "$1" main reload
   elif test "$bavailable" -lt "$restart_threshold" && test -f "$DAT/disk-full-read-only-pending-restart-$1"; then
-    pg_ctlcluster "$1" main restart
+    # Terminate customer backends so new connections pick up the read-only
+    # default applied by the earlier `reload`. We cannot `pg_ctlcluster restart`
+    # here because the cluster is managed by systemd and pg_ctlcluster refuses
+    # to act on it; this service runs as postgres without sudo. `ubi_replication`
+    # is preserved so standbys keep streaming; `ubi_monitoring` is preserved
+    # so metrics scraping continues.
+    psql -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE usename NOT IN ('ubi_replication', 'ubi_monitoring') AND pid <> pg_backend_pid();" >/dev/null
     rm -f "$DAT/disk-full-read-only-pending-restart-$1"
   fi
 fi

--- a/rhizome/postgres/bin/disk-full-check
+++ b/rhizome/postgres/bin/disk-full-check
@@ -11,10 +11,20 @@ if test "$btotal" -le 68719476736; then # Smaller thresholds for disks <= 64GB (
   readonly_threshold=1073741824   # 1GB
   restart_threshold=536870912     # 512MB
   human_buffer_size=500M
-else
+elif test "$btotal" -le 137438953472; then # Smaller thresholds for disks <= 128GB (minimum cloud size)
   recover_threshold=7516192768    # 7GB
   readonly_threshold=5368709120   # 5GB
   restart_threshold=3221225472    # 3GB
+  human_buffer_size=1G
+elif test "$btotal" -le 549755813888; then # Disks between 128GB and 512GB
+  recover_threshold=10737418240   # 10GB
+  readonly_threshold=7516192768   # 7GB
+  restart_threshold=5368709120    # 5GB
+  human_buffer_size=1G
+else # all larger sizes
+  recover_threshold=$((btotal * 3 / 100))     # 3%
+  readonly_threshold=$((btotal * 2 / 100))    # 2%
+  restart_threshold=$((btotal * 1 / 100))     # 1%
   human_buffer_size=1G
 fi
 

--- a/rhizome/postgres/spec/disk_full_check_spec.rb
+++ b/rhizome/postgres/spec/disk_full_check_spec.rb
@@ -17,12 +17,29 @@ RSpec.describe "disk-full-check" do
     FileUtils.mkdir_p(File.join(dat, "16", "data"))
     FileUtils.mkdir_p(bin)
     FileUtils.touch(File.join(dat, "pg_ctl_calls"))
+    FileUtils.touch(File.join(dat, "psql_calls"))
 
     File.write(File.join(bin, "pg_ctlcluster"), <<~SH)
       #!/bin/sh
       echo "$3" >> "#{dat}/pg_ctl_calls"
     SH
     File.chmod(0o755, File.join(bin, "pg_ctlcluster"))
+
+    # Stub psql: capture the SQL passed via -c so we can assert the
+    # pg_terminate_backend invocation issued by the restart path.
+    File.write(File.join(bin, "psql"), <<~SH)
+      #!/bin/sh
+      # find the argument after -c and append to psql_calls
+      while [ $# -gt 0 ]; do
+        if [ "$1" = "-c" ]; then
+          shift
+          echo "$1" >> "#{dat}/psql_calls"
+          break
+        fi
+        shift
+      done
+    SH
+    File.chmod(0o755, File.join(bin, "psql"))
 
     File.write(File.join(bin, "fallocate"), <<~SH)
       #!/bin/sh
@@ -55,6 +72,10 @@ RSpec.describe "disk-full-check" do
 
   def pg_ctl_calls
     File.read(File.join(dat, "pg_ctl_calls")).strip
+  end
+
+  def psql_calls
+    File.read(File.join(dat, "psql_calls")).strip
   end
 
   def auto_conf_content
@@ -122,18 +143,22 @@ RSpec.describe "disk-full-check" do
   describe "critical, <3GB available" do
     before { fake_df(50, 2_000_000_000) }
 
-    it "restarts when pending restart marker exists" do
+    it "terminates customer backends when pending restart marker exists" do
       File.write(auto_conf, "default_transaction_read_only = 'on'\n")
       FileUtils.touch(pending_restart)
       run_check
-      expect(pg_ctl_calls).to eq "restart"
+      expect(pg_ctl_calls).to eq ""
+      expect(psql_calls).to include("pg_terminate_backend")
+      expect(psql_calls).to include("ubi_replication")
+      expect(psql_calls).to include("ubi_monitoring")
       expect(File.exist?(pending_restart)).to be false
     end
 
-    it "does not restart without pending restart marker" do
+    it "does not terminate backends without pending restart marker" do
       File.write(auto_conf, "default_transaction_read_only = 'on'\n")
       run_check
       expect(pg_ctl_calls).to eq ""
+      expect(psql_calls).to eq ""
     end
   end
 
@@ -183,6 +208,15 @@ RSpec.describe "disk-full-check" do
       expect(pg_ctl_calls).to eq "reload"
     end
 
+    it "terminates customer backends below 5GB when pending restart marker exists" do
+      fake_df(98, 4 * 1024**3, total: total) # 4GB < 5GB
+      File.write(auto_conf, "default_transaction_read_only = 'on'\n")
+      FileUtils.touch(pending_restart)
+      run_check
+      expect(psql_calls).to include("pg_terminate_backend")
+      expect(File.exist?(pending_restart)).to be false
+    end
+
     it "clears read-only above 10GB" do
       fake_df(90, 12 * 1024**3, total: total) # 12GB > 10GB
       File.write(auto_conf, "default_transaction_read_only = 'on'\n")
@@ -208,6 +242,14 @@ RSpec.describe "disk-full-check" do
       run_check
       expect(auto_conf_content).to include("default_transaction_read_only = 'on'")
       expect(pg_ctl_calls).to eq "reload"
+    end
+
+    it "terminates customer backends below 1% when pending restart marker exists" do
+      fake_df(99, 5 * 1024**3, total: total) # 5GB < 1% (~10.24G)
+      File.write(auto_conf, "default_transaction_read_only = 'on'\n")
+      FileUtils.touch(pending_restart)
+      run_check
+      expect(psql_calls).to include("pg_terminate_backend")
     end
 
     it "clears read-only above 3%" do

--- a/rhizome/postgres/spec/disk_full_check_spec.rb
+++ b/rhizome/postgres/spec/disk_full_check_spec.rb
@@ -37,11 +37,12 @@ RSpec.describe "disk-full-check" do
     FileUtils.rm_rf(tmpdir)
   end
 
-  def fake_df(usedp, avail)
+  def fake_df(usedp, avail, total: 107374182400)
+    used = total - avail
     File.write(File.join(bin, "df"), <<~SH)
       #!/bin/sh
       echo "Filesystem     1B-blocks          Used     Available Use% Mounted on"
-      echo "/dev/sda1      107374182400 53687091200 #{avail} #{usedp}% #{dat}"
+      echo "/dev/sda1      #{total} #{used} #{avail} #{usedp}% #{dat}"
     SH
     File.chmod(0o755, File.join(bin, "df"))
   end
@@ -133,6 +134,88 @@ RSpec.describe "disk-full-check" do
       File.write(auto_conf, "default_transaction_read_only = 'on'\n")
       run_check
       expect(pg_ctl_calls).to eq ""
+    end
+  end
+
+  # Tier boundaries (matching disk-full-check):
+  #   <= 64GB   (hobby)        recover 2GB,  readonly 1GB,   restart 512MB
+  #   <= 128GB                 recover 7GB,  readonly 5GB,   restart 3GB
+  #   <= 512GB                 recover 10GB, readonly 7GB,   restart 5GB
+  #    > 512GB  (percentage)   recover 3%,   readonly 2%,    restart 1%
+  describe "tier: <= 64GB (hobby)" do
+    let(:total) { 32 * 1024**3 } # 32GB
+
+    it "stays in margin between 1GB and 2GB available" do
+      fake_df(95, 1_500_000_000, total: total) # 1.5GB
+      run_check
+      expect(pg_ctl_calls).to eq ""
+      expect(File.exist?(human_buffer)).to be false
+    end
+
+    it "sets read-only below 1GB" do
+      fake_df(98, 900_000_000, total: total) # 0.9GB < 1GB
+      run_check
+      expect(auto_conf_content).to include("default_transaction_read_only = 'on'")
+      expect(pg_ctl_calls).to eq "reload"
+    end
+
+    it "creates a 500M human buffer above 2GB" do
+      fake_df(80, 3_000_000_000, total: total) # 3GB > 2GB
+      run_check
+      expect(File.exist?(human_buffer)).to be true
+    end
+  end
+
+  describe "tier: <= 512GB" do
+    let(:total) { 256 * 1024**3 } # 256GB
+
+    it "stays in margin between 7GB and 10GB available" do
+      fake_df(96, 8 * 1024**3, total: total) # 8GB: above 7GB, below 10GB
+      run_check
+      expect(pg_ctl_calls).to eq ""
+      expect(File.exist?(human_buffer)).to be false
+    end
+
+    it "sets read-only below 7GB" do
+      fake_df(97, 6 * 1024**3, total: total) # 6GB < 7GB
+      run_check
+      expect(auto_conf_content).to include("default_transaction_read_only = 'on'")
+      expect(pg_ctl_calls).to eq "reload"
+    end
+
+    it "clears read-only above 10GB" do
+      fake_df(90, 12 * 1024**3, total: total) # 12GB > 10GB
+      File.write(auto_conf, "default_transaction_read_only = 'on'\n")
+      FileUtils.touch(pending_restart)
+      run_check
+      expect(auto_conf_content).not_to include("default_transaction_read_only")
+      expect(pg_ctl_calls).to eq "reload"
+    end
+  end
+
+  describe "tier: > 512GB (percentage-based)" do
+    let(:total) { 1024 * 1024**3 } # 1TB -> recover 3% = 30.72GB, readonly 2% = 20.48GB, restart 1% = 10.24GB
+
+    it "stays in margin between 2% and 3%" do
+      fake_df(97, 25 * 1024**3, total: total) # 25GB: above 2%(~20.5G), below 3%(~30.7G)
+      run_check
+      expect(pg_ctl_calls).to eq ""
+      expect(File.exist?(human_buffer)).to be false
+    end
+
+    it "sets read-only below 2%" do
+      fake_df(98, 15 * 1024**3, total: total) # 15GB < 2% (~20.5G)
+      run_check
+      expect(auto_conf_content).to include("default_transaction_read_only = 'on'")
+      expect(pg_ctl_calls).to eq "reload"
+    end
+
+    it "clears read-only above 3%" do
+      fake_df(90, 40 * 1024**3, total: total) # 40GB > 3% (~30.7G)
+      File.write(auto_conf, "default_transaction_read_only = 'on'\n")
+      run_check
+      expect(auto_conf_content).not_to include("default_transaction_read_only")
+      expect(pg_ctl_calls).to eq "reload"
     end
   end
 end


### PR DESCRIPTION
## Summary

Two related fixes to `rhizome/postgres/bin/disk-full-check`:

### 1. Add storage threshold tiers for medium/large/xl disks

Raise the `default_transaction_readonly` thresholds for larger disks based on the percentage of free space left:

| Disk size              | recover | readonly | restart |
|------------------------|---------|----------|---------|
| `<= 64GB` (hobby)      | 2GB     | 1GB      | 512MB   |
| `<= 128GB`             | 7GB     | 5GB      | 3GB     |
| `<= 512GB` (new)       | 10GB    | 7GB      | 5GB     |
| `> 512GB` (new, %)     | 3%      | 2%       | 1%      |

Motivation: with the current throttling situation we still see 1–2 incidents per week of disk 100% used and server down before auto-scale completes. Higher thresholds reduce risk during expected higher service usage after the public beta announcement.

Spec gains three new `describe` blocks exercising the boundary conditions for the hobby, `<=512GB`, and `>512GB` tiers. `fake_df` is refactored to accept a `total:` keyword (default 100GB) so each tier can be tested with a representative disk size.

### 2. Terminate backends via psql instead of pg_ctlcluster restart

When `avail < restart_threshold`, the script called `pg_ctlcluster "$1" main restart`. This fails on systemd-managed clusters: `pg_ctlcluster` detects `/run/systemd/system` + active `postgresql@%v-main.service` and either redirects to `systemctl` (root) or errors out (non-root) — see `/usr/bin/pg_ctlcluster:407` from the `postgresql-common` package. The `disk-full-check` service runs as `User=postgres` without sudo, so neither branch helps.

Effect in production: marker file persisted, service exited `status=1` on every 20s tick, customer sessions opened before the readonly reload kept writing, cluster could crash on out-of-disk.

Fix: replace the restart with dropping all non-system client connections via `pg_terminate_backend`. This is the mitigation we frequently do in production as the last resort.

## Test plan

- [x] Existing spec passes
- [x] New tier-boundary specs cover hobby (≤64GB), 128GB, ≤512GB, and >512GB cases
- [x] Manual verification on a systemd-managed cluster that connections are dropped without the script exiting non-zero