### PR TITLE
Demock `nexus_spec` and remove redundant `display_state` update.

### DIFF
--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -613,8 +613,6 @@ class Prog::Vm::Metal::Nexus < Prog::Base
   end
 
   label def start_after_host_reboot
-    vm.update(display_state: "starting")
-
     secrets_json = JSON.generate({
       storage: vm.storage_secrets,
     })

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -876,27 +876,25 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     end
 
     it "hops to wait if sshable and billing record created" do
+      vm.update(allocated_at: Time.now - 100)
       vm.incr_update_firewall_rules
       adr = Address.create(cidr: "10.0.0.0/24", routed_to_host_id: vm_host.id)
       AssignedVmAddress.create(ip: "10.0.0.1", address_id: adr.id, dst_vm_id: vm.id)
       expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1)
-      now = Time.now
-      expect(Time).to receive(:now).and_return(now).at_least(:once)
-      expect(vm).to receive(:update).with(display_state: "running", provisioned_at: now).and_return(true)
       expect(Clog).to receive(:emit).with("vm provisioned", instance_of(Array)).and_call_original
-      allow(vm).to receive(:allocated_at).and_return(now - 100)
       expect { nx.wait_sshable }.to hop("wait")
+      expect(vm.reload.display_state).to eq("running")
+      expect(vm.provisioned_at).to be_within(10).of(Time.now)
     end
 
     it "skips a check if ipv4 is not enabled" do
+      vm.update(allocated_at: Time.now - 100)
       vm.incr_update_firewall_rules
       expect(vm.ip4).to be_nil
-      now = Time.now
-      expect(Time).to receive(:now).and_return(now).at_least(:once)
-      expect(vm).to receive(:update).with(display_state: "running", provisioned_at: now).and_return(true)
       expect(Clog).to receive(:emit).with("vm provisioned", instance_of(Array)).and_call_original
-      allow(vm).to receive(:allocated_at).and_return(now - 100)
       expect { nx.wait_sshable }.to hop("wait")
+      expect(vm.reload.display_state).to eq("running")
+      expect(vm.provisioned_at).to be_within(10).of(Time.now)
     end
   end
 
@@ -1076,7 +1074,6 @@ RSpec.describe Prog::Vm::Metal::Nexus do
   describe "#update_firewall_rules" do
     it "hops to wait_firewall_rules" do
       vm.incr_update_firewall_rules
-      expect(vm).to receive(:location).and_return(instance_double(Location, aws?: false, provider_dispatcher_group_name: "metal"))
       expect(nx).to receive(:push).with(Prog::Vnet::Metal::UpdateFirewallRules, {}, :update_firewall_rules)
       expect { nx.update_firewall_rules }
         .to change { vm.reload.update_firewall_rules_set? }.from(true).to(false)
@@ -1537,10 +1534,9 @@ RSpec.describe Prog::Vm::Metal::Nexus do
         /sudo host\/bin\/setup-vm recreate-unpersisted #{nx.vm_name}/,
         {stdin: /{"storage":{"vm.*_0":{"key":"key","init_vector":"iv","algorithm":"aes-256-gcm","auth_data":"somedata"}}}/},
       )
-      expect(vm).to receive(:update).with(display_state: "starting")
-      expect(vm).to receive(:update).with(display_state: "running")
-      expect(vm).to receive(:incr_update_firewall_rules)
       expect { nx.start_after_host_reboot }.to hop("wait")
+        .and change { vm.reload.update_firewall_rules_set? }.from(false).to(true)
+      expect(vm.reload.display_state).to eq("running")
     end
   end
 


### PR DESCRIPTION
### Demock database and time operations in prog/vm/metal/nexus_spec.rb 
Use actual database operations instead of mocking database operations. Do time range checks instead of mocking `Time.now`.

### Remove redundant display_state update from start_after_host_reboot 
`start_after_host_reboot` had two `vm.update(display_state: ...)` calls in the same label. Since each label runs in a READ COMMITTED transaction, the first update is redundant: it is not visible to other transactions before commit, and it is not read again within the same transaction.