### PR TITLE
Avoid let! in the specs

### DIFF
--- a/spec/lib/pagination_spec.rb
+++ b/spec/lib/pagination_spec.rb
@@ -5,16 +5,21 @@ require_relative "../model/spec_helper"
 RSpec.describe Pagination do
   let(:project) { Project.create(name: "default") }
 
-  let!(:first_vm) do
-    Prog::Vm::Nexus.assemble("dummy-public key", project.id, name: "dummy-vm-1").subject
-  end
-
-  let!(:second_vm) do
-    Prog::Vm::Nexus.assemble("dummy-public key", project.id, name: "dummy-vm-2").subject
-  end
-
   describe "#validate_paginated_result" do
     describe "success" do
+      let(:first_vm) do
+        Prog::Vm::Nexus.assemble("dummy-public key", project.id, name: "dummy-vm-1").subject
+      end
+
+      let(:second_vm) do
+        Prog::Vm::Nexus.assemble("dummy-public key", project.id, name: "dummy-vm-2").subject
+      end
+
+      before do
+        first_vm
+        second_vm
+      end
+
       it "order column" do
         result = project.vms_dataset.paginated_result(order_column: "name")
         expect(result[:items][0].ubid).to eq(first_vm.ubid)

--- a/spec/lib/pagination_spec.rb
+++ b/spec/lib/pagination_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Pagination do
       end
     end
 
-    describe "unsuccesful" do
+    describe "unsuccessful" do
       it "invalid start after" do
         expect { project.vms_dataset.paginated_result(start_after: "invalidubid") }.to raise_error(Validation::ValidationFailed)
       end

--- a/spec/model/ai/inference_endpoint_spec.rb
+++ b/spec/model/ai/inference_endpoint_spec.rb
@@ -38,10 +38,11 @@ RSpec.describe InferenceEndpoint do
   end
 
   describe "#display_states" do
-    let!(:strand) { Strand.create_with_id(inference_endpoint, prog: "Ai::InferenceEndpointNexus", label: "wait") }
+    let(:strand) { Strand.create_with_id(inference_endpoint, prog: "Ai::InferenceEndpointNexus", label: "wait") }
 
     context "when state is running" do
       it "returns 'running'" do
+        strand
         expect(inference_endpoint.display_state).to eq("running")
       end
     end

--- a/spec/model/kubernetes/kubernetes_etcd_backup_spec.rb
+++ b/spec/model/kubernetes/kubernetes_etcd_backup_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe KubernetesEtcdBackup do
     end
 
     context "when blob storage is configured" do
-      let!(:minio_cluster) { MinioCluster.create(project_id: project.id, location_id: location.id, name: "minio-cluster", admin_user: "admin", admin_password: "password", root_cert_1: "certs") }
+      let(:minio_cluster) { MinioCluster.create(project_id: project.id, location_id: location.id, name: "minio-cluster", admin_user: "admin", admin_password: "password", root_cert_1: "certs") }
 
       before do
         allow(minio_cluster).to receive(:url).and_return("https://minio.test")

--- a/spec/prog/ai/inference_router_replica_nexus_spec.rb
+++ b/spec/prog/ai/inference_router_replica_nexus_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Prog::Ai::InferenceRouterReplicaNexus do
       private_subnet_id: private_subnet.id,
     )
   }
-  let!(:inference_router_model) {
+  let(:inference_router_model) {
     InferenceRouterModel.create(
       model_name: "test-model",
       prompt_billing_resource: "test-model-input",
@@ -481,6 +481,10 @@ RSpec.describe Prog::Ai::InferenceRouterReplicaNexus do
 
   describe "#update_billing_records" do
     let(:p1) { Project.create(name: "default") }
+
+    before do
+      inference_router_model
+    end
 
     it "updates billing records" do
       expect(BillingRecord.count).to eq(0)

--- a/spec/prog/storage/remove_spdk_spec.rb
+++ b/spec/prog/storage/remove_spdk_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Prog::Storage::RemoveSpdk do
   let(:spdk_installation) {
     SpdkInstallation.create(version: "v23.09-ubi-0.2", allocation_weight: 100, vm_host_id: vm_host.id)
   }
-  let!(:second_spdk) {
+  let(:second_spdk) {
     SpdkInstallation.create(version: "v23.09-ubi-0.3", allocation_weight: 100, vm_host_id: vm_host.id)
   }
 
@@ -21,6 +21,7 @@ RSpec.describe Prog::Storage::RemoveSpdk do
 
   describe "#start" do
     it "hops to wait_volumes" do
+      second_spdk
       expect { remove_spdk.start }.to hop("wait_volumes")
       expect(spdk_installation.reload.allocation_weight).to eq(0)
     end


### PR DESCRIPTION
`let!` eagerly evaluates before every spec, while `let` only evaluates if it is referenced. In many cases, using `let!` results in unnecessary code execution. I think it's better to be explicit and use `let` instead. In many cases, we can reduce the number of specs using the variable, which speeds up the specs. We only had a handful of cases using `let!`, so it's pretty simple to remove.