### PR TITLE
bypass maintenance window when disk usage >= 95%

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -279,7 +279,7 @@ class PostgresResource < Sequel::Model
 
   def handle_storage_auto_scale
     begin
-      disk_usage_percent = representative_server.vm.sshable.cmd("df --output=pcent /dat | tail -n 1").strip.delete("%").to_i
+      disk_usage_percent = representative_server.disk_usage_percent
     rescue
       Clog.emit("Failed to check disk usage for #{ubid}, skipping storage auto-scale check", representative_server)
       return

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -259,6 +259,10 @@ class PostgresServer < Sequel::Model
     0
   end
 
+  def disk_usage_percent
+    Integer(vm.sshable.cmd("df --output=pcent /dat | tail -n 1").strip.delete("%"), 10)
+  end
+
   def lsn_monitor_ds
     POSTGRES_MONITOR_DB[:postgres_lsn_monitor].where(postgres_server_id: id)
   end

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -41,7 +41,15 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
   end
 
   label def wait_for_maintenance_window
-    nap 10 * 60 unless postgres_resource.in_maintenance_window?
+    unless postgres_resource.in_maintenance_window?
+      ignore_window = begin
+        postgres_resource.representative_server.disk_usage_percent >= 95
+      rescue Sshable::SshError, *Sshable::SSH_CONNECTION_ERRORS => e
+        Clog.emit("Maintenance failed to check disk usage", Util.exception_to_hash(e, into: {resource_id: postgres_resource.id}))
+        nap 60
+      end
+      nap 10 * 60 unless ignore_window
+    end
 
     hop_provision_servers unless postgres_resource.has_enough_fresh_servers?
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -627,6 +627,18 @@ RSpec.describe PostgresServer do
     end
   end
 
+  describe "#disk_usage_percent" do
+    it "returns the percentage reported by df on /dat" do
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with("df --output=pcent /dat | tail -n 1").and_return("  95%\n")
+      expect(postgres_server.disk_usage_percent).to eq(95)
+    end
+
+    it "raises when the ssh command fails" do
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with("df --output=pcent /dat | tail -n 1").and_raise(RuntimeError)
+      expect { postgres_server.disk_usage_percent }.to raise_error(RuntimeError)
+    end
+  end
+
   it "initiates a new health monitor session" do
     forward = instance_double(Net::SSH::Service::Forward)
     expect(forward).to receive(:local_socket)

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -444,9 +444,25 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect { nx.wait_for_maintenance_window }.to hop("recycle_representative_server")
     end
 
-    it "waits if not in maintenance window" do
+    it "waits if not in maintenance window and disk under 95%" do
       pg.update(maintenance_window_start_at: (Time.now.utc.hour + 12) % 24)
+      create_server(is_representative: true)
+      expect(nx.postgres_resource.representative_server).to receive(:disk_usage_percent).and_return(94)
       expect { nx.wait_for_maintenance_window }.to nap(10 * 60)
+    end
+
+    it "bypasses maintenance window when disk at or above 95%" do
+      pg.update(maintenance_window_start_at: (Time.now.utc.hour + 12) % 24)
+      create_server(is_representative: true)
+      expect(nx.postgres_resource.representative_server).to receive(:disk_usage_percent).and_return(95)
+      expect { nx.wait_for_maintenance_window }.to hop("recycle_representative_server")
+    end
+
+    it "naps shorter if disk check ssh fails" do
+      pg.update(maintenance_window_start_at: (Time.now.utc.hour + 12) % 24)
+      create_server(is_representative: true)
+      expect(nx.postgres_resource.representative_server).to receive(:disk_usage_percent).and_raise(Sshable::SshError.new("df", "", "", 1, nil))
+      expect { nx.wait_for_maintenance_window }.to nap(60)
     end
   end
 


### PR DESCRIPTION
recently had instance stuck in read only on 99% disk, waiting 9h for maintenance window