### PR TITLE
Default new VM boot image to ubuntu-noble

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -166,7 +166,7 @@ module Config
   override :vhost_block_backend_version, "v0.2.2", string
 
   # Boot Images
-  override :default_boot_image_name, "ubuntu-jammy", string
+  override :default_boot_image_name, "ubuntu-noble", string
 
   # Machine Images
   override :machine_image_max_size_gib, 40, int

--- a/spec/routes/api/cli/vm/create_spec.rb
+++ b/spec/routes/api/cli/vm/create_spec.rb
@@ -105,6 +105,11 @@ RSpec.describe Clover, "cli vm create" do
     expect(Vm.count).to eq 0
   end
 
+  it "defaults the boot image to ubuntu-noble when -b is omitted" do
+    cli(%w[vm eu-central-h1/test-vm create] << "a a")
+    expect(Vm.first.boot_image).to eq "ubuntu-noble"
+  end
+
   it "shows errors if trying to create a vm with an invalid number of arguments" do
     expect(Vm.count).to eq 0
     expect(cli(%W[vm eu-north-h1/test-vm2 create], status: 400).b).to start_with("! Invalid number of arguments for vm create subcommand (requires: 1, given: 0)")

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe CloverAdmin do
     vm = Prog::Vm::Nexus.assemble("dummy key", project.id, name: "my-vm").subject
     click_link "Vm"
     expect(page.title).to eq "Ubicloud Admin - Vm - Browse"
-    expect(page.all("#autoforme_content td").map(&:text)).to eq ["my-vm", "creating", "Default", "", "hetzner-fsn1", "x64", "ubuntu-jammy", "standard", "2", vm.created_at.to_s]
+    expect(page.all("#autoforme_content td").map(&:text)).to eq ["my-vm", "creating", "Default", "", "hetzner-fsn1", "x64", "ubuntu-noble", "standard", "2", vm.created_at.to_s]
 
     click_link vm.name
     expect(page.title).to eq "Ubicloud Admin - Vm #{vm.ubid}"
@@ -415,7 +415,7 @@ RSpec.describe CloverAdmin do
 
     within(".association", text: "vms") { click_link "(table)" }
     expect(page.title).to eq "Ubicloud Admin - Vm - Search"
-    expect(page.all("#autoforme_content td").map(&:text)).to eq ["assoc-table-vm", "creating", "assoc-table-test", "", "hetzner-fsn1", "x64", "ubuntu-jammy", "standard", "2", vm.created_at.to_s]
+    expect(page.all("#autoforme_content td").map(&:text)).to eq ["assoc-table-vm", "creating", "assoc-table-test", "", "hetzner-fsn1", "x64", "ubuntu-noble", "standard", "2", vm.created_at.to_s]
 
     expect(Config).to receive(:postgres_service_project_id).and_return(project.id).at_least(:once)
     pg = Prog::Postgres::PostgresResourceNexus.assemble(


### PR DESCRIPTION
When the CLI's -b flag is omitted, default new VMs to noble instead of the older jammy, which will reach end of life in May 2027.

Users can still create VMs from 22.04 by passing -b ubuntu-jammy explicitly.