### PR TITLE
Apply firewall rules before machine image catchup

### DIFF
--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -197,12 +197,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     vm.update(display_state: "running", provisioned_at: Time.now)
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: (Time.now - vm.allocated_at).round(3)}}])
 
-    if vm.vm_storage_volumes.any?(&:machine_image_version_id)
-      register_deadline("wait", 1800, allow_extension: true)
-      hop_wait_storage_catchup
-    else
-      hop_wait
-    end
+    hop_wait
   end
 
   label def wait_storage_catchup
@@ -279,6 +274,11 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     when_update_firewall_rules_set? do
       register_deadline("wait", 5 * 60)
       hop_update_firewall_rules
+    end
+
+    unless vm.vm_storage_volumes_dataset.exclude(machine_image_version_id: nil).empty?
+      register_deadline("wait", 30 * 60)
+      hop_wait_storage_catchup
     end
 
     when_update_spdk_dependency_set? do

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -898,14 +898,6 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       allow(vm).to receive(:allocated_at).and_return(now - 100)
       expect { nx.wait_sshable }.to hop("wait")
     end
-
-    it "hops to wait_storage_catchup when a volume has machine_image_version_id" do
-      miv = create_machine_image_version_metal
-      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, machine_image_version_id: miv.id)
-      vm.incr_update_firewall_rules
-      allow(vm).to receive(:allocated_at).and_return(Time.now - 100)
-      expect { nx.wait_sshable }.to hop("wait_storage_catchup")
-    end
   end
 
   describe "#wait_storage_catchup" do
@@ -1042,6 +1034,19 @@ RSpec.describe Prog::Vm::Metal::Nexus do
 
     it "hops to update_firewall_rules when needed" do
       vm.incr_update_firewall_rules
+      expect { nx.wait }.to hop("update_firewall_rules")
+    end
+
+    it "hops to wait_storage_catchup when needed" do
+      miv = create_machine_image_version_metal
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, machine_image_version_id: miv.id)
+      expect { nx.wait }.to hop("wait_storage_catchup")
+    end
+
+    it "hops to update_firewall_rules before wait_storage_catchup" do
+      vm.incr_update_firewall_rules
+      miv = create_machine_image_version_metal
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, machine_image_version_id: miv.id)
       expect { nx.wait }.to hop("update_firewall_rules")
     end
 


### PR DESCRIPTION
When a VM boots from a large machine image, ssh comes up well before storage catchup finishes. Until now, the firewall rules were only installed after catchup, so any connection during that window bypassed the user's policy.

In practice this meant that with the default allow-all firewall, nothing except ssh worked during catchup: no HTTP, no ping.

Move waiting for storage catchup to after firewalls have been updated for the first time.
