### PR TITLE
Allow using recycling standbys for unplanned failovers

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -292,14 +292,12 @@ class PostgresServer < Sequel::Model
 
     target = candidates
       .map { {server: it, lsn: it.current_lsn} }
-      # Priority: recycle-readiness (avoid promoting a server we'll recycle)
-      # > slot-readiness (safe to promote) > lsn (minimize data loss)
-      # > intended type (post-failover stability) > family rank (prefer newer).
       .max_by {
         slot_score = (it[:server].physical_slot_ready_id == resource.representative_server.id) ? 1 : 0
+        recycle_score = it[:server].needs_recycling? ? 0 : 1
         type_score = it[:server].fallback_active? ? 0 : 1
         rank_score = Option.postgres_family_rank(it[:server].vm.family)
-        [slot_score, lsn2int(it[:lsn]), type_score, rank_score]
+        [slot_score, lsn2int(it[:lsn]), recycle_score, type_score, rank_score]
       }
 
     return nil if target.nil?

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -276,7 +276,11 @@ class PostgresServer < Sequel::Model
   def failover_target(mode: "unplanned")
     candidates = resource.servers
       .reject { it.is_representative }
-      .select { it.strand.label == "wait" && !it.needs_recycling? }
+      .select { it.strand.label == "wait" }
+
+    if mode == "planned"
+      candidates = candidates.reject { it.needs_recycling? }
+    end
 
     if mode == "planned" && !read_replica?
       ready = candidates.select { it.physical_slot_ready_id == resource.representative_server.id }
@@ -288,7 +292,8 @@ class PostgresServer < Sequel::Model
 
     target = candidates
       .map { {server: it, lsn: it.current_lsn} }
-      # Priority: slot-readiness (safe to promote) > lsn (minimize data loss)
+      # Priority: recycle-readiness (avoid promoting a server we'll recycle)
+      # > slot-readiness (safe to promote) > lsn (minimize data loss)
       # > intended type (post-failover stability) > family rank (prefer newer).
       .max_by {
         slot_score = (it[:server].physical_slot_ready_id == resource.representative_server.id) ? 1 : 0

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -389,14 +389,12 @@ class PostgresServer < Sequel::Model
 
     target = candidates
       .map { {server: it, lsn: it.current_lsn} }
-      # Priority: recycle-readiness (avoid promoting a server we'll recycle)
-      # > slot-readiness (safe to promote) > lsn (minimize data loss)
-      # > intended type (post-failover stability) > family rank (prefer newer).
       .max_by {
         slot_score = (it[:server].physical_slot_ready_id == resource.representative_server.id) ? 1 : 0
+        recycle_score = it[:server].needs_recycling? ? 0 : 1
         type_score = it[:server].fallback_active? ? 0 : 1
         rank_score = Option.postgres_family_rank(it[:server].vm.family)
-        [slot_score, lsn2int(it[:lsn]), type_score, rank_score]
+        [slot_score, lsn2int(it[:lsn]), recycle_score, type_score, rank_score]
       }
 
     return nil if target.nil?

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -373,7 +373,11 @@ class PostgresServer < Sequel::Model
   def failover_target(mode: "unplanned")
     candidates = resource.servers
       .reject { it.is_representative }
-      .select { it.strand.label == "wait" && !it.needs_recycling? }
+      .select { it.strand.label == "wait" }
+
+    if mode == "planned"
+      candidates = candidates.reject { it.needs_recycling? }
+    end
 
     if mode == "planned" && !read_replica?
       ready = candidates.select { it.physical_slot_ready_id == resource.representative_server.id }
@@ -385,7 +389,8 @@ class PostgresServer < Sequel::Model
 
     target = candidates
       .map { {server: it, lsn: it.current_lsn} }
-      # Priority: slot-readiness (safe to promote) > lsn (minimize data loss)
+      # Priority: recycle-readiness (avoid promoting a server we'll recycle)
+      # > slot-readiness (safe to promote) > lsn (minimize data loss)
       # > intended type (post-failover stability) > family rank (prefer newer).
       .max_by {
         slot_score = (it[:server].physical_slot_ready_id == resource.representative_server.id) ? 1 : 0

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -725,11 +725,6 @@ SQL
 
     nap 0 if resource.ongoing_failover? || postgres_server.trigger_failover(mode: "unplanned")
 
-    when_configure_set? do
-      decr_configure
-      hop_configure
-    end
-
     if available?
       decr_checkup
       decr_recycle_unavailable_server

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -576,6 +576,7 @@ SQL
     query = DB["SELECT sync_state FROM pg_stat_replication WHERE application_name = :ubid", ubid: postgres_server.ubid]
     sync_state = resource.representative_server.run_query(query).chomp
     hop_wait if ["quorum", "sync"].include?(sync_state)
+    hop_wait_catch_up if sync_state == "async"
 
     nap 30
   end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -602,6 +602,7 @@ SQL
     query = DB["SELECT sync_state FROM pg_stat_replication WHERE application_name = :ubid", ubid: postgres_server.ubid]
     sync_state = resource.representative_server.run_query(query).chomp
     hop_wait if ["quorum", "sync"].include?(sync_state)
+    hop_wait_catch_up if sync_state == "async"
 
     nap 30
   end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -765,11 +765,6 @@ SQL
 
     nap 0 if postgres_server.is_representative && (resource.ongoing_failover? || postgres_server.trigger_failover(mode: "unplanned"))
 
-    when_configure_set? do
-      decr_configure
-      hop_configure
-    end
-
     if available?
       decr_checkup
       decr_recycle_unavailable_server

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe PostgresServer do
       expect(postgres_server.failover_target).to be_nil
     end
 
-    it "returns nil if there is no fresh standby" do
+    it "returns nil for planned failover if there is no fresh standby" do
       expect(postgres_server).to receive(:is_representative).and_return(true)
       standby_server = described_class.new { it.id = "c068cac7-ed45-82db-bf38-a003582b36ef" }
       expect(standby_server).to receive(:resource).at_least(:once).and_return(resource)
@@ -322,7 +322,7 @@ RSpec.describe PostgresServer do
 
       expect(resource).to receive(:servers).and_return([postgres_server, standby_server]).at_least(:once)
       expect(resource).to receive(:target_vm_size).and_return("standard-2")
-      expect(postgres_server.failover_target).to be_nil
+      expect(postgres_server.failover_target(mode: "planned")).to be_nil
     end
 
     it "returns the standby with highest lsn in sync replication" do
@@ -361,6 +361,21 @@ RSpec.describe PostgresServer do
       ])
       expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
       expect(postgres_server.failover_target.ubid).to eq("pgubidstandby1")
+    end
+
+    it "considers a standby needing recycling for unplanned failover" do
+      allow(resource).to receive(:servers).and_return([
+        postgres_server,
+        instance_double(described_class, ubid: "pgubidrecycling", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: true, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: standby_vm),
+      ])
+      expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
+      expect(postgres_server.failover_target.ubid).to eq("pgubidrecycling")
+    end
+
+    it "skips a standby needing recycling for planned failover" do
+      standby = instance_double(described_class, ubid: "pgubidrecycling", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: true, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: standby_vm)
+      expect(resource).to receive(:servers).and_return([postgres_server, standby]).at_least(:once)
+      expect(postgres_server.failover_target(mode: "planned")).to be_nil
     end
 
     it "returns nil for planned failover when no standby has physical_slot_ready" do
@@ -516,14 +531,14 @@ RSpec.describe PostgresServer do
       expect(postgres_server.failover_target).to be_nil
     end
 
-    it "returns nil if there is no fresh read_replica" do
+    it "returns nil for planned failover if there is no fresh read_replica" do
       replica_server = described_class.new { it.id = "c068cac7-ed45-82db-bf38-a003582b36ef" }
       expect(replica_server).to receive(:resource).at_least(:once).and_return(resource)
       expect(replica_server).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
       expect(replica_server).to receive(:vm).and_return(instance_double(Vm, display_size: "standard-4")).at_least(:once)
       expect(resource).to receive(:servers).and_return([postgres_server, replica_server]).at_least(:once)
       expect(resource).to receive(:target_vm_size).and_return("standard-2")
-      expect(postgres_server.failover_target).to be_nil
+      expect(postgres_server.failover_target(mode: "planned")).to be_nil
     end
 
     it "returns the replica with highest lsn" do

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -557,7 +557,7 @@ RSpec.describe PostgresServer do
       expect(postgres_server.failover_target).to be_nil
     end
 
-    it "returns nil if there is no fresh standby" do
+    it "returns nil for planned failover if there is no fresh standby" do
       expect(postgres_server).to receive(:is_representative).and_return(true)
       standby_server = described_class.new { it.id = "c068cac7-ed45-82db-bf38-a003582b36ef" }
       expect(standby_server).to receive(:resource).at_least(:once).and_return(resource)
@@ -567,7 +567,7 @@ RSpec.describe PostgresServer do
 
       expect(resource).to receive(:servers).and_return([postgres_server, standby_server]).at_least(:once)
       expect(resource).to receive(:target_vm_size).and_return("standard-2")
-      expect(postgres_server.failover_target).to be_nil
+      expect(postgres_server.failover_target(mode: "planned")).to be_nil
     end
 
     it "returns the standby with highest lsn in sync replication" do
@@ -606,6 +606,21 @@ RSpec.describe PostgresServer do
       ])
       expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
       expect(postgres_server.failover_target.ubid).to eq("pgubidstandby1")
+    end
+
+    it "considers a standby needing recycling for unplanned failover" do
+      allow(resource).to receive(:servers).and_return([
+        postgres_server,
+        instance_double(described_class, ubid: "pgubidrecycling", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: true, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: standby_vm),
+      ])
+      expect(resource).to receive(:ha_type).and_return(PostgresResource::HaType::SYNC)
+      expect(postgres_server.failover_target.ubid).to eq("pgubidrecycling")
+    end
+
+    it "skips a standby needing recycling for planned failover" do
+      standby = instance_double(described_class, ubid: "pgubidrecycling", is_representative: false, current_lsn: "1/10", strand: instance_double(Strand, label: "wait"), needs_recycling?: true, read_replica?: false, physical_slot_ready_id: postgres_server.id, synchronization_status: "ready", fallback_active?: false, vm: standby_vm)
+      expect(resource).to receive(:servers).and_return([postgres_server, standby]).at_least(:once)
+      expect(postgres_server.failover_target(mode: "planned")).to be_nil
     end
 
     it "returns nil for planned failover when no standby has physical_slot_ready" do
@@ -761,14 +776,14 @@ RSpec.describe PostgresServer do
       expect(postgres_server.failover_target).to be_nil
     end
 
-    it "returns nil if there is no fresh read_replica" do
+    it "returns nil for planned failover if there is no fresh read_replica" do
       replica_server = described_class.new { it.id = "c068cac7-ed45-82db-bf38-a003582b36ef" }
       expect(replica_server).to receive(:resource).at_least(:once).and_return(resource)
       expect(replica_server).to receive(:strand).and_return(instance_double(Strand, label: "wait"))
       expect(replica_server).to receive(:vm).and_return(instance_double(Vm, display_size: "standard-4")).at_least(:once)
       expect(resource).to receive(:servers).and_return([postgres_server, replica_server]).at_least(:once)
       expect(resource).to receive(:target_vm_size).and_return("standard-2")
-      expect(postgres_server.failover_target).to be_nil
+      expect(postgres_server.failover_target(mode: "planned")).to be_nil
     end
 
     it "returns the replica with highest lsn" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1376,11 +1376,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   end
 
   describe "#unavailable" do
-    it "hops to configure if configure is set" do
-      nx.incr_configure
-      expect { nx.unavailable }.to hop("configure")
-    end
-
     it "hops to lockout if lockout is set" do
       nx.incr_lockout
       expect { nx.unavailable }.to hop("lockout")

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1154,9 +1154,18 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "naps and registers a deadline while sync replication is not established" do
-      expect(standby_nx).to receive(:register_deadline).with("wait", 5 * 60).twice
-      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("", "async")
+      expect(standby_nx).to receive(:register_deadline).with("wait", 5 * 60)
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("")
       expect { standby_nx.wait_synchronization }.to nap(30)
+    end
+
+    it "hops to wait_catch_up if replication is async" do
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("async")
+      expect { standby_nx.wait_synchronization }.to hop("wait_catch_up")
+    end
+
+    it "naps if sync replication is not established" do
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("")
       expect { standby_nx.wait_synchronization }.to nap(30)
     end
   end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1510,11 +1510,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   end
 
   describe "#unavailable" do
-    it "hops to configure if configure is set" do
-      nx.incr_configure
-      expect { nx.unavailable }.to hop("configure")
-    end
-
     it "hops to lockout if lockout is set" do
       nx.incr_lockout
       expect { nx.unavailable }.to hop("lockout")

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1257,9 +1257,18 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "naps and registers a deadline while sync replication is not established" do
-      expect(standby_nx).to receive(:register_deadline).with("wait", 5 * 60).twice
-      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("", "async")
+      expect(standby_nx).to receive(:register_deadline).with("wait", 5 * 60)
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("")
       expect { standby_nx.wait_synchronization }.to nap(30)
+    end
+
+    it "hops to wait_catch_up if replication is async" do
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("async")
+      expect { standby_nx.wait_synchronization }.to hop("wait_catch_up")
+    end
+
+    it "naps if sync replication is not established" do
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("")
       expect { standby_nx.wait_synchronization }.to nap(30)
     end
   end


### PR DESCRIPTION
**Allow using recycling standby for unplanned failovers**
Eventhough we are planning to recycle them, these standbys could be
useful in unplanned failover scenarios. Eventually system would converge
to the target state anyway, but in meantime, we avoid the downtime by
failing over to the standbys we would recycle.

**Prefer a standby not needing recycling for failovers**

**Hop back to wait_catch_up if needed**
If we perform failover while trying to synchronize sync standbys, we
need to run the logic for initial catch up again.

**Don't hop to configure from unavailable**
This was added to recover from config errors causing unavailability, but
it is not very robust fix. It wouldn't work when VM is unaccessible and
exiting from unavailable state would prevent us performing failovers
when necessary.

Te original problem still exists but it is less serious than before
given our checks while applying config options. We should revisit it
with a more robust mechanism though.