### PR TITLE
Add zizmor to daily CI and fix its findings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -73,10 +75,11 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ env.PUSH_IMAGE }}
 
       - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         if: ${{ env.PUSH_IMAGE == 'true' }}
@@ -128,5 +131,7 @@ jobs:
             $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect image
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect "$IMAGE_NAME:$VERSION"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover

--- a/.github/workflows/csi-build.yml
+++ b/.github/workflows/csi-build.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify gemspec version was bumped if image contents changed
         run: |
@@ -66,6 +67,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
@@ -112,5 +115,7 @@ jobs:
 
       - name: Inspect image
         if: ${{ env.PUSH_IMAGE == 'true' }}
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect "$IMAGE_NAME:$VERSION"

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -2,11 +2,16 @@ name: Daily CI
 
 permissions:
   contents: read
+  actions: read
+  security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
 
 on:
   workflow_dispatch:
   schedule:
     - cron:  '42 9 * * 1-5'
+  pull_request:
+    paths:
+      - '.github/workflows/daily-ci.yml'
 
 jobs:
   daily-ci:
@@ -19,6 +24,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover
@@ -36,6 +43,12 @@ jobs:
 
     - name: Run route specs checking no SSH access from web process
       run: bundle exec rake route_spec
+
+    - name: Run zizmor
+      uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+      with:
+        inputs: |
+          .github/
 
     - name: Send notification if failed
       if: ${{ failure() && github.ref_name == 'main' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,6 @@ run-name: E2E ${{ github.event_name }} ${{ inputs.providers }}
 
 permissions:
   contents: read
-  pull-requests: write
-  actions: write
 
 on:
   workflow_dispatch:
@@ -23,10 +21,16 @@ on:
   schedule:
     - cron:  '0 */2 * * *'
 
+env:
+  INPUT_PROVIDERS: ${{ inputs.providers }}
+  INPUT_TEST_CASES: ${{ inputs.test_cases }}
+
 jobs:
   setup:
     if: vars.RUN_E2E == 'true'
     runs-on: ubuntu-slim
+    permissions:
+      actions: write # Required to cancel in-progress/queued E2E runs.
     outputs:
       providers: ${{ steps.set-providers.outputs.providers }}
       has_github_runner: ${{ steps.set-providers.outputs.has_github_runner }}
@@ -34,7 +38,7 @@ jobs:
     steps:
       - name: Cancel in-progress scheduled E2E runs
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const runs = await github.rest.actions.listWorkflowRuns({
@@ -56,7 +60,7 @@ jobs:
       - name: Skip scheduled run if another E2E run is already queued behind a running one
         if: github.event_name == 'schedule'
         id: skip_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const listOthers = async (status) => {
@@ -86,12 +90,12 @@ jobs:
         id: set-providers
         run: |
           providers="metal,aws,gcp"
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.providers }}" ]]; then
-            providers="${{ inputs.providers }}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "$INPUT_PROVIDERS" ]]; then
+            providers="$INPUT_PROVIDERS"
           fi
           # Convert comma-separated list to JSON array
           has_github_runner=false
-          if [[ "${{ github.event_name }}" != "workflow_dispatch" || "${{ inputs.test_cases }}" == *"github_runner"* ]]; then
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" || "$INPUT_TEST_CASES" == *"github_runner"* ]]; then
             has_github_runner=true
           fi
           echo "providers=$(echo "$providers" | jq -Rc 'split(",")')" >> $GITHUB_OUTPUT
@@ -113,6 +117,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Setup SSH access
       uses: ubicloud/ssh-runner@b6ccad69f047c476b84a54a990f89b1ea5f2a828 # v2.0
@@ -153,13 +159,15 @@ jobs:
         sed -i "s/^\([^:]*\): \(.*\)/\1: bash -c 'for i in {1..4}; do \2 \&\& break || echo \"Attempt \$i failed, retrying...\"; sleep 1; done'/" Procfile
 
     - name: Add e2e script to Procfile
+      env:
+        PROVIDER: ${{ matrix.provider }}
       run: |
         test_cases="$(yq -r '[.[].name] | join(",")' config/e2e_test_cases.yml)"
-        if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.test_cases }}" ]]; then
-          test_cases="${{ inputs.test_cases }}"
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "$INPUT_TEST_CASES" ]]; then
+          test_cases="$INPUT_TEST_CASES"
         fi
-        echo "Running e2e ${{ matrix.provider }} test cases:$test_cases"
-        echo "e2e: bin/e2e --provider=${{ matrix.provider }} --test-cases=$test_cases" >> Procfile
+        echo "Running e2e $PROVIDER test cases:$test_cases"
+        echo "e2e: bin/e2e --provider=$PROVIDER --test-cases=$test_cases" >> Procfile
 
     - name: Persist env vars to .env.rb
       run: |
@@ -381,6 +389,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Download e2e logs
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -467,6 +477,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Download e2e logs
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/kubernetes-csi-ci.yml
+++ b/.github/workflows/kubernetes-csi-ci.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Ruby for CSI gems
       uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0

--- a/.github/workflows/monitor-ci.yml
+++ b/.github/workflows/monitor-ci.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover

--- a/.github/workflows/respirate-ci.yml
+++ b/.github/workflows/respirate-ci.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Clover
       uses: ./.github/actions/setup-clover

--- a/.github/workflows/rhizome.yml
+++ b/.github/workflows/rhizome.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,14 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      # CLA assistant requires pull_request_target to comment on and label
+      # PRs from forks. The job does not check out or run PR code.
+      - cla.yml
+      # require_e2e listens for E2E CI completions to post commit statuses.
+      # The job does not check out or run any code from the triggering run.
+      - require_e2e.yml
+  archived-uses:
+    ignore:
+      # contributor-assistant/github-action is archived upstream but still
+      # works; it is pinned to a commit hash so the code cannot change.
+      - cla.yml


### PR DESCRIPTION
zizmor is a static analysis tool for GitHub Actions. It catches
common security issues in workflows, such as code injection through
template expansion and overly broad token permissions. Run it in the
daily CI to keep the per-PR workflow lean, and also on pull requests
that touch daily-ci.yml so the step itself stays exercised.

Fix all findings it reports so the new check starts green:

- artipacked: set persist-credentials: false on every checkout step.
  No workflow pushes or fetches after checkout, so none of them need
  the stored token.

- template-injection: move expansions of workflow inputs, step
  outputs, and matrix values out of run scripts into env vars, so
  they reach the shell as data instead of being spliced into code.

- excessive-permissions: scope e2e.yml permissions to the jobs that
  need them. actions: write moves to the setup job, which cancels
  runs; pull-requests: write was unused and is removed.

- unpinned-uses: pin actions/github-script in e2e.yml to the same
  v9.0.0 hash require_e2e.yml already uses.

- dangerous-triggers, archived-uses: suppress in .github/zizmor.yml
  with reasons. cla.yml needs pull_request_target to handle forks,
  require_e2e.yml consumes workflow_run by design, and the archived
  contributor-assistant action is pinned to a hash.
