### PR TITLE
Use IPv4 instead of IPv6 VM address in RolloutRhizome

### DIFF
--- a/prog/rollout_rhizome.rb
+++ b/prog/rollout_rhizome.rb
@@ -79,6 +79,7 @@ class Prog::RolloutRhizome < Prog::Base
         unix_user: "rhizome",
         force_host_id: vm_host.id,
         location_id: vm_host.location_id,
+        enable_ip4: true,
       )
     end
     update_stack(
@@ -97,7 +98,7 @@ class Prog::RolloutRhizome < Prog::Base
     Vm.eager(:location).where(id: initial_vm_ids).all do
       # id is used for ubid in a Clog.emit call
       sshable = Sshable.new_with_id(
-        host: it.ip6_string,
+        host: it.ip4_string,
         raw_private_key_1: SshKey.from_binary(Base64.strict_decode64(frame.fetch("initial_vms_keypair"))).keypair,
         unix_user: "rhizome",
       )

--- a/spec/prog/rollout_rhizome_spec.rb
+++ b/spec/prog/rollout_rhizome_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Prog::RolloutRhizome do
     it "creates vms and hops" do
       strand_ds = Strand.where(prog: "Vm::Metal::Nexus", label: "start")
       expect { nx.setup_vms_on_initial_hosts }.to hop("wait_vms_on_initial_hosts")
-        .and change { Vm.count }.from(0).to(2)
+        .and change { Vm.where(:ip4_enabled).count }.from(0).to(2)
         .and change { strand_ds.count }.from(0).to(2)
       SshKey.from_binary(Base64.strict_decode64(st.stack[0]["initial_vms_keypair"]))
       expect(Vm.select_order_map(:id)).to eq st.stack[0]["initial_vm_ids"].sort!
@@ -129,7 +129,11 @@ RSpec.describe Prog::RolloutRhizome do
       expect { nx.setup_vms_on_initial_hosts }.to hop("wait_vms_on_initial_hosts")
       refresh_frame(nx)
 
-      ips = Vm.eager(:location).all.map { it.ip6_string }
+      vms = Vm.eager(:location).all.each_with_index do |vm, i|
+        AssignedVmAddress.create(ip: "10.#{i}.0.1", dst_vm_id: vm.id)
+      end
+      ips = vms.map(&:ip4_string)
+      expect(ips.all?).to be true
       ssh_key = SshKey.from_binary(Base64.strict_decode64(st.stack[0]["initial_vms_keypair"]))
 
       called = 0


### PR DESCRIPTION
Heroku and Dokku both seem to not work correctly with publicly routable IPv6 addresses.

Tested that this fixes the `Errno::ENETUNREACH` error in staging.