### PR TITLE
Re-query live sibling AZs on AWS postgres VM retry

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -26,6 +26,18 @@ class PostgresServer < Sequel::Model
     VictoriaMetricsResource.client_for_project(Config.postgres_service_project_id)
   end
 
+  # Builds the full AZ exclusion list for placing this VM's NIC. Combines the
+  # caller's per-VM exclusions with live sibling AZs when the postgres resource
+  # has sibling-AZ spread enabled. Returns the simple merge for non-postgres VMs.
+  # Either list may be nil.
+  def self.excluded_azs(vm, unsupported_azs, exclude_availability_zones)
+    azs = (unsupported_azs || []) + (exclude_availability_zones || [])
+    if (ps = self[vm_id: vm.id]) && ps.resource.use_different_az_set?
+      azs += ps.resource.new_server_exclusion_filters.exclude_availability_zones
+    end
+    azs.compact.uniq
+  end
+
   def before_destroy
     super
     lsn_monitor_ds.delete

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -215,10 +215,13 @@ class Prog::Vm::Aws::Nexus < Prog::Base
 
   label def wait_old_nic_deleted
     nap 1 if nic&.reload
-    # Combine permanent (unsupported_azs) and transient (exclude_availability_zones)
-    # exclusions when creating the replacement NIC in a different AZ.
-    all_excluded_azs = ((frame["unsupported_azs"] || []) + (frame["exclude_availability_zones"] || [])).uniq
-    nic = Prog::Vnet::NicNexus.assemble(frame["private_subnet_id"], name: vm.name + "-nic", exclude_availability_zones: all_excluded_azs).subject
+    if (ps = PostgresServer[vm_id: vm.id]) && ps.resource.use_different_az_set?
+      # A nil sibling subnet_az means a sibling NIC strand hasn't reached
+      # create_subnet yet; wait for it to settle before placing.
+      nap 1 if ps.resource.new_server_exclusion_filters.exclude_availability_zones.include?(nil)
+    end
+    excluded = PostgresServer.excluded_azs(vm, frame["unsupported_azs"], frame["exclude_availability_zones"])
+    nic = Prog::Vnet::NicNexus.assemble(frame["private_subnet_id"], name: "#{vm.name}-nic", exclude_availability_zones: excluded).subject
     nic.update(vm_id: vm.id)
     hop_wait_nic_recreated
   end
@@ -440,24 +443,27 @@ class Prog::Vm::Aws::Nexus < Prog::Base
     end
 
     total_azs = nic.private_subnet.private_subnet_aws_resource.aws_subnets.count
-    all_tried = (unsupported_azs + exclude_availability_zones).uniq.size >= total_azs
+    all_tried = PostgresServer.excluded_azs(vm, unsupported_azs, exclude_availability_zones).size >= total_azs
 
-    if all_tried && try_postgres_family_fallback
-      update_stack({"unsupported_azs" => [], "exclude_availability_zones" => []})
-      nap 0
-    end
+    Clog.emit("retrying in different az", {retry_different_az: {vm:, error: e.class.name, message: e.message, last_az: current_az, last_az_failure_type: az_failure_type, unsupported_azs:, exclude_availability_zones:}})
 
-    if all_tried && unsupported_azs.size >= total_azs
-      Clog.emit("all azs unsupported for instance type", {retry_different_az_unsupported: {vm:, error: e.class.name, message: e.message, unsupported_azs:}})
-      Prog::PageNexus.assemble("#{vm.name} instance type unsupported in all AZs", ["InstanceTypeUnsupported", vm.id], vm.ubid)
-      update_stack({"unsupported_azs" => unsupported_azs, "exclude_availability_zones" => []})
-      nap 60 * 60
-    elsif all_tried
-      Clog.emit("resetting transient az exclusions", {retry_different_az_reset: {vm:, error: e.class.name, message: e.message, unsupported_azs:, exclude_availability_zones:}})
-      update_stack({"unsupported_azs" => unsupported_azs, "exclude_availability_zones" => []})
-      nap 5 * 60
+    if all_tried
+      old_family = vm.family
+      if try_postgres_family_fallback
+        Clog.emit("postgres az exhausted, trying fallback family", {postgres_family_fallback: {vm:, from: old_family, to: vm.family, last_az: current_az, last_az_failure_type: az_failure_type, unsupported_azs:, exclude_availability_zones:, total_azs:}})
+        update_stack({"unsupported_azs" => [], "exclude_availability_zones" => []})
+        nap 0
+      elsif unsupported_azs.size >= total_azs
+        Clog.emit("all azs unsupported for instance type", {retry_different_az_unsupported: {vm:, error: e.class.name, message: e.message, unsupported_azs:, exclude_availability_zones:}})
+        Prog::PageNexus.assemble("#{vm.name} instance type unsupported in all AZs", ["InstanceTypeUnsupported", vm.id], vm.ubid)
+        update_stack({"unsupported_azs" => unsupported_azs, "exclude_availability_zones" => []})
+        nap 60 * 60
+      else
+        Clog.emit("resetting transient az exclusions", {retry_different_az_reset: {vm:, error: e.class.name, message: e.message, unsupported_azs:, exclude_availability_zones:}})
+        update_stack({"unsupported_azs" => unsupported_azs, "exclude_availability_zones" => []})
+        nap 5 * 60
+      end
     else
-      Clog.emit("retrying in different az", {retry_different_az: {vm:, error: e.class.name, message: e.message, unsupported_azs:, exclude_availability_zones:}})
       update_stack({"unsupported_azs" => unsupported_azs, "exclude_availability_zones" => exclude_availability_zones})
       nic.incr_destroy
       hop_wait_old_nic_deleted
@@ -477,7 +483,6 @@ class Prog::Vm::Aws::Nexus < Prog::Base
     next_family = candidates.find { |f| allowed_families.include?(f) }
     return false unless next_family
 
-    Clog.emit("postgres az exhausted, trying fallback family", {postgres_family_fallback: {vm:, from: vm.family, to: next_family}})
     DB.transaction do
       vm.update(family: next_family)
       ps.incr_ignore_instance_size_mismatch unless ps.ignore_instance_size_mismatch_set?

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -219,6 +219,35 @@ RSpec.describe PostgresServer do
     expect(postgres_server).not_to be_read_replica
   end
 
+  describe ".excluded_azs" do
+    let(:target_vm) { instance_double(Vm, id: "vm-id") }
+
+    it "merges the two input lists when there is no postgres server for the vm" do
+      allow(described_class).to receive(:[]).with(vm_id: "vm-id").and_return(nil)
+      expect(described_class.excluded_azs(target_vm, ["a"], ["b"])).to contain_exactly("a", "b")
+    end
+
+    it "treats nil inputs as empty" do
+      allow(described_class).to receive(:[]).with(vm_id: "vm-id").and_return(nil)
+      expect(described_class.excluded_azs(target_vm, nil, nil)).to eq([])
+    end
+
+    it "returns simple merge when the postgres resource does not have use_different_az set" do
+      resource_dbl = instance_double(PostgresResource, use_different_az_set?: false)
+      ps_dbl = instance_double(described_class, resource: resource_dbl)
+      allow(described_class).to receive(:[]).with(vm_id: "vm-id").and_return(ps_dbl)
+      expect(described_class.excluded_azs(target_vm, ["a"], ["b"])).to contain_exactly("a", "b")
+    end
+
+    it "merges live sibling AZs in when use_different_az is set, deduped" do
+      filters = PostgresResource::ServerExclusionFilters.new([], [], ["b", "c"], nil)
+      resource_dbl = instance_double(PostgresResource, use_different_az_set?: true, new_server_exclusion_filters: filters)
+      ps_dbl = instance_double(described_class, resource: resource_dbl)
+      allow(described_class).to receive(:[]).with(vm_id: "vm-id").and_return(ps_dbl)
+      expect(described_class.excluded_azs(target_vm, ["a"], ["b"])).to contain_exactly("a", "b", "c")
+    end
+  end
+
   describe "#fallback_active?" do
     before { Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait") }
 

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -486,6 +486,7 @@ usermod -L ubuntu
 
       it "resets only exclude_availability_zones when all AZs tried" do
         refresh_frame(nx, new_values: {"unsupported_azs" => ["b", "c", "d"], "exclude_availability_zones" => ["e", "f"]})
+        expect(Clog).to receive(:emit).with("retrying in different az", instance_of(Hash))
         expect(Clog).to receive(:emit).with("resetting transient az exclusions", instance_of(Hash))
         expect { nx.create_instance }.to nap(300)
         expect(st.stack.last["unsupported_azs"]).to eq(["b", "c", "d"])
@@ -517,6 +518,7 @@ usermod -L ubuntu
 
       it "pages and naps 1 hour when all AZs are unsupported" do
         refresh_frame(nx, new_values: {"unsupported_azs" => ["b", "c", "d", "e", "f"]})
+        expect(Clog).to receive(:emit).with("retrying in different az", instance_of(Hash))
         expect(Clog).to receive(:emit).with("all azs unsupported for instance type", instance_of(Hash))
         expect(Prog::PageNexus).to receive(:assemble).with("#{vm.name} instance type unsupported in all AZs", ["InstanceTypeUnsupported", vm.id], vm.ubid)
         expect { nx.create_instance }.to nap(60 * 60)
@@ -526,6 +528,7 @@ usermod -L ubuntu
 
       it "preserves unsupported_azs when resetting transient exclusions" do
         refresh_frame(nx, new_values: {"unsupported_azs" => ["b", "c", "d"], "exclude_availability_zones" => ["e", "f"]})
+        expect(Clog).to receive(:emit).with("retrying in different az", instance_of(Hash))
         expect(Clog).to receive(:emit).with("resetting transient az exclusions", instance_of(Hash))
         expect { nx.create_instance }.to nap(300)
         expect(st.stack.last["unsupported_azs"]).to eq(["b", "c", "d", "a"])
@@ -544,6 +547,25 @@ usermod -L ubuntu
         expect { nx.create_instance }.to hop("wait_old_nic_deleted")
         expect(st.stack.last["unsupported_azs"]).to eq(["a", "b"])
       end
+
+      it "fires fallback when frame plus live siblings cover all AZs" do
+        # Frame has 5 entries (4 seeded + current_az "a" added on retry). Total
+        # AZs is 6. Without sibling-aware all_tried, fallback would NOT fire
+        # (5 < 6). With one live sibling in the remaining AZ, all_tried fires.
+        sibling_vm = Prog::Vm::Nexus.assemble_with_sshable(project.id, **vm_params.merge(name: "sibling-fallback-test")).subject
+        NicAwsResource.create_with_id(sibling_vm.nic.id, subnet_az: "c")
+        resource = create_postgres_resource(project:, location_id: location.id)
+        resource.update(target_vm_size: vm.display_size, target_storage_size_gib: vm.vm_storage_volumes.reject(&:boot).sum(&:size_gib))
+        resource.incr_use_different_az
+        timeline = create_postgres_timeline(location_id: location.id)
+        PostgresServer.create(timeline:, resource_id: resource.id, vm_id: sibling_vm.id, is_representative: true, synchronization_status: "ready", timeline_access: "push", version: resource.target_version)
+        PostgresServer.create(timeline:, resource_id: resource.id, vm_id: vm.id, synchronization_status: "ready", timeline_access: "fetch", version: resource.target_version)
+        refresh_frame(nx, new_values: {"unsupported_azs" => ["b", "d", "e", "f"]})
+
+        expect(nx).to receive(:try_postgres_family_fallback).and_return(true)
+        expect { nx.create_instance }.to nap(0)
+        expect(st.stack.last["unsupported_azs"]).to eq([])
+      end
     end
 
     describe "mixed error sequences" do
@@ -556,6 +578,7 @@ usermod -L ubuntu
       it "resets transient but keeps permanent when mixed errors exhaust all AZs" do
         refresh_frame(nx, new_values: {"unsupported_azs" => ["b", "c", "d"], "exclude_availability_zones" => ["e", "f"]})
         client.stub_responses(:run_instances, Aws::EC2::Errors::InsufficientInstanceCapacity.new(nil, "Insufficient capacity"))
+        expect(Clog).to receive(:emit).with("retrying in different az", instance_of(Hash))
         expect(Clog).to receive(:emit).with("resetting transient az exclusions", instance_of(Hash))
         expect { nx.create_instance }.to nap(300)
         expect(st.stack.last["unsupported_azs"]).to eq(["b", "c", "d"])
@@ -574,6 +597,7 @@ usermod -L ubuntu
         refresh_frame(nx, new_values: {"unsupported_azs" => ["b", "c", "d"], "exclude_availability_zones" => ["e", "f"]})
         client.stub_responses(:run_instances, Aws::EC2::Errors::Unsupported.new(nil, "Instance type not supported"))
         expect(Prog::PageNexus).not_to receive(:assemble)
+        expect(Clog).to receive(:emit).with("retrying in different az", instance_of(Hash))
         expect(Clog).to receive(:emit).with("resetting transient az exclusions", instance_of(Hash))
         expect { nx.create_instance }.to nap(300)
         expect(st.stack.last["unsupported_azs"]).to eq(["b", "c", "d", "a"])
@@ -742,6 +766,48 @@ usermod -L ubuntu
       expect(vm.reload.nic.id).not_to eq(old_nic.id)
       expect(vm.nic.strand.label).to eq("start")
       expect(vm.nic.strand.stack.first["exclude_availability_zones"]).to eq(["a", "b"])
+    end
+
+    it "appends sibling AZs from the postgres resource on retry" do
+      sibling_vm = Prog::Vm::Nexus.assemble_with_sshable(project.id, **vm_params.merge(name: "sibling-vm")).subject
+      NicAwsResource.create_with_id(sibling_vm.nic.id, subnet_az: "c")
+      resource = create_postgres_resource(project:, location_id: location.id)
+      resource.update(target_vm_size: vm.display_size, target_storage_size_gib: vm.vm_storage_volumes.reject(&:boot).sum(&:size_gib))
+      resource.incr_use_different_az
+      timeline = create_postgres_timeline(location_id: location.id)
+      PostgresServer.create(timeline:, resource_id: resource.id, vm_id: sibling_vm.id, is_representative: true, synchronization_status: "ready", timeline_access: "push", version: resource.target_version)
+      PostgresServer.create(timeline:, resource_id: resource.id, vm_id: vm.id, synchronization_status: "ready", timeline_access: "fetch", version: resource.target_version)
+      old_nic.update(vm_id: nil)
+      vm.reload
+
+      expect { nx.wait_old_nic_deleted }.to hop("wait_nic_recreated")
+      expect(vm.reload.nic.strand.stack.first["exclude_availability_zones"]).to contain_exactly("a", "b", "c")
+    end
+
+    it "naps when a sibling NIC has not yet populated subnet_az" do
+      sibling_vm = Prog::Vm::Nexus.assemble_with_sshable(project.id, **vm_params.merge(name: "sibling-vm")).subject
+      NicAwsResource.create_with_id(sibling_vm.nic.id)
+      resource = create_postgres_resource(project:, location_id: location.id)
+      resource.update(target_vm_size: vm.display_size, target_storage_size_gib: vm.vm_storage_volumes.reject(&:boot).sum(&:size_gib))
+      resource.incr_use_different_az
+      timeline = create_postgres_timeline(location_id: location.id)
+      PostgresServer.create(timeline:, resource_id: resource.id, vm_id: sibling_vm.id, is_representative: true, synchronization_status: "ready", timeline_access: "push", version: resource.target_version)
+      PostgresServer.create(timeline:, resource_id: resource.id, vm_id: vm.id, synchronization_status: "ready", timeline_access: "fetch", version: resource.target_version)
+      old_nic.update(vm_id: nil)
+      vm.reload
+
+      expect { nx.wait_old_nic_deleted }.to nap(1)
+    end
+
+    it "skips sibling AZ lookup when use_different_az is not set" do
+      resource = create_postgres_resource(project:, location_id: location.id)
+      timeline = create_postgres_timeline(location_id: location.id)
+      PostgresServer.create(timeline:, resource_id: resource.id, vm_id: vm.id, is_representative: true, synchronization_status: "ready", timeline_access: "push", version: resource.target_version)
+      old_nic.update(vm_id: nil)
+      vm.reload
+
+      expect { nx.wait_old_nic_deleted }.to hop("wait_nic_recreated")
+      expect(vm.reload.nic.strand.stack.first["exclude_availability_zones"]).to eq(["a", "b"])
     end
   end
 


### PR DESCRIPTION
Sibling AZs seeded into the VM strand frame are a snapshot at
creation. A sibling provisioned later is missing from frame, so
retry_in_different_az's all_tried check undercounts and family
fallback never fires. wait_old_nic_deleted then hands
select_aws_subnet an effectively-all-excluded list, falling into
the random-fallback branch and landing on a sibling-occupied AZ.
Sync HA in eu-west-1 on r8gd-class instances reproduced this
routinely; the same race affects a retrying primary as well.

PostgresServer.excluded_azs combines per-VM exclusions with live
siblings; used by both retry_in_different_az's all_tried decision
and wait_old_nic_deleted's exclude list. wait_old_nic_deleted naps
when a sibling's NIC strand hasn't yet populated subnet_az.

Hoist "retrying in different az" to fire on every AZ failure (not
only the non-exhausted retry branch). Enrich the family-fallback
log with the AZ state that drove the decision.
