### PR TITLE
page when standby stuck in wait_synchronization

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -563,6 +563,8 @@ SQL
   end
 
   label def wait_synchronization
+    register_deadline("wait", 5 * 60)
+
     query = DB["SELECT sync_state FROM pg_stat_replication WHERE application_name = :ubid", ubid: postgres_server.ubid]
     sync_state = resource.representative_server.run_query(query).chomp
     hop_wait if ["quorum", "sync"].include?(sync_state)

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1147,12 +1147,14 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "hops to wait if sync replication is established" do
+      expect(standby_nx).to receive(:register_deadline).with("wait", 5 * 60).twice
       expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("quorum", "sync")
       expect { standby_nx.wait_synchronization }.to hop("wait")
       expect { standby_nx.wait_synchronization }.to hop("wait")
     end
 
-    it "naps if sync replication is not established" do
+    it "naps and registers a deadline while sync replication is not established" do
+      expect(standby_nx).to receive(:register_deadline).with("wait", 5 * 60).twice
       expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("", "async")
       expect { standby_nx.wait_synchronization }.to nap(30)
       expect { standby_nx.wait_synchronization }.to nap(30)


### PR DESCRIPTION
A standby that diverges after an unplanned failover can enter wait_synchronization with a wal hole, leaving resource silently below its target healthy server count with no alert

wait_catch_up's caught-up branch hops here without registering a deadline when lsn_caught_up is true on first entry, which is exactly the diverged case (LSN sits within the 80MB caught-up window while replication can't establish)

ConvergePostgresResource did not alert either. Its progress deadline extends on the sum of disk/LSN across all waiting servers, so healthy peer's advancing LSN keeps pushing the deadline out and masks the stuck server indefinitely

fixes #5527