### PR TITLE
Do not show VMs attached to other load balancers as attachable in Web UI

### DIFF
--- a/spec/routes/web/load_balancer_spec.rb
+++ b/spec/routes/web/load_balancer_spec.rb
@@ -325,6 +325,7 @@ RSpec.describe Clover, "load balancer" do
 
         expect(page.title).to eq("Ubicloud - #{lb2.name}")
         expect(page).to have_content "VM is already attached to a load balancer"
+        expect(page.html).not_to include(vm.name)
         expect(lb2.vms.count).to eq(0)
       end
 

--- a/views/networking/load_balancer/vms.erb
+++ b/views/networking/load_balancer/vms.erb
@@ -3,7 +3,7 @@
     ds = ds.where(Sequel[:vm][:ip4_enabled] => true)
   end
   attachable_vms = dataset_authorize(ds, "Vm:view")
-    .exclude(Sequel[:vm][:id] => @lb.vms_dataset.select(Sequel[:vm][:id]))
+    .exclude(Sequel[:vm][:id] => LoadBalancerVm.where(vm_id: @project.vms_dataset.select(:id)).select(:vm_id))
     .all
 load_balancer_path = "#{@project.path}#{@lb.path}"
 edit_perm = has_permission?("LoadBalancer:edit", @lb) %>


### PR DESCRIPTION
Previously, the page only excluded VMs attached to the current load balancer, not VMs attached to other load balancers. However, the route to add a VM to a load balancer checks that the VM is not associated with any load balancer, so there is no reason to show such VMs as options.