### PR TITLE
Increase free runner credits from $1 to $2

### DIFF
--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -149,10 +149,9 @@ class InvoiceGenerator
           project_content[:cost] -= project_content[:credit]
         end
 
-        # Each project have $1 github runner credit every month
-        # 1$ github credit won't be shown on the portal billing page for now.
+        # Each project have 1250 minutes (2$) runner credit every month
         github_usage = project_content[:resources].flat_map { it[:line_items] }.select { it[:resource_type] == "GitHubRunnerMinutes" }.sum { it[:cost] }
-        github_credit = [1.0, github_usage, project_content[:cost]].min
+        github_credit = [2.0, github_usage, project_content[:cost]].min
         if github_credit > 0
           project_content[:github_credit] = github_credit
           project_content[:credit] += project_content[:github_credit]

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -347,8 +347,8 @@ RSpec.describe InvoiceGenerator do
 
     invoice = described_class.new(begin_time, end_time).run.first.content
 
-    expect(invoice["cost"]).to eq(invoice["subtotal"] - 1)
-    expect(invoice["credit"]).to eq(1)
+    expect(invoice["cost"]).to eq(invoice["subtotal"] - 2)
+    expect(invoice["credit"]).to eq(2)
     expect(p1.reload.credit).to eq(0)
   end
 
@@ -361,10 +361,10 @@ RSpec.describe InvoiceGenerator do
     p1.update(credit: 10, discount: 10)
     after = described_class.new(begin_time, end_time, save_result: true, eur_rate: 1.1).run.first.content
 
-    expect(before["cost"]).to eq(before["subtotal"].round(3) - 1)
-    expect(after["cost"]).to eq((before["subtotal"] * 0.9 - 11).round(3))
+    expect(before["cost"]).to eq(before["subtotal"].round(3) - 2)
+    expect(after["cost"]).to eq((before["subtotal"] * 0.9 - 12).round(3))
     expect(after["discount"]).to eq((before["subtotal"] * 0.1).round(3))
-    expect(after["credit"]).to eq(11)
+    expect(after["credit"]).to eq(12)
     expect(p1.reload.credit).to eq(0)
   end
 


### PR DESCRIPTION
We give 1,250 free runner minutes monthly to all our customers. This was equivalent to $1 with standard runners. Since we've made premium runners the default, we've decided to increase the free runner credits to $2.