### PR TITLE
Show boot image in VM overview

### DIFF
--- a/cli-commands/vm/post/show.rb
+++ b/cli-commands/vm/post/show.rb
@@ -4,7 +4,7 @@ class UbiCli
   on("vm").run_on("show") do
     desc "Show details for a virtual machine"
 
-    fields = %w[id name state location size unix-user storage-size-gib ip6 ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls].freeze.each(&:freeze)
+    fields = %w[id name state location size unix-user storage-size-gib boot-image ip6 ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls].freeze.each(&:freeze)
     firewall_fields = %w[id name description location path firewall-rules].freeze.each(&:freeze)
     firewall_rule_fields = %w[id cidr port-range protocol].freeze.each(&:freeze)
 

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -166,6 +166,10 @@ class Vm < Sequel::Model
     vm_size.name
   end
 
+  def display_boot_image
+    Option::BootImages.find { |bi| bi.name == boot_image }&.display_name || boot_image
+  end
+
   # Various names in linux, like interface names, are obliged to be
   # short, so truncate the ubid. This does introduce the spectre of
   # collisions.  When the time comes, we'll have to ensure it doesn't

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -3935,6 +3935,9 @@ components:
     Vm:
       type: object
       properties:
+        boot_image:
+          description: Boot image of the VM
+          type: string
         id:
           description: ID of the VM
           type: string
@@ -3975,6 +3978,7 @@ components:
           type: string
       additionalProperties: false
       required:
+        - boot_image
         - id
         - ip4
         - ip4_enabled

--- a/serializers/vm.rb
+++ b/serializers/vm.rb
@@ -10,6 +10,7 @@ class Serializers::Vm < Serializers::Base
       size: vm.display_size,
       unix_user: vm.unix_user,
       storage_size_gib: vm.storage_size_gib,
+      boot_image: vm.boot_image,
       ip6: vm.ip6,
       ip4_enabled: vm.ip4_enabled,
       ip4: vm.ip4,

--- a/spec/routes/api/cli/golden-files/help -r vm.txt
+++ b/spec/routes/api/cli/golden-files/help -r vm.txt
@@ -111,8 +111,8 @@ Options:
     -w, --firewall-fields=fields     show specific firewall fields (comma separated)
 
 Allowed Option Values:
-    Fields: id name state location size unix-user storage-size-gib ip6
-            ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls
+    Fields: id name state location size unix-user storage-size-gib boot-image
+            ip6 ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls
     Firewall Rule Fields: id cidr port-range protocol
     Firewall Fields: id name description location path firewall-rules
 

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -1382,8 +1382,8 @@ Options:
     -w, --firewall-fields=fields     show specific firewall fields (comma separated)
 
 Allowed Option Values:
-    Fields: id name state location size unix-user storage-size-gib ip6
-            ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls
+    Fields: id name state location size unix-user storage-size-gib boot-image
+            ip6 ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls
     Firewall Rule Fields: id cidr port-range protocol
     Firewall Fields: id name description location path firewall-rules
 

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f invalid.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show -f invalid.txt
@@ -11,7 +11,7 @@ Options:
     -w, --firewall-fields=fields     show specific firewall fields (comma separated)
 
 Allowed Option Values:
-    Fields: id name state location size unix-user storage-size-gib ip6
-            ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls
+    Fields: id name state location size unix-user storage-size-gib boot-image
+            ip6 ip4-enabled ip4 private-ipv4 private-ipv6 subnet firewalls
     Firewall Rule Fields: id cidr port-range protocol
     Firewall Fields: id name description location path firewall-rules

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_test-vm show.txt
@@ -5,6 +5,7 @@ location: eu-central-h1
 size: standard-2
 unix-user: ubi
 storage-size-gib: 40
+boot-image: ubuntu-noble
 ip6: 
 ip4-enabled: true
 ip4: 128.0.0.1

--- a/spec/routes/api/cli/golden-files/vm eu-central-h1_vmdzyppz6j166jh5e9t2dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm eu-central-h1_vmdzyppz6j166jh5e9t2dwrfas show.txt
@@ -5,6 +5,7 @@ location: eu-central-h1
 size: standard-2
 unix-user: ubi
 storage-size-gib: 40
+boot-image: ubuntu-noble
 ip6: 
 ip4-enabled: true
 ip4: 128.0.0.1

--- a/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfas show.txt
+++ b/spec/routes/api/cli/golden-files/vm vmdzyppz6j166jh5e9t2dwrfas show.txt
@@ -5,6 +5,7 @@ location: eu-central-h1
 size: standard-2
 unix-user: ubi
 storage-size-gib: 40
+boot-image: ubuntu-noble
 ip6: 
 ip4-enabled: true
 ip4: 128.0.0.1

--- a/spec/routes/api/cli/vm/show_spec.rb
+++ b/spec/routes/api/cli/vm/show_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Clover, "cli vm show" do
       size: standard-2
       unix-user: ubi
       storage-size-gib: 0
+      boot-image: ubuntu-jammy
       ip6: 128:1234::2
       ip4-enabled: false
       ip4: 128.0.0.1

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -835,6 +835,13 @@ RSpec.describe Clover, "vm" do
 
         expect(page.title).to eq("Ubicloud - #{vm.name}")
         expect(page).to have_content vm.name
+        expect(page).to have_content "Ubuntu Noble 24.04 LTS"
+      end
+
+      it "shows the raw boot image reference when the boot image is a machine image" do
+        vm.update(boot_image: "my-image@latest")
+        visit "#{project.path}#{vm.path}"
+        expect(page).to have_content "my-image@latest"
       end
 
       it "raises forbidden when does not have permissions" do

--- a/spec/serializers/vm_spec.rb
+++ b/spec/serializers/vm_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Serializers::Vm do
   let(:vm) {
     project = Project.create(name: "test-project")
     vm_host = create_vm_host(location_id: Location::HETZNER_FSN1_ID)
-    vm = Prog::Vm::Nexus.assemble("dummy-public key", project.id, name: "test-vm", location_id: Location::HETZNER_FSN1_ID, enable_ip4: true).subject
+    vm = Prog::Vm::Nexus.assemble("dummy-public key", project.id, name: "test-vm", location_id: Location::HETZNER_FSN1_ID, enable_ip4: true, boot_image: "ubuntu-noble").subject
     vm.update(display_state: "running", vm_host_id: vm_host.id)
     vm.vm_storage_volumes.first.update(size_gib: 100)
     add_ipv4_to_vm(vm, "192.168.1.0")
@@ -25,6 +25,7 @@ RSpec.describe Serializers::Vm do
       expected_result = {
         id: vm.ubid,
         name: "test-vm",
+        boot_image: "ubuntu-noble",
         state: "running",
         location: "eu-central-h1",
         size: "standard-2",
@@ -44,6 +45,7 @@ RSpec.describe Serializers::Vm do
       expected_result = {
         id: vm.ubid,
         name: "test-vm",
+        boot_image: "ubuntu-noble",
         state: "running",
         location: "eu-central-h1",
         size: "standard-2",

--- a/views/vm/overview.erb
+++ b/views/vm/overview.erb
@@ -7,7 +7,8 @@
       ["Name", @vm.name],
       ["Location", @vm.display_location],
       ["Size", @vm.display_size],
-      ["Storage", (@vm.storage_size_gib > 0) ? "#{@vm.storage_size_gib} GB" : nil]
+      ["Storage", (@vm.storage_size_gib > 0) ? "#{@vm.storage_size_gib} GB" : nil],
+      ["Boot Image", @vm.display_boot_image]
     ]
   if (gpu = @vm.display_gpu)
     data << ["GPU", gpu]


### PR DESCRIPTION
### Show boot image in VM overview 
With the addition of UMIs, VMs have more options to boot from, so showing the boot image in the VM overview is useful.

For base boot images, the image display name is shown. For machine images, the overview shows `name@version`, which is already stored in the VM's `boot_image` field during assembly. This matches the options users see when creating a VM in the UI.

### Surface boot_image through API and CLI `vm show`
The web details page already shows the boot image. This change keeps the CLI surface aligned with it.

When creating VMs using CLI, users specify boot images by name, such as `ubuntu-jammy`, rather than display names like `Ubuntu Jammy 22.04 LTS`. To stay consistent with that, the API and CLI expose the boot image's name instead of its display name.