### PR TITLE
(wip) Block source VM destroy while a machine image is being captured

### DIFF
--- a/prog/machine_image/create_version_metal.rb
+++ b/prog/machine_image/create_version_metal.rb
@@ -16,6 +16,17 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
     fail MachineImageError, "Source VM's storage volume must be encrypted" unless sv.key_encryption_key_1
 
     DB.transaction do
+      # Lock the source VM row to serialize with any concurrent destroy
+      # operation. The destroy prog updates source_vm.display_state, which
+      # blocks behind this lock, ensuring our display_state recheck below
+      # reflects state that the destroy hasn't yet committed past.
+      source_vm.lock!
+      fail MachineImageError, "Source VM must be stopped" unless source_vm.display_state == "stopped"
+
+      # Prevents the VM from being destroyed while we capture from it. The
+      # decr happens in #finish once no other captures still target this VM.
+      source_vm.incr_prevent_destroy
+
       miv = MachineImageVersion.create(
         machine_image_id: machine_image.id,
         version:,
@@ -79,6 +90,9 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
       archive_size_mib: (frame["archive_size_bytes"]/1048576r).ceil,
     )
     machine_image_version.metal.create_billing_record
+
+    release_source_vm_prevent_destroy
+
     if frame["destroy_source_after"]
       source_vm.incr_destroy
     end
@@ -86,6 +100,24 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
       machine_image_version.machine_image.update(latest_version_id: machine_image_version.id)
     end
     pop "Metal machine image version is created and enabled"
+  end
+
+  # Drop the prevent_destroy semaphore set by .assemble — but only if no
+  # other CreateVersionMetal strand is still capturing the same source VM.
+  # Decr removes every prevent_destroy semaphore for the VM, so without the
+  # check we'd unlock the VM while a sibling capture is still archiving.
+  # The row lock on source_vm serializes against concurrent assemble and
+  # finish calls touching the same VM.
+  def release_source_vm_prevent_destroy
+    DB.transaction do
+      source_vm.lock!
+      others = Strand
+        .where(prog: "MachineImage::CreateVersionMetal", exitval: nil)
+        .exclude(id: strand.id)
+        .where(Sequel.lit("stack->0->>'source_vm_id' = ?", source_vm.id))
+        .any?
+      source_vm.decr_prevent_destroy unless others
+    end
   end
 
   def archive_params_json

--- a/spec/prog/machine_image/create_version_metal_spec.rb
+++ b/spec/prog/machine_image/create_version_metal_spec.rb
@@ -158,6 +158,32 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
       expect(strand.stack.first["destroy_source_after"]).to be true
       expect(strand.stack.first["set_as_latest"]).to be true
     end
+
+    it "sets prevent_destroy on the source VM so it can't be destroyed mid-capture" do
+      described_class.assemble(machine_image, "2.0", source_vm, store)
+
+      expect(source_vm.reload.prevent_destroy_set?).to be true
+    end
+
+    it "rejects assembly when the source VM is already being destroyed" do
+      source_vm.incr_destroy
+
+      expect {
+        described_class.assemble(machine_image, "2.0", source_vm, store)
+      }.to raise_error(MachineImageError, "Source VM must be stopped")
+    end
+
+    it "rejects assembly when the source VM state changes between pre-check and locked recheck" do
+      # First call (outside transaction) passes; second call (inside, after
+      # lock!) sees the changed state — simulating a concurrent destroy
+      # winning the race for display_state.
+      allow(source_vm).to receive(:display_state).and_return("stopped", "deleting")
+
+      expect {
+        described_class.assemble(machine_image, "2.0", source_vm, store)
+      }.to raise_error(MachineImageError, "Source VM must be stopped")
+      expect(source_vm.reload.prevent_destroy_set?).to be false
+    end
   end
 
   describe "#archive" do
@@ -240,6 +266,45 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
 
       machine_image.reload
       expect(machine_image.latest_version.id).to eq(mi_version_metal.id)
+    end
+
+    it "clears prevent_destroy on the source VM when no other captures are active" do
+      source_vm.incr_prevent_destroy
+
+      expect { prog.finish }.to exit({"msg" => "Metal machine image version is created and enabled"})
+
+      expect(source_vm.reload.prevent_destroy_set?).to be false
+    end
+
+    it "leaves prevent_destroy set when another capture is still active for the same VM" do
+      source_vm.incr_prevent_destroy
+      sibling_miv = MachineImageVersion.create(machine_image_id: machine_image.id, version: "sibling")
+      Strand.create_with_id(
+        sibling_miv,
+        prog: "MachineImage::CreateVersionMetal",
+        label: "archive",
+        stack: [{"source_vm_id" => source_vm.id}],
+      )
+
+      expect { prog.finish }.to exit({"msg" => "Metal machine image version is created and enabled"})
+
+      expect(source_vm.reload.prevent_destroy_set?).to be true
+    end
+
+    it "ignores exited strands when checking for other active captures" do
+      source_vm.incr_prevent_destroy
+      exited_miv = MachineImageVersion.create(machine_image_id: machine_image.id, version: "exited")
+      Strand.create_with_id(
+        exited_miv,
+        prog: "MachineImage::CreateVersionMetal",
+        label: "archive",
+        stack: [{"source_vm_id" => source_vm.id}],
+        exitval: {"msg" => "done"},
+      )
+
+      expect { prog.finish }.to exit({"msg" => "Metal machine image version is created and enabled"})
+
+      expect(source_vm.reload.prevent_destroy_set?).to be false
     end
   end
 


### PR DESCRIPTION
CreateVersionMetal now sets the prevent_destroy semaphore on the source VM under a row lock at .assemble time (with a recheck of display_state to catch a destroy that raced past the pre-check) and clears it at #finish. Concurrent captures of the same VM ref-count via a strand lookup: the clear runs only when no other CreateVersionMetal strand is still archiving the same VM. The row lock on source_vm at both ends serializes .assemble and #finish across captures.