### PR TITLE
Revert "Charge legacy GitHub installations at the old runner rates"

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -121,13 +121,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     end
     billed_vm_size += "-arm" if arch == "arm64"
     github_runner.update(billed_vm_size:)
-    # We continue to charge existing customers with the old rates until June 1st
-    active_at = if Time.now < Time.utc(2026, 6) && installation.created_at < Time.utc(2026, 5)
-      Time.utc(2026, 4, 30)
-    else
-      Time.now
-    end
-    rate_id = BillingRate.from_resource_properties("GitHubRunnerMinutes", billed_vm_size, "global", false, active_at)["id"]
+    rate_id = BillingRate.from_resource_properties("GitHubRunnerMinutes", billed_vm_size, "global")["id"]
 
     retries = 0
     begin

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -287,35 +287,6 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
         4.times { nx.update_billing_record }
       }.to raise_error(Sequel::Postgres::ExclusionConstraintViolation)
     end
-
-    it "uses the legacy billing rate for installations created before May 1, 2026 when run before June 1, 2026" do
-      runner.update(ready_at: now - 5 * 60)
-      nx.update_billing_record
-
-      br = BillingRecord[resource_id: project.id]
-      expect(br.billing_rate_id).to eq("d772d0aa-0b40-4b7a-aceb-72f6211f7cad")
-    end
-
-    it "uses the new billing rate for installations created on/after May 1, 2026" do
-      installation.update(created_at: Time.utc(2026, 5, 1))
-      may_now = Time.utc(2026, 5, 15)
-      allow(Time).to receive(:now).and_return(may_now)
-      runner.update(created_at: may_now, ready_at: may_now - 5 * 60)
-      nx.update_billing_record
-
-      br = BillingRecord[resource_id: project.id]
-      expect(br.billing_rate_id).to eq("12c84463-3456-4dcd-9873-a7a32a15709c")
-    end
-
-    it "uses the new billing rate for legacy installations after June 1, 2026" do
-      june_now = Time.utc(2026, 6, 15)
-      allow(Time).to receive(:now).and_return(june_now)
-      runner.update(ready_at: june_now - 5 * 60)
-      nx.update_billing_record
-
-      br = BillingRecord[resource_id: project.id]
-      expect(br.billing_rate_id).to eq("12c84463-3456-4dcd-9873-a7a32a15709c")
-    end
   end
 
   describe "#before_destroy" do


### PR DESCRIPTION
This reverts commit aea34c311f03df17a02654caa225bde41f3ad016.

This only applied between May 1st and June 1st, so it can be removed since it has already expired.