### PR TITLE
Batch AWS firewall rule sync into one label

### DIFF
--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -292,7 +292,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
   end
 
   label def update_firewall_rules
-    if retval&.dig("msg") == "firewall rule is added"
+    if retval&.dig("msg") == "firewall rules synced"
       hop_wait
     end
 

--- a/prog/vnet/aws/update_firewall_rules.rb
+++ b/prog/vnet/aws/update_firewall_rules.rb
@@ -4,79 +4,80 @@ class Prog::Vnet::Aws::UpdateFirewallRules < Prog::Base
   subject_is :vm
 
   def before_run
-    pop "firewall rule is added" if vm.destroy_set?
+    pop "firewall rules synced" if vm.destroy_set?
   end
 
   label def update_firewall_rules
-    rules = vm.firewall_rules
-    rules.select(&:port_range).map! do |rule|
-      perm = {
-        ip_protocol: rule.protocol,
-        from_port: rule.port_range.begin,
-        to_port: rule.port_range.end - 1,
-      }
-      if rule.ip6?
-        perm[:ipv_6_ranges] = [{cidr_ipv_6: rule.cidr.to_s}]
-      else
-        perm[:ip_ranges] = [{cidr_ip: rule.cidr.to_s}]
-      end
+    existing = existing_rules
+    desired = desired_rules
+    add_rules = desired - existing
+    revoke_perms = combine_to_permissions(existing - desired)
 
+    unless add_rules.empty?
       begin
-        aws_client.authorize_security_group_ingress({
-          group_id: vm.private_subnets.first.private_subnet_aws_resource.security_group_id,
-          ip_permissions: [perm],
-        })
+        aws_client.authorize_security_group_ingress(group_id:, ip_permissions: combine_to_permissions(add_rules))
       rescue Aws::EC2::Errors::InvalidPermissionDuplicate
-        next
+        # On duplicate, AWS may not add every rule in the batch; re-describe and retry.
+        nap 0
+      rescue Aws::EC2::Errors::RulesPerSecurityGroupLimitExceeded => e
+        Prog::PageNexus.assemble(
+          "AWS security group #{group_id} rule limit exceeded: #{existing.size} existing + #{add_rules.size} attempted",
+          ["AwsSgRuleLimitExceeded", group_id],
+          vm.ubid,
+          extra_data: {aws_error: e.message, existing_count: existing.size, attempted_additions: add_rules.size},
+        )
+        nap 10 * 60
       end
     end
 
-    hop_remove_aws_old_rules
+    unless revoke_perms.empty?
+      begin
+        aws_client.revoke_security_group_ingress(group_id:, ip_permissions: revoke_perms)
+      rescue Aws::EC2::Errors::InvalidPermissionNotFound
+        # On NotFound, AWS may not revoke every rule in the batch; re-describe and retry.
+        nap 0
+      end
+    end
+
+    Page.from_tag_parts("AwsSgRuleLimitExceeded", group_id)&.incr_resolve
+    pop "firewall rules synced"
   end
 
+  # Label eliminated; merged into update_firewall_rules. Shim kept for in-flight strands; delete in a later release.
   label def remove_aws_old_rules
-    rules = vm.firewall_rules
-    ip6_rules, ip4_rules = rules.select(&:port_range).partition(&:ip6?)
+    hop_update_firewall_rules
+  end
 
-    # Fetch existing security group rules
-    security_group = aws_client.describe_security_groups({
-      group_ids: [vm.private_subnets.first.private_subnet_aws_resource.security_group_id],
-    }).security_groups.first
+  # Rules the vm should have, as [protocol, from_port, to_port, cidr] tuples
+  def desired_rules
+    vm.firewall_rules.select(&:port_range).map do |rule|
+      [rule.protocol, rule.port_range.begin, rule.port_range.end - 1, rule.cidr.to_s]
+    end.uniq
+  end
 
-    # Remove existing rules that aren't in our current rules list
-    permissions_to_revoke = security_group.ip_permissions.filter_map do |permission|
-      ip_ranges_to_revoke = permission.ip_ranges.select do |ip_range|
-        ip4_rules.none? { |r| r.protocol == permission.ip_protocol && r.cidr.to_s == ip_range.cidr_ip && r.port_range.begin == permission.from_port && r.port_range.end - 1 == permission.to_port }
+  # Rules currently in the security group, as [protocol, from_port, to_port, cidr] tuples
+  def existing_rules
+    rules = aws_client.describe_security_groups(group_ids: [group_id]).security_groups.first.ip_permissions.flat_map do |permission|
+      (permission.ip_ranges.map(&:cidr_ip) + permission.ipv_6_ranges.map(&:cidr_ipv_6)).map do |cidr|
+        [permission.ip_protocol, permission.from_port, permission.to_port, cidr]
       end
+    end
+    rules.uniq
+  end
 
-      ipv_6_ranges_to_revoke = permission.ipv_6_ranges.select do |ip_range|
-        ip6_rules.none? { |r| r.protocol == permission.ip_protocol && r.cidr.to_s == ip_range.cidr_ipv_6 && r.port_range.begin == permission.from_port && r.port_range.end - 1 == permission.to_port }
-      end
-
-      next if ip_ranges_to_revoke.empty? && ipv_6_ranges_to_revoke.empty?
-
-      perm = {
-        ip_protocol: permission.ip_protocol,
-        from_port: permission.from_port,
-        to_port: permission.to_port,
-      }
-      perm[:ip_ranges] = ip_ranges_to_revoke if ip_ranges_to_revoke.any?
-      perm[:ipv_6_ranges] = ipv_6_ranges_to_revoke if ipv_6_ranges_to_revoke.any?
+  # Collapse tuples into AWS ip_permissions, one entry per protocol/port range.
+  def combine_to_permissions(rules)
+    rules.group_by { |protocol, from_port, to_port, _| [protocol, from_port, to_port] }.map do |(protocol, from_port, to_port), grouped|
+      ip6, ip4 = grouped.map(&:last).partition { |cidr| cidr.include?(":") }
+      perm = {ip_protocol: protocol, from_port:, to_port:}
+      perm[:ip_ranges] = ip4.map { |cidr| {cidr_ip: cidr} } unless ip4.empty?
+      perm[:ipv_6_ranges] = ip6.map { |cidr| {cidr_ipv_6: cidr} } unless ip6.empty?
       perm
     end
+  end
 
-    if permissions_to_revoke.any?
-      permissions_to_revoke.each do |perm|
-        aws_client.revoke_security_group_ingress({
-          group_id: vm.private_subnets.first.private_subnet_aws_resource.security_group_id,
-          ip_permissions: [perm],
-        })
-      rescue Aws::EC2::Errors::InvalidPermissionNotFound
-        next
-      end
-    end
-
-    pop "firewall rule is added"
+  def group_id
+    @group_id ||= vm.private_subnets.first.private_subnet_aws_resource.security_group_id
   end
 
   def aws_client

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -831,7 +831,7 @@ usermod -L ubuntu
     end
 
     it "hops to wait if firewall rules are applied" do
-      expect(nx).to receive(:retval).and_return({"msg" => "firewall rule is added"})
+      expect(nx).to receive(:retval).and_return({"msg" => "firewall rules synced"})
       expect { nx.update_firewall_rules }.to hop("wait")
     end
   end

--- a/spec/prog/vnet/aws/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/aws/update_firewall_rules_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
     it "pops if vm is to be destroyed" do
       expect(nx).to receive(:vm).and_return(vm).at_least(:once)
       expect(vm).to receive(:destroy_set?).and_return(true)
-      expect { nx.before_run }.to exit({"msg" => "firewall rule is added"})
+      expect { nx.before_run }.to exit({"msg" => "firewall rules synced"})
     end
 
     it "does not pop if vm is not to be destroyed" do
@@ -31,114 +31,7 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
     end
   end
 
-  describe "update_firewall_rules" do
-    let(:ec2_client) { instance_double(Aws::EC2::Client) }
-
-    before do
-      lcred = instance_double(LocationCredentialAws, client: ec2_client)
-      loc = instance_double(Location, provider: "aws", location_credential_aws: lcred)
-      allow(nx).to receive(:vm).and_return(vm)
-      allow(vm).to receive(:location).and_return(loc)
-    end
-
-    it "hops to remove_aws_old_rules if there are no fw rules to add" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:firewall_rules).and_return([])
-      expect { nx.update_firewall_rules }.to hop("remove_aws_old_rules")
-    end
-
-    it "hops to remove_aws_firewall_rules after adding new rules" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:firewall_rules).and_return([
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
-      ])
-      expect(vm.private_subnets.first).to receive(:private_subnet_aws_resource).and_return(instance_double(PrivateSubnetAwsResource, security_group_id: "sg-1234567890")).at_least(:once)
-      expect(ec2_client).to receive(:authorize_security_group_ingress).with({
-        group_id: "sg-1234567890",
-        ip_permissions: [
-          {
-            ip_protocol: "tcp",
-            from_port: 80,
-            to_port: 9999,
-            ip_ranges: [{cidr_ip: "0.0.0.0/0"}],
-          },
-        ],
-      })
-      expect(ec2_client).to receive(:authorize_security_group_ingress).with({
-        group_id: "sg-1234567890",
-        ip_permissions: [
-          {
-            ip_protocol: "tcp",
-            from_port: 22,
-            to_port: 22,
-            ip_ranges: [{cidr_ip: "1.1.1.1/32"}],
-          },
-        ],
-      })
-      expect(ec2_client).to receive(:authorize_security_group_ingress).with({
-        group_id: "sg-1234567890",
-        ip_permissions: [
-          {
-            ip_protocol: "tcp",
-            from_port: 80,
-            to_port: 9999,
-            ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}],
-          },
-        ],
-      })
-
-      expect { nx.update_firewall_rules }.to hop("remove_aws_old_rules")
-    end
-
-    it "continues and hops to remove_aws_old_rules if there is a duplicate rule" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:firewall_rules).and_return([
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
-      ])
-      expect(vm.private_subnets.first).to receive(:private_subnet_aws_resource).and_return(instance_double(PrivateSubnetAwsResource, security_group_id: "sg-1234567890")).at_least(:once)
-      expect(ec2_client).to receive(:authorize_security_group_ingress).with({
-        group_id: "sg-1234567890",
-        ip_permissions: [
-          {
-            ip_protocol: "tcp",
-            from_port: 80,
-            to_port: 9999,
-            ip_ranges: [{cidr_ip: "0.0.0.0/0"}],
-          },
-        ],
-      }).and_raise(Aws::EC2::Errors::InvalidPermissionDuplicate.new("Duplicate", "Duplicate"))
-      expect(ec2_client).to receive(:authorize_security_group_ingress).with({
-        group_id: "sg-1234567890",
-        ip_permissions: [
-          {
-            ip_protocol: "tcp",
-            from_port: 22,
-            to_port: 22,
-            ip_ranges: [{cidr_ip: "1.1.1.1/32"}],
-          },
-        ],
-      })
-      expect(ec2_client).to receive(:authorize_security_group_ingress).with({
-        group_id: "sg-1234567890",
-        ip_permissions: [
-          {
-            ip_protocol: "tcp",
-            from_port: 80,
-            to_port: 9999,
-            ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}],
-          },
-        ],
-      })
-
-      expect { nx.update_firewall_rules }.to hop("remove_aws_old_rules")
-    end
-  end
-
-  describe "#remove_aws_old_rules" do
+  describe "#update_firewall_rules" do
     let(:ec2_client) { Aws::EC2::Client.new(stub_responses: true) }
 
     before do
@@ -146,88 +39,193 @@ RSpec.describe Prog::Vnet::Aws::UpdateFirewallRules do
       loc = instance_double(Location, provider: "aws", location_credential_aws: lcred)
       allow(nx).to receive(:vm).and_return(vm)
       allow(vm).to receive(:location).and_return(loc)
+      allow(vm.private_subnets.first).to receive(:private_subnet_aws_resource).and_return(instance_double(PrivateSubnetAwsResource, security_group_id: "sg-1234567890"))
     end
 
-    it "removes old rules" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
+    it "exits without authorize or revoke when desired and existing match" do
       expect(vm).to receive(:firewall_rules).and_return([
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
+        instance_double(FirewallRule, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
+        instance_double(FirewallRule, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
       ])
-      expect(vm.private_subnets.first).to receive(:private_subnet_aws_resource).and_return(instance_double(PrivateSubnetAwsResource, security_group_id: "sg-1234567890")).at_least(:once)
       ec2_client.stub_responses(:describe_security_groups, security_groups: [ip_permissions: [
-        {
-          ip_protocol: "tcp",
-          from_port: 0,
-          to_port: 100,
-          ip_ranges: [],
-          ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}],
-        },
-        {
-          ip_protocol: "udp",
-          from_port: 0,
-          to_port: 100,
-          ip_ranges: [{cidr_ip: "0.0.0.0/0"}],
-          ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}],
-        },
-        {
-          ip_protocol: "tcp",
-          from_port: 0,
-          to_port: 100,
-          ip_ranges: [{cidr_ip: "10.10.10.10/32"}],
-          ipv_6_ranges: [],
-        },
-        {
-          ip_protocol: "tcp",
-          from_port: 80,
-          to_port: 9999,
-          ip_ranges: [],
-          ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}],
-        },
-        {
-          ip_protocol: "tcp",
-          from_port: 80,
-          to_port: 9999,
-          ip_ranges: [{cidr_ip: "0.0.0.0/0"}],
-          ipv_6_ranges: [],
-        },
+        {ip_protocol: "tcp", from_port: 80, to_port: 9999, ip_ranges: [{cidr_ip: "0.0.0.0/0"}], ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]},
       ]])
-
-      expect(ec2_client).to receive(:revoke_security_group_ingress).with({group_id: "sg-1234567890", ip_permissions: [{from_port: 0, ip_protocol: "udp", ip_ranges: [Aws::EC2::Types::IpRange.new(cidr_ip: "0.0.0.0/0")], ipv_6_ranges: [Aws::EC2::Types::Ipv6Range.new(cidr_ipv_6: "fd00::1/128")], to_port: 100}]})
-      expect(ec2_client).to receive(:revoke_security_group_ingress).with({group_id: "sg-1234567890", ip_permissions: [{from_port: 0, ip_protocol: "tcp", ipv_6_ranges: [Aws::EC2::Types::Ipv6Range.new(cidr_ipv_6: "fd00::1/128")], to_port: 100}]})
-      expect(ec2_client).to receive(:revoke_security_group_ingress).with({group_id: "sg-1234567890", ip_permissions: [{from_port: 0, ip_protocol: "tcp", ip_ranges: [Aws::EC2::Types::IpRange.new(cidr_ip: "10.10.10.10/32")], to_port: 100}]}).and_raise(Aws::EC2::Errors::InvalidPermissionNotFound.new("Duplicate", "Duplicate"))
-
-      expect { nx.remove_aws_old_rules }.to exit({"msg" => "firewall rule is added"})
-    end
-
-    it "doesn't make a call if there are no old rules" do
-      expect(nx).to receive(:vm).and_return(vm).at_least(:once)
-      expect(vm).to receive(:firewall_rules).and_return([
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: false, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
-        instance_double(FirewallRule, ip6?: true, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
-      ])
-      expect(vm.private_subnets.first).to receive(:private_subnet_aws_resource).and_return(instance_double(PrivateSubnetAwsResource, security_group_id: "sg-1234567890")).at_least(:once)
-      ec2_client.stub_responses(:describe_security_groups, security_groups: [ip_permissions: [
-        {
-          ip_protocol: "tcp",
-          from_port: 80,
-          to_port: 9999,
-          ip_ranges: [{cidr_ip: "0.0.0.0/0"}],
-          ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}],
-        },
-        {
-          ip_protocol: "tcp",
-          from_port: 80,
-          to_port: 9999,
-          ip_ranges: [{cidr_ip: "0.0.0.0/0"}],
-          ipv_6_ranges: [],
-        },
-      ]])
+      expect(ec2_client).not_to receive(:authorize_security_group_ingress)
       expect(ec2_client).not_to receive(:revoke_security_group_ingress)
 
-      expect { nx.remove_aws_old_rules }.to exit({"msg" => "firewall rule is added"})
+      expect { nx.update_firewall_rules }.to exit({"msg" => "firewall rules synced"})
+    end
+
+    it "exits without any call when there are no desired or existing rules" do
+      expect(vm).to receive(:firewall_rules).and_return([])
+      ec2_client.stub_responses(:describe_security_groups, security_groups: [ip_permissions: []])
+      expect(ec2_client).not_to receive(:authorize_security_group_ingress)
+      expect(ec2_client).not_to receive(:revoke_security_group_ingress)
+
+      expect { nx.update_firewall_rules }.to exit({"msg" => "firewall rules synced"})
+    end
+
+    it "authorizes only rules missing from the security group in a single call" do
+      expect(vm).to receive(:firewall_rules).and_return([
+        instance_double(FirewallRule, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
+        instance_double(FirewallRule, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
+        instance_double(FirewallRule, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
+      ])
+      ec2_client.stub_responses(:describe_security_groups, security_groups: [ip_permissions: [
+        {ip_protocol: "tcp", from_port: 80, to_port: 9999, ip_ranges: [{cidr_ip: "0.0.0.0/0"}], ipv_6_ranges: []},
+      ]])
+      expect(ec2_client).to receive(:authorize_security_group_ingress).with({
+        group_id: "sg-1234567890",
+        ip_permissions: [
+          {ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "1.1.1.1/32"}]},
+          {ip_protocol: "tcp", from_port: 80, to_port: 9999, ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]},
+        ],
+      })
+      expect(ec2_client).not_to receive(:revoke_security_group_ingress)
+
+      expect { nx.update_firewall_rules }.to exit({"msg" => "firewall rules synced"})
+    end
+
+    it "revokes only rules absent from the desired set in a single call" do
+      expect(vm).to receive(:firewall_rules).and_return([])
+      ec2_client.stub_responses(:describe_security_groups, security_groups: [ip_permissions: [
+        {ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "1.1.1.1/32"}], ipv_6_ranges: []},
+        {ip_protocol: "tcp", from_port: 80, to_port: 9999, ip_ranges: [{cidr_ip: "0.0.0.0/0"}], ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]},
+      ]])
+      expect(ec2_client).not_to receive(:authorize_security_group_ingress)
+      expect(ec2_client).to receive(:revoke_security_group_ingress).with({
+        group_id: "sg-1234567890",
+        ip_permissions: [
+          {ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "1.1.1.1/32"}]},
+          {ip_protocol: "tcp", from_port: 80, to_port: 9999, ip_ranges: [{cidr_ip: "0.0.0.0/0"}], ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]},
+        ],
+      })
+
+      expect { nx.update_firewall_rules }.to exit({"msg" => "firewall rules synced"})
+    end
+
+    it "authorizes additions and revokes removals in one pass" do
+      expect(vm).to receive(:firewall_rules).and_return([
+        instance_double(FirewallRule, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
+        instance_double(FirewallRule, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
+        instance_double(FirewallRule, cidr: NetAddr::IPv6Net.parse("fd00::1/128"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
+      ])
+      ec2_client.stub_responses(:describe_security_groups, security_groups: [ip_permissions: [
+        {ip_protocol: "tcp", from_port: 0, to_port: 100, ip_ranges: [], ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]},
+        {ip_protocol: "udp", from_port: 0, to_port: 100, ip_ranges: [{cidr_ip: "0.0.0.0/0"}], ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]},
+        {ip_protocol: "tcp", from_port: 0, to_port: 100, ip_ranges: [{cidr_ip: "10.10.10.10/32"}], ipv_6_ranges: []},
+        {ip_protocol: "tcp", from_port: 80, to_port: 9999, ip_ranges: [], ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]},
+        {ip_protocol: "tcp", from_port: 80, to_port: 9999, ip_ranges: [{cidr_ip: "0.0.0.0/0"}], ipv_6_ranges: []},
+      ]])
+      expect(ec2_client).to receive(:authorize_security_group_ingress).with({
+        group_id: "sg-1234567890",
+        ip_permissions: [
+          {ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "1.1.1.1/32"}]},
+        ],
+      })
+      expect(ec2_client).to receive(:revoke_security_group_ingress).with({
+        group_id: "sg-1234567890",
+        ip_permissions: [
+          {ip_protocol: "tcp", from_port: 0, to_port: 100, ip_ranges: [{cidr_ip: "10.10.10.10/32"}], ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]},
+          {ip_protocol: "udp", from_port: 0, to_port: 100, ip_ranges: [{cidr_ip: "0.0.0.0/0"}], ipv_6_ranges: [{cidr_ipv_6: "fd00::1/128"}]},
+        ],
+      })
+
+      expect { nx.update_firewall_rules }.to exit({"msg" => "firewall rules synced"})
+    end
+
+    it "naps for re-describe when authorize fails with InvalidPermissionDuplicate" do
+      expect(vm).to receive(:firewall_rules).and_return([
+        instance_double(FirewallRule, cidr: NetAddr::IPv4Net.parse("0.0.0.0/0"), port_range: Sequel.pg_range(80..10000), protocol: "tcp"),
+      ])
+      ec2_client.stub_responses(:describe_security_groups, security_groups: [ip_permissions: []])
+      expect(ec2_client).to receive(:authorize_security_group_ingress).and_raise(Aws::EC2::Errors::InvalidPermissionDuplicate.new("Duplicate", "Duplicate"))
+      expect(ec2_client).not_to receive(:revoke_security_group_ingress)
+
+      expect { nx.update_firewall_rules }.to nap(0)
+    end
+
+    it "naps for re-describe when revoke fails with InvalidPermissionNotFound" do
+      expect(vm).to receive(:firewall_rules).and_return([])
+      ec2_client.stub_responses(:describe_security_groups, security_groups: [ip_permissions: [
+        {ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "1.1.1.1/32"}], ipv_6_ranges: []},
+      ]])
+      expect(ec2_client).to receive(:revoke_security_group_ingress).and_raise(Aws::EC2::Errors::InvalidPermissionNotFound.new("NotFound", "NotFound"))
+
+      expect { nx.update_firewall_rules }.to nap(0)
+    end
+
+    it "pages and naps without revoking when authorize hits the SG rule limit" do
+      allow(vm).to receive(:ubid).and_return("vmubid")
+      expect(vm).to receive(:firewall_rules).and_return([
+        instance_double(FirewallRule, cidr: NetAddr::IPv4Net.parse("1.1.1.1/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
+      ])
+      ec2_client.stub_responses(:describe_security_groups, security_groups: [ip_permissions: [
+        {ip_protocol: "tcp", from_port: 80, to_port: 9999, ip_ranges: [{cidr_ip: "0.0.0.0/0"}], ipv_6_ranges: []},
+      ]])
+      expect(ec2_client).to receive(:authorize_security_group_ingress).and_raise(Aws::EC2::Errors::RulesPerSecurityGroupLimitExceeded.new("LimitExceeded", "rule limit reached"))
+      expect(ec2_client).not_to receive(:revoke_security_group_ingress)
+      expect(Prog::PageNexus).to receive(:assemble).with(
+        /AWS security group sg-1234567890 rule limit exceeded/,
+        ["AwsSgRuleLimitExceeded", "sg-1234567890"],
+        "vmubid",
+        hash_including(extra_data: hash_including(aws_error: "rule limit reached")),
+      )
+
+      expect { nx.update_firewall_rules }.to nap(10 * 60)
+    end
+
+    it "converges in three passes when sibling strands race authorize and revoke" do
+      rules = [
+        instance_double(FirewallRule, cidr: NetAddr::IPv4Net.parse("10.0.0.1/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
+        instance_double(FirewallRule, cidr: NetAddr::IPv4Net.parse("10.0.0.2/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
+        instance_double(FirewallRule, cidr: NetAddr::IPv4Net.parse("10.0.0.3/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
+        instance_double(FirewallRule, cidr: NetAddr::IPv4Net.parse("10.0.0.4/32"), port_range: Sequel.pg_range(22..23), protocol: "tcp"),
+      ]
+      allow(vm).to receive(:firewall_rules).and_return(rules)
+
+      stale_a = {ip_protocol: "tcp", from_port: 0, to_port: 9, ip_ranges: [{cidr_ip: "192.168.1.0/24"}], ipv_6_ranges: []}
+      stale_b = {ip_protocol: "tcp", from_port: 0, to_port: 9, ip_ranges: [{cidr_ip: "192.168.2.0/24"}], ipv_6_ranges: []}
+      stale_c = {ip_protocol: "tcp", from_port: 0, to_port: 9, ip_ranges: [{cidr_ip: "192.168.3.0/24"}], ipv_6_ranges: []}
+      sibling_added = {ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "10.0.0.1/32"}], ipv_6_ranges: []}
+      all_desired = {ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "10.0.0.1/32"}, {cidr_ip: "10.0.0.2/32"}, {cidr_ip: "10.0.0.3/32"}, {cidr_ip: "10.0.0.4/32"}], ipv_6_ranges: []}
+
+      ec2_client.stub_responses(:describe_security_groups,
+        # Pass 1: 3 stale rules; nothing of ours added yet.
+        {security_groups: [ip_permissions: [stale_a, stale_b, stale_c]]},
+        # Pass 2: a sibling raced ahead and added 10.0.0.1, so our pass 1 authorize raised Duplicate.
+        {security_groups: [ip_permissions: [sibling_added, stale_a, stale_b, stale_c]]},
+        # Pass 3: our pass 2 authorize added the rest; a sibling revoked 192.168.1.0/24 between our describe and revoke.
+        {security_groups: [ip_permissions: [all_desired, stale_b, stale_c]]})
+
+      expect(ec2_client).to receive(:authorize_security_group_ingress).twice.and_invoke(
+        ->(*) { raise Aws::EC2::Errors::InvalidPermissionDuplicate.new("Duplicate", "Duplicate") },
+        ->(*) {},
+      )
+      expect(ec2_client).to receive(:revoke_security_group_ingress).twice.and_invoke(
+        ->(*) { raise Aws::EC2::Errors::InvalidPermissionNotFound.new("NotFound", "NotFound") },
+        ->(*) {},
+      )
+
+      expect { nx.update_firewall_rules }.to nap(0)
+      expect { nx.update_firewall_rules }.to nap(0)
+      expect { nx.update_firewall_rules }.to exit({"msg" => "firewall rules synced"})
+    end
+
+    it "resolves a prior rule-limit page on a successful sync" do
+      page = Page.create(tag: Page.generate_tag(["AwsSgRuleLimitExceeded", "sg-1234567890"]), summary: "old")
+      Strand.create_with_id(page, prog: "PageNexus", label: "wait")
+      expect(vm).to receive(:firewall_rules).and_return([])
+      ec2_client.stub_responses(:describe_security_groups, security_groups: [ip_permissions: []])
+
+      expect { nx.update_firewall_rules }.to exit({"msg" => "firewall rules synced"})
+      expect(page.resolve_set?).to be true
+    end
+  end
+
+  describe "#remove_aws_old_rules" do
+    it "hops back to update_firewall_rules so parked strands resync" do
+      expect { nx.remove_aws_old_rules }.to hop("update_firewall_rules")
     end
   end
 end


### PR DESCRIPTION
The per-rule loop made N+M API calls and timed out with 300+ rules. Merge update_firewall_rules and remove_aws_old_rules into one label that diffs desired vs existing rule tuples and applies adds and removes in two bulk calls.

Every VM in a subnet pushes its own UpdateFirewallRules against the shared security group, so authorize/revoke regularly hit InvalidPermissionDuplicate or InvalidPermissionNotFound. AWS may drop the whole batch on either; hop back to re-describe so the diff shrinks until it converges. The parent's 5-minute wait deadline pages if it doesn't.

Page on RulesPerSecurityGroupLimitExceeded with the existing-vs-attempted counts; resolve on a successful sync.

Keep remove_aws_old_rules as a hop shim for strands parked at the removed label; safe to delete after one release.