### PR TITLE
Retry GCE instance creation on transient INTERNAL_ERROR

### DIFF
--- a/prog/vm/gcp/nexus.rb
+++ b/prog/vm/gcp/nexus.rb
@@ -133,7 +133,7 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
   label def wait_create_op
     poll_and_clear_gcp_op("create_vm") do |op|
       error_code = op_error_code(op)
-      if %w[ZONE_RESOURCE_POOL_EXHAUSTED ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS QUOTA_EXCEEDED].freeze.include?(error_code)
+      if %w[ZONE_RESOURCE_POOL_EXHAUSTED ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS QUOTA_EXCEEDED INTERNAL_ERROR].freeze.include?(error_code)
         clear_gcp_op("create_vm")
         # Stash the backoff delay; #start naps it off before retrying (nap here would re-enter wait_create_op).
         update_stack({"retry_zone_delay" => bump_excluded_zone("GCE operation error: #{error_code}")})

--- a/spec/prog/vm/gcp/nexus_spec.rb
+++ b/spec/prog/vm/gcp/nexus_spec.rb
@@ -487,7 +487,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       expect { nx.wait_create_op }.to raise_error(RuntimeError, /GCE instance creation failed.*operation failed/)
     end
 
-    %w[ZONE_RESOURCE_POOL_EXHAUSTED ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS QUOTA_EXCEEDED].each do |code|
+    %w[ZONE_RESOURCE_POOL_EXHAUSTED ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS QUOTA_EXCEEDED INTERNAL_ERROR].each do |code|
       it "retries in a different zone on #{code} operation error" do
         refresh_frame(nx, new_values: {"create_vm" => {"name" => "op-123", "scope" => "zone", "scope_value" => "us-central1-a"}, "gcp_zone_suffix" => "a"})
         ensure_vm_gcp_resource(vm, "a")


### PR DESCRIPTION
A GCE create operation that completes with INTERNAL_ERROR (HTTP 503)
fell through wait_create_op's retryable check, which only matched the
capacity codes (ZONE_RESOURCE_POOL_EXHAUSTED, QUOTA_EXCEEDED), down to
the terminal raise. Because poll_and_clear_gcp_op only clears the op
after its block runs, raising inside the block leaves the failed
operation set: every strand retry re-polls the same DONE-with-error
operation and raises again, never issuing a fresh insert. A transient
503 therefore wedges provisioning until an external timeout instead of
recovering once GCE settles.

Treat INTERNAL_ERROR like the capacity codes: clear the op, exclude the
zone, and hop back to start to attempt a fresh create.
