### PR TITLE
Skip postgres servers stuck at start label in bin/monitor

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -50,7 +50,7 @@ else
   runner_args = {ignore_threads: 2}
   monitor_models = [
     VmHost,
-    PostgresServer,
+    PostgresServer.exclude(id: Semaphore.where(name: "initial_provisioning").where(strand_id: PostgresServer.select(:id)).select(:strand_id)),
     MinioServer,
     GithubRunner.exclude(ready_at: nil),
     LoadBalancerVmPort,
@@ -66,7 +66,7 @@ else
   ]
 
   metric_export_models = [
-    PostgresServer,
+    PostgresServer.exclude(id: Semaphore.where(name: "initial_provisioning").where(strand_id: PostgresServer.select(:id)).select(:strand_id)),
     VmHost,
   ]
 end


### PR DESCRIPTION
PostgresServer rows are created at the beginning of provisioning, before the VM's Sshable.host is updated from "temp_<strand_id>" to a real IP. While the postgres strand naps at start waiting for the VM strand to reach wait_sshable, every monitor scan tries to SSH the temp_ host, fails with Socket::ResolutionError, and after 5 minutes of continuous failures pages SshableUnreachable. Any postgres VM provision longer than 5 minutes -- AZ retries, family fallback, capacity contention -- triggers a false-positive page.

Filter PostgresServer in both monitor_models and metric_export_models to skip strand.label = "start". Once the postgres strand hops past start (which gates on vm.strand.label == "wait"), Sshable.host is real and monitoring engages normally.

A VM that becomes unreachable later in its lifecycle (recycle, host outage, transient network failure) still flows through the same monitor->page path. That's the right behavior for genuine outages but also generates noise during expected events; distinguishing the two cleanly is harder and not addressed here.