### PR TITLE
Fix free-upgrade badge spec broken by standard-runner cutoff

### DIFF
--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "shows badge for free premium runner upgrade" do
-      installation.update(created_at: Time.now)
+      installation.update(created_at: Time.utc(2026, 6, 5) - 1)
 
       visit "#{project.path}/github/#{installation.ubid}/setting"
       expect(page.status_code).to eq(200)


### PR DESCRIPTION
The setting view now wraps the premium-runner card in `standard_runner_allowed?`, which returns false for installations created on or after 2026-06-05. The badge test set `created_at: Time.now`, which trips that gate today and hides the badge along with the rest of the card. Use a created_at one second before the cutoff so the card renders while keeping `free_runner_upgrade?` true.