### PR TITLE
Have CertNexus schedule waiting strands

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -79,7 +79,12 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         superuser_password:, ha_type:, target_version:, flavor:, parent_id:, tags:, restore_target:, hostname_version:, user_config:, pgbouncer_user_config:)
 
       if need_initial_cert_id
-        strand_args[:stack][0]["initial_cert_id"] = Prog::Vnet::CertNexus.assemble(postgres_resource.cert_hostname, postgres_resource.dns_zone.id, private_hostname: postgres_resource.cert_private_hostname).id
+        strand_args[:stack][0]["initial_cert_id"] = Prog::Vnet::CertNexus.assemble(
+          postgres_resource.cert_hostname,
+          postgres_resource.dns_zone.id,
+          private_hostname: postgres_resource.cert_private_hostname,
+          waiting_strand_id: postgres_resource_id,
+        ).id
       end
 
       PostgresInitScript.create_with_id(postgres_resource, init_script:) if init_script && !init_script.empty?
@@ -248,7 +253,12 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     postgres_resource.save_changes
 
     if use_publicly_signed_certificates? && OpenSSL::X509::Certificate.new(postgres_resource.server_cert).not_after < Time.now + 60 * 60 * 24 * 13
-      update_stack("refresh_cert_id" => Prog::Vnet::CertNexus.assemble(postgres_resource.cert_hostname, postgres_resource.dns_zone.id, private_hostname: postgres_resource.cert_private_hostname).id)
+      update_stack("refresh_cert_id" => Prog::Vnet::CertNexus.assemble(
+        postgres_resource.cert_hostname,
+        postgres_resource.dns_zone.id,
+        private_hostname: postgres_resource.cert_private_hostname,
+        waiting_strand_id: postgres_resource.id,
+      ).id)
       hop_wait_refresh_public_cert
     end
 
@@ -416,7 +426,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   def wait_for_public_cert(frame_key)
     cert_id = frame.fetch(frame_key)
     cert = Cert.with_pk!(cert_id)
-    nap 10 unless cert.cert
+    nap(10 * 60) unless cert.cert
 
     postgres_resource.server_cert = cert.cert
     postgres_resource.server_cert_key = OpenSSL::PKey::EC.new(cert.csr_key).to_pem

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -8,7 +8,7 @@ class Prog::Vnet::CertNexus < Prog::Base
 
   REVOKE_REASON = "cessationOfOperation"
 
-  def self.assemble(hostname, dns_zone_id, private_hostname: nil)
+  def self.assemble(hostname, dns_zone_id, private_hostname: nil, waiting_strand_id: nil)
     unless Config.development? || DnsZone[dns_zone_id]
       fail "Given DNS zone doesn't exist with the id #{dns_zone_id}"
     end
@@ -16,7 +16,7 @@ class Prog::Vnet::CertNexus < Prog::Base
     DB.transaction do
       cert = Cert.create(hostname:, dns_zone_id:, private_hostname:)
 
-      Strand.create_with_id(cert, prog: "Vnet::CertNexus", label: "start", stack: [{"restarted" => 0}])
+      Strand.create_with_id(cert, prog: "Vnet::CertNexus", label: "start", stack: [{"restarted" => 0, "waiting_strand_id" => waiting_strand_id}])
     end
   end
 
@@ -124,6 +124,9 @@ class Prog::Vnet::CertNexus < Prog::Base
     when "valid"
       cert.update(cert: acme_order.certificate, created_at: Time.now)
       cleanup_dns_challenge_records
+      if (waiting_strand_id = frame["waiting_strand_id"])
+        Strand.where(id: waiting_strand_id).update(schedule: Sequel::CURRENT_TIMESTAMP)
+      end
       hop_wait
     else
       Clog.emit("Certificate finalization failed", {order_status:})

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -89,7 +89,9 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
   end
 
   label def create_new_cert
-    cert = Prog::Vnet::CertNexus.assemble(load_balancer.cert_hostname, load_balancer.dns_zone&.id, private_hostname: load_balancer.cert_private_hostname).subject
+    cert = Prog::Vnet::CertNexus.assemble(load_balancer.cert_hostname, load_balancer.dns_zone&.id,
+      private_hostname: load_balancer.cert_private_hostname,
+      waiting_strand_id: strand.id).subject
     load_balancer.add_cert(cert)
     update_stack("cert" => cert.id)
     hop_wait_cert_provisioning
@@ -98,7 +100,7 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
   label def wait_cert_provisioning
     # Wait until the cert we created in create_new_cert actually has a cert
     if frame["cert"] ? Cert[frame["cert"]].cert.nil? : load_balancer.need_certificates?
-      nap 60
+      nap(10 * 60)
     elsif load_balancer.refresh_cert_set?
       load_balancer.vms.each do |vm|
         bud Prog::Vnet::CertServer, {"subject_id" => load_balancer.id, "vm_id" => vm.id}, :reshare_certificate

--- a/prog/vnet/maintain_presigned_certs.rb
+++ b/prog/vnet/maintain_presigned_certs.rb
@@ -30,7 +30,9 @@ class Prog::Vnet::MaintainPresignedCerts < Prog::Base
 
   def request_cert
     ubid = generate_ubid
-    st = Prog::Vnet::CertNexus.assemble("*.#{ubid}.#{domain}", dns_zone.id, private_hostname: "*.#{ubid}.private.#{domain}")
+    st = Prog::Vnet::CertNexus.assemble("*.#{ubid}.#{domain}", dns_zone.id,
+      private_hostname: "*.#{ubid}.private.#{domain}",
+      waiting_strand_id: strand.id)
     update_stack(
       id_key => ubid.to_uuid,
       "cert_id" => st.id,
@@ -42,7 +44,7 @@ class Prog::Vnet::MaintainPresignedCerts < Prog::Base
   def wait_for_signed_cert
     cert_id = frame["cert_id"]
     if (cert_strand = Strand[cert_id])
-      nap 10 unless cert_strand.label == "wait"
+      nap(10 * 60) unless cert_strand.label == "wait"
       ds.insert(id_key.to_sym => frame[id_key], :cert_id => frame["cert_id"])
     else
       # Info page for visibility, as this indicates a problem in the code or a manual deletion of the strand.

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -182,6 +182,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(cert.hostname).to eq "*.#{pg.ubid}.postgres.ubicloud.com"
       expect(cert.private_hostname).to eq "*.#{pg.ubid}.private.postgres.ubicloud.com"
       expect(cert.strand.label).to eq "start"
+      expect(cert.strand.stack[0]["waiting_strand_id"]).to eq pg.id
     end
 
     it "sets use_different_az semaphore for AWS locations when FF is set" do
@@ -449,7 +450,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     it "naps if needing an initial cert and one is not available" do
       nx.postgres_resource.update(hostname_version: "v3")
       refresh_frame(nx, new_values: {"use_publicly_signed_certificates" => true, "initial_cert_id" => Cert.create(hostname: "*.#{postgres_resource.ubid}.pg.example.com").id})
-      expect { nx.initialize_certificates }.to nap(10)
+      expect { nx.initialize_certificates }.to nap(600)
     end
 
     it "uses initial cert if avaliable" do
@@ -591,6 +592,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(cert.hostname).to eq "*.#{postgres_resource.ubid}.postgres.ubicloud.com"
       expect(cert.private_hostname).to eq "*.#{postgres_resource.ubid}.private.postgres.ubicloud.com"
       expect(cert.strand.label).to eq "start"
+      expect(cert.strand.stack[0]["waiting_strand_id"]).to eq postgres_resource.id
     end
   end
 
@@ -607,7 +609,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     end
 
     it "naps if cert not ready" do
-      expect { nx.wait_refresh_public_cert }.to nap(10)
+      expect { nx.wait_refresh_public_cert }.to nap(600)
     end
 
     it "updates cert and hops if cert is ready" do

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -67,6 +67,14 @@ RSpec.describe Prog::Vnet::CertNexus do
       expect(cert.private_hostname).to eq "private.test-hostname"
     end
 
+    it "supports waiting_strand_id argument" do
+      waiting_strand_id = Strand.generate_uuid
+      st = described_class.assemble("test-hostname", dns_zone.id, waiting_strand_id:)
+      cert = st.subject
+      expect(cert.hostname).to eq "test-hostname"
+      expect(st.stack[0]["waiting_strand_id"]).to eq waiting_strand_id
+    end
+
     it "fails if dns_zone is not valid" do
       id = SecureRandom.uuid
       expect {
@@ -275,6 +283,18 @@ RSpec.describe Prog::Vnet::CertNexus do
       expect { nx.wait_cert_finalization }.to hop("wait")
         .and change { DnsRecord.where(:tombstoned).count }.from(0).to(1)
       expect(cert.reload.cert).to eq("test-certificate")
+    end
+
+    it "schedules waiting strand if waiting_strand_id is set" do
+      waiting_strand = Strand.create(prog: "Test", label: "start", schedule: Time.now - 10000)
+      refresh_frame(nx, new_values: {"waiting_strand_id" => waiting_strand.id})
+      expect(@acme_order).to receive(:status).and_return("valid")
+      expect(@acme_order).to receive(:certificate).and_return("test-certificate")
+      DnsRecord.create(dns_zone_id: dns_zone.id, name: "test-record-name.cert-hostname.test-dns-zone.com.", type: "test-record-type", ttl: 600, data: "test-record-content")
+      expect { nx.wait_cert_finalization }.to hop("wait")
+        .and change { DnsRecord.where(:tombstoned).count }.from(0).to(1)
+      expect(cert.reload.cert).to eq("test-certificate")
+      expect(waiting_strand.reload.schedule).to be_within(10).of(Time.now)
     end
   end
 

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -138,11 +138,13 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
   describe "#create_new_cert" do
     it "creates a new cert" do
       domain = "#{nx.load_balancer.private_subnet.ubid[-5..]}.lb.ubicloud.com"
+      cert_ds = Cert.where(hostname: "test-lb.#{domain}", private_hostname: "private.test-lb.#{domain}")
       expect { nx.create_new_cert }.to hop("wait_cert_provisioning")
         .and change { Strand.where(prog: "Vnet::CertNexus").count }.from(1).to(2)
-        .and change { Cert.where(hostname: "test-lb.#{domain}", private_hostname: "private.test-lb.#{domain}").count }.from(0).to(1)
+        .and change { cert_ds.count }.from(0).to(1)
         .and change { nx.load_balancer.certs.count }.from(1).to(2)
       expect(st.reload.stack[0]["cert"]).to be_a String
+      expect(cert_ds.first.strand.stack[0]["waiting_strand_id"]).to eq st.id
     end
 
     it "creates a cert without dns zone in development" do
@@ -157,13 +159,13 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
   describe "#wait_cert_provisioning" do
     it "naps for 60 seconds if need_certificates? is true" do
       expect(nx.load_balancer).to receive(:need_certificates?).and_return(true)
-      expect { nx.wait_cert_provisioning }.to nap(60)
+      expect { nx.wait_cert_provisioning }.to nap(600)
     end
 
     it "naps for 60 seconds if cert is set in frame but does not have valid cert entry" do
       cert = Cert.create(hostname: nx.load_balancer.hostname)
       refresh_frame(nx, new_values: {"cert" => cert.id})
-      expect { nx.wait_cert_provisioning }.to nap(60)
+      expect { nx.wait_cert_provisioning }.to nap(600)
     end
 
     it "hops to wait_cert_broadcast if certificate is ready and refresh_cert is set" do

--- a/spec/prog/vnet/maintain_presigned_load_balancer_certs_spec.rb
+++ b/spec/prog/vnet/maintain_presigned_load_balancer_certs_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Prog::Vnet::MaintainPresignedLoadBalancerCerts do
       expect(lb_ubid).to start_with("1b")
       expect(cert_id).to eq cert.id
       expect(cert.strand.label).to eq "start"
+      expect(cert.strand.stack[0]["waiting_strand_id"]).to eq prog.strand.id
       expect(cert.hostname).to eq "*.#{lb_ubid}.lb2.ubicloud.com"
       expect(cert.private_hostname).to eq "*.#{lb_ubid}.private.lb2.ubicloud.com"
       expect(cert.dns_zone_id).to eq dns_zone.id
@@ -94,7 +95,7 @@ RSpec.describe Prog::Vnet::MaintainPresignedLoadBalancerCerts do
       frame = prog.strand.stack[0]
       Strand.create_with_id(frame.fetch("cert_id"), prog: "Vnet::CertNexus", label: "start")
       refresh_frame(prog, new_values: {"last_cert_created" => Time.now.to_i - 50})
-      expect { prog.wait_for_signed_cert }.to nap(10)
+      expect { prog.wait_for_signed_cert }.to nap(600)
     end
 
     it "hops if cert strand is in wait" do

--- a/spec/prog/vnet/maintain_presigned_postgres_certs_spec.rb
+++ b/spec/prog/vnet/maintain_presigned_postgres_certs_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Prog::Vnet::MaintainPresignedPostgresCerts do
       expect(pg_ubid).to start_with("pg")
       expect(cert_id).to eq cert.id
       expect(cert.strand.label).to eq "start"
+      expect(cert.strand.stack[0]["waiting_strand_id"]).to eq prog.strand.id
       expect(cert.hostname).to eq "*.#{pg_ubid}.pg.ubicloud.com"
       expect(cert.private_hostname).to eq "*.#{pg_ubid}.private.pg.ubicloud.com"
       expect(cert.dns_zone_id).to eq dns_zone.id
@@ -94,7 +95,7 @@ RSpec.describe Prog::Vnet::MaintainPresignedPostgresCerts do
       frame = prog.strand.stack[0]
       Strand.create_with_id(frame.fetch("cert_id"), prog: "Vnet::CertNexus", label: "start")
       refresh_frame(prog, new_values: {"last_cert_created" => Time.now.to_i - 50})
-      expect { prog.wait_for_signed_cert }.to nap(10)
+      expect { prog.wait_for_signed_cert }.to nap(600)
     end
 
     it "hops if cert strand is in wait" do


### PR DESCRIPTION
Requested in https://github.com/ubicloud/ubicloud/pull/5483#discussion_r3326981381

This can remove the need for polling. Technically, the code still polls, but it polls much less frequently, and it is unlikely to nap more than once (the first nap is right after the hop, since we don't have a feature that hops and naps at the same time).

Adjust the 4 progs that use CertNexus to set waiting_strand_id so they can use this scheduling.