### PR TITLE
Disallow SSH access from web process

### DIFF
--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -37,6 +37,9 @@ jobs:
     - name: Run each spec file in separate process
       run: bundle exec rake spec_separate
 
+    - name: Run route specs checking no SSH access from web process
+      run: bundle exec rake route_spec
+
     - name: Send notification if failed
       if: ${{ failure() && github.ref_name == 'main' }}
       uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3

--- a/Rakefile
+++ b/Rakefile
@@ -199,6 +199,11 @@ task "api_spec" do
   sh({"RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1"}, "bundle", "exec", "turbo_tests", "-n", nproc.call, "spec/routes/api")
 end
 
+desc "Run route specs checking no SSH access from web process"
+task "route_spec" do
+  sh({"RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1", "PROCESS_TYPE" => "web"}, "bundle", "exec", "turbo_tests", "-n", nproc.call, "spec/routes")
+end
+
 desc "Run rhizome (data plane) tests"
 task "rhizome_spec" do
   sh "COVERAGE=rhizome bundle exec rspec -O /dev/null rhizome"

--- a/clover.rb
+++ b/clover.rb
@@ -890,6 +890,32 @@ class Clover < Roda
 
   # :nocov:
   if Config.test?
+    hash_branch(:webhook_prefix, "test-ssh-access") do |r|
+      response = +""
+
+      response << (defined?(Net::SSH::Connection) ? "defined-" : "undefined-")
+
+      sshable = Sshable.new(host: "127.1.2.3")
+
+      begin
+        sshable.start_fresh_session
+      rescue NameError => e
+        response << e.message << "-"
+      else
+        raise
+      end
+
+      begin
+        sshable.cmd("true")
+      rescue RuntimeError => e
+        response << e.message
+      else
+        raise
+      end
+
+      response
+    end
+
     # :nocov:
     hash_branch(:webhook_prefix, "test-error") do |r|
       raise(typecast_params.str("message") || "test error")

--- a/lib/net_ssh.rb
+++ b/lib/net_ssh.rb
@@ -139,13 +139,24 @@ module NetSsh
           super(WarnUnsafe.convert(command, self.class, __callee__, **kw), **pass_kw)
         end
       end
-      # :nocov:
 
-      ::Net::SSH::Connection::Session.prepend self
+      if ENV["PROCESS_TYPE"] == "web"
+        ::Net::SSH.send(:remove_const, :Connection)
+        ::Net::SSH.singleton_class.send(:undef_method, :start)
+      # :nocov:
+      else
+        ::Net::SSH::Connection::Session.prepend self
+      end
     end
 
     module Sshable
-      if Config.test?
+      # :nocov:
+      if ENV["PROCESS_TYPE"] == "web"
+        def cmd(cmd, _skip_command_checking: false, **kw)
+          raise "Sshable#cmd is not allowed from the web process"
+        end
+      # :nocov:
+      elsif Config.test?
         def _cmd(command, stdin: nil, log: true, timeout: :default)
           raise MissingMock, "Sshable#_cmd not mocked. You must add a spec that checks for the expected command. Command: #{command.inspect}"
         end

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -100,6 +100,13 @@ RSpec.describe Clover do
     expect { visit "/webhook/test-error?message=treat+as+unexpected+error" }.to raise_error(RuntimeError, "treat as unexpected error")
   end
 
+  if ENV["PROCESS_TYPE"] == "web"
+    it "disallows SSH access from web process" do
+      visit "/webhook/test-ssh-access"
+      expect(page.body).to eq "undefined-undefined method 'start' for module Net::SSH-Sshable#cmd is not allowed from the web process"
+    end
+  end
+
   it "does not have broken links" do
     create_account
     login


### PR DESCRIPTION
When loading net_ssh, if PROCESS_TYPE is web, remove the Net::SSH::Connection constant and undef the Net::SSH.start method, breaking SSH access.

There shouldn't be any SSH access from the web process, so this shouldn't break things. Add a test-only route and a spec checking for this. The spec needs to be run with PROCESS_TYPE=web, so add a separate rake task for it, and add that rake task to the daily CI.