### PR TITLE
Extra postgres config validation

### DIFF
--- a/lib/validation/postgres_config_validator.rb
+++ b/lib/validation/postgres_config_validator.rb
@@ -2,6 +2,21 @@
 
 module Validation
   class PostgresConfigValidator
+    # Custom option keys have two parts separated by a dot:
+    # https://www.postgresql.org/docs/18/runtime-config-custom.html
+    #
+    # Each part must start with a letter or underscore followed by letters,
+    # digits, or underscores.
+    # https://github.com/postgres/postgres/blob/0392fb900eb89f52988cccd33046443c39c70d1c/src/backend/utils/misc/guc.c#L957
+    #
+    # Notes:
+    # - Postgres implementation allows >= 2 parts, but docs only mention 2
+    #   parts, so we enforce 2 parts per the docs.
+    # - Postgres allows dollars and high-bit characters in option names, but the
+    #   PgCommon.pm preloader rejects them before passing them to postgres, so
+    #   disallow them here.
+    EXTENSION_KEY_REGEX = /\A[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*\z/
+
     def initialize(version)
       case version
       when "17"
@@ -40,9 +55,7 @@ module Validation
           "Value cannot be empty"
         elsif valid_config?(key)
           validate_config(key, value)
-        elsif key.split(".").length == 2
-          # Unknown customized option, ignore validation for it.
-          # Ref: https://www.postgresql.org/docs/17/runtime-config-custom.html#RUNTIME-CONFIG-CUSTOM
+        elsif EXTENSION_KEY_REGEX.match?(key)
           nil
         else
           "Unknown configuration parameter"

--- a/lib/validation/postgres_config_validator.rb
+++ b/lib/validation/postgres_config_validator.rb
@@ -51,8 +51,11 @@ module Validation
     def validation_errors(config)
       errors = {}
       config.each do |key, value|
-        errors[key] = if value.to_s.empty?
+        str = value.to_s
+        errors[key] = if str.empty?
           "Value cannot be empty"
+        elsif str.include?("\n")
+          "Value cannot contain newlines"
         elsif valid_config?(key)
           validate_config(key, value)
         elsif EXTENSION_KEY_REGEX.match?(key)

--- a/spec/lib/validation/postgres_config_validator_spec.rb
+++ b/spec/lib/validation/postgres_config_validator_spec.rb
@@ -113,6 +113,13 @@ RSpec.describe Validation::PostgresConfigValidator do
         expect { validator.validate(config) }.to raise_error(Validation::ValidationFailed)
       end
 
+      it "rejects newline characters in value" do
+        config = {"ext.option" => "my\napp"}
+        expect { validator.validate(config) }.to raise_error(Validation::ValidationFailed) do |error|
+          expect(error.details["ext.option"]).to include("Value cannot contain newlines")
+        end
+      end
+
       it "returns no errors for non-string value" do
         config = {"max_connections" => 100}
         expect { validator.validate(config) }.not_to raise_error

--- a/spec/lib/validation/postgres_config_validator_spec.rb
+++ b/spec/lib/validation/postgres_config_validator_spec.rb
@@ -76,9 +76,41 @@ RSpec.describe Validation::PostgresConfigValidator do
         expect { validator.validate(config) }.not_to raise_error
       end
 
-      it "returns no errors for unknown customized option" do
+      it "returns no errors for valid customized option" do
         config = {"citus.shard_count" => "32"}
         expect { validator.validate(config) }.not_to raise_error
+      end
+
+      it "rejects customized option with invalid characters" do
+        config = {"citus.shard-count" => "32"}
+        expect { validator.validate(config) }.to raise_error(Validation::ValidationFailed)
+      end
+
+      it "rejects $ in each part for customized option, both at the start and in the middle" do
+        expect { validator.validate({"$citus.shard_count" => "32"}) }.to raise_error(Validation::ValidationFailed)
+        expect { validator.validate({"citus.$shard_count" => "32"}) }.to raise_error(Validation::ValidationFailed)
+        expect { validator.validate({"citus.shard$count" => "32"}) }.to raise_error(Validation::ValidationFailed)
+        expect { validator.validate({"c$itus.shard_count" => "32"}) }.to raise_error(Validation::ValidationFailed)
+      end
+
+      it "rejects digits as the first character in each part for customized option" do
+        expect { validator.validate({"1citus.shard_count" => "32"}) }.to raise_error(Validation::ValidationFailed)
+        expect { validator.validate({"citus.1shard_count" => "32"}) }.to raise_error(Validation::ValidationFailed)
+      end
+
+      it "rejects empty part for customized option" do
+        expect { validator.validate({".shard_count" => "32"}) }.to raise_error(Validation::ValidationFailed)
+        expect { validator.validate({"citus." => "32"}) }.to raise_error(Validation::ValidationFailed)
+      end
+
+      it "accepts digits as non-start characters in each part for customized option" do
+        config = {"c1tus.shard_c0unt" => "32"}
+        expect { validator.validate(config) }.not_to raise_error
+      end
+
+      it "rejects customized option with more than two parts" do
+        config = {"citus.shard.count.extra" => "32"}
+        expect { validator.validate(config) }.to raise_error(Validation::ValidationFailed)
       end
 
       it "returns no errors for non-string value" do


### PR DESCRIPTION
### Validate extension config keys 

Postgres docs say custom options have two parts separated by dots. Postgres enforces each part to be letter/underscore followed by sequence of letters, underscores, or digits.

Not validating could break postgres load among other possible issues. For example, users could enter Key "1$b.c" Value "xyz" and next postgres restart would error out:

```
May 20 19:43:14 vmz60r15 postgresql@18-main[675]: Error: invalid line 1
in /etc/postgresql/18/main/conf.d/099-user.conf: 1$b.c = 'xyz'
```

### Reject new lines in postgres config values. 

Previously, new lines were allowed. Setting a.b = 'some\nvalue' was breaking string quoting, and generating a config file like:

```
a.b = 'some
value'
```

Which broke postgres restart with:

```
May 21 00:08:26 vmnsct8t postgresql@18-main[58266]: Error: invalid line 1
in /etc/postgresql/18/main/conf.d/099-user.conf: a.b = 'some
```

With the new change newlines are rejected:

```
$ ubi pg eu-central-h1/pg1 add-config-entries $'a.b=some\nvalue'
! Unexpected response status: 400
Details: Validation failed for following fields: pg_config.a.b
  pg_config.a.b: Value cannot contain newlines
```

(`\r` is allowed based on postgres `guc-file.l`, so just reject `\n`)