### PR TITLE
Improve firewalls security

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -45,7 +45,7 @@ def test_metal(options, test_cases)
     wait_until(minio_cluster_st, "wait")
   end
 
-  if options[:test_cases].include?("kubernetes") || options[:test_cases].include?("kubernetes_upgrade")
+  if options[:test_cases].include?("kubernetes") || options[:test_cases].include?("kubernetes_upgrade") || options[:test_cases].include?("kubernetes_firewall")
     Project[Config.kubernetes_service_project_id] ||
       Project.create_with_id(Config.kubernetes_service_project_id, name: "Ubicloud-Kubernetes-Resources")
     Project[Config.load_balancer_service_project_id] ||
@@ -100,6 +100,7 @@ def test_metal(options, test_cases)
     wait_until(lb_dns_zone_st, "wait")
     tests_to_wait << Prog::Test::Kubernetes.assemble if options[:test_cases].include?("kubernetes")
     tests_to_wait << Prog::Test::KubernetesUpgrade.assemble if options[:test_cases].include?("kubernetes_upgrade")
+    tests_to_wait << Prog::Test::KubernetesFirewall.assemble if options[:test_cases].include?("kubernetes_firewall")
   end
 
   # Although wait_until will be blocked while checking the first one

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -8,3 +8,4 @@
 - { name: postgres_firewall,         images: ["postgres-ubuntu-2204"] }
 - { name: kubernetes,                images: ["ubuntu-noble", "kubernetes-v1_35"] }
 - { name: kubernetes_upgrade,        images: ["ubuntu-noble", "kubernetes-v1_35", "kubernetes-v1_36"] }
+- { name: kubernetes_firewall,       images: ["ubuntu-noble", "kubernetes-v1_35"] }

--- a/lib/kubernetes/client.rb
+++ b/lib/kubernetes/client.rb
@@ -88,9 +88,21 @@ class Kubernetes::Client
     extra_ports.each { |port| @load_balancer.remove_port(port) }
     missing_ports.each { |port| @load_balancer.add_port(port[0], port[1]) }
 
+    sync_lb_firewall_rules
+
     return unless @load_balancer.strand.label == "wait"
 
     svc_list.each { |svc| set_load_balancer_hostname(svc, @load_balancer.hostname) }
+  end
+
+  def sync_lb_firewall_rules
+    extra_rules, missing_keys = @kubernetes_cluster.firewall_rule_diff_for_lb(@load_balancer)
+    return if extra_rules.empty? && missing_keys.empty?
+
+    firewall = @kubernetes_cluster.internal_worker_vm_firewall
+    extra_rules.each { |r| firewall.remove_firewall_rule(r) }
+    missing_keys.each { |(cidr, port)| firewall.insert_firewall_rule(cidr, Sequel.pg_range(port..port), description: "k8s-svc-lb:#{port}") }
+    firewall.vms.each(&:incr_update_firewall_rules)
   end
 
   def any_lb_services_modified?

--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -111,6 +111,19 @@ class KubernetesCluster < Sequel::Model
     [extra_ports, missing_ports]
   end
 
+  def firewall_rule_diff_for_lb(load_balancer)
+    existing = internal_worker_vm_firewall
+      .firewall_rules_dataset
+      .where(Sequel[:description].like("k8s-svc-lb:%"))
+      .all
+    existing_by_key = existing.to_h { |r| [[r.cidr.to_s, r.port_range.begin], r] }
+    desired_keys = load_balancer.ports_dataset.all.flat_map { |p| [["0.0.0.0/0", p.src_port], ["::/0", p.src_port]] }
+
+    missing_keys = desired_keys - existing_by_key.keys
+    extra_rules = (existing_by_key.keys - desired_keys).map { existing_by_key[it] }
+    [extra_rules, missing_keys]
+  end
+
   def kubeadm_recorded_version
     raw = client.kubectl("-n kube-system get cm kubeadm-config -o jsonpath='{.data.ClusterConfiguration}'")
     YAML.safe_load(raw)["kubernetesVersion"]

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -15,14 +15,22 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       Validation.validate_kubernetes_location(location_id)
 
       ubid = KubernetesCluster.generate_ubid
-      # Will create customer private subnet with customer firewall
+      customer_firewall = Firewall.create(name: "#{ubid}-firewall", location_id:, project_id:)
       subnet = Prog::Vnet::SubnetNexus.assemble(
         project_id,
         name: "#{ubid}-subnet",
         location_id:,
-        firewall_name: "#{ubid}-firewall",
+        firewall_id: customer_firewall.id,
         ipv4_range_size: 16,
       ).subject
+
+      port_range = Sequel.pg_range(0..65535)
+      intra_subnet_rules = [
+        {cidr: subnet.net4.to_s, port_range:, protocol: "tcp"},
+        {cidr: subnet.net4.to_s, port_range:, protocol: "udp"},
+        {cidr: subnet.net6.to_s, port_range:, protocol: "tcp"},
+        {cidr: subnet.net6.to_s, port_range:, protocol: "udp"},
+      ]
 
       # Internal control plane node firewall, will be directly attached to kubernetes control plane VMs
       internal_cp_vm_firewall = Firewall.create(name: "#{ubid}-cp-vm-firewall", location_id:, description: "Kubernetes control plane node internal firewall", project_id: Config.kubernetes_service_project_id)
@@ -30,18 +38,13 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
         Config.control_plane_outbound_cidrs.map { {cidr: it, port_range: Sequel.pg_range(22..22)} } + [
           {cidr: "0.0.0.0/0", port_range: Sequel.pg_range(443..443)},
           {cidr: "::/0", port_range: Sequel.pg_range(443..443)},
-          {cidr: subnet.net4.to_s, port_range: Sequel.pg_range(10250..10250)},
-          {cidr: subnet.net6.to_s, port_range: Sequel.pg_range(10250..10250)},
-        ],
+        ] + intra_subnet_rules,
       )
 
       # Internal worker node firewall, will be directly attached to kubernetes worker VMs
       internal_worker_vm_firewall = Firewall.create(name: "#{ubid}-worker-vm-firewall", location_id:, description: "Kubernetes worker node internal firewall", project_id: Config.kubernetes_service_project_id)
       internal_worker_vm_firewall.replace_firewall_rules(
-        Config.control_plane_outbound_cidrs.map { {cidr: it, port_range: Sequel.pg_range(22..22)} } + [
-          {cidr: subnet.net4.to_s, port_range: Sequel.pg_range(10250..10250)},
-          {cidr: subnet.net6.to_s, port_range: Sequel.pg_range(10250..10250)},
-        ],
+        Config.control_plane_outbound_cidrs.map { {cidr: it, port_range: Sequel.pg_range(22..22)} } + intra_subnet_rules,
       )
 
       id = ubid.to_uuid

--- a/prog/test/kubernetes_firewall.rb
+++ b/prog/test/kubernetes_firewall.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class Prog::Test::KubernetesFirewall < Prog::Test::KubernetesBase
+  frame_accessor :probe_vm_id, :probe_subnet_id
+
+  def self.assemble
+    super(cluster_name: "kubernetes-test-firewall", worker_node_count: 1)
+  end
+
+  label :start
+  label :destroy_kubernetes
+  label :finish
+  label :failed
+
+  label def wait_for_kubernetes_bootstrap
+    hop_test_node_isolation if kubernetes_cluster.strand.label == "wait"
+    nap 10
+  end
+
+  label def test_node_isolation
+    # Provision a probe VM in a separate private subnet and confirm the
+    # locked-down customer firewall keeps the cluster nodes unreachable from
+    # outside the cluster's own subnet.
+    subnet = Prog::Vnet::SubnetNexus.assemble(kubernetes_test_project_id, name: "#{cluster_name}-probe-subnet", location_id: Location::HETZNER_FSN1_ID).subject
+    probe_vm = Prog::Vm::Nexus.assemble_with_sshable(kubernetes_test_project_id, sshable_unix_user: "ubi", name: "#{cluster_name}-probe", private_subnet_id: subnet.id, boot_image: "ubuntu-noble", enable_ip4: true).subject
+
+    self.probe_subnet_id = subnet.id
+    self.probe_vm_id = probe_vm.id
+    hop_wait_probe_vm
+  end
+
+  label def wait_probe_vm
+    nap 10 unless probe_vm.strand.label == "wait"
+    probe_vm.sshable.cmd("sudo apt-get update && sudo apt-get install -y netcat-openbsd")
+    hop_verify_node_isolation
+  end
+
+  label def verify_node_isolation
+    reachable_node = kubernetes_cluster.all_nodes.find { node_port_reachable?(it, 10250) }
+    if reachable_node
+      self.fail_message = "node #{reachable_node.name} is reachable on port 10250 from a foreign subnet despite the locked-down customer firewall"
+    end
+    hop_teardown_probe
+  end
+
+  label def teardown_probe
+    probe_vm.incr_destroy
+    probe_subnet.firewalls.each(&:destroy)
+    probe_subnet.incr_destroy
+    hop_wait_probe_teardown
+  end
+
+  label def wait_probe_teardown
+    nap 5 if probe_vm || probe_subnet
+    hop_destroy_kubernetes
+  end
+
+  def probe_vm
+    @probe_vm ||= Vm[probe_vm_id]
+  end
+
+  def probe_subnet
+    @probe_subnet ||= PrivateSubnet[probe_subnet_id]
+  end
+
+  def node_port_reachable?(node, port)
+    {"-4" => node.vm.ip4_string, "-6" => node.vm.ip6_string}.any? { |family, ip| tcp_reachable?(ip, port, family) }
+  end
+
+  def tcp_reachable?(ip, port, family)
+    probe_vm.sshable.cmd("nc -zvw 5 :family :ip :port", family:, ip:, port: port.to_s)
+    true
+  rescue Sshable::SshError
+    false
+  end
+end

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -3,7 +3,7 @@
 class Prog::Vnet::SubnetNexus < Prog::Base
   subject_is :private_subnet
 
-  def self.assemble(project_id, name: nil, location_id: Location::HETZNER_FSN1_ID, ipv6_range: nil, ipv4_range: nil, allow_only_ssh: false, firewall_id: nil, firewall_name: nil, ipv4_range_size: nil, preferred_azs: [])
+  def self.assemble(project_id, name: nil, location_id: Location::HETZNER_FSN1_ID, ipv6_range: nil, ipv4_range: nil, allow_only_ssh: false, firewall_id: nil, ipv4_range_size: nil, preferred_azs: [])
     unless (project = Project[project_id])
       fail "No existing project"
     end
@@ -34,15 +34,13 @@ class Prog::Vnet::SubnetNexus < Prog::Base
       else
         port_range = allow_only_ssh ? 22..22 : 0..65535
 
-        unless firewall_name
-          firewall_name = "#{name[0, 55]}-default"
-          # As is typical when checking before inserting, there is a race condition here with
-          # a user concurrently manually creating a firewall with the same name.  However,
-          # the worst case scenario is a bogus error message, and the user could try creating
-          # the private subnet again.
-          unless firewall_dataset.where(Sequel[:firewall][:name] => firewall_name).empty?
-            firewall_name = "#{name[0, 47]}-default-#{Array.new(7) { UBID.from_base32(rand(32)) }.join}"
-          end
+        firewall_name = "#{name[0, 55]}-default"
+        # As is typical when checking before inserting, there is a race condition here with
+        # a user concurrently manually creating a firewall with the same name.  However,
+        # the worst case scenario is a bogus error message, and the user could try creating
+        # the private subnet again.
+        unless firewall_dataset.where(Sequel[:firewall][:name] => firewall_name).empty?
+          firewall_name = "#{name[0, 47]}-default-#{Array.new(7) { UBID.from_base32(rand(32)) }.join}"
         end
 
         firewall = Firewall.create(name: firewall_name, location_id: location.id, project_id:)

--- a/spec/lib/kubernetes/client_spec.rb
+++ b/spec/lib/kubernetes/client_spec.rb
@@ -2,20 +2,23 @@
 
 RSpec.describe Kubernetes::Client do
   let(:project) { Project.create(name: "test") }
-  let(:private_subnet) { PrivateSubnet.create(project_id: project.id, name: "test", location_id: Location::HETZNER_FSN1_ID, net6: "fe80::/64", net4: "192.168.0.0/24") }
   let(:kubernetes_cluster) {
-    KubernetesCluster.create(
+    Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "test",
       version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
-      private_subnet_id: private_subnet.id,
       location_id: Location::HETZNER_FSN1_ID,
       project_id: project.id,
       target_node_size: "standard-2",
-    )
+    ).subject
   }
+  let(:private_subnet) { kubernetes_cluster.private_subnet }
   let(:session) { Net::SSH::Connection::Session.allocate }
   let(:kubernetes_client) { described_class.new(kubernetes_cluster, session) }
+
+  before do
+    allow(Config).to receive(:kubernetes_service_project_id).and_return(Project.create(name: "UbicloudKubernetesService").id)
+  end
 
   describe "service_deleted?" do
     it "detects deleted service" do
@@ -314,27 +317,13 @@ RSpec.describe Kubernetes::Client do
     end
 
     it "determintes the modification because hostname is not set" do
-      response = {
-        "items" => [
-          {
-            "metadata" => {"name" => "svc", "namespace" => "default", "creationTimestamp" => "2024-01-03T00:00:00Z"},
-            "status" => {
-              "loadBalancer" => {
-                "ingress" => [
-                  {},
-                ],
-              },
-            },
-          },
-        ],
-      }.to_json
+      response = {"items" => [{
+        "metadata" => {"name" => "svc", "namespace" => "default", "creationTimestamp" => "2024-01-03T00:00:00Z"},
+        "spec" => {"ports" => [{"port" => 80, "nodePort" => 8000}]},
+        "status" => {"loadBalancer" => {"ingress" => [{}]}},
+      }]}.to_json
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(response, 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
-
-      allow(kubernetes_cluster).to receive_messages(
-        vm_diff_for_lb: [[], []],
-        port_diff_for_lb: [[], []],
-      )
       expect(kubernetes_client.any_lb_services_modified?).to be(true)
     end
   end
@@ -385,6 +374,64 @@ RSpec.describe Kubernetes::Client do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new({"items" => [{}]}.to_json, 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get service --all-namespaces --field-selector spec.type=LoadBalancer -ojson").and_return(response)
       expect { kubernetes_client.sync_kubernetes_services }.to raise_error("services load balancer does not exist.")
+    end
+  end
+
+  describe "sync_lb_firewall_rules" do
+    let(:firewall) { kubernetes_cluster.internal_worker_vm_firewall }
+
+    before do
+      lb = Prog::Vnet::LoadBalancerNexus.assemble_with_multiple_ports(
+        private_subnet.id, ports: [], name: kubernetes_cluster.services_load_balancer_name,
+        algorithm: "hash_based", health_check_endpoint: "/", health_check_protocol: "tcp",
+      ).subject
+      kubernetes_cluster.update(services_lb: lb)
+    end
+
+    def lb_rule_keys
+      firewall.firewall_rules_dataset
+        .where(Sequel[:description].like("k8s-svc-lb:%"))
+        .select_map([Sequel[:cidr].cast(String).as(:cidr), Sequel.function(:lower, :port_range).as(:port), :description])
+        .sort
+    end
+
+    it "adds rules for new LB ports" do
+      kubernetes_cluster.services_lb.add_port(443, 31234)
+      kubernetes_cluster.services_lb.add_port(80, 31235)
+      kubernetes_client.sync_lb_firewall_rules
+      expect(lb_rule_keys).to eq [
+        ["0.0.0.0/0", 80, "k8s-svc-lb:80"],
+        ["0.0.0.0/0", 443, "k8s-svc-lb:443"],
+        ["::/0", 80, "k8s-svc-lb:80"],
+        ["::/0", 443, "k8s-svc-lb:443"],
+      ]
+    end
+
+    it "removes rules whose LB port is gone" do
+      kubernetes_cluster.services_lb.add_port(443, 31234)
+      kubernetes_client.sync_lb_firewall_rules
+      kubernetes_cluster.services_lb.remove_port(kubernetes_cluster.services_lb.ports.first)
+      kubernetes_client.sync_lb_firewall_rules
+      expect(lb_rule_keys).to be_empty
+    end
+
+    it "increments update_firewall_rules on attached VMs when rules change" do
+      kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "test-np", node_count: 1, kubernetes_cluster_id: kubernetes_cluster.id, target_node_size: "standard-2").subject
+      vm = Prog::Kubernetes::KubernetesNodeNexus.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "worker-vm", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-#{kubernetes_cluster.version.tr(".", "_")}", enable_ip4: true, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kn.id).subject.vm
+      vm.semaphores_dataset.destroy
+      kubernetes_cluster.services_lb.add_port(443, 31234)
+      kubernetes_client.sync_lb_firewall_rules
+      expect(vm.semaphores_dataset.select_map(:name)).to eq ["update_firewall_rules"]
+    end
+
+    it "is idempotent when rules already match the LB ports" do
+      kubernetes_cluster.services_lb.add_port(443, 31234)
+      kubernetes_client.sync_lb_firewall_rules
+      rule_ids_before = firewall.firewall_rules.select { it.description&.start_with?("k8s-svc-lb:") }.map(&:id).sort
+      kubernetes_client.sync_lb_firewall_rules
+      firewall.reload
+      rule_ids_after = firewall.firewall_rules.select { it.description&.start_with?("k8s-svc-lb:") }.map(&:id).sort
+      expect(rule_ids_after).to eq rule_ids_before
     end
   end
 end

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -223,6 +223,38 @@ RSpec.describe KubernetesCluster do
     end
   end
 
+  describe "#firewall_rule_diff_for_lb" do
+    let(:lb) {
+      Prog::Vnet::LoadBalancerNexus.assemble_with_multiple_ports(
+        kc.private_subnet_id, ports: [], name: kc.services_load_balancer_name,
+        algorithm: "hash_based", health_check_endpoint: "/", health_check_protocol: "tcp",
+      ).subject
+    }
+
+    it "reports missing keys for ports not yet in the firewall" do
+      lb.add_port(443, 31234)
+      extra, missing = kc.firewall_rule_diff_for_lb(lb)
+      expect(extra).to be_empty
+      expect(missing).to eq [["0.0.0.0/0", 443], ["::/0", 443]]
+    end
+
+    it "reports extra rules for descriptions whose port is no longer on the LB" do
+      kc.internal_worker_vm_firewall.insert_firewall_rule("0.0.0.0/0", Sequel.pg_range(443..443), description: "k8s-svc-lb:443")
+      extra, missing = kc.firewall_rule_diff_for_lb(lb)
+      expect(missing).to be_empty
+      expect(extra.map(&:description)).to eq ["k8s-svc-lb:443"]
+    end
+
+    it "ignores rules without the k8s-svc-lb prefix" do
+      kc.internal_worker_vm_firewall.insert_firewall_rule("10.0.0.0/8", Sequel.pg_range(5432..5432), description: "operator-added")
+      kc.internal_worker_vm_firewall.insert_firewall_rule("172.16.0.0/12", Sequel.pg_range(9999..9999))
+      lb.add_port(443, 31234)
+      extra, missing = kc.firewall_rule_diff_for_lb(lb)
+      expect(extra).to be_empty
+      expect(missing).to eq [["0.0.0.0/0", 443], ["::/0", 443]]
+    end
+  end
+
   describe "#validate" do
     it "validates cp_node_count" do
       kc.cp_node_count = 0

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(kc.version).to eq Option.selectable_kubernetes_versions.first
       expect(kc.location_id).to eq Location::HETZNER_FSN1_ID
       expect(kc.cp_node_count).to eq 3
+      expect(kc.private_subnet.name).to eq "#{kc.ubid}-subnet"
       expect(kc.project.id).to eq customer_project.id
       expect(kc.strand.label).to eq "start"
       expect(kc.target_node_size).to eq "standard-8"
@@ -115,22 +116,26 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
       internal_firewall = kc.internal_cp_vm_firewall
       expect(internal_firewall.project_id).to eq Config.kubernetes_service_project_id
-      expect(internal_firewall.firewall_rules.map { "#{it.cidr}:#{it.port_range.to_range}" }.sort).to eq [
-        "0.0.0.0/0:22...23",
-        "0.0.0.0/0:443...444",
-        "#{kc.private_subnet.net4}:10250...10251",
-        "::/0:22...23",
-        "::/0:443...444",
-        "#{kc.private_subnet.net6}:10250...10251",
+      expect(internal_firewall.firewall_rules.map { "#{it.cidr}:#{it.port_range.to_range}:#{it.protocol}" }.sort).to eq [
+        "0.0.0.0/0:22...23:tcp",
+        "0.0.0.0/0:443...444:tcp",
+        "#{kc.private_subnet.net4}:0...65536:tcp",
+        "#{kc.private_subnet.net4}:0...65536:udp",
+        "::/0:22...23:tcp",
+        "::/0:443...444:tcp",
+        "#{kc.private_subnet.net6}:0...65536:tcp",
+        "#{kc.private_subnet.net6}:0...65536:udp",
       ]
 
       internal_firewall = kc.internal_worker_vm_firewall
       expect(internal_firewall.project_id).to eq Config.kubernetes_service_project_id
-      expect(internal_firewall.firewall_rules.map { "#{it.cidr}:#{it.port_range.to_range}" }.sort).to eq [
-        "0.0.0.0/0:22...23",
-        "#{kc.private_subnet.net4}:10250...10251",
-        "::/0:22...23",
-        "#{kc.private_subnet.net6}:10250...10251",
+      expect(internal_firewall.firewall_rules.map { "#{it.cidr}:#{it.port_range.to_range}:#{it.protocol}" }.sort).to eq [
+        "0.0.0.0/0:22...23:tcp",
+        "#{kc.private_subnet.net4}:0...65536:tcp",
+        "#{kc.private_subnet.net4}:0...65536:udp",
+        "::/0:22...23:tcp",
+        "#{kc.private_subnet.net6}:0...65536:tcp",
+        "#{kc.private_subnet.net6}:0...65536:udp",
       ]
     end
 
@@ -148,12 +153,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       customer_firewall = Firewall.first(name: "#{kc.ubid}-firewall", project_id: customer_project.id)
       expect(kc.private_subnet.firewalls).to eq [customer_firewall]
       expect(customer_firewall.project_id).to eq customer_project.id
-      expect(customer_firewall.firewall_rules.map { "#{it.cidr}:#{it.port_range.to_range}:#{it.protocol}" }.sort).to eq [
-        "0.0.0.0/0:0...65536:tcp",
-        "0.0.0.0/0:0...65536:udp",
-        "::/0:0...65536:tcp",
-        "::/0:0...65536:udp",
-      ]
+      expect(customer_firewall.firewall_rules).to eq []
     end
   end
 

--- a/spec/prog/test/kubernetes_firewall_spec.rb
+++ b/spec/prog/test/kubernetes_firewall_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Test::KubernetesFirewall do
+  subject(:kubernetes_test) {
+    described_class.new(Strand.new(prog: "Test::KubernetesFirewall", label: "start", stack: strand_stack))
+  }
+
+  let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id}] }
+
+  let(:kubernetes_service_project_id) { Project.generate_uuid }
+  let(:kubernetes_test_project) { Project.create(name: "Kubernetes-Test-Project") }
+  let(:kubernetes_service_project) { Project.create_with_id(kubernetes_service_project_id, name: "Ubicloud-Kubernetes-Resources") }
+  let(:session) { Net::SSH::Connection::Session.allocate }
+  let(:kubernetes_cluster) {
+    kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "test-cluster", version: Option.selectable_kubernetes_versions.last, location_id: Location::HETZNER_FSN1_ID,
+      project_id: kubernetes_test_project.id, cp_node_count: 1, target_node_size: "standard-2").subject
+    lb = LoadBalancer.create(private_subnet_id: kc.private_subnet.id, name: "api-lb", health_check_endpoint: "/healthz", project_id: kubernetes_test_project.id)
+    kc.update(api_server_lb_id: lb.id)
+    kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "test-cluster-np", node_count: 1, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
+    Prog::Kubernetes::KubernetesNodeNexus.assemble(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "cp-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-4", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: Option.selectable_kubernetes_versions.first, enable_ip4: true, kubernetes_cluster_id: kc.id)
+    Prog::Kubernetes::KubernetesNodeNexus.assemble(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "w1-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-4", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: Option.selectable_kubernetes_versions.first, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
+    kc
+  }
+  let(:probe_subnet) { Prog::Vnet::SubnetNexus.assemble(kubernetes_test_project.id, name: "kubernetes-test-firewall-probe-subnet", location_id: Location::HETZNER_FSN1_ID).subject }
+  let(:probe_vm) { Prog::Vm::Nexus.assemble_with_sshable(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "kubernetes-test-firewall-probe", private_subnet_id: probe_subnet.id, boot_image: "ubuntu-noble", enable_ip4: true).subject }
+
+  before do
+    allow(Config).to receive(:kubernetes_service_project_id).and_return(kubernetes_service_project.id)
+  end
+
+  describe ".assemble" do
+    let(:strand_stack) { [{}] }
+
+    it "assembles a single-worker firewall test cluster" do
+      expect(Config).to receive(:kubernetes_service_project_id).at_least(:once).and_return(Project.generate_uuid)
+      st = described_class.assemble
+      expect(st.prog).to eq("Test::KubernetesFirewall")
+      expect(st.label).to eq("start")
+      expect(st.stack.first["cluster_name"]).to eq("kubernetes-test-firewall")
+      expect(st.stack.first["worker_node_count"]).to eq(1)
+    end
+  end
+
+  describe "#wait_for_kubernetes_bootstrap" do
+    it "hops to test_node_isolation if cluster is ready" do
+      kubernetes_cluster.strand.update(label: "wait")
+      expect { kubernetes_test.wait_for_kubernetes_bootstrap }.to hop("test_node_isolation")
+    end
+
+    it "naps if cluster is not ready" do
+      expect { kubernetes_test.wait_for_kubernetes_bootstrap }.to nap(10)
+    end
+  end
+
+  describe "#test_node_isolation" do
+    let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "kubernetes_test_project_id" => kubernetes_test_project.id, "cluster_name" => "kubernetes-test-firewall"}] }
+
+    it "provisions a probe vm in a separate subnet and hops to wait_probe_vm" do
+      expect { kubernetes_test.test_node_isolation }.to hop("wait_probe_vm")
+      stack = kubernetes_test.strand.stack.first
+      probe = Vm[stack["probe_vm_id"]]
+      expect(probe.name).to eq "kubernetes-test-firewall-probe"
+      expect(probe.private_subnets.first.id).to eq stack["probe_subnet_id"]
+      expect(PrivateSubnet[stack["probe_subnet_id"]].name).to eq "kubernetes-test-firewall-probe-subnet"
+    end
+  end
+
+  describe "#wait_probe_vm" do
+    let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "probe_vm_id" => probe_vm.id}] }
+
+    it "naps until the probe vm is running" do
+      probe_vm.strand.update(label: "start")
+      expect { kubernetes_test.wait_probe_vm }.to nap(10)
+    end
+
+    it "installs netcat and hops to verify_node_isolation" do
+      probe_vm.strand.update(label: "wait")
+      expect(kubernetes_test.probe_vm.sshable).to receive(:_cmd).with("sudo apt-get update && sudo apt-get install -y netcat-openbsd")
+      expect { kubernetes_test.wait_probe_vm }.to hop("verify_node_isolation")
+    end
+  end
+
+  describe "#verify_node_isolation" do
+    let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "probe_vm_id" => probe_vm.id}] }
+
+    before do
+      kubernetes_cluster.all_nodes.each_with_index do |n, i|
+        n.vm.update(ephemeral_net6: "2a01:4f8:10a:128#{i}::/64")
+        AssignedVmAddress.create(dst_vm_id: n.vm.id, ip: "1.2.3.#{i}/32")
+      end
+    end
+
+    it "hops to teardown_probe when the probe cannot reach any node over IPv4 or IPv6" do
+      kubernetes_cluster.all_nodes.each do |node|
+        expect(kubernetes_test.probe_vm.sshable).to receive(:_cmd).with("nc -zvw 5 -4 #{node.vm.ip4_string} 10250").and_raise(Sshable::SshError.new("blocked", "", "", 1, nil))
+        expect(kubernetes_test.probe_vm.sshable).to receive(:_cmd).with("nc -zvw 5 -6 #{node.vm.ip6_string} 10250").and_raise(Sshable::SshError.new("blocked", "", "", 1, nil))
+      end
+      expect { kubernetes_test.verify_node_isolation }.to hop("teardown_probe")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to be_nil
+    end
+
+    it "sets fail_message when the probe can reach a node over IPv4" do
+      node = kubernetes_cluster.all_nodes.first
+      expect(kubernetes_test.probe_vm.sshable).to receive(:_cmd).with("nc -zvw 5 -4 #{node.vm.ip4_string} 10250").and_return("succeeded")
+      expect { kubernetes_test.verify_node_isolation }.to hop("teardown_probe")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq "node #{node.name} is reachable on port 10250 from a foreign subnet despite the locked-down customer firewall"
+    end
+
+    it "sets fail_message when the probe can reach a node only over IPv6" do
+      node = kubernetes_cluster.all_nodes.first
+      expect(kubernetes_test.probe_vm.sshable).to receive(:_cmd).with("nc -zvw 5 -4 #{node.vm.ip4_string} 10250").and_raise(Sshable::SshError.new("blocked", "", "", 1, nil))
+      expect(kubernetes_test.probe_vm.sshable).to receive(:_cmd).with("nc -zvw 5 -6 #{node.vm.ip6_string} 10250").and_return("succeeded")
+      expect { kubernetes_test.verify_node_isolation }.to hop("teardown_probe")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq "node #{node.name} is reachable on port 10250 from a foreign subnet despite the locked-down customer firewall"
+    end
+  end
+
+  describe "#teardown_probe" do
+    let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "probe_vm_id" => probe_vm.id, "probe_subnet_id" => probe_subnet.id}] }
+
+    it "destroys the probe vm, its firewall, and its subnet, then hops" do
+      firewall = probe_subnet.firewalls.first
+      expect { kubernetes_test.teardown_probe }.to hop("wait_probe_teardown").and change { Firewall.where(id: firewall.id).count }.from(1).to(0)
+      expect(probe_vm.reload.destroy_set?).to be true
+      expect(probe_subnet.reload.destroy_set?).to be true
+    end
+  end
+
+  describe "#wait_probe_teardown" do
+    context "when the probe vm still exists" do
+      let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "probe_vm_id" => probe_vm.id, "probe_subnet_id" => probe_subnet.id}] }
+
+      it "naps" do
+        expect { kubernetes_test.wait_probe_teardown }.to nap(5)
+      end
+    end
+
+    context "when only the probe subnet remains" do
+      let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "probe_subnet_id" => probe_subnet.id}] }
+
+      it "naps" do
+        expect { kubernetes_test.wait_probe_teardown }.to nap(5)
+      end
+    end
+
+    context "when the probe vm and subnet are gone" do
+      it "hops to destroy_kubernetes" do
+        expect { kubernetes_test.wait_probe_teardown }.to hop("destroy_kubernetes")
+      end
+    end
+  end
+end

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Prog::Test::Kubernetes do
 
   let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id}] }
 
-  let(:kubernetes_service_project_id) { "546a1ed8-53e5-86d2-966c-fb782d2ae3aa" }
+  let(:kubernetes_service_project_id) { Project.generate_uuid }
   let(:kubernetes_test_project) { Project.create(name: "Kubernetes-Test-Project") }
   let(:kubernetes_service_project) { Project.create_with_id(kubernetes_service_project_id, name: "Ubicloud-Kubernetes-Resources") }
   let(:session) { Net::SSH::Connection::Session.allocate }
@@ -44,9 +44,8 @@ RSpec.describe Prog::Test::Kubernetes do
     let(:strand_stack) { [{}] }
 
     it "creates test and service projects and a strand" do
-      expect(Config).to receive(:kubernetes_service_project_id).at_least(:once).and_return("4fd01c1a-f022-43e8-bd3d-6dbe214df6ed")
+      expect(Config).to receive(:kubernetes_service_project_id).at_least(:once).and_return(Project.generate_uuid)
       described_class.assemble
-      expect(Project["4fd01c1a-f022-43e8-bd3d-6dbe214df6ed"]).not_to be_nil
       expect(Project.where(name: "Kubernetes-Test-Project").count).to eq(1)
     end
 

--- a/spec/prog/test/kubernetes_upgrade_spec.rb
+++ b/spec/prog/test/kubernetes_upgrade_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Prog::Test::KubernetesUpgrade do
 
   let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "worker_node_count" => 1}] }
 
-  let(:kubernetes_service_project_id) { "546a1ed8-53e5-86d2-966c-fb782d2ae3aa" }
+  let(:kubernetes_service_project_id) { Project.generate_uuid }
   let(:kubernetes_test_project) { Project.create(name: "Kubernetes-Test-Project") }
   let(:kubernetes_service_project) { Project.create_with_id(kubernetes_service_project_id, name: "Ubicloud-Kubernetes-Resources") }
   let(:session) { Net::SSH::Connection::Session.allocate }
@@ -42,9 +42,8 @@ RSpec.describe Prog::Test::KubernetesUpgrade do
     let(:strand_stack) { [{}] }
 
     it "creates test and service projects and a strand for the upgrade cluster" do
-      expect(Config).to receive(:kubernetes_service_project_id).at_least(:once).and_return("4fd01c1a-f022-43e8-bd3d-6dbe214df6ed")
+      expect(Config).to receive(:kubernetes_service_project_id).at_least(:once).and_return(Project.generate_uuid)
       st = described_class.assemble
-      expect(Project["4fd01c1a-f022-43e8-bd3d-6dbe214df6ed"]).not_to be_nil
       expect(Project.where(name: "Kubernetes-Test-Project").count).to eq(1)
       expect(st.prog).to eq("Test::KubernetesUpgrade")
       expect(st.label).to eq("start")


### PR DESCRIPTION
**Avoid hardcoded UUIDs in spec/prog/test/kubernetes* specs**

**Lock down customer subnet firewall on new k8s clusters**
New Kubernetes clusters that get an auto-created private subnet no longer inherit SubnetNexus's wide-open 0..65535 default; the customer firewall now starts empty. External access for LB-published Services will be opened on demand by a follow-up sync change.

The cluster-critical intra-subnet allows (v4+v6, tcp+udp, all ports) live on the internal cp/worker VM firewalls instead, which are attached directly to the node VMs and owned by the Kubernetes service project, subsuming their previous subnet-scoped 10250 rules. Since customers cannot edit those firewalls, no customer firewall change can break cluster-internal traffic such as pod-to-apiserver connections, which reach the control plane's private IP directly rather than through the LB.

**Open services LB ports on the internal worker firewall**
Allow external access only for ports published on the services LB: one tcp rule per src_port on 0.0.0.0/0 and ::/0 (the per-VM firewall generator already expands src_port to the nodePort for marked LB-DNATted traffic). The rules carry the description
"k8s-svc-lb:<src_port>" to distinguish them from the ssh and intra-subnet rules on the same firewall.

KubernetesCluster#firewall_rule_diff_for_lb computes the diff and Kubernetes::Client#sync_lb_firewall_rules applies it during sync_kubernetes_services. Since rule edits only propagate to subnet-attached VMs, the sync also increments update_firewall_rules on the firewall's directly attached worker VMs.

**Add k8s firewall e2e test for node isolation**
New Prog::Test::KubernetesFirewall provisions a probe VM in a separate subnet and verifies the locked-down customer firewall keeps cluster nodes unreachable.

**Remove firewall_name parameter from SubnetNexus.assemble**
Its only user, KubernetesClusterNexus.assemble, recently switched to pre-creating the customer firewall and passing firewall_id, leaving the parameter without callers.