### PR TITLE
don't serialize vm in postgres /servers

### DIFF
--- a/cli-commands/pg/post/list-servers.rb
+++ b/cli-commands/pg/post/list-servers.rb
@@ -11,6 +11,6 @@ UbiCli.on("pg").run_on("list-servers") do
 
   run do |opts|
     servers = sdk_object.servers
-    response(format_rows(%i[id role state synchronization_status vm vm_size], servers, headers: opts[key][:"no-headers"] != false))
+    response(format_rows(%i[id role state synchronization_status vm_size], servers, headers: opts[key][:"no-headers"] != false))
   end
 end

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -3788,15 +3788,12 @@ components:
         fallback_active:
           description: Whether the server is running on a fallback instance type
           type: boolean
-        vm:
-          $ref: '#/components/schemas/Vm'
       additionalProperties: false
       required:
         - id
         - role
         - state
         - synchronization_status
-        - vm
     PostgresBackup:
       type: object
       properties:

--- a/serializers/postgres_server.rb
+++ b/serializers/postgres_server.rb
@@ -9,7 +9,6 @@ class Serializers::PostgresServer < Serializers::Base
       synchronization_status: server.synchronization_status,
       vm_size: server.vm.display_size,
       fallback_active: server.fallback_active?,
-      vm: Serializers::Vm.serialize(server.vm),
     }
   end
 end

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -1289,7 +1289,6 @@ RSpec.describe Clover, "postgres" do
         expect(server).to have_key("role")
         expect(server).to have_key("state")
         expect(server).to have_key("synchronization_status")
-        expect(server).to have_key("vm")
       end
     end
 

--- a/spec/serializers/postgres_server_spec.rb
+++ b/spec/serializers/postgres_server_spec.rb
@@ -41,8 +41,6 @@ RSpec.describe Serializers::PostgresServer do
     expect(data[:state]).to eq("running")
     expect(data[:synchronization_status]).to eq("ready")
     expect(data).not_to have_key(:is_representative)
-    expect(data[:vm]).to be_a(Hash)
-    expect(data[:vm][:id]).to eq(server.vm.ubid)
   end
 
   it "serializes a standby server" do


### PR DESCRIPTION
should not leak this info, vm can live in internal project