### PR TITLE
Let users boot a VM from a machine image

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -46,6 +46,14 @@
   &:has(select#ssh_public_key option[value^=sk]:checked) #public-key-wrapper {
     display: none;
   }
+
+  #machine-image-block {
+    display: none;
+  }
+
+  &:has(input[name=boot_image][value=__machine_image]:checked) #machine-image-block {
+    display: block;
+  }
 }
 
 #firewall-rule-form {

--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -45,6 +45,15 @@ class Clover
     end
     assemble_params.compact!
 
+    # Web-only: translate the MI sentinel into "<name>@latest". API/CLI
+    # callers pass boot_image="name@version" directly; if they pass the
+    # sentinel, it falls through to validate_boot_image as an invalid name.
+    if web? && assemble_params[:boot_image] == "__machine_image"
+      machine_image = typecast_params.nonempty_str("machine_image")
+      fail Validation::ValidationFailed.new({machine_image: "Pick a machine image"}) unless machine_image
+      assemble_params[:boot_image] = "#{machine_image}@latest"
+    end
+
     # Generally parameter validation is handled in progs while creating resources.
     # Since Vm::Nexus both handles VM creation requests from user and also Postgres
     # service, moved the boot_image validation here to not allow users to pass
@@ -212,7 +221,22 @@ class Clover
 
     boot_images = Option::BootImages.map(&:name)
     boot_images.reject! { |name| name == "gpu-ubuntu-noble" } unless @show_gpu != false
+
+    # VM create is currently x64-only, so only surface x64 MIs.
+    machine_image_options = dataset_authorize(@project.machine_images_dataset, "MachineImage:view")
+      .exclude(latest_version_id: nil)
+      .where(arch: "x64")
+      .map { |mi| {location_id: mi.location_id, value: mi.name, display_name: "#{mi.name}@latest"} }
+
+    boot_images << "__machine_image" if machine_image_options.any?
     options.add_option(name: "boot_image", values: boot_images)
+
+    if machine_image_options.any?
+      options.add_option(name: "machine_image", values: machine_image_options, parent: "location") do |location, mi|
+        mi[:location_id] == location.id
+      end
+    end
+
     options.add_option(name: "unix_user")
     options.add_option(name: "ssh_public_key", values: @project.ssh_public_keys)
     options.add_option(name: "public_key")

--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -54,6 +54,18 @@ class Clover
       assemble_params[:boot_image] = "#{machine_image}@latest"
     end
 
+    # Any boot_image containing "@" refers to a machine image. Verify the
+    # user can view a matching MI in @location. Version validity is checked
+    # downstream by Vm::Nexus.assemble; we only need the auth check here.
+    # Covers both web (sentinel-translated) and api/cli (direct) submissions.
+    if assemble_params[:boot_image]&.include?("@")
+      mi_name = assemble_params[:boot_image].split("@", 2).first
+      unless dataset_authorize(@project.machine_images_dataset, "MachineImage:view").first(location_id: @location.id, name: mi_name, arch: "x64")
+        key = web? ? :machine_image : :boot_image
+        fail Validation::ValidationFailed.new({key => "Selected machine image is not available"})
+      end
+    end
+
     # Generally parameter validation is handled in progs while creating resources.
     # Since Vm::Nexus both handles VM creation requests from user and also Postgres
     # service, moved the boot_image validation here to not allow users to pass

--- a/helpers/vm.rb
+++ b/helpers/vm.rb
@@ -229,7 +229,9 @@ class Clover
       .map { |mi| {location_id: mi.location_id, value: mi.name, display_name: "#{mi.name}@latest"} }
 
     boot_images << "__machine_image" if machine_image_options.any?
-    options.add_option(name: "boot_image", values: boot_images)
+    options.add_option(name: "boot_image", values: boot_images, parent: "location") do |location, bi|
+      bi != "__machine_image" || machine_image_options.any? { |mi| mi[:location_id] == location.id }
+    end
 
     if machine_image_options.any?
       options.add_option(name: "machine_image", values: machine_image_options, parent: "location") do |location, mi|

--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -67,7 +67,12 @@ module ContentGenerator
     end
 
     def self.boot_image(boot_image)
+      return "Machine Image" if boot_image == "__machine_image"
       Option::BootImages.find { it.name == boot_image }.display_name
+    end
+
+    def self.machine_image(_location, machine_image)
+      machine_image[:display_name]
     end
   end
 

--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -66,7 +66,7 @@ module ContentGenerator
       ]
     end
 
-    def self.boot_image(boot_image)
+    def self.boot_image(_location, boot_image)
       return "Machine Image" if boot_image == "__machine_image"
       Option::BootImages.find { it.name == boot_image }.display_name
     end

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -84,6 +84,30 @@ RSpec.describe Clover, "vm" do
         expect(Vm.first.ip4_enabled).to be false
       end
 
+      it "rejects the web-only machine_image field" do
+        expect {
+          post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+            public_key: "ssh key",
+            unix_user: "ubi",
+            size: "standard-2",
+            machine_image: "my-image@latest",
+          }.to_json
+        }.to raise_error(Committee::InvalidRequest, /schema does not define properties: machine_image/)
+      end
+
+      it "rejects the web MI sentinel as an invalid boot image name" do
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+          public_key: "ssh key",
+          unix_user: "ubi",
+          size: "standard-2",
+          boot_image: "__machine_image",
+        }.to_json
+
+        expect(last_response.status).to eq(400)
+        expect(JSON.parse(last_response.body).dig("error", "details", "boot_image")).to match(/not a valid boot image name/)
+        expect(Vm.count).to eq(0)
+      end
+
       it "success with private subnet" do
         ps_id = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dummy-ps-1", location_id: Location[display_name: TEST_LOCATION].id).ubid
 

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -95,6 +95,30 @@ RSpec.describe Clover, "vm" do
         }.to raise_error(Committee::InvalidRequest, /schema does not define properties: machine_image/)
       end
 
+      it "rejects boot_image referencing an MI the user cannot view" do
+        miv = create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "my-image", version: "v1").machine_image_version
+        miv.machine_image.update(latest_version_id: miv.id)
+
+        other_user = create_account("other_user@example.com")
+        other_user.add_project(project)
+        other_pat = ApiKey.create_personal_access_token(other_user, project:)
+        header "Authorization", "Bearer pat-#{other_pat.ubid}-#{other_pat.key}"
+        [other_user.id, other_pat.id].each do |sid|
+          AccessControlEntry.create(project_id: project.id, subject_id: sid, action_id: ActionType::NAME_MAP["Vm:create"])
+          AccessControlEntry.create(project_id: project.id, subject_id: sid, action_id: ActionType::NAME_MAP["PrivateSubnet:view"])
+        end
+
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
+          public_key: "ssh key",
+          unix_user: "ubi",
+          size: "standard-2",
+          boot_image: "my-image@latest",
+        }.to_json
+
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: boot_image", {"boot_image" => "Selected machine image is not available"})
+        expect(Vm.count).to eq(0)
+      end
+
       it "rejects the web MI sentinel as an invalid boot image name" do
         post "/project/#{project.ubid}/location/#{TEST_LOCATION}/vm/test-vm", {
           public_key: "ssh key",

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -265,6 +265,36 @@ RSpec.describe Clover, "vm" do
           expect(page).to have_no_field("boot_image", with: "__machine_image", disabled: :all)
         end
 
+        it "rejects a submission naming an MI the user cannot view" do
+          other_user = create_account("other_user@example.com", with_project: false)
+          other_user.add_project(project)
+          click_button "Log out"
+
+          AccessControlEntry.create(project_id: project.id, subject_id: other_user.id, action_id: ActionType::NAME_MAP["Vm:create"])
+          AccessControlEntry.create(project_id: project.id, subject_id: other_user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:view"])
+
+          # When opening the create VM page, the user has MachineImage:view
+          # permissions so the MI card is visible.
+          mi_view_ace = AccessControlEntry.create(project_id: project.id, subject_id: other_user.id, action_id: ActionType::NAME_MAP["MachineImage:view"])
+
+          login(other_user.email)
+          visit "#{project.path}/vm/create"
+
+          fill_in "Name", with: "dummy-vm"
+          fill_in "SSH Public Key", with: "a a"
+          choose option: Location::HETZNER_FSN1_UBID
+          choose option: "__machine_image"
+          select "my-image@latest", from: "machine_image"
+          choose option: "standard-2"
+
+          # Revoke MachineImage:view before submitting the form.
+          mi_view_ace.destroy
+
+          click_button "Create"
+          expect(page).to have_flash_error("Validation failed for following fields: machine_image")
+          expect(Vm.count).to eq(0)
+        end
+
         it "creates a vm from the picked machine image" do
           visit "#{project.path}/vm/create"
           fill_in "Name", with: "dummy-vm"

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -216,6 +216,92 @@ RSpec.describe Clover, "vm" do
         expect(Vm.first.public_key).to eq "a a"
       end
 
+      it "does not show the Machine Image card when no MI has a published latest version" do
+        create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "unpublished", version: "v1")
+        visit "#{project.path}/vm/create"
+        expect(page).to have_no_field("boot_image", with: "__machine_image", disabled: :all)
+        expect(page).to have_no_select("machine_image")
+      end
+
+      describe "with a published machine image" do
+        let(:miv) do
+          v = create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "my-image", version: "v1").machine_image_version
+          v.machine_image.update(latest_version_id: v.id)
+          v
+        end
+
+        before do
+          miv
+        end
+
+        it "shows the Machine Image boot card and machine_image select" do
+          visit "#{project.path}/vm/create"
+          expect(page).to have_field("boot_image", with: "__machine_image", count: 1, disabled: false)
+          expect(page).to have_select("machine_image", with_options: ["my-image@latest"])
+        end
+
+        it "excludes other machine images without a latest version" do
+          create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, machine_image_store_id: miv.metal.store_id, name: "unpublished", version: "v1")
+          visit "#{project.path}/vm/create"
+          expect(page).to have_select("machine_image", with_options: ["my-image@latest"])
+          expect(page).to have_no_select("machine_image", with_options: ["unpublished@latest"])
+        end
+
+        it "is hidden when the user lacks MachineImage:view permission" do
+          other_user = create_account("other_user@example.com", with_project: false)
+          other_user.add_project(project)
+          AccessControlEntry.create(project_id: project.id, subject_id: other_user.id, action_id: ActionType::NAME_MAP["Vm:create"])
+          AccessControlEntry.create(project_id: project.id, subject_id: other_user.id, action_id: ActionType::NAME_MAP["PrivateSubnet:view"])
+          click_button "Log out"
+          login(other_user.email)
+
+          visit "#{project.path}/vm/create"
+          expect(page).to have_no_field("boot_image", with: "__machine_image", disabled: :all)
+        end
+
+        it "creates a vm from the picked machine image" do
+          visit "#{project.path}/vm/create"
+          fill_in "Name", with: "dummy-vm"
+          fill_in "SSH Public Key", with: "a a"
+          choose option: Location::HETZNER_FSN1_UBID
+          choose option: "__machine_image"
+          select "my-image@latest", from: "machine_image"
+          choose option: "standard-2"
+          click_button "Create"
+
+          expect(page).to have_flash_notice("'dummy-vm' will be ready in a few minutes")
+          expect(Vm.first.boot_image).to eq("my-image@latest")
+        end
+
+        it "ignores machine_image when a base boot image is picked" do
+          visit "#{project.path}/vm/create"
+          fill_in "Name", with: "dummy-vm"
+          fill_in "SSH Public Key", with: "a a"
+          choose option: Location::HETZNER_FSN1_UBID
+          choose option: "ubuntu-jammy"
+          select "my-image@latest", from: "machine_image"
+          choose option: "standard-2"
+          click_button "Create"
+
+          expect(page).to have_flash_notice("'dummy-vm' will be ready in a few minutes")
+          expect(Vm.first.boot_image).to eq("ubuntu-jammy")
+        end
+
+        it "rejects the Machine Image card without a machine_image selection" do
+          visit "#{project.path}/vm/create"
+          fill_in "Name", with: "dummy-vm"
+          fill_in "SSH Public Key", with: "a a"
+          choose option: Location::HETZNER_FSN1_UBID
+          choose option: "__machine_image"
+          choose option: "standard-2"
+          click_button "Create"
+
+          expect(page).to have_flash_error("Validation failed for following fields: machine_image")
+          expect(page).to have_content("Pick a machine image")
+          expect(Vm.count).to eq(0)
+        end
+      end
+
       it "can create new virtual machine using init script" do
         visit "#{project.path}/vm/create"
 

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -240,6 +240,12 @@ RSpec.describe Clover, "vm" do
           expect(page).to have_select("machine_image", with_options: ["my-image@latest"])
         end
 
+        it "scopes the Machine Image card to locations with a published MI" do
+          visit "#{project.path}/vm/create"
+          expect(page).to have_css("label.form_location_#{Location::HETZNER_FSN1_UBID} input[value=__machine_image]", visible: :all)
+          expect(page).to have_no_css("label.form_location_#{Location::HETZNER_HEL1_UBID} input[value=__machine_image]", visible: :all)
+        end
+
         it "excludes other machine images without a latest version" do
           create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, machine_image_store_id: miv.metal.store_id, name: "unpublished", version: "v1")
           visit "#{project.path}/vm/create"

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -49,8 +49,19 @@ current_usage = @project.current_resource_usage("VmVCpu")
   form_elements.concat(elements)
 
   form_elements.push(
-    {name: "boot_image", type: "radio_small_cards", label: "Boot Image", required: "required", content_generator: ContentGenerator::Vm.method(:boot_image)},
-    {name: "unix_user", type: "text", label: "Username", placeholder: "ubi", value: "ubi", required: "required", opening_tag: "<div class='sm:col-span-2'>"}
+    {name: "boot_image", type: "radio_small_cards", label: "Boot Image", required: "required", content_generator: ContentGenerator::Vm.method(:boot_image)}
+  )
+
+  if @option_parents.key?("machine_image")
+    form_elements.push(
+      {name: "machine_image", type: "select", label: "Machine Image", placeholder: "Select a machine image",
+       content_generator: ContentGenerator::Vm.method(:machine_image),
+       opening_tag: "<div id='machine-image-block' class='col-span-full sm:col-span-2'>"}
+    )
+  end
+
+  form_elements.push(
+    {name: "unix_user", type: "text", label: "Username", placeholder: "ubi", value: "ubi", required: "required", opening_tag: "<div class='sm:col-start-1 sm:col-span-2'>"}
   )
 
   public_key_params = {name: "public_key", type: "textarea", label: "SSH Public Key", placeholder: "ssh-ed25519 AAAA...", opening_tag: "<div id='public-key-wrapper' class='col-span-full'>"}


### PR DESCRIPTION
On the VM create form, projects with published machine images now see a "Machine Image" card in the Boot Image picker. Picking it reveals a dropdown listing the project's machine images for the chosen location. Each option uses `<name>@latest` so the VM is booted from whichever version is current at create time, and the list only includes images that actually have a published version.

If the project has no machine images, the card and dropdown stay hidden and nothing about the existing flow changes.

A future change may add a separate select for picking a specific version, so users can pin a VM to an older version of an image instead of always following the latest.

When user has machine images a "Machine Image" option is added to "Boot Image"
 
<img width="895" height="465" alt="image" src="https://github.com/user-attachments/assets/2357928e-f97e-48b4-aace-90e4ea27fc4a" />

Clicking it adds a select with machine images available for the location

<img width="882" height="586" alt="image" src="https://github.com/user-attachments/assets/2890f214-c3cb-49cf-884f-23426e68749a" />

If user doesn't have any machine images, the Machine Image option isn't added.