### PR TITLE
Add vm rescue mode

### DIFF
--- a/migrate/20260528_vm_add_in_rescue_mode.rb
+++ b/migrate/20260528_vm_add_in_rescue_mode.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:vm) do
+      add_column :in_rescue_mode, :boolean, default: false, null: false
+    end
+    add_enum_value(:vm_display_state, "rescue")
+  end
+end

--- a/model/metal/vm.rb
+++ b/model/metal/vm.rb
@@ -119,7 +119,17 @@ class Vm < Sequel::Model
         hugepages:,
         init_script: init_script&.init_script || "",
         ipv6_disabled: project.get_ff_ipv6_disabled || false,
+        rescue_mode: in_rescue_mode,
+        rescue_image: in_rescue_mode ? {name: rescue_boot_image.name, version: rescue_boot_image.version} : nil,
       )
+    end
+
+    # Looks up the BootImage with name "rescue" on the host. Callers should
+    # only invoke this when entering rescue mode; raises if no rescue image
+    # is activated on the host.
+    def rescue_boot_image
+      vm_host.boot_images_dataset.where(name: "rescue").exclude(activated_at: nil).order(Sequel.desc(:version)).first ||
+        fail("no rescue boot image is activated on #{vm_host.name}")
     end
 
     def storage_volumes

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -43,7 +43,8 @@ class Vm < Sequel::Model
   plugin ResourceMethods, redacted_columns: :public_key
   plugin ProviderDispatcher, __FILE__
   plugin SemaphoreMethods, :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules,
-    :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started, :restart, :start, :stop, :migrate_to_separate_progs, :admin_stop, :stopping
+    :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started, :restart, :start, :stop, :migrate_to_separate_progs, :admin_stop, :stopping,
+    :rescue, :exit_rescue
   include HealthMonitorMethods
 
   include ObjectTag::Cleanup
@@ -262,6 +263,7 @@ end
 #  cpu_percent_limit       | integer                  |
 #  cpu_burst_percent_limit | integer                  |
 #  location_id             | uuid                     | NOT NULL
+#  in_rescue_mode          | boolean                  | NOT NULL DEFAULT false
 # Indexes:
 #  vm_pkey                             | PRIMARY KEY btree (id)
 #  vm_ephemeral_net6_key               | UNIQUE btree (ephemeral_net6)

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -271,6 +271,10 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       hop_stopped
     end
 
+    if vm.in_rescue_mode
+      hop_in_rescue
+    end
+
     when_start_after_host_reboot_set? do
       register_deadline("wait", 5 * 60)
       hop_start_after_host_reboot
@@ -289,6 +293,11 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     when_restart_set? do
       register_deadline("wait", 5 * 60)
       hop_restart
+    end
+
+    when_rescue_set? do
+      register_deadline("wait", 10 * 60)
+      hop_enter_rescue
     end
 
     when_checkup_set? do
@@ -322,6 +331,52 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     decr_restart
     host.sshable.cmd("sudo host/bin/setup-vm restart :vm_name", vm_name:)
     hop_wait
+  end
+
+  label def enter_rescue
+    decr_rescue
+    DB.transaction do
+      vm.update(in_rescue_mode: true, display_state: "rescue")
+    end
+    write_params_json
+    host.sshable.cmd("sudo host/bin/setup-vm enter-rescue :vm_name :image_path",
+      vm_name:, image_path: rescue_image_path)
+    hop_in_rescue
+  end
+
+  label def in_rescue
+    when_stop_set? do
+      hop_stopped
+    end
+
+    when_start_after_host_reboot_set? do
+      register_deadline("wait", 5 * 60)
+      hop_start_after_host_reboot
+    end
+
+    when_exit_rescue_set? do
+      register_deadline("wait", 10 * 60)
+      hop_exit_rescue
+    end
+
+    nap 6 * 60 * 60
+  end
+
+  label def exit_rescue
+    decr_exit_rescue
+    DB.transaction do
+      vm.update(in_rescue_mode: false, display_state: "running")
+    end
+    write_params_json
+    host.sshable.cmd("sudo host/bin/setup-vm exit-rescue :vm_name", vm_name:)
+    hop_wait
+  end
+
+  # On-host path of the rescue boot image to be copied into the ephemeral
+  # rescue disk by the rhizome side.
+  def rescue_image_path
+    image = vm.rescue_boot_image
+    "/var/storage/images/#{image.name}-#{image.version}.raw"
   end
 
   label def start_after_stop

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -122,6 +122,20 @@ when "reassign-ip6"
     slice_name, cpu_percent_limit, cpu_burst_percent_limit, ipv6_disabled, init_script)
 when "restart"
   vm_setup.restart(slice_name, cpu_burst_percent_limit)
+when "enter-rescue"
+  unless (rescue_image_path = ARGV.shift)
+    puts "expected rescue image path as argument"
+    exit 1
+  end
+  vm_setup.enter_rescue(
+    rescue_image_path, max_vcpus, cpu_topology, mem_gib, storage_volumes,
+    nics, pci_devices, slice_name, cpu_percent_limit, cpu_burst_percent_limit,
+  )
+when "exit-rescue"
+  vm_setup.exit_rescue(
+    max_vcpus, cpu_topology, mem_gib, storage_volumes, nics, pci_devices,
+    slice_name, cpu_percent_limit, cpu_burst_percent_limit,
+  )
 else
   puts "Invalid action #{action}"
   exit 1

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -57,6 +57,7 @@ class VmPath
     nftables_conf
     prep.json
     cert
+    rescue.img
   ].each do |file_name|
     method_name = file_name.tr(".-", "_")
     fail "BUG" if method_defined?(method_name)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -81,6 +81,34 @@ class VmSetup
     enable_bursting(slice_name, cpu_burst_percent_limit) unless cpu_burst_percent_limit == 0
   end
 
+  # Enter rescue mode: stop the VM, copy the rescue image to the ephemeral
+  # rescue disk (writable), regenerate the systemd unit so the rescue disk
+  # boots first and the VM's storage volumes are attached as data disks,
+  # then restart the VM. Networking is unchanged so the rescue VM keeps the
+  # original IPs.
+  def enter_rescue(rescue_image_path, max_vcpus, cpu_topology, mem_gib, storage_params,
+    nics, pci_devices, slice_name, cpu_percent_limit, cpu_burst_percent_limit)
+    r "systemctl stop #{q_vm}"
+    FileUtils.cp(rescue_image_path, vp.rescue_img)
+    FileUtils.chown @vm_name, @vm_name, vp.rescue_img
+    install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics,
+      pci_devices, slice_name, cpu_percent_limit, rescue_disk_path: vp.rescue_img)
+    start_systemd_unit
+    enable_bursting(slice_name, cpu_burst_percent_limit) unless cpu_burst_percent_limit == 0
+  end
+
+  # Exit rescue mode: stop the VM, delete the ephemeral rescue disk,
+  # regenerate the normal systemd unit, restart the VM.
+  def exit_rescue(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices,
+    slice_name, cpu_percent_limit, cpu_burst_percent_limit)
+    r "systemctl stop #{q_vm}"
+    rm_if_exists vp.rescue_img
+    install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics,
+      pci_devices, slice_name, cpu_percent_limit)
+    start_systemd_unit
+    enable_bursting(slice_name, cpu_burst_percent_limit) unless cpu_burst_percent_limit == 0
+  end
+
   def reassign_ip6(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology,
     mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices, boot_image,
     dns_ipv4, slice_name, cpu_percent_limit, cpu_burst_percent_limit, ipv6_disabled, init_script)
@@ -628,7 +656,7 @@ DNSMASQ_CONF
     r("/usr/bin/fmpm -a #{gpu_partition_id}", expect: [0, 239]) if gpu_partition_id
   end
 
-  def install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices, slice_name, cpu_percent_limit)
+  def install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices, slice_name, cpu_percent_limit, rescue_disk_path: nil)
     fail "BUG" if /["'\s]/.match?(cpu_topology)
 
     tapnames = nics.map { "-i #{_1.tap}" }.join(" ")
@@ -713,6 +741,7 @@ DNSMASQ_SERVICE
       storage_params: storage_params,
       nics: nics,
       pci_devices: pci_devices,
+      rescue_disk_path: rescue_disk_path,
     )
 
     vp.write_systemd_service(vm_service)
@@ -738,7 +767,7 @@ DNSMASQ_SERVICE
     r "systemctl restart #{q_vm}"
   end
 
-  def build_ch_service(header:, footer:, slice_name:, mem_gib:, max_vcpus:, cpu_topology:, storage_volumes:, storage_params:, nics:, pci_devices:)
+  def build_ch_service(header:, footer:, slice_name:, mem_gib:, max_vcpus:, cpu_topology:, storage_volumes:, storage_params:, nics:, pci_devices:, rescue_disk_path: nil)
     disk_params = storage_volumes.map { |volume|
       if volume.read_only
         "path=#{volume.image_path},readonly=on"
@@ -746,6 +775,7 @@ DNSMASQ_SERVICE
         "vhost_user=true,socket=#{volume.vhost_sock},num_queues=#{volume.num_queues},queue_size=#{volume.queue_size}"
       end
     }
+    disk_params.unshift("path=#{rescue_disk_path}") if rescue_disk_path
     disk_params << "path=#{vp.cloudinit_img}"
 
     disk_args =
@@ -790,7 +820,7 @@ DNSMASQ_SERVICE
     SERVICE
   end
 
-  def build_qemu_service(header:, footer:, slice_name:, mem_gib:, max_vcpus:, cpu_topology:, storage_volumes:, storage_params:, nics:, pci_devices:)
+  def build_qemu_service(header:, footer:, slice_name:, mem_gib:, max_vcpus:, cpu_topology:, storage_volumes:, storage_params:, nics:, pci_devices:, rescue_disk_path: nil)
     disk_parts = storage_volumes.each_with_index.flat_map do |vol, i|
       if vol.read_only
         [
@@ -803,6 +833,12 @@ DNSMASQ_SERVICE
           "-device vhost-user-blk-pci,chardev=vhostblk#{i},num-queues=#{vol.num_queues},queue-size=#{vol.queue_size},romfile=",
         ]
       end
+    end
+    if rescue_disk_path
+      disk_parts.unshift(
+        "-drive if=none,file=#{rescue_disk_path},format=raw,id=rescue",
+        "-device virtio-blk-pci,drive=rescue,romfile=",
+      )
     end
     disk_parts += [
       "-drive if=none,file=#{vp.cloudinit_img},format=raw,readonly=on,id=cidrive",

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -542,6 +542,52 @@ RSpec.describe VmSetup do
     end
   end
 
+  describe "#enter_rescue" do
+    let(:install_args) { [2, "1:1:1:2", 2, [], [], [], "system.slice", 0] }
+
+    it "stops the VM, copies the rescue image, reinstalls the unit with rescue_disk_path, and restarts" do
+      vps = instance_spy(VmPath, rescue_img: "/vm/test/rescue.img")
+      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:r).with("systemctl stop test")
+      expect(FileUtils).to receive(:cp).with("/var/storage/images/rescue-1.raw", "/vm/test/rescue.img")
+      expect(FileUtils).to receive(:chown).with("test", "test", "/vm/test/rescue.img")
+      expect(vs).to receive(:install_systemd_unit).with(*install_args, rescue_disk_path: "/vm/test/rescue.img")
+      expect(vs).to receive(:start_systemd_unit)
+      expect(vs).to receive(:enable_bursting).with("system.slice", 50)
+
+      vs.enter_rescue("/var/storage/images/rescue-1.raw", *install_args, 50)
+    end
+
+    it "skips enable_bursting when cpu_burst_percent_limit is 0" do
+      vps = instance_spy(VmPath, rescue_img: "/vm/test/rescue.img")
+      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:r).with("systemctl stop test")
+      expect(FileUtils).to receive(:cp)
+      expect(FileUtils).to receive(:chown)
+      expect(vs).to receive(:install_systemd_unit)
+      expect(vs).to receive(:start_systemd_unit)
+      expect(vs).not_to receive(:enable_bursting)
+
+      vs.enter_rescue("/var/storage/images/rescue-1.raw", *install_args, 0)
+    end
+  end
+
+  describe "#exit_rescue" do
+    let(:install_args) { [2, "1:1:1:2", 2, [], [], [], "system.slice", 0] }
+
+    it "stops the VM, deletes the rescue image, reinstalls the unit without rescue_disk_path, and restarts" do
+      vps = instance_spy(VmPath, rescue_img: "/vm/test/rescue.img")
+      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:r).with("systemctl stop test")
+      expect(vs).to receive(:rm_if_exists).with("/vm/test/rescue.img")
+      expect(vs).to receive(:install_systemd_unit).with(*install_args)
+      expect(vs).to receive(:start_systemd_unit)
+      expect(vs).to receive(:enable_bursting).with("system.slice", 50)
+
+      vs.exit_rescue(*install_args, 50)
+    end
+  end
+
   describe "#storage" do
     let(:storage_params) {
       [

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -1066,6 +1066,68 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(nx).to receive(:available?).and_return(true)
       expect { nx.wait }.to nap(6 * 60 * 60)
     end
+
+    it "hops to enter_rescue when rescue is set" do
+      vm.incr_rescue
+      expect { nx.wait }.to hop("enter_rescue")
+    end
+
+    it "hops to in_rescue when the vm is already in rescue mode" do
+      vm.update(in_rescue_mode: true)
+      expect { nx.wait }.to hop("in_rescue")
+    end
+  end
+
+  describe "#enter_rescue" do
+    it "stops the vm, regenerates the unit, and hops to in_rescue" do
+      vm.incr_rescue
+      image = instance_double(BootImage, name: "rescue", version: "1")
+      expect(vm).to receive(:rescue_boot_image).and_return(image)
+      expect(nx).to receive(:write_params_json)
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm enter-rescue #{vm.inhost_name} /var/storage/images/rescue-1.raw")
+      expect { nx.enter_rescue }.to hop("in_rescue")
+        .and change { vm.reload.in_rescue_mode }.from(false).to(true)
+        .and change { vm.reload.rescue_set? }.from(true).to(false)
+      expect(vm.reload.display_state).to eq "rescue"
+    end
+  end
+
+  describe "#in_rescue" do
+    before do
+      vm.update(in_rescue_mode: true, display_state: "rescue")
+    end
+
+    it "naps when nothing to do" do
+      expect { nx.in_rescue }.to nap(6 * 60 * 60)
+    end
+
+    it "hops to stopped when stop is set" do
+      vm.incr_stop
+      expect { nx.in_rescue }.to hop("stopped")
+    end
+
+    it "hops to start_after_host_reboot when needed" do
+      vm.incr_start_after_host_reboot
+      expect { nx.in_rescue }.to hop("start_after_host_reboot")
+    end
+
+    it "hops to exit_rescue when exit_rescue is set" do
+      vm.incr_exit_rescue
+      expect { nx.in_rescue }.to hop("exit_rescue")
+    end
+  end
+
+  describe "#exit_rescue" do
+    it "regenerates the normal unit, clears in_rescue_mode, and hops to wait" do
+      vm.update(in_rescue_mode: true, display_state: "rescue")
+      vm.incr_exit_rescue
+      expect(nx).to receive(:write_params_json)
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm exit-rescue #{vm.inhost_name}")
+      expect { nx.exit_rescue }.to hop("wait")
+        .and change { vm.reload.in_rescue_mode }.from(true).to(false)
+        .and change { vm.reload.exit_rescue_set? }.from(true).to(false)
+      expect(vm.reload.display_state).to eq "running"
+    end
   end
 
   describe "#update_firewall_rules" do


### PR DESCRIPTION
A new vm.incr_rescue semaphore stops the VM and boots a minimal "rescue" VM in its place: same netns, same IPs, same firewall, with the original storage volumes attached as data disks. A vm.incr_exit_rescue semaphore tears it back down and resumes the original VM.

The rescue boot image is looked up on the VM's host by name "rescue" (activated BootImage). It is copied into an ephemeral writable file under /vm/<vm_name>/rescue.img on entry and deleted on exit, so the rescue env is throwaway.

Wire-up:

- model: new vm.in_rescue_mode column plus :rescue and :exit_rescue semaphores. The "rescue" value is added to the vm_display_state enum. Vm::Metal#params_json now emits rescue_mode and rescue_image fields when in_rescue_mode.

- prog: three new labels - enter_rescue, in_rescue, exit_rescue. wait dispatches rescue to enter_rescue and short-circuits to in_rescue if vm.in_rescue_mode is set (covers stop/start cycles through wait).

- rhizome: setup-vm gains enter-rescue and exit-rescue actions. install_systemd_unit takes an optional rescue_disk_path keyword; when given, the cloud-hypervisor / qemu disk args are prepended with a writable raw-file disk so the rescue OS boots first.