### PR TITLE
Update to Ruby 4.0.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby 4.0.4
+ruby 4.0.5
 nodejs 24.12.0
 golang 1.24.0
 victoria-metrics v1.113.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci
 RUN npm run prod
 
 
-FROM docker.io/library/ruby:4.0.4-alpine3.23 AS bundler
+FROM docker.io/library/ruby:4.0.5-alpine3.23 AS bundler
 # Install build dependencies
 # - build-base, git, curl: To ensure certain gems can be compiled
 # - postgresql-dev: Required for postgresql gem
@@ -20,7 +20,7 @@ COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
 
-FROM docker.io/library/ruby:4.0.4-alpine3.23
+FROM docker.io/library/ruby:4.0.5-alpine3.23
 # Install runtime dependencies
 # - tzdata: The public-domain time zone database
 # - curl: Required for healthcheck and some basic operations

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 #
 # Update BUNDLED WITH version in Gemfile.lock to match bundler version that
 # ships with this Ruby version.
-ruby "4.0.4"
+ruby "4.0.5"
 
 gem "acme-client"
 gem "argon2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -644,7 +644,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-  ruby 4.0.4
+  ruby 4.0.5
 
 BUNDLED WITH
   4.0.10


### PR DESCRIPTION
I put Ruby 4.0.4 into production yesterday afternoon, and just a few hours later, 4.0.5 got released.

4.0.5 fixes a security issue: https://www.ruby-lang.org/en/news/2026/05/20/getaddrinfo-cve-2026-46727/ . I'm not sure whether the security issue affects us, but since that is the only change since 4.0.4 other than a rdoc version bump, this should be safe.