### PR TITLE
Fix route_spec rake tasks

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -908,7 +908,9 @@ class Clover < Roda
 
       response << (defined?(Net::SSH::Connection) ? "defined-" : "undefined-")
 
-      sshable = Sshable.new(host: "127.1.2.3")
+      # Use absolute constant reference to work around model hiding (only acceptable
+      # as this is test-only code)
+      sshable = ::Sshable.new(host: "127.1.2.3")
 
       begin
         sshable.start_fresh_session


### PR DESCRIPTION
With the improved model hiding, Sshable is no longer allowed to be directly referenced in Clover. Work around this by using an absolute constant reference.