### PR TITLE
Postgres disk-full: pg_log_throttle on disk pressure

### DIFF
--- a/rhizome/postgres/bin/disk-full-check
+++ b/rhizome/postgres/bin/disk-full-check
@@ -28,13 +28,46 @@ else # all larger sizes
   human_buffer_size=1G
 fi
 
+# pg_log_throttle: force minimize verbosity of Postgres logs under severe 
+# disk pressure (restart_threshold), by linking file with low verbosity configs.
+PG_LOG_THROTTLE_SRC="${PG_LOG_THROTTLE_SRC:-/etc/postgresql-common/pg-logs-throttle}"
+CONF_D="${CONF_D:-/etc/postgresql/$1/main/conf.d}"
+PG_LOG_THROTTLE_CONF="991-pg-logs-throttle.conf"
+
+# Skip the enable/disable path if the file is not installed (older instances)
+pg_log_throttle_supported=0
+if test -f "$PG_LOG_THROTTLE_SRC/$PG_LOG_THROTTLE_CONF" && test -d "$CONF_D"; then
+  pg_log_throttle_supported=1
+fi
+
+enable_pg_log_throttle() {
+  if test -e "$CONF_D/$PG_LOG_THROTTLE_CONF"; then
+    return 1
+  fi
+  ln -sf "$PG_LOG_THROTTLE_SRC/$PG_LOG_THROTTLE_CONF" "$CONF_D/$PG_LOG_THROTTLE_CONF"
+}
+
+disable_pg_log_throttle() {
+  if ! test -e "$CONF_D/$PG_LOG_THROTTLE_CONF"; then
+    return 1
+  fi
+  rm -f "$CONF_D/$PG_LOG_THROTTLE_CONF"
+}
+
+reload_needed=0
+
 if test "$bavailable" -gt "$recover_threshold"; then
   if grep -q "default_transaction_read_only = 'on'" "$PGDATA/postgresql.auto.conf"; then
     sed -i "/default_transaction_read_only = 'on'/d" "$PGDATA/postgresql.auto.conf"
     test -f "$DAT/disk-full-read-only-pending-restart-$1" && rm -f "$DAT/disk-full-read-only-pending-restart-$1"
-    pg_ctlcluster "$1" main reload
+    reload_needed=1
   elif ! test -f "$DAT/disk-full-human-buffer"; then
     fallocate -l "$human_buffer_size" "$DAT/disk-full-human-buffer"
+  fi
+  if test "$pg_log_throttle_supported" = 1; then
+    if disable_pg_log_throttle; then
+      reload_needed=1
+    fi
   fi
 elif test "$bavailable" -lt "$readonly_threshold"; then
   if ! grep -q "default_transaction_read_only = 'on'" "$PGDATA/postgresql.auto.conf"; then
@@ -43,7 +76,7 @@ elif test "$bavailable" -lt "$readonly_threshold"; then
     fi
     echo "default_transaction_read_only = 'on'" >> "$PGDATA/postgresql.auto.conf"
     touch "$DAT/disk-full-read-only-pending-restart-$1"
-    pg_ctlcluster "$1" main reload
+    reload_needed=1
   elif test "$bavailable" -lt "$restart_threshold" && test -f "$DAT/disk-full-read-only-pending-restart-$1"; then
     # Terminate customer backends so new connections pick up the read-only
     # default applied by the earlier `reload`. We cannot `pg_ctlcluster restart`
@@ -53,5 +86,14 @@ elif test "$bavailable" -lt "$readonly_threshold"; then
     # so metrics scraping continues.
     psql -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE usename NOT IN ('ubi_replication', 'ubi_monitoring') AND pid <> pg_backend_pid();" >/dev/null
     rm -f "$DAT/disk-full-read-only-pending-restart-$1"
+    if test "$pg_log_throttle_supported" = 1; then
+      if enable_pg_log_throttle; then
+        reload_needed=1
+      fi
+    fi
   fi
+fi
+
+if test "$reload_needed" = 1; then
+  pg_ctlcluster "$1" main reload
 fi

--- a/rhizome/postgres/lib/pg-logs-throttle/991-pg-logs-throttle.conf
+++ b/rhizome/postgres/lib/pg-logs-throttle/991-pg-logs-throttle.conf
@@ -1,0 +1,18 @@
+# Overrides common log verbosity settings that can produce large log files under heavy load or frequent user errors.
+
+log_error_verbosity      = 'terse'
+log_statement            = 'none'
+log_min_duration_statement = -1
+log_duration             = off
+log_transaction_sample_rate = 0
+log_statement_sample_rate = 0
+debug_print_parse        = off
+debug_print_rewritten    = off
+debug_print_plan         = off
+debug_pretty_print       = off
+log_min_messages         = 'log'
+log_min_error_statement  = 'panic'
+log_connections          = off
+log_disconnections       = off
+log_lock_waits           = off
+log_temp_files           = -1

--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -84,6 +84,11 @@ class PostgresSetup
     # Install to path postgres can access
     r "install -m 0755 #{File.expand_path("../bin/disk-full-check", __dir__).shellescape} /usr/local/sbin/disk-full-check"
 
+    # Stage pg_log_throttle conf outside conf.d/ so PG does not load it
+    # until disk-full-check symlinks it in at the restart threshold.
+    r "install -d -m 0755 /etc/postgresql-common/pg-logs-throttle"
+    r "install -m 0644 #{File.expand_path("../lib/pg-logs-throttle/991-pg-logs-throttle.conf", __dir__).shellescape} /etc/postgresql-common/pg-logs-throttle/991-pg-logs-throttle.conf"
+
     safe_write_to_file("/etc/systemd/system/disk-full-check@.service", <<~DISKFULL)
       [Unit]
       Wants=disk-full-check@%i.timer

--- a/rhizome/postgres/spec/disk_full_check_spec.rb
+++ b/rhizome/postgres/spec/disk_full_check_spec.rb
@@ -12,10 +12,16 @@ RSpec.describe "disk-full-check" do
   let(:auto_conf) { File.join(dat, "16", "data", "postgresql.auto.conf") }
   let(:pending_restart) { File.join(dat, "disk-full-read-only-pending-restart-16") }
   let(:human_buffer) { File.join(dat, "disk-full-human-buffer") }
+  let(:pg_log_throttle_src) { File.join(tmpdir, "pg-logs-throttle") }
+  let(:conf_d) { File.join(tmpdir, "conf.d") }
+  let(:pg_log_throttle_conf) { File.join(conf_d, "991-pg-logs-throttle.conf") }
 
   before do
     FileUtils.mkdir_p(File.join(dat, "16", "data"))
     FileUtils.mkdir_p(bin)
+    FileUtils.mkdir_p(pg_log_throttle_src)
+    FileUtils.mkdir_p(conf_d)
+    File.write(File.join(pg_log_throttle_src, "991-pg-logs-throttle.conf"), "# pg_log_throttle\n")
     FileUtils.touch(File.join(dat, "pg_ctl_calls"))
     FileUtils.touch(File.join(dat, "psql_calls"))
 
@@ -65,7 +71,8 @@ RSpec.describe "disk-full-check" do
   end
 
   def run_check
-    stdout, stderr, status = Open3.capture3({"PATH" => "#{bin}:#{ENV["PATH"]}", "DAT" => dat}, "bash", script, "16")
+    env = {"PATH" => "#{bin}:#{ENV["PATH"]}", "DAT" => dat, "PG_LOG_THROTTLE_SRC" => pg_log_throttle_src, "CONF_D" => conf_d}
+    stdout, stderr, status = Open3.capture3(env, "bash", script, "16")
     raise "disk-full-check failed: #{stderr}" unless status.success?
     stdout
   end
@@ -147,7 +154,7 @@ RSpec.describe "disk-full-check" do
       File.write(auto_conf, "default_transaction_read_only = 'on'\n")
       FileUtils.touch(pending_restart)
       run_check
-      expect(pg_ctl_calls).to eq ""
+      expect(pg_ctl_calls).to eq "reload"  # pg_log_throttle enables, requires reload
       expect(psql_calls).to include("pg_terminate_backend")
       expect(psql_calls).to include("ubi_replication")
       expect(psql_calls).to include("ubi_monitoring")
@@ -159,6 +166,51 @@ RSpec.describe "disk-full-check" do
       run_check
       expect(pg_ctl_calls).to eq ""
       expect(psql_calls).to eq ""
+    end
+  end
+
+  describe "pg_log_throttle" do
+    it "does not enable pg_log_throttle on first tick at readonly threshold" do
+      fake_df(50, 4_000_000_000) # < 5GB readonly threshold
+      run_check
+      expect(File.symlink?(pg_log_throttle_conf)).to be false
+      expect(pg_ctl_calls).to eq "reload"
+    end
+
+    it "enables pg_log_throttle on the second tick when below restart threshold" do
+      fake_df(50, 2_000_000_000) # < 3GB restart threshold
+      File.write(auto_conf, "default_transaction_read_only = 'on'\n")
+      FileUtils.touch(pending_restart)
+      run_check
+      expect(File.symlink?(pg_log_throttle_conf)).to be true
+      expect(File.readlink(pg_log_throttle_conf)).to eq File.join(pg_log_throttle_src, "991-pg-logs-throttle.conf")
+      expect(pg_ctl_calls).to eq "reload"
+      expect(psql_calls).to include("pg_terminate_backend")
+    end
+
+    it "removes pg_log_throttle and reloads on recovery" do
+      fake_df(50, 53_687_091_200) # > 10GB recover threshold
+      File.write(auto_conf, "default_transaction_read_only = 'on'\n")
+      File.symlink(File.join(pg_log_throttle_src, "991-pg-logs-throttle.conf"), pg_log_throttle_conf)
+      run_check
+      expect(File.symlink?(pg_log_throttle_conf)).to be false
+      expect(pg_ctl_calls).to eq "reload"
+    end
+
+    it "is idempotent: re-running readonly does not change pg_log_throttle state" do
+      fake_df(50, 4_000_000_000)
+      run_check
+      File.write(File.join(dat, "pg_ctl_calls"), "") # clear
+      run_check
+      expect(pg_ctl_calls).to eq ""
+      expect(File.symlink?(pg_log_throttle_conf)).to be false
+    end
+
+    it "tolerates missing CONF_D (no crash, no symlink)" do
+      FileUtils.rm_rf(conf_d)
+      fake_df(50, 4_000_000_000)
+      run_check # would crash if intolerant
+      expect(File.exist?(conf_d)).to be false
     end
   end
 


### PR DESCRIPTION
Why: Under heaby load or frequent user error (including read-only transaction
write attempts), pg log becomes a source of disk full risk, not mitigated
by the current throttling

What: Low verbosity logs config template, symlinked into conf.d folder
under restart_threshold to force minimize the log size.
Link removed after recover_threshold reached.