### PR TITLE
Use model hiding in UbiCli

### DIFF
--- a/cli-commands/ai.rb
+++ b/cli-commands/ai.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-UbiCli.on("ai") do
-  desc "Manage AI features"
+class UbiCli
+  on("ai") do
+    desc "Manage AI features"
 
-  banner "ubi ai [command] ..."
+    banner "ubi ai [command] ..."
 
-  # :nocov:
-  unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
-    autoload_subcommand_dir("cli-commands/ai")
+    # :nocov:
+    unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
+      autoload_subcommand_dir("cli-commands/ai")
+    end
+    # :nocov:
   end
-  # :nocov:
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/ai")

--- a/cli-commands/ai/api-key.rb
+++ b/cli-commands/ai/api-key.rb
@@ -1,28 +1,30 @@
 # frozen_string_literal: true
 
-UbiCli.on("ai", "api-key") do
-  desc "Manage AI inference API keys"
+class UbiCli
+  on("ai", "api-key") do
+    desc "Manage AI inference API keys"
 
-  banner "ubi ai api-key [command] ..."
-  post_banner "ubi ai api-key api-key-id [post-command] ..."
+    banner "ubi ai api-key [command] ..."
+    post_banner "ubi ai api-key api-key-id [post-command] ..."
 
-  # :nocov:
-  unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
-    autoload_subcommand_dir("cli-commands/ai/api-key")
-    autoload_post_subcommand_dir("cli-commands/ai/api-key/post")
-  end
-  # :nocov:
-
-  args(1...)
-
-  run do |(id, *argv), opts, command|
-    unless /\Aak[a-z0-9]{24}\z/.match?(id)
-      raise Rodish::CommandFailure, "no inference API key with id #{id} exists"
+    # :nocov:
+    unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
+      autoload_subcommand_dir("cli-commands/ai/api-key")
+      autoload_post_subcommand_dir("cli-commands/ai/api-key/post")
     end
+    # :nocov:
 
-    @sdk_object = sdk[id]
+    args(1...)
 
-    command.run(self, opts, argv)
+    run do |(id, *argv), opts, command|
+      unless /\Aak[a-z0-9]{24}\z/.match?(id)
+        raise Rodish::CommandFailure, "no inference API key with id #{id} exists"
+      end
+
+      @sdk_object = sdk[id]
+
+      command.run(self, opts, argv)
+    end
   end
 end
 

--- a/cli-commands/ai/api-key/create.rb
+++ b/cli-commands/ai/api-key/create.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.on("ai", "api-key", "create") do
-  desc "Create an inference API key"
+class UbiCli
+  on("ai", "api-key", "create") do
+    desc "Create an inference API key"
 
-  banner "ubi ai api-key create"
+    banner "ubi ai api-key create"
 
-  run do
-    iak = sdk.inference_api_key.create
-    response("Created inference API key with id:#{iak.id} key:#{iak.key}")
+    run do
+      iak = sdk.inference_api_key.create
+      response("Created inference API key with id:#{iak.id} key:#{iak.key}")
+    end
   end
 end

--- a/cli-commands/ai/api-key/list.rb
+++ b/cli-commands/ai/api-key/list.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
-UbiCli.on("ai", "api-key", "list") do
-  desc "List inference API keys"
+class UbiCli
+  on("ai", "api-key", "list") do
+    desc "List inference API keys"
 
-  key = :api_key_list
+    key = :api_key_list
 
-  options("ubi ai api-key list [options]", key:) do
-    on("-N", "--no-headers", "do not show headers")
-  end
+    options("ubi ai api-key list [options]", key:) do
+      on("-N", "--no-headers", "do not show headers")
+    end
 
-  run do |opts|
-    opts = opts[key]
-    items = sdk.inference_api_key.list
-    response(format_rows(%i[id key], items, headers: opts[:"no-headers"] != false))
+    run do |opts|
+      opts = opts[key]
+      items = sdk.inference_api_key.list
+      response(format_rows(%i[id key], items, headers: opts[:"no-headers"] != false))
+    end
   end
 end

--- a/cli-commands/ai/api-key/post/destroy.rb
+++ b/cli-commands/ai/api-key/post/destroy.rb
@@ -1,25 +1,27 @@
 # frozen_string_literal: true
 
-UbiCli.on("ai", "api-key").run_on("destroy") do
-  desc "Destroy an inference API key"
+class UbiCli
+  on("ai", "api-key").run_on("destroy") do
+    desc "Destroy an inference API key"
 
-  options("ubi ai api-key api-key-id destroy [options]", key: :destroy) do
-    on("-f", "--force", "do not require confirmation")
-  end
+    options("ubi ai api-key api-key-id destroy [options]", key: :destroy) do
+      on("-f", "--force", "do not require confirmation")
+    end
 
-  run do |opts|
-    if opts.dig(:destroy, :force) || opts[:confirm] == @sdk_object.id[2, 6]
-      @sdk_object.destroy
-      response("Inference API key, if it exists, has been destroyed")
-    elsif opts[:confirm]
-      invalid_confirmation <<~END
-        ! Confirmation of destruction not successful
-      END
-    else
-      require_confirmation("Confirmation", <<~END)
-        Destroying this inference API key is not recoverable.
-        Enter the following to confirm destruction of the inference API key: #{@sdk_object.id[2, 6]}
-      END
+    run do |opts|
+      if opts.dig(:destroy, :force) || opts[:confirm] == @sdk_object.id[2, 6]
+        @sdk_object.destroy
+        response("Inference API key, if it exists, has been destroyed")
+      elsif opts[:confirm]
+        invalid_confirmation <<~END
+          ! Confirmation of destruction not successful
+        END
+      else
+        require_confirmation("Confirmation", <<~END)
+          Destroying this inference API key is not recoverable.
+          Enter the following to confirm destruction of the inference API key: #{@sdk_object.id[2, 6]}
+        END
+      end
     end
   end
 end

--- a/cli-commands/ai/api-key/post/show.rb
+++ b/cli-commands/ai/api-key/post/show.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-UbiCli.on("ai", "api-key").run_on("show") do
-  desc "Show details for an inference API key"
+class UbiCli
+  on("ai", "api-key").run_on("show") do
+    desc "Show details for an inference API key"
 
-  banner "ubi ai api-key api-key-id show"
+    banner "ubi ai api-key api-key-id show"
 
-  run do
-    iak = @sdk_object
-    body = []
-    body << "id: " << iak.id << "\n"
-    body << "key: " << iak.key << "\n"
-    response(body)
+    run do
+      iak = @sdk_object
+      body = []
+      body << "id: " << iak.id << "\n"
+      body << "key: " << iak.key << "\n"
+      response(body)
+    end
   end
 end

--- a/cli-commands/ai/endpoint.rb
+++ b/cli-commands/ai/endpoint.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-UbiCli.on("ai", "endpoint") do
-  desc "Manage AI inference endpoints"
+class UbiCli
+  on("ai", "endpoint") do
+    desc "Manage AI inference endpoints"
 
-  banner "ubi ai endpoint [command] ..."
+    banner "ubi ai endpoint [command] ..."
 
-  # :nocov:
-  unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
-    autoload_subcommand_dir("cli-commands/ai/endpoint")
+    # :nocov:
+    unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
+      autoload_subcommand_dir("cli-commands/ai/endpoint")
+    end
+    # :nocov:
   end
-  # :nocov:
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/ai/endpoint")

--- a/cli-commands/ai/endpoint/list.rb
+++ b/cli-commands/ai/endpoint/list.rb
@@ -1,38 +1,40 @@
 # frozen_string_literal: true
 
-UbiCli.on("ai", "endpoint", "list") do
-  desc "List inference endpoints"
+class UbiCli
+  on("ai", "endpoint", "list") do
+    desc "List inference endpoints"
 
-  fields = %w[name display-name hf-model capability multimodal context-length url input-price output-price].freeze
-  default_fields = %w[name capability multimodal context-length input-price output-price].freeze
+    fields = %w[name display-name hf-model capability multimodal context-length url input-price output-price].freeze
+    default_fields = %w[name capability multimodal context-length input-price output-price].freeze
 
-  key = :endpoint_list
+    key = :endpoint_list
 
-  options("ubi ai endpoint list [options]", key:) do
-    on("-f", "--fields=fields", "show specific fields (comma separated)")
-    on("-N", "--no-headers", "do not show headers")
-  end
-  help_option_values("Fields:", fields)
-
-  run do |opts, command|
-    opts = opts[key]
-    items = sdk.inference_endpoint.list.map do |ie|
-      price = ie[:price] || {}
-      tags = ie[:tags] || {}
-      {
-        name: ie[:name],
-        display_name: ie[:display_name],
-        hf_model: tags[:hf_model],
-        capability: tags[:capability],
-        multimodal: tags[:multimodal],
-        context_length: tags[:context_length],
-        url: ie[:url],
-        input_price: price[:per_million_prompt_tokens],
-        output_price: price[:per_million_completion_tokens],
-      }
+    options("ubi ai endpoint list [options]", key:) do
+      on("-f", "--fields=fields", "show specific fields (comma separated)")
+      on("-N", "--no-headers", "do not show headers")
     end
-    given = opts[:fields]
-    keys = underscore_keys(given ? check_fields(given, fields, "ai endpoint list -f option", command) : default_fields)
-    response(format_rows(keys, items, headers: opts[:"no-headers"] != false))
+    help_option_values("Fields:", fields)
+
+    run do |opts, command|
+      opts = opts[key]
+      items = sdk.inference_endpoint.list.map do |ie|
+        price = ie[:price] || {}
+        tags = ie[:tags] || {}
+        {
+          name: ie[:name],
+          display_name: ie[:display_name],
+          hf_model: tags[:hf_model],
+          capability: tags[:capability],
+          multimodal: tags[:multimodal],
+          context_length: tags[:context_length],
+          url: ie[:url],
+          input_price: price[:per_million_prompt_tokens],
+          output_price: price[:per_million_completion_tokens],
+        }
+      end
+      given = opts[:fields]
+      keys = underscore_keys(given ? check_fields(given, fields, "ai endpoint list -f option", command) : default_fields)
+      response(format_rows(keys, items, headers: opts[:"no-headers"] != false))
+    end
   end
 end

--- a/cli-commands/al.rb
+++ b/cli-commands/al.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-UbiCli.on("al") do
-  desc "View project audit log"
+class UbiCli
+  on("al") do
+    desc "View project audit log"
 
-  banner "ubi al command [...]"
+    banner "ubi al command [...]"
 
-  # :nocov:
-  unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
-    autoload_subcommand_dir("cli-commands/al")
+    # :nocov:
+    unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
+      autoload_subcommand_dir("cli-commands/al")
+    end
+    # :nocov:
   end
-  # :nocov:
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/al")

--- a/cli-commands/al/search.rb
+++ b/cli-commands/al/search.rb
@@ -1,29 +1,31 @@
 # frozen_string_literal: true
 
-UbiCli.on("al", "search") do
-  desc "Search project audit log entries in CSV format"
+class UbiCli
+  on("al", "search") do
+    desc "Search project audit log entries in CSV format"
 
-  key = :audit_log_search
+    key = :audit_log_search
 
-  options("ubi al search [options]", key:) do
-    on("-N", "--no-headers", "do not show headers")
-    on("-a", "--action=action", "only show entries for the given action")
-    on("-e", "--end=end-date", "only show prior to end date")
-    on("-o", "--object=object", "only show entries affecting the given object ID")
-    on("-s", "--subject=account", "only show entries with the given account name/email/ID")
-    on("--limit=limit", "limit number of records returned")
-    on("--pagination-key=key", "continue a previous search")
-  end
-
-  run do |opts, command|
-    opts = underscore_keys(opts[key])
-    no_headers = opts.delete(:no_headers)
-    logs = sdk.audit_log.search(**opts)
-
-    body = format_paginated_csv(logs, "ubi al search", no_headers:, header_row: "At,Action,Account,Objects") do |log|
-      [log.at, log.action, log.subject_name || log.subject_id, log.object_ids.join(" ")]
+    options("ubi al search [options]", key:) do
+      on("-N", "--no-headers", "do not show headers")
+      on("-a", "--action=action", "only show entries for the given action")
+      on("-e", "--end=end-date", "only show prior to end date")
+      on("-o", "--object=object", "only show entries affecting the given object ID")
+      on("-s", "--subject=account", "only show entries with the given account name/email/ID")
+      on("--limit=limit", "limit number of records returned")
+      on("--pagination-key=key", "continue a previous search")
     end
 
-    response(body)
+    run do |opts, command|
+      opts = underscore_keys(opts[key])
+      no_headers = opts.delete(:no_headers)
+      logs = sdk.audit_log.search(**opts)
+
+      body = format_paginated_csv(logs, "ubi al search", no_headers:, header_row: "At,Action,Account,Objects") do |log|
+        [log.at, log.action, log.subject_name || log.subject_id, log.object_ids.join(" ")]
+      end
+
+      response(body)
+    end
   end
 end

--- a/cli-commands/fw.rb
+++ b/cli-commands/fw.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-UbiCli.base("fw") do
-  banner "ubi fw command [...]"
-  post_banner "ubi fw (location/fw-name | fw-id) post-command [...]"
+class UbiCli
+  base("fw") do
+    banner "ubi fw command [...]"
+    post_banner "ubi fw (location/fw-name | fw-id) post-command [...]"
+  end
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/fw")

--- a/cli-commands/fw/list.rb
+++ b/cli-commands/fw/list.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.list("fw", %w[location name id])
+class UbiCli
+  list("fw", %w[location name id])
+end

--- a/cli-commands/fw/post/add-rule.rb
+++ b/cli-commands/fw/post/add-rule.rb
@@ -1,24 +1,26 @@
 # frozen_string_literal: true
 
-UbiCli.on("fw").run_on("add-rule") do
-  desc "Add a firewall rule"
+class UbiCli
+  on("fw").run_on("add-rule") do
+    desc "Add a firewall rule"
 
-  options("ubi fw (location/fw-name | fw-id) add-rule [options] (cidr | ps-id | ps-name)", key: :fw_add_rule) do
-    on("-s", "--start-port=port", Integer, "starting (or only) port to allow (default: 0)")
-    on("-e", "--end-port=port", Integer, "ending port to allow (default: 65535)")
-    on("-p", "--protocol=protocol", "protocol to allow (tcp or udp, default: tcp)")
-    on("-d", "--description=desc", "description of rule")
-  end
+    options("ubi fw (location/fw-name | fw-id) add-rule [options] (cidr | ps-id | ps-name)", key: :fw_add_rule) do
+      on("-s", "--start-port=port", Integer, "starting (or only) port to allow (default: 0)")
+      on("-e", "--end-port=port", Integer, "ending port to allow (default: 65535)")
+      on("-p", "--protocol=protocol", "protocol to allow (tcp or udp, default: tcp)")
+      on("-d", "--description=desc", "description of rule")
+    end
 
-  args 1
+    args 1
 
-  run do |cidr, opts|
-    body = sdk_object.add_rule(cidr, **underscore_keys(opts[:fw_add_rule]))
+    run do |cidr, opts|
+      body = sdk_object.add_rule(cidr, **underscore_keys(opts[:fw_add_rule]))
 
-    if body.is_a?(Array)
-      response("Added firewall rules with ids: #{body.map { it[:id] }.join(" ")}")
-    else
-      response("Added firewall rule with id: #{body[:id]}")
+      if body.is_a?(Array)
+        response("Added firewall rules with ids: #{body.map { it[:id] }.join(" ")}")
+      else
+        response("Added firewall rule with id: #{body[:id]}")
+      end
     end
   end
 end

--- a/cli-commands/fw/post/attach-subnet.rb
+++ b/cli-commands/fw/post/attach-subnet.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-UbiCli.on("fw").run_on("attach-subnet") do
-  desc "Attach a private subnet to a firewall"
+class UbiCli
+  on("fw").run_on("attach-subnet") do
+    desc "Attach a private subnet to a firewall"
 
-  banner "ubi fw (location/fw-name | fw-id) attach-subnet (ps-name | ps-id)"
+    banner "ubi fw (location/fw-name | fw-id) attach-subnet (ps-name | ps-id)"
 
-  args 1
+    args 1
 
-  run do |subnet_id|
-    id = sdk_object.attach_subnet(convert_name_to_id(sdk.private_subnet, subnet_id)).id
-    response("Attached private subnet #{subnet_id} to firewall with id #{id}")
+    run do |subnet_id|
+      id = sdk_object.attach_subnet(convert_name_to_id(sdk.private_subnet, subnet_id)).id
+      response("Attached private subnet #{subnet_id} to firewall with id #{id}")
+    end
   end
 end

--- a/cli-commands/fw/post/create.rb
+++ b/cli-commands/fw/post/create.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-UbiCli.on("fw").run_on("create") do
-  desc "Create a firewall"
+class UbiCli
+  on("fw").run_on("create") do
+    desc "Create a firewall"
 
-  options("ubi fw location/fw-name create [options]", key: :fw_create) do
-    on("-d", "--description=desc", "description for firewall")
-  end
+    options("ubi fw location/fw-name create [options]", key: :fw_create) do
+      on("-d", "--description=desc", "description for firewall")
+    end
 
-  run do |opts|
-    params = underscore_keys(opts[:fw_create])
-    id = sdk.firewall.create(location: @location, name: @name, **params).id
-    response("Firewall created with id: #{id}")
+    run do |opts|
+      params = underscore_keys(opts[:fw_create])
+      id = sdk.firewall.create(location: @location, name: @name, **params).id
+      response("Firewall created with id: #{id}")
+    end
   end
 end

--- a/cli-commands/fw/post/delete-rule.rb
+++ b/cli-commands/fw/post/delete-rule.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-UbiCli.on("fw").run_on("delete-rule") do
-  desc "Remove a firewall rule"
+class UbiCli
+  on("fw").run_on("delete-rule") do
+    desc "Remove a firewall rule"
 
-  banner "ubi fw (location/fw-name | fw-id) delete-rule rule-id"
+    banner "ubi fw (location/fw-name | fw-id) delete-rule rule-id"
 
-  args 1
+    args 1
 
-  run do |rule_id, _, cmd|
-    check_no_slash(rule_id, "invalid rule id format", cmd)
-    sdk_object.delete_rule(rule_id)
-    response("Firewall rule, if it existed, has been deleted")
+    run do |rule_id, _, cmd|
+      check_no_slash(rule_id, "invalid rule id format", cmd)
+      sdk_object.delete_rule(rule_id)
+      response("Firewall rule, if it existed, has been deleted")
+    end
   end
 end

--- a/cli-commands/fw/post/destroy.rb
+++ b/cli-commands/fw/post/destroy.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.destroy("fw")
+class UbiCli
+  destroy("fw")
+end

--- a/cli-commands/fw/post/detach-subnet.rb
+++ b/cli-commands/fw/post/detach-subnet.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-UbiCli.on("fw").run_on("detach-subnet") do
-  desc "Detach a private subnet from a firewall"
+class UbiCli
+  on("fw").run_on("detach-subnet") do
+    desc "Detach a private subnet from a firewall"
 
-  banner "ubi fw (location/fw-name | fw-id) detach-subnet (ps-name | ps-id)"
+    banner "ubi fw (location/fw-name | fw-id) detach-subnet (ps-name | ps-id)"
 
-  args 1
+    args 1
 
-  run do |subnet_id|
-    id = sdk_object.detach_subnet(convert_name_to_id(sdk.private_subnet, subnet_id)).id
-    response("Detached private subnet #{subnet_id} from firewall with id #{id}")
+    run do |subnet_id|
+      id = sdk_object.detach_subnet(convert_name_to_id(sdk.private_subnet, subnet_id)).id
+      response("Detached private subnet #{subnet_id} from firewall with id #{id}")
+    end
   end
 end

--- a/cli-commands/fw/post/modify-rule.rb
+++ b/cli-commands/fw/post/modify-rule.rb
@@ -1,24 +1,26 @@
 # frozen_string_literal: true
 
-UbiCli.on("fw").run_on("modify-rule") do
-  desc "Modify a firewall rule"
+class UbiCli
+  on("fw").run_on("modify-rule") do
+    desc "Modify a firewall rule"
 
-  options("ubi fw (location/fw-name | fw-id) modify-rule options rule-id", key: :fw_modify_rule) do
-    on("-c", "--cidr=ip-range", "IPv4 or IPv6 range to allow")
-    on("-s", "--start-port=port", Integer, "starting (or only) port to allow (default: 0)")
-    on("-e", "--end-port=port", Integer, "ending port to allow (default: 65535)")
-    on("-p", "--protocol=protocol", "protocol to allow (tcp or udp)")
-    on("-d", "--description=desc", "description of rule")
-  end
-
-  args 1
-
-  run do |rule_id, opts, cmd|
-    opts = underscore_keys(opts[:fw_modify_rule])
-    if opts.empty?
-      raise Rodish::CommandFailure.new("Must provide at least one option (-c, -s, -e, -p, or -d)", cmd)
+    options("ubi fw (location/fw-name | fw-id) modify-rule options rule-id", key: :fw_modify_rule) do
+      on("-c", "--cidr=ip-range", "IPv4 or IPv6 range to allow")
+      on("-s", "--start-port=port", Integer, "starting (or only) port to allow (default: 0)")
+      on("-e", "--end-port=port", Integer, "ending port to allow (default: 65535)")
+      on("-p", "--protocol=protocol", "protocol to allow (tcp or udp)")
+      on("-d", "--description=desc", "description of rule")
     end
-    id = sdk_object.modify_rule(rule_id, **opts)[:id]
-    response("Modified firewall rule with id: #{id}")
+
+    args 1
+
+    run do |rule_id, opts, cmd|
+      opts = underscore_keys(opts[:fw_modify_rule])
+      if opts.empty?
+        raise Rodish::CommandFailure.new("Must provide at least one option (-c, -s, -e, -p, or -d)", cmd)
+      end
+      id = sdk_object.modify_rule(rule_id, **opts)[:id]
+      response("Modified firewall rule with id: #{id}")
+    end
   end
 end

--- a/cli-commands/fw/post/rename.rb
+++ b/cli-commands/fw/post/rename.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.rename("fw")
+class UbiCli
+  rename("fw")
+end

--- a/cli-commands/fw/post/show.rb
+++ b/cli-commands/fw/post/show.rb
@@ -1,66 +1,68 @@
 # frozen_string_literal: true
 
-UbiCli.on("fw").run_on("show") do
-  desc "Show details for a firewall"
+class UbiCli
+  on("fw").run_on("show") do
+    desc "Show details for a firewall"
 
-  fields = %w[id name location description firewall-rules private-subnets].freeze.each(&:freeze)
-  firewall_rule_fields = %w[id cidr port-range protocol].freeze.each(&:freeze)
-  private_subnet_fields = %w[id name state location net4 net6 nics].freeze.each(&:freeze)
-  nic_fields = %w[id name private-ipv4 private-ipv6 vm-name].freeze.each(&:freeze)
+    fields = %w[id name location description firewall-rules private-subnets].freeze.each(&:freeze)
+    firewall_rule_fields = %w[id cidr port-range protocol].freeze.each(&:freeze)
+    private_subnet_fields = %w[id name state location net4 net6 nics].freeze.each(&:freeze)
+    nic_fields = %w[id name private-ipv4 private-ipv6 vm-name].freeze.each(&:freeze)
 
-  options("ubi fw (location/fw-name | fw-id) show [options]", key: :fw_show) do
-    on("-f", "--fields=fields", "show specific fields (comma separated)")
-    on("-n", "--nic-fields=fields", "show specific nic fields (comma separated)")
-    on("-p", "--priv-subnet-fields=fields", "show specific private subnet fields (comma separated)")
-    on("-r", "--rule-fields=fields", "show specific firewall rule fields (comma separated)")
-  end
-  help_option_values("Fields:", fields)
-  help_option_values("Nic Fields:", nic_fields)
-  help_option_values("Private Subnet Fields:", private_subnet_fields)
-  help_option_values("Firewall Rule Fields:", firewall_rule_fields)
+    options("ubi fw (location/fw-name | fw-id) show [options]", key: :fw_show) do
+      on("-f", "--fields=fields", "show specific fields (comma separated)")
+      on("-n", "--nic-fields=fields", "show specific nic fields (comma separated)")
+      on("-p", "--priv-subnet-fields=fields", "show specific private subnet fields (comma separated)")
+      on("-r", "--rule-fields=fields", "show specific firewall rule fields (comma separated)")
+    end
+    help_option_values("Fields:", fields)
+    help_option_values("Nic Fields:", nic_fields)
+    help_option_values("Private Subnet Fields:", private_subnet_fields)
+    help_option_values("Firewall Rule Fields:", firewall_rule_fields)
 
-  run do |opts, cmd|
-    data = sdk_object.info
-    opts = opts[:fw_show]
-    keys = underscore_keys(check_fields(opts[:fields], fields, "fw show -f option", cmd))
-    firewall_rule_keys = underscore_keys(check_fields(opts[:"rule-fields"], firewall_rule_fields, "fw show -r option", cmd))
-    private_subnet_keys = underscore_keys(check_fields(opts[:"priv-subnet-fields"], private_subnet_fields, "fw show -p option", cmd))
-    nic_keys = underscore_keys(check_fields(opts[:"nic-fields"], nic_fields, "fw show -n option", cmd))
+    run do |opts, cmd|
+      data = sdk_object.info
+      opts = opts[:fw_show]
+      keys = underscore_keys(check_fields(opts[:fields], fields, "fw show -f option", cmd))
+      firewall_rule_keys = underscore_keys(check_fields(opts[:"rule-fields"], firewall_rule_fields, "fw show -r option", cmd))
+      private_subnet_keys = underscore_keys(check_fields(opts[:"priv-subnet-fields"], private_subnet_fields, "fw show -p option", cmd))
+      nic_keys = underscore_keys(check_fields(opts[:"nic-fields"], nic_fields, "fw show -n option", cmd))
 
-    body = []
+      body = []
 
-    each_with_dashed(keys) do |key, display_key|
-      case key
-      when :firewall_rules
-        body << "rules:\n"
-        data[key].each_with_index do |rule, i|
-          body << "  " << (i + 1).to_s << ": "
-          firewall_rule_keys.each do |fwr_key|
-            body << rule[fwr_key].to_s << "  "
+      each_with_dashed(keys) do |key, display_key|
+        case key
+        when :firewall_rules
+          body << "rules:\n"
+          data[key].each_with_index do |rule, i|
+            body << "  " << (i + 1).to_s << ": "
+            firewall_rule_keys.each do |fwr_key|
+              body << rule[fwr_key].to_s << "  "
+            end
+            body << "\n"
           end
-          body << "\n"
-        end
-      when :private_subnets
-        data[key].each_with_index do |ps, i|
-          body << "private subnet " << (i + 1).to_s << ":\n"
-          each_with_dashed(private_subnet_keys) do |ps_key, display_ps_key|
-            if ps_key == :nics
-              ps[ps_key].each_with_index do |nic, i|
-                body << "  nic " << (i + 1).to_s << ":\n"
-                each_with_dashed(nic_keys) do |nic_key, display_nic_key|
-                  body << "    " << display_nic_key << ": " << nic[nic_key].to_s << "\n"
+        when :private_subnets
+          data[key].each_with_index do |ps, i|
+            body << "private subnet " << (i + 1).to_s << ":\n"
+            each_with_dashed(private_subnet_keys) do |ps_key, display_ps_key|
+              if ps_key == :nics
+                ps[ps_key].each_with_index do |nic, i|
+                  body << "  nic " << (i + 1).to_s << ":\n"
+                  each_with_dashed(nic_keys) do |nic_key, display_nic_key|
+                    body << "    " << display_nic_key << ": " << nic[nic_key].to_s << "\n"
+                  end
                 end
+              else
+                body << "  " << display_ps_key << ": " << ps[ps_key].to_s << "\n"
               end
-            else
-              body << "  " << display_ps_key << ": " << ps[ps_key].to_s << "\n"
             end
           end
+        else
+          body << display_key << ": " << data[key].to_s << "\n"
         end
-      else
-        body << display_key << ": " << data[key].to_s << "\n"
       end
-    end
 
-    response(body)
+      response(body)
+    end
   end
 end

--- a/cli-commands/fw/post/update-description.rb
+++ b/cli-commands/fw/post/update-description.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-UbiCli.on("fw").run_on("update-description") do
-  desc "Update the description for a firewall"
+class UbiCli
+  on("fw").run_on("update-description") do
+    desc "Update the description for a firewall"
 
-  banner "ubi fw (location/fw-name | fw-id) update-description new-description"
+    banner "ubi fw (location/fw-name | fw-id) update-description new-description"
 
-  args 1
+    args 1
 
-  run do |description|
-    sdk_object.update_description(description)
-    response("Firewall description updated to #{description}")
+    run do |description|
+      sdk_object.update_description(description)
+      response("Firewall description updated to #{description}")
+    end
   end
 end

--- a/cli-commands/gh.rb
+++ b/cli-commands/gh.rb
@@ -1,35 +1,37 @@
 # frozen_string_literal: true
 
-UbiCli.on("gh") do
-  desc "Manage GitHub integration"
+class UbiCli
+  on("gh") do
+    desc "Manage GitHub integration"
 
-  banner "ubi gh command [...]"
-  post_banner "ubi gh (installation-name/repository-name) post-command [...]"
+    banner "ubi gh command [...]"
+    post_banner "ubi gh (installation-name/repository-name) post-command [...]"
 
-  # :nocov:
-  unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
-    autoload_subcommand_dir("cli-commands/gh")
-    autoload_post_subcommand_dir("cli-commands/gh/post")
-  end
-  # :nocov:
-
-  args(2...)
-
-  run do |(ref, *argv), opts, command|
-    if command.post_subcommand(ref)
-      # support swapped reference and post command arguments
-      argv.insert(1, ref)
-      ref = argv.shift
+    # :nocov:
+    unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
+      autoload_subcommand_dir("cli-commands/gh")
+      autoload_post_subcommand_dir("cli-commands/gh/post")
     end
+    # :nocov:
 
-    installation_name, name, extra = ref.split("/", 3)
+    args(2...)
 
-    if extra || !name
-      raise Rodish::CommandFailure.new("invalid gh reference (#{ref.inspect}), should be in installation-name/repository-name format", command)
+    run do |(ref, *argv), opts, command|
+      if command.post_subcommand(ref)
+        # support swapped reference and post command arguments
+        argv.insert(1, ref)
+        ref = argv.shift
+      end
+
+      installation_name, name, extra = ref.split("/", 3)
+
+      if extra || !name
+        raise Rodish::CommandFailure.new("invalid gh reference (#{ref.inspect}), should be in installation-name/repository-name format", command)
+      end
+
+      @repository = sdk.github_repository.new(installation_name:, name:)
+      command.run(self, opts, argv)
     end
-
-    @repository = sdk.github_repository.new(installation_name:, name:)
-    command.run(self, opts, argv)
   end
 end
 

--- a/cli-commands/gh/installation.rb
+++ b/cli-commands/gh/installation.rb
@@ -1,24 +1,26 @@
 # frozen_string_literal: true
 
-UbiCli.on("gh", "installation") do
-  desc "Manage GitHub installations"
+class UbiCli
+  on("gh", "installation") do
+    desc "Manage GitHub installations"
 
-  banner "ubi gh installation command [...]"
-  post_banner "ubi gh installation installation-name post-command [...]"
+    banner "ubi gh installation command [...]"
+    post_banner "ubi gh installation installation-name post-command [...]"
 
-  # :nocov:
-  unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
-    autoload_subcommand_dir("cli-commands/gh/installation")
-    autoload_post_subcommand_dir("cli-commands/gh/installation/post")
-  end
-  # :nocov:
+    # :nocov:
+    unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
+      autoload_subcommand_dir("cli-commands/gh/installation")
+      autoload_post_subcommand_dir("cli-commands/gh/installation/post")
+    end
+    # :nocov:
 
-  args(2...)
+    args(2...)
 
-  run do |(ref, *argv), opts, command|
-    check_no_slash(ref, "invalid GitHub installation reference (#{ref.inspect}), should not include /", command)
-    @installation = sdk.github_installation.new(ref)
-    command.run(self, opts, argv)
+    run do |(ref, *argv), opts, command|
+      check_no_slash(ref, "invalid GitHub installation reference (#{ref.inspect}), should not include /", command)
+      @installation = sdk.github_installation.new(ref)
+      command.run(self, opts, argv)
+    end
   end
 end
 

--- a/cli-commands/gh/installation/list.rb
+++ b/cli-commands/gh/installation/list.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-UbiCli.on("gh", "installation", "list") do
-  desc "List GitHub installations"
+class UbiCli
+  on("gh", "installation", "list") do
+    desc "List GitHub installations"
 
-  key = :github_installations_list
+    key = :github_installations_list
 
-  options("ubi gh installation list [options]", key:) do
-    on("-N", "--no-headers", "do not show headers")
-  end
+    options("ubi gh installation list [options]", key:) do
+      on("-N", "--no-headers", "do not show headers")
+    end
 
-  run do |opts|
-    response(format_rows(%i[id name], sdk.github_installation.list, headers: opts[key][:"no-headers"] != false))
+    run do |opts|
+      response(format_rows(%i[id name], sdk.github_installation.list, headers: opts[key][:"no-headers"] != false))
+    end
   end
 end

--- a/cli-commands/gh/installation/post/list-repositories.rb
+++ b/cli-commands/gh/installation/post/list-repositories.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-UbiCli.on("gh", "installation").run_on("list-repositories") do
-  desc "List GitHub repositories for an installation"
+class UbiCli
+  on("gh", "installation").run_on("list-repositories") do
+    desc "List GitHub repositories for an installation"
 
-  key = :github_repositories_list
+    key = :github_repositories_list
 
-  options("ubi gh installation installation-name list-repositories [options]", key:) do
-    on("-N", "--no-headers", "do not show headers")
-  end
+    options("ubi gh installation installation-name list-repositories [options]", key:) do
+      on("-N", "--no-headers", "do not show headers")
+    end
 
-  run do |opts|
-    response(format_rows(%i[id name], @installation.repositories, headers: opts[key][:"no-headers"] != false))
+    run do |opts|
+      response(format_rows(%i[id name], @installation.repositories, headers: opts[key][:"no-headers"] != false))
+    end
   end
 end

--- a/cli-commands/gh/post/list-cache-entries.rb
+++ b/cli-commands/gh/post/list-cache-entries.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-UbiCli.on("gh").run_on("list-cache-entries") do
-  desc "List cache entries for a GitHub repository"
+class UbiCli
+  on("gh").run_on("list-cache-entries") do
+    desc "List cache entries for a GitHub repository"
 
-  key = :cache_entries_list
+    key = :cache_entries_list
 
-  options("ubi gh installation-name/repository-name list-cache-entries [options]", key:) do
-    on("-N", "--no-headers", "do not show headers")
-  end
+    options("ubi gh installation-name/repository-name list-cache-entries [options]", key:) do
+      on("-N", "--no-headers", "do not show headers")
+    end
 
-  run do |opts|
-    cache_entries = @repository.cache_entries.each { it.values[:size] = Clover.humanize_size(it[:size]) }
-    response(format_rows(%i[id scope size created_at last_accessed_at key], cache_entries, headers: opts[key][:"no-headers"] != false))
+    run do |opts|
+      cache_entries = @repository.cache_entries.each { it.values[:size] = Clover.humanize_size(it[:size]) }
+      response(format_rows(%i[id scope size created_at last_accessed_at key], cache_entries, headers: opts[key][:"no-headers"] != false))
+    end
   end
 end

--- a/cli-commands/gh/post/remove-all-cache-entries.rb
+++ b/cli-commands/gh/post/remove-all-cache-entries.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.on("gh").run_on("remove-all-cache-entries") do
-  desc "Remove all cache entries for a GitHub repository"
+class UbiCli
+  on("gh").run_on("remove-all-cache-entries") do
+    desc "Remove all cache entries for a GitHub repository"
 
-  banner "ubi gh installation-name/repository-name remove-all-cache-entries"
+    banner "ubi gh installation-name/repository-name remove-all-cache-entries"
 
-  run do
-    @repository.remove_all_cache_entries
-    response("All cache entries, if they exist, are now scheduled for destruction")
+    run do
+      @repository.remove_all_cache_entries
+      response("All cache entries, if they exist, are now scheduled for destruction")
+    end
   end
 end

--- a/cli-commands/gh/post/remove-cache-entry.rb
+++ b/cli-commands/gh/post/remove-cache-entry.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-UbiCli.on("gh").run_on("remove-cache-entry") do
-  desc "Remove cache entry for a GitHub repository"
+class UbiCli
+  on("gh").run_on("remove-cache-entry") do
+    desc "Remove cache entry for a GitHub repository"
 
-  banner "ubi gh installation-name/repository-name remove-cache-entry cache-entry-id"
+    banner "ubi gh installation-name/repository-name remove-cache-entry cache-entry-id"
 
-  args 1
+    args 1
 
-  run do |id, _, cmd|
-    check_no_slash(id, "invalid cache entry id format, should not include /", cmd)
-    @repository.remove_cache_entry(id)
-    response("Cache entry, if it exists, is now scheduled for destruction")
+    run do |id, _, cmd|
+      check_no_slash(id, "invalid cache entry id format, should not include /", cmd)
+      @repository.remove_cache_entry(id)
+      response("Cache entry, if it exists, is now scheduled for destruction")
+    end
   end
 end

--- a/cli-commands/help.rb
+++ b/cli-commands/help.rb
@@ -1,53 +1,55 @@
 # frozen_string_literal: true
 
-UbiCli.on("help") do
-  desc "Get command help"
+class UbiCli
+  on("help") do
+    desc "Get command help"
 
-  options("ubi help [options] [command [subcommand]]") do
-    on("-r", "--recursive", "also show documentation for all subcommands of command")
-    on("-u", "--usage", "only show usage")
-  end
-
-  args(0..)
-
-  run do |argv, opts|
-    orig_command = command = UbiCli.command
-
-    argv.each do |arg|
-      break unless (command = command.subcommand(arg) || command.post_subcommand(arg))
-
-      orig_command = command
+    options("ubi help [options] [command [subcommand]]") do
+      on("-r", "--recursive", "also show documentation for all subcommands of command")
+      on("-u", "--usage", "only show usage")
     end
 
-    usage = opts[:usage]
-    if command
-      if opts[:recursive]
-        body = []
-        command.each_subcommand do |_, cmd|
-          if usage
-            cmd.each_banner do |banner|
-              body << banner << "\n"
-            end
-          else
-            # When we want to switch to context-sensitive help
-            # body << cmd.context_help(self) << "\n\n"
-            body << cmd.help << "\n\n"
-          end
-        end
-        response(body)
-      elsif usage
-        body = []
-        command.each_banner do |banner|
-          body << banner << "\n"
-        end
-        response(body)
-      else
-        # When we want to switch to context-sensitive help
-        # response(command.context_help(self))
-        response(command.help)
+    args(0..)
+
+    run do |argv, opts|
+      orig_command = command = UbiCli.command
+
+      argv.each do |arg|
+        break unless (command = command.subcommand(arg) || command.post_subcommand(arg))
+
+        orig_command = command
       end
-    else
-      orig_command.raise_failure("invalid command: #{argv.join(" ")}")
+
+      usage = opts[:usage]
+      if command
+        if opts[:recursive]
+          body = []
+          command.each_subcommand do |_, cmd|
+            if usage
+              cmd.each_banner do |banner|
+                body << banner << "\n"
+              end
+            else
+              # When we want to switch to context-sensitive help
+              # body << cmd.context_help(self) << "\n\n"
+              body << cmd.help << "\n\n"
+            end
+          end
+          response(body)
+        elsif usage
+          body = []
+          command.each_banner do |banner|
+            body << banner << "\n"
+          end
+          response(body)
+        else
+          # When we want to switch to context-sensitive help
+          # response(command.context_help(self))
+          response(command.help)
+        end
+      else
+        orig_command.raise_failure("invalid command: #{argv.join(" ")}")
+      end
     end
   end
 end

--- a/cli-commands/kc.rb
+++ b/cli-commands/kc.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-UbiCli.base("kc") do
-  banner "ubi kc command [...]"
-  post_banner "ubi kc (location/kc-name | kc-id) post-command [...]"
+class UbiCli
+  base("kc") do
+    banner "ubi kc command [...]"
+    post_banner "ubi kc (location/kc-name | kc-id) post-command [...]"
+  end
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/kc")

--- a/cli-commands/kc/list.rb
+++ b/cli-commands/kc/list.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.list("kc", %w[location name id display_state version cp_node_count])
+class UbiCli
+  list("kc", %w[location name id display_state version cp_node_count])
+end

--- a/cli-commands/kc/post/create.rb
+++ b/cli-commands/kc/post/create.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
-UbiCli.on("kc").run_on("create") do
-  desc "Create a Kubernetes cluster"
+class UbiCli
+  on("kc").run_on("create") do
+    desc "Create a Kubernetes cluster"
 
-  options("ubi kc location/kc-name create [options]", key: :kc_create) do
-    on("-v", "--version=version", "Kubernetes version")
-    on("-c", "--cp-node-count=count", Integer, "Control plane node count")
-    on("-w", "--worker-node-count=count", Integer, "Worker node count")
-    on("-z", "--worker-size=size", "Worker size")
-  end
-  help_option_values("Version:", Option.selectable_kubernetes_versions)
-  help_option_values("Control Plane Node Count:", Option::KubernetesCPOptions.map(&:cp_node_count))
+    options("ubi kc location/kc-name create [options]", key: :kc_create) do
+      on("-v", "--version=version", "Kubernetes version")
+      on("-c", "--cp-node-count=count", Integer, "Control plane node count")
+      on("-w", "--worker-node-count=count", Integer, "Worker node count")
+      on("-z", "--worker-size=size", "Worker size")
+    end
+    help_option_values("Version:", Option.selectable_kubernetes_versions)
+    help_option_values("Control Plane Node Count:", Option::KubernetesCPOptions.map(&:cp_node_count))
 
-  run do |opts|
-    params = underscore_keys(opts[:kc_create])
-    params[:cp_nodes] = params.delete(:cp_node_count) if params[:cp_node_count]
-    params[:worker_nodes] = params.delete(:worker_node_count) if params[:worker_node_count]
-    id = sdk.kubernetes_cluster.create(location: @location, name: @name, **params).id
-    response("Kubernetes cluster created with id: #{id}")
+    run do |opts|
+      params = underscore_keys(opts[:kc_create])
+      params[:cp_nodes] = params.delete(:cp_node_count) if params[:cp_node_count]
+      params[:worker_nodes] = params.delete(:worker_node_count) if params[:worker_node_count]
+      id = sdk.kubernetes_cluster.create(location: @location, name: @name, **params).id
+      response("Kubernetes cluster created with id: #{id}")
+    end
   end
 end

--- a/cli-commands/kc/post/destroy.rb
+++ b/cli-commands/kc/post/destroy.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.destroy("kc")
+class UbiCli
+  destroy("kc")
+end

--- a/cli-commands/kc/post/kubeconfig.rb
+++ b/cli-commands/kc/post/kubeconfig.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-UbiCli.on("kc").run_on("kubeconfig") do
-  desc "Print kubeconfig.yaml for a Kubernetes cluster"
+class UbiCli
+  on("kc").run_on("kubeconfig") do
+    desc "Print kubeconfig.yaml for a Kubernetes cluster"
 
-  banner "ubi kc (location/kc-name | kc-id) kubeconfig"
+    banner "ubi kc (location/kc-name | kc-id) kubeconfig"
 
-  run do
-    response(sdk_object.kubeconfig)
+    run do
+      response(sdk_object.kubeconfig)
+    end
   end
 end

--- a/cli-commands/kc/post/rename.rb
+++ b/cli-commands/kc/post/rename.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.rename("kc")
+class UbiCli
+  rename("kc")
+end

--- a/cli-commands/kc/post/resize-nodepool.rb
+++ b/cli-commands/kc/post/resize-nodepool.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
-UbiCli.on("kc").run_on("resize-nodepool") do
-  desc "Resize a Kubernetes cluster nodepool"
+class UbiCli
+  on("kc").run_on("resize-nodepool") do
+    desc "Resize a Kubernetes cluster nodepool"
 
-  banner "ubi kc (location/kc-name | kc-id) resize-nodepool (np-name | np-id) node-count"
+    banner "ubi kc (location/kc-name | kc-id) resize-nodepool (np-name | np-id) node-count"
 
-  args 2
+    args 2
 
-  run do |nodepool_ref, node_count, _, cmd|
-    node_count = Integer(node_count, exception: false)
+    run do |nodepool_ref, node_count, _, cmd|
+      node_count = Integer(node_count, exception: false)
 
-    unless node_count&.>(0)
-      cmd.raise_failure("the node count must be a positive integer")
+      unless node_count&.>(0)
+        cmd.raise_failure("the node count must be a positive integer")
+      end
+
+      sdk_object.resize_nodepool(nodepool_ref, node_count)
+
+      response("Resized nodepool #{nodepool_ref} to #{node_count} nodes.")
     end
-
-    sdk_object.resize_nodepool(nodepool_ref, node_count)
-
-    response("Resized nodepool #{nodepool_ref} to #{node_count} nodes.")
   end
 end

--- a/cli-commands/kc/post/show.rb
+++ b/cli-commands/kc/post/show.rb
@@ -1,60 +1,62 @@
 # frozen_string_literal: true
 
-UbiCli.on("kc").run_on("show") do
-  desc "Show details for a Kubernetes cluster"
+class UbiCli
+  on("kc").run_on("show") do
+    desc "Show details for a Kubernetes cluster"
 
-  fields = %w[id name location display-state cp-node-count node-size version nodepools cp-vms].freeze.each(&:freeze)
-  nodepool_fields = %w[id name node-count node-size vms].freeze.each(&:freeze)
-  vm_fields = %w[id name state location size unix-user storage-size-gib ip6 ip4-enabled ip4].freeze.each(&:freeze)
+    fields = %w[id name location display-state cp-node-count node-size version nodepools cp-vms].freeze.each(&:freeze)
+    nodepool_fields = %w[id name node-count node-size vms].freeze.each(&:freeze)
+    vm_fields = %w[id name state location size unix-user storage-size-gib ip6 ip4-enabled ip4].freeze.each(&:freeze)
 
-  options("ubi kc (location/kc-name | kc-id) show [options]", key: :kc_show) do
-    on("-f", "--fields=fields", "show specific fields (comma separated)")
-    on("-n", "--nodepool-fields=fields", "show specific nodepool fields (comma separated)")
-    on("-v", "--vm-fields=fields", "show specific virtual machine fields (comma separated)")
-  end
-  help_option_values("Fields:", fields)
-  help_option_values("Nodepool Fields:", nodepool_fields)
-  help_option_values("Virtual Machine Fields:", vm_fields)
+    options("ubi kc (location/kc-name | kc-id) show [options]", key: :kc_show) do
+      on("-f", "--fields=fields", "show specific fields (comma separated)")
+      on("-n", "--nodepool-fields=fields", "show specific nodepool fields (comma separated)")
+      on("-v", "--vm-fields=fields", "show specific virtual machine fields (comma separated)")
+    end
+    help_option_values("Fields:", fields)
+    help_option_values("Nodepool Fields:", nodepool_fields)
+    help_option_values("Virtual Machine Fields:", vm_fields)
 
-  run do |opts, cmd|
-    data = sdk_object.info
-    opts = opts[:kc_show]
-    keys = underscore_keys(check_fields(opts[:fields], fields, "kc show -f option", cmd))
-    nodepool_keys = underscore_keys(check_fields(opts[:"nodepool-fields"], nodepool_fields, "kc show -n option", cmd))
-    vm_keys = underscore_keys(check_fields(opts[:"vm-fields"], vm_fields, "kc show -v option", cmd))
+    run do |opts, cmd|
+      data = sdk_object.info
+      opts = opts[:kc_show]
+      keys = underscore_keys(check_fields(opts[:fields], fields, "kc show -f option", cmd))
+      nodepool_keys = underscore_keys(check_fields(opts[:"nodepool-fields"], nodepool_fields, "kc show -n option", cmd))
+      vm_keys = underscore_keys(check_fields(opts[:"vm-fields"], vm_fields, "kc show -v option", cmd))
 
-    body = []
+      body = []
 
-    each_with_dashed(keys) do |key, display_key|
-      case key
-      when :nodepools
-        data[key].each_with_index do |nodepool, i|
-          body << "nodepool " << (i + 1).to_s << ":\n"
-          each_with_dashed(nodepool_keys) do |np_key, display_np_key|
-            if np_key == :vms
-              nodepool[np_key].each_with_index do |vm, i|
-                body << "  vm " << (i + 1).to_s << ":\n"
-                each_with_dashed(vm_keys) do |vm_key, display_vm_key|
-                  body << "    " << display_vm_key << ": " << vm[vm_key].to_s << "\n"
+      each_with_dashed(keys) do |key, display_key|
+        case key
+        when :nodepools
+          data[key].each_with_index do |nodepool, i|
+            body << "nodepool " << (i + 1).to_s << ":\n"
+            each_with_dashed(nodepool_keys) do |np_key, display_np_key|
+              if np_key == :vms
+                nodepool[np_key].each_with_index do |vm, i|
+                  body << "  vm " << (i + 1).to_s << ":\n"
+                  each_with_dashed(vm_keys) do |vm_key, display_vm_key|
+                    body << "    " << display_vm_key << ": " << vm[vm_key].to_s << "\n"
+                  end
                 end
+              else
+                body << "  " << display_np_key << ": " << nodepool[np_key].to_s << "\n"
               end
-            else
-              body << "  " << display_np_key << ": " << nodepool[np_key].to_s << "\n"
             end
           end
-        end
-      when :cp_vms
-        data[key].each_with_index do |vm, i|
-          body << "cp-vms " << (i + 1).to_s << ":\n"
-          each_with_dashed(vm_keys) do |vm_key, display_vm_key|
-            body << "  " << display_vm_key << ": " << vm[vm_key].to_s << "\n"
+        when :cp_vms
+          data[key].each_with_index do |vm, i|
+            body << "cp-vms " << (i + 1).to_s << ":\n"
+            each_with_dashed(vm_keys) do |vm_key, display_vm_key|
+              body << "  " << display_vm_key << ": " << vm[vm_key].to_s << "\n"
+            end
           end
+        else
+          body << display_key << ": " << data[key].to_s << "\n"
         end
-      else
-        body << display_key << ": " << data[key].to_s << "\n"
       end
-    end
 
-    response(body)
+      response(body)
+    end
   end
 end

--- a/cli-commands/kc/post/upgrade.rb
+++ b/cli-commands/kc/post/upgrade.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.on("kc").run_on("upgrade") do
-  desc "Upgrade a Kubernetes cluster to the next supported version"
+class UbiCli
+  on("kc").run_on("upgrade") do
+    desc "Upgrade a Kubernetes cluster to the next supported version"
 
-  banner "ubi kc (location/kc-name | kc-id) upgrade"
+    banner "ubi kc (location/kc-name | kc-id) upgrade"
 
-  run do |opts, cmd|
-    data = sdk_object.upgrade
-    response("Scheduled version upgrade of Kubneretes cluster with id #{data.id} to version #{data.version}.")
+    run do |opts, cmd|
+      data = sdk_object.upgrade
+      response("Scheduled version upgrade of Kubneretes cluster with id #{data.id} to version #{data.version}.")
+    end
   end
 end

--- a/cli-commands/lb.rb
+++ b/cli-commands/lb.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-UbiCli.base("lb") do
-  banner "ubi lb command [...]"
-  post_banner "ubi lb (location/lb-name | lb-id) post-command [...]"
+class UbiCli
+  base("lb") do
+    banner "ubi lb command [...]"
+    post_banner "ubi lb (location/lb-name | lb-id) post-command [...]"
+  end
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/lb")

--- a/cli-commands/lb/list.rb
+++ b/cli-commands/lb/list.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.list("lb", %w[location name id src-port dst-port hostname])
+class UbiCli
+  list("lb", %w[location name id src-port dst-port hostname])
+end

--- a/cli-commands/lb/post/attach-vm.rb
+++ b/cli-commands/lb/post/attach-vm.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-UbiCli.on("lb").run_on("attach-vm") do
-  desc "Attach a virtual machine to a load balancer"
+class UbiCli
+  on("lb").run_on("attach-vm") do
+    desc "Attach a virtual machine to a load balancer"
 
-  banner "ubi lb (location/lb-name | lb-id) attach-vm (vm-name | vm-id)"
+    banner "ubi lb (location/lb-name | lb-id) attach-vm (vm-name | vm-id)"
 
-  args 1
+    args 1
 
-  run do |vm_id|
-    id = sdk_object.attach_vm(convert_name_to_id(sdk.vm, vm_id)).id
-    response("Attached VM #{vm_id} to load balancer with id #{id}")
+    run do |vm_id|
+      id = sdk_object.attach_vm(convert_name_to_id(sdk.vm, vm_id)).id
+      response("Attached VM #{vm_id} to load balancer with id #{id}")
+    end
   end
 end

--- a/cli-commands/lb/post/create.rb
+++ b/cli-commands/lb/post/create.rb
@@ -1,36 +1,38 @@
 # frozen_string_literal: true
 
-UbiCli.on("lb").run_on("create") do
-  desc "Create a load balancer"
-  algorithms = %w[round_robin hash_based].freeze.each(&:freeze)
-  health_check_protocols = %w[http https tcp].freeze.each(&:freeze)
-  stacks = %w[dual ipv4 ipv6].freeze.each(&:freeze)
+class UbiCli
+  on("lb").run_on("create") do
+    desc "Create a load balancer"
+    algorithms = %w[round_robin hash_based].freeze.each(&:freeze)
+    health_check_protocols = %w[http https tcp].freeze.each(&:freeze)
+    stacks = %w[dual ipv4 ipv6].freeze.each(&:freeze)
 
-  options("ubi lb location/lb-name create [options] (ps-name | ps-id) src-port dst-port", key: :lb_create) do
-    on("-a", "--algorithm=alg", algorithms, "set the algorithm to use")
-    on("-e", "--check-endpoint=path", "set the health check endpoint (default: #{Prog::Vnet::LoadBalancerNexus::DEFAULT_HEALTH_CHECK_ENDPOINT})")
-    on("-p", "--check-protocol=proto", health_check_protocols, "set the health check protocol")
-    on("-s", "--stack=stack", stacks, "set the stack")
-    on("-c", "--cert-enabled=bool", "SSL certificate enabled")
-  end
-  help_option_values("Algorithm:", algorithms)
-  help_option_values("Health Check Protocol:", health_check_protocols)
-  help_option_values("Stack:", stacks)
-
-  args 3
-
-  run do |private_subnet_id, src_port, dst_port, opts, cmd|
-    private_subnet_id = convert_name_to_id(sdk.private_subnet, private_subnet_id)
-    params = underscore_keys(opts[:lb_create])
-    if (endpoint = params.delete(:check_endpoint))
-      params[:health_check_endpoint] = endpoint
+    options("ubi lb location/lb-name create [options] (ps-name | ps-id) src-port dst-port", key: :lb_create) do
+      on("-a", "--algorithm=alg", algorithms, "set the algorithm to use")
+      on("-e", "--check-endpoint=path", "set the health check endpoint (default: #{Prog::Vnet::LoadBalancerNexus::DEFAULT_HEALTH_CHECK_ENDPOINT})")
+      on("-p", "--check-protocol=proto", health_check_protocols, "set the health check protocol")
+      on("-s", "--stack=stack", stacks, "set the stack")
+      on("-c", "--cert-enabled=bool", "SSL certificate enabled")
     end
-    params[:health_check_protocol] = params.delete(:check_protocol)
-    params[:private_subnet_id] = private_subnet_id
-    params[:src_port] = need_integer_arg(src_port, "src-port", cmd)
-    params[:dst_port] = need_integer_arg(dst_port, "dst-port", cmd)
-    need_boolean_arg(params[:cert_enabled], "cert-enabled", cmd) if params[:cert_enabled]
-    id = sdk.load_balancer.create(location: @location, name: @name, **params).id
-    response("Load balancer created with id: #{id}")
+    help_option_values("Algorithm:", algorithms)
+    help_option_values("Health Check Protocol:", health_check_protocols)
+    help_option_values("Stack:", stacks)
+
+    args 3
+
+    run do |private_subnet_id, src_port, dst_port, opts, cmd|
+      private_subnet_id = convert_name_to_id(sdk.private_subnet, private_subnet_id)
+      params = underscore_keys(opts[:lb_create])
+      if (endpoint = params.delete(:check_endpoint))
+        params[:health_check_endpoint] = endpoint
+      end
+      params[:health_check_protocol] = params.delete(:check_protocol)
+      params[:private_subnet_id] = private_subnet_id
+      params[:src_port] = need_integer_arg(src_port, "src-port", cmd)
+      params[:dst_port] = need_integer_arg(dst_port, "dst-port", cmd)
+      need_boolean_arg(params[:cert_enabled], "cert-enabled", cmd) if params[:cert_enabled]
+      id = sdk.load_balancer.create(location: @location, name: @name, **params).id
+      response("Load balancer created with id: #{id}")
+    end
   end
 end

--- a/cli-commands/lb/post/destroy.rb
+++ b/cli-commands/lb/post/destroy.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.destroy("lb")
+class UbiCli
+  destroy("lb")
+end

--- a/cli-commands/lb/post/detach-vm.rb
+++ b/cli-commands/lb/post/detach-vm.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-UbiCli.on("lb").run_on("detach-vm") do
-  desc "Detach a virtual machine from a load balancer"
+class UbiCli
+  on("lb").run_on("detach-vm") do
+    desc "Detach a virtual machine from a load balancer"
 
-  banner "ubi lb (location/lb-name | lb-id) detach-vm (vm-name | vm-id)"
+    banner "ubi lb (location/lb-name | lb-id) detach-vm (vm-name | vm-id)"
 
-  args 1
+    args 1
 
-  run do |vm_id|
-    id = sdk_object.detach_vm(convert_name_to_id(sdk.vm, vm_id)).id
-    response("Detached VM #{vm_id} from load balancer with id #{id}")
+    run do |vm_id|
+      id = sdk_object.detach_vm(convert_name_to_id(sdk.vm, vm_id)).id
+      response("Detached VM #{vm_id} from load balancer with id #{id}")
+    end
   end
 end

--- a/cli-commands/lb/post/disable-ssl-certificate.rb
+++ b/cli-commands/lb/post/disable-ssl-certificate.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.on("lb").run_on("disable-ssl-certificate") do
-  desc "Disable the SSL certificate for a load balancer"
+class UbiCli
+  on("lb").run_on("disable-ssl-certificate") do
+    desc "Disable the SSL certificate for a load balancer"
 
-  banner "ubi lb (location/lb-name | lb-id) disable-ssl-certificate"
+    banner "ubi lb (location/lb-name | lb-id) disable-ssl-certificate"
 
-  run do
-    id = sdk_object.toggle_ssl_certificate(cert_enabled: false).id
-    response("Disabled SSL certificate for load balancer with id #{id}")
+    run do
+      id = sdk_object.toggle_ssl_certificate(cert_enabled: false).id
+      response("Disabled SSL certificate for load balancer with id #{id}")
+    end
   end
 end

--- a/cli-commands/lb/post/enable-ssl-certificate.rb
+++ b/cli-commands/lb/post/enable-ssl-certificate.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.on("lb").run_on("enable-ssl-certificate") do
-  desc "Enable the SSL certificate for a load balancer"
+class UbiCli
+  on("lb").run_on("enable-ssl-certificate") do
+    desc "Enable the SSL certificate for a load balancer"
 
-  banner "ubi lb (location/lb-name | lb-id) enable-ssl-certificate"
+    banner "ubi lb (location/lb-name | lb-id) enable-ssl-certificate"
 
-  run do
-    id = sdk_object.toggle_ssl_certificate(cert_enabled: true).id
-    response("Enabled SSL certificate for load balancer with id #{id}")
+    run do
+      id = sdk_object.toggle_ssl_certificate(cert_enabled: true).id
+      response("Enabled SSL certificate for load balancer with id #{id}")
+    end
   end
 end

--- a/cli-commands/lb/post/rename.rb
+++ b/cli-commands/lb/post/rename.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.rename("lb")
+class UbiCli
+  rename("lb")
+end

--- a/cli-commands/lb/post/show.rb
+++ b/cli-commands/lb/post/show.rb
@@ -1,35 +1,37 @@
 # frozen_string_literal: true
 
-UbiCli.on("lb").run_on("show") do
-  desc "Show details for a load balancer"
+class UbiCli
+  on("lb").run_on("show") do
+    desc "Show details for a load balancer"
 
-  fields = %w[id name state location hostname algorithm stack health-check-endpoint health-check-protocol src-port dst-port subnet vms cert-enabled].freeze.each(&:freeze)
+    fields = %w[id name state location hostname algorithm stack health-check-endpoint health-check-protocol src-port dst-port subnet vms cert-enabled].freeze.each(&:freeze)
 
-  options("ubi lb (location/lb-name | lb-id) show [options]", key: :lb_show) do
-    on("-f", "--fields=fields", "show specific fields (comma separated)")
-  end
-  help_option_values("Fields:", fields)
-
-  run do |opts, cmd|
-    data = sdk_object.info
-    keys = underscore_keys(check_fields(opts[:lb_show][:fields], fields, "lb show -f option", cmd))
-
-    body = []
-
-    each_with_dashed(keys) do |key, display_key|
-      case key
-      when :vms
-        body << "vms:\n"
-        data[key].each do |vm|
-          body << "  " << vm.id << "\n"
-        end
-      when :subnet
-        body << display_key << ": " << data.subnet.name << "\n"
-      else
-        body << display_key << ": " << data[key].to_s << "\n"
-      end
+    options("ubi lb (location/lb-name | lb-id) show [options]", key: :lb_show) do
+      on("-f", "--fields=fields", "show specific fields (comma separated)")
     end
+    help_option_values("Fields:", fields)
 
-    response(body)
+    run do |opts, cmd|
+      data = sdk_object.info
+      keys = underscore_keys(check_fields(opts[:lb_show][:fields], fields, "lb show -f option", cmd))
+
+      body = []
+
+      each_with_dashed(keys) do |key, display_key|
+        case key
+        when :vms
+          body << "vms:\n"
+          data[key].each do |vm|
+            body << "  " << vm.id << "\n"
+          end
+        when :subnet
+          body << display_key << ": " << data.subnet.name << "\n"
+        else
+          body << display_key << ": " << data[key].to_s << "\n"
+        end
+      end
+
+      response(body)
+    end
   end
 end

--- a/cli-commands/lb/post/update.rb
+++ b/cli-commands/lb/post/update.rb
@@ -13,7 +13,7 @@ class UbiCli
       src_port = need_integer_arg(src_port, "src-port", cmd)
       dst_port = need_integer_arg(dst_port, "dst-port", cmd)
       cert_enabled = need_boolean_arg(cert_enabled, "cert-enabled", cmd)
-      DB.ignore_duplicate_queries do
+      ignore_duplicate_queries do
         vms = vms.map { convert_name_to_id(sdk.vm, it) }
       end
       id = sdk_object.update(algorithm:, src_port:, dst_port:, health_check_endpoint:, cert_enabled:, vms:).id

--- a/cli-commands/lb/post/update.rb
+++ b/cli-commands/lb/post/update.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
-UbiCli.on("lb").run_on("update") do
-  desc "Update a load balancer"
+class UbiCli
+  on("lb").run_on("update") do
+    desc "Update a load balancer"
 
-  banner "ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint cert-enabled [(vm-name | vm-id) [...]]"
+    banner "ubi lb (location/lb-name | lb-id) update algorithm src-port dst-port health-check-endpoint cert-enabled [(vm-name | vm-id) [...]]"
 
-  args(4...)
+    args(4...)
 
-  run do |argv, _, cmd|
-    algorithm, src_port, dst_port, health_check_endpoint, cert_enabled, *vms = argv
-    src_port = need_integer_arg(src_port, "src-port", cmd)
-    dst_port = need_integer_arg(dst_port, "dst-port", cmd)
-    cert_enabled = need_boolean_arg(cert_enabled, "cert-enabled", cmd)
-    DB.ignore_duplicate_queries do
-      vms = vms.map { convert_name_to_id(sdk.vm, it) }
+    run do |argv, _, cmd|
+      algorithm, src_port, dst_port, health_check_endpoint, cert_enabled, *vms = argv
+      src_port = need_integer_arg(src_port, "src-port", cmd)
+      dst_port = need_integer_arg(dst_port, "dst-port", cmd)
+      cert_enabled = need_boolean_arg(cert_enabled, "cert-enabled", cmd)
+      DB.ignore_duplicate_queries do
+        vms = vms.map { convert_name_to_id(sdk.vm, it) }
+      end
+      id = sdk_object.update(algorithm:, src_port:, dst_port:, health_check_endpoint:, cert_enabled:, vms:).id
+      response("Updated load balancer with id #{id}")
     end
-    id = sdk_object.update(algorithm:, src_port:, dst_port:, health_check_endpoint:, cert_enabled:, vms:).id
-    response("Updated load balancer with id #{id}")
   end
 end

--- a/cli-commands/mi.rb
+++ b/cli-commands/mi.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-UbiCli.base("mi") do
-  banner "ubi mi command [...]"
-  post_banner "ubi mi (location/mi-name | mi-id) post-command [...]"
+class UbiCli
+  base("mi") do
+    banner "ubi mi command [...]"
+    post_banner "ubi mi (location/mi-name | mi-id) post-command [...]"
+  end
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/mi")

--- a/cli-commands/mi/list.rb
+++ b/cli-commands/mi/list.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.list("mi", %w[location name id arch latest-version created-at])
+class UbiCli
+  list("mi", %w[location name id arch latest-version created-at])
+end

--- a/cli-commands/mi/post/create-version.rb
+++ b/cli-commands/mi/post/create-version.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
-UbiCli.on("mi").run_on("create-version") do
-  desc "Create a new version of a machine image from a stopped VM"
+class UbiCli
+  on("mi").run_on("create-version") do
+    desc "Create a new version of a machine image from a stopped VM"
 
-  options("ubi mi (location/mi-name | mi-id) create-version [options] (vm-name | vm-id)", key: :mi_create_version) do
-    on("-V", "--version=version", "version label (default: timestamp)")
-    on("-d", "--destroy-source", "destroy the source VM after capture")
-  end
+    options("ubi mi (location/mi-name | mi-id) create-version [options] (vm-name | vm-id)", key: :mi_create_version) do
+      on("-V", "--version=version", "version label (default: timestamp)")
+      on("-d", "--destroy-source", "destroy the source VM after capture")
+    end
 
-  args 1
+    args 1
 
-  run do |vm_ref, opts|
-    params = underscore_keys(opts[:mi_create_version])
-    version = params[:version] || Time.now.utc.strftime("%Y%m%d%H%M%S")
-    result = sdk_object.create_version(version, vm: convert_name_to_id(sdk.vm, vm_ref), destroy_source: params[:destroy_source])
-    response("Machine image version created with id: #{result.id}")
+    run do |vm_ref, opts|
+      params = underscore_keys(opts[:mi_create_version])
+      version = params[:version] || Time.now.utc.strftime("%Y%m%d%H%M%S")
+      result = sdk_object.create_version(version, vm: convert_name_to_id(sdk.vm, vm_ref), destroy_source: params[:destroy_source])
+      response("Machine image version created with id: #{result.id}")
+    end
   end
 end

--- a/cli-commands/mi/post/create.rb
+++ b/cli-commands/mi/post/create.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
-UbiCli.on("mi").run_on("create") do
-  desc "Create a machine image from a stopped VM"
+class UbiCli
+  on("mi").run_on("create") do
+    desc "Create a machine image from a stopped VM"
 
-  options("ubi mi location/mi-name create [options] (vm-name | vm-id)", key: :mi_create) do
-    on("-V", "--version=version", "version label (default: timestamp)")
-    on("-d", "--destroy-source", "destroy the source VM after capture")
-  end
+    options("ubi mi location/mi-name create [options] (vm-name | vm-id)", key: :mi_create) do
+      on("-V", "--version=version", "version label (default: timestamp)")
+      on("-d", "--destroy-source", "destroy the source VM after capture")
+    end
 
-  args 1
+    args 1
 
-  run do |vm_ref, opts|
-    params = underscore_keys(opts[:mi_create])
-    body = {vm: convert_name_to_id(sdk.vm, vm_ref)}
-    body[:version] = params[:version] if params[:version]
-    body[:destroy_source] = true if params[:destroy_source]
+    run do |vm_ref, opts|
+      params = underscore_keys(opts[:mi_create])
+      body = {vm: convert_name_to_id(sdk.vm, vm_ref)}
+      body[:version] = params[:version] if params[:version]
+      body[:destroy_source] = true if params[:destroy_source]
 
-    result = sdk.machine_image.create(location: @location, name: @name, **body)
-    response("Machine image created with id: #{result.id}")
+      result = sdk.machine_image.create(location: @location, name: @name, **body)
+      response("Machine image created with id: #{result.id}")
+    end
   end
 end

--- a/cli-commands/mi/post/destroy-version.rb
+++ b/cli-commands/mi/post/destroy-version.rb
@@ -1,28 +1,30 @@
 # frozen_string_literal: true
 
-UbiCli.on("mi").run_on("destroy-version") do
-  desc "Destroy a non-latest version of a machine image"
+class UbiCli
+  on("mi").run_on("destroy-version") do
+    desc "Destroy a non-latest version of a machine image"
 
-  options("ubi mi (location/mi-name | mi-id) destroy-version [options] version", key: :mi_destroy_version) do
-    on("-f", "--force", "do not require confirmation")
-  end
+    options("ubi mi (location/mi-name | mi-id) destroy-version [options] version", key: :mi_destroy_version) do
+      on("-f", "--force", "do not require confirmation")
+    end
 
-  args 1
+    args 1
 
-  run do |version, opts|
-    params = opts[:mi_destroy_version]
-    if params[:force] || opts[:confirm] == version
-      sdk_object.destroy_version(version)
-      response("Machine image version #{version} is now scheduled for destruction")
-    elsif opts[:confirm]
-      invalid_confirmation <<~END
-        ! Confirmation of machine image version label not successful.
-      END
-    else
-      require_confirmation("Confirmation", <<~END)
-        Destroying this machine image version is not recoverable.
-        Enter the following to confirm destruction of the machine image version: #{version}
-      END
+    run do |version, opts|
+      params = opts[:mi_destroy_version]
+      if params[:force] || opts[:confirm] == version
+        sdk_object.destroy_version(version)
+        response("Machine image version #{version} is now scheduled for destruction")
+      elsif opts[:confirm]
+        invalid_confirmation <<~END
+          ! Confirmation of machine image version label not successful.
+        END
+      else
+        require_confirmation("Confirmation", <<~END)
+          Destroying this machine image version is not recoverable.
+          Enter the following to confirm destruction of the machine image version: #{version}
+        END
+      end
     end
   end
 end

--- a/cli-commands/mi/post/destroy.rb
+++ b/cli-commands/mi/post/destroy.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.destroy("mi")
+class UbiCli
+  destroy("mi")
+end

--- a/cli-commands/mi/post/list-versions.rb
+++ b/cli-commands/mi/post/list-versions.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
-UbiCli.on("mi").run_on("list-versions") do
-  desc "List versions of a machine image"
+class UbiCli
+  on("mi").run_on("list-versions") do
+    desc "List versions of a machine image"
 
-  fields = %w[version id state actual-size-mib archive-size-mib created-at latest].freeze.each(&:freeze)
+    fields = %w[version id state actual-size-mib archive-size-mib created-at latest].freeze.each(&:freeze)
 
-  key = :mi_list_versions
+    key = :mi_list_versions
 
-  options("ubi mi (location/mi-name | mi-id) list-versions [options]", key:) do
-    on("-f", "--fields=fields", "show specific fields (comma separated)")
-    on("-N", "--no-headers", "do not show headers")
-  end
-  help_option_values("Fields:", fields)
+    options("ubi mi (location/mi-name | mi-id) list-versions [options]", key:) do
+      on("-f", "--fields=fields", "show specific fields (comma separated)")
+      on("-N", "--no-headers", "do not show headers")
+    end
+    help_option_values("Fields:", fields)
 
-  run do |opts, cmd|
-    opts = opts[key]
-    versions = sdk_object.list_versions
-    keys = underscore_keys(check_fields(opts[:fields], fields, "mi list-versions -f option", cmd))
-    response(format_rows(keys, versions, headers: opts[:"no-headers"] != false))
+    run do |opts, cmd|
+      opts = opts[key]
+      versions = sdk_object.list_versions
+      keys = underscore_keys(check_fields(opts[:fields], fields, "mi list-versions -f option", cmd))
+      response(format_rows(keys, versions, headers: opts[:"no-headers"] != false))
+    end
   end
 end

--- a/cli-commands/mi/post/rename.rb
+++ b/cli-commands/mi/post/rename.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.rename("mi")
+class UbiCli
+  rename("mi")
+end

--- a/cli-commands/mi/post/set-latest.rb
+++ b/cli-commands/mi/post/set-latest.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-UbiCli.on("mi").run_on("set-latest") do
-  desc "Set the latest version of a machine image"
+class UbiCli
+  on("mi").run_on("set-latest") do
+    desc "Set the latest version of a machine image"
 
-  banner "ubi mi (location/mi-name | mi-id) set-latest version"
+    banner "ubi mi (location/mi-name | mi-id) set-latest version"
 
-  args 1
+    args 1
 
-  run do |version|
-    sdk_object.set_latest_version(version)
-    response("Machine image latest version set to #{version}")
+    run do |version|
+      sdk_object.set_latest_version(version)
+      response("Machine image latest version set to #{version}")
+    end
   end
 end

--- a/cli-commands/mi/post/show.rb
+++ b/cli-commands/mi/post/show.rb
@@ -1,25 +1,27 @@
 # frozen_string_literal: true
 
-UbiCli.on("mi").run_on("show") do
-  desc "Show details for a machine image"
+class UbiCli
+  on("mi").run_on("show") do
+    desc "Show details for a machine image"
 
-  fields = %w[id name location arch latest-version created-at].freeze.each(&:freeze)
+    fields = %w[id name location arch latest-version created-at].freeze.each(&:freeze)
 
-  options("ubi mi (location/mi-name | mi-id) show [options]", key: :mi_show) do
-    on("-f", "--fields=fields", "show specific fields (comma separated)")
-  end
-  help_option_values("Fields:", fields)
-
-  run do |opts, cmd|
-    data = sdk_object.info
-    opts = opts[:mi_show]
-    keys = underscore_keys(check_fields(opts[:fields], fields, "mi show -f option", cmd))
-
-    body = []
-    each_with_dashed(keys) do |key, display_key|
-      body << display_key << ": " << data[key].to_s << "\n"
+    options("ubi mi (location/mi-name | mi-id) show [options]", key: :mi_show) do
+      on("-f", "--fields=fields", "show specific fields (comma separated)")
     end
+    help_option_values("Fields:", fields)
 
-    response(body)
+    run do |opts, cmd|
+      data = sdk_object.info
+      opts = opts[:mi_show]
+      keys = underscore_keys(check_fields(opts[:fields], fields, "mi show -f option", cmd))
+
+      body = []
+      each_with_dashed(keys) do |key, display_key|
+        body << display_key << ": " << data[key].to_s << "\n"
+      end
+
+      response(body)
+    end
   end
 end

--- a/cli-commands/mi/post/unset-latest.rb
+++ b/cli-commands/mi/post/unset-latest.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.on("mi").run_on("unset-latest") do
-  desc "Unset the latest version of a machine image"
+class UbiCli
+  on("mi").run_on("unset-latest") do
+    desc "Unset the latest version of a machine image"
 
-  banner "ubi mi (location/mi-name | mi-id) unset-latest"
+    banner "ubi mi (location/mi-name | mi-id) unset-latest"
 
-  run do
-    sdk_object.set_latest_version(nil)
-    response("Machine image latest version unset")
+    run do
+      sdk_object.set_latest_version(nil)
+      response("Machine image latest version unset")
+    end
   end
 end

--- a/cli-commands/pg.rb
+++ b/cli-commands/pg.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-UbiCli.base("pg") do
-  banner "ubi pg command [...]"
+class UbiCli
+  base("pg") do
+    banner "ubi pg command [...]"
 
-  post_options("ubi pg (location/pg-name | pg-id) [post-options] post-command [...]", key: :pg_psql) do
-    on("-d", "--dbname=name", "override database name")
-    on("-U", "--username=name", "override username")
+    post_options("ubi pg (location/pg-name | pg-id) [post-options] post-command [...]", key: :pg_psql) do
+      on("-d", "--dbname=name", "override database name")
+      on("-U", "--username=name", "override username")
+    end
   end
 end
 

--- a/cli-commands/pg/list.rb
+++ b/cli-commands/pg/list.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.list("pg", %w[location name id version flavor])
+class UbiCli
+  list("pg", %w[location name id version flavor])
+end

--- a/cli-commands/pg/post/add-cert-auth-user.rb
+++ b/cli-commands/pg/post/add-cert-auth-user.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("add-cert-auth-user") do
-  desc "Add user to list of users authenticating with client certificate authentication"
+class UbiCli
+  on("pg").run_on("add-cert-auth-user") do
+    desc "Add user to list of users authenticating with client certificate authentication"
 
-  banner "ubi pg (location/pg-name | pg-id) add-cert-auth-user name"
+    banner "ubi pg (location/pg-name | pg-id) add-cert-auth-user name"
 
-  args 1
+    args 1
 
-  run do |name|
-    data = sdk_object.add_cert_auth_user(name)
-    body = []
-    body << "Users using certificate authentication:\n"
-    data[:items].each_with_index do |user, i|
-      body << "  " << (i + 1).to_s << ": " << user << "\n"
+    run do |name|
+      data = sdk_object.add_cert_auth_user(name)
+      body = []
+      body << "Users using certificate authentication:\n"
+      data[:items].each_with_index do |user, i|
+        body << "  " << (i + 1).to_s << ": " << user << "\n"
+      end
+      response(body)
     end
-    response(body)
   end
 end

--- a/cli-commands/pg/post/add-config-entries.rb
+++ b/cli-commands/pg/post/add-config-entries.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("add-config-entries") do
-  desc "Add configuration entries to a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("add-config-entries") do
+    desc "Add configuration entries to a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) add-config-entries key=value [...]"
+    banner "ubi pg (location/pg-name | pg-id) add-config-entries key=value [...]"
 
-  args(1..)
+    args(1..)
 
-  run do |args, _, cmd|
-    config_entries_response(sdk_object.update_config(**kv_entries_to_hash(args, cmd)), body: ["Updated config:\n"])
+    run do |args, _, cmd|
+      config_entries_response(sdk_object.update_config(**kv_entries_to_hash(args, cmd)), body: ["Updated config:\n"])
+    end
   end
 end

--- a/cli-commands/pg/post/add-firewall-rule.rb
+++ b/cli-commands/pg/post/add-firewall-rule.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("add-firewall-rule") do
-  desc "Add a PostgreSQL firewall rule"
+class UbiCli
+  on("pg").run_on("add-firewall-rule") do
+    desc "Add a PostgreSQL firewall rule"
 
-  options("ubi pg (location/pg-name | pg-id) add-firewall-rule [options] cidr", key: :pg_fw_rule) do
-    on("-d", "--description=desc", "description of rule")
-  end
+    options("ubi pg (location/pg-name | pg-id) add-firewall-rule [options] cidr", key: :pg_fw_rule) do
+      on("-d", "--description=desc", "description of rule")
+    end
 
-  args 1
+    args 1
 
-  run do |cidr, opts|
-    data = sdk_object.add_firewall_rule(cidr, description: opts[:pg_fw_rule][:description])
-    response("Firewall rule added to PostgreSQL database.\n  rule id: #{data[:id]}\n  cidr: #{data[:cidr]}\n  description: #{data[:description].inspect}")
+    run do |cidr, opts|
+      data = sdk_object.add_firewall_rule(cidr, description: opts[:pg_fw_rule][:description])
+      response("Firewall rule added to PostgreSQL database.\n  rule id: #{data[:id]}\n  cidr: #{data[:cidr]}\n  description: #{data[:description].inspect}")
+    end
   end
 end

--- a/cli-commands/pg/post/add-metric-destination.rb
+++ b/cli-commands/pg/post/add-metric-destination.rb
@@ -1,20 +1,22 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("add-metric-destination") do
-  desc "Add a PostgreSQL metric destination"
+class UbiCli
+  on("pg").run_on("add-metric-destination") do
+    desc "Add a PostgreSQL metric destination"
 
-  banner "ubi pg (location/pg-name | pg-id) add-metric-destination username password url"
+    banner "ubi pg (location/pg-name | pg-id) add-metric-destination username password url"
 
-  args 3
+    args 3
 
-  run do |username, password, url|
-    data = sdk_object.add_metric_destination(username:, password:, url:)
-    body = []
-    body << "Metric destination added to PostgreSQL database.\n"
-    body << "Current metric destinations:\n"
-    data[:metric_destinations].each_with_index do |md, i|
-      body << "  " << (i + 1).to_s << ": " << md[:id] << "  " << md[:username].to_s << "  " << md[:url] << "\n"
+    run do |username, password, url|
+      data = sdk_object.add_metric_destination(username:, password:, url:)
+      body = []
+      body << "Metric destination added to PostgreSQL database.\n"
+      body << "Current metric destinations:\n"
+      data[:metric_destinations].each_with_index do |md, i|
+        body << "  " << (i + 1).to_s << ": " << md[:id] << "  " << md[:username].to_s << "  " << md[:url] << "\n"
+      end
+      response(body)
     end
-    response(body)
   end
 end

--- a/cli-commands/pg/post/add-otlp-log-destination.rb
+++ b/cli-commands/pg/post/add-otlp-log-destination.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("add-otlp-log-destination") do
-  desc "Add an OTLP HTTP log destination to a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("add-otlp-log-destination") do
+    desc "Add an OTLP HTTP log destination to a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) add-otlp-log-destination name url [header_name=value [...]]"
+    banner "ubi pg (location/pg-name | pg-id) add-otlp-log-destination name url [header_name=value [...]]"
 
-  args(2..)
+    args(2..)
 
-  run do |args, _, cmd|
-    name, url, *extra_args = args
-    headers = kv_entries_to_hash(extra_args, cmd)
-    ld = sdk_object.add_otlp_log_destination(name:, url:, headers:)
-    response("Log destination added to PostgreSQL database.\n  id: #{ld[:id]}\n")
+    run do |args, _, cmd|
+      name, url, *extra_args = args
+      headers = kv_entries_to_hash(extra_args, cmd)
+      ld = sdk_object.add_otlp_log_destination(name:, url:, headers:)
+      response("Log destination added to PostgreSQL database.\n  id: #{ld[:id]}\n")
+    end
   end
 end

--- a/cli-commands/pg/post/add-pgbouncer-config-entries.rb
+++ b/cli-commands/pg/post/add-pgbouncer-config-entries.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("add-pgbouncer-config-entries") do
-  desc "Add pgbouncer configuration entries to a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("add-pgbouncer-config-entries") do
+    desc "Add pgbouncer configuration entries to a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) add-pgbouncer-config-entries key=value [...]"
+    banner "ubi pg (location/pg-name | pg-id) add-pgbouncer-config-entries key=value [...]"
 
-  args(1..)
+    args(1..)
 
-  run do |args, _, cmd|
-    config_entries_response(sdk_object.update_pgbouncer_config(**kv_entries_to_hash(args, cmd)), body: ["Updated pgbouncer config:\n"])
+    run do |args, _, cmd|
+      config_entries_response(sdk_object.update_pgbouncer_config(**kv_entries_to_hash(args, cmd)), body: ["Updated pgbouncer config:\n"])
+    end
   end
 end

--- a/cli-commands/pg/post/add-syslog-log-destination.rb
+++ b/cli-commands/pg/post/add-syslog-log-destination.rb
@@ -1,20 +1,22 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("add-syslog-log-destination") do
-  desc "Add a syslog (RFC 5424 over TLS) log destination to a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("add-syslog-log-destination") do
+    desc "Add a syslog (RFC 5424 over TLS) log destination to a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) add-syslog-log-destination name host [port] [sd-id/key=value [...]]"
+    banner "ubi pg (location/pg-name | pg-id) add-syslog-log-destination name host [port] [sd-id/key=value [...]]"
 
-  args(2..)
+    args(2..)
 
-  run do |args, _, cmd|
-    name, host, *rest = args
-    port = 6514
-    if rest.first&.match?(/\A\d+\z/)
-      port = Integer(rest.shift)
+    run do |args, _, cmd|
+      name, host, *rest = args
+      port = 6514
+      if rest.first&.match?(/\A\d+\z/)
+        port = Integer(rest.shift)
+      end
+      structured_data = structured_data_args_to_hash(rest, cmd) || {}
+      ld = sdk_object.add_syslog_log_destination(name:, host:, port:, structured_data:)
+      response("Log destination added to PostgreSQL database.\n  id: #{ld[:id]}\n")
     end
-    structured_data = structured_data_args_to_hash(rest, cmd) || {}
-    ld = sdk_object.add_syslog_log_destination(name:, host:, port:, structured_data:)
-    response("Log destination added to PostgreSQL database.\n  id: #{ld[:id]}\n")
   end
 end

--- a/cli-commands/pg/post/ca-certificates.rb
+++ b/cli-commands/pg/post/ca-certificates.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("ca-certificates") do
-  desc "Print CA certificates for a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("ca-certificates") do
+    desc "Print CA certificates for a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) ca-certificates"
+    banner "ubi pg (location/pg-name | pg-id) ca-certificates"
 
-  run do
-    response(sdk_object.ca_certificates)
+    run do
+      response(sdk_object.ca_certificates)
+    end
   end
 end

--- a/cli-commands/pg/post/create-client-cert-keypair.rb
+++ b/cli-commands/pg/post/create-client-cert-keypair.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("create-client-cert-keypair") do
-  desc "Create client certificate keypair with given common name, expiring after a duration of seconds"
+class UbiCli
+  on("pg").run_on("create-client-cert-keypair") do
+    desc "Create client certificate keypair with given common name, expiring after a duration of seconds"
 
-  banner "ubi pg (location/pg-name | pg-id) create-client-cert-keypair common-name duration"
+    banner "ubi pg (location/pg-name | pg-id) create-client-cert-keypair common-name duration"
 
-  args 2
+    args 2
 
-  run do |common_name, duration|
-    response(sdk_object.create_client_cert_keypair(common_name:, duration: duration.to_i))
+    run do |common_name, duration|
+      response(sdk_object.create_client_cert_keypair(common_name:, duration: duration.to_i))
+    end
   end
 end

--- a/cli-commands/pg/post/create-read-replica.rb
+++ b/cli-commands/pg/post/create-read-replica.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("create-read-replica") do
-  desc "Create a read replica for a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("create-read-replica") do
+    desc "Create a read replica for a PostgreSQL database"
 
-  options("ubi pg (location/pg-name | pg-id) create-read-replica [options] name", key: :pg_create_read_replica) do
-    on("-c", "--pg-config=config", "postgres config (e.g key1=value1,key2=value2)")
-    on("-u", "--pgbouncer-config=config", "pgbouncer config (e.g. key1=value1,key2=value2)")
-    on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
-  end
+    options("ubi pg (location/pg-name | pg-id) create-read-replica [options] name", key: :pg_create_read_replica) do
+      on("-c", "--pg-config=config", "postgres config (e.g key1=value1,key2=value2)")
+      on("-u", "--pgbouncer-config=config", "pgbouncer config (e.g. key1=value1,key2=value2)")
+      on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
+    end
 
-  args 1
+    args 1
 
-  run do |name, opts, cmd|
-    params = underscore_keys(opts[:pg_create_read_replica])
-    pg_tags_to_hash(params, cmd)
-    params_to_hash(params, :pg_config, "config", cmd)
-    params_to_hash(params, :pgbouncer_config, "pgbouncer config", cmd)
-    id = sdk_object.create_read_replica(name, **params).id
-    response("Read replica for PostgreSQL database created with id: #{id}")
+    run do |name, opts, cmd|
+      params = underscore_keys(opts[:pg_create_read_replica])
+      pg_tags_to_hash(params, cmd)
+      params_to_hash(params, :pg_config, "config", cmd)
+      params_to_hash(params, :pgbouncer_config, "pgbouncer config", cmd)
+      id = sdk_object.create_read_replica(name, **params).id
+      response("Read replica for PostgreSQL database created with id: #{id}")
+    end
   end
 end

--- a/cli-commands/pg/post/create.rb
+++ b/cli-commands/pg/post/create.rb
@@ -1,32 +1,34 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("create") do
-  desc "Create a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("create") do
+    desc "Create a PostgreSQL database"
 
-  options("ubi pg location/pg-name create [options]", key: :pg_create) do
-    on("-f", "--flavor=type", Option::POSTGRES_FLAVOR_OPTIONS.keys, "flavor")
-    on("-h", "--ha-type=type", Option::POSTGRES_HA_OPTIONS.keys, "replication type")
-    on("-s", "--size=size", Option::POSTGRES_LEGACY_SIZE_OPTIONS.keys, "server size")
-    on("-S", "--storage-size=size", Option::POSTGRES_STORAGE_SIZE_OPTIONS.map(&:to_s), "storage size GB")
-    on("-v", "--version=version", Option::POSTGRES_VERSION_OPTIONS[PostgresResource::Flavor::STANDARD], "PostgreSQL version")
-    on("-c", "--pg-config=config", "postgres config (e.g. key1=value1,key2=value2)")
-    on("-u", "--pgbouncer-config=config", "pgbouncer config (e.g. key1=value1,key2=value2)")
-    on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
-    on("-R", "--restrict-by-default", "restrict access by default (add firewall rules to allow access)")
-    on("-P", "--private-subnet-name=name", "override name of created private subnet")
-  end
-  help_option_values("Flavor:", Option::POSTGRES_FLAVOR_OPTIONS.keys)
-  help_option_values("Replication Type:", Option::POSTGRES_HA_OPTIONS.keys)
-  help_option_values("Size:", Option::POSTGRES_SIZE_OPTIONS.keys)
-  help_option_values("Storage Size:", Option::POSTGRES_STORAGE_SIZE_OPTIONS)
-  help_option_values("Version:", Option::POSTGRES_VERSION_OPTIONS[PostgresResource::Flavor::STANDARD])
+    options("ubi pg location/pg-name create [options]", key: :pg_create) do
+      on("-f", "--flavor=type", Option::POSTGRES_FLAVOR_OPTIONS.keys, "flavor")
+      on("-h", "--ha-type=type", Option::POSTGRES_HA_OPTIONS.keys, "replication type")
+      on("-s", "--size=size", Option::POSTGRES_LEGACY_SIZE_OPTIONS.keys, "server size")
+      on("-S", "--storage-size=size", Option::POSTGRES_STORAGE_SIZE_OPTIONS.map(&:to_s), "storage size GB")
+      on("-v", "--version=version", Option::POSTGRES_VERSION_OPTIONS[PostgresResource::Flavor::STANDARD], "PostgreSQL version")
+      on("-c", "--pg-config=config", "postgres config (e.g. key1=value1,key2=value2)")
+      on("-u", "--pgbouncer-config=config", "pgbouncer config (e.g. key1=value1,key2=value2)")
+      on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
+      on("-R", "--restrict-by-default", "restrict access by default (add firewall rules to allow access)")
+      on("-P", "--private-subnet-name=name", "override name of created private subnet")
+    end
+    help_option_values("Flavor:", Option::POSTGRES_FLAVOR_OPTIONS.keys)
+    help_option_values("Replication Type:", Option::POSTGRES_HA_OPTIONS.keys)
+    help_option_values("Size:", Option::POSTGRES_SIZE_OPTIONS.keys)
+    help_option_values("Storage Size:", Option::POSTGRES_STORAGE_SIZE_OPTIONS)
+    help_option_values("Version:", Option::POSTGRES_VERSION_OPTIONS[PostgresResource::Flavor::STANDARD])
 
-  run do |opts, cmd|
-    params = underscore_keys(opts[:pg_create])
-    pg_tags_to_hash(params, cmd)
-    params_to_hash(params, :pg_config, "config", cmd)
-    params_to_hash(params, :pgbouncer_config, "pgbouncer config", cmd)
-    id = sdk.postgres.create(location: @location, name: @name, **params).id
-    response("PostgreSQL database created with id: #{id}")
+    run do |opts, cmd|
+      params = underscore_keys(opts[:pg_create])
+      pg_tags_to_hash(params, cmd)
+      params_to_hash(params, :pg_config, "config", cmd)
+      params_to_hash(params, :pgbouncer_config, "pgbouncer config", cmd)
+      id = sdk.postgres.create(location: @location, name: @name, **params).id
+      response("PostgreSQL database created with id: #{id}")
+    end
   end
 end

--- a/cli-commands/pg/post/delete-firewall-rule.rb
+++ b/cli-commands/pg/post/delete-firewall-rule.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("delete-firewall-rule") do
-  desc "Delete a PostgreSQL firewall rule"
+class UbiCli
+  on("pg").run_on("delete-firewall-rule") do
+    desc "Delete a PostgreSQL firewall rule"
 
-  banner "ubi pg (location/pg-name | pg-id) delete-firewall-rule rule-id"
+    banner "ubi pg (location/pg-name | pg-id) delete-firewall-rule rule-id"
 
-  args 1
+    args 1
 
-  run do |ubid, _, cmd|
-    check_no_slash(ubid, "invalid firewall rule id format", cmd)
-    sdk_object.delete_firewall_rule(ubid)
-    response("Firewall rule, if it exists, has been scheduled for deletion")
+    run do |ubid, _, cmd|
+      check_no_slash(ubid, "invalid firewall rule id format", cmd)
+      sdk_object.delete_firewall_rule(ubid)
+      response("Firewall rule, if it exists, has been scheduled for deletion")
+    end
   end
 end

--- a/cli-commands/pg/post/delete-log-destination.rb
+++ b/cli-commands/pg/post/delete-log-destination.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("delete-log-destination") do
-  desc "Delete a PostgreSQL log destination"
+class UbiCli
+  on("pg").run_on("delete-log-destination") do
+    desc "Delete a PostgreSQL log destination"
 
-  banner "ubi pg (location/pg-name | pg-id) delete-log-destination ld-id"
+    banner "ubi pg (location/pg-name | pg-id) delete-log-destination ld-id"
 
-  args 1
+    args 1
 
-  run do |ubid, _, cmd|
-    check_no_slash(ubid, "invalid log destination id format", cmd)
-    sdk_object.delete_log_destination(ubid)
-    response("Log destination, if it exists, has been scheduled for deletion")
+    run do |ubid, _, cmd|
+      check_no_slash(ubid, "invalid log destination id format", cmd)
+      sdk_object.delete_log_destination(ubid)
+      response("Log destination, if it exists, has been scheduled for deletion")
+    end
   end
 end

--- a/cli-commands/pg/post/delete-metric-destination.rb
+++ b/cli-commands/pg/post/delete-metric-destination.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("delete-metric-destination") do
-  desc "Delete a PostgreSQL metric destination"
+class UbiCli
+  on("pg").run_on("delete-metric-destination") do
+    desc "Delete a PostgreSQL metric destination"
 
-  banner "ubi pg (location/pg-name | pg-id) delete-metric-destination md-id"
+    banner "ubi pg (location/pg-name | pg-id) delete-metric-destination md-id"
 
-  args 1
+    args 1
 
-  run do |ubid, _, cmd|
-    check_no_slash(ubid, "invalid metric destination id format", cmd)
-    sdk_object.delete_metric_destination(ubid)
-    response("Metric destination, if it exists, has been scheduled for deletion")
+    run do |ubid, _, cmd|
+      check_no_slash(ubid, "invalid metric destination id format", cmd)
+      sdk_object.delete_metric_destination(ubid)
+      response("Metric destination, if it exists, has been scheduled for deletion")
+    end
   end
 end

--- a/cli-commands/pg/post/destroy.rb
+++ b/cli-commands/pg/post/destroy.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.destroy("pg")
+class UbiCli
+  destroy("pg")
+end

--- a/cli-commands/pg/post/get-logs.rb
+++ b/cli-commands/pg/post/get-logs.rb
@@ -1,34 +1,36 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("get-logs") do
-  desc "Fetch logs for a PostgreSQL database in CSV format"
+class UbiCli
+  on("pg").run_on("get-logs") do
+    desc "Fetch logs for a PostgreSQL database in CSV format"
 
-  key = :pg_get_logs
+    key = :pg_get_logs
 
-  options("ubi pg (location/pg-name | pg-id) get-logs [options]", key:) do
-    on("-s", "--start=time", "start time (RFC3339, default: 30 minutes ago)")
-    on("-e", "--end=time", "end time (RFC3339, default: now)")
-    on("--stream-name=stream", Option::POSTGRES_LOG_STREAM_OPTIONS, "filter by log stream")
-    on("--server-role=role", Option::POSTGRES_LOG_SERVER_ROLE_OPTIONS, "filter by server role")
-    on("--severity-level=level", Option::POSTGRES_LOG_LEVEL_OPTIONS, "filter by log severity level")
-    on("--query-pattern=pattern", "pattern for substring match against log message")
-    on("-l", "--max-log-lines=n", "number of log lines to return (default: 50, max: 500)", Integer)
-    on("--pagination-key=key", "continue a previous search")
-    on("-N", "--no-headers", "do not show headers")
-  end
-  help_option_values("Stream:", Option::POSTGRES_LOG_STREAM_OPTIONS)
-  help_option_values("Server Role:", Option::POSTGRES_LOG_SERVER_ROLE_OPTIONS)
-  help_option_values("Level:", Option::POSTGRES_LOG_LEVEL_OPTIONS)
-
-  run do |opts|
-    o = underscore_keys(opts[key])
-    no_headers = o.delete(:no_headers)
-    page = sdk_object.logs(**o.compact)
-
-    body = format_paginated_csv(page, "ubi pg #{@location}/#{@name} get-logs", no_headers:, header_row: "Timestamp,ServerRole,Stream,Level,Message") do |log|
-      log.values_at(:timestamp, :server_role, :stream_name, :severity_level, :message)
+    options("ubi pg (location/pg-name | pg-id) get-logs [options]", key:) do
+      on("-s", "--start=time", "start time (RFC3339, default: 30 minutes ago)")
+      on("-e", "--end=time", "end time (RFC3339, default: now)")
+      on("--stream-name=stream", Option::POSTGRES_LOG_STREAM_OPTIONS, "filter by log stream")
+      on("--server-role=role", Option::POSTGRES_LOG_SERVER_ROLE_OPTIONS, "filter by server role")
+      on("--severity-level=level", Option::POSTGRES_LOG_LEVEL_OPTIONS, "filter by log severity level")
+      on("--query-pattern=pattern", "pattern for substring match against log message")
+      on("-l", "--max-log-lines=n", "number of log lines to return (default: 50, max: 500)", Integer)
+      on("--pagination-key=key", "continue a previous search")
+      on("-N", "--no-headers", "do not show headers")
     end
+    help_option_values("Stream:", Option::POSTGRES_LOG_STREAM_OPTIONS)
+    help_option_values("Server Role:", Option::POSTGRES_LOG_SERVER_ROLE_OPTIONS)
+    help_option_values("Level:", Option::POSTGRES_LOG_LEVEL_OPTIONS)
 
-    response(body)
+    run do |opts|
+      o = underscore_keys(opts[key])
+      no_headers = o.delete(:no_headers)
+      page = sdk_object.logs(**o.compact)
+
+      body = format_paginated_csv(page, "ubi pg #{@location}/#{@name} get-logs", no_headers:, header_row: "Timestamp,ServerRole,Stream,Level,Message") do |log|
+        log.values_at(:timestamp, :server_role, :stream_name, :severity_level, :message)
+      end
+
+      response(body)
+    end
   end
 end

--- a/cli-commands/pg/post/list-backups.rb
+++ b/cli-commands/pg/post/list-backups.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("list-backups") do
-  desc "List backups for a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("list-backups") do
+    desc "List backups for a PostgreSQL database"
 
-  key = :backups_list
+    key = :backups_list
 
-  options("ubi pg (location/pg-name | pg-id) list-backups [options]", key:) do
-    on("-N", "--no-headers", "do not show headers")
-  end
+    options("ubi pg (location/pg-name | pg-id) list-backups [options]", key:) do
+      on("-N", "--no-headers", "do not show headers")
+    end
 
-  run do |opts|
-    backups = sdk_object.backups
-    response(format_rows(%i[key last_modified], backups, headers: opts[key][:"no-headers"] != false))
+    run do |opts|
+      backups = sdk_object.backups
+      response(format_rows(%i[key last_modified], backups, headers: opts[key][:"no-headers"] != false))
+    end
   end
 end

--- a/cli-commands/pg/post/list-servers.rb
+++ b/cli-commands/pg/post/list-servers.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("list-servers") do
-  desc "List servers for a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("list-servers") do
+    desc "List servers for a PostgreSQL database"
 
-  key = :servers_list
+    key = :servers_list
 
-  options("ubi pg (location/pg-name | pg-id) list-servers [options]", key:) do
-    on("-N", "--no-headers", "do not show headers")
-  end
+    options("ubi pg (location/pg-name | pg-id) list-servers [options]", key:) do
+      on("-N", "--no-headers", "do not show headers")
+    end
 
-  run do |opts|
-    servers = sdk_object.servers
-    response(format_rows(%i[id role state synchronization_status vm vm_size], servers, headers: opts[key][:"no-headers"] != false))
+    run do |opts|
+      servers = sdk_object.servers
+      response(format_rows(%i[id role state synchronization_status vm vm_size], servers, headers: opts[key][:"no-headers"] != false))
+    end
   end
 end

--- a/cli-commands/pg/post/modify-firewall-rule.rb
+++ b/cli-commands/pg/post/modify-firewall-rule.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("modify-firewall-rule") do
-  desc "Modify a PostgreSQL firewall rule"
+class UbiCli
+  on("pg").run_on("modify-firewall-rule") do
+    desc "Modify a PostgreSQL firewall rule"
 
-  options("ubi pg (location/pg-name | pg-id) modify-firewall-rule [options] rule-id", key: :pg_fw_mod) do
-    on("-c", "--cidr=cidr", "ip range to allow in cidr format (e.g. 1.2.3.0/24)")
-    on("-d", "--description=desc", "description of rule")
-  end
+    options("ubi pg (location/pg-name | pg-id) modify-firewall-rule [options] rule-id", key: :pg_fw_mod) do
+      on("-c", "--cidr=cidr", "ip range to allow in cidr format (e.g. 1.2.3.0/24)")
+      on("-d", "--description=desc", "description of rule")
+    end
 
-  args 1
+    args 1
 
-  run do |ubid, opts, cmd|
-    check_no_slash(ubid, "invalid firewall rule id format", cmd)
-    params = opts[:pg_fw_mod]
-    data = sdk_object.modify_firewall_rule(ubid, cidr: params[:cidr], description: params[:description])
-    response("PostgreSQL database firewall rule modified.\n  rule id: #{data[:id]}\n  cidr: #{data[:cidr]}\n  description: #{data[:description].inspect}")
+    run do |ubid, opts, cmd|
+      check_no_slash(ubid, "invalid firewall rule id format", cmd)
+      params = opts[:pg_fw_mod]
+      data = sdk_object.modify_firewall_rule(ubid, cidr: params[:cidr], description: params[:description])
+      response("PostgreSQL database firewall rule modified.\n  rule id: #{data[:id]}\n  cidr: #{data[:cidr]}\n  description: #{data[:description].inspect}")
+    end
   end
 end

--- a/cli-commands/pg/post/modify.rb
+++ b/cli-commands/pg/post/modify.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("modify") do
-  desc "Modify a PostgreSQL database cluster"
+class UbiCli
+  on("pg").run_on("modify") do
+    desc "Modify a PostgreSQL database cluster"
 
-  options("ubi pg (location/pg-name | pg-id) modify [options]", key: :pg_modify) do
-    on("-h", "--ha-type=type", Option::POSTGRES_HA_OPTIONS.keys, "replication type")
-    on("-s", "--size=size", Option::POSTGRES_LEGACY_SIZE_OPTIONS.keys, "server size")
-    on("-S", "--storage-size=size", Option::POSTGRES_STORAGE_SIZE_OPTIONS.map(&:to_s), "storage size GB")
-    on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
-  end
-  help_option_values("Replication Type:", Option::POSTGRES_HA_OPTIONS.keys)
-  help_option_values("Size:", Option::POSTGRES_SIZE_OPTIONS.keys)
-  help_option_values("Storage Size:", Option::POSTGRES_STORAGE_SIZE_OPTIONS)
+    options("ubi pg (location/pg-name | pg-id) modify [options]", key: :pg_modify) do
+      on("-h", "--ha-type=type", Option::POSTGRES_HA_OPTIONS.keys, "replication type")
+      on("-s", "--size=size", Option::POSTGRES_LEGACY_SIZE_OPTIONS.keys, "server size")
+      on("-S", "--storage-size=size", Option::POSTGRES_STORAGE_SIZE_OPTIONS.map(&:to_s), "storage size GB")
+      on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
+    end
+    help_option_values("Replication Type:", Option::POSTGRES_HA_OPTIONS.keys)
+    help_option_values("Size:", Option::POSTGRES_SIZE_OPTIONS.keys)
+    help_option_values("Storage Size:", Option::POSTGRES_STORAGE_SIZE_OPTIONS)
 
-  run do |opts, cmd|
-    params = underscore_keys(opts[:pg_modify])
-    pg_tags_to_hash(params, cmd)
-    id = sdk_object.modify(**params).id
-    response("Modified PostgreSQL database with id: #{id}")
+    run do |opts, cmd|
+      params = underscore_keys(opts[:pg_modify])
+      pg_tags_to_hash(params, cmd)
+      id = sdk_object.modify(**params).id
+      response("Modified PostgreSQL database with id: #{id}")
+    end
   end
 end

--- a/cli-commands/pg/post/pg_dump.rb
+++ b/cli-commands/pg/post/pg_dump.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.pg_cmd("pg_dump", "Dump a single PostgreSQL database using `pg_dump`")
+class UbiCli
+  pg_cmd("pg_dump", "Dump a single PostgreSQL database using `pg_dump`")
+end

--- a/cli-commands/pg/post/pg_dumpall.rb
+++ b/cli-commands/pg/post/pg_dumpall.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-UbiCli.pg_cmd("pg_dumpall", "Dump a entire PostgreSQL database cluster using `pg_dumpall`") do |argv|
-  conn_string = argv.pop
-  argv.pop # --
-  argv << "-d#{conn_string}"
+class UbiCli
+  pg_cmd("pg_dumpall", "Dump a entire PostgreSQL database cluster using `pg_dumpall`") do |argv|
+    conn_string = argv.pop
+    argv.pop # --
+    argv << "-d#{conn_string}"
+  end
 end

--- a/cli-commands/pg/post/promote-read-replica.rb
+++ b/cli-commands/pg/post/promote-read-replica.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("promote-read-replica") do
-  desc "Promote a read replica PostgreSQL database to a primary"
+class UbiCli
+  on("pg").run_on("promote-read-replica") do
+    desc "Promote a read replica PostgreSQL database to a primary"
 
-  banner "ubi pg (location/pg-name | pg-id) promote-read-replica"
+    banner "ubi pg (location/pg-name | pg-id) promote-read-replica"
 
-  run do
-    id = sdk_object.promote_read_replica.id
-    response("Promoted PostgreSQL database with id #{id} from read replica to primary.")
+    run do
+      id = sdk_object.promote_read_replica.id
+      response("Promoted PostgreSQL database with id #{id} from read replica to primary.")
+    end
   end
 end

--- a/cli-commands/pg/post/psql.rb
+++ b/cli-commands/pg/post/psql.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.pg_cmd("psql", "Connect to a PostgreSQL database using `psql`")
+class UbiCli
+  pg_cmd("psql", "Connect to a PostgreSQL database using `psql`")
+end

--- a/cli-commands/pg/post/recycle.rb
+++ b/cli-commands/pg/post/recycle.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("recycle") do
-  desc "Request recycle of primary"
+class UbiCli
+  on("pg").run_on("recycle") do
+    desc "Request recycle of primary"
 
-  banner "ubi pg (location/pg-name | pg-id) recycle"
+    banner "ubi pg (location/pg-name | pg-id) recycle"
 
-  run do
-    id = sdk_object.recycle.id
-    response("Recycle requested for PostgreSQL database with id #{id}")
+    run do
+      id = sdk_object.recycle.id
+      response("Recycle requested for PostgreSQL database with id #{id}")
+    end
   end
 end

--- a/cli-commands/pg/post/remove-cert-auth-user.rb
+++ b/cli-commands/pg/post/remove-cert-auth-user.rb
@@ -1,23 +1,25 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("remove-cert-auth-user") do
-  desc "Remove user from list of users authenticating with client certificate authentication"
+class UbiCli
+  on("pg").run_on("remove-cert-auth-user") do
+    desc "Remove user from list of users authenticating with client certificate authentication"
 
-  banner "ubi pg (location/pg-name | pg-id) remove-cert-auth-user name"
+    banner "ubi pg (location/pg-name | pg-id) remove-cert-auth-user name"
 
-  args 1
+    args 1
 
-  run do |name|
-    data = sdk_object.remove_cert_auth_user(name)
-    body = []
-    body << "Users using certificate authentication:\n"
-    if data[:items].empty?
-      body << "No users using certificate authentication.\n"
-    else
-      data[:items].each_with_index do |user, i|
-        body << "  " << (i + 1).to_s << ": " << user << "\n"
+    run do |name|
+      data = sdk_object.remove_cert_auth_user(name)
+      body = []
+      body << "Users using certificate authentication:\n"
+      if data[:items].empty?
+        body << "No users using certificate authentication.\n"
+      else
+        data[:items].each_with_index do |user, i|
+          body << "  " << (i + 1).to_s << ": " << user << "\n"
+        end
       end
+      response(body)
     end
-    response(body)
   end
 end

--- a/cli-commands/pg/post/remove-config-entries.rb
+++ b/cli-commands/pg/post/remove-config-entries.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("remove-config-entries") do
-  desc "Remove configuration entries from a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("remove-config-entries") do
+    desc "Remove configuration entries from a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) remove-config-entries key [...]"
+    banner "ubi pg (location/pg-name | pg-id) remove-config-entries key [...]"
 
-  args(1..)
+    args(1..)
 
-  run do |args, _, cmd|
-    config_entries_response(sdk_object.update_config(**args.to_h { [it, nil] }), body: ["Updated config:\n"])
+    run do |args, _, cmd|
+      config_entries_response(sdk_object.update_config(**args.to_h { [it, nil] }), body: ["Updated config:\n"])
+    end
   end
 end

--- a/cli-commands/pg/post/remove-pgbouncer-config-entries.rb
+++ b/cli-commands/pg/post/remove-pgbouncer-config-entries.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("remove-pgbouncer-config-entries") do
-  desc "Remove pgbouncer configuration entries from a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("remove-pgbouncer-config-entries") do
+    desc "Remove pgbouncer configuration entries from a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) remove-pgbouncer-config-entries key [...]"
+    banner "ubi pg (location/pg-name | pg-id) remove-pgbouncer-config-entries key [...]"
 
-  args(1..)
+    args(1..)
 
-  run do |args, _, cmd|
-    config_entries_response(sdk_object.update_pgbouncer_config(**args.to_h { [it, nil] }), body: ["Updated pgbouncer config:\n"])
+    run do |args, _, cmd|
+      config_entries_response(sdk_object.update_pgbouncer_config(**args.to_h { [it, nil] }), body: ["Updated pgbouncer config:\n"])
+    end
   end
 end

--- a/cli-commands/pg/post/rename.rb
+++ b/cli-commands/pg/post/rename.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.rename("pg")
+class UbiCli
+  rename("pg")
+end

--- a/cli-commands/pg/post/reset-superuser-password.rb
+++ b/cli-commands/pg/post/reset-superuser-password.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("reset-superuser-password") do
-  desc "Reset the superuser password for a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("reset-superuser-password") do
+    desc "Reset the superuser password for a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) reset-superuser-password new-password"
+    banner "ubi pg (location/pg-name | pg-id) reset-superuser-password new-password"
 
-  args 1
+    args 1
 
-  run do |password|
-    id = sdk_object.reset_superuser_password(password).id
-    response("Superuser password reset scheduled for PostgreSQL database with id: #{id}")
+    run do |password|
+      id = sdk_object.reset_superuser_password(password).id
+      response("Superuser password reset scheduled for PostgreSQL database with id: #{id}")
+    end
   end
 end

--- a/cli-commands/pg/post/restart.rb
+++ b/cli-commands/pg/post/restart.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("restart") do
-  desc "Restart a PostgreSQL database cluster"
+class UbiCli
+  on("pg").run_on("restart") do
+    desc "Restart a PostgreSQL database cluster"
 
-  banner "ubi pg (location/pg-name | pg-id) restart"
+    banner "ubi pg (location/pg-name | pg-id) restart"
 
-  run do
-    id = sdk_object.restart.id
-    response("Scheduled restart of PostgreSQL database with id #{id}")
+    run do
+      id = sdk_object.restart.id
+      response("Scheduled restart of PostgreSQL database with id #{id}")
+    end
   end
 end

--- a/cli-commands/pg/post/restore.rb
+++ b/cli-commands/pg/post/restore.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("restore") do
-  desc "Restore a PostgreSQL database backup to a new database"
+class UbiCli
+  on("pg").run_on("restore") do
+    desc "Restore a PostgreSQL database backup to a new database"
 
-  options("ubi pg (location/pg-name | pg-id) restore [options] new-db-name restore-time", key: :pg_restore) do
-    on("-c", "--pg-config=config", "postgres config (e.g. key1=value1,key2=value2)")
-    on("-u", "--pgbouncer-config=config", "pgbouncer config (e.g. key1=value1,key2=value2)")
-    on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
-  end
+    options("ubi pg (location/pg-name | pg-id) restore [options] new-db-name restore-time", key: :pg_restore) do
+      on("-c", "--pg-config=config", "postgres config (e.g. key1=value1,key2=value2)")
+      on("-u", "--pgbouncer-config=config", "pgbouncer config (e.g. key1=value1,key2=value2)")
+      on("-t", "--tags=tags", "tags (e.g. key1=value1,key2=value2)")
+    end
 
-  args 2
+    args 2
 
-  run do |name, restore_target, opts, cmd|
-    params = underscore_keys(opts[:pg_restore])
-    pg_tags_to_hash(params, cmd)
-    params_to_hash(params, :pg_config, "config", cmd)
-    params_to_hash(params, :pgbouncer_config, "pgbouncer config", cmd)
-    id = sdk_object.restore(name:, restore_target:, **params).id
-    response("Restored PostgreSQL database scheduled for creation with id: #{id}")
+    run do |name, restore_target, opts, cmd|
+      params = underscore_keys(opts[:pg_restore])
+      pg_tags_to_hash(params, cmd)
+      params_to_hash(params, :pg_config, "config", cmd)
+      params_to_hash(params, :pgbouncer_config, "pgbouncer config", cmd)
+      id = sdk_object.restore(name:, restore_target:, **params).id
+      response("Restored PostgreSQL database scheduled for creation with id: #{id}")
+    end
   end
 end

--- a/cli-commands/pg/post/set-maintenance-window.rb
+++ b/cli-commands/pg/post/set-maintenance-window.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("set-maintenance-window") do
-  desc "Set the maintenance window for a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("set-maintenance-window") do
+    desc "Set the maintenance window for a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) set-maintenance-window start-hour"
+    banner "ubi pg (location/pg-name | pg-id) set-maintenance-window start-hour"
 
-  help_example "ubi pg pg-id set-maintenance-window 3   #  3 am"
-  help_example "ubi pg pg-id set-maintenance-window 23  # 11 pm"
-  help_example "ubi pg pg-id set-maintenance-window \"\"  # unset"
+    help_example "ubi pg pg-id set-maintenance-window 3   #  3 am"
+    help_example "ubi pg pg-id set-maintenance-window 23  # 11 pm"
+    help_example "ubi pg pg-id set-maintenance-window \"\"  # unset"
 
-  args 1
+    args 1
 
-  run do |hour|
-    hour = nil if hour.empty?
-    if (start = sdk_object.set_maintenance_window(hour).maintenance_window_start_at)
-      response("Starting hour for maintenance window for PostgreSQL database with id #{sdk_object.id} set to #{start}.")
-    else
-      response("Unset maintenance window for PostgreSQL database with id #{sdk_object.id}.")
+    run do |hour|
+      hour = nil if hour.empty?
+      if (start = sdk_object.set_maintenance_window(hour).maintenance_window_start_at)
+        response("Starting hour for maintenance window for PostgreSQL database with id #{sdk_object.id} set to #{start}.")
+      else
+        response("Unset maintenance window for PostgreSQL database with id #{sdk_object.id}.")
+      end
     end
   end
 end

--- a/cli-commands/pg/post/show-config.rb
+++ b/cli-commands/pg/post/show-config.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("show-config") do
-  desc "Show configuration for a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("show-config") do
+    desc "Show configuration for a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) show-config"
+    banner "ubi pg (location/pg-name | pg-id) show-config"
 
-  run do
-    config_entries_response(sdk_object.config)
+    run do
+      config_entries_response(sdk_object.config)
+    end
   end
 end

--- a/cli-commands/pg/post/show-default-config.rb
+++ b/cli-commands/pg/post/show-default-config.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("show-default-config") do
-  desc "Show default configuration for a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("show-default-config") do
+    desc "Show default configuration for a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) show-default-config"
+    banner "ubi pg (location/pg-name | pg-id) show-default-config"
 
-  run do
-    config_entries_response(sdk_object.default_pg_config)
+    run do
+      config_entries_response(sdk_object.default_pg_config)
+    end
   end
 end

--- a/cli-commands/pg/post/show-pgbouncer-config.rb
+++ b/cli-commands/pg/post/show-pgbouncer-config.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("show-pgbouncer-config") do
-  desc "Show pgbouncer configuration for a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("show-pgbouncer-config") do
+    desc "Show pgbouncer configuration for a PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) show-pgbouncer-config"
+    banner "ubi pg (location/pg-name | pg-id) show-pgbouncer-config"
 
-  run do
-    config_entries_response(sdk_object.pgbouncer_config)
+    run do
+      config_entries_response(sdk_object.pgbouncer_config)
+    end
   end
 end

--- a/cli-commands/pg/post/show-upgrade-status.rb
+++ b/cli-commands/pg/post/show-upgrade-status.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("show-upgrade-status") do
-  desc "Show the status of a major version upgrade of the PostgreSQL database"
+class UbiCli
+  on("pg").run_on("show-upgrade-status") do
+    desc "Show the status of a major version upgrade of the PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) show-upgrade-status"
+    banner "ubi pg (location/pg-name | pg-id) show-upgrade-status"
 
-  run do
-    upgrade_status = sdk_object.upgrade_status
-    body = []
-    body << "Major version upgrade of PostgreSQL database #{sdk_object.id} to version #{upgrade_status[:target_version]}\n"
-    body << "Status: #{upgrade_status[:upgrade_status]}\n"
-    body << "Stage: #{upgrade_status[:upgrade_stage] || "N/A"}\n"
-    response(body)
+    run do
+      upgrade_status = sdk_object.upgrade_status
+      body = []
+      body << "Major version upgrade of PostgreSQL database #{sdk_object.id} to version #{upgrade_status[:target_version]}\n"
+      body << "Status: #{upgrade_status[:upgrade_status]}\n"
+      body << "Stage: #{upgrade_status[:upgrade_stage] || "N/A"}\n"
+      response(body)
+    end
   end
 end

--- a/cli-commands/pg/post/show.rb
+++ b/cli-commands/pg/post/show.rb
@@ -1,62 +1,64 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("show") do
-  desc "Show details for a PostgreSQL database"
+class UbiCli
+  on("pg").run_on("show") do
+    desc "Show details for a PostgreSQL database"
 
-  fields = %w[id name state location vm-size target-vm-size storage-size-gib target-storage-size-gib version target-version ha-type flavor connection-string primary earliest-restore-time maintenance-window-start-at read-replica parent tags firewall-rules metric-destinations log-destinations read-replicas ca-certificates].freeze.each(&:freeze)
+    fields = %w[id name state location vm-size target-vm-size storage-size-gib target-storage-size-gib version target-version ha-type flavor connection-string primary earliest-restore-time maintenance-window-start-at read-replica parent tags firewall-rules metric-destinations log-destinations read-replicas ca-certificates].freeze.each(&:freeze)
 
-  options("ubi pg (location/pg-name | pg-id) show [options]", key: :pg_show) do
-    on("-f", "--fields=fields", "show specific fields (comma separated)")
-  end
-  help_option_values("Fields:", fields)
-
-  run do |opts, cmd|
-    data = sdk_object.info
-    opts = opts[:pg_show]
-    keys = check_fields(opts[:fields], fields, "pg show -f option", cmd)
-
-    body = []
-
-    each_with_dashed(underscore_keys(keys)) do |key, display_key|
-      case key
-      when :parent
-        body << "parent: "
-        if (parent = sdk_object.parent)
-          body << parent.split("/").values_at(-3, -1).join("/")
-        end
-        body << "\n"
-      when :tags
-        body << "tags:\n"
-        sdk_object.tags.sort.each do |k, v|
-          body << "  " << k << ": " << v << "\n"
-        end
-      when :firewall_rules
-        body << "firewall-rules:\n"
-        data[key].each_with_index do |rule, i|
-          body << "  " << (i + 1).to_s << ": " << rule[:id] << "  " << rule[:cidr].to_s << "  " << rule[:port].to_s << "  " << rule[:description].to_s << "\n"
-        end
-      when :metric_destinations
-        body << "metric-destinations:\n"
-        data[key].each_with_index do |md, i|
-          body << "  " << (i + 1).to_s << ": " << md[:id] << "  " << md[:username].to_s << "  " << md[:url] << "\n"
-        end
-      when :log_destinations
-        body << "log-destinations:\n"
-        data[key].each_with_index do |ld, i|
-          body << "  " << (i + 1).to_s << ": " << ld[:id] << "  " << ld[:name] << "  " << ld[:type] << "  " << ld[:url] << "\n"
-        end
-      when :read_replicas
-        body << "read-replicas:\n"
-        sdk_object.read_replicas.each do |rr|
-          body << "  " << rr[:location] << "/" << rr[:name] << "\n"
-        end
-      when :ca_certificates
-        body << "ca-certificates:\n" << data[key].to_s << "\n"
-      else
-        body << display_key << ": " << data[key].to_s << "\n"
-      end
+    options("ubi pg (location/pg-name | pg-id) show [options]", key: :pg_show) do
+      on("-f", "--fields=fields", "show specific fields (comma separated)")
     end
+    help_option_values("Fields:", fields)
 
-    response(body)
+    run do |opts, cmd|
+      data = sdk_object.info
+      opts = opts[:pg_show]
+      keys = check_fields(opts[:fields], fields, "pg show -f option", cmd)
+
+      body = []
+
+      each_with_dashed(underscore_keys(keys)) do |key, display_key|
+        case key
+        when :parent
+          body << "parent: "
+          if (parent = sdk_object.parent)
+            body << parent.split("/").values_at(-3, -1).join("/")
+          end
+          body << "\n"
+        when :tags
+          body << "tags:\n"
+          sdk_object.tags.sort.each do |k, v|
+            body << "  " << k << ": " << v << "\n"
+          end
+        when :firewall_rules
+          body << "firewall-rules:\n"
+          data[key].each_with_index do |rule, i|
+            body << "  " << (i + 1).to_s << ": " << rule[:id] << "  " << rule[:cidr].to_s << "  " << rule[:port].to_s << "  " << rule[:description].to_s << "\n"
+          end
+        when :metric_destinations
+          body << "metric-destinations:\n"
+          data[key].each_with_index do |md, i|
+            body << "  " << (i + 1).to_s << ": " << md[:id] << "  " << md[:username].to_s << "  " << md[:url] << "\n"
+          end
+        when :log_destinations
+          body << "log-destinations:\n"
+          data[key].each_with_index do |ld, i|
+            body << "  " << (i + 1).to_s << ": " << ld[:id] << "  " << ld[:name] << "  " << ld[:type] << "  " << ld[:url] << "\n"
+          end
+        when :read_replicas
+          body << "read-replicas:\n"
+          sdk_object.read_replicas.each do |rr|
+            body << "  " << rr[:location] << "/" << rr[:name] << "\n"
+          end
+        when :ca_certificates
+          body << "ca-certificates:\n" << data[key].to_s << "\n"
+        else
+          body << display_key << ": " << data[key].to_s << "\n"
+        end
+      end
+
+      response(body)
+    end
   end
 end

--- a/cli-commands/pg/post/upgrade.rb
+++ b/cli-commands/pg/post/upgrade.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.on("pg").run_on("upgrade") do
-  desc "Schedule a major version upgrade of the PostgreSQL database"
+class UbiCli
+  on("pg").run_on("upgrade") do
+    desc "Schedule a major version upgrade of the PostgreSQL database"
 
-  banner "ubi pg (location/pg-name | pg-id) upgrade"
+    banner "ubi pg (location/pg-name | pg-id) upgrade"
 
-  run do
-    id = sdk_object.upgrade.id
-    response("Scheduled major version upgrade of PostgreSQL database with id #{id} to version #{sdk_object.target_version}.")
+    run do
+      id = sdk_object.upgrade.id
+      response("Scheduled major version upgrade of PostgreSQL database with id #{id} to version #{sdk_object.target_version}.")
+    end
   end
 end

--- a/cli-commands/ps.rb
+++ b/cli-commands/ps.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-UbiCli.base("ps") do
-  banner "ubi ps command [...]"
-  post_banner "ubi ps (location/ps-name | ps-id) post-command [...]"
+class UbiCli
+  base("ps") do
+    banner "ubi ps command [...]"
+    post_banner "ubi ps (location/ps-name | ps-id) post-command [...]"
+  end
 end
 
 Unreloader.record_dependency(__FILE__, "cli-commands/ps")

--- a/cli-commands/ps/list.rb
+++ b/cli-commands/ps/list.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.list("ps", %w[location name id net4 net6])
+class UbiCli
+  list("ps", %w[location name id net4 net6])
+end

--- a/cli-commands/ps/post/connect.rb
+++ b/cli-commands/ps/post/connect.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-UbiCli.on("ps").run_on("connect") do
-  desc "Connect a private subnet to another private subnet"
+class UbiCli
+  on("ps").run_on("connect") do
+    desc "Connect a private subnet to another private subnet"
 
-  banner "ubi ps (location/ps-name | ps-id) connect (ps-name | ps-id)"
+    banner "ubi ps (location/ps-name | ps-id) connect (ps-name | ps-id)"
 
-  args 1
+    args 1
 
-  run do |ps_id|
-    id = sdk_object.connect(convert_name_to_id(sdk.private_subnet, ps_id)).id
-    response("Connected private subnet #{ps_id} to #{id}")
+    run do |ps_id|
+      id = sdk_object.connect(convert_name_to_id(sdk.private_subnet, ps_id)).id
+      response("Connected private subnet #{ps_id} to #{id}")
+    end
   end
 end

--- a/cli-commands/ps/post/create.rb
+++ b/cli-commands/ps/post/create.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
-UbiCli.on("ps").run_on("create") do
-  desc "Create a private subnet"
+class UbiCli
+  on("ps").run_on("create") do
+    desc "Create a private subnet"
 
-  options("ubi ps location/ps-name create [options]", key: :ps_create) do
-    on("-f", "--firewall-id=fw-id-or-name", "add to given firewall")
-  end
-
-  run do |opts|
-    params = underscore_keys(opts[:ps_create])
-    if params[:firewall_id]
-      params[:firewall_id] = convert_name_to_id(sdk.firewall, params[:firewall_id])
+    options("ubi ps location/ps-name create [options]", key: :ps_create) do
+      on("-f", "--firewall-id=fw-id-or-name", "add to given firewall")
     end
-    id = sdk.private_subnet.create(location: @location, name: @name, **params).id
-    response("Private subnet created with id: #{id}")
+
+    run do |opts|
+      params = underscore_keys(opts[:ps_create])
+      if params[:firewall_id]
+        params[:firewall_id] = convert_name_to_id(sdk.firewall, params[:firewall_id])
+      end
+      id = sdk.private_subnet.create(location: @location, name: @name, **params).id
+      response("Private subnet created with id: #{id}")
+    end
   end
 end

--- a/cli-commands/ps/post/destroy.rb
+++ b/cli-commands/ps/post/destroy.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.destroy("ps")
+class UbiCli
+  destroy("ps")
+end

--- a/cli-commands/ps/post/disconnect.rb
+++ b/cli-commands/ps/post/disconnect.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
-UbiCli.on("ps").run_on("disconnect") do
-  desc "Disconnect a private subnet from another private subnet"
+class UbiCli
+  on("ps").run_on("disconnect") do
+    desc "Disconnect a private subnet from another private subnet"
 
-  banner "ubi ps (location/ps-name | ps-id) disconnect (ps-name | ps-id)"
+    banner "ubi ps (location/ps-name | ps-id) disconnect (ps-name | ps-id)"
 
-  args 1
+    args 1
 
-  run do |ps_id, _, cmd|
-    arg = ps_id
-    ps_id = convert_name_to_id(sdk.private_subnet, ps_id)
-    check_no_slash(ps_id, "invalid private subnet id format", cmd)
-    id = sdk_object.disconnect(ps_id).id
-    response("Disconnected private subnet #{arg} from #{id}")
+    run do |ps_id, _, cmd|
+      arg = ps_id
+      ps_id = convert_name_to_id(sdk.private_subnet, ps_id)
+      check_no_slash(ps_id, "invalid private subnet id format", cmd)
+      id = sdk_object.disconnect(ps_id).id
+      response("Disconnected private subnet #{arg} from #{id}")
+    end
   end
 end

--- a/cli-commands/ps/post/rename.rb
+++ b/cli-commands/ps/post/rename.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.rename("ps")
+class UbiCli
+  rename("ps")
+end

--- a/cli-commands/ps/post/show.rb
+++ b/cli-commands/ps/post/show.rb
@@ -1,66 +1,68 @@
 # frozen_string_literal: true
 
-UbiCli.on("ps").run_on("show") do
-  desc "Show details for a private subnet"
+class UbiCli
+  on("ps").run_on("show") do
+    desc "Show details for a private subnet"
 
-  fields = %w[id name state location net4 net6 firewalls nics].freeze.each(&:freeze)
-  firewall_fields = %w[id name description location path firewall-rules].freeze.each(&:freeze)
-  firewall_rule_fields = %w[id cidr port-range protocol].freeze.each(&:freeze)
-  nic_fields = %w[id name private-ipv4 private-ipv6 vm-name].freeze.each(&:freeze)
+    fields = %w[id name state location net4 net6 firewalls nics].freeze.each(&:freeze)
+    firewall_fields = %w[id name description location path firewall-rules].freeze.each(&:freeze)
+    firewall_rule_fields = %w[id cidr port-range protocol].freeze.each(&:freeze)
+    nic_fields = %w[id name private-ipv4 private-ipv6 vm-name].freeze.each(&:freeze)
 
-  options("ubi ps (location/ps-name | ps-id) show [options]", key: :ps_show) do
-    on("-f", "--fields=fields", "show specific fields (comma separated)")
-    on("-n", "--nic-fields=fields", "show specific nic fields (comma separated)")
-    on("-r", "--rule-fields=fields", "show specific firewall rule fields (comma separated)")
-    on("-w", "--firewall-fields=fields", "show specific firewall fields (comma separated)")
-  end
-  help_option_values("Fields:", fields)
-  help_option_values("Nic Fields:", nic_fields)
-  help_option_values("Firewall Rule Fields:", firewall_rule_fields)
-  help_option_values("Firewall Fields:", firewall_fields)
+    options("ubi ps (location/ps-name | ps-id) show [options]", key: :ps_show) do
+      on("-f", "--fields=fields", "show specific fields (comma separated)")
+      on("-n", "--nic-fields=fields", "show specific nic fields (comma separated)")
+      on("-r", "--rule-fields=fields", "show specific firewall rule fields (comma separated)")
+      on("-w", "--firewall-fields=fields", "show specific firewall fields (comma separated)")
+    end
+    help_option_values("Fields:", fields)
+    help_option_values("Nic Fields:", nic_fields)
+    help_option_values("Firewall Rule Fields:", firewall_rule_fields)
+    help_option_values("Firewall Fields:", firewall_fields)
 
-  run do |opts, cmd|
-    data = sdk_object.info
-    opts = opts[:ps_show]
-    keys = underscore_keys(check_fields(opts[:fields], fields, "ps show -f option", cmd))
-    firewall_keys = underscore_keys(check_fields(opts[:"firewall-fields"], firewall_fields, "ps show -w option", cmd))
-    firewall_rule_keys = underscore_keys(check_fields(opts[:"rule-fields"], firewall_rule_fields, "ps show -r option", cmd))
-    nic_keys = underscore_keys(check_fields(opts[:"nic-fields"], nic_fields, "ps show -n option", cmd))
+    run do |opts, cmd|
+      data = sdk_object.info
+      opts = opts[:ps_show]
+      keys = underscore_keys(check_fields(opts[:fields], fields, "ps show -f option", cmd))
+      firewall_keys = underscore_keys(check_fields(opts[:"firewall-fields"], firewall_fields, "ps show -w option", cmd))
+      firewall_rule_keys = underscore_keys(check_fields(opts[:"rule-fields"], firewall_rule_fields, "ps show -r option", cmd))
+      nic_keys = underscore_keys(check_fields(opts[:"nic-fields"], nic_fields, "ps show -n option", cmd))
 
-    body = []
+      body = []
 
-    each_with_dashed(keys) do |key, display_key|
-      case key
-      when :firewalls
-        data[key].each_with_index do |firewall, i|
-          body << "firewall " << (i + 1).to_s << ":\n"
-          each_with_dashed(firewall_keys) do |fw_key, display_fw_key|
-            if fw_key == :firewall_rules
-              body << "  rules:\n"
-              firewall[fw_key].each_with_index do |rule, i|
-                body << "   " << (i + 1).to_s << ": "
-                firewall_rule_keys.each do |fwr_key|
-                  body << rule[fwr_key].to_s << "  "
+      each_with_dashed(keys) do |key, display_key|
+        case key
+        when :firewalls
+          data[key].each_with_index do |firewall, i|
+            body << "firewall " << (i + 1).to_s << ":\n"
+            each_with_dashed(firewall_keys) do |fw_key, display_fw_key|
+              if fw_key == :firewall_rules
+                body << "  rules:\n"
+                firewall[fw_key].each_with_index do |rule, i|
+                  body << "   " << (i + 1).to_s << ": "
+                  firewall_rule_keys.each do |fwr_key|
+                    body << rule[fwr_key].to_s << "  "
+                  end
+                  body << "\n"
                 end
-                body << "\n"
+              else
+                body << "  " << display_fw_key << ": " << firewall[fw_key].to_s << "\n"
               end
-            else
-              body << "  " << display_fw_key << ": " << firewall[fw_key].to_s << "\n"
             end
           end
-        end
-      when :nics
-        data[key].each_with_index do |nic, i|
-          body << "nic " << (i + 1).to_s << ":\n"
-          each_with_dashed(nic_keys) do |nic_key, display_nic_key|
-            body << "  " << display_nic_key << ": " << nic[nic_key].to_s << "\n"
+        when :nics
+          data[key].each_with_index do |nic, i|
+            body << "nic " << (i + 1).to_s << ":\n"
+            each_with_dashed(nic_keys) do |nic_key, display_nic_key|
+              body << "  " << display_nic_key << ": " << nic[nic_key].to_s << "\n"
+            end
           end
+        else
+          body << display_key << ": " << data[key].to_s << "\n"
         end
-      else
-        body << display_key << ": " << data[key].to_s << "\n"
       end
-    end
 
-    response(body)
+      response(body)
+    end
   end
 end

--- a/cli-commands/sk.rb
+++ b/cli-commands/sk.rb
@@ -1,24 +1,26 @@
 # frozen_string_literal: true
 
-UbiCli.on("sk") do
-  desc "Manage SSH public keys"
+class UbiCli
+  on("sk") do
+    desc "Manage SSH public keys"
 
-  banner "ubi sk command [...]"
-  post_banner "ubi sk (sk-name | sk-id) post-command [...]"
+    banner "ubi sk command [...]"
+    post_banner "ubi sk (sk-name | sk-id) post-command [...]"
 
-  # :nocov:
-  unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
-    autoload_subcommand_dir("cli-commands/sk")
-    autoload_post_subcommand_dir("cli-commands/sk/post")
-  end
-  # :nocov:
+    # :nocov:
+    unless Config.production? || ENV["FORCE_AUTOLOAD"] == "1"
+      autoload_subcommand_dir("cli-commands/sk")
+      autoload_post_subcommand_dir("cli-commands/sk/post")
+    end
+    # :nocov:
 
-  args(2...)
+    args(2...)
 
-  run do |(ref, *argv), opts, command|
-    check_no_slash(ref, "invalid ssh public key reference (#{ref.inspect}), should not include /", command)
-    @sdk_object = sdk.ssh_public_key.new(ref)
-    command.run(self, opts, argv)
+    run do |(ref, *argv), opts, command|
+      check_no_slash(ref, "invalid ssh public key reference (#{ref.inspect}), should not include /", command)
+      @sdk_object = sdk.ssh_public_key.new(ref)
+      command.run(self, opts, argv)
+    end
   end
 end
 

--- a/cli-commands/sk/list.rb
+++ b/cli-commands/sk/list.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
-UbiCli.on("sk", "list") do
-  desc "List SSH public keys"
+class UbiCli
+  on("sk", "list") do
+    desc "List SSH public keys"
 
-  key = :ssh_public_key_list
+    key = :ssh_public_key_list
 
-  options("ubi sk list [options]", key:) do
-    on("-N", "--no-headers", "do not show headers")
-  end
+    options("ubi sk list [options]", key:) do
+      on("-N", "--no-headers", "do not show headers")
+    end
 
-  run do |opts|
-    opts = opts[key]
-    items = sdk.ssh_public_key.list
-    response(format_rows(%i[id name], items, headers: opts[:"no-headers"] != false))
+    run do |opts|
+      opts = opts[key]
+      items = sdk.ssh_public_key.list
+      response(format_rows(%i[id name], items, headers: opts[:"no-headers"] != false))
+    end
   end
 end

--- a/cli-commands/sk/post/create.rb
+++ b/cli-commands/sk/post/create.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
-UbiCli.on("sk").run_on("create") do
-  desc "Register an SSH public key"
+class UbiCli
+  on("sk").run_on("create") do
+    desc "Register an SSH public key"
 
-  banner "ubi sk sk-name create public-key"
+    banner "ubi sk sk-name create public-key"
 
-  help_example 'ubi sk my-sk-name create "$(cat ~/.ssh/id_ed25519.pub)"'
-  help_example 'ubi sk my-sk-name create "$(cat ~/.ssh/authorized_keys)"'
+    help_example 'ubi sk my-sk-name create "$(cat ~/.ssh/id_ed25519.pub)"'
+    help_example 'ubi sk my-sk-name create "$(cat ~/.ssh/authorized_keys)"'
 
-  args 1
+    args 1
 
-  run do |public_key|
-    id = sdk.ssh_public_key.create(name: @sdk_object.name, public_key:).id
-    response("SSH public key registered with id: #{id}")
+    run do |public_key|
+      id = sdk.ssh_public_key.create(name: @sdk_object.name, public_key:).id
+      response("SSH public key registered with id: #{id}")
+    end
   end
 end

--- a/cli-commands/sk/post/destroy.rb
+++ b/cli-commands/sk/post/destroy.rb
@@ -1,25 +1,27 @@
 # frozen_string_literal: true
 
-UbiCli.on("sk").run_on("destroy") do
-  desc "Destroy an SSH public key"
+class UbiCli
+  on("sk").run_on("destroy") do
+    desc "Destroy an SSH public key"
 
-  options("ubi sk (sk-name | sk-id) destroy [options]", key: :destroy) do
-    on("-f", "--force", "do not require confirmation")
-  end
+    options("ubi sk (sk-name | sk-id) destroy [options]", key: :destroy) do
+      on("-f", "--force", "do not require confirmation")
+    end
 
-  run do |opts|
-    if opts.dig(:destroy, :force) || opts[:confirm] == @sdk_object.name
-      @sdk_object.destroy
-      response("SSH public key has been removed")
-    elsif opts[:confirm]
-      invalid_confirmation <<~END
-        ! Confirmation of SSH public key name not successful.
-      END
-    else
-      require_confirmation("Confirmation", <<~END)
-        Destroying this SSH public key is not recoverable.
-        Enter the following to confirm destruction of the SSH public key: #{@sdk_object.name}
-      END
+    run do |opts|
+      if opts.dig(:destroy, :force) || opts[:confirm] == @sdk_object.name
+        @sdk_object.destroy
+        response("SSH public key has been removed")
+      elsif opts[:confirm]
+        invalid_confirmation <<~END
+          ! Confirmation of SSH public key name not successful.
+        END
+      else
+        require_confirmation("Confirmation", <<~END)
+          Destroying this SSH public key is not recoverable.
+          Enter the following to confirm destruction of the SSH public key: #{@sdk_object.name}
+        END
+      end
     end
   end
 end

--- a/cli-commands/sk/post/rename.rb
+++ b/cli-commands/sk/post/rename.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-UbiCli.on("sk").run_on("rename") do
-  desc "Rename an SSH public key"
+class UbiCli
+  on("sk").run_on("rename") do
+    desc "Rename an SSH public key"
 
-  banner "ubi sk (sk-id | sk-name) rename new-name"
+    banner "ubi sk (sk-id | sk-name) rename new-name"
 
-  args 1
+    args 1
 
-  run do |name|
-    @sdk_object.rename_to(name)
-    response("SSH public key with id #{@sdk_object.id} renamed to #{@sdk_object.name}")
+    run do |name|
+      @sdk_object.rename_to(name)
+      response("SSH public key with id #{@sdk_object.id} renamed to #{@sdk_object.name}")
+    end
   end
 end

--- a/cli-commands/sk/post/show.rb
+++ b/cli-commands/sk/post/show.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-UbiCli.on("sk").run_on("show") do
-  desc "Show details for an SSH public key"
+class UbiCli
+  on("sk").run_on("show") do
+    desc "Show details for an SSH public key"
 
-  banner "ubi sk (sk-id | sk-name) show"
+    banner "ubi sk (sk-id | sk-name) show"
 
-  run do
-    ssh_public_key = @sdk_object
-    response([
-      "id: ", ssh_public_key.id, "\n",
-      "name: ", ssh_public_key.name, "\n",
-      "public key:\n", ssh_public_key.public_key,
-    ])
+    run do
+      ssh_public_key = @sdk_object
+      response([
+        "id: ", ssh_public_key.id, "\n",
+        "name: ", ssh_public_key.name, "\n",
+        "public key:\n", ssh_public_key.public_key,
+      ])
+    end
   end
 end

--- a/cli-commands/sk/post/update.rb
+++ b/cli-commands/sk/post/update.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-UbiCli.on("sk").run_on("update") do
-  desc "Update an SSH public key"
+class UbiCli
+  on("sk").run_on("update") do
+    desc "Update an SSH public key"
 
-  banner "ubi sk (sk-id | sk-name) update public-key"
+    banner "ubi sk (sk-id | sk-name) update public-key"
 
-  help_example 'ubi sk my-sk-name update "$(cat ~/.ssh/id_ed25519.pub)"'
+    help_example 'ubi sk my-sk-name update "$(cat ~/.ssh/id_ed25519.pub)"'
 
-  args 1
+    args 1
 
-  run do |public_key|
-    @sdk_object.update_public_key(public_key)
-    response("SSH public key with id #{@sdk_object.id} updated")
+    run do |public_key|
+      @sdk_object.update_public_key(public_key)
+      response("SSH public key with id #{@sdk_object.id} updated")
+    end
   end
 end

--- a/cli-commands/version.rb
+++ b/cli-commands/version.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-UbiCli.on("version") do
-  desc "Display CLI program version"
+class UbiCli
+  on("version") do
+    desc "Display CLI program version"
 
-  banner "ubi version"
+    banner "ubi version"
 
-  run do
-    response(client_version)
+    run do
+      response(client_version)
+    end
   end
 end

--- a/cli-commands/vm.rb
+++ b/cli-commands/vm.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.base("vm") do
-  banner "ubi vm command [...]"
+class UbiCli
+  base("vm") do
+    banner "ubi vm command [...]"
 
-  post_options("ubi vm (location/vm-name | vm-id) [post-options] post-command [...]", key: :vm_ssh) do
-    on("-4", "--ip4", "use IPv4 address")
-    on("-6", "--ip6", "use IPv6 address")
-    on("-u", "--user user", "override username")
+    post_options("ubi vm (location/vm-name | vm-id) [post-options] post-command [...]", key: :vm_ssh) do
+      on("-4", "--ip4", "use IPv4 address")
+      on("-6", "--ip6", "use IPv6 address")
+      on("-u", "--user user", "override username")
+    end
   end
 end
 

--- a/cli-commands/vm/list.rb
+++ b/cli-commands/vm/list.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.list("vm", %w[location name id ip4 ip6])
+class UbiCli
+  list("vm", %w[location name id ip4 ip6])
+end

--- a/cli-commands/vm/post/create.rb
+++ b/cli-commands/vm/post/create.rb
@@ -1,58 +1,60 @@
 # frozen_string_literal: true
 
-UbiCli.on("vm").run_on("create") do
-  desc "Create a virtual machine"
+class UbiCli
+  on("vm").run_on("create") do
+    desc "Create a virtual machine"
 
-  vm_sizes = Option::VmSizes.select(&:visible)
-  server_sizes = vm_sizes.map(&:name).uniq.freeze
-  storage_sizes = vm_sizes.map(&:storage_size_options).flatten.uniq.sort.map(&:to_s).freeze.each(&:freeze)
+    vm_sizes = Option::VmSizes.select(&:visible)
+    server_sizes = vm_sizes.map(&:name).uniq.freeze
+    storage_sizes = vm_sizes.map(&:storage_size_options).flatten.uniq.sort.map(&:to_s).freeze.each(&:freeze)
 
-  options("ubi vm location/vm-name create [options] public-key", key: :vm_create) do
-    on("-6", "--ipv6-only", "do not enable IPv4")
-    on("-b", "--boot-image=image_name", "boot image")
-    on("-i", "--init-script=script", "use given init script")
-    on("-p", "--private-subnet-id=ps-id", "place VM into specific private subnet (also accepts ps-name)")
-    on("-s", "--size=size", server_sizes, "server size")
-    on("-S", "--storage-size=size", storage_sizes, "storage size")
-    on("-u", "--unix-user=username", "username (default: ubi)")
-  end
-  help_option_values("Boot Image:", Option::BootImages.map(&:name) + ["machine-image-name@version", "machine-image-name@latest"])
-  help_option_values("Size:", server_sizes)
-  help_option_values("Storage Size:", storage_sizes)
-
-  help_example 'ubi vm eu-central-h1/my-vm-name create "$(cat ~/.ssh/id_ed25519.pub)"'
-  help_example 'ubi vm eu-central-h1/my-vm-name create "$(cat ~/.ssh/authorized_keys)"'
-  help_example "ubi vm eu-central-h1/my-vm-name create registered-ssh-public-key-name"
-  help_example 'ubi vm eu-central-h1/my-vm-name create -i "$(cat /path/to/init/script)" registered-ssh-public-key-name'
-
-  args 1
-
-  run do |public_key, opts, command|
-    params = underscore_keys(opts[:vm_create])
-    unless params.delete(:ipv6_only)
-      params[:enable_ip4] = "1"
+    options("ubi vm location/vm-name create [options] public-key", key: :vm_create) do
+      on("-6", "--ipv6-only", "do not enable IPv4")
+      on("-b", "--boot-image=image_name", "boot image")
+      on("-i", "--init-script=script", "use given init script")
+      on("-p", "--private-subnet-id=ps-id", "place VM into specific private subnet (also accepts ps-name)")
+      on("-s", "--size=size", server_sizes, "server size")
+      on("-S", "--storage-size=size", storage_sizes, "storage size")
+      on("-u", "--unix-user=username", "username (default: ubi)")
     end
-    if params[:private_subnet_id]
-      params[:private_subnet_id] = convert_name_to_id(sdk.private_subnet, params[:private_subnet_id])
-    end
+    help_option_values("Boot Image:", Option::BootImages.map(&:name) + ["machine-image-name@version", "machine-image-name@latest"])
+    help_option_values("Size:", server_sizes)
+    help_option_values("Storage Size:", storage_sizes)
 
-    params[:public_key] = public_key
-    begin
-      id = sdk.vm.create(location: @location, name: @name, **params).id
-    rescue Ubicloud::Error => e
-      if e.code == 400 && e.params.dig("error", "message").match?(/public_key invalid SSH public key format|public_key must contain at least one valid SSH public key/)
-        raise Rodish::CommandFailure.new(<<~END.chomp, command)
-          Invalid SSH public key provided:
+    help_example 'ubi vm eu-central-h1/my-vm-name create "$(cat ~/.ssh/id_ed25519.pub)"'
+    help_example 'ubi vm eu-central-h1/my-vm-name create "$(cat ~/.ssh/authorized_keys)"'
+    help_example "ubi vm eu-central-h1/my-vm-name create registered-ssh-public-key-name"
+    help_example 'ubi vm eu-central-h1/my-vm-name create -i "$(cat /path/to/init/script)" registered-ssh-public-key-name'
 
-          #{public_key}
+    args 1
 
-          The public key given must be the name of a registered SSH public key,
-          or must be a valid SSH public key
-        END
+    run do |public_key, opts, command|
+      params = underscore_keys(opts[:vm_create])
+      unless params.delete(:ipv6_only)
+        params[:enable_ip4] = "1"
+      end
+      if params[:private_subnet_id]
+        params[:private_subnet_id] = convert_name_to_id(sdk.private_subnet, params[:private_subnet_id])
       end
 
-      raise
+      params[:public_key] = public_key
+      begin
+        id = sdk.vm.create(location: @location, name: @name, **params).id
+      rescue Ubicloud::Error => e
+        if e.code == 400 && e.params.dig("error", "message").match?(/public_key invalid SSH public key format|public_key must contain at least one valid SSH public key/)
+          raise Rodish::CommandFailure.new(<<~END.chomp, command)
+            Invalid SSH public key provided:
+
+            #{public_key}
+
+            The public key given must be the name of a registered SSH public key,
+            or must be a valid SSH public key
+          END
+        end
+
+        raise
+      end
+      response("VM created with id: #{id}")
     end
-    response("VM created with id: #{id}")
   end
 end

--- a/cli-commands/vm/post/destroy.rb
+++ b/cli-commands/vm/post/destroy.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.destroy("vm")
+class UbiCli
+  destroy("vm")
+end

--- a/cli-commands/vm/post/rename.rb
+++ b/cli-commands/vm/post/rename.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-UbiCli.rename("vm")
+class UbiCli
+  rename("vm")
+end

--- a/cli-commands/vm/post/restart.rb
+++ b/cli-commands/vm/post/restart.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.on("vm").run_on("restart") do
-  desc "Restart a virtual machine"
+class UbiCli
+  on("vm").run_on("restart") do
+    desc "Restart a virtual machine"
 
-  banner "ubi vm (location/vm-name | vm-id) restart"
+    banner "ubi vm (location/vm-name | vm-id) restart"
 
-  run do
-    id = sdk_object.restart.id
-    response("Scheduled restart of VM with id #{id}")
+    run do
+      id = sdk_object.restart.id
+      response("Scheduled restart of VM with id #{id}")
+    end
   end
 end

--- a/cli-commands/vm/post/scp.rb
+++ b/cli-commands/vm/post/scp.rb
@@ -1,32 +1,34 @@
 # frozen_string_literal: true
 
-UbiCli.on("vm").run_on("scp") do
-  desc "Copy files to or from virtual machine using `scp`"
+class UbiCli
+  on("vm").run_on("scp") do
+    desc "Copy files to or from virtual machine using `scp`"
 
-  skip_option_parsing("ubi vm (location/vm-name | vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)")
+    skip_option_parsing("ubi vm (location/vm-name | vm-id) [options] scp [scp-options] (local-path :remote-path | :remote-path local-path)")
 
-  args(2...)
+    args(2...)
 
-  run do |(*argv, path1, path2), opts|
-    remote_path1 = path1[0] == ":"
-    remote_path2 = path2[0] == ":"
+    run do |(*argv, path1, path2), opts|
+      remote_path1 = path1[0] == ":"
+      remote_path2 = path2[0] == ":"
 
-    if remote_path1 ^ remote_path2
-      handle_ssh(opts) do |user:, address:|
-        address = "[#{address}]" if address.include?(":")
-        remote = "#{user}@#{address}"
+      if remote_path1 ^ remote_path2
+        handle_ssh(opts) do |user:, address:|
+          address = "[#{address}]" if address.include?(":")
+          remote = "#{user}@#{address}"
 
-        if remote_path1
-          path1 = "#{remote}#{path1}"
-        else
-          path2 = "#{remote}#{path2}"
+          if remote_path1
+            path1 = "#{remote}#{path1}"
+          else
+            path2 = "#{remote}#{path2}"
+          end
+
+          ["scp", *argv, "--", path1, path2]
         end
-
-        ["scp", *argv, "--", path1, path2]
+      else
+        error = "! Only one path should be remote (start with ':')\n"
+        [400, {"content-type" => "text/plain", "content-length" => error.bytesize.to_s}, [error]]
       end
-    else
-      error = "! Only one path should be remote (start with ':')\n"
-      [400, {"content-type" => "text/plain", "content-length" => error.bytesize.to_s}, [error]]
     end
   end
 end

--- a/cli-commands/vm/post/sftp.rb
+++ b/cli-commands/vm/post/sftp.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-UbiCli.on("vm").run_on("sftp") do
-  desc "Copy files to or from virtual machine using `sftp`"
+class UbiCli
+  on("vm").run_on("sftp") do
+    desc "Copy files to or from virtual machine using `sftp`"
 
-  skip_option_parsing("ubi vm (location/vm-name | vm-id) [options] sftp [sftp-options]")
+    skip_option_parsing("ubi vm (location/vm-name | vm-id) [options] sftp [sftp-options]")
 
-  args(0...)
+    args(0...)
 
-  run do |argv, opts|
-    handle_ssh(opts) do |user:, address:|
-      address = "[#{address}]" if address.include?(":")
-      ["sftp", *argv, "--", "#{user}@#{address}"]
+    run do |argv, opts|
+      handle_ssh(opts) do |user:, address:|
+        address = "[#{address}]" if address.include?(":")
+        ["sftp", *argv, "--", "#{user}@#{address}"]
+      end
     end
   end
 end

--- a/cli-commands/vm/post/show.rb
+++ b/cli-commands/vm/post/show.rb
@@ -1,59 +1,61 @@
 # frozen_string_literal: true
 
-UbiCli.on("vm").run_on("show") do
-  desc "Show details for a virtual machine"
+class UbiCli
+  on("vm").run_on("show") do
+    desc "Show details for a virtual machine"
 
-  fields = %w[id name state location size unix-user storage-size-gib ip6 ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls].freeze.each(&:freeze)
-  firewall_fields = %w[id name description location path firewall-rules].freeze.each(&:freeze)
-  firewall_rule_fields = %w[id cidr port-range protocol].freeze.each(&:freeze)
+    fields = %w[id name state location size unix-user storage-size-gib ip6 ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls].freeze.each(&:freeze)
+    firewall_fields = %w[id name description location path firewall-rules].freeze.each(&:freeze)
+    firewall_rule_fields = %w[id cidr port-range protocol].freeze.each(&:freeze)
 
-  options("ubi vm (location/vm-name | vm-id) show [options]", key: :vm_show) do
-    on("-f", "--fields=fields", "show specific fields (comma separated)")
-    on("-r", "--rule-fields=fields", "show specific firewall rule fields (comma separated)")
-    on("-w", "--firewall-fields=fields", "show specific firewall fields (comma separated)")
-  end
-  help_option_values("Fields:", fields)
-  help_option_values("Firewall Rule Fields:", firewall_rule_fields)
-  help_option_values("Firewall Fields:", firewall_fields)
+    options("ubi vm (location/vm-name | vm-id) show [options]", key: :vm_show) do
+      on("-f", "--fields=fields", "show specific fields (comma separated)")
+      on("-r", "--rule-fields=fields", "show specific firewall rule fields (comma separated)")
+      on("-w", "--firewall-fields=fields", "show specific firewall fields (comma separated)")
+    end
+    help_option_values("Fields:", fields)
+    help_option_values("Firewall Rule Fields:", firewall_rule_fields)
+    help_option_values("Firewall Fields:", firewall_fields)
 
-  run do |opts, cmd|
-    data = sdk_object.info
-    opts = opts[:vm_show]
-    keys = check_fields(opts[:fields], fields, "vm show -f option", cmd)
-    firewall_keys = check_fields(opts[:"firewall-fields"], firewall_fields, "vm show -w option", cmd)
-    firewall_rule_keys = check_fields(opts[:"rule-fields"], firewall_rule_fields, "vm show -r option", cmd)
+    run do |opts, cmd|
+      data = sdk_object.info
+      opts = opts[:vm_show]
+      keys = check_fields(opts[:fields], fields, "vm show -f option", cmd)
+      firewall_keys = check_fields(opts[:"firewall-fields"], firewall_fields, "vm show -w option", cmd)
+      firewall_rule_keys = check_fields(opts[:"rule-fields"], firewall_rule_fields, "vm show -r option", cmd)
 
-    body = []
+      body = []
 
-    firewall_keys = underscore_keys(firewall_keys)
-    firewall_rule_keys = underscore_keys(firewall_rule_keys)
-    each_with_dashed(underscore_keys(keys)) do |key, display_key|
-      case key
-      when :firewalls
-        data[key].each_with_index do |firewall, i|
-          body << "firewall " << (i + 1).to_s << ":\n"
-          each_with_dashed(firewall_keys) do |fw_key, display_fw_key|
-            if fw_key == :firewall_rules
-              body << "  rules:\n"
-              firewall[fw_key].each_with_index do |rule, i|
-                body << "    " << (i + 1).to_s << ": "
-                firewall_rule_keys.each do |fwr_key|
-                  body << rule[fwr_key].to_s << "  "
+      firewall_keys = underscore_keys(firewall_keys)
+      firewall_rule_keys = underscore_keys(firewall_rule_keys)
+      each_with_dashed(underscore_keys(keys)) do |key, display_key|
+        case key
+        when :firewalls
+          data[key].each_with_index do |firewall, i|
+            body << "firewall " << (i + 1).to_s << ":\n"
+            each_with_dashed(firewall_keys) do |fw_key, display_fw_key|
+              if fw_key == :firewall_rules
+                body << "  rules:\n"
+                firewall[fw_key].each_with_index do |rule, i|
+                  body << "    " << (i + 1).to_s << ": "
+                  firewall_rule_keys.each do |fwr_key|
+                    body << rule[fwr_key].to_s << "  "
+                  end
+                  body << "\n"
                 end
-                body << "\n"
+              else
+                body << "  " << display_fw_key << ": " << firewall[fw_key].to_s << "\n"
               end
-            else
-              body << "  " << display_fw_key << ": " << firewall[fw_key].to_s << "\n"
             end
           end
+        when :subnet
+          body << display_key << ": " << data[key].name << "\n"
+        else
+          body << display_key << ": " << data[key].to_s << "\n"
         end
-      when :subnet
-        body << display_key << ": " << data[key].name << "\n"
-      else
-        body << display_key << ": " << data[key].to_s << "\n"
       end
-    end
 
-    response(body)
+      response(body)
+    end
   end
 end

--- a/cli-commands/vm/post/ssh.rb
+++ b/cli-commands/vm/post/ssh.rb
@@ -1,20 +1,22 @@
 # frozen_string_literal: true
 
-UbiCli.on("vm").run_on("ssh") do
-  desc "Connect to a virtual machine using `ssh`"
+class UbiCli
+  on("vm").run_on("ssh") do
+    desc "Connect to a virtual machine using `ssh`"
 
-  skip_option_parsing("ubi vm (location/vm-name | vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]")
+    skip_option_parsing("ubi vm (location/vm-name | vm-id) [options] ssh [ssh-options --] [remote-cmd [remote-cmd-arg ...]]")
 
-  args(0...)
+    args(0...)
 
-  run do |argv, opts|
-    handle_ssh(opts) do |user:, address:|
-      if (i = argv.index("--"))
-        options = argv[0...i]
-        argv = argv[(i + 1)...]
+    run do |argv, opts|
+      handle_ssh(opts) do |user:, address:|
+        if (i = argv.index("--"))
+          options = argv[0...i]
+          argv = argv[(i + 1)...]
+        end
+
+        ["ssh", *options, "--", "#{user}@#{address}", *argv]
       end
-
-      ["ssh", *options, "--", "#{user}@#{address}", *argv]
     end
   end
 end

--- a/cli-commands/vm/post/start.rb
+++ b/cli-commands/vm/post/start.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-UbiCli.on("vm").run_on("start") do
-  desc "Start a virtual machine"
+class UbiCli
+  on("vm").run_on("start") do
+    desc "Start a virtual machine"
 
-  banner "ubi vm (location/vm-name | vm-id) start"
+    banner "ubi vm (location/vm-name | vm-id) start"
 
-  run do
-    id = sdk_object.start.id
-    response("Scheduled start of VM with id #{id}")
+    run do
+      id = sdk_object.start.id
+      response("Scheduled start of VM with id #{id}")
+    end
   end
 end

--- a/cli-commands/vm/post/stop.rb
+++ b/cli-commands/vm/post/stop.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-UbiCli.on("vm").run_on("stop") do
-  desc "Stop a virtual machine"
+class UbiCli
+  on("vm").run_on("stop") do
+    desc "Stop a virtual machine"
 
-  banner "ubi vm (location/vm-name | vm-id) stop"
+    banner "ubi vm (location/vm-name | vm-id) stop"
 
-  run do
-    id = sdk_object.stop.id
-    response(<<END)
-Scheduled stop of VM with id #{id}.
-Note that stopped VMs still accrue billing charges. To stop billing charges,
-destroy the VM.
-END
+    run do
+      id = sdk_object.stop.id
+      response(<<END)
+  Scheduled stop of VM with id #{id}.
+  Note that stopped VMs still accrue billing charges. To stop billing charges,
+  destroy the VM.
+  END
+    end
   end
 end

--- a/cli-commands/vm/post/stop.rb
+++ b/cli-commands/vm/post/stop.rb
@@ -9,10 +9,10 @@ class UbiCli
     run do
       id = sdk_object.stop.id
       response(<<END)
-  Scheduled stop of VM with id #{id}.
-  Note that stopped VMs still accrue billing charges. To stop billing charges,
-  destroy the VM.
-  END
+Scheduled stop of VM with id #{id}.
+Note that stopped VMs still accrue billing charges. To stop billing charges,
+destroy the VM.
+END
     end
   end
 end

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -530,6 +530,30 @@ class UbiCli
   end
   # :nocov:
 
+  class DirectModelAccess < StandardError; end
+
+  if Config.unfrozen_test? && ENV["FORCE_AUTOLOAD"] == "1"
+    def self.models_loaded
+      Sequel::Model.descendants.each do |model|
+        name = model.name
+        autoload(name, "./vendor/hidden_class") if /\A[A-Za-z0-9]+\z/.match?(name)
+      end
+      autoload(:DB, "./vendor/hidden_class")
+    end
+  # :nocov:
+  else
+    def self.models_loaded
+      # nothing
+    end
+  end
+  # :nocov:
+
+  # Allow direct access to DB here for the sole purpose of ignoring
+  # duplicate queries.
+  def ignore_duplicate_queries(&)
+    ::DB.ignore_duplicate_queries(&)
+  end
+
   Unreloader.record_dependency(__FILE__, "cli-commands")
   if force_autoload
     Unreloader.require("cli-commands") {}

--- a/lib/ubi_cli.rb
+++ b/lib/ubi_cli.rb
@@ -530,7 +530,6 @@ class UbiCli
   end
   # :nocov:
 
-  Unreloader.record_dependency("lib/rodish.rb", __FILE__)
   Unreloader.record_dependency(__FILE__, "cli-commands")
   if force_autoload
     Unreloader.require("cli-commands") {}

--- a/loader.rb
+++ b/loader.rb
@@ -177,6 +177,7 @@ if force_autoload
   end
 
   Clover.models_loaded
+  UbiCli.models_loaded
 end
 
 case Config.mail_driver

--- a/vendor/hidden_class.rb
+++ b/vendor/hidden_class.rb
@@ -1,0 +1,3 @@
+# :nocov:
+raise UbiCli::DirectModelAccess, "Attempt to access a hidden class in UbiCli"
+# :nocov:


### PR DESCRIPTION
UbiCli code should not be accessing models or the database directly, as all access should go through the API. This will prevent problems in the future if a developer who isn't knolwedge about how the CLI should work tries to directly access the database or models in the CLI layer.

This looks like a large change from the +/-, but the actual changes are minor if you ignore whitespace changes. See commit messages for details.