### PR TITLE
Drop version list from `mi show` / Add `latest` to `mi list-versions`

### DIFF
--- a/cli-commands/mi/post/list-versions.rb
+++ b/cli-commands/mi/post/list-versions.rb
@@ -3,7 +3,7 @@
 UbiCli.on("mi").run_on("list-versions") do
   desc "List versions of a machine image"
 
-  fields = %w[version id state actual-size-mib archive-size-mib created-at].freeze.each(&:freeze)
+  fields = %w[version id state actual-size-mib archive-size-mib created-at latest].freeze.each(&:freeze)
 
   key = :mi_list_versions
 

--- a/cli-commands/mi/post/show.rb
+++ b/cli-commands/mi/post/show.rb
@@ -3,36 +3,21 @@
 UbiCli.on("mi").run_on("show") do
   desc "Show details for a machine image"
 
-  fields = %w[id name location arch latest-version created-at versions].freeze.each(&:freeze)
-  version_fields = %w[version id state actual-size-mib archive-size-mib created-at].freeze.each(&:freeze)
+  fields = %w[id name location arch latest-version created-at].freeze.each(&:freeze)
 
   options("ubi mi (location/mi-name | mi-id) show [options]", key: :mi_show) do
     on("-f", "--fields=fields", "show specific fields (comma separated)")
-    on("-v", "--version-fields=fields", "show specific version fields (comma separated)")
   end
   help_option_values("Fields:", fields)
-  help_option_values("Version Fields:", version_fields)
 
   run do |opts, cmd|
     data = sdk_object.info
     opts = opts[:mi_show]
     keys = underscore_keys(check_fields(opts[:fields], fields, "mi show -f option", cmd))
-    version_keys = underscore_keys(check_fields(opts[:"version-fields"], version_fields, "mi show -v option", cmd))
 
     body = []
-
     each_with_dashed(keys) do |key, display_key|
-      case key
-      when :versions
-        data[key].each_with_index do |version, i|
-          body << "version " << (i + 1).to_s << ":\n"
-          each_with_dashed(version_keys) do |v_key, display_v_key|
-            body << "  " << display_v_key << ": " << version[v_key].to_s << "\n"
-          end
-        end
-      else
-        body << display_key << ": " << data[key].to_s << "\n"
-      end
+      body << display_key << ": " << data[key].to_s << "\n"
     end
 
     response(body)

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1053,7 +1053,7 @@ paths:
                 - vm
       responses:
         '200':
-          $ref: '#/components/responses/MachineImageDetailed'
+          $ref: '#/components/responses/MachineImage'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1077,7 +1077,7 @@ paths:
         - $ref: '#/components/parameters/machine_image_reference'
       responses:
         '200':
-          $ref: '#/components/responses/MachineImageDetailed'
+          $ref: '#/components/responses/MachineImage'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -1103,7 +1103,7 @@ paths:
                 - latest_version
       responses:
         '200':
-          $ref: '#/components/responses/MachineImageDetailed'
+          $ref: '#/components/responses/MachineImage'
         default:
           $ref: '#/components/responses/Error'
       tags:
@@ -4664,23 +4664,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/MachineImage'
-    MachineImageDetailed:
-      description: A machine image with version details
-      content:
-        application/json:
-          schema:
-            type: object
-            additionalProperties: false
-            allOf:
-              - $ref: '#/components/schemas/MachineImage'
-              - additionalProperties: false
-                required:
-                  - versions
-                properties:
-                  versions:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/MachineImageVersion'
     MachineImages:
       description: A list of machine images
       content:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -3512,12 +3512,16 @@ components:
           description: Creation timestamp
           type: string
           format: date-time
+        latest:
+          description: True if this is the machine image's currently-published latest version
+          type: boolean
       additionalProperties: false
       required:
         - id
         - version
         - state
         - created_at
+        - latest
     Nic:
       type: object
       properties:

--- a/routes/project/location/machine_image.rb
+++ b/routes/project/location/machine_image.rb
@@ -33,7 +33,7 @@ class Clover
               )
               miv = assemble_machine_image_version(mi, version, source_vm)
               audit_log(mi, "create", [miv])
-              Serializers::MachineImage.serialize(mi, {detailed: true})
+              Serializers::MachineImage.serialize(mi)
             end
           end
 
@@ -48,7 +48,7 @@ class Clover
 
         r.get true do
           authorize("MachineImage:view", mi)
-          Serializers::MachineImage.serialize(mi, {detailed: true})
+          Serializers::MachineImage.serialize(mi)
         end
 
         r.patch true do
@@ -71,7 +71,7 @@ class Clover
             audit_log(mi, "update_latest_version", miv ? [miv] : [])
           end
 
-          Serializers::MachineImage.serialize(mi.refresh, {detailed: true})
+          Serializers::MachineImage.serialize(mi.refresh)
         end
 
         r.delete true do

--- a/routes/project/location/machine_image.rb
+++ b/routes/project/location/machine_image.rb
@@ -93,7 +93,7 @@ class Clover
         r.on "version" do
           r.get true do
             authorize("MachineImage:view", mi)
-            paginated_result(mi.versions_dataset.eager(:metal), Serializers::MachineImageVersion)
+            paginated_result(mi.versions_dataset.eager(:metal), Serializers::MachineImageVersion, latest_version_id: mi.latest_version_id)
           end
 
           r.on(/([a-zA-Z0-9][a-zA-Z0-9._-]{0,63})/) do |version|
@@ -107,7 +107,7 @@ class Clover
               DB.transaction do
                 miv = assemble_machine_image_version(mi, version, source_vm)
                 audit_log(mi, "create_version", [miv])
-                Serializers::MachineImageVersion.serialize(miv)
+                Serializers::MachineImageVersion.serialize(miv, latest_version_id: mi.latest_version_id)
               end
             end
 

--- a/sdk/ruby/lib/ubicloud/model/machine_image.rb
+++ b/sdk/ruby/lib/ubicloud/model/machine_image.rb
@@ -6,7 +6,7 @@ module Ubicloud
 
     set_fragment "machine-image"
 
-    set_columns :id, :name, :location, :arch, :latest_version, :created_at, :versions
+    set_columns :id, :name, :location, :arch, :latest_version, :created_at
 
     # Set the latest version of this machine image. Pass a version label or nil to unset.
     def set_latest_version(version)

--- a/sdk/ruby/lib/ubicloud/model/machine_image_version.rb
+++ b/sdk/ruby/lib/ubicloud/model/machine_image_version.rb
@@ -4,7 +4,7 @@ module Ubicloud
   class MachineImageVersion < BaseModel
     set_prefix "mv"
 
-    set_columns :id, :version, :state, :actual_size_mib, :archive_size_mib, :created_at
+    set_columns :id, :version, :state, :actual_size_mib, :archive_size_mib, :created_at, :latest
 
     # Create a new instance from a hash returned by the Ubicloud API.
     def initialize(adapter, values)

--- a/serializers/machine_image.rb
+++ b/serializers/machine_image.rb
@@ -2,7 +2,7 @@
 
 class Serializers::MachineImage < Serializers::Base
   def self.serialize_internal(mi, options = {})
-    base = {
+    {
       id: mi.ubid,
       name: mi.name,
       location: mi.display_location,
@@ -10,9 +10,5 @@ class Serializers::MachineImage < Serializers::Base
       latest_version: mi.latest_version&.version,
       created_at: mi.created_at.iso8601,
     }
-
-    base[:versions] = Serializers::MachineImageVersion.serialize(mi.versions_dataset.eager(:metal).all) if options[:detailed]
-
-    base
   end
 end

--- a/serializers/machine_image_version.rb
+++ b/serializers/machine_image_version.rb
@@ -10,6 +10,7 @@ class Serializers::MachineImageVersion < Serializers::Base
       actual_size_mib: miv.actual_size_mib,
       archive_size_mib: metal&.archive_size_mib,
       created_at: miv.created_at.iso8601,
+      latest: miv.id == options[:latest_version_id],
     }
   end
 end

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -646,11 +646,9 @@ Usage:
 
 Options:
     -f, --fields=fields              show specific fields (comma separated)
-    -v, --version-fields=fields      show specific version fields (comma separated)
 
 Allowed Option Values:
-    Fields: id name location arch latest-version created-at versions
-    Version Fields: version id state actual-size-mib archive-size-mib created-at
+    Fields: id name location arch latest-version created-at
 
 
 Unset the latest version of a machine image

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -624,7 +624,7 @@ Options:
     -N, --no-headers                 do not show headers
 
 Allowed Option Values:
-    Fields: version id state actual-size-mib archive-size-mib created-at
+    Fields: version id state actual-size-mib archive-size-mib created-at latest
 
 
 Rename a machine image

--- a/spec/routes/api/cli/mi/list_versions_spec.rb
+++ b/spec/routes/api/cli/mi/list_versions_spec.rb
@@ -14,16 +14,22 @@ RSpec.describe Clover, "cli mi list-versions" do
 
   it "lists versions without headers when -N is given" do
     body = cli(%W[mi eu-central-h1/#{@mi.name} list-versions -N])
-    expect(body).to eq("v1  #{@miv.ubid}  ready  5120  1024  #{@miv.created_at.iso8601}\n")
+    expect(body).to eq("v1  #{@miv.ubid}  ready  5120  1024  #{@miv.created_at.iso8601}  false\n")
   end
 
   it "shows headers by default" do
     body = cli(%W[mi eu-central-h1/#{@mi.name} list-versions])
-    expect(body).to eq("version  id                          state  actual-size-mib  archive-size-mib  created-at               \nv1       #{@miv.ubid}  ready  5120             1024              #{@miv.created_at.iso8601}\n")
+    expect(body).to eq("version  id                          state  actual-size-mib  archive-size-mib  created-at                 latest\nv1       #{@miv.ubid}  ready  5120             1024              #{@miv.created_at.iso8601}  false \n")
   end
 
   it "restricts fields with -f" do
     body = cli(%W[mi eu-central-h1/#{@mi.name} list-versions -N -f version])
     expect(body).to eq("v1\n")
+  end
+
+  it "marks the machine image's latest version with latest=true" do
+    @mi.update(latest_version_id: @miv.id)
+    body = cli(%W[mi eu-central-h1/#{@mi.name} list-versions -N -f version,latest])
+    expect(body).to eq("v1  true\n")
   end
 end

--- a/spec/routes/api/cli/mi/show_spec.rb
+++ b/spec/routes/api/cli/mi/show_spec.rb
@@ -13,15 +13,12 @@ RSpec.describe Clover, "cli mi show" do
   end
 
   it "shows machine image details" do
-    body = cli(%W[mi eu-central-h1/#{@mi.name} show -f id,name,arch,latest-version,versions -v version,state])
+    body = cli(%W[mi eu-central-h1/#{@mi.name} show -f id,name,arch,latest-version])
     expect(body).to eq <<~END
       id: #{@mi.ubid}
       name: #{@mi.name}
       arch: x64
       latest-version: v1
-      version 1:
-        version: v1
-        state: ready
     END
   end
 
@@ -38,17 +35,6 @@ RSpec.describe Clover, "cli mi show" do
   it "rejects invalid fields" do
     expect(cli(%W[mi eu-central-h1/#{@mi.name} show -f bogus], status: 400)).to start_with(
       "! Invalid field(s) given in mi show -f option",
-    )
-  end
-
-  it "restricts version fields with -v" do
-    body = cli(%W[mi eu-central-h1/#{@mi.name} show -f versions -v version,state])
-    expect(body).to eq("version 1:\n  version: v1\n  state: ready\n")
-  end
-
-  it "rejects invalid version fields" do
-    expect(cli(%W[mi eu-central-h1/#{@mi.name} show -v bogus], status: 400)).to start_with(
-      "! Invalid field(s) given in mi show -v option",
     )
   end
 end

--- a/spec/routes/api/project/location/machine_image_spec.rb
+++ b/spec/routes/api/project/location/machine_image_spec.rb
@@ -349,9 +349,20 @@ RSpec.describe Clover, "machine-image" do
       expect(body["count"]).to eq(2)
       with_metal = body["items"].find { |i| i["version"] == mi_version.version }
       expect(with_metal["state"]).to eq("ready")
+      expect(with_metal["latest"]).to be false
       no_metal = body["items"].find { |i| i["version"] == "v-no-metal" }
       expect(no_metal["state"]).to be_nil
       expect(no_metal["archive_size_mib"]).to be_nil
+    end
+
+    it "marks only the machine image's latest version with latest=true" do
+      latest = MachineImageVersion.create(machine_image_id: mi.id, version: "v2")
+      MachineImageVersion.create(machine_image_id: mi.id, version: "v3")
+      mi.update(latest_version_id: latest.id)
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/machine-image/#{mi.name}/version"
+      expect(last_response.status).to eq(200)
+      latest_by_version = JSON.parse(last_response.body)["items"].to_h { |i| [i["version"], i["latest"]] }
+      expect(latest_by_version).to eq(mi_version.version => false, "v2" => true, "v3" => false)
     end
   end
 

--- a/spec/routes/api/project/location/machine_image_spec.rb
+++ b/spec/routes/api/project/location/machine_image_spec.rb
@@ -39,15 +39,13 @@ RSpec.describe Clover, "machine-image" do
   end
 
   describe "get" do
-    it "returns image by name with versions detail" do
+    it "returns image by name" do
       mi.update(latest_version_id: mi_version.id)
       get "/project/#{project.ubid}/location/#{TEST_LOCATION}/machine-image/#{mi.name}"
       expect(last_response.status).to eq(200)
       body = JSON.parse(last_response.body)
       expect(body["name"]).to eq(mi.name)
       expect(body["latest_version"]).to eq(mi_version.version)
-      expect(body["versions"]).to be_an(Array)
-      expect(body["versions"].first["state"]).to eq("ready")
     end
 
     it "returns image by ubid" do
@@ -61,13 +59,6 @@ RSpec.describe Clover, "machine-image" do
       store
       get "/project/#{project.ubid}/location/#{TEST_LOCATION}/machine-image/missing"
       expect(last_response.status).to eq(404)
-    end
-
-    it "reports non-ready state from display_state" do
-      mi_version_metal.update(enabled: false, archive_size_mib: nil)
-      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/machine-image/#{mi.name}"
-      expect(last_response.status).to eq(200)
-      expect(JSON.parse(last_response.body)["versions"].first["state"]).to eq("creating")
     end
   end
 


### PR DESCRIPTION
### Drop versions list from mi show 

`mi list-versions` already returns the version list, so including the same list in `mi show` is redundant. The machine-image API is still feature-flag gated and not publicly available, so the breaking response shape change is acceptable.

### Mark the latest version in mi list-versions 

Add a boolean `latest` field on MachineImageVersion so callers can tell which version is currently set as the machine image's latest. The machine-image API is still feature-flag gated and not publicly available, so the schema addition is acceptable.