### PR TITLE
VAT validation improvements

### DIFF
--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -58,8 +58,8 @@ class InvoiceGenerator
         # Invoices are issued by Ubicloud Inc. for non-EU customers without VAT applied.
         # Invoices are issued by Ubicloud B.V. for EU customers.
         #   - If the customer has provided a VAT number from the Netherlands, we charge 21% VAT.
-        #   - If the customer has provided a VAT number from another European country, we include a reverse charge notice along with 0% VAT.
-        #   - If the customer hasn't provided a VAT number, we charge 21% VAT until non-Dutch EU sales exceed annual threshold, than we charge local VAT.
+        #   - If the customer has provided a VAT number from another European country that we have validated, we include a reverse charge notice along with 0% VAT.
+        #   - If the customer hasn't provided a VAT number, or the one they provided has not been validated, we charge 21% VAT until non-Dutch EU sales exceed annual threshold, than we charge local VAT.
         project_content[:issuer_info] = if is_eu
           {
             name: "Ubicloud B.V.",
@@ -82,7 +82,7 @@ class InvoiceGenerator
           }
         end
         vat_info = if is_eu
-          if (tax_id = project_content[:billing_info]["tax_id"]) && !tax_id.empty? && country.alpha2 != "NL"
+          if (tax_id = project_content[:billing_info]["tax_id"]) && !tax_id.empty? && country.alpha2 != "NL" && bi.valid_vat == true
             {rate: 0, reversed: true}
           else
             {rate: Config.annual_non_dutch_eu_sales_exceed_threshold ? country.vat_rates["standard"] : 21, reversed: false, eur_rate: @eur_rate}

--- a/model/billing_info.rb
+++ b/model/billing_info.rb
@@ -38,6 +38,10 @@ class BillingInfo < Sequel::Model
     !stripe_data&.[]("address").to_s.empty?
   end
 
+  def email
+    stripe_data&.[]("email")
+  end
+
   def country
     ISO3166::Country.new(stripe_data["country"])
   end

--- a/prog/validate_vat.rb
+++ b/prog/validate_vat.rb
@@ -8,18 +8,16 @@ class Prog::ValidateVat < Prog::Base
   label def start
     billing_info.update(valid_vat: billing_info.validate_vat)
 
-    if !billing_info.valid_vat && (email = Config.invalid_vat_notification_email)
-      stripe_data = billing_info.stripe_data
-      Util.send_email(email, "Customer entered invalid VAT",
+    if !billing_info.valid_vat && (email = billing_info.email || billing_info.project.accounts.first&.email || Config.invalid_vat_notification_email)
+      Util.send_email(email, "Your VAT number could not be verified",
         greeting: "Hello,",
-        body: ["Customer entered invalid VAT.",
-          "Project ID: #{billing_info.project.ubid}",
-          "Name: #{stripe_data["name"]}",
-          "E-mail: #{stripe_data["email"]}",
-          "Country Code: #{stripe_data["country"]}",
-          "Country: #{billing_info.country.common_name}",
-          "Company Name: #{stripe_data["company_name"]}",
-          "VAT ID: #{stripe_data["tax_id"]}"])
+        body: ["The VAT number you entered, \"#{billing_info.stripe_data["tax_id"]}\", could not be verified in the VIES system.",
+          "To ensure the correct tax treatment is applied, please provide a valid VAT number. You can confirm the status of your VAT number in the VIES database using the link below.",
+          "If a valid VAT number is not provided, VAT may be applied to your invoices.",
+          "If you have any questions or require assistance, please contact us at support@ubicloud.com."],
+        button_title: "Check VAT in VIES",
+        button_link: "https://ec.europa.eu/taxation_customs/vies/#/vat-validation",
+        cc: Config.invalid_vat_notification_email)
     end
 
     pop "VAT validated"

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -215,13 +215,22 @@ RSpec.describe InvoiceGenerator do
       check_invoice_for_single_vm(invoices, p1, vm1, 30 * day, begin_time - 90 * day, expected_vat_info: {"amount" => 6.509, "eur_rate" => 0.85, "rate" => 21, "reversed" => false})
     end
 
-    it "reverse charges VAT for non-Dutch EU customer with tax id" do
+    it "reverse charges VAT for non-Dutch EU customer with validated tax id" do
       expect(customers_service).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "metadata" => {"tax_id" => "123456"}, "address" => {"line1" => "123 Main St", "country" => "DE"}}).at_least(:once)
-      p1.update(billing_info_id: BillingInfo.create(stripe_id: "cs_1234567890").id)
+      p1.update(billing_info_id: BillingInfo.create(stripe_id: "cs_1234567890", valid_vat: true).id)
 
       generate_billing_record(p1, vm1, Sequel::Postgres::PGRange.new(begin_time - 90 * day, nil))
       invoices = described_class.new(begin_time, end_time).run
       check_invoice_for_single_vm(invoices, p1, vm1, 30 * day, begin_time - 90 * day, expected_vat_info: {"rate" => 0, "reversed" => true})
+    end
+
+    it "charges VAT for non-Dutch EU customer whose tax id failed validation" do
+      expect(customers_service).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "metadata" => {"tax_id" => "123456"}, "address" => {"line1" => "123 Main St", "country" => "DE"}}).at_least(:once)
+      p1.update(billing_info_id: BillingInfo.create(stripe_id: "cs_1234567890", valid_vat: false).id)
+
+      generate_billing_record(p1, vm1, Sequel::Postgres::PGRange.new(begin_time - 90 * day, nil))
+      invoices = described_class.new(begin_time, end_time, eur_rate: 0.85).run
+      check_invoice_for_single_vm(invoices, p1, vm1, 30 * day, begin_time - 90 * day, expected_vat_info: {"amount" => 6.509, "eur_rate" => 0.85, "rate" => 21, "reversed" => false})
     end
 
     it "charges 21% VAT for non-Dutch EU customer without tax id until threshold" do

--- a/spec/model/billing_info_spec.rb
+++ b/spec/model/billing_info_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe BillingInfo do
     end
   end
 
+  it "returns the customer email from Stripe data" do
+    expect(customers_service).to receive(:retrieve).and_return({"email" => "customer@example.com", "metadata" => {}})
+    expect(billing_info.email).to eq("customer@example.com")
+  end
+
+  it "returns nil when Stripe data is nil" do
+    expect(customers_service).to receive(:retrieve).and_return(nil)
+    expect(billing_info.email).to be_nil
+  end
+
   it "delete Stripe customer if Stripe enabled" do
     expect(customers_service).to receive(:delete).with("cs_1234567890")
 

--- a/spec/prog/validate_vat_spec.rb
+++ b/spec/prog/validate_vat_spec.rb
@@ -19,11 +19,35 @@ RSpec.describe Prog::ValidateVat do
       }.to change(billing_info, :valid_vat).from(nil).to(true)
     end
 
-    it "sends email notification if VAT is invalid" do
-      Project.create(name: "test", billing_info:)
-      expect(Config).to receive(:invalid_vat_notification_email).and_return("dummy@mail.com")
-      expect(Util).to receive(:send_email)
-      expect(billing_info).to receive(:stripe_data).and_return({"country" => "DE", "tax_id" => 123123}).at_least(:once)
+    it "sends email to the customer cc'ing the notification address if VAT is invalid" do
+      expect(billing_info).to receive(:email).and_return("customer@mail.com")
+      expect(billing_info).to receive(:stripe_data).and_return({"tax_id" => "DE123456789"})
+      expect(Config).to receive(:invalid_vat_notification_email).and_return("notify@ubicloud.com")
+      expect(Util).to receive(:send_email).with("customer@mail.com", "Your VAT number could not be verified", hash_including(:greeting, body: include(include('"DE123456789"')), cc: "notify@ubicloud.com"))
+      expect(billing_info).to receive(:validate_vat).and_return(false)
+      expect {
+        expect { vv.start }.to exit({"msg" => "VAT validated"})
+      }.to change(billing_info, :valid_vat).from(nil).to(false)
+    end
+
+    it "falls back to the first project account when billing email is missing" do
+      project = Project.create(name: "test", billing_info:)
+      project.add_account(Account.create(email: "account@mail.com"))
+      expect(billing_info).to receive(:email).and_return(nil)
+      expect(billing_info).to receive(:stripe_data).and_return({"tax_id" => "DE123456789"})
+      expect(Config).to receive(:invalid_vat_notification_email).and_return("notify@ubicloud.com")
+      expect(Util).to receive(:send_email).with("account@mail.com", "Your VAT number could not be verified", hash_including(:greeting, :body, cc: "notify@ubicloud.com"))
+      expect(billing_info).to receive(:validate_vat).and_return(false)
+      expect {
+        expect { vv.start }.to exit({"msg" => "VAT validated"})
+      }.to change(billing_info, :valid_vat).from(nil).to(false)
+    end
+
+    it "does not send email if VAT is invalid but no customer email can be found" do
+      project = Project.create(name: "test", billing_info:)
+      expect(billing_info).to receive(:email).and_return(nil)
+      expect(project.accounts).to be_empty
+      expect(Util).not_to receive(:send_email)
       expect(billing_info).to receive(:validate_vat).and_return(false)
       expect {
         expect { vv.start }.to exit({"msg" => "VAT validated"})

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -618,6 +618,7 @@ RSpec.describe Clover, "billing" do
 
         visit "#{project.path}/billing"
         expect(page).to have_content "VAT subject to reverse charge."
+        expect(page).to have_no_content "could not be validated in the VIES database"
         click_link invoice.name
 
         expect(page.status_code).to eq(200)
@@ -625,6 +626,16 @@ RSpec.describe Clover, "billing" do
         expect(text).to include("Ubicloud B.V.")
         expect(text).to include("test-vm")
         expect(text).to include("VAT subject to reverse charge")
+      end
+
+      it "warns when the entered VAT ID could not be validated" do
+        expect(customers_service).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"country" => "DE"}, "metadata" => {"tax_id" => "123123123"}}).at_least(:once)
+        billing_info.update(valid_vat: false)
+
+        visit "#{project.path}/billing"
+
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content "The VAT ID you entered could not be verified in the VIES database."
       end
 
       it "show finalized invoice as PDF without bank transfer info" do

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -613,6 +613,7 @@ RSpec.describe Clover, "billing" do
 
       it "show finalized invoice as PDF from EU issuer with reversed charge" do
         expect(customers_service).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"country" => "DE"}, "metadata" => {"tax_id" => "123123123"}}).at_least(:once)
+        billing_info.update(valid_vat: true)
         bi = billing_record(Time.utc(2023, 6), Time.utc(2023, 7))
         invoice = InvoiceGenerator.new(bi.span.begin, bi.span.end, save_result: true, eur_rate: 1.1).run.first
 

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -120,7 +120,10 @@ end
                   ) %>
                   <% if billing_info.country&.in_eu_vat? %>
                     <div class="mt-2 text-sm text-gray-500">
-                      <% if billing_info.country.alpha2 == "NL" %>
+                      <% if billing_info.valid_vat == false %>
+                        The VAT ID you entered could not be verified in the VIES database. Please enter a valid VAT ID,
+                        otherwise VAT may be charged even if you don't expect to pay it.
+                      <% elsif billing_info.country.alpha2 == "NL" %>
                         21% VAT is collected from customers located in the Netherlands.
                       <% elsif stripe_data["tax_id"].to_s.strip.empty? %>
                         EU registered business can enter their VAT ID to remove VAT from future invoices.


### PR DESCRIPTION
- **Email the customer when their VAT fails validation**
  When a customer enters a VAT number that VIES rejects, we previously
  only emailed an internal notification address. Acting on it meant a
  maintainer had to manually reach out to the customer, spending time on
  work that the system can do on its own.
  
  Send the notice directly to the customer instead, falling back to the
  first project account when no billing email is set, and keep ourselves
  in the loop via cc. The body quotes the rejected number, warns that VAT
  may be charged otherwise, and links to the VIES checker.
  
  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  
<img width="1566" height="1468" alt="CleanShot 2026-06-02 at 18 58 10@2x" src="https://github.com/user-attachments/assets/8b3c68f7-c636-440f-be4f-0a1c26c764f4" />

- **Warn on the billing page when a VAT ID fails validation**
  The billing page already explains the VAT treatment for EU customers,
  but said nothing when a customer's VAT ID had been rejected by VIES.
  Such customers had no in-app signal that their entry was unusable until
  VAT showed up on an invoice.
  
  Show a notice in the existing VAT info line when valid_vat is false. A
  nil value still falls through to the normal messages, since it means the
  VAT was either not checked yet or did not need checking.
  
  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  

- **Only reverse charge VAT once the VAT number is validated**
  We applied the reverse charge to any non-Dutch EU customer who had
  entered a VAT number, regardless of whether it was genuine. A customer
  could enter a bogus number and avoid VAT they actually owe.
  
  Require valid_vat to be true before reverse charging. A false (rejected
  by VIES) or nil (not yet validated) value now charges VAT instead, which
  is the safe default until we have confirmed the number.
  
  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  