### PR TITLE
Accept expiration_days: in set_lifecycle_policy

### DIFF
--- a/model/postgres/aws/postgres_timeline.rb
+++ b/model/postgres/aws/postgres_timeline.rb
@@ -68,7 +68,7 @@ PGDATA=/dat/#{version}/data
     rescue ::Aws::S3::Errors::BucketAlreadyOwnedByYou
     end
 
-    def aws_set_lifecycle_policy
+    def aws_set_lifecycle_policy(expiration_days: BACKUP_BUCKET_EXPIRATION_DAYS)
       blob_storage_client.put_bucket_lifecycle_configuration({
         bucket: ubid,
         lifecycle_configuration: {
@@ -77,7 +77,7 @@ PGDATA=/dat/#{version}/data
               id: "DeleteOldBackups",
               status: "Enabled",
               expiration: {
-                days: BACKUP_BUCKET_EXPIRATION_DAYS,
+                days: expiration_days,
               },
               filter: {},
             },

--- a/model/postgres/gcp/postgres_timeline.rb
+++ b/model/postgres/gcp/postgres_timeline.rb
@@ -56,10 +56,10 @@ PGDATA=/dat/#{version}/data
       nil
     end
 
-    def gcp_set_lifecycle_policy
+    def gcp_set_lifecycle_policy(expiration_days: BACKUP_BUCKET_EXPIRATION_DAYS)
       bucket = blob_storage_client.bucket(ubid)
       bucket.lifecycle do |l|
-        l.add_delete_rule(age: BACKUP_BUCKET_EXPIRATION_DAYS)
+        l.add_delete_rule(age: expiration_days)
       end
     end
 

--- a/model/postgres/metal/postgres_timeline.rb
+++ b/model/postgres/metal/postgres_timeline.rb
@@ -51,8 +51,8 @@ PGDATA=/dat/#{version}/data
       raise unless e.message.include?("BucketAlreadyOwnedByYou")
     end
 
-    def metal_set_lifecycle_policy
-      blob_storage_client.set_lifecycle_policy(ubid, ubid, BACKUP_BUCKET_EXPIRATION_DAYS)
+    def metal_set_lifecycle_policy(expiration_days: BACKUP_BUCKET_EXPIRATION_DAYS)
+      blob_storage_client.set_lifecycle_policy(ubid, ubid, expiration_days)
     end
 
     def metal_destroy_blob_storage

--- a/spec/model/postgres/gcp/postgres_timeline_spec.rb
+++ b/spec/model/postgres/gcp/postgres_timeline_spec.rb
@@ -165,19 +165,24 @@ PGDATA=/dat/17/data
     end
 
     describe "#set_lifecycle_policy" do
-      it "sets delete lifecycle rule on the bucket" do
-        storage_client = instance_double(Google::Cloud::Storage::Project)
-        bucket = instance_double(Google::Cloud::Storage::Bucket)
+      let(:storage_client) { instance_double(Google::Cloud::Storage::Project) }
+      let(:bucket) { instance_double(Google::Cloud::Storage::Bucket) }
+      let(:lifecycle) { instance_double(Google::Cloud::Storage::Bucket::Lifecycle) }
+
+      before do
         expect(postgres_timeline).to receive(:blob_storage_client).and_return(storage_client)
         expect(storage_client).to receive(:bucket).with(postgres_timeline.ubid).and_return(bucket)
+        expect(bucket).to receive(:lifecycle).and_yield(lifecycle)
+      end
 
-        expect(bucket).to receive(:lifecycle).and_yield(
-          instance_double(Google::Cloud::Storage::Bucket::Lifecycle).tap do |l|
-            expect(l).to receive(:add_delete_rule).with(age: PostgresTimeline::BACKUP_BUCKET_EXPIRATION_DAYS)
-          end,
-        )
-
+      it "sets delete lifecycle rule on the bucket" do
+        expect(lifecycle).to receive(:add_delete_rule).with(age: PostgresTimeline::BACKUP_BUCKET_EXPIRATION_DAYS)
         postgres_timeline.set_lifecycle_policy
+      end
+
+      it "honors expiration_days: override" do
+        expect(lifecycle).to receive(:add_delete_rule).with(age: 30)
+        postgres_timeline.set_lifecycle_policy(expiration_days: 30)
       end
     end
 

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -306,11 +306,25 @@ PGDATA=/dat/17/data
       postgres_timeline.create_bucket
     end
 
-    it "sets lifecycle policy" do
-      expect(postgres_timeline).to receive(:location).and_return(instance_double(Location, aws?: true, provider_dispatcher_group_name: "aws", name: "us-west-2", location_credential_aws: instance_double(LocationCredentialAws, credentials: nil))).at_least(:once)
-      s3_client.stub_responses(:put_bucket_lifecycle_configuration)
-      expect(s3_client).to receive(:put_bucket_lifecycle_configuration).with({bucket: postgres_timeline.ubid, lifecycle_configuration: {rules: [{id: "DeleteOldBackups", status: "Enabled", expiration: {days: 8}, filter: {}}]}}).and_return(true)
-      expect(postgres_timeline.set_lifecycle_policy).to be(true)
+    describe "#set_lifecycle_policy" do
+      def expected_lifecycle_config(days)
+        {bucket: postgres_timeline.ubid, lifecycle_configuration: {rules: [{id: "DeleteOldBackups", status: "Enabled", expiration: {days:}, filter: {}}]}}
+      end
+
+      before do
+        expect(postgres_timeline).to receive(:location).and_return(instance_double(Location, aws?: true, provider_dispatcher_group_name: "aws", name: "us-west-2", location_credential_aws: instance_double(LocationCredentialAws, credentials: nil))).at_least(:once)
+        s3_client.stub_responses(:put_bucket_lifecycle_configuration)
+      end
+
+      it "defaults to BACKUP_BUCKET_EXPIRATION_DAYS" do
+        expect(s3_client).to receive(:put_bucket_lifecycle_configuration).with(expected_lifecycle_config(PostgresTimeline::BACKUP_BUCKET_EXPIRATION_DAYS)).and_return(true)
+        expect(postgres_timeline.set_lifecycle_policy).to be(true)
+      end
+
+      it "honors expiration_days: override" do
+        expect(s3_client).to receive(:put_bucket_lifecycle_configuration).with(expected_lifecycle_config(30)).and_return(true)
+        expect(postgres_timeline.set_lifecycle_policy(expiration_days: 30)).to be(true)
+      end
     end
   end
 
@@ -338,9 +352,16 @@ PGDATA=/dat/17/data
       expect { postgres_timeline.create_bucket }.to raise_error(RuntimeError, /something else/)
     end
 
-    it "sets lifecycle policy" do
-      expect(minio_client).to receive(:set_lifecycle_policy).with(postgres_timeline.ubid, postgres_timeline.ubid, 8).and_return(true)
-      expect(postgres_timeline.set_lifecycle_policy).to be(true)
+    describe "#set_lifecycle_policy" do
+      it "defaults to BACKUP_BUCKET_EXPIRATION_DAYS" do
+        expect(minio_client).to receive(:set_lifecycle_policy).with(postgres_timeline.ubid, postgres_timeline.ubid, PostgresTimeline::BACKUP_BUCKET_EXPIRATION_DAYS).and_return(true)
+        expect(postgres_timeline.set_lifecycle_policy).to be(true)
+      end
+
+      it "honors expiration_days: override" do
+        expect(minio_client).to receive(:set_lifecycle_policy).with(postgres_timeline.ubid, postgres_timeline.ubid, 30).and_return(true)
+        expect(postgres_timeline.set_lifecycle_policy(expiration_days: 30)).to be(true)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Each provider's `*_set_lifecycle_policy` gains an optional `expiration_days:` kwarg, defaulting to `BACKUP_BUCKET_EXPIRATION_DAYS`. Flows through the existing `ProviderDispatcher`.

## Why

Lets callers override the retention window for a specific bucket without touching the global default — useful when an operation legitimately wants a different TTL on one timeline's bucket while the rest of the fleet stays on the default.

## Backward compatibility

All existing call sites continue to work unchanged — the kwarg has a default. No tests required updates; new override coverage added for each provider.

## Test plan

- [x] Existing AWS/GCP/metal lifecycle specs still pass (3 specs verify default behavior).
- [x] New override specs assert the provided `expiration_days:` value reaches the underlying client call across all three providers (3 new specs).
- [x] Full `spec/model/postgres/postgres_timeline_spec.rb` and `spec/model/postgres/gcp/postgres_timeline_spec.rb` pass locally (57 examples).