### PR TITLE
Fix runtime host match

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -153,7 +153,7 @@ class Clover < Roda
         :api
       elsif host.start_with?("admin.")
         :admin
-      elsif request.path_info.start_with?("/runtime")
+      elsif request.path_info.start_with?("/runtime/")
         :runtime
       end
     end

--- a/spec/routes/runtime/auth_spec.rb
+++ b/spec/routes/runtime/auth_spec.rb
@@ -4,14 +4,14 @@ require_relative "spec_helper"
 
 RSpec.describe Clover, "auth" do
   it "no jwt token" do
-    get "/runtime"
+    get "/runtime/"
 
     expect(last_response).to have_runtime_error(400, "invalid JWT format or claim in Authorization header")
   end
 
   it "wrong jwt token" do
     header "Authorization", "Bearer wrongjwt"
-    get "/runtime"
+    get "/runtime/"
 
     expect(last_response).to have_runtime_error(400, "invalid JWT format or claim in Authorization header")
   end
@@ -19,14 +19,14 @@ RSpec.describe Clover, "auth" do
   it "valid jwt token but no active vm" do
     vm = Vm.new_with_id
     header "Authorization", "Bearer #{vm.runtime_token}"
-    get "/runtime"
+    get "/runtime/"
 
     expect(last_response).to have_runtime_error(400, "invalid JWT format or claim in Authorization header")
   end
 
   it "valid jwt token with an active vm" do
     login_runtime(create_vm)
-    get "/runtime"
+    get "/runtime/"
 
     expect(last_response.status).to eq(404)
   end


### PR DESCRIPTION
Require /runtime/ instead of /runtime, so it doesn't match scans like /runtime-config.js. We don't supports requests for /runtime itself.

Fixes a runtime exception of the form:

Roda::RodaError: session called on request not using sessions