### PR TITLE
don't trigger unplanned failover while postgres restarting

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -626,7 +626,7 @@ SQL
     end
 
     when_checkup_set? do
-      unless available?
+      unless restart_set? || available?
         register_deadline("wait", 5 * 60)
         hop_unavailable
       end
@@ -644,9 +644,8 @@ SQL
       if daemonized_restart
         decr_restart
         unregister_deadline("complete_restart")
-      else
-        nap 1
       end
+      nap 1
     end
 
     when_configure_metrics_set? do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1242,6 +1242,16 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.wait }.to nap(6 * 60 * 60)
     end
 
+    it "skips failover while restarting even if checkup is set and unavailable" do
+      nx.incr_checkup
+      nx.incr_restart
+      expect(nx).not_to receive(:available?)
+      expect(nx).to receive(:register_deadline).with("complete_restart", 2 * 60)
+      expect(nx).to receive(:daemonized_restart).and_return(false)
+      expect { nx.wait }.to nap(1)
+      expect(postgres_server.reload.checkup_set?).to be false
+    end
+
     it "hops to configure_metrics if configure_metrics is set" do
       nx.incr_configure_metrics
       expect(nx).to receive(:register_deadline).with("wait", 3 * 60)
@@ -1285,7 +1295,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx).to receive(:register_deadline).with("complete_restart", 2 * 60)
       expect(nx).to receive(:daemonized_restart).and_return(true)
       expect(nx).to receive(:unregister_deadline).with("complete_restart")
-      expect { nx.wait }.to nap(6 * 60 * 60)
+      expect { nx.wait }.to nap(1)
       expect(Semaphore.where(strand_id: postgres_server.id, name: "restart").count).to eq(0)
     end
 


### PR DESCRIPTION
there's already a 2m deadline to page if restart stuck

fixes #5525