### PR TITLE
Show billing rate of billing record in admin panel

### DIFF
--- a/spec/routes/web/admin/model/billing_record_spec.rb
+++ b/spec/routes/web/admin/model/billing_record_spec.rb
@@ -18,5 +18,10 @@ RSpec.describe CloverAdmin, "BillingRecord" do
     click_link @instance.admin_label
     expect(page.status_code).to eq 200
     expect(page.title).to eq "Ubicloud Admin - BillingRecord #{@instance.ubid}"
+
+    rate = @instance.billing_rate
+    expect(page).to have_content("Billing Rate")
+    expect(page).to have_content(rate["resource_type"])
+    expect(page).to have_content(rate["unit_price"].to_s)
   end
 end

--- a/views/admin/extras/BillingRecord.erb
+++ b/views/admin/extras/BillingRecord.erb
@@ -1,0 +1,7 @@
+<%# locals: (obj:) %>
+
+<%== part("components/table",
+  title: "Billing Rate",
+  table_class: "billing-rate-table",
+  data: obj.billing_rate.map { |k, v| {"Column" => k, "Value" => v} }
+) %>


### PR DESCRIPTION
Since we load billing rates from a static file, they aren't shown in the admin panel. We now show the rate details on the billing record's page.