### PR TITLE
Drop inactive or lagging logical replication slots when disk close to full.

### DIFF
--- a/rhizome/postgres/bin/disk-full-check
+++ b/rhizome/postgres/bin/disk-full-check
@@ -3,8 +3,23 @@ set -eu
 
 DAT=${DAT:-/dat}
 
+# Logical slot WAL retention threshold to drop the slot. see drop_inactive_or_lagging_logical_slots
+LOGICAL_SLOT_MAX_WAL_BYTES=2147483648
+
 read name btotal bused bavailable usedp mount_path <<< "$(df -P -B1 "$DAT" | tail -n +2)"
 PGDATA="$DAT/$1/data"
+
+# Drop logical replication slots that are inactive or retain more than
+# LOGICAL_SLOT_MAX_WAL_BYTES of WAL, then CHECKPOINT.
+drop_inactive_or_lagging_logical_slots() {
+  # Query: drop each matching slot and return the WAL bytes held by the most lagging
+  local slots_held_bytes
+  slots_held_bytes=$(psql -d postgres -At -c "SELECT COALESCE(MAX(wal_bytes), 0) FROM (SELECT pg_drop_replication_slot(slot_name), pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS wal_bytes FROM pg_replication_slots WHERE slot_type = 'logical' AND (NOT active OR pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) > $LOGICAL_SLOT_MAX_WAL_BYTES)) t;" 2>/dev/null) || return 1
+  test "${slots_held_bytes:-0}" -eq 0 && return 1
+  echo "[disk-full-check] dropped inactive or lagging logical slots holding ${slots_held_bytes} bytes of WAL; checkpointing"
+  psql -d postgres -c "CHECKPOINT" >/dev/null 2>&1 || true
+  return 0
+}
 
 if test "$btotal" -le 68719476736; then # Smaller thresholds for disks <= 64GB (hobby)
   recover_threshold=2147483648    # 2GB
@@ -78,6 +93,11 @@ elif test "$bavailable" -lt "$readonly_threshold"; then
     touch "$DAT/disk-full-read-only-pending-restart-$1"
     reload_needed=1
   elif test "$bavailable" -lt "$restart_threshold" && test -f "$DAT/disk-full-read-only-pending-restart-$1"; then
+    # Try to free WAL first by dropping inactive or lagging logical replication slots
+    if drop_inactive_or_lagging_logical_slots; then
+      exit 0
+    fi
+
     # Terminate customer backends so new connections pick up the read-only
     # default applied by the earlier `reload`. We cannot `pg_ctlcluster restart`
     # here because the cluster is managed by systemd and pg_ctlcluster refuses

--- a/rhizome/postgres/spec/disk_full_check_spec.rb
+++ b/rhizome/postgres/spec/disk_full_check_spec.rb
@@ -31,15 +31,21 @@ RSpec.describe "disk-full-check" do
     SH
     File.chmod(0o755, File.join(bin, "pg_ctlcluster"))
 
-    # Stub psql: capture the SQL passed via -c so we can assert the
-    # pg_terminate_backend invocation issued by the restart path.
+    # Stub psql: capture the SQL passed via -c so we can assert the issued
+    # statements. For the slot-drop+sum query (single call now), echo
+    # STUCK_SLOTS_BYTES (defaulting to 0) so the bash caller can decide
+    # whether to follow up with a CHECKPOINT.
     File.write(File.join(bin, "psql"), <<~SH)
       #!/bin/sh
-      # find the argument after -c and append to psql_calls
       while [ $# -gt 0 ]; do
         if [ "$1" = "-c" ]; then
           shift
           echo "$1" >> "#{dat}/psql_calls"
+          case "$1" in
+            *pg_drop_replication_slot*|*pg_replication_slots*)
+              echo "${STUCK_SLOTS_BYTES:-0}"
+              ;;
+          esac
           break
         fi
         shift
@@ -70,8 +76,9 @@ RSpec.describe "disk-full-check" do
     File.chmod(0o755, File.join(bin, "df"))
   end
 
-  def run_check
+  def run_check(stuck_slots_bytes: nil)
     env = {"PATH" => "#{bin}:#{ENV["PATH"]}", "DAT" => dat, "PG_LOG_THROTTLE_SRC" => pg_log_throttle_src, "CONF_D" => conf_d}
+    env["STUCK_SLOTS_BYTES"] = stuck_slots_bytes.to_s if stuck_slots_bytes
     stdout, stderr, status = Open3.capture3(env, "bash", script, "16")
     raise "disk-full-check failed: #{stderr}" unless status.success?
     stdout
@@ -222,6 +229,42 @@ RSpec.describe "disk-full-check" do
       fake_df(50, 4_000_000_000)
       run_check # would crash if intolerant
       expect(File.exist?(conf_d)).to be false
+    end
+  end
+
+  describe "inactive or lagging logical slot cleanup at restart_threshold" do
+    before do
+      fake_df(50, 2_000_000_000) # < 3GB restart threshold
+      File.write(auto_conf, "default_transaction_read_only = 'on'\n")
+      FileUtils.touch(pending_restart)
+    end
+
+    it "issues a single drop+sum query over pg_replication_slots" do
+      run_check
+      expect(psql_calls).to include("pg_drop_replication_slot")
+      expect(psql_calls).to include("pg_replication_slots")
+      expect(psql_calls).to include("slot_type = 'logical'")
+      expect(psql_calls).to include("NOT active")
+      expect(psql_calls).to include("2147483648")
+    end
+
+    it "no matching slots (sum=0): skips CHECKPOINT, terminates backends, no freed-bytes log" do
+      out = run_check
+      expect(psql_calls).not_to include("CHECKPOINT")
+      expect(psql_calls).to include("pg_terminate_backend")
+      expect(out).not_to include("dropped inactive or lagging logical slots")
+    end
+
+    it "inactive or lagging slots (sum>0): CHECKPOINTs, logs freed bytes, exits (no terminate this tick)" do
+      out = run_check(stuck_slots_bytes: 3_221_225_472) # 3 GB
+      expect(psql_calls).to include("CHECKPOINT")
+      # Exit-after-drop: next 20s tick re-reads df and decides whether more
+      # mitigation is still needed. Terminate must NOT have run this tick.
+      expect(psql_calls).not_to include("pg_terminate_backend")
+      # Pending marker stays so the next tick can still enter this branch.
+      expect(File.exist?(pending_restart)).to be true
+      # Operator-visible log line includes the freed byte count.
+      expect(out).to include("dropped inactive or lagging logical slots holding 3221225472 bytes of WAL")
     end
   end
 


### PR DESCRIPTION
Drop inactive or lagging logical replication slots when disk
close to full.

When a server crosses restart_threshold disk usage, an inactive or
sufficiently lagging (2 GB+) logical replication slot is a
common culprit: it pins WAL that cannot be removed, so the disk
fills with no application-visible cause. Drop such slots to release
that WAL before the instance runs out of space.

Dropping any slot triggers a checkpoint and skips the rest of the
script, since the drop plus checkpoint is guaranteed to reclaim
space and makes the other, more disruptive recovery actions
unnecessary.

