### PR TITLE
Show VMs using each machine image version

### DIFF
--- a/cli-commands/mi/post/list-versions.rb
+++ b/cli-commands/mi/post/list-versions.rb
@@ -3,7 +3,7 @@
 UbiCli.on("mi").run_on("list-versions") do
   desc "List versions of a machine image"
 
-  fields = %w[version id state actual-size-mib archive-size-mib created-at].freeze.each(&:freeze)
+  fields = %w[version id state actual-size-mib archive-size-mib created-at vms-count].freeze.each(&:freeze)
 
   key = :mi_list_versions
 

--- a/cli-commands/mi/post/show.rb
+++ b/cli-commands/mi/post/show.rb
@@ -4,7 +4,7 @@ UbiCli.on("mi").run_on("show") do
   desc "Show details for a machine image"
 
   fields = %w[id name location arch latest-version created-at versions].freeze.each(&:freeze)
-  version_fields = %w[version id state actual-size-mib archive-size-mib created-at].freeze.each(&:freeze)
+  version_fields = %w[version id state actual-size-mib archive-size-mib created-at vms-count vms].freeze.each(&:freeze)
 
   options("ubi mi (location/mi-name | mi-id) show [options]", key: :mi_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
@@ -27,7 +27,13 @@ UbiCli.on("mi").run_on("show") do
         data[key].each_with_index do |version, i|
           body << "version " << (i + 1).to_s << ":\n"
           each_with_dashed(version_keys) do |v_key, display_v_key|
-            body << "  " << display_v_key << ": " << version[v_key].to_s << "\n"
+            value = version[v_key]
+            if value.is_a?(Array)
+              body << "  " << display_v_key << ":\n"
+              value.each { body << "    - " << it << "\n" }
+            else
+              body << "  " << display_v_key << ": " << value.to_s << "\n"
+            end
           end
         end
       else

--- a/model/machine_image/machine_image_version.rb
+++ b/model/machine_image/machine_image_version.rb
@@ -6,6 +6,7 @@ class MachineImageVersion < Sequel::Model
   one_to_one :strand, key: :id
   many_to_one :machine_image, read_only: true
   one_to_one :metal, class: MachineImageVersionMetal, key: :id, read_only: true
+  one_to_many :vm_storage_volumes, read_only: true
 
   plugin ResourceMethods
 

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -3512,12 +3512,23 @@ components:
           description: Creation timestamp
           type: string
           format: date-time
+        vms_count:
+          description: Number of VMs provisioned from this version
+          type: integer
+        vms:
+          description: UBIDs of VMs provisioned from this version
+          type: array
+          items:
+            type: string
+            pattern: ^vm[0-9a-hj-km-np-tv-z]{24}$
       additionalProperties: false
       required:
         - id
         - version
         - state
         - created_at
+        - vms_count
+        - vms
     Nic:
       type: object
       properties:

--- a/routes/project/location/machine_image.rb
+++ b/routes/project/location/machine_image.rb
@@ -33,7 +33,7 @@ class Clover
               )
               miv = assemble_machine_image_version(mi, version, source_vm)
               audit_log(mi, "create", [miv])
-              Serializers::MachineImage.serialize(mi, {detailed: true})
+              Serializers::MachineImage.serialize(mi, {detailed: true, visible_vms: dataset_authorize(@project.vms_dataset, "Vm:view").select(:id)})
             end
           end
 
@@ -48,7 +48,7 @@ class Clover
 
         r.get true do
           authorize("MachineImage:view", mi)
-          Serializers::MachineImage.serialize(mi, {detailed: true})
+          Serializers::MachineImage.serialize(mi, {detailed: true, visible_vms: dataset_authorize(@project.vms_dataset, "Vm:view").select(:id)})
         end
 
         r.patch true do
@@ -71,7 +71,7 @@ class Clover
             audit_log(mi, "update_latest_version", miv ? [miv] : [])
           end
 
-          Serializers::MachineImage.serialize(mi.refresh, {detailed: true})
+          Serializers::MachineImage.serialize(mi.refresh, {detailed: true, visible_vms: dataset_authorize(@project.vms_dataset, "Vm:view").select(:id)})
         end
 
         r.delete true do
@@ -93,7 +93,8 @@ class Clover
         r.on "version" do
           r.get true do
             authorize("MachineImage:view", mi)
-            paginated_result(mi.versions_dataset.eager(:metal), Serializers::MachineImageVersion)
+            visible_vms = dataset_authorize(@project.vms_dataset, "Vm:view").select(:id)
+            paginated_result(mi.versions_dataset.eager(:metal, vm_storage_volumes: ->(ds) { ds.where(vm_id: visible_vms) }), Serializers::MachineImageVersion)
           end
 
           r.on(/([a-zA-Z0-9][a-zA-Z0-9._-]{0,63})/) do |version|
@@ -107,6 +108,7 @@ class Clover
               DB.transaction do
                 miv = assemble_machine_image_version(mi, version, source_vm)
                 audit_log(mi, "create_version", [miv])
+                miv.associations[:vm_storage_volumes] = []
                 Serializers::MachineImageVersion.serialize(miv)
               end
             end

--- a/serializers/machine_image.rb
+++ b/serializers/machine_image.rb
@@ -11,7 +11,11 @@ class Serializers::MachineImage < Serializers::Base
       created_at: mi.created_at.iso8601,
     }
 
-    base[:versions] = Serializers::MachineImageVersion.serialize(mi.versions_dataset.eager(:metal).all) if options[:detailed]
+    if options[:detailed]
+      visible_vms = options[:visible_vms] || []
+      versions = mi.versions_dataset.eager(:metal, vm_storage_volumes: ->(ds) { ds.where(vm_id: visible_vms) }).all
+      base[:versions] = Serializers::MachineImageVersion.serialize(versions)
+    end
 
     base
   end

--- a/serializers/machine_image_version.rb
+++ b/serializers/machine_image_version.rb
@@ -3,6 +3,7 @@
 class Serializers::MachineImageVersion < Serializers::Base
   def self.serialize_internal(miv, options = {})
     metal = miv.metal
+    vm_ubids = miv.vm_storage_volumes.map { |vsv| UBID.to_ubid(vsv.vm_id) }.sort.uniq
     {
       id: miv.ubid,
       version: miv.version,
@@ -10,6 +11,8 @@ class Serializers::MachineImageVersion < Serializers::Base
       actual_size_mib: miv.actual_size_mib,
       archive_size_mib: metal&.archive_size_mib,
       created_at: miv.created_at.iso8601,
+      vms_count: vm_ubids.size,
+      vms: vm_ubids,
     }
   end
 end

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -625,6 +625,7 @@ Options:
 
 Allowed Option Values:
     Fields: version id state actual-size-mib archive-size-mib created-at
+            vms-count
 
 
 Rename a machine image
@@ -651,6 +652,7 @@ Options:
 Allowed Option Values:
     Fields: id name location arch latest-version created-at versions
     Version Fields: version id state actual-size-mib archive-size-mib created-at
+                    vms-count vms
 
 
 Unset the latest version of a machine image

--- a/spec/routes/api/cli/mi/list_versions_spec.rb
+++ b/spec/routes/api/cli/mi/list_versions_spec.rb
@@ -14,16 +14,33 @@ RSpec.describe Clover, "cli mi list-versions" do
 
   it "lists versions without headers when -N is given" do
     body = cli(%W[mi eu-central-h1/#{@mi.name} list-versions -N])
-    expect(body).to eq("v1  #{@miv.ubid}  ready  5120  1024  #{@miv.created_at.iso8601}\n")
+    expect(body).to eq("v1  #{@miv.ubid}  ready  5120  1024  #{@miv.created_at.iso8601}  0\n")
   end
 
   it "shows headers by default" do
     body = cli(%W[mi eu-central-h1/#{@mi.name} list-versions])
-    expect(body).to eq("version  id                          state  actual-size-mib  archive-size-mib  created-at               \nv1       #{@miv.ubid}  ready  5120             1024              #{@miv.created_at.iso8601}\n")
+    expect(body).to eq("version  id                          state  actual-size-mib  archive-size-mib  created-at                 vms-count\nv1       #{@miv.ubid}  ready  5120             1024              #{@miv.created_at.iso8601}  0        \n")
   end
 
   it "restricts fields with -f" do
     body = cli(%W[mi eu-central-h1/#{@mi.name} list-versions -N -f version])
     expect(body).to eq("v1\n")
+  end
+
+  it "reports the count of VMs using each version" do
+    vbb = create_vhost_block_backend(allocation_weight: 100, vm_host_id: create_vm_host(location_id:).id)
+    sd = StorageDevice.create(name: "vda", total_storage_gib: 100, available_storage_gib: 50, vm_host_id: vbb.vm_host_id)
+    vm = create_vm(project_id: @project.id, location_id:, vm_host_id: vbb.vm_host_id)
+    VmStorageVolume.create(
+      vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0,
+      storage_device_id: sd.id,
+      vhost_block_backend_id: vbb.id,
+      machine_image_version_id: @miv.id,
+      key_encryption_key_1_id: StorageKeyEncryptionKey.create_random(auth_data: "k").id,
+      vring_workers: 1,
+    )
+
+    body = cli(%W[mi eu-central-h1/#{@mi.name} list-versions -N -f version,vms-count])
+    expect(body).to eq("v1  1\n")
   end
 end

--- a/spec/routes/api/cli/mi/show_spec.rb
+++ b/spec/routes/api/cli/mi/show_spec.rb
@@ -51,4 +51,27 @@ RSpec.describe Clover, "cli mi show" do
       "! Invalid field(s) given in mi show -v option",
     )
   end
+
+  it "lists VMs using a version" do
+    vbb = create_vhost_block_backend(allocation_weight: 100, vm_host_id: create_vm_host(location_id:).id)
+    sd = StorageDevice.create(name: "vda", total_storage_gib: 100, available_storage_gib: 50, vm_host_id: vbb.vm_host_id)
+    vm = create_vm(name: "consumer", project_id: @project.id, location_id:, vm_host_id: vbb.vm_host_id)
+    VmStorageVolume.create(
+      vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0,
+      storage_device_id: sd.id,
+      vhost_block_backend_id: vbb.id,
+      machine_image_version_id: @mi_metal.machine_image_version.id,
+      key_encryption_key_1_id: StorageKeyEncryptionKey.create_random(auth_data: "k").id,
+      vring_workers: 1,
+    )
+
+    body = cli(%W[mi eu-central-h1/#{@mi.name} show -f versions -v version,vms-count,vms])
+    expect(body).to eq <<~END
+      version 1:
+        version: v1
+        vms-count: 1
+        vms:
+          - #{vm.ubid}
+    END
+  end
 end

--- a/spec/routes/api/project/location/machine_image_spec.rb
+++ b/spec/routes/api/project/location/machine_image_spec.rb
@@ -362,6 +362,51 @@ RSpec.describe Clover, "machine-image" do
       expect(no_metal["state"]).to be_nil
       expect(no_metal["archive_size_mib"]).to be_nil
     end
+
+    it "reports the VMs using each version" do
+      vbb = create_vhost_block_backend(allocation_weight: 100, vm_host_id: create_vm_host(location_id:).id)
+      sd = StorageDevice.create(name: "vda", total_storage_gib: 100, available_storage_gib: 50, vm_host_id: vbb.vm_host_id)
+      vm = create_vm(project_id: project.id, location_id:, vm_host_id: vbb.vm_host_id)
+      VmStorageVolume.create(
+        vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0,
+        storage_device_id: sd.id,
+        vhost_block_backend_id: vbb.id,
+        machine_image_version_id: mi_version.id,
+        key_encryption_key_1_id: StorageKeyEncryptionKey.create_random(auth_data: "k").id,
+        vring_workers: 1,
+      )
+
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/machine-image/#{mi.name}/version"
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      item = body["items"].first
+      expect(item["vms_count"]).to eq(1)
+      expect(item["vms"]).to eq([vm.ubid])
+    end
+
+    it "hides VMs the caller cannot Vm:view" do
+      vbb = create_vhost_block_backend(allocation_weight: 100, vm_host_id: create_vm_host(location_id:).id)
+      sd = StorageDevice.create(name: "vda", total_storage_gib: 100, available_storage_gib: 50, vm_host_id: vbb.vm_host_id)
+      vm = create_vm(project_id: project.id, location_id:, vm_host_id: vbb.vm_host_id)
+      VmStorageVolume.create(
+        vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0,
+        storage_device_id: sd.id,
+        vhost_block_backend_id: vbb.id,
+        machine_image_version_id: mi_version.id,
+        key_encryption_key_1_id: StorageKeyEncryptionKey.create_random(auth_data: "k").id,
+        vring_workers: 1,
+      )
+
+      AccessControlEntry.dataset.destroy
+      AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["MachineImage:view"])
+      AccessControlEntry.create(project_id: project.id, subject_id: @pat.id, action_id: ActionType::NAME_MAP["MachineImage:view"])
+
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/machine-image/#{mi.name}/version"
+      expect(last_response.status).to eq(200)
+      item = JSON.parse(last_response.body)["items"].first
+      expect(item["vms_count"]).to eq(0)
+      expect(item["vms"]).to eq([])
+    end
   end
 
   describe "version create" do


### PR DESCRIPTION
Each machine image version now reports the VMs that still depend on it. list-versions shows the count as an extra column; show prints the UBIDs as a list under each version block.

A machine image version can't be deleted while any VM is still fetching from it, so surfacing the list makes it easy to track which VMs are holding a version alive.

VMs fetch from the machine image eagerly and disassociate from it once they're caught up.