### PR TITLE
Make VmSetup#interfaces idempotent against a stale vetho

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -218,30 +218,20 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
   end
 
   def interfaces(nics, multiqueue)
-    # We first delete the network namespace for idempotency. Instead
-    # we could catch various exceptions for each command run, and if
-    # the error message matches certain text, we could resume. But
-    # the "ip link add" step generates the MAC addresses randomly,
-    # which makes it unsuitable for error message matching. Deleting
-    # and recreating the network namespace seems easier and safer.
+    # Delete prior state for idempotency. "ip netns del" usually takes
+    # the veth pair with it, but kernel cleanup of the host-side vetho
+    # peer is asynchronous, so we follow up with an explicit "ip link
+    # del" to guarantee it's gone before we add it again.
     begin
       r "ip netns del #{q_vm}"
     rescue CommandFail => ex
       raise unless /Cannot remove namespace file ".*": No such file or directory/.match?(ex.stderr)
     end
 
-    # After the above deletion, the vetho interface may still exist because the
-    # namespace deletion does not handle related interface deletion
-    # in an atomic way. The command returns success and the cleanup of the
-    # vetho* interface may be done a little bit later. Here, we wait for the
-    # interface to disappear before going ahead because the ip link add command
-    # is not idempotent, either.
-    5.times do
-      if File.exist?("/sys/class/net/vetho#{q_vm}")
-        sleep 0.1
-      else
-        break
-      end
+    begin
+      r "ip link del vetho#{q_vm}"
+    rescue CommandFail => ex
+      raise unless ex.stderr.include?("Cannot find device")
     end
 
     r "ip netns add #{q_vm}"

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -752,8 +752,7 @@ NFTABLES_CONF
   describe "#interfaces" do
     it "can setup interfaces without multiqueue" do
       expect(vs).to receive(:r).with("ip netns del test")
-      expect(File).to receive(:exist?).with("/sys/class/net/vethotest").and_return(true, false)
-      expect(vs).to receive(:sleep).with(0.1).once
+      expect(vs).to receive(:r).with("ip link del vethotest")
 
       expect(vs).to receive(:r).with("ip netns add test")
       expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
@@ -766,7 +765,7 @@ NFTABLES_CONF
 
     it "can setup interfaces with multiqueue" do
       expect(vs).to receive(:r).with("ip netns del test")
-      expect(File).to receive(:exist?).with("/sys/class/net/vethotest").and_return(false)
+      expect(vs).to receive(:r).with("ip link del vethotest")
 
       expect(vs).to receive(:r).with("ip netns add test")
       expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
@@ -777,8 +776,27 @@ NFTABLES_CONF
       vs.interfaces(nics, true)
     end
 
+    it "tolerates a missing netns and a missing vetho on the host" do
+      expect(vs).to receive(:r).with("ip netns del test").and_raise(CommandFail.new("", "", "Cannot remove namespace file \"/var/run/netns/test\": No such file or directory"))
+      expect(vs).to receive(:r).with("ip link del vethotest").and_raise(CommandFail.new("", "", "Cannot find device \"vethotest\""))
+
+      expect(vs).to receive(:r).with("ip netns add test")
+      expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
+      expect(vs).to receive(:r).with("ip link add vethotest addr 00:00:00:00:00:00 type veth peer name vethitest addr 00:00:00:00:00:00 netns test")
+      nics = [VmSetup::Nic.new(nil, nil, "nctest", nil, "1.1.1.1")]
+      expect(vs).to receive(:r).with("ip -n test tuntap add dev nctest mode tap user test  ")
+      expect(vs).to receive(:r).with("ip -n test addr replace 1.1.1.1 dev nctest")
+      vs.interfaces(nics, false)
+    end
+
     it "fails if network namespace can not be deleted" do
       expect(vs).to receive(:r).with("ip netns del test").and_raise(CommandFail.new("", "", "error"))
+      expect { vs.interfaces([VmSetup::Nic.new(nil, nil, "nctest", nil, "1.1.1.1")], false) }.to raise_error(CommandFail)
+    end
+
+    it "fails if vetho deletion errors with an unexpected message" do
+      expect(vs).to receive(:r).with("ip netns del test")
+      expect(vs).to receive(:r).with("ip link del vethotest").and_raise(CommandFail.new("", "", "error"))
       expect { vs.interfaces([VmSetup::Nic.new(nil, nil, "nctest", nil, "1.1.1.1")], false) }.to raise_error(CommandFail)
     end
   end


### PR DESCRIPTION
The host-side vetho peer of the netns-bound veth is normally cleaned up by "ip netns del", but the kernel does that asynchronously. The prior code polled /sys/class/net for up to 500 ms and then assumed the device was gone; under load that wasn't always true, and the subsequent "ip link add" failed with "RTNETLINK answers: File exists" on setup-vm recreate-unpersisted.

Replace the poll with an explicit "ip link del vetho..." that ignores "Cannot find device". The del call is synchronous, so when it returns the device (and its peer) are gone before we recreate the namespace.