### PR TITLE
Lock GCP VPC row when destroying its last subnet

### DIFF
--- a/prog/vnet/gcp/subnet_nexus.rb
+++ b/prog/vnet/gcp/subnet_nexus.rb
@@ -202,7 +202,7 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   end
 
   label def finish_destroy
-    gcp_vpc = private_subnet.gcp_vpc
+    gcp_vpc = private_subnet.gcp_vpc(&:for_no_key_update)
     private_subnet.destroy
 
     if gcp_vpc && gcp_vpc.private_subnets_dataset.empty?

--- a/spec/prog/vnet/gcp/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_spec.rb
@@ -695,6 +695,17 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
       expect(Semaphore.where(strand_id: gcp_vpc.id, name: "destroy").count).to eq(1)
     end
 
+    it "loads the gcp_vpc with a FOR NO KEY UPDATE lock so concurrent teardowns serialize" do
+      captured = nil
+      allow(nx.private_subnet).to receive(:gcp_vpc).and_wrap_original do |original, &block|
+        captured = block
+        original.call(&block)
+      end
+      expect { nx.finish_destroy }.to exit({"msg" => "subnet destroyed"})
+      expect(captured.call(GcpVpc.dataset).sql).to include("FOR NO KEY UPDATE")
+      expect(Semaphore.where(strand_id: gcp_vpc.id, name: "destroy").count).to eq(1)
+    end
+
     it "handles nil gcp_vpc gracefully" do
       DB[:private_subnet_gcp_vpc].where(private_subnet_id: ps.id).delete
       nx.private_subnet.refresh


### PR DESCRIPTION
A GCP VPC is shared by every dedicated postgres subnet in a project and location. Its destroy is never requested directly; instead the last private subnet to leave triggers it from SubnetNexus#finish_destroy, which destroys its own subnet and then checks whether the VPC has any subnets left before calling incr_destroy on it.

That check is unsynchronized. When two subnets in the same VPC are torn down concurrently, each transaction deletes its own subnet and then, within its own snapshot, still sees the other subnet present. Neither observes an empty set, so neither calls incr_destroy and the VPC is orphaned. This stranded a VPC in the upgrade-postgres e2e test, whose wait_resources_destroyed step naps until the destroy of the GCP VPC, and hung the teardown until the job timed out.

Take a FOR NO KEY UPDATE lock on the gcp_vpc row before the membership check so concurrent finish_destroy transactions serialize on it. The last one out then observes the now-empty set and triggers the VPC destroy. NO KEY UPDATE is enough to serialize the destroys against each other while still allowing a subnet to attach to the VPC; the VPC destroy re-checks emptiness before deleting the network either way.