### PR TITLE
Update to Puma 8.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,7 +389,7 @@ GEM
       byebug (~> 13.0)
       pry (>= 0.13, < 0.17)
     public_suffix (7.0.5)
-    puma (7.1.0)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)

--- a/puma_config.rb
+++ b/puma_config.rb
@@ -2,7 +2,7 @@
 
 # :nocov:
 environment ENV["RACK_ENV"] || "development"
-port ENV["PORT"] || "3000"
+bind "tcp://0.0.0.0:#{ENV["PORT"] || "3000"}"
 threads 15, 15
 enable_keep_alives false
 silence_fork_callback_warning


### PR DESCRIPTION
Some performance improvements.

One significant change is listening on :: instead of 0.0.0.0 by default for production, if the computer supports IPv6. I'm unsure whether this will cause issues in practice, but just in case, use bind in puma_config.rb to explicitly request the previous behavior.