### PR TITLE
Make admin search case-insensitive

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1328,7 +1328,7 @@ class CloverAdmin < Roda
         next view("search")
       end
       patterns = terms.map { "%#{klass.dataset.escape_like(it)}%" }
-      @search_results = klass.grep(columns, patterns).limit(11).all
+      @search_results = klass.grep(columns, patterns, case_insensitive: true).limit(11).all
       if @search_results.length > 10
         @truncated = @search_results.pop
       end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -88,6 +88,15 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - Account #{account.ubid}"
   end
 
+  it "searches case-insensitively" do
+    account = create_account
+    account.update(name: "UniqueTestName")
+
+    fill_in "UBID, UUID, or prefix:term", with: "ac:uniquetestname"
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - Account #{account.ubid}"
+  end
+
   it "searches by vm name with prefix and redirects for single result" do
     project = Project.create(name: "Default")
     vm = Prog::Vm::Nexus.assemble("dummy key", project.id, name: "unique-vm-search").subject


### PR DESCRIPTION
The admin /search route matched column values with LIKE, so a query only resolved when its casing matched the stored value exactly. This forced operators to recall the exact case of names, emails, and other indexed fields, which is rarely how those values are remembered.