### PR TITLE
Show TCP/UDP protocol in firewall rules in cli vm/ps/fw show output

### DIFF
--- a/cli-commands/fw/post/show.rb
+++ b/cli-commands/fw/post/show.rb
@@ -4,7 +4,7 @@ UbiCli.on("fw").run_on("show") do
   desc "Show details for a firewall"
 
   fields = %w[id name location description firewall-rules private-subnets].freeze.each(&:freeze)
-  firewall_rule_fields = %w[id cidr port-range].freeze.each(&:freeze)
+  firewall_rule_fields = %w[id cidr port-range protocol].freeze.each(&:freeze)
   private_subnet_fields = %w[id name state location net4 net6 nics].freeze.each(&:freeze)
   nic_fields = %w[id name private-ipv4 private-ipv6 vm-name].freeze.each(&:freeze)
 

--- a/cli-commands/ps/post/show.rb
+++ b/cli-commands/ps/post/show.rb
@@ -5,7 +5,7 @@ UbiCli.on("ps").run_on("show") do
 
   fields = %w[id name state location net4 net6 firewalls nics].freeze.each(&:freeze)
   firewall_fields = %w[id name description location path firewall-rules].freeze.each(&:freeze)
-  firewall_rule_fields = %w[id cidr port-range].freeze.each(&:freeze)
+  firewall_rule_fields = %w[id cidr port-range protocol].freeze.each(&:freeze)
   nic_fields = %w[id name private-ipv4 private-ipv6 vm-name].freeze.each(&:freeze)
 
   options("ubi ps (location/ps-name | ps-id) show [options]", key: :ps_show) do

--- a/cli-commands/vm/post/show.rb
+++ b/cli-commands/vm/post/show.rb
@@ -5,7 +5,7 @@ UbiCli.on("vm").run_on("show") do
 
   fields = %w[id name state location size unix-user storage-size-gib ip6 ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls].freeze.each(&:freeze)
   firewall_fields = %w[id name description location path firewall-rules].freeze.each(&:freeze)
-  firewall_rule_fields = %w[id cidr port-range].freeze.each(&:freeze)
+  firewall_rule_fields = %w[id cidr port-range protocol].freeze.each(&:freeze)
 
   options("ubi vm (location/vm-name | vm-id) show [options]", key: :vm_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -f bad.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -f bad.txt
@@ -15,4 +15,4 @@ Allowed Option Values:
     Fields: id name location description firewall-rules private-subnets
     Nic Fields: id name private-ipv4 private-ipv6 vm-name
     Private Subnet Fields: id name state location net4 net6 nics
-    Firewall Rule Fields: id cidr port-range
+    Firewall Rule Fields: id cidr port-range protocol

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -f private-subnets,firewall-rules.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -f private-subnets,firewall-rules.txt
@@ -12,7 +12,7 @@ private subnet 1:
     private-ipv6: fda0:d79a:93e7:d4fd:1c2::2
     vm-name: test-vm
 rules:
-  1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-  2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-  3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-  4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+  1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+  2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+  3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+  4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -n bad.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -n bad.txt
@@ -15,4 +15,4 @@ Allowed Option Values:
     Fields: id name location description firewall-rules private-subnets
     Nic Fields: id name private-ipv4 private-ipv6 vm-name
     Private Subnet Fields: id name state location net4 net6 nics
-    Firewall Rule Fields: id cidr port-range
+    Firewall Rule Fields: id cidr port-range protocol

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -p bad.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -p bad.txt
@@ -15,4 +15,4 @@ Allowed Option Values:
     Fields: id name location description firewall-rules private-subnets
     Nic Fields: id name private-ipv4 private-ipv6 vm-name
     Private Subnet Fields: id name state location net4 net6 nics
-    Firewall Rule Fields: id cidr port-range
+    Firewall Rule Fields: id cidr port-range protocol

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -r bad.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show -r bad.txt
@@ -15,4 +15,4 @@ Allowed Option Values:
     Fields: id name location description firewall-rules private-subnets
     Nic Fields: id name private-ipv4 private-ipv6 vm-name
     Private Subnet Fields: id name state location net4 net6 nics
-    Firewall Rule Fields: id cidr port-range
+    Firewall Rule Fields: id cidr port-range protocol

--- a/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show.txt
+++ b/spec/routes/api/cli/golden-files/fw eu-central-h1_default-eu-central-h1-default show.txt
@@ -3,10 +3,10 @@ name: default-eu-central-h1-default
 location: eu-central-h1
 description: Default firewall
 rules:
-  1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-  2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-  3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-  4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+  1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+  2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+  3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+  4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  
 private subnet 1:
   id: psfzm9e26xky5m9ggetw4dpqe2
   name: default-eu-central-h1

--- a/spec/routes/api/cli/golden-files/fw fw4gj2v4h1fe3q28q0hnf7g8n1 show.txt
+++ b/spec/routes/api/cli/golden-files/fw fw4gj2v4h1fe3q28q0hnf7g8n1 show.txt
@@ -3,10 +3,10 @@ name: default-eu-central-h1-default
 location: eu-central-h1
 description: Default firewall
 rules:
-  1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-  2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-  3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-  4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+  1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+  2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+  3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+  4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  
 private subnet 1:
   id: psfzm9e26xky5m9ggetw4dpqe2
   name: default-eu-central-h1

--- a/spec/routes/api/cli/golden-files/fw show eu-central-h1_default-eu-central-h1-default.txt
+++ b/spec/routes/api/cli/golden-files/fw show eu-central-h1_default-eu-central-h1-default.txt
@@ -3,10 +3,10 @@ name: default-eu-central-h1-default
 location: eu-central-h1
 description: Default firewall
 rules:
-  1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-  2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-  3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-  4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+  1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+  2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+  3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+  4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  
 private subnet 1:
   id: psfzm9e26xky5m9ggetw4dpqe2
   name: default-eu-central-h1

--- a/spec/routes/api/cli/golden-files/help -r vm.txt
+++ b/spec/routes/api/cli/golden-files/help -r vm.txt
@@ -113,7 +113,7 @@ Options:
 Allowed Option Values:
     Fields: id name state location size unix-user storage-size-gib ip6
             ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls
-    Firewall Rule Fields: id cidr port-range
+    Firewall Rule Fields: id cidr port-range protocol
     Firewall Fields: id name description location path firewall-rules
 
 

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -243,7 +243,7 @@ Allowed Option Values:
     Fields: id name location description firewall-rules private-subnets
     Nic Fields: id name private-ipv4 private-ipv6 vm-name
     Private Subnet Fields: id name state location net4 net6 nics
-    Firewall Rule Fields: id cidr port-range
+    Firewall Rule Fields: id cidr port-range protocol
 
 
 Update the description for a firewall
@@ -1195,7 +1195,7 @@ Options:
 Allowed Option Values:
     Fields: id name state location net4 net6 firewalls nics
     Nic Fields: id name private-ipv4 private-ipv6 vm-name
-    Firewall Rule Fields: id cidr port-range
+    Firewall Rule Fields: id cidr port-range protocol
     Firewall Fields: id name description location path firewall-rules
 
 
@@ -1386,7 +1386,7 @@ Options:
 Allowed Option Values:
     Fields: id name state location size unix-user storage-size-gib ip6
             ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls
-    Firewall Rule Fields: id cidr port-range
+    Firewall Rule Fields: id cidr port-range protocol
     Firewall Fields: id name description location path firewall-rules
 
 

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -f firewalls,nics.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -f firewalls,nics.txt
@@ -5,10 +5,10 @@ firewall 1:
   location: eu-central-h1
   path: 
   rules:
-   1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-   2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-   3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-   4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+   1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+   2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+   3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+   4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  
 nic 1:
   id: nc69z0cda8jt0g5b120hamn4vf
   name: test-vm-nic

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -f firewalls.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -f firewalls.txt
@@ -5,7 +5,7 @@ firewall 1:
   location: eu-central-h1
   path: 
   rules:
-   1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-   2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-   3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-   4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+   1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+   2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+   3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+   4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -w firewall-rules.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show -w firewall-rules.txt
@@ -6,10 +6,10 @@ net4: 172.27.99.128/26
 net6: fdd9:1ea7:125d:5fa4::/64
 firewall 1:
   rules:
-   1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-   2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-   3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-   4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+   1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+   2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+   3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+   4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  
 nic 1:
   id: nc69z0cda8jt0g5b120hamn4vf
   name: test-vm-nic

--- a/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show.txt
+++ b/spec/routes/api/cli/golden-files/ps eu-central-h1_default-eu-central-h1 show.txt
@@ -11,10 +11,10 @@ firewall 1:
   location: eu-central-h1
   path: 
   rules:
-   1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-   2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-   3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-   4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+   1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+   2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+   3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+   4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  
 nic 1:
   id: nc69z0cda8jt0g5b120hamn4vf
   name: test-vm-nic

--- a/spec/routes/api/cli/golden-files/ps psfzm9e26xky5m9ggetw4dpqe2 show.txt
+++ b/spec/routes/api/cli/golden-files/ps psfzm9e26xky5m9ggetw4dpqe2 show.txt
@@ -11,10 +11,10 @@ firewall 1:
   location: eu-central-h1
   path: 
   rules:
-   1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-   2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-   3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-   4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+   1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+   2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+   3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+   4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  
 nic 1:
   id: nc69z0cda8jt0g5b120hamn4vf
   name: test-vm-nic

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f firewalls -w firewall-rules.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f firewalls -w firewall-rules.txt
@@ -1,6 +1,6 @@
 firewall 1:
   rules:
-    1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-    2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-    3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-    4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+    1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+    2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+    3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+    4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f firewalls.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f firewalls.txt
@@ -5,7 +5,7 @@ firewall 1:
   location: eu-central-h1
   path: /location/eu-central-h1/firewall/default-eu-central-h1-default
   rules:
-    1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-    2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-    3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-    4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+    1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+    2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+    3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+    4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f invalid.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f invalid.txt
@@ -13,5 +13,5 @@ Options:
 Allowed Option Values:
     Fields: id name state location size unix-user storage-size-gib ip6
             ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls
-    Firewall Rule Fields: id cidr port-range
+    Firewall Rule Fields: id cidr port-range protocol
     Firewall Fields: id name description location path firewall-rules

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show.txt
@@ -18,7 +18,7 @@ firewall 1:
   location: eu-central-h1
   path: /location/eu-central-h1/firewall/default-eu-central-h1-default
   rules:
-    1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-    2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-    3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-    4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+    1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+    2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+    3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+    4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_vmdzyppz6j166jh5e9t2dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_vmdzyppz6j166jh5e9t2dwrfas show.txt
@@ -18,7 +18,7 @@ firewall 1:
   location: eu-central-h1
   path: /location/eu-central-h1/firewall/default-eu-central-h1-default
   rules:
-    1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-    2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-    3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-    4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+    1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+    2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+    3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+    4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfas show.txt
@@ -18,7 +18,7 @@ firewall 1:
   location: eu-central-h1
   path: /location/eu-central-h1/firewall/default-eu-central-h1-default
   rules:
-    1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  
-    2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  
-    3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  
-    4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  
+    1: fra7jvrz94be7qy8qrq8n1jrp1  0.0.0.0/0  0..65535  tcp  
+    2: frek9rkejx123kdw7qk9pwp9r0  0.0.0.0/0  0..65535  udp  
+    3: fr7cv7h5bz324maazy93ykn8s4  ::/0  0..65535  tcp  
+    4: frgyxj9tzccy1kdwvx0hyzhnna  ::/0  0..65535  udp  

--- a/spec/routes/api/cli/vm/show_spec.rb
+++ b/spec/routes/api/cli/vm/show_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe Clover, "cli vm show" do
         location: eu-central-h1
         path: /location/eu-central-h1/firewall/default-eu-central-h1-default
         rules:
-          1: #{@fw.firewall_rules[0].ubid}  0.0.0.0/0  0..65535  
-          2: #{@fw.firewall_rules[1].ubid}  0.0.0.0/0  0..65535  
-          3: #{@fw.firewall_rules[2].ubid}  ::/0  0..65535  
-          4: #{@fw.firewall_rules[3].ubid}  ::/0  0..65535  
+          1: #{@fw.firewall_rules[0].ubid}  0.0.0.0/0  0..65535  tcp  
+          2: #{@fw.firewall_rules[1].ubid}  0.0.0.0/0  0..65535  udp  
+          3: #{@fw.firewall_rules[2].ubid}  ::/0  0..65535  tcp  
+          4: #{@fw.firewall_rules[3].ubid}  ::/0  0..65535  udp  
     END
   end
 


### PR DESCRIPTION
This was missed during the UDP firewall rule support. This fixes the default case for subnets, where it looks we have duplicate rules.