### PR TITLE
Add machine image select to the VM create form (option A)

### DIFF
--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -39,11 +39,24 @@ class Clover
     end
 
     assemble_params = typecast_params.convert!(symbolize: true) do |tp|
-      tp.nonempty_str(["size", "unix_user", "boot_image", "private_subnet_id", "gpu", "init_script"])
+      tp.nonempty_str(["size", "unix_user", "boot_image", "private_subnet_id", "gpu", "init_script", "machine_image"])
       tp.pos_int("storage_size")
       tp.bool("enable_ip4")
     end
     assemble_params.compact!
+
+    # The web form's machine-image select submits as `machine_image`; map
+    # it onto the boot_image used downstream. The API doesn't accept this
+    # field (it's not in the OpenAPI schema); API users pass boot_image
+    # directly using the "name@version" format.
+    #
+    # The form pre-checks the first boot_image radio on page load and the
+    # mutual-exclusion JS clears it when a machine image is picked. With JS
+    # disabled both fields submit, and we treat the machine_image as the
+    # more specific user intent.
+    if (mi = assemble_params.delete(:machine_image))
+      assemble_params[:boot_image] = mi
+    end
 
     # Generally parameter validation is handled in progs while creating resources.
     # Since Vm::Nexus both handles VM creation requests from user and also Postgres
@@ -213,11 +226,40 @@ class Clover
     boot_images = Option::BootImages.map(&:name)
     boot_images.reject! { |name| name == "gpu-ubuntu-noble" } unless @show_gpu != false
     options.add_option(name: "boot_image", values: boot_images)
+
+    machine_image_options = project_machine_image_options
+    if machine_image_options.any?
+      options.add_option(name: "machine_image", values: machine_image_options, parent: "location") do |location, mi|
+        mi[:location_id] == location.id
+      end
+    end
+
     options.add_option(name: "unix_user")
     options.add_option(name: "ssh_public_key", values: @project.ssh_public_keys)
     options.add_option(name: "public_key")
     options.add_option(name: "init_script")
 
     options.serialize
+  end
+
+  # Project's machine images with a published latest version, tagged with
+  # their location_id so the form can scope them to the selected location.
+  # Returns [] when the machine image feature is disabled or the project
+  # has no usable images, in which case generate_vm_options skips adding
+  # the option entirely.
+  def project_machine_image_options
+    return [] unless @project.get_ff_machine_image
+
+    dataset_authorize(@project.machine_images_dataset, "MachineImage:view")
+      .exclude(latest_version_id: nil)
+      .eager(:latest_version)
+      .all
+      .map do |mi|
+        {
+          location_id: mi.location_id,
+          value: "#{mi.name}@latest",
+          display_name: "#{mi.name} (#{mi.latest_version.version})",
+        }
+      end
   end
 end

--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -69,6 +69,10 @@ module ContentGenerator
     def self.boot_image(boot_image)
       Option::BootImages.find { it.name == boot_image }.display_name
     end
+
+    def self.machine_image(_location, machine_image)
+      machine_image[:display_name]
+    end
   end
 
   module Postgres

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -216,6 +216,59 @@ RSpec.describe Clover, "vm" do
         expect(Vm.first.public_key).to eq "a a"
       end
 
+      def publish_machine_image(name: "my-image", version: "v1")
+        mivm = create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name:, version:)
+        miv = mivm.machine_image_version
+        miv.machine_image.update(latest_version_id: miv.id)
+        miv
+      end
+
+      it "hides the Machine Image select when the project has no machine images" do
+        project.set_ff_machine_image(true)
+        visit "#{project.path}/vm/create"
+        expect(page).to have_no_select "machine_image"
+      end
+
+      it "hides the Machine Image select when ff_machine_image is disabled" do
+        publish_machine_image
+        visit "#{project.path}/vm/create"
+        expect(page).to have_no_select "machine_image"
+      end
+
+      it "hides machine images without a published latest version" do
+        project.set_ff_machine_image(true)
+        create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "unpublished", version: "v1")
+        visit "#{project.path}/vm/create"
+        expect(page).to have_no_select "machine_image"
+      end
+
+      it "hides machine images the user lacks MachineImage:view permission for" do
+        project.set_ff_machine_image(true)
+        publish_machine_image
+        AccessControlEntry.dataset.destroy
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Vm:create"])
+        AccessControlEntry.create(project_id: project.id, subject_id: user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:view"])
+        visit "#{project.path}/vm/create"
+        expect(page).to have_no_select "machine_image"
+      end
+
+      it "can create a vm from a machine image selected on the form" do
+        project.set_ff_machine_image(true)
+        publish_machine_image
+        visit "#{project.path}/vm/create"
+        fill_in "Name", with: "dummy-vm"
+        fill_in "SSH Public Key", with: "a a"
+        choose option: Location::HETZNER_FSN1_UBID
+        choose option: "standard-2"
+        select "my-image (v1)", from: "machine_image"
+
+        click_button "Create"
+
+        expect(page).to have_flash_notice("'dummy-vm' will be ready in a few minutes")
+        expect(Vm.count).to eq(1)
+        expect(Vm.first.boot_image).to eq("my-image@latest")
+      end
+
       it "can create new virtual machine using init script" do
         visit "#{project.path}/vm/create"
 

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -49,7 +49,17 @@ current_usage = @project.current_resource_usage("VmVCpu")
   form_elements.concat(elements)
 
   form_elements.push(
-    {name: "boot_image", type: "radio_small_cards", label: "Boot Image", required: "required", content_generator: ContentGenerator::Vm.method(:boot_image)},
+    {name: "boot_image", type: "radio_small_cards", label: "Boot Image", required: "required", content_generator: ContentGenerator::Vm.method(:boot_image)}
+  )
+
+  if @option_parents.key?("machine_image")
+    form_elements.push(
+      {name: "machine_image", type: "select", label: "Machine Image", placeholder: "(none — use a base image above)",
+       content_generator: ContentGenerator::Vm.method(:machine_image), opening_tag: "<div class='sm:col-span-3' id='machine-image-wrapper'>"}
+    )
+  end
+
+  form_elements.push(
     {name: "unix_user", type: "text", label: "Username", placeholder: "ubi", value: "ubi", required: "required", opening_tag: "<div class='sm:col-span-2'>"}
   )
 
@@ -77,3 +87,44 @@ current_usage = @project.current_resource_usage("VmVCpu")
 %>
 
 <%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>
+
+<% if @option_parents.key?("machine_image")
+  nonce = SecureRandom.hex(32)
+  content_security_policy.add_script_src [:nonce, nonce] %>
+<script nonce="<%= nonce %>">
+(function () {
+  const form = document.getElementById('creation-form');
+  if (!form) return;
+  const mi = form.querySelector('select[name="machine_image"]');
+  const bootRadios = form.querySelectorAll('input[name="boot_image"]');
+  const locationRadios = form.querySelectorAll('input[name="location"]');
+  if (!mi || bootRadios.length === 0) return;
+
+  function syncBootRequired() {
+    const required = !mi.value;
+    bootRadios.forEach(r => required ? r.setAttribute('required', 'required') : r.removeAttribute('required'));
+  }
+
+  mi.addEventListener('change', () => {
+    if (mi.value) {
+      bootRadios.forEach(r => { r.checked = false; });
+    }
+    syncBootRequired();
+  });
+
+  bootRadios.forEach(r => r.addEventListener('change', () => {
+    if (r.checked) {
+      mi.value = '';
+      syncBootRequired();
+    }
+  }));
+
+  // The shared redrawChildOptions in app.js resets the machine_image select
+  // when the location changes (programmatically, without firing 'change'),
+  // so re-evaluate boot_image's required state after that runs.
+  locationRadios.forEach(r => r.addEventListener('change', syncBootRequired));
+
+  syncBootRequired();
+})();
+</script>
+<% end %>


### PR DESCRIPTION
When the project has any machine images with a published latest version, the VM create form shows a Machine Image select below the base Boot Image radio cards, scoped to the selected location. Picking a machine image clears the Boot Image radio and vice versa; on submit the chosen machine image is passed as boot_image using the existing name@latest format.