### PR TITLE
Discover AWS Postgres data disks via lsblk

### DIFF
--- a/model/postgres/aws/postgres_server.rb
+++ b/model/postgres/aws/postgres_server.rb
@@ -18,11 +18,7 @@ class PostgresServer < Sequel::Model
     def aws_storage_device_paths
       # Sort whole block devices by size and drop the smallest (EBS boot, fixed
       # at 16 GiB). Remaining devices are instance-store NVMes — the disks we
-      # RAID for data. Avoid relying on VmStorageVolume row count, which is
-      # split per a 1900 GiB cap that doesn't match every AWS family's actual
-      # per-disk packaging (e.g. r8id.16xlarge ships 1x3800, r8gd.12xlarge
-      # ships 3x950). -n suppresses the lsblk header; -e 7 excludes loopback
-      # devices (snap mounts).
+      # RAID for data.
       vm.sshable.cmd("lsblk -b -d -n -e 7 -o NAME,SIZE | sort -n -k2 | tail -n +2 | awk '{print \"/dev/\"$1}'").strip.split
     end
 

--- a/model/postgres/aws/postgres_server.rb
+++ b/model/postgres/aws/postgres_server.rb
@@ -16,11 +16,14 @@ class PostgresServer < Sequel::Model
     end
 
     def aws_storage_device_paths
-      # On AWS, pick the largest block device to use as the data disk,
-      # since the device path detected by the VmStorageVolume is not always
-      # correct.
-      storage_device_count = vm.vm_storage_volumes.count { it.boot == false }
-      vm.sshable.cmd("lsblk -b -d -o NAME,SIZE | sort -n -k2 | tail -n:storage_device_count |  awk '{print \"/dev/\"$1}'", storage_device_count:).strip.split
+      # Sort whole block devices by size and drop the smallest (EBS boot, fixed
+      # at 16 GiB). Remaining devices are instance-store NVMes — the disks we
+      # RAID for data. Avoid relying on VmStorageVolume row count, which is
+      # split per a 1900 GiB cap that doesn't match every AWS family's actual
+      # per-disk packaging (e.g. r8id.16xlarge ships 1x3800, r8gd.12xlarge
+      # ships 3x950). -n suppresses the lsblk header; -e 7 excludes loopback
+      # devices (snap mounts).
+      vm.sshable.cmd("lsblk -b -d -n -e 7 -o NAME,SIZE | sort -n -k2 | tail -n +2 | awk '{print \"/dev/\"$1}'").strip.split
     end
 
     def aws_attach_s3_policy_if_needed

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -132,35 +132,19 @@ class Prog::Vm::Nexus < Prog::Base
       end
 
       prog = if location.aws?
-        disk_index = 0
-        storage_volumes.each do |volume|
-          max_disk_size =
-            case vm_size.family
-            when "i8ge", "i7ie"
-              case vm_size.vcpus
-              when 2, 4, 8
-                2500.0
-              else
-                7500.0
-              end
-            when "i8g", "i7i"
-              3750.0
-            else
-              1900.0
-            end
-          disk_count = (volume[:size_gib] / max_disk_size).ceil
-
-          disk_count.times do
-            VmStorageVolume.create(
-              vm_id: vm.id,
-              size_gib: volume[:size_gib] / disk_count,
-              boot: volume[:boot],
-              use_bdev_ubi: false,
-              disk_index:,
-            )
-
-            disk_index += 1
-          end
+        # On AWS, one VmStorageVolume per requested storage_volume — AWS attaches
+        # instance-store NVMes per the instance type, not per record. Device
+        # discovery for mdadm is done at provisioning time via lsblk (see
+        # PostgresServer::Aws#aws_storage_device_paths), so record count doesn't
+        # drive disk count.
+        storage_volumes.each_with_index do |volume, disk_index|
+          VmStorageVolume.create(
+            vm_id: vm.id,
+            size_gib: volume[:size_gib],
+            boot: volume[:boot],
+            use_bdev_ubi: false,
+            disk_index:,
+          )
         end
         "Vm::Aws::Nexus"
       elsif location.gcp?

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -759,12 +759,8 @@ RSpec.describe PostgresServer do
   end
 
   it "returns the right storage_device_paths for AWS" do
-    vm # load before setting aws provider so test controls VmStorageVolume setup
     location.update(provider: "aws")
-    VmStorageVolume.create(vm:, disk_index: 0, boot: true, size_gib: 64)
-    VmStorageVolume.create(vm:, disk_index: 1, boot: false, size_gib: 1024)
-    VmStorageVolume.create(vm:, disk_index: 2, boot: false, size_gib: 1024)
-    expect(postgres_server.vm.sshable).to receive(:_cmd).with("lsblk -b -d -o NAME,SIZE | sort -n -k2 | tail -n2 |  awk '{print \"/dev/\"$1}'").and_return("/dev/nvme1n1\n/dev/nvme2n1\n")
+    expect(postgres_server.vm.sshable).to receive(:_cmd).with("lsblk -b -d -n -e 7 -o NAME,SIZE | sort -n -k2 | tail -n +2 | awk '{print \"/dev/\"$1}'").and_return("/dev/nvme1n1\n/dev/nvme2n1\n")
     expect(postgres_server.storage_device_paths).to eq(["/dev/nvme1n1", "/dev/nvme2n1"])
   end
 

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -92,37 +92,20 @@ usermod -L ubuntu
       loc
     }
 
-    it "creates correct number of storage volumes for storage optimized instance types" do
+    it "creates one VmStorageVolume per input storage volume on AWS" do
       storage_volumes = [
         {encrypted: true, size_gib: 30},
         {encrypted: true, size_gib: 7500},
       ]
 
       vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, location_id: assemble_loc.id, size: "i8g.8xlarge", arch: "arm64", storage_volumes:).subject
-      expect(vm.vm_storage_volumes.count).to eq(3)
+      expect(vm.vm_storage_volumes.count).to eq(2)
+      expect(vm.vm_storage_volumes.map(&:size_gib).sort).to eq([30, 7500])
     end
 
     it "hops to start_aws if location is aws" do
       st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, location_id: assemble_loc.id)
       expect(st.label).to eq("start")
-    end
-
-    it "gives correct max_disk_size for vm family" do
-      vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, location_id: assemble_loc.id, size: "i7ie.24xlarge").subject
-      expect(vm.vm_storage_volumes.count).to eq(8)
-      expect(vm.vm_storage_volumes.sum { it.size_gib }).to eq(60000)
-    end
-
-    it "gives correct size even when volume size smaller than max disk size" do
-      vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, location_id: assemble_loc.id, size: "i7ie.large").subject
-      expect(vm.vm_storage_volumes.count).to eq(1)
-      expect(vm.vm_storage_volumes.sum { it.size_gib }).to equal(1250)
-    end
-
-    it "gives correct max_disk_size for vm family with specialized disk size" do
-      vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, location_id: assemble_loc.id, size: "i7ie.2xlarge").subject
-      expect(vm.vm_storage_volumes.count).to eq(2)
-      expect(vm.vm_storage_volumes.sum { it.size_gib }).to equal(5000)
     end
 
     it "fails if machine image is provided for non-metal location" do


### PR DESCRIPTION
`aws_storage_device_paths` sizes its lsblk tail by the count of non-boot VmStorageVolume rows. Those rows are created by a per-family max_disk_size cap in `Vm::Nexus.assemble` that splits each input volume into N records. The cap doesn't match every AWS family's per-disk packaging:

  - r8id sizes >=12xlarge ship one disk larger than 1900 GB. The cap overcounts, lsblk returns the EBS boot device as well, and mdadm assembles it into the RAID.
  - `r8gd.12xlarge` ships 3 x 950 GB. The cap undercounts, and one instance-store NVMe is not used.

Read the layout from the host instead. `lsblk -b -d -n -e 7 -o NAME,SIZE` sorted by size, drop the smallest entry. The smallest on a Postgres VM is the 16 GiB EBS boot disk; everything else is instance store. `-e 7` excludes loopback devices, which would otherwise sort below boot and shift the result.

Drop the cap and the row split it produced. The AWS branch in Vm::Nexus.assemble creates one VmStorageVolume per input volume. Metal and GCP branches are unchanged.

Manually verified on `r8id.16xlarge, m8gd.12xlarge, r6gd.medium, r6id.8xlarge, m6gd.16xlarge, c6id.12xlarge`.