### PR TITLE
Always encrypt UMI archives

### DIFF
--- a/rhizome/host/lib/storage_archive.rb
+++ b/rhizome/host/lib/storage_archive.rb
@@ -68,6 +68,7 @@ class StorageArchive
       "--target-config", "/dev/stdin",
       "--compression", "zstd",
       "--zstd-level", "3",
+      "--encrypt",
       "--stats", @stats_file,
     ]
     env = {"RUST_LOG" => "info"}

--- a/rhizome/host/spec/storage_archive_spec.rb
+++ b/rhizome/host/spec/storage_archive_spec.rb
@@ -125,6 +125,7 @@ allow_inline_plaintext_secrets = true
           "--target-config", "/dev/stdin",
           "--compression", "zstd",
           "--zstd-level", "3",
+          "--encrypt",
           "--stats", "/path/to/stats.json",
         ],
         kek_pipe: disk_kek_path,
@@ -148,6 +149,7 @@ allow_inline_plaintext_secrets = true
         "--target-config", "/dev/stdin",
         "--compression", "zstd",
         "--zstd-level", "3",
+        "--encrypt",
         "--stats", "/path/to/stats.json",
         stdin: built_config,
       )
@@ -173,6 +175,7 @@ allow_inline_plaintext_secrets = true
           "--target-config", "/dev/stdin",
           "--compression", "zstd",
           "--zstd-level", "3",
+          "--encrypt",
           "--stats", "/path/to/stats.json",
           stdin: instance_of(String),
         )


### PR DESCRIPTION
Previously we had missed to pass the `--encrypt` arg to ubiblk's `archive` command which produced unencrypted UMI archives. Since UMI archives can contain sensitive data, they should be encrypted.