### PR TITLE
Include subjectAltName in self-signed cert created by CertNexus

### DIFF
--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -32,7 +32,13 @@ class Prog::Vnet::CertNexus < Prog::Base
     register_deadline("wait", 10 * 60)
 
     if Config.development? && cert.dns_zone_id.nil?
-      crt, key = Util.create_certificate(subject: "/CN=" + cert.hostname, duration: 60 * 60 * 24 * 30 * 3)
+      san = "subjectAltName=DNS:#{cert.hostname}"
+      san += ",DNS:#{cert.private_hostname}" if cert.private_hostname
+      crt, key = Util.create_certificate(
+        subject: "/CN=" + cert.hostname,
+        extensions: [san],
+        duration: 60 * 60 * 24 * 30 * 3,
+      )
       cert.update(cert: crt, csr_key: key.to_der)
       hop_wait
     end

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -129,6 +129,27 @@ RSpec.describe Prog::Vnet::CertNexus do
       self_signed_nx = described_class.new(self_signed_strand)
 
       expect { self_signed_nx.start }.to hop("wait")
+      sans = OpenSSL::X509::Certificate.new(self_signed_cert.reload.cert)
+        .extensions
+        .find { it.oid == "subjectAltName" }
+        .value
+        .split(", ")
+      expect(sans).to eq ["DNS:self-signed-host"]
+    end
+
+    it "includes private hostname in self-signed certificate" do
+      expect(Config).to receive(:development?).and_return(true).at_least(:once)
+      self_signed_cert = Cert.create(hostname: "self-signed-host", dns_zone_id: nil, private_hostname: "private.self-signed-host")
+      self_signed_strand = Strand.create_with_id(self_signed_cert, prog: "Vnet::CertNexus", label: "start", stack: [{"restarted" => 0}])
+      self_signed_nx = described_class.new(self_signed_strand)
+
+      expect { self_signed_nx.start }.to hop("wait")
+      sans = OpenSSL::X509::Certificate.new(self_signed_cert.reload.cert)
+        .extensions
+        .find { it.oid == "subjectAltName" }
+        .value
+        .split(", ")
+      expect(sans).to eq ["DNS:self-signed-host", "DNS:private.self-signed-host"]
     end
   end
 


### PR DESCRIPTION
In development environments, if the cert doesn't have a dns_zone, CertNexus creates a self-signed cert. This adds subjectAltName to the cert, and if a private hostname is used, includes the private hostname in the cert.