### PR TITLE
Update setup-ruby action hash/tag comment to support 4.0.5

### DIFF
--- a/.github/actions/setup-clover/action.yml
+++ b/.github/actions/setup-clover/action.yml
@@ -29,7 +29,7 @@ runs:
         until pg_isready -q; do sleep 1; done
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: .tool-versions
         bundler-cache: true

--- a/.github/workflows/csi-build.yml
+++ b/.github/workflows/csi-build.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: .tool-versions
 

--- a/.github/workflows/kubernetes-csi-ci.yml
+++ b/.github/workflows/kubernetes-csi-ci.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Ruby for CSI gems
-      uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       env:
         BUNDLE_GEMFILE: kubernetes/csi/Gemfile
       with:

--- a/.github/workflows/rhizome.yml
+++ b/.github/workflows/rhizome.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,23 @@
 
 source "https://rubygems.org"
 
-# Update ruby version in Dockerfile and .tool_versions when updating this
+# Updating the Ruby version requires updating the version in the following files:
 #
-# Update BUNDLED WITH version in Gemfile.lock to match bundler version that
-# ships with this Ruby version.
+# * Gemfile (this file)
+# * Dockerfile (2 places)
+# * .tool_versions
+#
+# Then update the setup-ruby action hash/tag comment in the following action/workflow files:
+#
+# * .github/actions/setup-clover/action.yml
+# * .github/workflows/csi-build.yml
+# * .github/workflows/kubernetes-csi-ci.yml
+# * .github/workflows/rhizome.yml
+#
+# Then update BUNDLED WITH version in Gemfile.lock to match bundler version that
+# ships with the new Ruby version.
+#
+# Then run bundle install.
 ruby "4.0.5"
 
 gem "acme-client"


### PR DESCRIPTION
Now that we are pinning actions to hashes, we need to update the hash when updating the Ruby version. Update the instructions in Gemfile to include updating these files.