### PR TITLE
Remove unneeded force: true when deleting

### DIFF
--- a/model/account.rb
+++ b/model/account.rb
@@ -57,7 +57,7 @@ class Account < Sequel::Model(:accounts)
 
   def suspend
     update(suspended_at: Time.now)
-    DB[:account_active_session_keys].where(account_id: id).delete(force: true)
+    DB[:account_active_session_keys].where(account_id: id).delete
     api_keys_dataset.update(is_valid: false)
     PaymentMethod.where(billing_info_id: projects_dataset.select(:billing_info_id)).update(fraud: true)
     ProjectInvitation.where(inviter_id: id).destroy

--- a/model/dns_zone/dns_zone.rb
+++ b/model/dns_zone/dns_zone.rb
@@ -64,7 +64,7 @@ class DnsZone < Sequel::Model
 
       records_to_purge = obsoleted_records + seen_tombstoned_records
       records_to_purge.uniq!(&:id)
-      DB[:seen_dns_records_by_dns_servers].where(dns_record_id: records_to_purge.map(&:id)).delete(force: true)
+      DB[:seen_dns_records_by_dns_servers].where(dns_record_id: records_to_purge.map(&:id)).delete
       records_to_purge.each(&:destroy)
 
       this.update(last_purged_at: Sequel::CURRENT_TIMESTAMP)

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -667,7 +667,7 @@ RSpec.describe Clover, "project" do
         project.remove_account(user2)
 
         DB.transaction(rollback: :always) do
-          DB[:account_password_hashes].where(id: user2.id).delete(force: true)
+          DB[:account_password_hashes].where(id: user2.id).delete
           user2.destroy
           within("#user-#{user2.ubid}") do
             click_button "Remove"


### PR DESCRIPTION
Bare datasets (datasets not associated with models) do not need to use force: true, because they don't support destroy.