### PR TITLE
Split AWS gems into their own Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,17 @@ updates:
     allow:
       - dependency-type: "all"
     groups:
+      aws-dependencies:
+        patterns:
+          - "*aws*"
       production-dependencies:
         dependency-type: "production"
+        exclude-patterns:
+          - "*aws*"
       development-dependencies:
         dependency-type: "development"
+        exclude-patterns:
+          - "*aws*"
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:


### PR DESCRIPTION
AWS SDK gems release new versions almost every day, and they are hard to exercise from our unit suite while the rest of our dependencies are well covered by tests. Lumping them into the existing production group makes those PRs risky to merge and slows the cadence of routine production updates.

For example, a token format change in a minor version upgrade of the AWS S3 package previously broke compatibility with other S3-compatible services such as MinIO and Cloudflare R2. So we should upgrade aws packages at a slower pace with more E2E testing.

Dependabot's "development" bucket is worse: it collapses every non-production Gemfile group (aws_kms, aws_rds_iam, rubocop, lint, test, development) into one PR, so a daily aws_kms upgrade ships alongside rubocop bumps and inflates the blast radius of an otherwise routine dev update.

Move any gem whose name contains "aws" into a dedicated aws-dependencies group so AWS churn is isolated from both the production PR and the development PR.