### PR TITLE
Avoid Regexp.new

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -44,14 +44,14 @@ autoload_normal = ->(subdirectory, include_first: false, flat: false, exclude_di
     # No matter how deep the file system traversal, this Regexp
     # only matches the filename in its capturing group,
     # i.e. it's like File.basename.
-    Regexp.new('\A.*?([^/]*)\.rb\z')
+    /\A.*?([^\/]*)\.rb\z/
   else
     # Capture the relative path of a traversed file, by using
     # Regexp.escape on the prefix that should *not* be
     # interpreted as modules/namespaces.  Since this is works on
     # absolute paths, the ignored content will often be like
     # "/home/myuser/..."
-    Regexp.new('\A' + Regexp.escape((File.file?(absolute) ? File.dirname(absolute) : absolute) + "/") + '(.*)\.rb\z')
+    /\A#{Regexp.escape((File.file?(absolute) ? File.dirname(absolute) : absolute) + "/")}(.*)\.rb\z/
   end
 
   # Copied from sequel/model/inflections.rb's camelize, to convert


### PR DESCRIPTION
Use a literal regexp. For the non-interpolated regexp, this ensures only a single Regexp object is allocated, instead of one per call to autoload_normal.  For the interpolated case, using a literal regexp avoids a string allocation and is in general faster.