### PR TITLE
Allow web-process SSH via ALLOW_WEB_SSH opt-in

### DIFF
--- a/lib/net_ssh.rb
+++ b/lib/net_ssh.rb
@@ -10,6 +10,9 @@ module NetSsh
   class PotentialInsecurity < StandardError
   end
 
+  # Allow SSH calls from web process if specific ENV variable is set.
+  WEB_SSH_DISABLED = ENV["PROCESS_TYPE"] == "web" && ENV["ALLOW_WEB_SSH"] != "true"
+
   def self.command(command, **)
     WarnUnsafe.convert(command, self, __callee__, **)
   end
@@ -140,7 +143,7 @@ module NetSsh
         end
       end
 
-      if ENV["PROCESS_TYPE"] == "web"
+      if WEB_SSH_DISABLED
         ::Net::SSH.send(:remove_const, :Connection)
         ::Net::SSH.singleton_class.send(:undef_method, :start)
       # :nocov:
@@ -151,7 +154,7 @@ module NetSsh
 
     module Sshable
       # :nocov:
-      if ENV["PROCESS_TYPE"] == "web"
+      if WEB_SSH_DISABLED
         def cmd(cmd, _skip_command_checking: false, **kw)
           raise "Sshable#cmd is not allowed from the web process"
         end


### PR DESCRIPTION
f7b506e0 disabled `Sshable#cmd` from the web process (and removes the `Net::SSH` machinery there). That's a good default, but some deployments still issue SSH synchronously from web routes and need an escape hatch.

This gates both the `Net::SSH` teardown and the `Sshable#cmd` guard behind a single `WEB_SSH_DISABLED` predicate that honors an `ALLOW_WEB_SSH` opt-in. Default behavior is unchanged — web-process SSH stays disabled — but setting `ALLOW_WEB_SSH=true` in the web process restores the prior behavior for deployments that need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)