### PR TITLE
Do not emit an admin route exception for CloverError

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -134,10 +134,10 @@ class CloverAdmin < Roda
 
     raise e if Config.test? && !ENV["DONT_RAISE_ADMIN_ERRORS"]
 
-    Clog.emit("admin route exception", Util.exception_to_hash(e))
     @page_title = if e.is_a?(CloverError)
       "#{e.type}: #{e.message}"
     else
+      Clog.emit("admin route exception", Util.exception_to_hash(e))
       "Internal Server Error"
     end
     view(content: "")


### PR DESCRIPTION
These errors are not unexpected exceptions, they are expected centralized error handling, so we shouldn't emit a log for them.