### PR TITLE
wal_keep_size = 96MB

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -52,6 +52,7 @@ class PostgresServer < Sequel::Model
       "max_parallel_maintenance_workers" => "2",
       "min_wal_size" => "80MB",
       "max_wal_size" => "5GB",
+      "wal_keep_size" => "96MB",
       "wal_compression" => "lz4",
       "default_toast_compression" => "lz4",
       "random_page_cost" => "1.1",

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show-default-config.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show-default-config.txt
@@ -39,4 +39,5 @@ tcp_keepalives_idle=2
 tcp_keepalives_interval=2
 timezone='UTC'
 wal_compression=lz4
+wal_keep_size=96MB
 work_mem=1MB


### PR DESCRIPTION
system uses an 80MB "caught up enough" indicator,
set wal_keep_size to 96MB to try play well with that

this is especially useful in 2 standby HA setups where oldest standby may need to pull from new primary,
& wal hole would prevent catching up with s3

may've prevented #5526