### PR TITLE
Add cert renewal

### DIFF
--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -11,7 +11,7 @@ class KubernetesCluster < Sequel::Model
   many_to_one :project, read_only: true
   many_to_many :cp_vms, join_table: :kubernetes_node, right_key: :vm_id, class: :Vm, order: :created_at, conditions: {kubernetes_nodepool_id: nil}, read_only: true
   one_to_many :nodes, class: :KubernetesNode, order: :created_at, conditions: {kubernetes_nodepool_id: nil}, read_only: true
-  one_to_many :functional_nodes, class: :KubernetesNode, order: :created_at, conditions: {kubernetes_nodepool_id: nil, state: "active"}, read_only: true
+  one_to_many :functional_nodes, class: :KubernetesNode, order: :created_at, conditions: {kubernetes_nodepool_id: nil, state: ["active", "renewing_certs"]}, read_only: true
   one_to_many :nodepools, class: :KubernetesNodepool, read_only: true
   one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id, read_only: true, &:active
   many_to_one :location, read_only: true

--- a/model/kubernetes/kubernetes_node.rb
+++ b/model/kubernetes/kubernetes_node.rb
@@ -9,7 +9,7 @@ class KubernetesNode < Sequel::Model
   many_to_one :kubernetes_nodepool, read_only: true
 
   plugin ResourceMethods
-  plugin SemaphoreMethods, :destroy, :retire, :checkup
+  plugin SemaphoreMethods, :destroy, :retire, :checkup, :renew_certs
   include HealthMonitorMethods
 
   MESH_STATUS_FILE_PATH = "/var/lib/ubicsi/mesh_status.json"
@@ -109,6 +109,11 @@ class KubernetesNode < Sequel::Model
 
   def install_rhizome
     Strand.create(prog: "InstallRhizome", label: "start", stack: [{subject_id: vm.sshable.id, target_folder: "kubernetes"}])
+  end
+
+  def cert_expire_at
+    enddate = sshable.cmd("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").chomp.delete_prefix("notAfter=")
+    Time.strptime(enddate.sub(/\bGMT\z/, "+0000"), "%b %e %H:%M:%S %Y %z")
   end
 
   def name

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -203,6 +203,23 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     hop_wait
   end
 
+  CERT_RENEWAL_WINDOW = 60 * 24 * 60 * 60
+
+  def cp_node_renewal_in_flight?
+    cp_nodes = kubernetes_cluster.nodes
+    cp_nodes.any? { |n| n.state == "renewing_certs" } ||
+      Semaphore.where(strand_id: cp_nodes.map(&:id), name: "renew_certs").any?
+  end
+
+  def renew_expiring_cp_certs
+    nap 30 if cp_node_renewal_in_flight?
+    expiring = kubernetes_cluster.nodes.find { |n| n.cert_expire_at < Time.now + CERT_RENEWAL_WINDOW }
+    if expiring
+      expiring.incr_renew_certs
+      nap 30
+    end
+  end
+
   label def wait
     when_sync_kubernetes_services_set? do
       hop_sync_kubernetes_services
@@ -235,6 +252,8 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     when_sync_kubeconfig_set? do
       hop_sync_kubeconfig
     end
+
+    renew_expiring_cp_certs
 
     if kubernetes_cluster.connectivity_check_target
       check_external_connectivity

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -52,7 +52,34 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
     when_retire_set? do
       hop_retire
     end
+
+    when_renew_certs_set? do
+      hop_renew_certs
+    end
+
     nap 6 * 60 * 60
+  end
+
+  label def renew_certs
+    register_deadline("wait", 10 * 60)
+    decr_renew_certs
+
+    state = kubernetes_node.sshable.d_check("renew_certs")
+    case state
+    when "Succeeded"
+      kubernetes_node.sshable.d_clean("renew_certs")
+      kubernetes_node.update(state: "active")
+      hop_wait
+    when "NotStarted"
+      kubernetes_node.update(state: "renewing_certs")
+      kubernetes_node.sshable.d_run("renew_certs", "/home/ubi/kubernetes/bin/renew-certs")
+      nap 30
+    when "InProgress"
+      nap 30
+    else
+      Clog.emit((state == "Failed") ? "renew_certs failed" : "got unknown state from daemonizer2 check: #{state}", {kubernetes_node: {ubid: kubernetes_node.ubid, name: kubernetes_node.name}})
+      nap 30
+    end
   end
 
   label def unavailable

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -5,7 +5,8 @@ class Prog::Test::Kubernetes < Prog::Test::Base
   frame_reader :kubernetes_service_project_id, :kubernetes_test_project_id
   frame_accessor :fail_message, :kubernetes_cluster_id, :read_hashes, :normal_pod_restart_test_node,
     :rsync_retry_source_node, :chained_migration_source_node, :drain_test_node_name, :reboot_node_id,
-    :nat_rules_before_reboot, :pod_access_rules_before_reboot, :migration_number
+    :nat_rules_before_reboot, :pod_access_rules_before_reboot, :migration_number,
+    :cert_expire_at_before_renew
 
   def self.assemble
     kubernetes_test_project = Project.create(name: "Kubernetes-Test-Project")
@@ -42,8 +43,22 @@ class Prog::Test::Kubernetes < Prog::Test::Base
   end
 
   label def wait_for_kubernetes_bootstrap
-    hop_test_nodes if kubernetes_cluster.strand.label == "wait"
+    hop_trigger_renew_certs if kubernetes_cluster.strand.label == "wait"
     nap 10
+  end
+
+  label def trigger_renew_certs
+    cp_node = kubernetes_cluster.nodes.first
+    self.cert_expire_at_before_renew = cp_node.cert_expire_at.to_s
+    cp_node.incr_renew_certs
+    hop_wait_for_renew_certs
+  end
+
+  label def wait_for_renew_certs
+    cp_node = kubernetes_cluster.nodes.first
+    nap 10 unless cp_node.strand.label == "wait" && cp_node.state == "active" && !cp_node.renew_certs_set?
+    nap 10 unless cp_node.cert_expire_at > Time.parse(cert_expire_at_before_renew)
+    hop_test_nodes
   end
 
   label def test_nodes

--- a/rhizome/kubernetes/bin/renew-certs
+++ b/rhizome/kubernetes/bin/renew-certs
@@ -1,0 +1,21 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+r("sudo kubeadm certs renew all")
+
+# Restart the static control-plane pods so they reload the new certs from disk.
+# kubelet recreates the pods automatically after the sandbox is stopped.
+pod_ids = r("sudo crictl pods --namespace kube-system --name 'kube-apiserver-|kube-controller-manager-|kube-scheduler-|etcd-' -q").split
+r("sudo", "crictl", "stopp", *pod_ids) unless pod_ids.empty?
+
+30.times do
+  r("kubectl --kubeconfig=/etc/kubernetes/admin.conf get --raw='/healthz'")
+  exit 0
+rescue CommandFail
+  sleep 5
+end
+
+puts "API server did not become healthy after cert renewal"
+exit 1

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -437,6 +437,15 @@ RSpec.describe KubernetesCluster do
     end
   end
 
+  describe "#functional_nodes" do
+    it "includes control-plane nodes in active and renewing_certs states" do
+      active = KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id, created_at: Time.now - 2)
+      renewing = KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id, state: "renewing_certs", created_at: Time.now - 1)
+      KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id, state: "draining")
+      expect(kc.reload.functional_nodes.map(&:id)).to eq([active.id, renewing.id])
+    end
+  end
+
   describe "#all_functional_nodes_ready?" do
     let(:ssh_session) { Net::SSH::Connection::Session.allocate }
     let(:client) { Kubernetes::Client.new(kc, ssh_session) }

--- a/spec/model/kubernetes/kubernetes_node_spec.rb
+++ b/spec/model/kubernetes/kubernetes_node_spec.rb
@@ -276,4 +276,16 @@ RSpec.describe KubernetesNode do
       expect(st.stack.first).to include("subject_id" => kn.vm.sshable.id, "target_folder" => "kubernetes")
     end
   end
+
+  describe "#cert_expire_at" do
+    it "reads and parses the apiserver cert expiry from the node as UTC" do
+      expect(kn.sshable).to receive(:_cmd).with("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").and_return("notAfter=May 21 19:50:47 2027 GMT\n")
+      expect(kn.cert_expire_at).to eq(Time.utc(2027, 5, 21, 19, 50, 47))
+    end
+
+    it "handles single-digit days padded with a space" do
+      expect(kn.sshable).to receive(:_cmd).with("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").and_return("notAfter=Jun  8 12:08:01 2027 GMT\n")
+      expect(kn.cert_expire_at).to eq(Time.utc(2027, 6, 8, 12, 8, 1))
+    end
+  end
 end

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -445,6 +445,12 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
   end
 
   describe "#wait" do
+    before do
+      kubernetes_cluster.nodes.each do |n|
+        allow(n.sshable).to receive(:_cmd).with("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").and_return("notAfter=#{(Time.now + 365 * 24 * 60 * 60).utc.strftime("%b %e %H:%M:%S %Y")} GMT\n")
+      end
+    end
+
     it "hops to the right sync_kubernetes_service when its semaphore is set" do
       nx.incr_sync_kubernetes_services
       expect { nx.wait }.to hop("sync_kubernetes_services")
@@ -490,6 +496,16 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect { nx.wait }.to nap(6 * 60 * 60)
     end
 
+    it "naps 30 seconds while a CP node is renewing its certs" do
+      kubernetes_cluster.nodes.first.update(state: "renewing_certs")
+      expect { nx.wait }.to nap(30)
+    end
+
+    it "naps 30 seconds while a CP node still has its renew_certs semaphore set" do
+      kubernetes_cluster.nodes.first.incr_renew_certs
+      expect { nx.wait }.to nap(30)
+    end
+
     it "creates or resolves depending on the connectivity to the connectivity_check_target set" do
       kubernetes_cluster.update(connectivity_check_target: "some.pg.ubicloud.com:5432")
 
@@ -523,6 +539,43 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect { nx.wait }.to nap(120)
 
       expect(Page.from_tag_parts("K8sExternalConnectivityFailed", kubernetes_cluster.ubid)).to be_nil
+    end
+  end
+
+  describe "#renew_expiring_cp_certs" do
+    it "increments renew_certs on the first CP node whose cert is within the renewal window and naps" do
+      n1, n2 = kubernetes_cluster.nodes
+      expect(n1.sshable).to receive(:_cmd).with("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").and_return("notAfter=#{(Time.now + 30 * 24 * 60 * 60).utc.strftime("%b %e %H:%M:%S %Y")} GMT\n")
+      expect { nx.renew_expiring_cp_certs }.to nap(30)
+      expect(n1.renew_certs_set?).to be true
+      expect(n2.renew_certs_set?).to be false
+    end
+
+    it "does nothing when no CP node's cert is within the renewal window" do
+      n1, n2 = kubernetes_cluster.nodes
+      expect(n1.sshable).to receive(:_cmd).with("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").and_return("notAfter=#{(Time.now + 365 * 24 * 60 * 60).utc.strftime("%b %e %H:%M:%S %Y")} GMT\n")
+      expect(n2.sshable).to receive(:_cmd).with("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").and_return("notAfter=#{(Time.now + 365 * 24 * 60 * 60).utc.strftime("%b %e %H:%M:%S %Y")} GMT\n")
+      nx.renew_expiring_cp_certs
+      expect(n1.renew_certs_set?).to be false
+      expect(n2.renew_certs_set?).to be false
+    end
+
+    it "naps without checking certs while a CP node is already renewing" do
+      n1, n2 = kubernetes_cluster.nodes
+      n1.update(state: "renewing_certs")
+      expect(n1.sshable).not_to receive(:_cmd)
+      expect(n2.sshable).not_to receive(:_cmd)
+      expect { nx.renew_expiring_cp_certs }.to nap(30)
+      expect(n2.renew_certs_set?).to be false
+    end
+
+    it "naps without checking certs while a CP node has the renew_certs semaphore set" do
+      n1, n2 = kubernetes_cluster.nodes
+      n1.incr_renew_certs
+      expect(n1.sshable).not_to receive(:_cmd)
+      expect(n2.sshable).not_to receive(:_cmd)
+      expect { nx.renew_expiring_cp_certs }.to nap(30)
+      expect(n2.renew_certs_set?).to be false
     end
   end
 

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
   subject(:nx) { described_class.new(kd.strand) }
 
   let(:project) { Project.create(name: "default") }
-  let(:subnet) { Prog::Vnet::SubnetNexus.assemble(Config.kubernetes_service_project_id, name: "test", ipv4_range_size: 16, ipv6_range: "fd40:1a0a:8d48:182a::/64").subject }
+  let(:subnet) { Prog::Vnet::SubnetNexus.assemble(project.id, name: "test", ipv4_range_size: 16, ipv6_range: "fd40:1a0a:8d48:182a::/64").subject }
   let(:kc) {
-    kc = KubernetesCluster.create(
+    kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "cluster",
       version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
@@ -16,9 +16,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       location_id: Location::HETZNER_FSN1_ID,
       project_id: project.id,
       target_node_size: "standard-2",
-    )
-    Firewall.create(name: "#{kc.ubid}-cp-vm-firewall", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id)
-    Firewall.create(name: "#{kc.ubid}-worker-vm-firewall", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id)
+    ).subject
 
     lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "lb", health_check_endpoint: "/", project_id: project.id)
     LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 123, dst_port: 456)
@@ -109,6 +107,58 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
     it "hops to unavailable when checkup semaphore is set" do
       nx.incr_checkup
       expect { nx.wait }.to hop("unavailable")
+    end
+
+    it "hops to renew_certs when renew_certs semaphore is set" do
+      nx.incr_renew_certs
+      expect { nx.wait }.to hop("renew_certs")
+    end
+  end
+
+  describe "#renew_certs" do
+    def node_sshable
+      nx.kubernetes_node.sshable
+    end
+
+    it "registers a 10-minute wait deadline on every entry" do
+      expect(node_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check renew_certs").and_return("InProgress")
+      expect { nx.renew_certs }.to nap(30)
+      frame = nx.strand.stack.first
+      expect(frame["deadline_target"]).to eq("wait")
+      expect(Time.parse(frame["deadline_at"].to_s)).to be_within(3).of(Time.now + 10 * 60)
+    end
+
+    it "starts the daemonizer, marks the node renewing_certs and naps when not started" do
+      nx.incr_renew_certs
+      expect(node_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check renew_certs").and_return("NotStarted")
+      expect(node_sshable).to receive(:_cmd).with("common/bin/daemonizer2 run renew_certs /home/ubi/kubernetes/bin/renew-certs", {log: true, stdin: nil})
+      expect { nx.renew_certs }.to nap(30)
+      expect(kd.reload.state).to eq("renewing_certs")
+      expect(kd.renew_certs_set?).to be false
+    end
+
+    it "naps when the daemonizer is in progress" do
+      expect(node_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check renew_certs").and_return("InProgress")
+      expect { nx.renew_certs }.to nap(30)
+    end
+
+    it "cleans the daemonizer, marks node active and hops to wait on success" do
+      kd.update(state: "renewing_certs")
+      expect(node_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check renew_certs").and_return("Succeeded")
+      expect(node_sshable).to receive(:_cmd).with("common/bin/daemonizer2 clean renew_certs")
+      expect { nx.renew_certs }.to hop("wait")
+      expect(kd.reload.state).to eq("active")
+    end
+
+    it "naps when the daemonizer fails so the deadline mechanism can fire" do
+      expect(node_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check renew_certs").and_return("Failed")
+      expect { nx.renew_certs }.to nap(30)
+    end
+
+    it "naps when the daemonizer returns an unknown state" do
+      expect(node_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check renew_certs").and_return("unknown")
+      expect(Clog).to receive(:emit).with("got unknown state from daemonizer2 check: unknown", {kubernetes_node: {ubid: kd.ubid, name: kd.name}})
+      expect { nx.renew_certs }.to nap(30)
     end
   end
 
@@ -310,10 +360,6 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
   end
 
   describe "#destroy" do
-    before do
-      Strand.create_with_id(kc, prog: "Kubernetes::KubernetesClusterNexus", label: "wait")
-    end
-
     it "destroys the vm and itself" do
       vm_id = kd.vm.id
       expect { nx.destroy }.to exit({"msg" => "kubernetes node is deleted"})

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Prog::Test::Kubernetes do
     kc
   }
   let(:sshable) { kubernetes_test.kubernetes_cluster.sshable }
+  let(:cp_node) { kubernetes_test.kubernetes_cluster.nodes.first }
 
   before do
     allow(Config).to receive(:kubernetes_service_project_id).and_return(kubernetes_service_project.id)
@@ -70,13 +71,44 @@ RSpec.describe Prog::Test::Kubernetes do
   end
 
   describe "#wait_for_kubernetes_bootstrap" do
-    it "hops to test_nodes if cluster is ready" do
+    it "hops to trigger_renew_certs if cluster is ready" do
       kubernetes_cluster.strand.update(label: "wait")
-      expect { kubernetes_test.wait_for_kubernetes_bootstrap }.to hop("test_nodes")
+      expect { kubernetes_test.wait_for_kubernetes_bootstrap }.to hop("trigger_renew_certs")
     end
 
     it "naps if cluster is not ready" do
       expect { kubernetes_test.wait_for_kubernetes_bootstrap }.to nap(10)
+    end
+  end
+
+  describe "#trigger_renew_certs" do
+    it "records the current cert expiry, triggers renewal on the CP node and wakes its strand" do
+      expect(cp_node.sshable).to receive(:_cmd).with("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").and_return("notAfter=#{(Time.now + 365 * 24 * 60 * 60).utc.strftime("%b %e %H:%M:%S %Y")} GMT\n")
+      expect { kubernetes_test.trigger_renew_certs }.to hop("wait_for_renew_certs")
+      expect(cp_node.reload.renew_certs_set?).to be true
+      expect(kubernetes_test.strand.stack.first["cert_expire_at_before_renew"]).not_to be_nil
+    end
+  end
+
+  describe "#wait_for_renew_certs" do
+    let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "cert_expire_at_before_renew" => (Time.now + 365 * 24 * 60 * 60).to_s}] }
+
+    it "naps while the CP node is still renewing its certs" do
+      cp_node.update(state: "renewing_certs")
+      cp_node.strand.update(label: "renew_certs")
+      expect { kubernetes_test.wait_for_renew_certs }.to nap(10)
+    end
+
+    it "naps when the renewal flow finished but the cert expiry has not advanced" do
+      cp_node.strand.update(label: "wait")
+      expect(cp_node.sshable).to receive(:_cmd).with("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").and_return("notAfter=#{(Time.now + 365 * 24 * 60 * 60).utc.strftime("%b %e %H:%M:%S %Y")} GMT\n")
+      expect { kubernetes_test.wait_for_renew_certs }.to nap(10)
+    end
+
+    it "hops to test_nodes once the renewal flow finished and the cert expiry has advanced" do
+      cp_node.strand.update(label: "wait")
+      expect(cp_node.sshable).to receive(:_cmd).with("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").and_return("notAfter=#{(Time.now + 400 * 24 * 60 * 60).utc.strftime("%b %e %H:%M:%S %Y")} GMT\n")
+      expect { kubernetes_test.wait_for_renew_certs }.to hop("test_nodes")
     end
   end
 


### PR DESCRIPTION
**Renew kubeadm control-plane certificates before they expire**
Each control-plane node's nexus checks its own apiserver cert once per wait cycle (every 24h): it reads the live expiry off the node with openssl and, when the cert expires within 60 days, hops to renew_certs. Worker nodes are skipped since they rotate their kubelet client cert themselves.

renew_certs runs kubeadm certs renew all via the new rhizome/kubernetes/bin/renew-certs script, restarts the static CP pods so they reload the certs from disk, and waits for the apiserver to come back healthy before marking the node active again. A 10-minute wait deadline is registered on entry so a stuck renewal pages, and a renew_certs semaphore allows forcing a renewal out of band.

functional_nodes now also matches state "renewing_certs" so cluster.sshable stays pinned to the same CP node while one is renewing, avoiding daemonizer state splitting across nodes for in-flight drain/backup ops.

**Add e2e tests for cert renewal**