### PR TITLE
Add Prog::Base.frame_#{reader,accessor} and use them

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -17,6 +17,13 @@ class Prog::Base
     @subject_id = frame.dig("subject_id") || @strand.id
   end
 
+  def self.frame_reader(*attr)
+    attr.each do |attr|
+      attr = attr.to_s
+      define_method(attr) { frame[attr] }
+    end
+  end
+
   # Searches the stack for the Prog that caused execution of the code,
   # which can be useful in logging from nested method calls.
   def self.current_prog

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -37,6 +37,9 @@ class Prog::Base
     end
   end
 
+  frame_reader :link
+  frame_accessor :deadline_at, :deadline_target, :deadline_start
+
   # Searches the stack for the Prog that caused execution of the code,
   # which can be useful in logging from nested method calls.
   def self.current_prog
@@ -142,7 +145,7 @@ end
       end,
     )
 
-    if strand.stack.length > 0 && (link = frame["link"])
+    if strand.stack.length > 0 && link
       # This is a multi-level stack with a back-link, i.e. one prog
       # calling another in the same Strand of execution.  The thing to
       # do here is pop the stack entry.
@@ -385,31 +388,28 @@ end
     strand.time_string(time)
   end
 
-  def register_deadline(deadline_target, deadline_in, allow_extension: false)
-    current_frame = strand.stack.first
+  def register_deadline(new_deadline_target, deadline_in, allow_extension: false)
     time = Time.now
     new_deadline = time + deadline_in
 
-    if (deadline_at = current_frame["deadline_at"]).nil? ||
-        (old_deadline_target = current_frame["deadline_target"]) != deadline_target ||
+    if deadline_at.nil? ||
+        deadline_target != new_deadline_target ||
         allow_extension ||
         Time.parse(deadline_at) > new_deadline
 
-      if old_deadline_target != deadline_target && (pg = Page.from_tag_parts("Deadline", strand.id, strand.prog, old_deadline_target))
+      if deadline_target != new_deadline_target && (pg = Page.from_tag_parts("Deadline", strand.id, strand.prog, deadline_target))
         pg.incr_resolve
       end
 
-      current_frame["deadline_target"] = deadline_target
+      self.deadline_target = new_deadline_target
 
       if allow_extension.is_a?(Integer)
-        current_frame["deadline_start"] ||= time_string(time)
-        cap = Time.parse(current_frame["deadline_start"]) + allow_extension
-        current_frame["deadline_at"] = time_string([new_deadline, cap].min)
-      else
-        current_frame["deadline_at"] = time_string(new_deadline)
+        self.deadline_start ||= time_string(time)
+        cap = Time.parse(deadline_start) + allow_extension
+        new_deadline = [new_deadline, cap].min
       end
 
-      strand.modified!(:stack)
+      self.deadline_at = time_string(new_deadline)
     end
   end
 

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -24,6 +24,19 @@ class Prog::Base
     end
   end
 
+  def self.frame_accessor(*attr)
+    frame_reader(*attr)
+
+    attr.each do |attr|
+      attr = attr.to_s
+      define_method(:"#{attr}=") do |v|
+        strand.modified!(:stack)
+        @frame = nil
+        strand.stack[0][attr] = v
+      end
+    end
+  end
+
   # Searches the stack for the Prog that caused execution of the code,
   # which can be useful in logging from nested method calls.
   def self.current_prog

--- a/prog/bootstrap_rhizome.rb
+++ b/prog/bootstrap_rhizome.rb
@@ -6,6 +6,8 @@ class Prog::BootstrapRhizome < Prog::Base
   subject_is :sshable
   semaphore :destroy
 
+  frame_reader :target_folder
+
   def user
     @user ||= frame.fetch("user", "root")
   end
@@ -84,6 +86,6 @@ echo :public_keys | sudo tee /home/rhizome/.ssh/authorized_keys > /dev/null
 sync
 SH
 
-    push Prog::InstallRhizome, {"target_folder" => frame["target_folder"]}
+    push Prog::InstallRhizome, {"target_folder" => target_folder}
   end
 end

--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -3,6 +3,8 @@
 class Prog::DnsZone::SetupDnsServerVm < Prog::Base
   subject_is :vm, :sshable
 
+  frame_reader :dns_server_id
+
   def self.assemble(dns_server, name: nil, vm_size: "standard-2", storage_size_gib: 30, location_id: Location::HETZNER_FSN1_ID, boot_image: "ubuntu-noble")
     fail "No existing Dns Server" unless dns_server
     fail "No existing Project" unless Project[Config.dns_service_project_id]
@@ -55,7 +57,7 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
   end
 
   def ds
-    @ds ||= DnsServer[frame["dns_server_id"]]
+    @ds ||= DnsServer[dns_server_id]
   end
 
   label def start

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -6,10 +6,8 @@ require "aws-sdk-s3"
 class Prog::DownloadBootImage < Prog::Base
   subject_is :sshable, :vm_host
   semaphore :cancel
-
-  def image_name
-    @image_name ||= frame.fetch("image_name")
-  end
+  frame_reader :download_r2, :custom_url, :exit_on_fail, :image_name
+  frame_accessor :restarted, :current_size_gib
 
   def version
     @version ||= frame["version"] || latest_boot_image_version(image_name)
@@ -31,13 +29,13 @@ class Prog::DownloadBootImage < Prog::Base
   end
 
   def download_from_r2?
-    frame["download_r2"] || Config.production?
+    download_r2 || Config.production?
   end
 
   def url
     @url ||=
-      if frame["custom_url"]
-        frame["custom_url"]
+      if custom_url
+        custom_url
       elsif download_from_blob_storage?
         suffixes = {
           "github" => "raw",
@@ -339,21 +337,21 @@ class Prog::DownloadBootImage < Prog::Base
       params = {image_name:, url:, version:, sha256sum:, certs:, use_htcat: download_from_r2?}
       sshable.cmd("common/bin/daemonizer 'host/bin/download-boot-image' :daemon_name", daemon_name:, stdin: params.to_json)
     when "Failed"
-      restarted = frame["restarted"] || 0
+      restarted = self.restarted || 0
       if restarted < 10
         sshable.cmd("cat var/log/:daemon_name.stderr || true", daemon_name:)
         sshable.cmd("cat var/log/:daemon_name.stdout || true", daemon_name:)
         sshable.cmd("common/bin/daemonizer --clean :daemon_name", daemon_name:)
-        update_stack({"restarted" => restarted + 1})
+        self.restarted = restarted + 1
       else
         Clog.emit("Failed to download boot image", {failed_boot_image_download: [vm_host, {image_name:, version:}]})
       end
-      if cancel_set? || (frame["exit_on_fail"] && restarted >= 10)
+      if cancel_set? || (exit_on_fail && restarted >= 10)
         image.destroy
         pop "operation cancelled"
       end
     when "InProgress"
-      update_stack({"current_size_gib" => image_size_gib(suffix: ".tmp")})
+      self.current_size_gib = image_size_gib(suffix: ".tmp")
     end
 
     nap 15
@@ -380,7 +378,7 @@ class Prog::DownloadBootImage < Prog::Base
       image,
       boot_image_download: {
         duration: (image.activated_at - image.created_at).round(2),
-        restarts: frame["restarted"] || 0,
+        restarts: restarted || 0,
         vm_host_ubid: vm_host.ubid,
         arch: vm_host.arch,
         location: vm_host.location.display_name,

--- a/prog/download_cloud_hypervisor.rb
+++ b/prog/download_cloud_hypervisor.rb
@@ -2,10 +2,7 @@
 
 class Prog::DownloadCloudHypervisor < Prog::Base
   subject_is :sshable, :vm_host
-
-  def version
-    @version ||= frame.fetch("version")
-  end
+  frame_reader :version
 
   def sha256_ch_bin
     @sha256_ch_bin ||= frame.fetch("sha256_ch_bin") || sha_256("ch-bin")

--- a/prog/download_firmware.rb
+++ b/prog/download_firmware.rb
@@ -2,14 +2,7 @@
 
 class Prog::DownloadFirmware < Prog::Base
   subject_is :sshable, :vm_host
-
-  def version
-    @version ||= frame.fetch("version")
-  end
-
-  def sha256
-    @sha256 ||= frame.fetch("sha256")
-  end
+  frame_reader :version, :sha256
 
   label def start
     fail "Version is required" if version.nil?

--- a/prog/github/delete_cache_entries.rb
+++ b/prog/github/delete_cache_entries.rb
@@ -2,6 +2,7 @@
 
 class Prog::Github::DeleteCacheEntries < Prog::Base
   subject_is :github_repository
+  frame_reader :initiated_at
 
   def self.assemble(repository_id, initiated_at: Time.now)
     Strand.create(
@@ -24,7 +25,9 @@ class Prog::Github::DeleteCacheEntries < Prog::Base
   end
 
   def next_entry
-    initiated_at = Time.parse(frame["initiated_at"])
-    github_repository.cache_entries_dataset.order(:created_at).first { created_at < initiated_at }
+    github_repository
+      .cache_entries_dataset
+      .order(:created_at)
+      .first(Sequel[:created_at] < Time.parse(initiated_at))
   end
 end

--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -7,6 +7,8 @@ require "openssl"
 class Prog::InstallRhizome < Prog::Base
   subject_is :sshable
   semaphore :destroy
+  frame_reader :target_folder, :install_specs
+  frame_accessor :rhizome_digest
 
   SKIP_VALIDATION = ["Gemfile.lock"]
 
@@ -16,8 +18,8 @@ class Prog::InstallRhizome < Prog::Base
     file_hash_map = {} # pun intended
     Gem::Package::TarWriter.new(tar) do |writer|
       base = Config.root + "/rhizome"
-      Dir.glob(["Gemfile", "Gemfile.lock", "common/**/*", "#{frame["target_folder"]}/**/*"], base:) do |file|
-        next if !frame["install_specs"] && file.end_with?("_spec.rb")
+      Dir.glob(["Gemfile", "Gemfile.lock", "common/**/*", "#{target_folder}/**/*"], base:) do |file|
+        next if !install_specs && file.end_with?("_spec.rb")
 
         full_path = base + "/" + file
         stat = File.stat(full_path)
@@ -39,8 +41,7 @@ class Prog::InstallRhizome < Prog::Base
       end
 
       hashes_json = JSON.generate(file_hash_map.sort.to_h)
-      digest = OpenSSL::Digest::SHA256.hexdigest(hashes_json)[0, 24]
-      update_stack({"rhizome_digest" => digest})
+      self.rhizome_digest = OpenSSL::Digest::SHA256.hexdigest(hashes_json)[0, 24]
       writer.add_file("hashes.json", 0o100755) do |tf|
         tf.write hashes_json
       end
@@ -53,7 +54,7 @@ class Prog::InstallRhizome < Prog::Base
   end
 
   label def install_gems
-    if frame["target_folder"] == "host"
+    if target_folder == "host"
       sshable.cmd("bundle config set --local path vendor/bundle && bundle install")
     end
 
@@ -62,9 +63,9 @@ class Prog::InstallRhizome < Prog::Base
 
   label def validate
     sshable.cmd("common/bin/validate")
-    folder = frame["target_folder"]
+    folder = target_folder
     commit = Config.git_commit_hash
-    digest = frame["rhizome_digest"]
+    digest = rhizome_digest
     RhizomeInstallation.dataset.insert_conflict(
       target: :id,
       update: {folder:, commit:, digest:, installed_at: Sequel::CURRENT_TIMESTAMP},

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -3,13 +3,16 @@
 class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
   subject_is :kubernetes_cluster
 
+  frame_reader :nodepool_id
+  frame_accessor :node_id
+
   def node
-    @node ||= KubernetesNode[frame["node_id"]]
+    @node ||= KubernetesNode[node_id]
   end
 
   def kubernetes_nodepool
     return @kubernetes_nodepool if defined?(@kubernetes_nodepool)
-    @kubernetes_nodepool = KubernetesNodepool[frame["nodepool_id"]]
+    @kubernetes_nodepool = KubernetesNodepool[nodepool_id]
   end
 
   def vm
@@ -71,7 +74,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     ).subject
     vm = node.vm
 
-    update_stack({"node_id" => node.id})
+    self.node_id = node.id
 
     unless kubernetes_nodepool
       kubernetes_cluster.api_server_lb.add_vm(vm)

--- a/prog/kubernetes/upgrade_kubernetes_node.rb
+++ b/prog/kubernetes/upgrade_kubernetes_node.rb
@@ -2,17 +2,19 @@
 
 class Prog::Kubernetes::UpgradeKubernetesNode < Prog::Base
   subject_is :kubernetes_cluster
+  frame_reader :old_node_id, :nodepool_id
+  frame_accessor :new_node_id
 
   def old_node
-    @old_node ||= KubernetesNode[frame.fetch("old_node_id")]
+    @old_node ||= KubernetesNode[old_node_id]
   end
 
   def new_node
-    @new_node ||= KubernetesNode[frame.fetch("new_node_id")]
+    @new_node ||= KubernetesNode[new_node_id]
   end
 
   def kubernetes_nodepool
-    @kubernetes_nodepool ||= KubernetesNodepool[frame.fetch("nodepool_id", nil)]
+    @kubernetes_nodepool ||= KubernetesNodepool[nodepool_id]
   end
 
   def before_run
@@ -44,7 +46,7 @@ class Prog::Kubernetes::UpgradeKubernetesNode < Prog::Base
     reap(reaper:) do
       # This will not work correctly if the strand has multiple children.
       # However, the strand has only has a single child created in start.
-      update_stack({"new_node_id" => node_id})
+      self.new_node_id = node_id
 
       hop_wait_node_ready
     end

--- a/prog/machine_image/create_version_metal.rb
+++ b/prog/machine_image/create_version_metal.rb
@@ -4,6 +4,8 @@ require "json"
 
 class Prog::MachineImage::CreateVersionMetal < Prog::Base
   subject_is :machine_image_version
+  frame_reader :source_vm_id, :destroy_source_after, :set_as_latest
+  frame_accessor :archive_size_bytes
 
   def self.assemble(machine_image, version, source_vm, store, destroy_source_after: false, set_as_latest: true)
     fail MachineImageError, "Source VM arch (#{source_vm.arch}) does not match machine image arch (#{machine_image.arch})" unless source_vm.arch == machine_image.arch
@@ -51,7 +53,7 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
     when "Succeeded"
       stats_json = sshable.cmd("cat :stats_path", stats_path: stats_file_path)
       stats = JSON.parse(stats_json)
-      update_stack("archive_size_bytes" => stats["physical_size_bytes"])
+      self.archive_size_bytes = stats["physical_size_bytes"]
       sshable.d_clean(unit_name)
       hop_finish
     when "Failed"
@@ -76,13 +78,13 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
 
     machine_image_version.metal.update(
       enabled: true,
-      archive_size_mib: (frame["archive_size_bytes"]/1048576r).ceil,
+      archive_size_mib: (archive_size_bytes/1048576r).ceil,
     )
     machine_image_version.metal.create_billing_record
-    if frame["destroy_source_after"]
+    if destroy_source_after
       source_vm.incr_destroy
     end
-    if frame["set_as_latest"]
+    if set_as_latest
       machine_image_version.machine_image.update(latest_version_id: machine_image_version.id)
     end
     pop "Metal machine image version is created and enabled"
@@ -111,6 +113,6 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
   end
 
   def source_vm
-    @source_vm ||= Vm[frame["source_vm_id"]]
+    @source_vm ||= Vm[source_vm_id]
   end
 end

--- a/prog/machine_image/create_version_metal_from_url.rb
+++ b/prog/machine_image/create_version_metal_from_url.rb
@@ -4,6 +4,8 @@ require "json"
 
 class Prog::MachineImage::CreateVersionMetalFromUrl < Prog::Base
   subject_is :machine_image_version
+  frame_reader :url, :sha256sum, :vm_host_id, :vhost_block_backend_version, :set_as_latest
+  frame_accessor :physical_size_bytes, :logical_size_bytes
 
   def self.assemble(machine_image, version, url, sha256sum, store, set_as_latest: true)
     vbb = VhostBlockBackend
@@ -51,7 +53,8 @@ class Prog::MachineImage::CreateVersionMetalFromUrl < Prog::Base
     when "Succeeded"
       stats_json = sshable.cmd("cat :stats_path", stats_path: stats_file_path)
       stats = JSON.parse(stats_json)
-      update_stack(stats.slice("physical_size_bytes", "logical_size_bytes"))
+      self.physical_size_bytes = stats["physical_size_bytes"]
+      self.logical_size_bytes = stats["logical_size_bytes"]
       sshable.d_clean(unit_name)
       hop_finish
     when "Failed"
@@ -59,7 +62,7 @@ class Prog::MachineImage::CreateVersionMetalFromUrl < Prog::Base
       nap 60
     when "NotStarted"
       sshable.d_run(unit_name,
-        "sudo", "host/bin/archive-url", frame["url"], frame["sha256sum"], frame["vhost_block_backend_version"], stats_file_path,
+        "sudo", "host/bin/archive-url", url, sha256sum, vhost_block_backend_version, stats_file_path,
         stdin: archive_params_json, log: false)
       nap 30
     when "InProgress"
@@ -75,13 +78,13 @@ class Prog::MachineImage::CreateVersionMetalFromUrl < Prog::Base
 
     machine_image_version.metal.update(
       enabled: true,
-      archive_size_mib: (frame["physical_size_bytes"]/1048576r).ceil,
+      archive_size_mib: (physical_size_bytes/1048576r).ceil,
     )
     machine_image_version.metal.create_billing_record
 
-    machine_image_version.update(actual_size_mib: (frame["logical_size_bytes"]/1048576r).ceil)
+    machine_image_version.update(actual_size_mib: (logical_size_bytes/1048576r).ceil)
 
-    if frame["set_as_latest"]
+    if set_as_latest
       machine_image_version.machine_image.update(latest_version_id: machine_image_version.id)
     end
 
@@ -110,6 +113,6 @@ class Prog::MachineImage::CreateVersionMetalFromUrl < Prog::Base
   end
 
   def vm_host
-    @vm_host ||= VmHost[frame["vm_host_id"]]
+    @vm_host ||= VmHost[vm_host_id]
   end
 end

--- a/prog/minio/minio_server_nexus.rb
+++ b/prog/minio/minio_server_nexus.rb
@@ -109,7 +109,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
         decr_initial_provisioning
       end
 
-      push self.class, frame, "minio_restart"
+      push self.class, {}, "minio_restart"
     end
 
     if minio_server.certificate_last_checked_at < Time.now - 60 * 60 * 24 * 30 # ~1 month
@@ -154,7 +154,7 @@ class Prog::Minio::MinioServerNexus < Prog::Base
       hop_wait
     end
 
-    bud self.class, frame, :minio_restart
+    bud self.class, {}, :minio_restart
     nap 5
   end
 

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -2,6 +2,7 @@
 
 class Prog::PageNexus < Prog::Base
   subject_is :page
+  frame_accessor :suppress_triggers
 
   def self.assemble(summary, tag_parts, related_resources, severity: "error", extra_data: {})
     DB.transaction do
@@ -54,7 +55,7 @@ class Prog::PageNexus < Prog::Base
   end
 
   label def start
-    page.trigger unless frame["suppress_triggers"]
+    page.trigger unless suppress_triggers
     hop_wait
   end
 
@@ -62,13 +63,13 @@ class Prog::PageNexus < Prog::Base
     when_retrigger_set? do
       # If retriggering due to an escalation, always trigger,
       # even if triggers were originally suppressed.
-      update_stack("suppress_triggers" => false)
+      self.suppress_triggers = false
       page.trigger
       decr_retrigger
     end
 
     when_resolve_set? do
-      page.resolve(notify: !frame["suppress_triggers"])
+      page.resolve(notify: !suppress_triggers)
       hop_wait_retention
     end
 

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -2,6 +2,7 @@
 
 class Prog::Postgres::ConvergePostgresResource < Prog::Base
   subject_is :postgres_resource
+  frame_accessor :total_disk_usage, :total_lsn, :servers_to_destroy
 
   label def start
     nap 60 if postgres_resource.read_replica? && !postgres_resource.parent.ready_for_read_replica?
@@ -42,7 +43,8 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
     previous_total_disk_usage = strand.stack.first["total_disk_usage"] || 0
     previous_total_lsn = strand.stack.first["total_lsn"] || 0
     if total_disk_usage > previous_total_disk_usage || total_lsn > previous_total_lsn
-      update_stack({"total_disk_usage" => [total_disk_usage, previous_total_disk_usage].max, "total_lsn" => [total_lsn, previous_total_lsn].max})
+      self.total_disk_usage = [total_disk_usage, previous_total_disk_usage].max
+      self.total_lsn = [total_lsn, previous_total_lsn].max
       register_deadline("wait_for_maintenance_window", 10 * 60, allow_extension: 24 * 60 * 60)
     end
 
@@ -157,7 +159,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
       .take(postgres_resource.target_standby_count) + [postgres_resource.representative_server]
     servers_to_destroy = (postgres_resource.servers - servers_to_keep)
     servers_to_destroy.each(&:incr_destroy)
-    update_stack({"servers_to_destroy" => servers_to_destroy.map(&:id)})
+    self.servers_to_destroy = servers_to_destroy.map(&:id)
 
     servers_to_keep.each(&:incr_configure)
     postgres_resource.incr_update_billing_records
@@ -166,7 +168,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
   end
 
   label def wait_prune_servers
-    nap 30 unless PostgresServer.where(id: frame["servers_to_destroy"]).empty?
+    nap 30 unless PostgresServer.where(id: servers_to_destroy).empty?
 
     pop "postgres resource is converged"
   end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -4,6 +4,8 @@ require "forwardable"
 
 class Prog::Postgres::PostgresServerNexus < Prog::Base
   subject_is :postgres_server
+  frame_accessor :disk_usage, :initialize_database_from_backup_try_count, :previous_lsn, :previous_disk_usage,
+    :lockout_succeeded, :lsn
 
   extend Forwardable
 
@@ -199,18 +201,18 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
       hop_refresh_certificates
     when "InProgress"
       disk_usage = postgres_server.data_disk_usage
-      previous_disk_usage = frame["disk_usage"] || 0
+      previous_disk_usage = self.disk_usage || 0
       if disk_usage > previous_disk_usage
-        update_stack({"disk_usage" => disk_usage})
+        self.disk_usage = disk_usage
         register_deadline("wait", 10 * 60, allow_extension: 24 * 60 * 60)
       end
     when "Failed", "NotStarted"
-      previous_try_count = frame["initialize_database_from_backup_try_count"] || 0
+      previous_try_count = initialize_database_from_backup_try_count || 0
       if previous_try_count >= 3
         Prog::PageNexus.assemble("#{postgres_server.ubid} initialize database from backup failed after 3 attempts",
           ["PGInitializeDatabaseFromBackupFailed", postgres_server.id], postgres_server.ubid)
       end
-      update_stack({"initialize_database_from_backup_try_count" => previous_try_count + 1})
+      self.initialize_database_from_backup_try_count = previous_try_count + 1
 
       backup_label = if postgres_server.standby? || postgres_server.read_replica?
         "LATEST"
@@ -548,14 +550,14 @@ SQL
     if (current_lsn = postgres_server.last_known_lsn)
       previous_lsn = strand.stack.first["previous_lsn"]
       if previous_lsn.nil? || postgres_server.lsn_diff(current_lsn, previous_lsn) > 0
-        update_stack({"previous_lsn" => current_lsn})
+        self.previous_lsn = current_lsn
         register_deadline("wait", 10 * 60, allow_extension: 24 * 60 * 60)
       end
     else
       disk_usage = postgres_server.data_disk_usage
       previous_disk_usage = strand.stack.first["previous_disk_usage"] || 0
       if disk_usage > previous_disk_usage
-        update_stack({"previous_disk_usage" => disk_usage})
+        self.previous_disk_usage = disk_usage
         register_deadline("wait", 10 * 60, allow_extension: 24 * 60 * 60)
       end
     end
@@ -687,12 +689,12 @@ SQL
       # The first time we are behind the primary, so, we'll just record the info
       # and nap
       unless previous_lsn
-        update_stack_lsn(lsn)
+        self.lsn = lsn
         nap 15 * 60
       end
 
       if postgres_server.lsn_diff(lsn, previous_lsn) > 0
-        update_stack_lsn(lsn)
+        self.lsn = lsn
         # Even if it is lagging, it has applied new wal files, so, we should
         # give it a chance to catch up
         decr_recycle_lagging_read_replica
@@ -804,7 +806,7 @@ SQL
   label def wait_lockout_attempt
     reaper = lambda do |child|
       if child.exitval == "lockout_succeeded"
-        update_stack({"lockout_succeeded" => true})
+        self.lockout_succeeded = true
       end
     end
 
@@ -930,10 +932,6 @@ SQL
     end
 
     false
-  end
-
-  def update_stack_lsn(lsn)
-    update_stack({"lsn" => lsn})
   end
 
   def postgres_exporter_queries_yaml

--- a/prog/redeliver_github_failures.rb
+++ b/prog/redeliver_github_failures.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 class Prog::RedeliverGithubFailures < Prog::Base
+  frame_reader :delivery_ids
+  frame_accessor :last_check_at
+
   label def wait
-    last_check_time = Time.parse(frame["last_check_at"])
+    last_check_time = Time.parse(last_check_at)
     remaining_seconds = 2 * 60 - (Time.now - last_check_time)
     nap remaining_seconds.to_i + 1 if remaining_seconds > 0
     failures = failed_deliveries(last_check_time)
@@ -11,7 +14,7 @@ class Prog::RedeliverGithubFailures < Prog::Base
     failures.each_slice(25) do |deliveries|
       bud Prog::RedeliverGithubFailures, {"delivery_ids" => deliveries.map { it[:id] }}, "redeliver"
     end
-    update_stack({"last_check_at" => Time.now.to_s})
+    self.last_check_at = Time.now.to_s
     hop_wait_redelivers
   end
 
@@ -21,7 +24,7 @@ class Prog::RedeliverGithubFailures < Prog::Base
   end
 
   label def redeliver
-    frame["delivery_ids"].each { client.post("/app/hook/deliveries/#{it}/attempts") }
+    delivery_ids.each { client.post("/app/hook/deliveries/#{it}/attempts") }
     pop "redelivered failures"
   end
 

--- a/prog/rollout_boot_image.rb
+++ b/prog/rollout_boot_image.rb
@@ -2,6 +2,7 @@
 
 class Prog::RolloutBootImage < Prog::Base
   semaphore :rollback, :pause
+  frame_reader :concurrency, :image_name, :version, :todo, :in_progress, :completed, :failures
 
   def self.assemble(vm_hosts:, concurrency:, image_name:, version:)
     todo = vm_hosts.sort_by(&:created_at).map(&:id)
@@ -18,34 +19,6 @@ class Prog::RolloutBootImage < Prog::Base
         "version" => version,
       }],
     )
-  end
-
-  def image_name
-    @image_name ||= frame.fetch("image_name")
-  end
-
-  def version
-    @version ||= frame.fetch("version")
-  end
-
-  def concurrency
-    @concurrency ||= frame.fetch("concurrency")
-  end
-
-  def todo
-    frame.fetch("todo")
-  end
-
-  def in_progress
-    frame.fetch("in_progress")
-  end
-
-  def completed
-    frame.fetch("completed")
-  end
-
-  def failures
-    frame.fetch("failures")
   end
 
   label def wait

--- a/prog/rollout_rhizome.rb
+++ b/prog/rollout_rhizome.rb
@@ -2,6 +2,9 @@
 
 class Prog::RolloutRhizome < Prog::Base
   semaphore :pause, :github_runners_work, :destroy
+  frame_reader :vm_project_id, :initial_host_ids, :initial_github_runner_host_ids
+  frame_accessor :next_runner_time, :remaining_host_ids, :completed, :monitor_github_runners_until,
+    :initial_vm_ids, :initial_vms_keypair
 
   def self.assemble(vm_project_id: Config.rollouts_project_id)
     vm_host_ds = VmHost
@@ -82,10 +85,8 @@ class Prog::RolloutRhizome < Prog::Base
         enable_ip4: true,
       )
     end
-    update_stack(
-      "initial_vm_ids" => vm_strands.map(&:id),
-      "initial_vms_keypair" => Base64.strict_encode64(ssh_key.keypair),
-    )
+    self.initial_vm_ids = vm_strands.map(&:id)
+    self.initial_vms_keypair = Base64.strict_encode64(ssh_key.keypair)
     hop_wait_vms_on_initial_hosts
   end
 
@@ -99,7 +100,7 @@ class Prog::RolloutRhizome < Prog::Base
       # id is used for ubid in a Clog.emit call
       sshable = Sshable.new_with_id(
         host: it.ip4_string,
-        raw_private_key_1: SshKey.from_binary(Base64.strict_decode64(frame.fetch("initial_vms_keypair"))).keypair,
+        raw_private_key_1: SshKey.from_binary(Base64.strict_decode64(initial_vms_keypair)).keypair,
         unix_user: "rhizome",
       )
       sshable.cmd("sudo apt update && sudo apt install -y fio")
@@ -112,8 +113,8 @@ class Prog::RolloutRhizome < Prog::Base
     Semaphore.incr(initial_vm_ids, "destroy")
     delete_from_stack("initial_vm_ids", "initial_vms_keypair")
 
-    if frame["initial_github_runner_host_ids"].empty?
-      update_stack("next_runner_time" => Time.now.to_i)
+    if initial_github_runner_host_ids.empty?
+      self.next_runner_time = Time.now.to_i
       hop_rollout_next
     else
       hop_install_on_initial_github_runners_hosts
@@ -121,8 +122,8 @@ class Prog::RolloutRhizome < Prog::Base
   end
 
   label def install_on_initial_github_runners_hosts
-    frame.fetch("initial_github_runner_host_ids").each { install_rhizome(it) }
-    update_stack("monitor_github_runners_until" => Time.now.to_i + 45 * 60)
+    initial_github_runner_host_ids.each { install_rhizome(it) }
+    self.monitor_github_runners_until = Time.now.to_i + 45 * 60
     hop_wait_initial_github_runners_rhizome_install
   end
 
@@ -131,10 +132,10 @@ class Prog::RolloutRhizome < Prog::Base
   end
 
   label def monitor_github_runners
-    nap_until(frame["monitor_github_runners_until"])
+    nap_until(monitor_github_runners_until)
 
     when_github_runners_work_set? do
-      update_stack("next_runner_time" => Time.now.to_i)
+      self.next_runner_time = Time.now.to_i
       hop_rollout_next
     end
 
@@ -143,24 +144,23 @@ class Prog::RolloutRhizome < Prog::Base
 
   label def wait
     reaper = lambda do |child|
-      update_stack(
-        "next_runner_time" => Time.now.to_i + 30,
-        "completed" => (frame.fetch("completed") << child.stack.first["subject_id"]),
-      )
+      self.next_runner_time = Time.now.to_i + 30
+      # Mutation works here, as previous line sets strand.modified!(:stack)
+      completed << child.stack.first["subject_id"]
     end
 
     reap(:rollout_next, reaper:)
   end
 
   label def rollout_next
-    nap_until(frame["next_runner_time"])
+    nap_until(next_runner_time)
 
     unless (next_vm_host_id = remaining_host_ids.shift)
       hop_destroy
     end
 
     install_rhizome(next_vm_host_id)
-    update_stack("remaining_host_ids" => remaining_host_ids)
+    strand.modified!(:stack)
     hop_wait
   end
 
@@ -176,22 +176,6 @@ class Prog::RolloutRhizome < Prog::Base
     now = Time.now.to_i
     time_left = time_int - now
     nap(time_left) if time_left > 0
-  end
-
-  def vm_project_id
-    frame.fetch("vm_project_id")
-  end
-
-  def initial_host_ids
-    frame.fetch("initial_host_ids")
-  end
-
-  def initial_vm_ids
-    frame.fetch("initial_vm_ids")
-  end
-
-  def remaining_host_ids
-    frame.fetch("remaining_host_ids")
   end
 
   def install_rhizome(vm_host_id)

--- a/prog/rollout_semaphore.rb
+++ b/prog/rollout_semaphore.rb
@@ -2,6 +2,8 @@
 
 class Prog::RolloutSemaphore < Prog::Base
   semaphore :pause, :destroy
+  frame_reader :semaphore, :gap, :initial_gap, :initial_num, :increment
+  frame_accessor :remaining, :completed, :next_increment_time
 
   # semaphore: Name of semaphore to increment.
   # ids: Array of object ids to increment semaphore on.
@@ -46,30 +48,25 @@ class Prog::RolloutSemaphore < Prog::Base
       nap 60 * 60
     end
 
-    remaining = frame.fetch("remaining")
     unless (next_id = remaining.shift)
       hop_destroy
     end
 
-    time_int = frame.fetch("next_increment_time")
+    time_int = next_increment_time
     now = Time.now.to_i
     time_left = time_int - now
     nap(time_left) if time_left > 0
 
-    if frame["increment"]
-      Semaphore.incr(next_id, frame.fetch("semaphore"))
+    if increment
+      Semaphore.incr(next_id, semaphore)
     else
-      Semaphore.where(strand_id: next_id, name: frame.fetch("semaphore")).destroy
+      Semaphore.where(strand_id: next_id, name: semaphore).destroy
     end
 
-    completed = frame.fetch("completed")
     completed << next_id
-    nap_time = frame.fetch((completed.size >= frame["initial_num"]) ? "gap" : "initial_gap")
-    update_stack(
-      "remaining" => remaining,
-      "completed" => completed,
-      "next_increment_time" => now + nap_time,
-    )
+    nap_time = (completed.size >= initial_num) ? gap : initial_gap
+    # Also handles remaining/completed modifications due to strand.modified!(:stack)
+    self.next_increment_time = now + nap_time
 
     nap(nap_time)
   end

--- a/prog/setup_grafana.rb
+++ b/prog/setup_grafana.rb
@@ -2,6 +2,7 @@
 
 class Prog::SetupGrafana < Prog::Base
   subject_is :sshable
+  frame_reader :domain, :cert_email
 
   def self.assemble(sshable_id, grafana_domain:, certificate_owner_email:)
     grafana_domain = grafana_domain.strip
@@ -14,14 +15,6 @@ class Prog::SetupGrafana < Prog::Base
     end
 
     Strand.create(prog: "SetupGrafana", label: "start", stack: [{subject_id: sshable.id, domain: grafana_domain, cert_email: certificate_owner_email}])
-  end
-
-  def domain
-    frame["domain"]
-  end
-
-  def cert_email
-    frame["cert_email"]
   end
 
   label def start

--- a/prog/storage/setup_spdk.rb
+++ b/prog/storage/setup_spdk.rb
@@ -2,6 +2,8 @@
 
 class Prog::Storage::SetupSpdk < Prog::Base
   subject_is :sshable, :vm_host
+  frame_reader :version, :start_service, :allocation_weight
+  alias_method :start_service?, :start_service
 
   SUPPORTED_SPDK_VERSIONS = [
     ["v23.09-ubi-0.3", "x64"],
@@ -22,7 +24,6 @@ class Prog::Storage::SetupSpdk < Prog::Base
   end
 
   label def start
-    version = frame["version"]
     arch = vm_host.arch
 
     # Rhizome's spdk_setup.rb uses one 1G hugepage per CPU core
@@ -32,10 +33,10 @@ class Prog::Storage::SetupSpdk < Prog::Base
 
     fail "Can't install more than 2 SPDKs on a host" if vm_host.spdk_installations.length > 1
 
-    fail "No available hugepages" if frame["start_service"] && vm_host.used_hugepages_1g > vm_host.total_hugepages_1g - spdk_hugepages
+    fail "No available hugepages" if start_service? && vm_host.used_hugepages_1g > vm_host.total_hugepages_1g - spdk_hugepages
 
     SpdkInstallation.create(
-      version: frame["version"],
+      version:,
       allocation_weight: 0,
       vm_host_id: vm_host.id,
       cpu_count: vm_host.spdk_cpu_count,
@@ -46,7 +47,6 @@ class Prog::Storage::SetupSpdk < Prog::Base
   end
 
   label def install_spdk
-    version = frame["version"]
     cpu_count = vm_host.spdk_cpu_count
     # YYY: drop the default value after updating production data
     os_version = vm_host.os_version || "ubuntu-22.04"
@@ -56,8 +56,7 @@ class Prog::Storage::SetupSpdk < Prog::Base
   end
 
   label def start_service
-    if frame["start_service"]
-      version = frame["version"]
+    if start_service?
       sshable.cmd("sudo host/bin/setup-spdk start :version", version:)
       sshable.cmd("sudo host/bin/setup-spdk verify :version", version:)
     end
@@ -67,13 +66,13 @@ class Prog::Storage::SetupSpdk < Prog::Base
 
   label def update_database
     spdk_installation = SpdkInstallation.where(
-      version: frame["version"],
+      version:,
       vm_host_id: vm_host.id,
     ).first
 
-    spdk_installation.update(allocation_weight: frame["allocation_weight"])
+    spdk_installation.update(allocation_weight:)
 
-    if frame["start_service"]
+    if start_service?
       VmHost.where(id: vm_host.id).update(
         used_hugepages_1g: Sequel[:used_hugepages_1g] + spdk_installation.hugepages,
       )

--- a/prog/storage/setup_vhost_block_backend.rb
+++ b/prog/storage/setup_vhost_block_backend.rb
@@ -2,6 +2,8 @@
 
 class Prog::Storage::SetupVhostBlockBackend < Prog::Base
   subject_is :sshable, :vm_host
+  frame_reader :version, :allocation_weight
+  frame_accessor :vhost_block_backend_id
 
   SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS = [
     ["v0.4.2", "x64"],
@@ -25,7 +27,6 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
   end
 
   label def start
-    version = frame["version"]
     arch = vm_host.arch
     fail "Unsupported version: #{version}, #{arch}" unless SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS.include? [version, arch]
 
@@ -35,19 +36,18 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
       vm_host_id: vm_host.id,
     )
 
-    update_stack(frame.merge("vhost_block_backend_id" => vbb.id))
+    self.vhost_block_backend_id = vbb.id
 
     register_deadline(nil, 5 * 60)
     hop_install_vhost_backend
   end
 
   label def install_vhost_backend
-    version = frame["version"]
     name = "setup-vhost-block-backend-#{version}"
     case sshable.cmd("common/bin/daemonizer --check :name", name:)
     when "Succeeded"
       sshable.cmd("common/bin/daemonizer --clean :name", name:)
-      VhostBlockBackend[frame["vhost_block_backend_id"]].update(allocation_weight: frame["allocation_weight"])
+      VhostBlockBackend[vhost_block_backend_id].update(allocation_weight:)
       pop "VhostBlockBackend was setup"
     when "Failed", "NotStarted"
       d_command = NetSsh.command("sudo host/bin/setup-vhost-block-backend install :version", version:)

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -2,6 +2,8 @@
 
 class Prog::Vm::Aws::Nexus < Prog::Base
   subject_is :vm, :aws_instance
+  frame_reader :alternative_families, :private_subnet_id
+  frame_accessor :unsupported_azs, :exclude_availability_zones
 
   def before_destroy
     register_deadline(nil, 5 * 60)
@@ -183,7 +185,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
       raise
     rescue Aws::EC2::Errors::InsufficientInstanceCapacity => e
       if is_runner? && (runner = GithubRunner[vm_id: vm.id])
-        next_family = if (families = frame["alternative_families"])
+        next_family = if (families = alternative_families)
           index = families.index(vm.family) || -1
           families[index + 1]
         end
@@ -217,8 +219,8 @@ class Prog::Vm::Aws::Nexus < Prog::Base
     nap 1 if nic&.reload
     # Combine permanent (unsupported_azs) and transient (exclude_availability_zones)
     # exclusions when creating the replacement NIC in a different AZ.
-    all_excluded_azs = ((frame["unsupported_azs"] || []) + (frame["exclude_availability_zones"] || [])).uniq
-    nic = Prog::Vnet::NicNexus.assemble(frame["private_subnet_id"], name: vm.name + "-nic", exclude_availability_zones: all_excluded_azs).subject
+    all_excluded_azs = ((unsupported_azs || []) + (exclude_availability_zones || [])).uniq
+    nic = Prog::Vnet::NicNexus.assemble(private_subnet_id, name: vm.name + "-nic", exclude_availability_zones: all_excluded_azs).subject
     nic.update(vm_id: vm.id)
     hop_wait_nic_recreated
   end
@@ -426,8 +428,8 @@ class Prog::Vm::Aws::Nexus < Prog::Base
   # and Unsupported errors) and exclude_availability_zones (transient, InsufficientCapacity only).
   # All unsupported: try family fallback, else page + 1hr nap. All tried: try family fallback, else reset transient + 5min.
   def retry_in_different_az(e, az_failure_type)
-    unsupported_azs = frame["unsupported_azs"] || []
-    exclude_availability_zones = frame["exclude_availability_zones"] || []
+    unsupported_azs = self.unsupported_azs || []
+    exclude_availability_zones = self.exclude_availability_zones || []
     current_az = nic.nic_aws_resource.subnet_az
 
     unless [:unsupported, :transient].include?(az_failure_type)
@@ -443,22 +445,26 @@ class Prog::Vm::Aws::Nexus < Prog::Base
     all_tried = (unsupported_azs + exclude_availability_zones).uniq.size >= total_azs
 
     if all_tried && try_postgres_family_fallback
-      update_stack({"unsupported_azs" => [], "exclude_availability_zones" => []})
+      self.unsupported_azs = []
+      self.exclude_availability_zones = []
       nap 0
     end
 
     if all_tried && unsupported_azs.size >= total_azs
       Clog.emit("all azs unsupported for instance type", {retry_different_az_unsupported: {vm:, error: e.class.name, message: e.message, unsupported_azs:}})
       Prog::PageNexus.assemble("#{vm.name} instance type unsupported in all AZs", ["InstanceTypeUnsupported", vm.id], vm.ubid)
-      update_stack({"unsupported_azs" => unsupported_azs, "exclude_availability_zones" => []})
+      self.unsupported_azs = unsupported_azs
+      self.exclude_availability_zones = []
       nap 60 * 60
     elsif all_tried
       Clog.emit("resetting transient az exclusions", {retry_different_az_reset: {vm:, error: e.class.name, message: e.message, unsupported_azs:, exclude_availability_zones:}})
-      update_stack({"unsupported_azs" => unsupported_azs, "exclude_availability_zones" => []})
+      self.unsupported_azs = unsupported_azs
+      self.exclude_availability_zones = []
       nap 5 * 60
     else
       Clog.emit("retrying in different az", {retry_different_az: {vm:, error: e.class.name, message: e.message, unsupported_azs:, exclude_availability_zones:}})
-      update_stack({"unsupported_azs" => unsupported_azs, "exclude_availability_zones" => exclude_availability_zones})
+      self.unsupported_azs = unsupported_azs
+      self.exclude_availability_zones = exclude_availability_zones
       nic.incr_destroy
       hop_wait_old_nic_deleted
     end

--- a/prog/vm/gcp/nexus.rb
+++ b/prog/vm/gcp/nexus.rb
@@ -4,6 +4,8 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
   include GcpLro
 
   subject_is :vm
+  frame_reader :unsupported_azs
+  frame_accessor :retry_zone_delay, :gcp_zone_suffix, :exclude_zones
 
   def before_destroy
     register_deadline(nil, 5 * 60)
@@ -11,8 +13,8 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
   end
 
   label def start
-    if (delay = frame["retry_zone_delay"])
-      update_stack({"retry_zone_delay" => nil})
+    if (delay = retry_zone_delay)
+      self.retry_zone_delay = nil
       nap delay
     end
     register_deadline("wait", 10 * 60)
@@ -22,11 +24,11 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
     # Zone selection is a VM concern. Pick a zone on first entry, then
     # honour the value already set by retry_zone_capacity on later entries.
     unless strand.stack.first.key?("gcp_zone_suffix")
-      excluded = (frame["exclude_zones"] || [].freeze) + (frame["unsupported_azs"] || [].freeze)
+      excluded = (exclude_zones || [].freeze) + (unsupported_azs || [].freeze)
       available = gcp_az_suffixes - excluded
       location_az = location_az_for(available.sample || gcp_az_suffixes.sample)
       VmGcpResource.create_with_id(vm, location_az_id: location_az.id) unless vm.vm_gcp_resource
-      update_stack({"gcp_zone_suffix" => location_az.az})
+      self.gcp_zone_suffix = location_az.az
     end
 
     user_data = NetSsh.command(<<~STARTUP, custom_user: vm.unix_user, public_keys: vm.sshable.keys.map(&:public_key).join("\n"))
@@ -136,7 +138,7 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
       if %w[ZONE_RESOURCE_POOL_EXHAUSTED ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS QUOTA_EXCEEDED INTERNAL_ERROR].freeze.include?(error_code)
         clear_gcp_op("create_vm")
         # Stash the backoff delay; #start naps it off before retrying (nap here would re-enter wait_create_op).
-        update_stack({"retry_zone_delay" => bump_excluded_zone("GCE operation error: #{error_code}")})
+        self.retry_zone_delay = bump_excluded_zone("GCE operation error: #{error_code}")
         hop_start
       end
       raise "GCE instance creation failed: #{op_error_message(op)}"
@@ -314,6 +316,7 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
     @gcp_zone ||= "#{gcp_region}-#{gcp_zone_suffix}"
   end
 
+  undef_method :gcp_zone_suffix
   def gcp_zone_suffix
     strand.stack.dig(0, "gcp_zone_suffix") || gcp_az_suffixes.sample
   end
@@ -347,7 +350,7 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
   end
 
   def bump_excluded_zone(error_message)
-    excluded = (frame["exclude_zones"] || [].freeze) + [gcp_zone_suffix]
+    excluded = (exclude_zones || [].freeze) + [gcp_zone_suffix]
     available = gcp_az_suffixes - excluded
 
     if available.empty?
@@ -365,10 +368,8 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
     new_suffix = available.sample
     # Clear memoized zone so the next iteration uses the new suffix
     @gcp_zone = nil
-    update_stack({
-      "gcp_zone_suffix" => new_suffix,
-      "exclude_zones" => excluded,
-    })
+    self.gcp_zone_suffix = new_suffix
+    self.exclude_zones = excluded
     vm.reload.vm_gcp_resource.update(location_az_id: location_az_for(new_suffix).id)
     # 5 minutes: all zones exhausted, exclusions reset. Wait for capacity to free up.
     # 5 seconds: still have untried zones. Move on to the next one quickly.

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -2,6 +2,7 @@
 
 class Prog::Vm::HostNexus < Prog::Base
   subject_is :sshable, :vm_host
+  frame_reader :vhost_block_backend_version, :default_boot_images
 
   def self.assemble(sshable_hostname, location_id: Location::HETZNER_FSN1_ID, family: "standard", net6: nil, ndp_needed: false, provider_name: nil, server_identifier: nil, vhost_block_backend_version: Config.vhost_block_backend_version, default_boot_images: [])
     DB.transaction do
@@ -129,14 +130,14 @@ class Prog::Vm::HostNexus < Prog::Base
     hop_download_boot_images if retval&.dig("msg") == "VhostBlockBackend was setup"
 
     push Prog::Storage::SetupVhostBlockBackend, {
-      "version" => frame["vhost_block_backend_version"],
+      "version" => vhost_block_backend_version,
       "allocation_weight" => 100,
     }
   end
 
   label def download_boot_images
     register_deadline("prep_reboot", 4 * 60 * 60)
-    frame["default_boot_images"].each { |image_name|
+    default_boot_images.each { |image_name|
       bud Prog::DownloadBootImage, {
         "image_name" => image_name,
       }

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -6,6 +6,9 @@ class Prog::Vm::Metal::Nexus < Prog::Base
   DEFAULT_SIZE = "standard-2"
 
   subject_is :vm
+  frame_reader :distinct_storage_devices, :exclude_host_ids, :exclude_data_centers, :gpu_count, :gpu_device,
+    :force_host_id, :storage_volumes
+  frame_accessor :reason_determined
 
   def vm_name
     @vm_name ||= vm.inhost_name
@@ -40,15 +43,15 @@ class Prog::Vm::Metal::Nexus < Prog::Base
   label def start
     queued_vms = Vm.join(:strand, id: :id).where(:location_id => vm.location_id, :arch => vm.arch, Sequel[:strand][:label] => "start")
     begin
-      distinct_storage_devices = frame["distinct_storage_devices"] || false
-      host_exclusion_filter = frame["exclude_host_ids"] || []
-      data_center_exclusion_filter = frame["exclude_data_centers"] || []
-      gpu_count = frame["gpu_count"] || 0
-      gpu_device = frame["gpu_device"] || nil
+      distinct_storage_devices = self.distinct_storage_devices || false
+      host_exclusion_filter = exclude_host_ids || []
+      data_center_exclusion_filter = exclude_data_centers || []
+      gpu_count = self.gpu_count || 0
+      gpu_device = self.gpu_device || nil
       runner = GithubRunner.first(vm_id: vm.id) if vm.location_id == Location::GITHUB_RUNNERS_ID
       allocation_state_filter, location_filter, location_preference, host_filter, family_filter =
-        if frame["force_host_id"]
-          [[], [], [], [frame["force_host_id"]], []]
+        if force_host_id
+          [[], [], [], [force_host_id], []]
         elsif vm.location_id == Location::GITHUB_RUNNERS_ID
           runner_location_filter = [Location::GITHUB_RUNNERS_ID, Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID]
           runner_location_preference = [Location::GITHUB_RUNNERS_ID]
@@ -75,7 +78,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       family_filter = ["standard"] if vm.family == "burstable"
 
       Scheduling::Allocator.allocate(
-        vm, frame["storage_volumes"],
+        vm, storage_volumes,
         distinct_storage_devices:,
         allocation_state_filter:,
         location_filter:,
@@ -293,7 +296,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
 
     when_checkup_set? do
       unless available?
-        update_stack("reason_determined" => false)
+        self.reason_determined = false
         hop_unavailable
       end
       decr_checkup
@@ -436,7 +439,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       decr_checkup
       Page.from_tag_parts("VmExit", vm.ubid)&.incr_resolve
       hop_wait
-    elsif !frame["reason_determined"]
+    elsif !reason_determined
       if running_map[vm_name]
         # Page due to weird situation, where VM process (generally cloud-hypervisor)
         # is running, but dnsmasq or storage process isn't. We explicitly check this,
@@ -446,7 +449,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
           ["VmExit", vm.ubid], vm.ubid,
           extra_data: {vm_host: host.ubid},
         )
-        update_stack("reason_determined" => true)
+        self.reason_determined = true
         nap 30
       end
 
@@ -494,7 +497,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
           ["VmExit", vm.ubid], vm.ubid,
           extra_data: {vm_host: host.ubid, result:, reason:},
         )
-        update_stack("reason_determined" => true)
+        self.reason_determined = true
       end
     end
 

--- a/prog/vnet/aws/backfill_aws_subnets.rb
+++ b/prog/vnet/aws/backfill_aws_subnets.rb
@@ -4,6 +4,7 @@ require "aws-sdk-ec2"
 
 class Prog::Vnet::Aws::BackfillAwsSubnets < Prog::Base
   subject_is :private_subnet
+  frame_accessor :az_subnet_map
 
   def self.assemble(private_subnet_id)
     unless (ps = PrivateSubnet[private_subnet_id])
@@ -90,13 +91,13 @@ class Prog::Vnet::Aws::BackfillAwsSubnets < Prog::Base
       }
     end
 
-    update_stack({"az_subnet_map" => az_subnet_map})
+    self.az_subnet_map = az_subnet_map
     hop_create_records
   end
 
   label def create_records
     azs = location.azs
-    az_subnet_map = frame["az_subnet_map"]
+    az_subnet_map = self.az_subnet_map
     vpc_ipv4 = private_subnet.net4
     ipv4_prefix = 24
 

--- a/prog/vnet/aws/nic_nexus.rb
+++ b/prog/vnet/aws/nic_nexus.rb
@@ -4,6 +4,7 @@ require "aws-sdk-ec2"
 
 class Prog::Vnet::Aws::NicNexus < Prog::Base
   subject_is :nic
+  frame_reader :aws_subnet_id
 
   label def start
     register_deadline("wait", 5 * 60)
@@ -24,7 +25,7 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
     end
 
     # AwsSubnet was selected at assemble time and stored in frame
-    aws_subnet = nic.private_subnet.private_subnet_aws_resource.aws_subnets_dataset.first(id: frame["aws_subnet_id"])
+    aws_subnet = nic.private_subnet.private_subnet_aws_resource.aws_subnets_dataset.first(id: aws_subnet_id)
     fail "No available AWS subnet found" unless aws_subnet
 
     nic.nic_aws_resource.update(

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -5,6 +5,8 @@ require "openssl"
 
 class Prog::Vnet::CertNexus < Prog::Base
   subject_is :cert
+  frame_reader :add_private
+  frame_accessor :last_dns_validation_request, :restarted
 
   REVOKE_REASON = "cessationOfOperation"
 
@@ -21,7 +23,7 @@ class Prog::Vnet::CertNexus < Prog::Base
   end
 
   def before_run
-    if frame["add_private"]
+    if add_private
       delete_from_stack("add_private")
       cert.update(private_hostname: "private.#{cert.hostname}")
     end
@@ -72,7 +74,7 @@ class Prog::Vnet::CertNexus < Prog::Base
     end
 
     each_authorization { it.dns.request_validation }
-    update_stack("last_dns_validation_request" => Time.now.to_i)
+    self.last_dns_validation_request = Time.now.to_i
 
     hop_wait_dns_validation
   end
@@ -85,12 +87,12 @@ class Prog::Vnet::CertNexus < Prog::Base
       when "pending", "processing"
         all_valid = false
         t = Time.now.to_i
-        if frame["last_dns_validation_request"]&.<(t - 120)
+        if last_dns_validation_request&.<(t - 120)
           # Rerequest DNS validation every 2 minutes, in case the ACME provider
           # checked originally and couldn't validate the DNS record, and won't
           # check again (or as quickly) until rerequested.
           dns_challenge.request_validation
-          update_stack("last_dns_validation_request" => t)
+          self.last_dns_validation_request = t
         end
       when "valid"
         # do nothing
@@ -144,12 +146,12 @@ class Prog::Vnet::CertNexus < Prog::Base
   label def restart
     when_restarted_set? do
       decr_restarted
-      update_stack({"restarted" => strand.stack.first["restarted"] + 1})
+      self.restarted += 1
       hop_start
     end
 
     cert.incr_restarted
-    nap [60 * (strand.stack.first["restarted"] + 1), 60 * 10].min
+    nap [60 * (restarted + 1), 60 * 10].min
   end
 
   label def destroy

--- a/prog/vnet/cert_server.rb
+++ b/prog/vnet/cert_server.rb
@@ -2,9 +2,10 @@
 
 class Prog::Vnet::CertServer < Prog::Base
   subject_is :load_balancer
+  frame_reader :vm_id
 
   def vm
-    @vm ||= Vm[frame.fetch("vm_id")]
+    @vm ||= Vm[vm_id]
   end
 
   label def before_run

--- a/prog/vnet/gcp/nic_nexus.rb
+++ b/prog/vnet/gcp/nic_nexus.rb
@@ -4,6 +4,7 @@ class Prog::Vnet::Gcp::NicNexus < Prog::Base
   include GcpLro
 
   subject_is :nic
+  frame_accessor :gcp_address_name
 
   label def start
     register_deadline("wait", 5 * 60)
@@ -49,12 +50,12 @@ class Prog::Vnet::Gcp::NicNexus < Prog::Base
       hop_wait
     end
     save_gcp_op("allocate_ip", op_name: op.name, scope: "region", scope_value: gcp_region)
-    update_stack({"gcp_address_name" => address_name})
+    self.gcp_address_name = address_name
     hop_wait_allocate_ip
   end
 
   label def wait_allocate_ip
-    address_name = frame["gcp_address_name"]
+    address_name = gcp_address_name
     poll_and_clear_gcp_op("allocate_ip") do |op|
       begin
         addresses_client.get(project: gcp_project_id, region: gcp_region, address: address_name)

--- a/prog/vnet/gcp/subnet_nexus.rb
+++ b/prog/vnet/gcp/subnet_nexus.rb
@@ -5,6 +5,7 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   include GcpFirewallPolicy
 
   subject_is :private_subnet
+  frame_accessor :tag_key_name, :subnet_tag_value_name, :pending_tag_key_crm_op, :pending_tag_value_crm_op
 
   CrmOperationError = GcpLro::CrmOperationError
 
@@ -91,23 +92,19 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   end
 
   label def create_tag_resources
-    tag_key_name = frame["tag_key_name"] || ensure_tag_key
-    update_stack({"tag_key_name" => tag_key_name}) unless frame["tag_key_name"]
+    self.tag_key_name ||= ensure_tag_key
     # Emit on every entry (including frame re-reads) so a strand that
     # crashed between creating the tag key and the next nap still surfaces
     # the name in foreman.log. The e2e cleanup grep applies sort -u.
     Clog.emit("GCP tag key created", {gcp_tag_key_created: tag_key_name})
 
-    subnet_tag_value_name = ensure_tag_value(tag_key_name, TAG_VALUE)
-    update_stack({"subnet_tag_value_name" => subnet_tag_value_name})
+    self.subnet_tag_value_name = ensure_tag_value(tag_key_name, TAG_VALUE)
     Clog.emit("GCP tag value created", {gcp_tag_value_created: subnet_tag_value_name})
     hop_create_subnet_allow_rules
   end
 
   label def create_subnet_allow_rules
     allocate_subnet_firewall_priority unless private_subnet.firewall_priority
-
-    subnet_tag_value_name = frame["subnet_tag_value_name"]
 
     # Allow same-subnet IPv4 egress (overrides the VPC-wide deny-egress)
     ensure_firewall_policy_rule(
@@ -324,7 +321,7 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
 
   def ensure_tag_key
     ensure_crm_resource(
-      pending_key: "pending_tag_key_crm_op",
+      pending_key: :pending_tag_key_crm_op,
       label: "Tag key",
       short_name: tag_key_short_name,
       lookup: -> { lookup_tag_key&.name },
@@ -349,7 +346,7 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
 
   def ensure_tag_value(parent_tag_key_name, short_name)
     ensure_crm_resource(
-      pending_key: "pending_tag_value_crm_op",
+      pending_key: :pending_tag_value_crm_op,
       label: "Tag value",
       short_name:,
       lookup: -> { lookup_tag_value_name(parent_tag_key_name, short_name) },
@@ -367,12 +364,12 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   # The create block is called to start the LRO; `lookup` is a proc that
   # returns the resource name (string) on fallback lookup or nil.
   def ensure_crm_resource(pending_key:, label:, short_name:, lookup:)
-    if (pending = frame[pending_key])
+    if (pending = send(pending_key))
       op = credential.crm_client.get_operation(pending)
       unless op.done?
         nap 5
       end
-      update_stack({pending_key => nil})
+      send(:"#{pending_key}=", nil)
       raise CrmOperationError.new(pending, op.error) if op.error
       name = op.response&.dig("name")
       return name if name
@@ -382,7 +379,7 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
 
     op = yield
     unless op.done?
-      update_stack({pending_key => op.name})
+      send(:"#{pending_key}=", op.name)
       nap 5
     end
     raise CrmOperationError.new(op.name, op.error) if op.error

--- a/prog/vnet/gcp/vpc_nexus.rb
+++ b/prog/vnet/gcp/vpc_nexus.rb
@@ -5,6 +5,8 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
   include GcpFirewallPolicy
 
   subject_is :gcp_vpc
+  frame_accessor :pending_assoc_names, :remove_assoc_resource_name, :pending_tag_key_names,
+    :pending_tag_value_names, :delete_tv, :delete_tk, :verify_assoc_try
 
   RFC1918_RANGES = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"].freeze
   GCE_INTERNAL_IPV6_RANGES = ["fd20::/20"].freeze
@@ -231,11 +233,9 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
       []
     end
 
-    update_stack({
-      "pending_tag_key_names" => pending_tag_key_names,
-      "pending_tag_value_names" => [],
-      "pending_assoc_names" => pending_assoc_names,
-    })
+    self.pending_tag_key_names = pending_tag_key_names
+    self.pending_tag_value_names = []
+    self.pending_assoc_names = pending_assoc_names
 
     if pending_assoc_names.any?
       hop_remove_policy_associations
@@ -247,7 +247,7 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
   end
 
   label def remove_policy_associations
-    pending = frame["pending_assoc_names"]
+    pending = pending_assoc_names
     assoc_name = pending.first
     new_pending = pending.drop(1)
 
@@ -260,7 +260,7 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
     rescue Google::Cloud::NotFoundError
       Clog.emit("GCP firewall policy association already gone; proceeding",
         {gcp_firewall_assoc_already_gone: {policy: firewall_policy_name, association: assoc_name}})
-      update_stack({"pending_assoc_names" => new_pending})
+      self.pending_assoc_names = new_pending
       if new_pending.any?
         hop_remove_policy_associations
       else
@@ -269,15 +269,13 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
     end
 
     save_gcp_op("remove_assoc", op_name: op.name, scope: "global")
-    update_stack({
-      "pending_assoc_names" => new_pending,
-      "remove_assoc_resource_name" => assoc_name,
-    })
+    self.pending_assoc_names = new_pending
+    self.remove_assoc_resource_name = assoc_name
     hop_wait_policy_association_removed
   end
 
   label def wait_policy_association_removed
-    assoc_name = frame["remove_assoc_resource_name"]
+    assoc_name = remove_assoc_resource_name
     poll_and_clear_gcp_op("remove_assoc") do |err_op|
       begin
         policy = get_firewall_policy
@@ -293,8 +291,8 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
         {gcp_firewall_assoc_already_gone: {policy: firewall_policy_name, association: assoc_name, lro_error: op_error_message(err_op)}})
     end
 
-    update_stack({"remove_assoc_resource_name" => nil})
-    if frame["pending_assoc_names"].any?
+    self.remove_assoc_resource_name = nil
+    if pending_assoc_names.any?
       hop_remove_policy_associations
     else
       hop_delete_firewall_policy_op
@@ -346,7 +344,7 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
   end
 
   label def delete_firewall_tag_values_start
-    pending_tk = frame["pending_tag_key_names"]
+    pending_tk = pending_tag_key_names
     if pending_tk.empty?
       hop_delete_vpc_network_op
     end
@@ -355,12 +353,12 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
     tv_names = credential.crm_client
       .fetch_all(items: :tag_values) { |token, s| s.list_tag_values(parent: tk_name, page_token: token) }
       .map(&:name)
-    update_stack({"pending_tag_value_names" => tv_names})
+    self.pending_tag_value_names = tv_names
     hop_delete_firewall_tag_values
   end
 
   label def delete_firewall_tag_values
-    pending_tv = frame["pending_tag_value_names"]
+    pending_tv = pending_tag_value_names
     if pending_tv.empty?
       hop_delete_firewall_tag_key_current
     end
@@ -374,20 +372,18 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
       raise unless e.status_code == 404
       Clog.emit("GCP tag value already gone; proceeding",
         {gcp_tag_value_already_gone: {tag_value: tv_name}})
-      update_stack({"pending_tag_value_names" => new_pending})
+      self.pending_tag_value_names = new_pending
       hop_delete_firewall_tag_values
     end
 
-    update_stack({
-      "pending_tag_value_names" => new_pending,
-      "delete_tv" => {"op_name" => op.name, "name" => tv_name},
-    })
+    self.pending_tag_value_names = new_pending
+    self.delete_tv = {"op_name" => op.name, "name" => tv_name}
     hop_wait_firewall_tag_value_deleted
   end
 
   label def wait_firewall_tag_value_deleted
-    op_name = frame["delete_tv"]["op_name"]
-    tv_name = frame["delete_tv"]["name"]
+    op_name = delete_tv["op_name"]
+    tv_name = delete_tv["name"]
     op = credential.crm_client.get_operation(op_name)
     nap 5 unless op.done?
 
@@ -402,12 +398,12 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
       end
     end
 
-    update_stack({"delete_tv" => nil})
+    self.delete_tv = nil
     hop_delete_firewall_tag_values
   end
 
   label def delete_firewall_tag_key_current
-    pending_tk = frame["pending_tag_key_names"]
+    pending_tk = pending_tag_key_names
     tk_name = pending_tk.first
 
     begin
@@ -416,19 +412,17 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
       raise unless e.status_code == 404
       Clog.emit("GCP tag key already gone; proceeding",
         {gcp_tag_key_already_gone: {tag_key: tk_name}})
-      update_stack({"pending_tag_key_names" => pending_tk.drop(1)})
+      self.pending_tag_key_names = pending_tk.drop(1)
       hop_delete_firewall_tag_values_start
     end
 
-    update_stack({
-      "delete_tk" => {"op_name" => op.name, "name" => tk_name},
-    })
+    self.delete_tk = {"op_name" => op.name, "name" => tk_name}
     hop_wait_firewall_tag_key_deleted
   end
 
   label def wait_firewall_tag_key_deleted
-    op_name = frame["delete_tk"]["op_name"]
-    tk_name = frame["delete_tk"]["name"]
+    op_name = delete_tk["op_name"]
+    tk_name = delete_tk["name"]
     op = credential.crm_client.get_operation(op_name)
     nap 5 unless op.done?
 
@@ -439,27 +433,23 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
         raise unless e.status_code == 404
         Clog.emit("GCP tag key already gone despite LRO error; proceeding",
           {gcp_tag_key_already_gone: {tag_key: tk_name, lro_error: op.error.message}})
-        update_stack({
-          "pending_tag_key_names" => frame["pending_tag_key_names"].drop(1),
-          "delete_tk" => nil,
-        })
+        self.pending_tag_key_names = pending_tag_key_names.drop(1)
+        self.delete_tk = nil
         hop_delete_firewall_tag_values_start
       end
 
       if op.error.code == 9
         Clog.emit("GCP tag key has new children after LRO; re-draining values",
           {gcp_tag_key_drift: {tag_key: tk_name, lro_error: op.error.message}})
-        update_stack({"delete_tk" => nil})
+        self.delete_tk = nil
         hop_delete_firewall_tag_values_start
       end
 
       raise "GCP tag key #{tk_name} deletion LRO failed (tag key still present): #{op.error.message}"
     end
 
-    update_stack({
-      "pending_tag_key_names" => frame["pending_tag_key_names"].drop(1),
-      "delete_tk" => nil,
-    })
+    self.pending_tag_key_names = pending_tag_key_names.drop(1)
+    self.delete_tk = nil
     hop_delete_firewall_tag_values_start
   end
 
@@ -533,12 +523,12 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
     policy = get_firewall_policy
     if policy.associations.any? { |a| a.attachment_target == vpc_target }
       emit_firewall_policy_association_created
-      update_stack({"verify_assoc_try" => 0})
+      self.verify_assoc_try = 0
       hop_create_vpc_deny_rules
     end
 
     current_associations = policy.associations.map { |a| {name: a.name, attachment_target: a.attachment_target} }
-    try = (frame["verify_assoc_try"] || 0) + 1
+    try = (verify_assoc_try || 0) + 1
     if try >= VERIFY_ASSOC_MAX_TRIES
       raise "GCP firewall policy #{firewall_policy_name} association with VPC #{gcp_vpc.name} (#{vpc_target}) not present after #{try} attempts; current associations: #{current_associations.inspect}"
     end
@@ -552,7 +542,7 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
         current_associations:,
       },
     })
-    update_stack({"verify_assoc_try" => try})
+    self.verify_assoc_try = try
     nap 5
   end
 

--- a/prog/vnet/gcp/vpc_update_firewall_rules.rb
+++ b/prog/vnet/gcp/vpc_update_firewall_rules.rb
@@ -14,6 +14,8 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
   CrmOperationError = GcpLro::CrmOperationError
 
   subject_is :gcp_vpc
+  frame_accessor :fw_tag_data, :pending_tag_key_crm_op, :pending_tag_key_fw_ubid,
+    :pending_tag_value_crm_op, :pending_tag_value_parent
 
   def before_run
     # If the VPC is being torn down, exit without touching shared state:
@@ -31,7 +33,7 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
     #
     # fw_tag_data caches completed firewalls across nap restarts so we
     # don't re-process them when polling a pending CRM operation.
-    fw_tag_data = frame["fw_tag_data"] || {}
+    fw_tag_data = self.fw_tag_data || {}
 
     vpc_firewalls.each do |fw|
       if fw_tag_data[fw.ubid]
@@ -55,7 +57,9 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
       sync_firewall_rules(fw.firewall_rules, tag_value_name)
 
       fw_tag_data[fw.ubid] = tag_value_name
-      update_stack({"fw_tag_data" => fw_tag_data, "pending_tag_key_crm_op" => nil, "pending_tag_value_crm_op" => nil})
+      self.fw_tag_data = fw_tag_data
+      self.pending_tag_key_crm_op = nil
+      self.pending_tag_value_crm_op = nil
     end
 
     # Clean up rules for firewalls no longer attached to any subnet or
@@ -85,12 +89,13 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
   def ensure_firewall_tag_key(firewall)
     short_name = "ubicloud-fw-#{firewall.ubid}"
 
-    if (pending = frame["pending_tag_key_crm_op"]) && frame["pending_tag_key_fw_ubid"] == firewall.ubid
+    if (pending = pending_tag_key_crm_op) && pending_tag_key_fw_ubid == firewall.ubid
       op = credential.crm_client.get_operation(pending)
       unless op.done?
         nap 5
       end
-      update_stack({"pending_tag_key_crm_op" => nil, "pending_tag_key_fw_ubid" => nil})
+      self.pending_tag_key_crm_op = nil
+      self.pending_tag_key_fw_ubid = nil
       raise CrmOperationError.new(pending, op.error) if op.error
       return op.response&.dig("name") || lookup_tag_key_name!(short_name)
     end
@@ -105,7 +110,8 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
 
     op = credential.crm_client.create_tag_key(tag_key_obj)
     unless op.done?
-      update_stack({"pending_tag_key_crm_op" => op.name, "pending_tag_key_fw_ubid" => firewall.ubid})
+      self.pending_tag_key_crm_op = op.name
+      self.pending_tag_key_fw_ubid = firewall.ubid
       nap 5
     end
     raise CrmOperationError.new(op.name, op.error) if op.error
@@ -131,12 +137,13 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
   end
 
   def ensure_tag_value(tag_key_name, short_name)
-    if (pending = frame["pending_tag_value_crm_op"]) && frame["pending_tag_value_parent"] == tag_key_name
+    if (pending = pending_tag_value_crm_op) && pending_tag_value_parent == tag_key_name
       op = credential.crm_client.get_operation(pending)
       unless op.done?
         nap 5
       end
-      update_stack({"pending_tag_value_crm_op" => nil, "pending_tag_value_parent" => nil})
+      self.pending_tag_value_crm_op = nil
+      self.pending_tag_value_parent = nil
       raise CrmOperationError.new(pending, op.error) if op.error
       return op.response&.dig("name") || lookup_tag_value_name!(tag_key_name, short_name)
     end
@@ -149,7 +156,8 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
 
     op = credential.crm_client.create_tag_value(tag_value_obj)
     unless op.done?
-      update_stack({"pending_tag_value_crm_op" => op.name, "pending_tag_value_parent" => tag_key_name})
+      self.pending_tag_value_crm_op = op.name
+      self.pending_tag_value_parent = tag_key_name
       nap 5
     end
     raise CrmOperationError.new(op.name, op.error) if op.error

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -7,6 +7,7 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
   DEFAULT_HEALTH_CHECK_ENDPOINT = "/up"
 
   subject_is :load_balancer
+  frame_accessor :cert
 
   def self.assemble_with_multiple_ports(private_subnet_id, ports:, name: nil, algorithm: "round_robin",
     health_check_endpoint: DEFAULT_HEALTH_CHECK_ENDPOINT, health_check_interval: 30, health_check_timeout: 15,
@@ -77,13 +78,13 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
   label def create_new_cert
     cert = Prog::Vnet::CertNexus.assemble(load_balancer.hostname, load_balancer.dns_zone&.id, private_hostname: "private.#{load_balancer.hostname}").subject
     load_balancer.add_cert(cert)
-    update_stack("cert" => cert.id)
+    self.cert = cert.id
     hop_wait_cert_provisioning
   end
 
   label def wait_cert_provisioning
     # Wait until the cert we created in create_new_cert actually has a cert
-    if frame["cert"] ? Cert[frame["cert"]].cert.nil? : load_balancer.need_certificates?
+    if cert ? Cert[cert].cert.nil? : load_balancer.need_certificates?
       nap 60
     elsif load_balancer.refresh_cert_set?
       load_balancer.vms.each do |vm|
@@ -93,14 +94,14 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
       hop_wait_cert_broadcast
     end
 
-    update_stack("cert" => nil)
+    self.cert = nil
     hop_wait
   end
 
   label def wait_cert_broadcast
     reap(nap: 1) do
       decr_refresh_cert
-      update_stack("cert" => nil)
+      self.cert = nil
       load_balancer.certs_dataset.exclude(id: load_balancer.active_cert.id).all do |cert|
         LoadBalancerCert[cert_id: cert.id].destroy
       end

--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -2,6 +2,7 @@
 
 class Prog::Vnet::Metal::SubnetNexus < Prog::Base
   subject_is :private_subnet
+  frame_accessor :locked_nics
 
   label def start
     hop_wait
@@ -50,7 +51,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
       private_subnet.create_tunnels(nics, nic)
     end
 
-    update_stack_locked_nics(locked_nics)
+    self.locked_nics = locked_nics
     hop_wait_inbound_setup
   end
 
@@ -80,7 +81,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
       private_subnet.update(state: "waiting", last_rekey_at: Time.now)
       get_locked_nics_dataset.update(encryption_key: nil, rekey_payload: nil)
       Semaphore.where(strand_id: nics.map(&:id), name: "lock").delete(force: true)
-      update_stack_locked_nics(nil)
+      self.locked_nics = nil
       hop_wait
     end
 
@@ -119,16 +120,12 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     nics_with_state(%w[active creating]).all
   end
 
-  def update_stack_locked_nics(locked_nics)
-    update_stack({"locked_nics" => locked_nics})
-  end
-
   def get_locked_nics
     get_locked_nics_dataset.all
   end
 
   def get_locked_nics_dataset
-    Nic.where(id: strand.stack.first["locked_nics"]).eager(:strand)
+    Nic.where(id: locked_nics).eager(:strand)
   end
 
   private

--- a/prog/vnet/update_load_balancer_node.rb
+++ b/prog/vnet/update_load_balancer_node.rb
@@ -2,9 +2,10 @@
 
 class Prog::Vnet::UpdateLoadBalancerNode < Prog::Base
   subject_is :vm
+  frame_reader :load_balancer_id
 
   def load_balancer
-    @load_balancer ||= LoadBalancer[frame.fetch("load_balancer_id")]
+    @load_balancer ||= LoadBalancer[load_balancer_id]
   end
 
   def inhost_name

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Prog::InstallRhizome do
 
   describe "#start" do
     it "writes tar" do
-      expect(ir).to receive(:update_stack).with({"rhizome_digest" => instance_of(String)}).and_call_original
       expect(ir.sshable).to receive(:_cmd) do |*args, **kwargs|
         expect(args).to eq ["tar xf -"]
 
@@ -22,6 +21,7 @@ RSpec.describe Prog::InstallRhizome do
         expect(kwargs[:stdin][257..261]).to eq "ustar"
       end
       expect { ir.start }.to hop("install_gems")
+        .and change { ir.strand.stack[0]["rhizome_digest"] }.from(nil).to(instance_of(String))
     end
 
     it "handles non-ascii content in tar" do

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -5,7 +5,9 @@ require_relative "../../model/spec_helper"
 RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   subject(:prog) { described_class.new(st) }
 
-  let(:st) { Strand.create(prog: "Kubernetes::ProvisionKubernetesNode", label: "start") }
+  let(:st) do
+    Strand.create(prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{"subject_id" => _kubernetes_cluster.id, "node_id" => node.id}])
+  end
 
   let(:project) {
     Project.create(name: "default")
@@ -14,7 +16,9 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     Prog::Vnet::SubnetNexus.assemble(project.id, name: "test", ipv4_range: "172.19.0.0/16", ipv6_range: "fd40:1a0a:8d48:182a::/64").subject
   }
 
-  let(:kubernetes_cluster) {
+  let(:kubernetes_cluster) { prog.kubernetes_cluster }
+
+  let(:_kubernetes_cluster) {
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "k8scluster",
       version: Option.selectable_kubernetes_versions.first,
@@ -47,14 +51,13 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     nic = Prog::Vnet::NicNexus.assemble(subnet.id, ipv4_addr: "172.19.145.64/26", ipv6_addr: "fd40:1a0a:8d48:182a::/79").subject
     vm = Prog::Vm::Nexus.assemble_with_sshable(Config.kubernetes_service_project_id, name: "test-vm", private_subnet_id: subnet.id, nic_id: nic.id).subject
     vm.update(ephemeral_net6: "2001:db8:85a3:73f2:1c4a::/79", created_at: Time.now - 1)
-    KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kubernetes_cluster.id)
+    KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: _kubernetes_cluster.id)
   }
 
-  let(:kubernetes_nodepool) { KubernetesNodepool.create(name: "k8stest-np", node_count: 2, kubernetes_cluster_id: kubernetes_cluster.id, target_node_size: "standard-8", target_node_storage_size_gib: 78) }
+  let(:kubernetes_nodepool) { KubernetesNodepool.create(name: "k8stest-np", node_count: 2, kubernetes_cluster_id: _kubernetes_cluster.id, target_node_size: "standard-8", target_node_storage_size_gib: 78) }
 
   before do
     allow(Config).to receive(:kubernetes_service_project_id).and_return(project.id)
-    allow(prog).to receive_messages(kubernetes_cluster:, frame: {"node_id" => node.id})
   end
 
   describe "random_ula_cidr" do
@@ -73,18 +76,18 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   describe "node" do
     it "finds the right node" do
       node = KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kubernetes_cluster.id)
-      expect(prog).to receive(:frame).and_return({"node_id" => node.id})
+      refresh_frame(prog, new_values: {"node_id" => node.id})
       expect(prog.node.id).to eq(node.id)
     end
   end
 
   describe "#before_run" do
     it "destroys itself if the kubernetes cluster is getting deleted" do
-      kubernetes_cluster.strand.update(label: "something")
-      expect(kubernetes_cluster.strand.label).to eq("something")
+      prog.kubernetes_cluster.strand.update(label: "something")
+      expect(prog.kubernetes_cluster.strand.label).to eq("something")
       prog.before_run # Nothing happens
 
-      kubernetes_cluster.strand.label = "destroy"
+      prog.kubernetes_cluster.strand.label = "destroy"
       expect { prog.before_run }.to exit({"msg" => "provisioning canceled"})
 
       prog.strand.label = "destroy"
@@ -112,12 +115,10 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     end
 
     it "creates a worker node and hops if a nodepool is given" do
-      expect(prog).to receive(:frame).and_return({"nodepool_id" => kubernetes_nodepool.id})
-      expect(kubernetes_nodepool.nodes.count).to eq(0)
+      refresh_frame(prog, new_values: {"nodepool_id" => kubernetes_nodepool.id})
 
       expect { prog.start }.to hop("bootstrap_rhizome")
-
-      expect(kubernetes_nodepool.reload.nodes.count).to eq(1)
+        .and change { kubernetes_nodepool.reload.nodes.count }.from(0).to(1)
 
       new_vm = kubernetes_nodepool.nodes.last.vm
       expect(new_vm.name).to start_with("#{kubernetes_nodepool.ubid}-")
@@ -144,8 +145,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
 
   describe "#bootstrap_rhizome" do
     it "waits until the node is ready" do
-      st = instance_double(Strand, label: "non-wait")
-      expect(prog.node.vm).to receive(:strand).and_return(st)
+      prog.node.vm.strand.update(label: "non-wait")
       expect { prog.bootstrap_rhizome }.to nap(5)
     end
 
@@ -171,8 +171,13 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now nftables").ordered
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now kubelet").ordered
 
-      expect(prog).to receive(:bud).with(Prog::BootstrapRhizome, {"target_folder" => "kubernetes", "subject_id" => prog.node.vm.id, "user" => "ubi"})
+      br_strand_ds = Strand.where(prog: "BootstrapRhizome")
       expect { prog.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")
+        .and change { br_strand_ds.count }.from(0).to(1)
+      br_frame = br_strand_ds.get(:stack)[0]
+      expect(br_frame["target_folder"]).to eq "kubernetes"
+      expect(br_frame["subject_id"]).to eq prog.node.vm.id
+      expect(br_frame["user"]).to eq "ubi"
     end
   end
 
@@ -191,17 +196,16 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
 
   describe "#assign_role" do
     it "hops to init_cluster if this is the first node of the cluster" do
-      expect(prog.kubernetes_cluster.nodes).to receive(:count).and_return(1)
+      node.destroy
       expect { prog.assign_role }.to hop("init_cluster")
     end
 
     it "hops to join_control_plane if this is the not the first node of the cluster" do
-      expect(prog.kubernetes_cluster.nodes.count).to eq(2)
       expect { prog.assign_role }.to hop("join_control_plane")
     end
 
     it "hops to join_worker if a nodepool is specified to the prog" do
-      expect(prog).to receive(:kubernetes_nodepool).and_return(kubernetes_nodepool)
+      refresh_frame(prog, new_values: {"nodepool_id" => kubernetes_nodepool.id})
       expect { prog.assign_role }.to hop("join_worker")
     end
   end
@@ -306,7 +310,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   describe "#join_worker" do
     before {
       allow(prog.vm).to receive(:sshable).and_return(Sshable.new)
-      allow(prog).to receive(:kubernetes_nodepool).and_return(kubernetes_nodepool)
+      refresh_frame(prog, new_values: {"nodepool_id" => kubernetes_nodepool.id})
     }
 
     it "runs the join-worker-node script if it's not started" do

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect(standby_from_assoc).to receive(:data_disk_usage).and_return(1024000)
       standby.update_last_known_lsn("0/0")
       expect { nx.wait_servers_to_be_ready }.to nap
-      expect(strand.reload.stack.first["total_disk_usage"]).to eq(1024000)
+      expect(strand.stack.first["total_disk_usage"]).to eq(1024000)
     end
 
     it "waits and extends deadline if lsn advanced" do
@@ -298,8 +298,8 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       strand.modified!(:stack)
       strand.save_changes
       expect { nx.wait_servers_to_be_ready }.to nap
-      expect(strand.reload.stack.first["total_lsn"]).to eq(standby.lsn2int("0/1234567"))
-      expect(strand.reload.stack.first["total_disk_usage"]).to eq(2048000)
+      expect(strand.stack.first["total_lsn"]).to eq(standby.lsn2int("0/1234567"))
+      expect(strand.stack.first["total_disk_usage"]).to eq(2048000)
     end
 
     it "waits without extending deadline if neither disk usage nor lsn increased" do
@@ -344,8 +344,8 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect(servers.reject { it.is_representative }).to all(receive(:data_disk_usage).and_return(512000))
 
       expect { nx.wait_servers_to_be_ready }.to nap
-      expect(strand.reload.stack.first["total_disk_usage"]).to eq(1024000)
-      expect(strand.reload.stack.first["total_lsn"]).to eq(standby1.lsn2int("0/100") + standby2.lsn2int("0/200"))
+      expect(strand.stack.first["total_disk_usage"]).to eq(1024000)
+      expect(strand.stack.first["total_lsn"]).to eq(standby1.lsn2int("0/100") + standby2.lsn2int("0/200"))
     end
 
     it "ignores recycling standbys when checking progress" do
@@ -363,7 +363,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect(fresh_from_assoc).to receive(:data_disk_usage).and_return(1024000)
       fresh_standby.update_last_known_lsn("0/0")
       expect { nx.wait_servers_to_be_ready }.to nap
-      expect(strand.reload.stack.first["total_disk_usage"]).to eq(1024000)
+      expect(strand.stack.first["total_disk_usage"]).to eq(1024000)
     end
   end
 
@@ -656,7 +656,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect(keep_server.reload.configure_set?).to be true
       expect(keep_server.destroy_set?).to be false
 
-      servers_to_destroy_ids = strand.reload.stack.first["servers_to_destroy"]
+      servers_to_destroy_ids = strand.stack.first["servers_to_destroy"]
       expect(servers_to_destroy_ids).to contain_exactly(recycling_server.id, unavailable_server.id, extra_server.id)
     end
 
@@ -700,7 +700,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect(old_server.reload.destroy_set?).to be true
       expect(new_server.reload.configure_set?).to be true
 
-      servers_to_destroy_ids = strand.reload.stack.first["servers_to_destroy"]
+      servers_to_destroy_ids = strand.stack.first["servers_to_destroy"]
       expect(servers_to_destroy_ids).to contain_exactly(old_server.id)
     end
   end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -507,7 +507,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(standby_nx.postgres_server).to receive(:data_disk_usage).and_return(1024000)
       expect(standby_nx).to receive(:register_deadline).with("wait", 10 * 60, allow_extension: 24 * 60 * 60)
       expect { standby_nx.initialize_database_from_backup }.to nap(5)
-      expect(frame_value(standby_nx, "disk_usage")).to eq(1024000)
+      expect(standby_nx.strand.stack[0]["disk_usage"]).to eq(1024000)
     end
 
     it "does not extend deadline when disk usage has not increased during InProgress" do
@@ -527,7 +527,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with(/daemonizer2 run/, anything)
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_database_from_backup").and_return("Failed")
       expect { nx.initialize_database_from_backup }.to nap(5)
-      expect(frame_value(nx, "initialize_database_from_backup_try_count")).to eq(1)
+      expect(nx.strand.stack[0]["initialize_database_from_backup_try_count"]).to eq(1)
     end
 
     it "creates a page when try count reaches 3" do
@@ -1343,8 +1343,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
         expect(replica_server).to receive(:current_lsn).and_return("1/A")
 
         refresh_frame(replica_nx, new_frame: {})
-        expect(replica_nx).to receive(:update_stack_lsn).with("1/A")
         expect { replica_nx.wait }.to nap(900)
+        expect(replica_nx.strand.stack[0]["lsn"]).to eq "1/A"
       end
 
       it "checks if there is no lag, simply naps" do
@@ -1359,8 +1359,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
         refresh_frame(replica_nx, new_frame: {"lsn" => "1/9"})
         expect(replica_server).to receive(:lsn_diff).with("1/A", "1/9").and_return(1)
         expect(replica_nx).to receive(:decr_recycle_lagging_read_replica)
-        expect(replica_nx).to receive(:update_stack_lsn).with("1/A")
         expect { replica_nx.wait }.to nap(900)
+        expect(replica_nx.strand.stack[0]["lsn"]).to eq "1/A"
       end
     end
   end
@@ -1797,16 +1797,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(server).to receive(:_run_query).with("SELECT 1").and_raise(Sshable::SshError)
       expect(sshable).to receive(:_cmd).with(a_string_matching(/find.*-mmin -5.*tail -n 50.*grep.*redo in progress/)).and_raise(Sshable::SshError)
       expect(nx.available?).to be(false)
-    end
-  end
-
-  describe ".update_stack_lsn" do
-    it "updates the lsn in the current frame" do
-      frame = [{"lsn" => "hello"}]
-      nx.strand.stack = frame
-      expect(nx.strand).to receive(:modified!)
-      nx.update_stack_lsn("update")
-      expect(frame.first["lsn"]).to eq("update")
     end
   end
 

--- a/spec/prog/rollout_rhizome_spec.rb
+++ b/spec/prog/rollout_rhizome_spec.rb
@@ -32,10 +32,6 @@ RSpec.describe Prog::RolloutRhizome do
     ]
   }
 
-  def reload_frame
-    st.reload.stack.first
-  end
-
   describe ".assemble" do
     it "creates strand with hosts to rollout to" do
       expect(st.label).to eq("start")
@@ -162,14 +158,14 @@ RSpec.describe Prog::RolloutRhizome do
       initial_vm_ids = st.stack[0]["initial_vm_ids"]
       expect { nx.destroy_vms_on_initial_hosts }.to hop("install_on_initial_github_runners_hosts")
         .and change { Semaphore.where(strand_id: initial_vm_ids, name: "destroy").count }.from(0).to(2)
-      expect(st.reload.stack[0].has_key?("initial_vm_ids")).to be false
+      expect(st.stack[0].has_key?("initial_vm_ids")).to be false
       expect(st.stack[0].has_key?("initial_vms_keypair")).to be false
     end
 
     it "skips github runner testing if there are no github runners" do
       refresh_frame(nx, new_values: {"initial_github_runner_host_ids" => [], "initial_vm_ids" => []})
       expect { nx.destroy_vms_on_initial_hosts }.to hop("rollout_next")
-      expect(st.reload.stack[0]["next_runner_time"]).to be_within(5).of(Time.now.to_i)
+      expect(st.stack[0]["next_runner_time"]).to be_within(5).of(Time.now.to_i)
     end
   end
 
@@ -182,7 +178,7 @@ RSpec.describe Prog::RolloutRhizome do
       ds.select_map(:stack).each do
         expect(ghr_ids).to include(it[0]["subject_id"])
       end
-      expect(st.reload.stack[0]["monitor_github_runners_until"]).to be_within(5).of(Time.now.to_i + 45 * 60)
+      expect(st.stack[0]["monitor_github_runners_until"]).to be_within(5).of(Time.now.to_i + 45 * 60)
     end
   end
 
@@ -207,7 +203,7 @@ RSpec.describe Prog::RolloutRhizome do
       refresh_frame(nx, new_values: {"monitor_github_runners_until" => Time.now.to_i - 10})
       nx.incr_github_runners_work
       expect { nx.monitor_github_runners }.to hop("rollout_next")
-      expect(st.reload.stack[0]["next_runner_time"]).to be_within(5).of(Time.now.to_i)
+      expect(st.stack[0]["next_runner_time"]).to be_within(5).of(Time.now.to_i)
     end
 
     it "naps otherwise" do
@@ -226,7 +222,7 @@ RSpec.describe Prog::RolloutRhizome do
       vm_host_id = VmHost.generate_uuid
       Strand.create(prog: "InstallRhizome", label: "start", parent_id: st.id, exitval: {msg: "installed rhizome"}, stack: [{"subject_id" => vm_host_id}])
       expect { nx.wait }.to hop("rollout_next")
-      expect(st.reload.stack[0]["next_runner_time"]).to be_within(5).of(Time.now.to_i + 30)
+      expect(st.stack[0]["next_runner_time"]).to be_within(5).of(Time.now.to_i + 30)
       expect(st.stack[0]["completed"]).to eq [vm_host_id]
     end
   end
@@ -248,7 +244,7 @@ RSpec.describe Prog::RolloutRhizome do
       next_host_id = st.stack[0]["remaining_host_ids"].first
       expect { nx.rollout_next }.to hop("wait")
         .and change { ds.count }.from(0).to(1)
-        .and change { st.reload.stack[0]["remaining_host_ids"].size }.from(2).to(1)
+        .and change { st.stack[0]["remaining_host_ids"].size }.from(2).to(1)
       expect(ds.get(:stack)[0]["subject_id"]).to eq next_host_id
     end
   end

--- a/spec/prog/rollout_semaphore_spec.rb
+++ b/spec/prog/rollout_semaphore_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe Prog::RolloutSemaphore do
   let(:pages) { Array.new(3) { Prog::PageNexus.assemble("test", ["test", it], []).subject } }
   let(:page_ids) { pages.map(&:id) }
 
-  def reload_frame
-    st.reload.stack.first
-  end
-
   describe ".assemble" do
     it "creates strand with objects to rollout semaphore to" do
       expect(st.label).to eq("start")
@@ -42,7 +38,7 @@ RSpec.describe Prog::RolloutSemaphore do
     it "increments semaphore on next object and naps" do
       expect { nx.start }.to nap(295...305)
         .and change { pages.first.reload.resolve_set? }.from(false).to(true)
-      expect(st.reload.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
+      expect(st.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
     end
 
     it "decrements semaphore on next object and naps if increment is not true" do
@@ -50,7 +46,7 @@ RSpec.describe Prog::RolloutSemaphore do
       refresh_frame(nx, new_values: {"increment" => false})
       expect { nx.start }.to nap(295...305)
         .and change { pages.first.reload.resolve_set? }.from(true).to(false)
-      expect(st.reload.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
+      expect(st.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
     end
 
     it "hops to destroy if there are no objects remaining" do
@@ -62,7 +58,7 @@ RSpec.describe Prog::RolloutSemaphore do
       refresh_frame(nx, new_values: {"initial_num" => 0})
       expect { nx.start }.to nap(55...65)
         .and change { pages.first.reload.resolve_set? }.from(false).to(true)
-      expect(st.reload.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 60)
+      expect(st.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 60)
     end
 
     it "naps if not yet at the next increment time" do

--- a/spec/prog/vm/gcp/nexus_spec.rb
+++ b/spec/prog/vm/gcp/nexus_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
     it "naps for the stashed retry_zone_delay and clears it" do
       refresh_frame(nx, new_values: {"retry_zone_delay" => 5 * 60})
       expect { nx.start }.to nap(5 * 60)
-      expect(st.reload.stack.first["retry_zone_delay"]).to be_nil
+      expect(st.stack.first["retry_zone_delay"]).to be_nil
     end
 
     it "creates a GCE instance without tags and hops to wait_create_op" do
@@ -196,7 +196,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       end
 
       expect { nx.start }.to hop("wait_create_op")
-      expect(st.reload.stack.first.dig("create_vm", "name")).to eq("op-12345")
+      expect(st.stack.first.dig("create_vm", "name")).to eq("op-12345")
     end
 
     it "selects a zone suffix and persists it in VM strand frame" do
@@ -207,7 +207,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       expect(compute_client).to receive(:insert).and_return(op)
 
       expect { nx.start }.to hop("wait_create_op")
-      expect(st.reload.stack.first["gcp_zone_suffix"]).to match(/\A[abc]\z/)
+      expect(st.stack.first["gcp_zone_suffix"]).to match(/\A[abc]\z/)
     end
 
     it "excludes zones from unsupported_azs on initial zone selection" do
@@ -219,7 +219,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       expect(compute_client).to receive(:insert).and_return(op)
 
       expect { nx.start }.to hop("wait_create_op")
-      expect(st.reload.stack.first["gcp_zone_suffix"]).to eq("c")
+      expect(st.stack.first["gcp_zone_suffix"]).to eq("c")
     end
 
     it "preserves existing gcp_zone_suffix on re-entry (retry case)" do
@@ -231,7 +231,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       expect(compute_client).to receive(:insert).and_return(op)
 
       expect { nx.start }.to hop("wait_create_op")
-      expect(st.reload.stack.first["gcp_zone_suffix"]).to eq("c")
+      expect(st.stack.first["gcp_zone_suffix"]).to eq("c")
     end
 
     it "uses reserved static IP from NicGcpResource in AccessConfig" do
@@ -276,7 +276,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
         expect(Clog).to receive(:emit).with("GCE zone retry", anything).and_call_original
 
         expect { nx.start }.to nap(5)
-        stack = st.reload.stack.first
+        stack = st.stack.first
         expect(stack["exclude_zones"]).to be_a(Array)
         expect(stack["exclude_zones"].length).to eq(1)
         expect(stack["gcp_zone_suffix"]).not_to eq(stack["exclude_zones"].first)
@@ -303,7 +303,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       expect(Clog).to receive(:emit).with("GCE zone retry exhausted, resetting exclusions", anything).and_call_original
 
       expect { nx.start }.to nap(5 * 60)
-      stack = st.reload.stack.first
+      stack = st.stack.first
       expect(stack["exclude_zones"]).to eq([])
     end
 
@@ -317,7 +317,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       expect(Clog).to receive(:emit).with("GCE zone retry", anything).and_call_original
 
       expect { nx.start }.to nap(5)
-      stack = st.reload.stack.first
+      stack = st.stack.first
       expect(stack["exclude_zones"]).to eq(["a", "b"])
       expect(stack["gcp_zone_suffix"]).to eq("c")
     end
@@ -418,7 +418,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       expect(compute_client).to receive(:insert).and_return(op)
 
       expect { nx.start }.to hop("wait_create_op")
-      suffix = st.reload.stack.first["gcp_zone_suffix"]
+      suffix = st.stack.first["gcp_zone_suffix"]
       resource = VmGcpResource[vm.id]
       expect(resource).not_to be_nil
       expect(resource.location_az).to eq(LocationAz[location_id: location.id, az: suffix])
@@ -449,7 +449,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       expect(Clog).to receive(:emit).with("GCE zone retry", anything).and_call_original
 
       expect { nx.start }.to nap(5)
-      new_suffix = st.reload.stack.first["gcp_zone_suffix"]
+      new_suffix = st.stack.first["gcp_zone_suffix"]
       expect(new_suffix).not_to eq("a")
       expect(VmGcpResource[vm.id].location_az.az).to eq(new_suffix)
     end
@@ -501,7 +501,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
         expect(Clog).to receive(:emit).with("GCE zone retry", anything).and_call_original
 
         expect { nx.wait_create_op }.to hop("start")
-        stack = st.reload.stack.first
+        stack = st.stack.first
         expect(stack["exclude_zones"]).to include("a")
         expect(stack["gcp_zone_suffix"]).not_to eq("a")
         expect(stack["create_vm_name"]).to be_nil
@@ -522,7 +522,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       expect(Clog).to receive(:emit).with("GCE zone retry exhausted, resetting exclusions", anything).and_call_original
 
       expect { nx.wait_create_op }.to hop("start")
-      stack = st.reload.stack.first
+      stack = st.stack.first
       expect(stack["exclude_zones"]).to eq([])
       expect(stack["retry_zone_delay"]).to eq(5 * 60)
     end
@@ -774,7 +774,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       ).and_return(op)
 
       expect { nx.destroy }.to hop("wait_destroy_op")
-      expect(st.reload.stack.first.dig("delete_vm", "name")).to eq("op-del-123")
+      expect(st.stack.first.dig("delete_vm", "name")).to eq("op-del-123")
     end
 
     it "handles already-deleted instances by hopping to finalize_destroy" do

--- a/spec/prog/vnet/aws/backfill_aws_subnets_spec.rb
+++ b/spec/prog/vnet/aws/backfill_aws_subnets_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe Prog::Vnet::Aws::BackfillAwsSubnets do
         ])
 
         expect { nx.fetch_existing_subnets }.to hop("create_records")
-        frame = nx.strand.reload.stack.first
+        frame = nx.strand.stack.first
         expect(frame["az_subnet_map"].keys).to contain_exactly("a", "b")
         expect(frame["az_subnet_map"]["a"]["subnet_id"]).to eq("subnet-a")
         expect(frame["az_subnet_map"]["b"]["subnet_id"]).to eq("subnet-b")
@@ -264,7 +264,7 @@ RSpec.describe Prog::Vnet::Aws::BackfillAwsSubnets do
       it "handles VPC with no existing subnets" do
         client.stub_responses(:describe_subnets, subnets: [])
         expect { nx.fetch_existing_subnets }.to hop("create_records")
-        frame = nx.strand.reload.stack.first
+        frame = nx.strand.stack.first
         expect(frame["az_subnet_map"]).to eq({})
       end
     end

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Prog::Vnet::CertNexus do
 
       expect(@order.authorizations.first.dns).to receive(:request_validation)
       expect { nx.wait_dns_update }.to hop("wait_dns_validation")
-      expect(st.reload.stack[0]["last_dns_validation_request"]).to be_within(10).of(Time.now.to_i)
+      expect(st.stack[0]["last_dns_validation_request"]).to be_within(10).of(Time.now.to_i)
     end
   end
 
@@ -193,7 +193,7 @@ RSpec.describe Prog::Vnet::CertNexus do
       expect(@challenge).to receive(:request_validation)
       refresh_frame(nx, new_values: {"last_dns_validation_request" => Time.now.to_i - 130})
       expect { nx.wait_dns_validation }.to nap(10)
-      expect(st.reload.stack[0]["last_dns_validation_request"]).to be_within(10).of(Time.now.to_i)
+      expect(st.stack[0]["last_dns_validation_request"]).to be_within(10).of(Time.now.to_i)
     end
 
     it "hops to restart if dns_challenge validation fails" do
@@ -312,23 +312,20 @@ RSpec.describe Prog::Vnet::CertNexus do
 
   describe "#restart" do
     it "increments the restart counter and naps according to the restart counter" do
-      nx.strand.stack.first["restarted"] = 3
-
+      refresh_frame(nx, new_values: {"restarted" => 3})
       expect { nx.restart }.to nap(60 * 4)
     end
 
     it "naps at most 10 minutes" do
-      nx.strand.stack.first["restarted"] = 20
-
+      refresh_frame(nx, new_values: {"restarted" => 20})
       expect { nx.restart }.to nap(60 * 10)
     end
 
     it "hops to start if restarted semaphore is set" do
-      nx.strand.stack.first["restarted"] = 0
-      expect(nx).to receive(:when_restarted_set?).and_yield
-      expect(nx).to receive(:decr_restarted)
-      expect(nx).to receive(:update_stack)
+      refresh_frame(nx, new_values: {"restarted" => 0})
+      nx.incr_restarted
       expect { nx.restart }.to hop("start")
+        .and change { Semaphore.where(name: "restarted").count }.from(1).to(0)
     end
   end
 

--- a/spec/prog/vnet/gcp/nic_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/nic_nexus_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Prog::Vnet::Gcp::NicNexus do
       end
 
       expect { nx.allocate_static_ip }.to hop("wait_allocate_ip")
-      expect(st.reload.stack.first.dig("allocate_ip", "name")).to eq("op-addr-123")
+      expect(st.stack.first.dig("allocate_ip", "name")).to eq("op-addr-123")
       expect(st.stack.first["gcp_address_name"]).to eq("ubicloud-#{nic.name}")
     end
 

--- a/spec/prog/vnet/gcp/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_nexus_spec.rb
@@ -340,11 +340,11 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
       expect(Clog).to receive(:emit).with("GCP firewall policy association created", hash_including(gcp_firewall_policy_association_created: "#{vpc_name}@#{vpc_name}")).and_call_original
 
       expect { nx.send(:verify_firewall_policy_associated_with_vpc!, vpc_target) }.to nap(5)
-      expect(frame_value(nx, "verify_assoc_try")).to eq(1)
+      expect(nx.strand.stack[0]["verify_assoc_try"]).to eq(1)
 
       refresh_frame(nx)
       expect { nx.send(:verify_firewall_policy_associated_with_vpc!, vpc_target) }.to hop("create_vpc_deny_rules")
-      expect(frame_value(nx, "verify_assoc_try")).to eq(0)
+      expect(nx.strand.stack[0]["verify_assoc_try"]).to eq(0)
     end
 
     it "raises a terminal error after VERIFY_ASSOC_MAX_TRIES unsuccessful attempts" do

--- a/spec/prog/vnet/gcp/vpc_update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_update_firewall_rules_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
 
       result = nx.send(:ensure_firewall_tag_key, firewall)
       expect(result).to eq("tagKeys/polled-1")
-      expect(st.reload.stack.first["pending_tag_key_crm_op"]).to be_nil
+      expect(st.stack.first["pending_tag_key_crm_op"]).to be_nil
     end
 
     it "handles 409 conflict by looking up existing key" do

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
         .and change { Strand.where(prog: "Vnet::CertNexus").count }.from(1).to(2)
         .and change { Cert.where(hostname: "test-lb.#{domain}", private_hostname: "private.test-lb.#{domain}").count }.from(0).to(1)
         .and change { nx.load_balancer.certs.count }.from(1).to(2)
-      expect(st.reload.stack[0]["cert"]).to be_a String
+      expect(st.stack[0]["cert"]).to be_a String
     end
 
     it "creates a cert without dns zone in development" do
@@ -145,7 +145,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       expect(Strand.where(prog: "Vnet::CertServer", label: "setup_cert_server").count).to eq 1
       expect(nx.load_balancer).to receive(:need_certificates?).and_return(false)
       expect { nx.wait_cert_provisioning }.to hop("wait")
-      expect(st.reload.stack[0].fetch("cert")).to be_nil
+      expect(st.stack[0].fetch("cert")).to be_nil
       expect(Strand.where(prog: "Vnet::CertServer", label: "reshare_certificate").all).to be_empty
     end
   end
@@ -177,7 +177,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       expect { nx.wait_cert_broadcast }.to hop("wait")
         .and change { cert_to_remove.strand.semaphores_dataset.where(name: "destroy").count }.from(0).to(1)
       expect(nx.load_balancer.reload.certs.count).to eq 1
-      expect(st.reload.stack[0].fetch("cert")).to be_nil
+      expect(st.stack[0].fetch("cert")).to be_nil
     end
   end
 

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -130,9 +130,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       Prog::Vnet::NicNexus.assemble(ps.id, name: "a").subject.update(rekey_payload: {})
     }
     let(:nx) {
-      nx = described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait_inbound_setup", id: ps.id))
-      nx.update_stack_locked_nics([nic.id])
-      nx
+      described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait_inbound_setup", id: ps.id, stack: [{"locked_nics" => [nic.id]}]))
     }
 
     it "naps 5 if state creation is ongoing" do
@@ -154,9 +152,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       Prog::Vnet::NicNexus.assemble(ps.id, name: "a").subject.update(rekey_payload: {})
     }
     let(:nx) {
-      nx = described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait_outbound_setup", id: ps.id))
-      nx.update_stack_locked_nics([nic.id])
-      nx
+      described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait_outbound_setup", id: ps.id, stack: [{"locked_nics" => [nic.id]}]))
     }
 
     it "donates if policy update is ongoing" do
@@ -178,9 +174,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       Prog::Vnet::NicNexus.assemble(ps.id, name: "a").subject.update(rekey_payload: {})
     }
     let(:nx) {
-      nx = described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait_old_state_drop", id: ps.id))
-      nx.update_stack_locked_nics([nic.id])
-      nx
+      described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait_old_state_drop", id: ps.id, stack: [{"locked_nics" => [nic.id]}]))
     }
 
     it "donates if policy update is ongoing" do


### PR DESCRIPTION
These work like attr_reader and attr_accessor, except they stored data in the frame instead of in instance variables. They replace almost all direct use of `frame`, and all use of `update_stack`.

This converts all non-test progs. Test progs can be converted later, and after they are converted, `update_stack` can be removed.

In terms of reviews:

* @pykello : Storage prog changes
* @byucesoy : Postgres prog changes
* @furkansahin : Network prog changes
* @mohi-kalantari : Kubernetes prog changes
* @enescakir : Other prog changes and overall design (everyone is also welcome to review the overall design)

This is inspired by an idea Enes had in 6bb19931aca9a7ebfa804a0cc5c2aaf0dc33ad67.