### PR TITLE
Fix nil handling for latest_backup_size_in_gib

### DIFF
--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -11,7 +11,7 @@ class PostgresTimeline < Sequel::Model
 
   plugin ResourceMethods, encrypted_columns: :secret_key
   plugin ProviderDispatcher, __FILE__
-  plugin SemaphoreMethods, :destroy, :take_backup_for_scale_down
+  plugin SemaphoreMethods, :destroy, :take_backup_for_converge
 
   BACKUP_BUCKET_EXPIRATION_DAYS = 8
 
@@ -22,7 +22,7 @@ class PostgresTimeline < Sequel::Model
   def need_backup?
     return false if blob_storage.nil?
     return false if leader.nil?
-    return true if take_backup_for_scale_down_set?
+    return true if take_backup_for_converge_set?
     return false if latest_backup_started_at && latest_backup_started_at > Time.now - 60 * 60 * backup_period_hours
 
     leader.vm.sshable.d_check("take_postgres_backup") != "InProgress"

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -7,10 +7,10 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
     nap 60 if postgres_resource.read_replica? && !postgres_resource.parent.ready_for_read_replica?
 
     timeline = postgres_resource.effective_timeline
-    nap 60 if timeline.take_backup_for_scale_down_set?
+    nap 60 if timeline.take_backup_for_converge_set?
 
-    if postgres_resource.latest_backup_too_large_for_target? && !timeline.take_backup_for_scale_down_set?
-      timeline.incr_take_backup_for_scale_down
+    if postgres_resource.latest_backup_too_large_for_target? && !timeline.take_backup_for_converge_set?
+      timeline.incr_take_backup_for_converge
       register_deadline("wait_for_maintenance_window", 6 * 60 * 60)
       nap 60
     end

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -9,7 +9,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
     timeline = postgres_resource.effective_timeline
     nap 60 if timeline.take_backup_for_converge_set?
 
-    if postgres_resource.latest_backup_too_large_for_target?
+    if timeline.latest_backup_size_in_gib.nil? || postgres_resource.latest_backup_too_large_for_target?
       timeline.incr_take_backup_for_converge
       register_deadline("wait_for_maintenance_window", 6 * 60 * 60)
       nap 60

--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -9,7 +9,7 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
     timeline = postgres_resource.effective_timeline
     nap 60 if timeline.take_backup_for_converge_set?
 
-    if postgres_resource.latest_backup_too_large_for_target? && !timeline.take_backup_for_converge_set?
+    if postgres_resource.latest_backup_too_large_for_target?
       timeline.incr_take_backup_for_converge
       register_deadline("wait_for_maintenance_window", 6 * 60 * 60)
       nap 60

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -75,7 +75,7 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
     case sshable.d_check("take_postgres_backup")
     when "Succeeded"
       sshable.d_clean("take_postgres_backup")
-      decr_take_backup_for_scale_down
+      decr_take_backup_for_converge
       hop_wait
     when "InProgress"
       nap 60

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -157,11 +157,11 @@ PGDATA=/dat/17/data
       expect(postgres_timeline.need_backup?).to be(false)
     end
 
-    it "returns true when take_backup_for_scale_down semaphore is set, even if last backup is recent" do
+    it "returns true when take_backup_for_converge semaphore is set, even if last backup is recent" do
       expect(postgres_timeline).to receive(:blob_storage).and_return("dummy-blob-storage")
       postgres_timeline.update(latest_backup_started_at: Time.now)
       Strand.create_with_id(postgres_timeline, prog: "Postgres::PostgresTimelineNexus", label: "wait")
-      postgres_timeline.incr_take_backup_for_scale_down
+      postgres_timeline.incr_take_backup_for_converge
       expect(postgres_timeline.need_backup?).to be(true)
     end
   end

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -94,18 +94,18 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
         timeline.update(latest_backup_size_in_gib: 1024)
       end
 
-      it "increments take_backup_for_scale_down, registers a deadline, and naps when the semaphore is not set" do
+      it "increments take_backup_for_converge, registers a deadline, and naps when the semaphore is not set" do
         expect(nx).to receive(:register_deadline).with("wait_for_maintenance_window", 6 * 60 * 60)
 
         expect { nx.start }.to nap(60)
-        expect(timeline.reload.take_backup_for_scale_down_set?).to be(true)
+        expect(timeline.reload.take_backup_for_converge_set?).to be(true)
       end
 
       it "naps without re-incrementing when the semaphore is still set" do
-        timeline.incr_take_backup_for_scale_down
+        timeline.incr_take_backup_for_converge
 
         expect { nx.start }.to nap(60)
-        expect(timeline.semaphores_dataset.where(name: "take_backup_for_scale_down").count).to eq(1)
+        expect(timeline.semaphores_dataset.where(name: "take_backup_for_converge").count).to eq(1)
       end
 
       it "hops to provision_servers once the recorded backup size fits the target" do

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -417,13 +417,13 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     end
 
     it "cleans up and hops to wait if the backup is successful" do
-      postgres_timeline.incr_take_backup_for_scale_down
+      postgres_timeline.incr_take_backup_for_converge
       sshable = nx.postgres_timeline.leader.vm.sshable
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("Succeeded").ordered
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 clean take_postgres_backup").ordered
 
       expect { nx.take_backup }.to hop("wait")
-      expect(postgres_timeline.reload.take_backup_for_scale_down_set?).to be(false)
+      expect(postgres_timeline.reload.take_backup_for_converge_set?).to be(false)
     end
 
     it "naps if a backup is already in progress" do


### PR DESCRIPTION
Convergence logic potentially requests a new backup based on  `latest_backup_size_in_gib`. If it is not set yet (i.e. for brand new timeline), it throws exception due to missing nil case handling. This PR fixes that.