### PR TITLE
Use frame_{reader,accessor} in Prog::Test::*

### DIFF
--- a/lib/gcp_lro.rb
+++ b/lib/gcp_lro.rb
@@ -17,15 +17,17 @@ module GcpLro
   end
 
   def save_gcp_op(name, op_name:, scope:, scope_value: nil)
-    update_stack(name => {
+    strand.stack.first[name] = {
       "name" => op_name,
       "scope" => scope,
       "scope_value" => scope_value,
-    })
+    }
+    strand.modified!(:stack)
+    @frame = nil
   end
 
   def clear_gcp_op(name)
-    update_stack(name => nil)
+    delete_from_stack(name)
   end
 
   def poll_gcp_op(name)

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -364,9 +364,11 @@ end
   end
 
   def delete_from_stack(*keys)
-    keys.flatten.each { |key| strand.stack.first.delete(key) }
+    frame = strand.stack.first
+    keys.flatten!
+    keys.each { frame.delete(it) }
     strand.modified!(:stack)
-    strand.save_changes
+    @frame = nil
   end
 
   # A hop is a kind of jump, as in, like a jump instruction.

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -363,12 +363,6 @@ end
     end
   end
 
-  def update_stack(new_frame)
-    strand.stack.first.merge!(new_frame)
-    strand.modified!(:stack)
-    strand.save_changes
-  end
-
   def delete_from_stack(*keys)
     keys.flatten.each { |key| strand.stack.first.delete(key) }
     strand.modified!(:stack)

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -4,6 +4,7 @@
 class Prog::Test < Prog::Base
   subject_is :sshable
   semaphore :test_semaphore, :destroy
+  frame_reader :test_level
 
   label def start
   end
@@ -51,12 +52,12 @@ class Prog::Test < Prog::Base
   end
 
   label def pusher2
-    pop frame["test_level"] if retval
+    pop test_level if retval
     push Prog::Test, {test_level: "3"}, :pusher3
   end
 
   label def pusher3
-    pop frame["test_level"]
+    pop test_level
   end
 
   label def hop_entry

--- a/prog/test/connected_subnets.rb
+++ b/prog/test/connected_subnets.rb
@@ -4,8 +4,11 @@ require "net/http"
 require "uri"
 
 class Prog::Test::ConnectedSubnets < Prog::Test::Base
+  frame_reader :subnet_id_multiple, :subnet_id_single
+  frame_accessor :vm_to_be_connected_id, :firewalls
+
   label def start
-    unless frame["vm_to_be_connected_id"]
+    unless vm_to_be_connected_id
       pss.map(&:vms).flatten.each do |vm|
         vm.sshable.cmd("sudo yum install -y nc") if vm.boot_image.include?("almalinux")
         vm.sshable.cmd("sudo apt-get update && sudo apt-get install -y netcat-openbsd") if vm.boot_image.include?("debian")
@@ -35,7 +38,7 @@ ExecStart=nc -l 8080 -6
       update_firewall_rules(ps_multiple, ps_single, config: :perform_tests_public_blocked)
       update_firewall_rules(ps_single, ps_multiple, config: :perform_tests_public_blocked)
       ps_multiple.connect_subnet(ps_single)
-      update_stack({"vm_to_be_connected_id" => vm_to_be_connected.id})
+      self.vm_to_be_connected_id = vm_to_be_connected.id
     end
 
     unless ps_multiple.strand.label == "wait" && ps_single.strand.label == "wait" &&
@@ -60,9 +63,9 @@ ExecStart=nc -l 8080 -6
   end
 
   label def perform_tests_private_ipv4
-    unless frame["firewalls"] == "connected_private_ipv4"
+    unless firewalls == "connected_private_ipv4"
       update_firewall_rules(ps_multiple, ps_single, config: :perform_connected_private_ipv4)
-      update_stack({"firewalls" => "connected_private_ipv4"})
+      self.firewalls = "connected_private_ipv4"
     end
 
     if ps_multiple.update_firewall_rules_set? || ps_multiple.vms.any? { |vm| vm.update_firewall_rules_set? }
@@ -77,9 +80,9 @@ ExecStart=nc -l 8080 -6
   end
 
   label def perform_tests_private_ipv6
-    unless frame["firewalls"] == "connected_private_ipv6"
+    unless firewalls == "connected_private_ipv6"
       update_firewall_rules(ps_multiple, ps_single, config: :perform_connected_private_ipv6)
-      update_stack({"firewalls" => "connected_private_ipv6"})
+      self.firewalls = "connected_private_ipv6"
     end
 
     if ps_multiple.update_firewall_rules_set? || ps_multiple.vms.any? { |vm| vm.update_firewall_rules_set? }
@@ -95,9 +98,9 @@ ExecStart=nc -l 8080 -6
   end
 
   label def perform_blocked_private_ipv4
-    unless frame["firewalls"] == "blocked_private_ipv4"
+    unless firewalls == "blocked_private_ipv4"
       update_firewall_rules(ps_multiple, ps_multiple, config: :perform_blocked_private_ipv4)
-      update_stack({"firewalls" => "blocked_private_ipv4"})
+      self.firewalls = "blocked_private_ipv4"
     end
 
     if ps_multiple.update_firewall_rules_set? || ps_multiple.vms.any? { |vm| vm.update_firewall_rules_set? }
@@ -112,9 +115,9 @@ ExecStart=nc -l 8080 -6
   end
 
   label def perform_blocked_private_ipv6
-    unless frame["firewalls"] == "blocked_private_ipv6"
+    unless firewalls == "blocked_private_ipv6"
       update_firewall_rules(ps_multiple, ps_multiple, config: :perform_blocked_private_ipv6)
-      update_stack({"firewalls" => "blocked_private_ipv6"})
+      self.firewalls = "blocked_private_ipv6"
     end
 
     if ps_multiple.update_firewall_rules_set? || ps_multiple.vms.any? { |vm| vm.update_firewall_rules_set? }
@@ -167,11 +170,11 @@ ExecStart=nc -l 8080 -6
   end
 
   def ps_multiple
-    @ps_multiple ||= PrivateSubnet[frame["subnet_id_multiple"]]
+    @ps_multiple ||= PrivateSubnet[subnet_id_multiple]
   end
 
   def ps_single
-    @ps_single ||= PrivateSubnet[frame["subnet_id_single"]]
+    @ps_single ||= PrivateSubnet[subnet_id_single]
   end
 
   def pss
@@ -179,7 +182,7 @@ ExecStart=nc -l 8080 -6
   end
 
   def vm_to_be_connected
-    connected_id = frame["vm_to_be_connected_id"]
+    connected_id = vm_to_be_connected_id
     @vm_to_be_connected ||= if connected_id
       ps_multiple.vms.find { |vm| vm.id == connected_id }
     else

--- a/prog/test/dns_zone.rb
+++ b/prog/test/dns_zone.rb
@@ -4,6 +4,9 @@ require "resolv"
 
 class Prog::Test::DnsZone < Prog::Test::Base
   semaphore :destroy_and_verify
+  frame_reader :zone_name, :project_id
+  frame_accessor :dns_zone_id, :dns_server_id, :setup_strand_id,
+    :cloudflare_zone_id, :cloudflare_record_ids, :sentinel_record_name
 
   PUBLIC_RESOLVERS = ["1.1.1.1", "8.8.8.8"].freeze
   # We want this as low as possible so back-to-back e2e runs don't wait on stale recursive
@@ -31,8 +34,8 @@ class Prog::Test::DnsZone < Prog::Test::Base
   label def start
     ds = DnsServer.create(name: ns_name)
     dz = DnsZone.create(
-      name: frame["zone_name"],
-      project_id: frame["project_id"],
+      name: zone_name,
+      project_id:,
       neg_ttl: 30,
       last_purged_at: Time.now,
     )
@@ -41,17 +44,15 @@ class Prog::Test::DnsZone < Prog::Test::Base
 
     setup_st = Prog::DnsZone::SetupDnsServerVm.assemble(ds, name: "dns-e2e")
 
-    update_stack({
-      "dns_zone_id" => dz.id,
-      "dns_server_id" => ds.id,
-      "setup_strand_id" => setup_st.id,
-    })
+    self.dns_zone_id = dz.id
+    self.dns_server_id = ds.id
+    self.setup_strand_id = setup_st.id
 
     hop_wait_setup
   end
 
   label def wait_setup
-    nap 10 if Strand[frame["setup_strand_id"]]
+    nap 10 if Strand[setup_strand_id]
     hop_register_cloudflare_records
   end
 
@@ -60,12 +61,10 @@ class Prog::Test::DnsZone < Prog::Test::Base
 
     a_record_id = cloudflare_client.ensure_dns_record(parent_zone_id, type: "A", name: ns_name, content: knot_vm.ip4.to_s, ttl: CLOUDFLARE_RECORD_TTL)
     aaaa_record_id = cloudflare_client.ensure_dns_record(parent_zone_id, type: "AAAA", name: ns_name, content: knot_vm.ip6.to_s, ttl: CLOUDFLARE_RECORD_TTL)
-    ns_record_id = cloudflare_client.ensure_dns_record(parent_zone_id, type: "NS", name: frame["zone_name"], content: ns_name, ttl: CLOUDFLARE_RECORD_TTL)
+    ns_record_id = cloudflare_client.ensure_dns_record(parent_zone_id, type: "NS", name: zone_name, content: ns_name, ttl: CLOUDFLARE_RECORD_TTL)
 
-    update_stack({
-      "cloudflare_zone_id" => parent_zone_id,
-      "cloudflare_record_ids" => [a_record_id, aaaa_record_id, ns_record_id],
-    })
+    self.cloudflare_zone_id = parent_zone_id
+    self.cloudflare_record_ids = [a_record_id, aaaa_record_id, ns_record_id]
 
     hop_insert_sentinel_records
   end
@@ -75,15 +74,15 @@ class Prog::Test::DnsZone < Prog::Test::Base
     # random prefix per run. wait_dns_propagation resolves these through
     # public resolvers to confirm the full chain is up. The random prefix
     # ensures we are not using the previous run's cached response.
-    sentinel_name = "_e2e_check_#{SecureRandom.alphanumeric(8).downcase}.#{frame["zone_name"]}"
+    sentinel_name = "_e2e_check_#{SecureRandom.alphanumeric(8).downcase}.#{zone_name}"
     dns_zone.insert_record(record_name: sentinel_name, type: "A", ttl: CLOUDFLARE_RECORD_TTL, data: SENTINEL_RECORD_IP4)
     dns_zone.insert_record(record_name: sentinel_name, type: "AAAA", ttl: CLOUDFLARE_RECORD_TTL, data: SENTINEL_RECORD_IP6)
-    update_stack({"sentinel_record_name" => sentinel_name})
+    self.sentinel_record_name = sentinel_name
     hop_wait_dns_propagation
   end
 
   label def wait_dns_propagation
-    sentinel_name = frame["sentinel_record_name"]
+    sentinel_name = sentinel_record_name
     seen = PUBLIC_RESOLVERS.all? do |resolver_ip|
       Resolv::DNS.open(nameserver: [resolver_ip]) do |dns|
         dns.timeouts = 3
@@ -104,7 +103,7 @@ class Prog::Test::DnsZone < Prog::Test::Base
   end
 
   label def trigger_destroy
-    cloudflare_client.delete_dns_records(frame["cloudflare_zone_id"], frame["cloudflare_record_ids"])
+    cloudflare_client.delete_dns_records(cloudflare_zone_id, cloudflare_record_ids)
     dns_server.retire_vm(knot_vm.id, force: true)
     hop_wait_destroy
   end
@@ -130,11 +129,11 @@ class Prog::Test::DnsZone < Prog::Test::Base
   end
 
   def dns_zone
-    @dns_zone ||= DnsZone[frame["dns_zone_id"]]
+    @dns_zone ||= DnsZone[dns_zone_id]
   end
 
   def dns_server
-    @dns_server ||= DnsServer[frame["dns_server_id"]]
+    @dns_server ||= DnsServer[dns_server_id]
   end
 
   def knot_vm

--- a/prog/test/firewall_rules.rb
+++ b/prog/test/firewall_rules.rb
@@ -5,6 +5,7 @@ require "uri"
 
 class Prog::Test::FirewallRules < Prog::Test::Base
   subject_is :firewall
+  frame_accessor :vm_to_be_connected_id, :firewalls
 
   label def start
     vms = [vm1, vm2, vm_outside]
@@ -34,15 +35,15 @@ ExecStart=nc -l 8080 -6
     vm1.sshable.cmd("sudo systemctl daemon-reload")
     vm1.sshable.cmd("sudo systemctl enable listening_ipv4.service")
     vm1.sshable.cmd("sudo systemctl enable listening_ipv6.service")
-    update_stack({"vm_to_be_connected_id" => vm1.id})
+    self.vm_to_be_connected_id = vm1.id
 
     hop_perform_tests_none
   end
 
   label def perform_tests_none
-    update_firewall_rules(config: :perform_tests_none) unless frame["firewalls"] == "none"
+    update_firewall_rules(config: :perform_tests_none) unless firewalls == "none"
 
-    update_stack({"firewalls" => "none"})
+    self.firewalls = "none"
 
     if firewall.private_subnets.first.update_firewall_rules_set? || firewall.private_subnets.first.vms.any? { |vm| vm.update_firewall_rules_set? }
       nap 5
@@ -59,9 +60,9 @@ ExecStart=nc -l 8080 -6
   end
 
   label def perform_tests_public_ipv4
-    update_firewall_rules(config: :perform_tests_public_ipv4) unless frame["firewalls"] == "public_ipv4"
+    update_firewall_rules(config: :perform_tests_public_ipv4) unless firewalls == "public_ipv4"
 
-    update_stack({"firewalls" => "public_ipv4"})
+    self.firewalls = "public_ipv4"
     if firewall.private_subnets.first.update_firewall_rules_set? || firewall.private_subnets.first.vms.any? { |vm| vm.update_firewall_rules_set? }
       nap 5
     end
@@ -73,9 +74,9 @@ ExecStart=nc -l 8080 -6
   end
 
   label def perform_tests_public_ipv6
-    update_firewall_rules(config: :perform_tests_public_ipv6) unless frame["firewalls"] == "public_ipv6"
+    update_firewall_rules(config: :perform_tests_public_ipv6) unless firewalls == "public_ipv6"
 
-    update_stack({"firewalls" => "public_ipv6"})
+    self.firewalls = "public_ipv6"
     if firewall.private_subnets.first.update_firewall_rules_set? || firewall.private_subnets.first.vms.any? { |vm| vm.update_firewall_rules_set? }
       nap 5
     end
@@ -88,9 +89,9 @@ ExecStart=nc -l 8080 -6
   end
 
   label def perform_tests_private_ipv4
-    update_firewall_rules(config: :perform_tests_private_ipv4) unless frame["firewalls"] == "private_ipv4"
+    update_firewall_rules(config: :perform_tests_private_ipv4) unless firewalls == "private_ipv4"
 
-    update_stack({"firewalls" => "private_ipv4"})
+    self.firewalls = "private_ipv4"
     if firewall.private_subnets.first.update_firewall_rules_set? || firewall.private_subnets.first.vms.any? { |vm| vm.update_firewall_rules_set? }
       nap 5
     end
@@ -103,9 +104,9 @@ ExecStart=nc -l 8080 -6
   end
 
   label def perform_tests_private_ipv6
-    update_firewall_rules(config: :perform_tests_private_ipv6) unless frame["firewalls"] == "private_ipv6"
+    update_firewall_rules(config: :perform_tests_private_ipv6) unless firewalls == "private_ipv6"
 
-    update_stack({"firewalls" => "private_ipv6"})
+    self.firewalls = "private_ipv6"
     if firewall.private_subnets.first.update_firewall_rules_set? || firewall.private_subnets.first.vms.any? { |vm| vm.update_firewall_rules_set? }
       nap 5
     end
@@ -150,7 +151,7 @@ ExecStart=nc -l 8080 -6
   end
 
   def vm1
-    connected_id = frame["vm_to_be_connected_id"]
+    connected_id = vm_to_be_connected_id
     @vm1 ||= if connected_id
       firewall.private_subnets.first.vms.find { |vm| vm.id == connected_id }
     else

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -10,6 +10,9 @@ class Prog::Test::GithubRunner < Prog::Test::Base
   WORKFLOW_NAME = "test.yml"
   BRANCH_NAME = "main"
 
+  frame_reader :provider, :customer_project_id, :labels
+  frame_accessor :vm_pool_id, :fail_message, :test_run_id
+
   def self.assemble(test_cases, provider: "metal")
     service_project = Project.create_with_id(Config.github_runner_service_project_id, name: "Github-Runner-Service-Project")
     Project.create_with_id(Config.vm_pool_project_id, name: "Vm-Pool-Service-Project")
@@ -55,12 +58,12 @@ class Prog::Test::GithubRunner < Prog::Test::Base
   end
 
   label def start
-    hop_trigger_test_run if frame["provider"] == "aws"
+    hop_trigger_test_run if provider == "aws"
     hop_create_vm_pool
   end
 
   label def create_vm_pool
-    label_data = Github.runner_labels[frame["labels"].first]
+    label_data = Github.runner_labels[labels.first]
     pool = Prog::Vm::VmPool.assemble(
       size: 2,
       vm_size: label_data["vm_size"],
@@ -69,13 +72,13 @@ class Prog::Test::GithubRunner < Prog::Test::Base
       storage_size_gib: label_data["storage_size_gib"],
       arch: label_data["arch"],
     ).subject
-    update_stack({"vm_pool_id" => pool.id})
+    self.vm_pool_id = pool.id
 
     hop_wait_vm_pool_to_be_ready
   end
 
   label def wait_vm_pool_to_be_ready
-    pool = VmPool[frame["vm_pool_id"]]
+    pool = VmPool[vm_pool_id]
     nap 10 unless pool.size == pool.vms_dataset.exclude(provisioned_at: nil).count
 
     # No need to provision a new VM to the pool when the first one is picked.
@@ -86,23 +89,23 @@ class Prog::Test::GithubRunner < Prog::Test::Base
   end
 
   label def trigger_test_run
-    inputs = {triggered_by: ENV["GITHUB_RUN_ID"], provider: frame["provider"], runners: frame["labels"].to_json}
+    inputs = {triggered_by: ENV["GITHUB_RUN_ID"], provider:, runners: labels.to_json}
     response = client.post("repos/#{repository_name}/actions/workflows/#{WORKFLOW_NAME}/dispatches", {ref: BRANCH_NAME, inputs:, return_run_details: true})
     unless response
-      update_stack({"fail_message" => "Couldn't trigger workflow"})
+      self.fail_message = "Couldn't trigger workflow"
       hop_clean_resources
     end
 
     Clog.emit("Triggered GitHub workflow run", {github_workflow_run: {run_id: response[:workflow_run_id], html_url: response[:html_url]}})
-    update_stack({"test_run_id" => response[:workflow_run_id]})
+    self.test_run_id = response[:workflow_run_id]
     hop_check_test_run
   end
 
   label def check_test_run
-    run = client.workflow_run(repository_name, frame["test_run_id"])
+    run = client.workflow_run(repository_name, test_run_id)
     conclusion = run[:conclusion]
     if FAIL_CONCLUSIONS.include?(conclusion)
-      update_stack({"fail_message" => "Test run failed with conclusion: #{conclusion}"})
+      self.fail_message = "Test run failed with conclusion: #{conclusion}"
     elsif IN_PROGRESS_CONCLUSIONS.include?(conclusion) || conclusion.nil?
       nap 15
     end
@@ -112,9 +115,9 @@ class Prog::Test::GithubRunner < Prog::Test::Base
 
   label def clean_resources
     begin
-      client.cancel_workflow_run(repository_name, frame["test_run_id"]) if frame["test_run_id"]
+      client.cancel_workflow_run(repository_name, test_run_id) if test_run_id
     rescue Octokit::Error
-      Clog.emit("Workflow run #{frame["test_run_id"]} has already been finished")
+      Clog.emit("Workflow run #{test_run_id} has already been finished")
     end
 
     if GithubRunner.any?
@@ -122,9 +125,9 @@ class Prog::Test::GithubRunner < Prog::Test::Base
       nap 15
     end
 
-    if (pool = VmPool[frame["vm_pool_id"]])
+    if (pool = VmPool[vm_pool_id])
       unless pool.vms.count.zero?
-        update_stack({"fail_message" => "The runner did not picked from the pool"})
+        self.fail_message = "The runner did not picked from the pool"
       end
       pool.incr_destroy
     end
@@ -142,9 +145,9 @@ class Prog::Test::GithubRunner < Prog::Test::Base
 
     Project[Config.github_runner_service_project_id]&.destroy
     Project[Config.vm_pool_project_id]&.destroy
-    Project[frame["customer_project_id"]]&.destroy
+    Project[customer_project_id]&.destroy
 
-    frame["fail_message"] ? fail_test(frame["fail_message"]) : hop_finish
+    fail_message ? fail_test(fail_message) : hop_finish
   end
 
   label def finish
@@ -156,7 +159,7 @@ class Prog::Test::GithubRunner < Prog::Test::Base
   end
 
   def repository_name
-    "#{REPOSITORY_NAME_PREFIX}-#{frame["provider"]}"
+    "#{REPOSITORY_NAME_PREFIX}-#{provider}"
   end
 
   def client

--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -2,6 +2,7 @@
 
 class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   semaphore :pause, :destroy
+  frame_accessor :primary_ubid, :failover_deadline
 
   def self.assemble(provider: "metal", **)
     super(provider:, project_name: "Postgres-HA-Test-Project", aws_location_name: "us-east-1", **)
@@ -22,7 +23,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
 
   label def test_postgres
     unless representative_server.run_query(test_queries_sql) == "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
-      update_stack({"fail_message" => "Failed to run test queries"})
+      self.fail_message = "Failed to run test queries"
       hop_destroy
     end
 
@@ -46,7 +47,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   label def trigger_failover
     Clog.emit("Postgres servers before failover: #{postgres_resource.servers.map { |s| "[#{s.ubid}, #{s.timeline_access}, #{s.strand.label}]" }.join(", ")}")
     primary = postgres_resource.servers.find { it.timeline_access == "push" }
-    update_stack({"primary_ubid" => primary.ubid})
+    self.primary_ubid = primary.ubid
     version = postgres_resource.version
 
     primary.vm.sshable.cmd("echo -e '\nfoobar = baz' | sudo tee -a /etc/postgresql/:version/main/conf.d/999-break.conf", version:)
@@ -58,17 +59,17 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   end
 
   label def wait_failover
-    deadline = frame["failover_deadline"]
+    deadline = failover_deadline
     unless deadline
       deadline = Time.now.to_i + 600
-      update_stack({"failover_deadline" => deadline})
+      self.failover_deadline = deadline
     end
 
-    new_primary = postgres_resource.servers(eager: :strand).find { |s| s.ubid != frame["primary_ubid"] && s.timeline_access == "push" && s.strand.label == "wait" }
+    new_primary = postgres_resource.servers(eager: :strand).find { |s| s.ubid != primary_ubid && s.timeline_access == "push" && s.strand.label == "wait" }
     hop_test_postgres_after_failover if new_primary
 
     if Time.now.to_i >= deadline
-      update_stack({"fail_message" => "Failover did not complete within 600 seconds"})
+      self.fail_message = "Failover did not complete within 600 seconds"
       hop_destroy
     end
 
@@ -78,27 +79,27 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   label def test_postgres_after_failover
     Clog.emit("Postgres servers after failover: #{postgres_resource.servers.map { |s| "[#{s.ubid}, #{s.timeline_access}, #{s.strand.label}]" }.join(", ")}")
 
-    new_candidate = postgres_resource.servers.filter { |s| s.ubid != frame["primary_ubid"] }.min_by(&:created_at)
+    new_candidate = postgres_resource.servers.filter { |s| s.ubid != primary_ubid }.min_by(&:created_at)
     # Get last few log lines from the new candidate for debugging.
     log_lines = new_candidate.vm.sshable.cmd("sudo find /dat/:version/data/pg_log/ -name 'postgresql-*.log' -exec tail -n 20 {} \\;", version: new_candidate.version)
     Clog.emit("Last log lines from new candidate (#{new_candidate.ubid}):\n#{log_lines}")
 
     Clog.emit("Running read queries after failover")
     unless representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
-      update_stack({"fail_message" => "Failed to run read queries after failover"})
+      self.fail_message = "Failed to run read queries after failover"
       hop_destroy
     end
 
     Clog.emit("Running write queries after failover")
     unless representative_server.run_query(test_queries_sql) == "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
-      update_stack({"fail_message" => "Failed to run write queries after failover"})
+      self.fail_message = "Failed to run write queries after failover"
     end
 
     hop_destroy
   end
 
   label def destroy_postgres
-    update_stack({"timeline_ids" => postgres_resource.servers_dataset.distinct.select_map(:timeline_id)})
+    self.timeline_ids = postgres_resource.servers_dataset.distinct.select_map(:timeline_id)
     postgres_resource.incr_destroy
     hop_wait_resources_destroyed
   end
@@ -107,7 +108,7 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
     nap 5 if postgres_resource
     nap_if_private_subnet
     nap_if_gcp_vpc
-    verify_timelines_destroyed(frame["timeline_ids"]) if frame["timeline_ids"]
+    verify_timelines_destroyed(timeline_ids) if timeline_ids
     hop_finish
   end
 

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -4,9 +4,8 @@ require_relative "../../lib/util"
 
 class Prog::Test::HetznerServer < Prog::Test::Base
   semaphore :verify_cleanup_and_destroy
-  frame_reader :server_id, :setup_host, :default_boot_images, :provider_name
+  frame_reader :server_id, :setup_host?, :default_boot_images, :provider_name
   frame_accessor :hostname, :vm_host_id, :available_storage_gib
-  alias_method :setup_host?, :setup_host
 
   def self.assemble(vm_host_id: nil, default_boot_images: [])
     frame = if vm_host_id
@@ -15,14 +14,14 @@ class Prog::Test::HetznerServer < Prog::Test::Base
         "vm_host_id" => vm_host.id,
         "server_id" => vm_host.provider.server_identifier,
         "hostname" => vm_host.sshable.host,
-        "setup_host" => false,
+        "setup_host?" => false,
         "default_boot_images" => default_boot_images,
         "provider_name" => vm_host.provider_name,
       }
     else
       {
         "server_id" => Config.e2e_hetzner_server_id,
-        "setup_host" => true,
+        "setup_host?" => true,
         "default_boot_images" => default_boot_images,
         "provider_name" => HostProvider::HETZNER_PROVIDER_NAME,
       }

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -4,23 +4,31 @@ require_relative "../../lib/util"
 
 class Prog::Test::HetznerServer < Prog::Test::Base
   semaphore :verify_cleanup_and_destroy
+  frame_reader :server_id, :setup_host, :default_boot_images, :provider_name
+  frame_accessor :hostname, :vm_host_id, :available_storage_gib
+  alias_method :setup_host?, :setup_host
 
   def self.assemble(vm_host_id: nil, default_boot_images: [])
     frame = if vm_host_id
       vm_host = VmHost[vm_host_id]
       {
-        vm_host_id: vm_host.id, server_id: vm_host.provider.server_identifier,
-        hostname: vm_host.sshable.host, setup_host: false,
-        default_boot_images:, provider_name: vm_host.provider_name,
+        "vm_host_id" => vm_host.id,
+        "server_id" => vm_host.provider.server_identifier,
+        "hostname" => vm_host.sshable.host,
+        "setup_host" => false,
+        "default_boot_images" => default_boot_images,
+        "provider_name" => vm_host.provider_name,
       }
     else
       {
-        server_id: Config.e2e_hetzner_server_id, setup_host: true,
-        default_boot_images:, provider_name: HostProvider::HETZNER_PROVIDER_NAME,
+        "server_id" => Config.e2e_hetzner_server_id,
+        "setup_host" => true,
+        "default_boot_images" => default_boot_images,
+        "provider_name" => HostProvider::HETZNER_PROVIDER_NAME,
       }
     end
 
-    if frame[:server_id].nil? || frame[:server_id].empty?
+    if frame["server_id"].nil? || frame["server_id"].empty?
       fail "E2E_HETZNER_SERVER_ID must be a nonempty string"
     end
 
@@ -32,19 +40,19 @@ class Prog::Test::HetznerServer < Prog::Test::Base
   end
 
   label def start
-    hop_wait_setup_host unless frame["setup_host"]
+    hop_wait_setup_host unless setup_host?
     hop_fetch_hostname
   end
 
   label def fetch_hostname
-    update_stack({"hostname" => hetzner_api.get_main_ip4})
+    self.hostname = hetzner_api.get_main_ip4
 
     hop_reimage
   end
 
   label def reimage
     hetzner_api.reimage(
-      frame["server_id"],
+      server_id,
       dist: "Ubuntu 24.04 LTS base",
     )
 
@@ -53,7 +61,7 @@ class Prog::Test::HetznerServer < Prog::Test::Base
 
   label def wait_reimage
     begin
-      Util.rootish_ssh(frame["hostname"], "root", [Config.hetzner_ssh_private_key], "echo 1")
+      Util.rootish_ssh(hostname, "root", [Config.hetzner_ssh_private_key], "echo 1")
     rescue
       nap 15
     end
@@ -63,12 +71,12 @@ class Prog::Test::HetznerServer < Prog::Test::Base
 
   label def setup_host
     vm_host = Prog::Vm::HostNexus.assemble(
-      frame["hostname"],
+      hostname,
       provider_name: HostProvider::HETZNER_PROVIDER_NAME,
-      server_identifier: frame["server_id"],
-      default_boot_images: frame["default_boot_images"],
+      server_identifier: server_id,
+      default_boot_images:,
     ).subject
-    update_stack({"vm_host_id" => vm_host.id})
+    self.vm_host_id = vm_host.id
 
     hop_wait_setup_host
   end
@@ -78,7 +86,7 @@ class Prog::Test::HetznerServer < Prog::Test::Base
       Clog.emit(vm_host.sshable.cmd("ls -lah /var/storage/images").strip.tr("\n", "\t")) if vm_host.strand.label == "wait_download_boot_images"
       nap 15
     end
-    update_stack({"available_storage_gib" => vm_host.available_storage_gib})
+    self.available_storage_gib = vm_host.available_storage_gib
 
     hop_verify_encrypted_swap
   end
@@ -98,7 +106,7 @@ class Prog::Test::HetznerServer < Prog::Test::Base
     end
 
     # We shouldn't install specs by default when running Prog::Vm::HostNexus.assemble
-    verify_specs_installation(installed: false) if frame["setup_host"]
+    verify_specs_installation(installed: false) if setup_host?
 
     # install specs
     push Prog::InstallRhizome, {subject_id: vm_host.id, target_folder: "host", install_specs: true}
@@ -157,14 +165,14 @@ class Prog::Test::HetznerServer < Prog::Test::Base
   label def verify_resources_reclaimed
     fail_test "used_cores is expected to be zero, actual: #{vm_host.used_cores}" unless vm_host.used_cores.zero?
     fail_test "used_hugepages_1g is expected to be zero, actual: #{vm_host.used_hugepages_1g}" unless vm_host.used_hugepages_1g.zero?
-    fail_test "available_storage_gib was not reclaimed as expected: #{frame["available_storage_gib"]}, actual: #{vm_host.available_storage_gib}" unless frame["available_storage_gib"] == vm_host.available_storage_gib
+    fail_test "available_storage_gib was not reclaimed as expected: #{available_storage_gib}, actual: #{vm_host.available_storage_gib}" unless available_storage_gib == vm_host.available_storage_gib
 
     hop_destroy_vm_host
   end
 
   label def destroy_vm_host
     # don't destroy the vm_host if we didn't set it up.
-    hop_finish unless frame["setup_host"]
+    hop_finish unless setup_host?
 
     vm_host.incr_destroy
 
@@ -191,14 +199,14 @@ class Prog::Test::HetznerServer < Prog::Test::Base
   def hetzner_api
     @hetzner_api ||= Hosting::HetznerApis.new(
       HostProvider.new do |hp|
-        hp.server_identifier = frame["server_id"]
+        hp.server_identifier = server_id
         hp.provider_name = HostProvider::HETZNER_PROVIDER_NAME
-        hp.id = frame["vm_host_id"]
+        hp.id = vm_host_id
       end,
     )
   end
 
   def vm_host
-    @vm_host ||= VmHost[frame["vm_host_id"]]
+    @vm_host ||= VmHost[vm_host_id]
   end
 end

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -2,6 +2,10 @@
 
 class Prog::Test::Kubernetes < Prog::Test::Base
   MIGRATION_TRIES = 1
+  frame_reader :kubernetes_service_project_id, :kubernetes_test_project_id
+  frame_accessor :fail_message, :kubernetes_cluster_id, :read_hashes, :normal_pod_restart_test_node,
+    :rsync_retry_source_node, :chained_migration_source_node, :drain_test_node_name, :reboot_node_id,
+    :nat_rules_before_reboot, :pod_access_rules_before_reboot, :migration_number
 
   def self.assemble
     kubernetes_test_project = Project.create(name: "Kubernetes-Test-Project")
@@ -21,7 +25,7 @@ class Prog::Test::Kubernetes < Prog::Test::Base
   label def start
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "kubernetes-test-standard",
-      project_id: frame["kubernetes_test_project_id"],
+      project_id: kubernetes_test_project_id,
       location_id: Location::HETZNER_FSN1_ID,
       version: Option.selectable_kubernetes_versions[1],
       cp_node_count: 1,
@@ -33,7 +37,7 @@ class Prog::Test::Kubernetes < Prog::Test::Base
       target_node_size: "standard-2",
     )
 
-    update_stack({"kubernetes_cluster_id" => kc.id})
+    self.kubernetes_cluster_id = kc.id
     hop_wait_for_kubernetes_bootstrap
   end
 
@@ -46,7 +50,7 @@ class Prog::Test::Kubernetes < Prog::Test::Base
     begin
       nodes_output = kubernetes_cluster.client.kubectl("get nodes")
     rescue RuntimeError => ex
-      update_stack({"fail_message" => "Failed to run test kubectl command: #{ex.message}"})
+      self.fail_message = "Failed to run test kubectl command: #{ex.message}"
       hop_destroy_kubernetes
     end
     missing_nodes = []
@@ -54,7 +58,7 @@ class Prog::Test::Kubernetes < Prog::Test::Base
       missing_nodes.append(node.name) unless nodes_output.include?(node.name)
     }
     if missing_nodes.any?
-      update_stack({"fail_message" => "node #{missing_nodes.join(", ")} not found in cluster"})
+      self.fail_message = "node #{missing_nodes.join(", ")} not found in cluster"
       hop_destroy_kubernetes
     end
     hop_test_csi
@@ -104,7 +108,7 @@ STS
     begin
       verify_mount
     rescue => e
-      update_stack({"fail_message" => e.message})
+      self.fail_message = e.message
       hop_destroy_kubernetes
     end
     hop_test_data_write
@@ -129,7 +133,7 @@ STS
       when "InProgress"
         nap 30
       when "Failed"
-        update_stack({"fail_message" => "daemonized write for random-data-#{i} failed"})
+        self.fail_message = "daemonized write for random-data-#{i} failed"
         hop_destroy_kubernetes
       end
     end
@@ -147,12 +151,12 @@ STS
       read_hash = kubernetes_cluster.client.kubectl("exec -t ubuntu-statefulset-0 -- sh -c :command", command:).strip
       kubernetes_cluster.sshable.d_clean(unit_name)
       if write_hash != read_hash
-        update_stack({"fail_message" => "wrong read hash for #{file}, expected: #{write_hash}, got: #{read_hash}"})
+        self.fail_message = "wrong read hash for #{file}, expected: #{write_hash}, got: #{read_hash}"
         hop_destroy_kubernetes
       end
       read_hashes[file] = read_hash
     end
-    update_stack({"read_hashes" => read_hashes})
+    self.read_hashes = read_hashes
     hop_test_pod_data_migration
   end
 
@@ -172,14 +176,14 @@ STS
     nap 5 unless pod_status == "Running"
     verify_data_hashes("migration")
     hop_test_normal_pod_restart if migration_number == MIGRATION_TRIES
-    increment_migration_number
+    self.migration_number += 1
     hop_test_pod_data_migration
   end
 
   label def test_normal_pod_restart
     client = kubernetes_cluster.client
     pod_node = client.kubectl("get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").strip
-    update_stack({"normal_pod_restart_test_node" => pod_node})
+    self.normal_pod_restart_test_node = pod_node
     client.kubectl("delete pod ubuntu-statefulset-0 --wait=false")
     hop_verify_normal_pod_restart
   end
@@ -189,14 +193,14 @@ STS
     pod_node = kubernetes_cluster.client.kubectl("get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").strip
     expected_pod_node = strand.stack.first["normal_pod_restart_test_node"]
     if pod_node != expected_pod_node
-      update_stack({"fail_message" => "unexpected pod node change after restart, expected: #{expected_pod_node}, got: #{pod_node}"})
+      self.fail_message = "unexpected pod node change after restart, expected: #{expected_pod_node}, got: #{pod_node}"
       hop_destroy_kubernetes
     end
 
     begin
       verify_mount
     rescue => e
-      update_stack({"fail_message" => e.message})
+      self.fail_message = e.message
       hop_destroy_kubernetes
     end
     hop_test_rsync_retry
@@ -208,7 +212,7 @@ STS
     pod_node_name = client.kubectl("get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").strip
     client.kubectl("cordon :pod_node_name", pod_node_name:)
     client.kubectl("delete pod ubuntu-statefulset-0 --wait=false")
-    update_stack({"rsync_retry_source_node" => pod_node_name})
+    self.rsync_retry_source_node = pod_node_name
     hop_kill_rsync_process
   end
 
@@ -233,7 +237,7 @@ STS
     pod_node_name = client.kubectl("get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").strip
     client.kubectl("cordon :pod_node_name", pod_node_name:)
     client.kubectl("delete pod ubuntu-statefulset-0 --wait=false")
-    update_stack({"chained_migration_source_node" => pod_node_name})
+    self.chained_migration_source_node = pod_node_name
     hop_cordon_chained_target
   end
 
@@ -262,7 +266,7 @@ STS
     }
 
     pod_node_name = client.kubectl("get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").strip
-    update_stack({"drain_test_node_name" => pod_node_name})
+    self.drain_test_node_name = pod_node_name
 
     pod_node = nodepool.nodes.find { it.name == pod_node_name }
     pod_node.incr_retire
@@ -281,7 +285,7 @@ STS
       begin
         kubernetes_cluster.client.kubectl("get node :drain_node_name", drain_node_name:)
       rescue => e
-        update_stack({"fail_message" => "Node #{drain_node_name} was removed while CSI data copy was still in progress: #{e.message}"})
+        self.fail_message = "Node #{drain_node_name} was removed while CSI data copy was still in progress: #{e.message}"
         hop_destroy_kubernetes
       end
     end
@@ -299,11 +303,11 @@ STS
     node = nodepool.nodes.first
     nat_rules = node.vm.sshable.cmd("sudo nft list chain ip nat postrouting")
     pod_access_rules = node.vm.sshable.cmd("sudo nft list chain ip6 pod_access ingress_egress_control")
-    update_stack({
-      "reboot_node_id" => node.id,
-      "nat_rules_before_reboot" => nat_rules,
-      "pod_access_rules_before_reboot" => pod_access_rules,
-    })
+
+    self.reboot_node_id = node.id
+    self.nat_rules_before_reboot = nat_rules
+    self.pod_access_rules_before_reboot = pod_access_rules
+
     begin
       node.vm.sshable.cmd("sudo systemctl reboot")
     rescue
@@ -314,16 +318,16 @@ STS
   end
 
   label def verify_reboot_nftables
-    reboot_node = nodepool.nodes.find { |n| n.id == frame["reboot_node_id"] }
+    reboot_node = nodepool.nodes.find { |n| n.id == reboot_node_id }
     nap 5 unless vm_ready?(reboot_node.vm)
     nat_rules = reboot_node.vm.sshable.cmd("sudo nft list chain ip nat postrouting")
     pod_access_rules = reboot_node.vm.sshable.cmd("sudo nft list chain ip6 pod_access ingress_egress_control")
-    if nat_rules != frame["nat_rules_before_reboot"]
-      update_stack({"fail_message" => "ip nat rules changed after reboot"})
+    if nat_rules != nat_rules_before_reboot
+      self.fail_message = "ip nat rules changed after reboot"
       hop_destroy_kubernetes
     end
-    if pod_access_rules != frame["pod_access_rules_before_reboot"]
-      update_stack({"fail_message" => "ip6 pod_access rules changed after reboot"})
+    if pod_access_rules != pod_access_rules_before_reboot
+      self.fail_message = "ip6 pod_access rules changed after reboot"
     end
     hop_test_upgrade
   end
@@ -331,7 +335,7 @@ STS
   label def test_upgrade
     upgrade_candidate = kubernetes_cluster.available_upgrade_version
     unless upgrade_candidate
-      update_stack({"fail_message" => "No upgrade candidate available"})
+      self.fail_message = "No upgrade candidate available"
       hop_destroy_kubernetes
     end
 
@@ -348,7 +352,7 @@ STS
 
     nodes = JSON.parse(kubernetes_cluster.client.kubectl("get nodes -o json"))["items"]
     unless nodes.size == 3 && nodes.all? { |n| n.dig("status", "nodeInfo", "kubeletVersion").start_with?("#{kubernetes_cluster.version}.") }
-      update_stack({"fail_message" => "Not all #{nodes.size} nodes upgraded to #{kubernetes_cluster.version}:\n#{kubernetes_cluster.client.kubectl("get nodes")}"})
+      self.fail_message = "Not all #{nodes.size} nodes upgraded to #{kubernetes_cluster.version}:\n#{kubernetes_cluster.client.kubectl("get nodes")}"
       hop_destroy_kubernetes
     end
 
@@ -370,7 +374,7 @@ STS
     nap 5 if kubernetes_cluster
     kubernetes_test_project.destroy
 
-    fail_test(frame["fail_message"]) if frame["fail_message"]
+    fail_test(fail_message) if fail_message
 
     pop "Kubernetes tests are finished!"
   end
@@ -389,23 +393,15 @@ STS
   end
 
   def kubernetes_test_project
-    @kubernetes_test_project ||= Project.with_pk(frame["kubernetes_test_project_id"])
+    @kubernetes_test_project ||= Project.with_pk(kubernetes_test_project_id)
   end
 
   def kubernetes_cluster
-    @kubernetes_cluster ||= KubernetesCluster.with_pk(frame["kubernetes_cluster_id"])
+    @kubernetes_cluster ||= KubernetesCluster.with_pk(kubernetes_cluster_id)
   end
 
   def nodepool
     kubernetes_cluster.nodepools.first
-  end
-
-  def migration_number
-    strand.stack.first["migration_number"]
-  end
-
-  def increment_migration_number
-    update_stack({"migration_number" => migration_number + 1})
   end
 
   def verify_mount
@@ -452,7 +448,7 @@ STS
       command = NetSsh.command("sha256sum /etc/data/:file | awk '{print $1}'", file:)
       new_hash = kubernetes_cluster.client.kubectl("exec -t ubuntu-statefulset-0 -- sh -c :command", command:).strip
       if new_hash != expected_hash
-        update_stack({"fail_message" => "data hash changed after #{context} for #{file}, expected: #{expected_hash}, got: #{new_hash}"})
+        self.fail_message = "data hash changed after #{context} for #{file}, expected: #{expected_hash}, got: #{new_hash}"
         hop_destroy_kubernetes
       end
     end

--- a/prog/test/local_e2e_loop.rb
+++ b/prog/test/local_e2e_loop.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class Prog::Test::LocalE2eLoop < Prog::Test::Base
+  frame_reader :prog_args, :nap_between
+  frame_accessor :progs, :starts, :successes, :failures, :nap, :current_strand
+  alias_method :nap_between_seconds, :nap_between
+  alias_method :nap?, :nap
+  remove_method :nap
+
   ALLOWED_PROGS = %w[
     PostgresResource
     HaPostgresResource
@@ -41,31 +47,30 @@ class Prog::Test::LocalE2eLoop < Prog::Test::Base
   end
 
   label def start
-    st = Prog::Test.const_get(frame["progs"].first).assemble(local_e2e: true, **frame["prog_args"].transform_keys(&:to_sym))
+    st = Prog::Test.const_get(progs.first).assemble(local_e2e: true, **prog_args.transform_keys(&:to_sym))
     st.update(parent_id: strand.id)
-    update_stack(
-      "current_strand" => st.id,
-      "starts" => frame["starts"] + 1,
-      "progs" => frame["progs"].rotate,
-    )
+    self.current_strand = st.id
+    self.starts += 1
+    progs.rotate!
     hop_wait
   end
 
   label def wait
     reap(:nap_between, reaper: lambda do |child|
-      key = (child.exitval["msg"] == "Postgres tests are finished!") ? "successes" : "failures"
-      update_stack(
-        "current_strand" => nil,
-        key => frame[key] + 1,
-        "nap" => true,
-      )
+      self.current_strand = nil
+      if child.exitval["msg"] == "Postgres tests are finished!"
+        self.successes += 1
+      else
+        self.failures += 1
+      end
+      self.nap = true
     end)
   end
 
   label def nap_between
-    if frame["nap"]
-      update_stack("nap" => false)
-      nap frame["nap_between"]
+    if nap?
+      self.nap = false
+      nap nap_between_seconds
     else
       hop_start
     end

--- a/prog/test/minio_cluster.rb
+++ b/prog/test/minio_cluster.rb
@@ -2,6 +2,8 @@
 
 class Prog::Test::MinioCluster < Prog::Test::Base
   semaphore :destroy_and_verify
+  frame_reader :project_id
+  frame_accessor :minio_cluster_id
 
   def self.assemble(project_id)
     Project[Config.minio_service_project_id] ||
@@ -16,11 +18,11 @@ class Prog::Test::MinioCluster < Prog::Test::Base
 
   label def start
     minio_cluster = Prog::Minio::MinioClusterNexus.assemble(
-      frame["project_id"],
+      project_id,
       "postgres-minio-e2e",
       Location::HETZNER_FSN1_ID, "minio-admin", 32, 1, 1, 1, "standard-2",
     ).subject
-    update_stack({"minio_cluster_id" => minio_cluster.id})
+    self.minio_cluster_id = minio_cluster.id
     hop_wait
   end
 
@@ -44,6 +46,6 @@ class Prog::Test::MinioCluster < Prog::Test::Base
   end
 
   def minio_cluster
-    @minio_cluster ||= MinioCluster[frame["minio_cluster_id"]]
+    @minio_cluster ||= MinioCluster[minio_cluster_id]
   end
 end

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Prog::Test::PostgresBase < Prog::Test::Base
+  frame_reader :provider, :family, :aws_location_name, :postgres_test_project_id, :local_e2e
+  frame_accessor :postgres_resource_id, :private_subnet_id, :location_id, :fail_message, :timeline_ids
+
   def self.assemble(provider:, project_name:, family: nil, aws_location_name: "us-west-2", local_e2e: false, gcp_dedicated_subnet_vpcs: false)
     postgres_test_project = if Config.local_e2e_postgres_test_project_id
       Project.with_pk!(Config.local_e2e_postgres_test_project_id)
@@ -53,35 +56,32 @@ class Prog::Test::PostgresBase < Prog::Test::Base
 
   def start(**)
     location_id, target_vm_size, target_storage_size_gib = self.class.postgres_test_location_options(
-      frame["provider"],
-      family: frame["family"],
-      aws_location_name: frame["aws_location_name"] || "us-west-2",
+      provider,
+      family:,
+      aws_location_name: aws_location_name || "us-west-2",
     )
 
     st = Prog::Postgres::PostgresResourceNexus.assemble(
-      project_id: frame["postgres_test_project_id"],
+      project_id: postgres_test_project_id,
       location_id:,
       target_vm_size:,
       target_storage_size_gib:,
       **,
     )
 
-    frame = {
-      "postgres_resource_id" => st.id,
-      "private_subnet_id" => st.subject.private_subnet_id,
-      "location_id" => location_id,
-    }
-    yield st.subject, frame if block_given?
-    update_stack(frame)
+    self.postgres_resource_id = st.id
+    self.private_subnet_id = st.subject.private_subnet_id
+    self.location_id = location_id
+    yield st.subject if block_given?
     hop_wait_postgres_resource
   end
 
   def postgres_test_project
-    @postgres_test_project ||= Project[frame["postgres_test_project_id"]]
+    @postgres_test_project ||= Project[postgres_test_project_id]
   end
 
   def postgres_resource
-    @postgres_resource ||= PostgresResource[frame["postgres_resource_id"]]
+    @postgres_resource ||= PostgresResource[postgres_resource_id]
   end
 
   def representative_server
@@ -97,14 +97,14 @@ class Prog::Test::PostgresBase < Prog::Test::Base
   end
 
   def nap_if_private_subnet
-    if PrivateSubnet[project_id: frame["postgres_test_project_id"]]
+    if PrivateSubnet[project_id: postgres_test_project_id]
       Clog.emit("Waiting for private subnet to be destroyed")
       nap 5
     end
   end
 
   def nap_if_gcp_vpc
-    if GcpVpc[project_id: frame["postgres_test_project_id"]]
+    if GcpVpc[project_id: postgres_test_project_id]
       Clog.emit("Waiting for GCP VPC to be destroyed")
       nap 5
     end
@@ -120,8 +120,8 @@ class Prog::Test::PostgresBase < Prog::Test::Base
 
   def finish
     postgres_test_project.destroy unless Config.local_e2e_postgres_test_project_id
-    if (fail_message = frame["fail_message"])
-      if frame["local_e2e"]
+    if fail_message
+      if local_e2e
         pop fail_message
       else
         fail_test(fail_message)
@@ -135,7 +135,7 @@ class Prog::Test::PostgresBase < Prog::Test::Base
   end
 
   def destroy
-    if frame["fail_message"] && frame["local_e2e"]
+    if fail_message && local_e2e
       unless destroy_set?
         Prog::PageNexus.assemble("Local E2E Failure: #{self.class.name}", ["LocalE2eFailure", strand.ubid], strand.ubid, severity: "info")
         nap 60 * 60 * 24 * 365

--- a/prog/test/postgres_firewall.rb
+++ b/prog/test/postgres_firewall.rb
@@ -5,6 +5,7 @@ require "uri"
 
 class Prog::Test::PostgresFirewall < Prog::Test::PostgresBase
   semaphore :destroy, :pause
+  frame_accessor :runner_ip, :pg_retries
 
   def self.assemble(provider: "metal", family: nil)
     super(provider:, family:, project_name: "Postgres-Firewall-Test-Project",
@@ -41,7 +42,7 @@ class Prog::Test::PostgresFirewall < Prog::Test::PostgresBase
     uri = URI("https://api.ipify.org")
     my_ip = Net::HTTP.get(uri)
     vm_ip = representative_server.vm.ip4_string
-    update_stack({"runner_ip" => my_ip})
+    self.runner_ip = my_ip
 
     allowed_ips = [my_ip, vm_ip].compact.uniq
     rules = allowed_ips.flat_map { |ip|
@@ -63,11 +64,10 @@ class Prog::Test::PostgresFirewall < Prog::Test::PostgresBase
     test_pg_connection(vm, should_succeed: true)
 
     fw_rules = postgres_resource.pg_firewall_rules
-    runner_ip = frame["runner_ip"]
     expected_cidrs = [runner_ip, vm.ip4_string].compact.uniq.map { "#{it}/32" }
     actual_cidrs = fw_rules.map { it.cidr.to_s }.uniq
     unless actual_cidrs.sort == expected_cidrs.sort
-      update_stack({"fail_message" => "Expected firewall CIDRs #{expected_cidrs} but got #{actual_cidrs}"})
+      self.fail_message = "Expected firewall CIDRs #{expected_cidrs} but got #{actual_cidrs}"
     end
 
     hop_test_block_all_rules
@@ -114,7 +114,7 @@ class Prog::Test::PostgresFirewall < Prog::Test::PostgresBase
   end
 
   label def destroy_postgres
-    update_stack({"timeline_ids" => postgres_resource.servers_dataset.distinct.select_map(:timeline_id)})
+    self.timeline_ids = postgres_resource.servers_dataset.distinct.select_map(:timeline_id)
     postgres_resource.incr_destroy
     hop_wait_resources_destroyed
   end
@@ -123,13 +123,13 @@ class Prog::Test::PostgresFirewall < Prog::Test::PostgresBase
     nap 5 if postgres_resource
     nap_if_private_subnet
     nap_if_gcp_vpc
-    verify_timelines_destroyed(frame["timeline_ids"]) if frame["timeline_ids"]
+    verify_timelines_destroyed(timeline_ids) if timeline_ids
     hop_destroy
   end
 
   label def destroy
     postgres_test_project.destroy unless Config.local_e2e_postgres_test_project_id
-    fail_test(frame["fail_message"]) if frame["fail_message"]
+    fail_test(fail_message) if fail_message
     pop "Postgres firewall tests are finished!"
   end
 
@@ -139,42 +139,39 @@ class Prog::Test::PostgresFirewall < Prog::Test::PostgresBase
 
   def test_pg_connection(vm, should_succeed:)
     ip = vm.ip4_string
+    pg_retries = self.pg_retries || {}
     begin
       vm.sshable.cmd("nc -zvw 5 :ip 5432", ip:)
     rescue Sshable::SshError, *Sshable::SSH_CONNECTION_ERRORS
       if should_succeed
-        retries = (frame.dig("pg_retries", "connect") || 0) + 1
+        retries = (pg_retries["connect"] || 0) + 1
         if retries < 10
-          update_stack({"pg_retries" => (frame["pg_retries"] || {}).merge("connect" => retries)})
+          self.pg_retries = pg_retries.merge("connect" => retries)
           nap 15
         end
-        update_stack({"pg_retries" => nil, "fail_message" => "Connection to #{ip}:5432 should have succeeded after #{retries} attempts"})
-      elsif frame.dig("pg_retries", "block")
+        self.pg_retries = nil
+        self.fail_message = "Connection to #{ip}:5432 should have succeeded after #{retries} attempts"
+      elsif pg_retries["block"]
         # nc was blocked as expected. Reset the negative-path retry
         # counter so a future phase that calls back here starts fresh.
-        update_stack({"pg_retries" => frame["pg_retries"].merge("block" => nil)})
+        self.pg_retries = pg_retries.merge("block" => nil)
       end
     else
       # nc reached port 5432. Reset the per-phase retry counter so the
       # next positive-path test_pg_connection caller starts from zero.
-      pg_retries = frame["pg_retries"]
-      pg_retries = pg_retries.merge("connect" => nil) if pg_retries&.[]("connect")
-      hash = {}
-      hash["pg_retries"] = pg_retries if pg_retries != frame["pg_retries"]
+      pg_retries = pg_retries.merge("connect" => nil) if pg_retries["connect"]
       unless should_succeed
         # GCP dataplane propagation can lag the API ACK by tens of
         # seconds, so a single nc success is not yet a verdict. Retry
         # with the same shape as the success path before giving up.
-        retries = (pg_retries&.[]("block") || 0) + 1
+        retries = (pg_retries["block"] || 0) + 1
         if retries < 10
-          hash["pg_retries"] = (pg_retries || {}).merge("block" => retries)
-          update_stack(hash)
+          self.pg_retries = pg_retries.merge("block" => retries)
           nap 15
         end
-        hash["pg_retries"] = nil
-        hash["fail_message"] = "Connection to #{ip}:5432 should have been blocked after #{retries} attempts"
+        self.fail_message = "Connection to #{ip}:5432 should have been blocked after #{retries} attempts"
       end
-      update_stack(hash) unless hash.empty?
+      self.pg_retries = nil
     end
   end
 end

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -22,14 +22,14 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
 
   label def test_postgres
     unless representative_server.run_query(test_queries_sql) == "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
-      update_stack({"fail_message" => "Failed to run test queries"})
+      self.fail_message = "Failed to run test queries"
     end
 
     hop_destroy
   end
 
   label def destroy_postgres
-    update_stack({"timeline_ids" => postgres_resource.servers_dataset.distinct.select_map(:timeline_id)})
+    self.timeline_ids = postgres_resource.servers_dataset.distinct.select_map(:timeline_id)
     postgres_resource.incr_destroy
     hop_wait_resources_destroyed
   end
@@ -38,7 +38,7 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
     nap 5 if postgres_resource
     nap_if_private_subnet
     nap_if_gcp_vpc
-    verify_timelines_destroyed(frame["timeline_ids"]) if frame["timeline_ids"]
+    verify_timelines_destroyed(timeline_ids) if timeline_ids
 
     hop_finish
   end

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -2,6 +2,7 @@
 
 class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   semaphore :pause, :destroy
+  frame_accessor :pre_upgrade_postgres_timeline_id, :read_replica_id
 
   def self.assemble(provider: "metal", start_version: "17", **)
     st = super(provider:, project_name: "Postgres-Upgrade-Test-Project", **)
@@ -20,7 +21,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
     end
 
     super(name: "postgres-test-upgrade-pg#{start_version}", ha_type: "async", target_version: start_version, user_config:) do |resource, frame|
-      frame["pre_upgrade_postgres_timeline_id"] = resource.timeline.id
+      self.pre_upgrade_postgres_timeline_id = resource.timeline.id
     end
   end
 
@@ -34,7 +35,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
     # PG17+ preserves logical slots across pg_upgrade & adds failover plus sync on standbys
     # PG16 logical slots are dropped by pg_upgrade, still create one to assert upgrade does not hang
     unless (standby = postgres_resource.servers.find { !it.is_representative })
-      update_stack({"fail_message" => "No standby found to verify failover slot sync"})
+      self.fail_message = "No standby found to verify failover slot sync"
       hop_destroy
     end
 
@@ -72,7 +73,7 @@ SQL
   label def test_postgres_before_read_replica
     Clog.emit("Testing Postgres before read replica creation")
     unless representative_server.run_query(test_queries_sql) == "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
-      update_stack({"fail_message" => "Failed to run test queries before read replica"})
+      self.fail_message = "Failed to run test queries before read replica"
       hop_destroy
     end
 
@@ -84,8 +85,8 @@ SQL
 
     # Create read replica using the PostgresResourceNexus with parent_id
     st = Prog::Postgres::PostgresResourceNexus.assemble(
-      project_id: frame["postgres_test_project_id"],
-      location_id: frame["location_id"],
+      project_id: postgres_test_project_id,
+      location_id:,
       parent_id: postgres_resource.id,
       name: "postgres-test-upgrade-replica",
       target_version: postgres_resource.version,
@@ -95,7 +96,7 @@ SQL
       pgbouncer_user_config: {},
     )
 
-    update_stack({"read_replica_id" => st.id})
+    self.read_replica_id = st.id
     hop_wait_read_replica
   end
 
@@ -109,13 +110,13 @@ SQL
 
     # Test primary
     unless representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
-      update_stack({"fail_message" => "Failed to run read queries on primary before upgrade"})
+      self.fail_message = "Failed to run read queries on primary before upgrade"
       hop_destroy
     end
 
     # Test read replica
     unless read_replica.representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
-      update_stack({"fail_message" => "Failed to run read queries on replica before upgrade"})
+      self.fail_message = "Failed to run read queries on replica before upgrade"
       hop_destroy
     end
 
@@ -192,7 +193,7 @@ SQL
     # Check for any failed states
     failed_servers = (postgres_resource.servers + read_replica.servers).filter { |s| s.strand.label == "failed" }
     if failed_servers.any?
-      update_stack({"fail_message" => "Upgrade failed: some servers are in failed state"})
+      self.fail_message = "Upgrade failed: some servers are in failed state"
       failed_servers.each do |server|
         Clog.emit("Failed server: #{server.ubid}, version=#{server.version}, state=#{server.strand.label}")
       end
@@ -209,40 +210,40 @@ SQL
     Clog.emit("Replica servers: #{read_replica.servers.map { |s| "[#{s.ubid}, v#{s.version}, #{s.timeline_access}, #{s.strand.label}]" }.join(", ")}")
 
     unless postgres_resource.servers.all? { |s| s.version == target_version }
-      update_stack({"fail_message" => "Not all primary servers upgraded to version #{target_version}"})
+      self.fail_message = "Not all primary servers upgraded to version #{target_version}"
       hop_destroy
     end
 
     unless read_replica.servers.all? { |s| s.version == target_version }
-      update_stack({"fail_message" => "Not all replica servers upgraded to version #{target_version}"})
+      self.fail_message = "Not all replica servers upgraded to version #{target_version}"
       hop_destroy
     end
 
     # Test read queries on primary (data should still be there)
     Clog.emit("Running read queries on primary after upgrade")
     unless representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
-      update_stack({"fail_message" => "Failed to run read queries on primary after upgrade"})
+      self.fail_message = "Failed to run read queries on primary after upgrade"
       hop_destroy
     end
 
     # Test read queries on read replica
     Clog.emit("Running read queries on replica after upgrade")
     unless read_replica.representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
-      update_stack({"fail_message" => "Failed to run read queries on replica after upgrade"})
+      self.fail_message = "Failed to run read queries on replica after upgrade"
       hop_destroy
     end
 
     # Test write queries on primary
     Clog.emit("Running write queries on primary after upgrade")
     unless representative_server.run_query(test_queries_sql) == "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
-      update_stack({"fail_message" => "Failed to run write queries after upgrade"})
+      self.fail_message = "Failed to run write queries after upgrade"
       hop_destroy
     end
 
     # Verify replica can still read the new data
     Clog.emit("Verifying replica can read updated data")
     unless read_replica.representative_server.run_query(read_queries_sql) == "4159.90\n415.99\n4.1"
-      update_stack({"fail_message" => "Failed to read updated data on replica after upgrade"})
+      self.fail_message = "Failed to read updated data on replica after upgrade"
       hop_destroy
     end
 
@@ -252,7 +253,7 @@ SQL
     slot_row = representative_server.run_query("SELECT failover FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").strip
     expected_row = (start_version.to_i >= 17) ? "t" : ""
     unless slot_row == expected_row
-      update_stack({"fail_message" => "Unexpected slot state after upgrade from v#{start_version}: expected #{expected_row.inspect}, got #{slot_row.inspect}"})
+      self.fail_message = "Unexpected slot state after upgrade from v#{start_version}: expected #{expected_row.inspect}, got #{slot_row.inspect}"
       hop_destroy
     end
 
@@ -263,7 +264,7 @@ SQL
   label def destroy_postgres
     primary_timeline_ids = postgres_resource.servers.map(&:timeline_id)
     replica_timeline_ids = read_replica ? read_replica.servers.map(&:timeline_id) : []
-    update_stack({"timeline_ids" => (primary_timeline_ids + replica_timeline_ids).uniq})
+    self.timeline_ids = (primary_timeline_ids + replica_timeline_ids).uniq
     read_replica&.incr_destroy
     postgres_resource.incr_destroy
     hop_wait_resources_destroyed
@@ -273,7 +274,7 @@ SQL
     nap 5 if read_replica || postgres_resource
     nap_if_private_subnet
     nap_if_gcp_vpc
-    verify_timelines_destroyed(frame["timeline_ids"]) if frame["timeline_ids"]
+    verify_timelines_destroyed(timeline_ids) if timeline_ids
     hop_finish
   end
 
@@ -282,7 +283,7 @@ SQL
   label :destroy
 
   def read_replica
-    @read_replica ||= PostgresResource[frame["read_replica_id"]]
+    @read_replica ||= PostgresResource[read_replica_id]
   end
 
   def start_version

--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -4,6 +4,7 @@ require "json"
 
 class Prog::Test::Vm < Prog::Test::Base
   subject_is :vm, :sshable
+  frame_reader :first_boot
 
   label def start
     hop_verify_dd
@@ -28,7 +29,6 @@ class Prog::Test::Vm < Prog::Test::Base
     # On first boot, create files with random content and store their sha256 sums
     # On subsequent boots, verify that the files still exist and their content matches
     num_files = 5
-    first_boot = frame.fetch("first_boot", true)
     if first_boot
       sshable.cmd("mkdir ~/persistence_test")
       (1..num_files).each do |_|

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class Prog::Test::VmGroup < Prog::Test::Base
+  frame_reader :test_reboot, :boot_images, :verify_host_capacity
+  frame_accessor :first_boot, :vms, :subnets, :project_id
+  alias_method :test_reboot?, :test_reboot
+  alias_method :verify_host_capacity?, :verify_host_capacity
+
   def self.assemble(boot_images:, test_reboot: true, verify_host_capacity: true)
     Strand.create(
       prog: "Test::VmGroup",
@@ -24,7 +29,6 @@ class Prog::Test::VmGroup < Prog::Test::Base
     size_options = ["standard-2", "burstable-1"]
     subnets = Array.new(2) { Prog::Vnet::SubnetNexus.assemble(project.id, name: "subnet-#{it}", location_id: Location::HETZNER_FSN1_ID) }
     encrypted = true
-    boot_images = frame.fetch("boot_images")
     storage_options = [
       [{encrypted:}, {encrypted:, size_gib: 5}],
       [{encrypted:, max_read_mbytes_per_sec: 200, max_write_mbytes_per_sec: 150}],
@@ -41,22 +45,20 @@ class Prog::Test::VmGroup < Prog::Test::Base
         enable_ip4: true)
     end
 
-    update_stack({
-      "vms" => vms.map(&:id),
-      "subnets" => subnets.map(&:id),
-      "project_id" => project.id,
-    })
+    self.vms = vms.map(&:id)
+    self.subnets = subnets.map(&:id)
+    self.project_id = project.id
 
     hop_wait_vms
   end
 
   label def wait_vms
-    nap 10 if frame["vms"].any? { Vm[it].display_state != "running" }
+    nap 10 if vms.any? { Vm[it].display_state != "running" }
     hop_verify_vms
   end
 
   label def verify_vms
-    frame["vms"].each { bud(Prog::Test::Vm, {"subject_id" => it, "first_boot" => frame["first_boot"]}) }
+    vms.each { bud(Prog::Test::Vm, {"subject_id" => it, "first_boot" => first_boot}) }
     hop_wait_verify_vms
   end
 
@@ -65,7 +67,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   label def verify_host_capacity
-    hop_verify_vm_host_slices if !frame["verify_host_capacity"]
+    hop_verify_vm_host_slices unless verify_host_capacity?
 
     vm_cores = vm_host.vms.sum(&:cores)
     slice_cores = vm_host.slices.sum(&:cores)
@@ -80,7 +82,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
       hop_verify_firewall_rules
     end
 
-    slices = frame["vms"].map { Vm[it].vm_host_slice&.id }.reject(&:nil?)
+    slices = vms.map { Vm[it].vm_host_slice&.id }.reject(&:nil?)
     push Prog::Test::VmHostSlices, {"slices" => slices}
   end
 
@@ -89,19 +91,19 @@ class Prog::Test::VmGroup < Prog::Test::Base
       hop_verify_connected_subnets
     end
 
-    push Prog::Test::FirewallRules, {subject_id: PrivateSubnet[frame["subnets"].first].firewalls.first.id}
+    push Prog::Test::FirewallRules, {subject_id: PrivateSubnet[subnets.first].firewalls.first.id}
   end
 
   label def verify_connected_subnets
     if retval&.dig("msg") == "Verified Connected Subnets!"
-      if frame["test_reboot"] && frame["first_boot"]
+      if test_reboot? && first_boot
         hop_test_reboot
       else
         hop_destroy_resources
       end
     end
 
-    ps1, ps2 = frame["subnets"].map { PrivateSubnet[it] }
+    ps1, ps2 = subnets.map { PrivateSubnet[it] }
     push Prog::Test::ConnectedSubnets, {subnet_id_multiple: ((ps1.vms.count > 1) ? ps1.id : ps2.id), subnet_id_single: ((ps1.vms.count > 1) ? ps2.id : ps1.id)}
   end
 
@@ -113,7 +115,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
   label def wait_reboot
     if vm_host.strand.label == "wait" && vm_host.strand.semaphores.empty?
       # Run VM tests again, but avoid rebooting again
-      update_stack({"first_boot" => false})
+      self.first_boot = false
       hop_verify_vms
     end
 
@@ -121,14 +123,14 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   label def destroy_resources
-    frame["vms"].each { Vm[it].incr_destroy }
-    frame["subnets"].each { PrivateSubnet[it].tap { |ps| ps.firewalls.each { |fw| fw.destroy } }.incr_destroy }
+    vms.each { Vm[it].incr_destroy }
+    subnets.each { PrivateSubnet[it].tap { |ps| ps.firewalls.each { |fw| fw.destroy } }.incr_destroy }
 
     hop_wait_resources_destroyed
   end
 
   label def wait_resources_destroyed
-    unless frame["vms"].all? { Vm[it].nil? } && frame["subnets"].all? { PrivateSubnet[it].nil? }
+    unless vms.all? { Vm[it].nil? } && subnets.all? { PrivateSubnet[it].nil? }
       nap 5
     end
 
@@ -136,7 +138,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   label def finish
-    Project[frame["project_id"]].destroy
+    Project[project_id].destroy
     pop "VmGroup tests finished!"
   end
 
@@ -145,6 +147,6 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   def vm_host
-    @vm_host ||= Vm[frame["vms"].first].vm_host
+    @vm_host ||= Vm[vms.first].vm_host
   end
 end

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -80,8 +80,8 @@ class Prog::Test::VmGroup < Prog::Test::Base
       hop_verify_firewall_rules
     end
 
-    slices = vms.map { Vm[it].vm_host_slice&.id }.reject(&:nil?)
-    push Prog::Test::VmHostSlices, {"slices" => slices}
+    slice_ids = vms.map { Vm[it].vm_host_slice&.id }.reject(&:nil?)
+    push Prog::Test::VmHostSlices, {"slice_ids" => slice_ids}
   end
 
   label def verify_firewall_rules

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -1,21 +1,19 @@
 # frozen_string_literal: true
 
 class Prog::Test::VmGroup < Prog::Test::Base
-  frame_reader :test_reboot, :boot_images, :verify_host_capacity
+  frame_reader :test_reboot?, :boot_images, :verify_host_capacity?
   frame_accessor :first_boot, :vms, :subnets, :project_id
-  alias_method :test_reboot?, :test_reboot
-  alias_method :verify_host_capacity?, :verify_host_capacity
 
   def self.assemble(boot_images:, test_reboot: true, verify_host_capacity: true)
     Strand.create(
       prog: "Test::VmGroup",
       label: "start",
       stack: [{
-        "test_reboot" => test_reboot,
+        "test_reboot?" => test_reboot,
         "first_boot" => true,
         "vms" => [],
         "boot_images" => boot_images,
-        "verify_host_capacity" => verify_host_capacity,
+        "verify_host_capacity?" => verify_host_capacity,
       }],
     )
   end

--- a/prog/test/vm_host_slices.rb
+++ b/prog/test/vm_host_slices.rb
@@ -3,8 +3,7 @@
 require "json"
 
 class Prog::Test::VmHostSlices < Prog::Test::Base
-  frame_reader :slices
-  alias_method :slice_ids, :slices
+  frame_reader :slice_ids
 
   label def start
     hop_verify_separation

--- a/prog/test/vm_host_slices.rb
+++ b/prog/test/vm_host_slices.rb
@@ -3,6 +3,9 @@
 require "json"
 
 class Prog::Test::VmHostSlices < Prog::Test::Base
+  frame_reader :slices
+  alias_method :slice_ids, :slices
+
   label def start
     hop_verify_separation
   end
@@ -37,6 +40,6 @@ class Prog::Test::VmHostSlices < Prog::Test::Base
   end
 
   def slices
-    @slices ||= frame["slices"].map { VmHostSlice[it] }
+    @slices ||= slice_ids.map { VmHostSlice[it] }
   end
 end

--- a/spec/lib/gcp_lro_spec.rb
+++ b/spec/lib/gcp_lro_spec.rb
@@ -129,12 +129,10 @@ RSpec.describe GcpLro do
   describe "#save_gcp_op and #clear_gcp_op" do
     it "saves and clears a named LRO slot" do
       nx.save_gcp_op("my_lro", op_name: "op-named", scope: "region", scope_value: "us-central1")
-      strand.reload
       expect(strand.stack.first["my_lro"]).to eq({"name" => "op-named", "scope" => "region", "scope_value" => "us-central1"})
 
       refresh_frame(nx)
       nx.clear_gcp_op("my_lro")
-      strand.reload
       expect(strand.stack.first["my_lro"]).to be_nil
     end
   end
@@ -150,7 +148,7 @@ RSpec.describe GcpLro do
       yielded = false
       expect { nx.poll_and_clear_gcp_op("gcp_op") { yielded = true } }.to raise_error(Prog::Base::Nap)
       expect(yielded).to be(false)
-      expect(strand.reload.stack.first["gcp_op"]).to eq({"name" => "op-abc", "scope" => "global", "scope_value" => nil})
+      expect(strand.stack.first["gcp_op"]).to eq({"name" => "op-abc", "scope" => "global", "scope_value" => nil})
     end
 
     it "clears the op and does not yield when the operation succeeds" do
@@ -160,7 +158,7 @@ RSpec.describe GcpLro do
       result = nx.poll_and_clear_gcp_op("gcp_op") { yielded = true }
       expect(yielded).to be(false)
       expect(result).to eq(op)
-      expect(strand.reload.stack.first["gcp_op"]).to be_nil
+      expect(strand.stack.first["gcp_op"]).to be_nil
     end
 
     it "yields the errored op then clears the op when the block falls through" do
@@ -174,7 +172,7 @@ RSpec.describe GcpLro do
       result = nx.poll_and_clear_gcp_op("gcp_op") { |o| yielded_op = o }
       expect(yielded_op).to eq(op)
       expect(result).to eq(op)
-      expect(strand.reload.stack.first["gcp_op"]).to be_nil
+      expect(strand.stack.first["gcp_op"]).to be_nil
     end
 
     it "does not clear the op when the recovery block raises" do
@@ -187,7 +185,7 @@ RSpec.describe GcpLro do
       expect {
         nx.poll_and_clear_gcp_op("gcp_op") { |_| raise "recovery failed" }
       }.to raise_error(RuntimeError, "recovery failed")
-      expect(strand.reload.stack.first["gcp_op"]).to eq({"name" => "op-abc", "scope" => "global", "scope_value" => nil})
+      expect(strand.stack.first["gcp_op"]).to eq({"name" => "op-abc", "scope" => "global", "scope_value" => nil})
     end
 
     it "works with a named LRO slot" do
@@ -199,7 +197,7 @@ RSpec.describe GcpLro do
         .and_return(op)
       result = nx.poll_and_clear_gcp_op("my_lro") {}
       expect(result).to eq(op)
-      expect(strand.reload.stack.first["my_lro"]).to be_nil
+      expect(strand.stack.first["my_lro"]).to be_nil
     end
   end
 end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -220,9 +220,7 @@ RSpec.describe Prog::Base do
       prg = described_class.new(st)
       prg.delete_from_stack("key1", "key3")
 
-      expect(frame_value(prg, "key1")).to be_nil
-      expect(frame_value(prg, "key2")).to eq("value2")
-      expect(frame_value(prg, "key3")).to be_nil
+      expect(prg.strand.stack[0]).to eq({"key2" => "value2"})
     end
   end
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -462,8 +462,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.initialize_database_from_backup }.to hop("refresh_certificates")
       expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
 
-      expect(frame_value(nx, "disk_usage")).to be_nil
-      expect(frame_value(nx, "initialize_database_from_backup_try_count")).to be_nil
+      expect(nx.strand.stack[0]["disk_usage"]).to be_nil
+      expect(nx.strand.stack[0]["initialize_database_from_backup_try_count"]).to be_nil
     end
 
     it "cleans up the stack and hops when succeeded without an existing page" do
@@ -472,8 +472,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_database_from_backup").and_return("Succeeded")
       expect { nx.initialize_database_from_backup }.to hop("refresh_certificates")
 
-      expect(frame_value(nx, "disk_usage")).to be_nil
-      expect(frame_value(nx, "initialize_database_from_backup_try_count")).to be_nil
+      expect(nx.strand.stack[0]["disk_usage"]).to be_nil
+      expect(nx.strand.stack[0]["initialize_database_from_backup_try_count"]).to be_nil
     end
 
     it "naps if script return unknown status" do

--- a/spec/prog/test/connected_subnets_spec.rb
+++ b/spec/prog/test/connected_subnets_spec.rb
@@ -59,8 +59,8 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable listening_ipv4.service")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable listening_ipv6.service")
-      expect(connected_subnets_test).to receive(:update_stack).with({"vm_to_be_connected_id" => vm1.id})
       expect { connected_subnets_test.start }.to nap(5)
+      expect(connected_subnets_test.strand.stack[0]["vm_to_be_connected_id"]).to eq vm1.id
     end
 
     it "hops to perform_tests_public_blocked" do
@@ -94,9 +94,9 @@ ExecStart=nc -l 8080 -6
     it "updates firewall rules, updates the stack, and naps" do
       expect(connected_subnets_test).to receive(:ps_multiple).and_return(ps_multiple).at_least(:once)
       expect(connected_subnets_test).to receive(:update_firewall_rules).with(ps_multiple, ps_single, config: :perform_connected_private_ipv4)
-      expect(connected_subnets_test).to receive(:update_stack).with({"firewalls" => "connected_private_ipv4"})
       expect(ps_multiple).to receive(:update_firewall_rules_set?).and_return(true)
       expect { connected_subnets_test.perform_tests_private_ipv4 }.to nap(5)
+      expect(connected_subnets_test.strand.stack[0]["firewalls"]).to eq "connected_private_ipv4"
     end
 
     it "tests connection between the two subnets and hops to perform_tests_private_ipv6" do
@@ -122,9 +122,9 @@ ExecStart=nc -l 8080 -6
     it "updates firewall rules, updates the stack, and naps" do
       expect(connected_subnets_test).to receive(:ps_multiple).and_return(ps_multiple).at_least(:once)
       expect(connected_subnets_test).to receive(:update_firewall_rules).with(ps_multiple, ps_single, config: :perform_connected_private_ipv6)
-      expect(connected_subnets_test).to receive(:update_stack).with({"firewalls" => "connected_private_ipv6"})
       expect(ps_multiple).to receive(:update_firewall_rules_set?).and_return(true)
       expect { connected_subnets_test.perform_tests_private_ipv6 }.to nap(5)
+      expect(connected_subnets_test.strand.stack[0]["firewalls"]).to eq "connected_private_ipv6"
     end
 
     it "tests connection between the two subnets and hops to perform_blocked_private_ipv4" do
@@ -148,9 +148,9 @@ ExecStart=nc -l 8080 -6
     it "updates firewall rules, updates the stack, and naps" do
       expect(connected_subnets_test).to receive(:ps_multiple).and_return(ps_multiple).at_least(:once)
       expect(connected_subnets_test).to receive(:update_firewall_rules).with(ps_multiple, ps_multiple, config: :perform_blocked_private_ipv4)
-      expect(connected_subnets_test).to receive(:update_stack).with({"firewalls" => "blocked_private_ipv4"})
       expect(ps_multiple).to receive(:update_firewall_rules_set?).and_return(true)
       expect { connected_subnets_test.perform_blocked_private_ipv4 }.to nap(5)
+      expect(connected_subnets_test.strand.stack[0]["firewalls"]).to eq "blocked_private_ipv4"
     end
 
     it "tests connection between the two subnets and hops to perform_blocked_private_ipv6" do
@@ -174,9 +174,9 @@ ExecStart=nc -l 8080 -6
     it "updates firewall rules, updates the stack, and naps" do
       expect(connected_subnets_test).to receive(:ps_multiple).and_return(ps_multiple).at_least(:once)
       expect(connected_subnets_test).to receive(:update_firewall_rules).with(ps_multiple, ps_multiple, config: :perform_blocked_private_ipv6)
-      expect(connected_subnets_test).to receive(:update_stack).with({"firewalls" => "blocked_private_ipv6"})
       expect(ps_multiple).to receive(:update_firewall_rules_set?).and_return(true)
       expect { connected_subnets_test.perform_blocked_private_ipv6 }.to nap(5)
+      expect(connected_subnets_test.strand.stack[0]["firewalls"]).to eq "blocked_private_ipv6"
     end
 
     it "tests connection between the two subnets and hops to perform_tests_public_blocked" do

--- a/spec/prog/test/dns_zone_spec.rb
+++ b/spec/prog/test/dns_zone_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Prog::Test::DnsZone do
       expect(dz.dns_servers.count).to eq(1)
       expect(dz.dns_servers.first.name).to eq("ns-e2e.#{parent_zone_name}")
       expect(Strand[dz.id].prog).to eq("DnsZone::DnsZoneNexus")
-      expect(Strand[frame_value(dns_zone_test, "setup_strand_id")]).not_to be_nil
+      expect(Strand[dns_zone_test.strand.stack[0]["setup_strand_id"]]).not_to be_nil
     end
   end
 
@@ -131,8 +131,8 @@ RSpec.describe Prog::Test::DnsZone do
       )
 
       expect { dns_zone_test.register_cloudflare_records }.to hop("insert_sentinel_records")
-      expect(frame_value(dns_zone_test, "cloudflare_zone_id")).to eq("parent-zone-id")
-      expect(frame_value(dns_zone_test, "cloudflare_record_ids")).to eq(["rec-a", "rec-aaaa", "rec-ns"])
+      expect(dns_zone_test.strand.stack[0]["cloudflare_zone_id"]).to eq("parent-zone-id")
+      expect(dns_zone_test.strand.stack[0]["cloudflare_record_ids"]).to eq(["rec-a", "rec-aaaa", "rec-ns"])
     end
   end
 
@@ -143,7 +143,7 @@ RSpec.describe Prog::Test::DnsZone do
 
       expect { dns_zone_test.insert_sentinel_records }.to hop("wait_dns_propagation")
 
-      sentinel_name = frame_value(dns_zone_test, "sentinel_record_name")
+      sentinel_name = dns_zone_test.strand.stack[0]["sentinel_record_name"]
       expect(sentinel_name).to start_with("_e2e_check_")
       expect(sentinel_name).to end_with(".#{zone_name}")
       expect(dz.records_dataset.where(type: "A").select_map([:name, :data])).to eq([["#{sentinel_name}.", described_class::SENTINEL_RECORD_IP4]])

--- a/spec/prog/test/firewall_rules_spec.rb
+++ b/spec/prog/test/firewall_rules_spec.rb
@@ -62,9 +62,8 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable listening_ipv4.service")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable listening_ipv6.service")
 
-      expect(firewall_test).to receive(:update_stack).with({"vm_to_be_connected_id" => "vm_1"})
-
       expect { firewall_test.start }.to hop("perform_tests_none")
+      expect(firewall_test.strand.stack[0]["vm_to_be_connected_id"]).to eq "vm_1"
     end
 
     it "installs nc to other vms too" do
@@ -98,9 +97,8 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable listening_ipv4.service")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable listening_ipv6.service")
 
-      expect(firewall_test).to receive(:update_stack).with({"vm_to_be_connected_id" => "vm_1"})
-
       expect { firewall_test.start }.to hop("perform_tests_none")
+      expect(firewall_test.strand.stack[0]["vm_to_be_connected_id"]).to eq "vm_1"
     end
   end
 
@@ -108,26 +106,25 @@ ExecStart=nc -l 8080 -6
     it "updates firewall rules when the frame is not set to none and naps if firewall rules are not updated" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => nil, "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_none)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "none"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(true)
       expect { firewall_test.perform_tests_none }.to nap(5)
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "none"
     end
 
     it "doesn't update firewall rules when the frame is set to none and naps if firewall rules are not updated" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "none", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "none"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(true)
       expect { firewall_test.perform_tests_none }.to nap(5)
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "none"
     end
 
     it "doesn't update firewall rules and tests connectivity and hops when the fw update is done" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "none", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "none"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -140,12 +137,12 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 1.1.1.1 8080").and_raise("nc: connect to 1.1.1.1 port 8080 (tcp) timed out")
 
       expect { firewall_test.perform_tests_none }.to hop("perform_tests_public_ipv4")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "none"
     end
 
     it "updates firewall rules and tests connectivity and fails when the fw update is done" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "none", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "none"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -159,6 +156,7 @@ ExecStart=nc -l 8080 -6
 
       expect { firewall_test.perform_tests_none }.to hop("failed")
       expect(strand.reload.exitval).to eq({"msg" => "vm2 should not be able to connect to vm1 on port 8080"})
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "none"
     end
   end
 
@@ -166,27 +164,26 @@ ExecStart=nc -l 8080 -6
     it "updates firewall rules and naps when the fw update is not done yet" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "none", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv4)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(true)
       expect { firewall_test.perform_tests_public_ipv4 }.to nap(5)
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "public_ipv4"
     end
 
     it "does not update firewall rules and naps when the fw update is not done yet" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(true)
       expect { firewall_test.perform_tests_public_ipv4 }.to nap(5)
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "public_ipv4"
     end
 
     it "does not update firewall rules but tests connectivity and fails when the VM2 cannot connect to VM1" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -194,13 +191,13 @@ ExecStart=nc -l 8080 -6
 
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 1.1.1.1 8080").and_raise("nc: connect to 1.1.1.1 port 8080 (tcp) timed out")
       expect { firewall_test.perform_tests_public_ipv4 }.to hop("failed")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "public_ipv4"
       expect(strand.reload.exitval).to eq({"msg" => "vm2 should be able to connect to 1.1.1.1 on port 8080"})
     end
 
     it "updates firewall rules and tests connectivity and fails when the VM2 can connect to VM1 but also the vm_outside can connect to VM1" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv4)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -211,13 +208,13 @@ ExecStart=nc -l 8080 -6
       vm_outside = instance_double(Vm, ip4: "1.1.1.3", inhost_name: "vm_outside", sshable:)
       expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
       expect { firewall_test.perform_tests_public_ipv4 }.to hop("failed")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "public_ipv4"
       expect(strand.reload.exitval).to eq({"msg" => "vm_outside should not be able to connect to vm1 on port 8080"})
     end
 
     it "updates firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1 but not the vm_outside" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv4)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv4"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -230,6 +227,7 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 1.1.1.1 8080").and_raise("nc: connect to 1.1.1.1 port 8080 (tcp) timed out")
 
       expect { firewall_test.perform_tests_public_ipv4 }.to hop("perform_tests_public_ipv6")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "public_ipv4"
     end
   end
 
@@ -237,27 +235,26 @@ ExecStart=nc -l 8080 -6
     it "updates firewall rules and naps when the fw update is not done yet" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv6)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(true)
       expect { firewall_test.perform_tests_public_ipv6 }.to nap(5)
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "public_ipv6"
     end
 
     it "does not update firewall rules and naps when the fw update is not done yet" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(true)
       expect { firewall_test.perform_tests_public_ipv6 }.to nap(5)
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "public_ipv6"
     end
 
     it "does not update firewall rules but tests connectivity and fails when the VM2 cannot connect to VM1" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv6)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -268,13 +265,13 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 2001:0db8:85a1::2 8080 -6").and_raise("nc: connect to 2001:0db8:85a1::/64 port 8080 (tcp) timed out")
 
       expect { firewall_test.perform_tests_public_ipv6 }.to hop("failed")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "public_ipv6"
       expect(strand.reload.exitval).to eq({"msg" => "vm2 should be able to connect to 2001:0db8:85a1::2 on port 8080"})
     end
 
     it "updates firewall rules and tests connectivity and fails when the VM2 can connect to VM1 but also the vm_outside can connect to VM1" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv6)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -287,13 +284,13 @@ ExecStart=nc -l 8080 -6
       expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 2001:0db8:85a1::2 8080 -6").and_return("success!").at_least(:once)
       expect { firewall_test.perform_tests_public_ipv6 }.to hop("failed")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "public_ipv6"
       expect(strand.reload.exitval).to eq({"msg" => "vm_outside should not be able to connect to 2001:0db8:85a1::2 on port 8080"})
     end
 
     it "updates firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1 but not the vm_outside" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_public_ipv6)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "public_ipv6"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -307,6 +304,7 @@ ExecStart=nc -l 8080 -6
       expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 2001:0db8:85a1::2 8080 -6").and_raise("nc: connect to 2001:0db8:85a1::/64 port 8080 (tcp) timed out")
       expect { firewall_test.perform_tests_public_ipv6 }.to hop("perform_tests_private_ipv4")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "public_ipv6"
     end
   end
 
@@ -314,27 +312,26 @@ ExecStart=nc -l 8080 -6
     it "updates firewall rules and naps when the fw update is not done yet" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "public_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv4)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(true)
       expect { firewall_test.perform_tests_private_ipv4 }.to nap(5)
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "private_ipv4"
     end
 
     it "does not update firewall rules and naps when the fw update is not done yet" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(true)
       expect { firewall_test.perform_tests_private_ipv4 }.to nap(5)
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "private_ipv4"
     end
 
     it "does not update firewall rules but tests connectivity and fails when the VM2 cannot connect to VM1" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv4)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -344,13 +341,13 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("sudo systemctl start listening_ipv4.service")
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 192.168.0.1 8080").and_raise("nc: connect to 192.168.0.1 port 8080 (tcp) timed out")
       expect { firewall_test.perform_tests_private_ipv4 }.to hop("failed")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "private_ipv4"
       expect(strand.reload.exitval).to eq({"msg" => "vm2 should be able to connect to 192.168.0.1 on port 8080"})
     end
 
     it "does not update firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv4)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -364,12 +361,12 @@ ExecStart=nc -l 8080 -6
       expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 1.1.1.1 8080").and_raise("nc: connect to 1.1.1.1 port 8080 (tcp) timed out")
       expect { firewall_test.perform_tests_private_ipv4 }.to hop("perform_tests_private_ipv6")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "private_ipv4"
     end
 
     it "does not update firewall rules and tests connectivity and fails when the vm_outside can connect to VM1 publicly" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv4)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv4"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -383,6 +380,7 @@ ExecStart=nc -l 8080 -6
       expect(firewall_test).to receive(:vm_outside).and_return(vm_outside).at_least(:once)
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 1.1.1.1 8080").and_return("success!").once
       expect { firewall_test.perform_tests_private_ipv4 }.to hop("failed")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "private_ipv4"
       expect(strand.reload.exitval).to eq({"msg" => "vm_outside should not be able to connect to 192.168.0.1 on port 8080"})
     end
   end
@@ -391,27 +389,26 @@ ExecStart=nc -l 8080 -6
     it "updates firewall rules and naps when the fw update is not done yet" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv4", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv6)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(true)
       expect { firewall_test.perform_tests_private_ipv6 }.to nap(5)
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "private_ipv6"
     end
 
     it "does not update firewall rules and naps when the fw update is not done yet" do
       expect(firewall_test).to receive(:frame).and_return({"firewalls" => "private_ipv6"})
       expect(firewall_test).not_to receive(:update_firewall_rules)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.last).to receive(:update_firewall_rules_set?).and_return(true)
       expect { firewall_test.perform_tests_private_ipv6 }.to nap(5)
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "private_ipv6"
     end
 
     it "does not update firewall rules but tests connectivity and fails when the VM2 cannot connect to VM1" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv6)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -421,13 +418,13 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("sudo systemctl start listening_ipv6.service")
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 fd01:db8:85a1::2 8080 -6").and_raise("nc: connect to fd01:0db8:85a1::2 port 8080 (tcp) timed out")
       expect { firewall_test.perform_tests_private_ipv6 }.to hop("failed")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "private_ipv6"
       expect(strand.reload.exitval).to eq({"msg" => "vm2 should be able to connect to fd01:db8:85a1::2 on port 8080"})
     end
 
     it "does not update firewall rules and tests connectivity and succeeds when the VM2 can connect to VM1" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv6)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -438,12 +435,12 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 fd01:db8:85a1::2 8080 -6").and_return("success!").once
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 2001:0db8:85a1::2 8080 -6").and_raise("nc: connect to 2001:0db8:85a1::2 port 8080 (tcp) timed out")
       expect { firewall_test.perform_tests_private_ipv6 }.to hop("finish")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "private_ipv6"
     end
 
     it "does not update firewall rules and tests connectivity and fails when the vm2 can connect to VM1 publicly" do
       expect(firewall_test).to receive_messages(frame: {"firewalls" => "private_ipv6", "vm_to_be_connected_id" => "vm_1"})
       expect(firewall_test).not_to receive(:update_firewall_rules).with(config: :perform_tests_private_ipv6)
-      expect(firewall_test).to receive(:update_stack).with({"firewalls" => "private_ipv6"})
 
       expect(private_subnet_1).to receive(:update_firewall_rules_set?).and_return(false)
       expect(firewall_test.firewall.private_subnets.first.vms.first).to receive(:update_firewall_rules_set?).and_return(false)
@@ -454,6 +451,7 @@ ExecStart=nc -l 8080 -6
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 fd01:db8:85a1::2 8080 -6").and_return("success!").once
       expect(sshable).to receive(:_cmd).with("nc -zvw 1 2001:0db8:85a1::2 8080 -6").and_return("success!").once
       expect { firewall_test.perform_tests_private_ipv6 }.to hop("failed")
+      expect(firewall_test.strand.stack[0]["firewalls"]).to eq "private_ipv6"
       expect(strand.reload.exitval).to eq({"msg" => "vm2 should not be able to connect to 2001:0db8:85a1::2 on port 8080"})
     end
   end

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Prog::Test::HaPostgresResource do
   describe "#start" do
     it "creates a postgres resource on metal and hops to wait_postgres_resource" do
       expect { pgr_test.start }.to hop("wait_postgres_resource")
-      postgres_resource_id = frame_value(pgr_test, "postgres_resource_id")
+      postgres_resource_id = pgr_test.strand.stack[0]["postgres_resource_id"]
       expect(postgres_resource_id).not_to be_nil
       expect(PostgresResource[postgres_resource_id]).not_to be_nil
     end
@@ -267,19 +267,19 @@ RSpec.describe Prog::Test::HaPostgresResource do
     it "fails if the postgres test fails" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("")
       expect { pgr_test.test_postgres_after_failover }.to hop("destroy")
-      expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run read queries after failover")
+      expect(pgr_test.strand.stack[0]["fail_message"]).to eq("Failed to run read queries after failover")
     end
 
     it "hops to destroy if the standby does not exit read-only mode" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "")
       expect { pgr_test.test_postgres_after_failover }.to hop("destroy")
-      expect(frame_value(pgr_test, "fail_message")).to eq("Failed to run write queries after failover")
+      expect(pgr_test.strand.stack[0]["fail_message"]).to eq("Failed to run write queries after failover")
     end
 
     it "hops to destroy if the postgres test succeeds" do
       allow(pgr_test.representative_server).to receive(:_run_query).and_return("4159.90\n415.99\n4.1", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1")
       expect { pgr_test.test_postgres_after_failover }.to hop("destroy")
-      expect(frame_value(pgr_test, "fail_message")).to be_nil
+      expect(pgr_test.strand.stack[0]["fail_message"]).to be_nil
     end
   end
 
@@ -293,7 +293,7 @@ RSpec.describe Prog::Test::HaPostgresResource do
     it "increments the destroy count and hops to wait_resources_destroyed" do
       expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
       expect(@pg_strand.subject.destroy_set?).to be true
-      expect(frame_value(pgr_test, "timeline_ids")).not_to be_empty
+      expect(pgr_test.strand.stack[0]["timeline_ids"]).not_to be_empty
     end
   end
 

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Prog::Test::HetznerServer do
       "hetzner_ssh_keypair" => "oOtAbOGFVHJjFyeQBgSfghi+YBuyQzBRsKABGZhOmDpmwxqx681mscsGBLaQ\n2iWQsOYBBVLDtQWe/gf3NRNyBw==\n",
       "server_id" => "1234",
       "additional_boot_images" => [],
-      "setup_host" => true,
+      "setup_host?" => true,
     })
     allow(hs_test).to receive(:hetzner_api).and_return(hetzner_api)
   }
@@ -36,18 +36,18 @@ RSpec.describe Prog::Test::HetznerServer do
       st = described_class.assemble(vm_host_id: vm_host.id)
       expect(st.stack.first["vm_host_id"]).to eq(vm_host.id)
       expect(st.stack.first["hostname"]).to eq("1.1.1.1")
-      expect(st.stack.first["setup_host"]).to be(false)
+      expect(st.stack.first["setup_host?"]).to be(false)
     end
   end
 
   describe "#start" do
     it "hops to fetch_hostname if setup_host is true" do
-      refresh_frame(hs_test, new_values: {"setup_host" => true})
+      refresh_frame(hs_test, new_values: {"setup_host?" => true})
       expect { hs_test.start }.to hop("fetch_hostname")
     end
 
     it "hops to wait_setup_host if vm_host_id is given" do
-      refresh_frame(hs_test, new_values: {"vm_host_id" => "123", "setup_host" => false})
+      refresh_frame(hs_test, new_values: {"vm_host_id" => "123", "setup_host?" => false})
       expect { hs_test.start }.to hop("wait_setup_host")
     end
   end
@@ -129,13 +129,13 @@ RSpec.describe Prog::Test::HetznerServer do
     end
 
     it "verifies specs haven't been installed when we setup the host & installs rhizome with specs" do
-      refresh_frame(hs_test, new_values: {"setup_host" => true})
+      refresh_frame(hs_test, new_values: {"setup_host?" => true})
       expect(hs_test).to receive(:verify_specs_installation).with(installed: false)
       expect { hs_test.install_integration_specs }.to hop("start", "InstallRhizome")
     end
 
     it "doesn't verify specs not installed if we didn't setup the host" do
-      refresh_frame(hs_test, new_values: {"setup_host" => false})
+      refresh_frame(hs_test, new_values: {"setup_host?" => false})
       expect(hs_test).not_to receive(:verify_specs_installation)
       expect { hs_test.install_integration_specs }.to hop("start", "InstallRhizome")
     end
@@ -259,12 +259,12 @@ RSpec.describe Prog::Test::HetznerServer do
 
   describe "#destroy" do
     it "does not delete key and vm host if existing vm host used" do
-      refresh_frame(hs_test, new_values: {"setup_host" => false})
+      refresh_frame(hs_test, new_values: {"setup_host?" => false})
       expect { hs_test.destroy_vm_host }.to hop("finish")
     end
 
     it "deletes vm host" do
-      refresh_frame(hs_test, new_values: {"setup_host" => true})
+      refresh_frame(hs_test, new_values: {"setup_host?" => true})
       expect { hs_test.destroy_vm_host }.to hop("wait_vm_host_destroyed")
       expect(vm_host.destroy_set?).to be true
     end

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "assembles kubernetes cluster and hops to wait_for_kubernetes_bootstrap" do
       expect(kubernetes_test).to receive(:frame).and_return({"kubernetes_test_project_id" => kubernetes_test_project.id})
-      expect(kubernetes_test).to receive(:update_stack)
 
       expect { kubernetes_test.start }.to hop("wait_for_kubernetes_bootstrap")
+      expect(kubernetes_test.strand.stack[0]["kubernetes_cluster_id"]).to eq KubernetesCluster.get(:id)
 
       expect(KubernetesCluster.count).to eq(1)
       expect(KubernetesNodepool.count).to eq(1)
@@ -98,9 +98,9 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "fails and hops to destroy_kubernetes with fail message" do
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_raise("cluster issue")
-      expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "Failed to run test kubectl command: cluster issue"})
 
       expect { kubernetes_test.test_nodes }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack[0]["fail_message"]).to eq "Failed to run test kubectl command: cluster issue"
     end
 
     it "fails if all nodes are not found and hops to destroy_kubernetes with fail message" do
@@ -110,9 +110,8 @@ RSpec.describe Prog::Test::Kubernetes do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("NAME                               STATUS   ROLES           AGE     VERSION\nkcz70f4yk68e0ne5n6s938pmb2-ut4i8   Ready    control-plane   7m47s   v1.34.0\n", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_return(response)
 
-      expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "node kngp6bg8qmx61gd46vk8cvdv6m-d2h94 not found in cluster"})
-
       expect { kubernetes_test.test_nodes }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack[0]["fail_message"]).to eq "node kngp6bg8qmx61gd46vk8cvdv6m-d2h94 not found in cluster"
     end
   end
 
@@ -155,15 +154,15 @@ RSpec.describe Prog::Test::Kubernetes do
     it "fails if the expected mount does not appear in lsblk output" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("no-data", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- lsblk").and_return(response)
-      expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "No /etc/data mount found in lsblk output"})
       expect { kubernetes_test.test_lsblk }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack[0]["fail_message"]).to eq "No /etc/data mount found in lsblk output"
     end
 
     it "fails if expected mount is not found for data volume" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINTS\nvda 252:0 0 40G 0 disk\n|-vda1 252:1 0 39.9G 0 part /etc/resolv.conf\n| /etc/hosts\n| /etc/data", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- lsblk").and_return(response)
-      expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "/etc/data is mounted incorrectly: | /etc/data"})
       expect { kubernetes_test.test_lsblk }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack[0]["fail_message"]).to eq "/etc/data is mounted incorrectly: | /etc/data"
     end
 
     it "hops to test_data_write if lsblk output is ok" do
@@ -207,8 +206,8 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "fails if a write has failed" do
       expect(sshable).to receive(:d_check).with("csi_data_write_1").and_return("Failed")
-      expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "daemonized write for random-data-1 failed"})
       expect { kubernetes_test.wait_data_write }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack[0]["fail_message"]).to eq "daemonized write for random-data-1 failed"
     end
 
     it "hops to verify_data_write when all writes have succeeded" do
@@ -234,8 +233,8 @@ RSpec.describe Prog::Test::Kubernetes do
         expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(read_response)
         expect(sshable).to receive(:d_clean).with("csi_data_write_#{i}")
       end
-      expect(kubernetes_test).to receive(:update_stack).with({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       expect { kubernetes_test.verify_data_write }.to hop("test_pod_data_migration")
+      expect(kubernetes_test.strand.stack[0]["read_hashes"]).to eq({"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"})
     end
 
     it "fails on the first file if write and read hashes don't match" do
@@ -271,7 +270,7 @@ RSpec.describe Prog::Test::Kubernetes do
 
   describe "#verify_data_after_migration" do
     before do
-      kubernetes_test.update_stack({"migration_number" => 0, "read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
+      refresh_frame(kubernetes_test, new_values: {"migration_number" => 0, "read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       expect(kubernetes_test).to receive(:kubernetes_cluster).and_return(kubernetes_cluster).at_least(:once)
     end
 
@@ -289,12 +288,11 @@ RSpec.describe Prog::Test::Kubernetes do
         response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
         expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
       end
-      expect(kubernetes_test).to receive(:increment_migration_number)
       expect { kubernetes_test.verify_data_after_migration }.to hop("test_pod_data_migration")
     end
 
     it "checks all data hashes and is done with migrations, hops to test_normal_pod_restart" do
-      kubernetes_test.update_stack({"migration_number" => Prog::Test::Kubernetes::MIGRATION_TRIES})
+      refresh_frame(kubernetes_test, new_values: {"migration_number" => Prog::Test::Kubernetes::MIGRATION_TRIES})
       expect(kubernetes_test).to receive(:pod_status).and_return("Running")
       (1..3).each do |i|
         response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
@@ -312,10 +310,10 @@ RSpec.describe Prog::Test::Kubernetes do
     it "saves the current node and deletes the pod and hops to verify_normal_pod_restart" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("nodename", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
-      expect(kubernetes_test).to receive(:update_stack).with({"normal_pod_restart_test_node" => "nodename"})
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete pod ubuntu-statefulset-0 --wait=false").and_return(response)
       expect { kubernetes_test.test_normal_pod_restart }.to hop("verify_normal_pod_restart")
+      expect(kubernetes_test.strand.stack[0]["normal_pod_restart_test_node"]).to eq "nodename"
     end
   end
 
@@ -337,7 +335,7 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("nodename", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
-      expect(kubernetes_test.strand).to receive(:stack).and_return([{"normal_pod_restart_test_node" => "nodename"}])
+      refresh_frame(kubernetes_test, new_values: {"normal_pod_restart_test_node" => "nodename"})
       expect(kubernetes_test).to receive(:verify_mount)
       expect { kubernetes_test.verify_normal_pod_restart }.to hop("test_rsync_retry")
     end
@@ -347,9 +345,9 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("othernode", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
-      expect(kubernetes_test.strand).to receive(:stack).and_return([{"normal_pod_restart_test_node" => "nodename"}])
-      expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "unexpected pod node change after restart, expected: nodename, got: othernode"})
+      refresh_frame(kubernetes_test, new_values: {"normal_pod_restart_test_node" => "nodename"})
       expect { kubernetes_test.verify_normal_pod_restart }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack[0]["fail_message"]).to eq "unexpected pod node change after restart, expected: nodename, got: othernode"
     end
 
     it "fails when verifying the mount" do
@@ -357,10 +355,10 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("nodename", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.spec.nodeName}").and_return(response)
-      expect(kubernetes_test.strand).to receive(:stack).and_return([{"normal_pod_restart_test_node" => "nodename"}])
+      refresh_frame(kubernetes_test, new_values: {"normal_pod_restart_test_node" => "nodename"})
       expect(kubernetes_test).to receive(:verify_mount).and_raise("some error")
-      expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "some error"})
       expect { kubernetes_test.verify_normal_pod_restart }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack[0]["fail_message"]).to eq "some error"
     end
   end
 
@@ -397,7 +395,6 @@ RSpec.describe Prog::Test::Kubernetes do
 
     before do
       KubernetesNode.create(vm_id: create_vm(name: "w1-node").id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id)
-      kubernetes_test.update_stack({"rsync_retry_source_node" => "w1-node"})
       expect(kubernetes_test).to receive(:kubernetes_cluster).and_return(kubernetes_cluster).at_least(:once)
     end
 
@@ -439,7 +436,7 @@ RSpec.describe Prog::Test::Kubernetes do
     end
 
     it "verifies data hashes and hops to test_node_not_deleted_during_copy" do
-      kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
+      refresh_frame(kubernetes_test, new_values: {"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       expect(kubernetes_test).to receive(:pod_status).and_return("Running")
       (1..3).each do |i|
         response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
@@ -484,7 +481,7 @@ RSpec.describe Prog::Test::Kubernetes do
 
     before do
       KubernetesNode.create(vm_id: create_vm(name: "w1-node").id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id)
-      kubernetes_test.update_stack({"chained_migration_source_node" => "w1-node"})
+      refresh_frame(kubernetes_test, new_values: {"chained_migration_source_node" => "w1-node"})
       expect(kubernetes_test).to receive(:kubernetes_cluster).and_return(kubernetes_cluster).at_least(:once)
     end
 
@@ -528,7 +525,7 @@ RSpec.describe Prog::Test::Kubernetes do
     end
 
     it "verifies data hashes and hops to test_node_not_deleted_during_copy" do
-      kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
+      refresh_frame(kubernetes_test, new_values: {"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       expect(kubernetes_test).to receive(:pod_status).and_return("Running")
       (1..3).each do |i|
         response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
@@ -570,13 +567,13 @@ RSpec.describe Prog::Test::Kubernetes do
     end
 
     it "hops to verify_data_after_drain when node record is destroyed" do
-      kubernetes_test.update_stack({"drain_test_node_name" => "gone-node"})
+      refresh_frame(kubernetes_test, new_values: {"drain_test_node_name" => "gone-node"})
       expect { kubernetes_test.verify_node_not_deleted_during_copy }.to hop("verify_data_after_drain")
     end
 
     it "naps when copy is pending and node still exists" do
       KubernetesNode.create(vm_id: create_vm(name: "w1-node").id, kubernetes_cluster_id: kubernetes_cluster.id)
-      kubernetes_test.update_stack({"drain_test_node_name" => "w1-node"})
+      refresh_frame(kubernetes_test, new_values: {"drain_test_node_name" => "w1-node"})
 
       pv_list = {"items" => [{
         "metadata" => {"annotations" => {"csi.ubicloud.com/old-pvc-object" => "data"}},
@@ -596,7 +593,7 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "fails when copy is pending but node is already removed" do
       KubernetesNode.create(vm_id: create_vm(name: "w1-node").id, kubernetes_cluster_id: kubernetes_cluster.id)
-      kubernetes_test.update_stack({"drain_test_node_name" => "w1-node"})
+      refresh_frame(kubernetes_test, new_values: {"drain_test_node_name" => "w1-node"})
 
       pv_list = {"items" => [{
         "metadata" => {"annotations" => {"csi.ubicloud.com/old-pvc-object" => "data"}},
@@ -616,7 +613,7 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "naps when no copy is pending but node still exists" do
       KubernetesNode.create(vm_id: create_vm(name: "w1-node").id, kubernetes_cluster_id: kubernetes_cluster.id)
-      kubernetes_test.update_stack({"drain_test_node_name" => "w1-node"})
+      refresh_frame(kubernetes_test, new_values: {"drain_test_node_name" => "w1-node"})
 
       pv_list = {"items" => []}
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(pv_list), 0)
@@ -640,7 +637,7 @@ RSpec.describe Prog::Test::Kubernetes do
     end
 
     it "verifies all data hashes and hops to test_reboot_nftables" do
-      kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
+      refresh_frame(kubernetes_test, new_values: {"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
       (1..3).each do |i|
@@ -692,7 +689,7 @@ RSpec.describe Prog::Test::Kubernetes do
     end
 
     it "naps if vm is not ready yet" do
-      kubernetes_test.update_stack({
+      refresh_frame(kubernetes_test, new_values: {
         "reboot_node_id" => node.id,
         "nat_rules_before_reboot" => "table ip nat { ... }",
         "pod_access_rules_before_reboot" => "table ip6 pod_access { ... }",
@@ -703,7 +700,7 @@ RSpec.describe Prog::Test::Kubernetes do
     end
 
     it "hops to test_upgrade when rules match" do
-      kubernetes_test.update_stack({
+      refresh_frame(kubernetes_test, new_values: {
         "reboot_node_id" => node.id,
         "nat_rules_before_reboot" => "table ip nat { ... }",
         "pod_access_rules_before_reboot" => "table ip6 pod_access { ... }",
@@ -716,7 +713,7 @@ RSpec.describe Prog::Test::Kubernetes do
     end
 
     it "sets fail_message when ip nat rules changed" do
-      kubernetes_test.update_stack({
+      refresh_frame(kubernetes_test, new_values: {
         "reboot_node_id" => node.id,
         "nat_rules_before_reboot" => "table ip nat { ... }",
         "pod_access_rules_before_reboot" => "table ip6 pod_access { ... }",
@@ -730,7 +727,7 @@ RSpec.describe Prog::Test::Kubernetes do
     end
 
     it "sets fail_message when ip6 pod_access rules changed" do
-      kubernetes_test.update_stack({
+      refresh_frame(kubernetes_test, new_values: {
         "reboot_node_id" => node.id,
         "nat_rules_before_reboot" => "table ip nat { ... }",
         "pod_access_rules_before_reboot" => "table ip6 pod_access { ... }",
@@ -856,7 +853,7 @@ RSpec.describe Prog::Test::Kubernetes do
     end
 
     it "verifies all data hashes and hops to destroy_kubernetes" do
-      kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
+      refresh_frame(kubernetes_test, new_values: {"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
       (1..3).each do |i|
@@ -867,7 +864,7 @@ RSpec.describe Prog::Test::Kubernetes do
     end
 
     it "sets fail_message and hops to destroy_kubernetes if a hash is wrong" do
-      kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
+      refresh_frame(kubernetes_test, new_values: {"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("corrupted_hash", 0)
@@ -955,21 +952,13 @@ RSpec.describe Prog::Test::Kubernetes do
     end
   end
 
-  describe "#increment_migration_number" do
-    it "increments the migration number" do
-      kubernetes_test.update_stack({"migration_number" => 0})
-      kubernetes_test.increment_migration_number
-      expect(kubernetes_test.migration_number).to eq(1)
-    end
-  end
-
   describe "#verify_data_hashes" do
     before do
       expect(kubernetes_test).to receive(:kubernetes_cluster).and_return(kubernetes_cluster).at_least(:once)
     end
 
     it "verifies all hashes match" do
-      kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
+      refresh_frame(kubernetes_test, new_values: {"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       (1..3).each do |i|
         response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
         expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
@@ -978,11 +967,11 @@ RSpec.describe Prog::Test::Kubernetes do
     end
 
     it "sets fail_message when a hash does not match" do
-      kubernetes_test.update_stack({"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
+      refresh_frame(kubernetes_test, new_values: {"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("wronghash", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-1\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
-      expect(kubernetes_test).to receive(:update_stack).with({"fail_message" => "data hash changed after migration for random-data-1, expected: hash1, got: wronghash"})
       expect { kubernetes_test.verify_data_hashes("migration") }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack[0]["fail_message"]).to eq "data hash changed after migration for random-data-1, expected: hash1, got: wronghash"
     end
   end
 end

--- a/spec/prog/test/minio_cluster_spec.rb
+++ b/spec/prog/test/minio_cluster_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Prog::Test::MinioCluster do
   describe "#start" do
     it "creates a minio cluster and hops to wait" do
       expect { minio_test.start }.to hop("wait")
-      minio_cluster_id = frame_value(minio_test, "minio_cluster_id")
+      minio_cluster_id = minio_test.strand.stack[0]["minio_cluster_id"]
       expect(minio_cluster_id).not_to be_nil
       expect(MinioCluster[minio_cluster_id]).not_to be_nil
     end

--- a/spec/prog/test/postgres_firewall_spec.rb
+++ b/spec/prog/test/postgres_firewall_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Prog::Test::PostgresFirewall do
 
       expect(Net::HTTP).to receive(:get).with(URI("https://api.ipify.org")).and_return("100.100.100.100")
       expect { pg_fw_test.test_restricted_firewall_rules }.to hop("wait_restricted_rules_applied")
-      expect(frame_value(pg_fw_test, "runner_ip")).to eq("100.100.100.100")
+      expect(pg_fw_test.strand.stack[0]["runner_ip"]).to eq("100.100.100.100")
     end
   end
 
@@ -282,7 +282,7 @@ RSpec.describe Prog::Test::PostgresFirewall do
 
       expect(sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432")
       expect { pg_fw_test.wait_restricted_rules_applied }.to hop("test_block_all_rules")
-      expect(frame_value(pg_fw_test, "fail_message")).to be_nil
+      expect(pg_fw_test.strand.stack[0]["fail_message"]).to be_nil
     end
 
     it "sets fail_message when firewall CIDRs do not match expected" do
@@ -294,7 +294,7 @@ RSpec.describe Prog::Test::PostgresFirewall do
 
       expect(sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432")
       expect { pg_fw_test.wait_restricted_rules_applied }.to hop("test_block_all_rules")
-      expect(frame_value(pg_fw_test, "fail_message")).to include("Expected firewall CIDRs")
+      expect(pg_fw_test.strand.stack[0]["fail_message"]).to include("Expected firewall CIDRs")
     end
   end
 
@@ -329,21 +329,21 @@ RSpec.describe Prog::Test::PostgresFirewall do
       expect(sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432")
         .and_raise(Sshable::SshError.new("nc -zvw 5 1.2.3.4 5432", "", "Connection refused", 1, nil))
       expect { pg_fw_test.wait_block_all_applied }.to hop("test_restore_open_rules")
-      expect(frame_value(pg_fw_test, "fail_message")).to be_nil
+      expect(pg_fw_test.strand.stack[0]["fail_message"]).to be_nil
     end
 
     it "naps when nc unexpectedly succeeds and the block-retry budget remains" do
       expect(sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432")
       expect { pg_fw_test.wait_block_all_applied }.to nap(15)
-      expect(frame_value(pg_fw_test, "pg_retries")&.dig("block")).to eq(1)
+      expect(pg_fw_test.strand.stack[0]["pg_retries"]["block"]).to eq(1)
     end
 
     it "sets fail_message when nc unexpectedly succeeds and the block-retry budget is exhausted" do
       expect(sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432")
       refresh_frame(pg_fw_test, new_values: {"pg_retries" => {"block" => 9}})
       expect { pg_fw_test.wait_block_all_applied }.to hop("test_restore_open_rules")
-      expect(frame_value(pg_fw_test, "fail_message")).to include("should have been blocked after 10 attempts")
-      expect(frame_value(pg_fw_test, "pg_retries")).to be_nil
+      expect(pg_fw_test.strand.stack[0]["fail_message"]).to include("should have been blocked after 10 attempts")
+      expect(pg_fw_test.strand.stack[0]["pg_retries"]).to be_nil
     end
   end
 
@@ -524,7 +524,7 @@ RSpec.describe Prog::Test::PostgresFirewall do
       vm = pg_fw_test.representative_server.vm
       expect(vm.sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432")
       expect { pg_fw_test.send(:test_pg_connection, vm, should_succeed: false) }.to nap(15)
-      expect(frame_value(pg_fw_test, "pg_retries")&.dig("block")).to eq(1)
+      expect(pg_fw_test.strand.stack[0]["pg_retries"]["block"]).to eq(1)
     end
 
     it "sets fail_message after exhausting block retries" do
@@ -532,8 +532,8 @@ RSpec.describe Prog::Test::PostgresFirewall do
       expect(vm.sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432")
       refresh_frame(pg_fw_test, new_values: {"pg_retries" => {"block" => 9}})
       pg_fw_test.send(:test_pg_connection, vm, should_succeed: false)
-      expect(frame_value(pg_fw_test, "fail_message")).to include("should have been blocked after 10 attempts")
-      expect(frame_value(pg_fw_test, "pg_retries")).to be_nil
+      expect(pg_fw_test.strand.stack[0]["fail_message"]).to include("should have been blocked after 10 attempts")
+      expect(pg_fw_test.strand.stack[0]["pg_retries"]).to be_nil
     end
 
     it "clears the connect retry counter when nc succeeds and should_succeed is false" do
@@ -541,14 +541,14 @@ RSpec.describe Prog::Test::PostgresFirewall do
       refresh_frame(pg_fw_test, new_values: {"pg_retries" => {"connect" => 4}})
       expect(vm.sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432")
       expect { pg_fw_test.send(:test_pg_connection, vm, should_succeed: false) }.to nap(15)
-      expect(frame_value(pg_fw_test, "pg_retries")&.dig("connect")).to be_nil
+      expect(pg_fw_test.strand.stack[0]["pg_retries"].fetch("connect")).to be_nil
     end
 
     it "does nothing when connection fails and should_succeed is false" do
       vm = pg_fw_test.representative_server.vm
       expect(vm.sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432").and_raise(Sshable::SshError.new("nc -zvw 5 1.2.3.4 5432", "", "Connection refused", 1, nil))
       pg_fw_test.send(:test_pg_connection, vm, should_succeed: false)
-      expect(frame_value(pg_fw_test, "fail_message")).to be_nil
+      expect(pg_fw_test.strand.stack[0]["fail_message"]).to be_nil
     end
 
     it "clears the block retry counter when nc is finally blocked as expected" do
@@ -556,14 +556,14 @@ RSpec.describe Prog::Test::PostgresFirewall do
       refresh_frame(pg_fw_test, new_values: {"pg_retries" => {"block" => 3}})
       expect(vm.sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432").and_raise(Sshable::SshError.new("nc -zvw 5 1.2.3.4 5432", "", "Connection refused", 1, nil))
       pg_fw_test.send(:test_pg_connection, vm, should_succeed: false)
-      expect(frame_value(pg_fw_test, "pg_retries")&.dig("block")).to be_nil
+      expect(pg_fw_test.strand.stack[0]["pg_retries"].fetch("block")).to be_nil
     end
 
     it "naps when connection fails and should_succeed is true" do
       vm = pg_fw_test.representative_server.vm
       expect(vm.sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432").and_raise(Sshable::SshError.new("nc -zvw 5 1.2.3.4 5432", "", "Connection refused", 1, nil))
       expect { pg_fw_test.send(:test_pg_connection, vm, should_succeed: true) }.to nap(15)
-      expect(frame_value(pg_fw_test, "pg_retries")&.dig("connect")).to eq(1)
+      expect(pg_fw_test.strand.stack[0]["pg_retries"]["connect"]).to eq(1)
     end
 
     it "sets fail_message after exhausting retries" do
@@ -571,8 +571,8 @@ RSpec.describe Prog::Test::PostgresFirewall do
       expect(vm.sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432").and_raise(Sshable::SshError.new("nc -zvw 5 1.2.3.4 5432", "", "Connection refused", 1, nil))
       refresh_frame(pg_fw_test, new_values: {"pg_retries" => {"connect" => 9}})
       pg_fw_test.send(:test_pg_connection, vm, should_succeed: true)
-      expect(frame_value(pg_fw_test, "fail_message")).to include("should have succeeded")
-      expect(frame_value(pg_fw_test, "pg_retries")).to be_nil
+      expect(pg_fw_test.strand.stack[0]["fail_message"]).to include("should have succeeded")
+      expect(pg_fw_test.strand.stack[0]["pg_retries"]).to be_nil
     end
 
     it "clears the connect retry counter on successful connect" do
@@ -580,13 +580,13 @@ RSpec.describe Prog::Test::PostgresFirewall do
       refresh_frame(pg_fw_test, new_values: {"pg_retries" => {"connect" => 4}})
       expect(vm.sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432")
       pg_fw_test.send(:test_pg_connection, vm, should_succeed: true)
-      expect(frame_value(pg_fw_test, "pg_retries")&.dig("connect")).to be_nil
+      expect(pg_fw_test.strand.stack[0]["pg_retries"]&.dig("connect")).to be_nil
     end
 
     it "does not touch the stack when connect succeeds without prior retries and should_succeed is true" do
       vm = pg_fw_test.representative_server.vm
       expect(vm.sshable).to receive(:_cmd).with("nc -zvw 5 1.2.3.4 5432")
-      expect(pg_fw_test).not_to receive(:update_stack)
+      pg_fw_test.strand.stack.freeze
       pg_fw_test.send(:test_pg_connection, vm, should_succeed: true)
     end
   end

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe Prog::Test::PostgresResource do
     it "increments the destroy count and hops to wait_resources_destroyed" do
       expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
       expect(Semaphore.where(strand_id: postgres_resource.id, name: "destroy").count).to eq(1)
-      expect(frame_value(pgr_test, "timeline_ids")).not_to be_empty
+      expect(pgr_test.strand.stack[0]["timeline_ids"]).not_to be_empty
     end
   end
 

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
   describe "#start" do
     it "creates a postgres resource with version 17 and async HA and hops to wait_postgres_resource" do
       expect { pgr_test.start }.to hop("wait_postgres_resource")
-      postgres_resource_id = frame_value(pgr_test, "postgres_resource_id")
+      postgres_resource_id = pgr_test.strand.stack[0]["postgres_resource_id"]
       expect(postgres_resource_id).not_to be_nil
       pg = PostgresResource[postgres_resource_id]
       expect(pg).not_to be_nil
       expect(pg.version).to eq("17")
       expect(pg.ha_type).to eq("async")
-      expect(frame_value(pgr_test, "location_id")).to eq(Location::HETZNER_FSN1_ID)
+      expect(pgr_test.strand.stack[0]["location_id"]).to eq(Location::HETZNER_FSN1_ID)
     end
 
     it "creates a postgres resource on aws and hops to wait_postgres_resource" do
@@ -136,7 +136,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     it "creates a PG16 resource without sync_replication_slots when start_version is 16" do
       pg16_test = described_class.new(described_class.assemble(start_version: "16"))
       expect { pg16_test.start }.to hop("wait_postgres_resource")
-      pg = PostgresResource[frame_value(pg16_test, "postgres_resource_id")]
+      pg = PostgresResource[pg16_test.strand.stack[0]["postgres_resource_id"]]
       expect(pg.version).to eq("16")
       expect(pg.user_config).not_to include("sync_replication_slots")
     end
@@ -227,7 +227,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
 
     it "creates a read replica and hops to wait_read_replica" do
       expect { pgr_test.create_read_replica }.to hop("wait_read_replica")
-      read_replica_id = frame_value(pgr_test, "read_replica_id")
+      read_replica_id = pgr_test.strand.stack[0]["read_replica_id"]
       expect(read_replica_id).not_to be_nil
       replica = PostgresResource[read_replica_id]
       expect(replica).not_to be_nil
@@ -531,14 +531,14 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
       expect(@pg_strand.subject.destroy_set?).to be true
       expect(@replica_strand.subject.destroy_set?).to be true
-      expect(frame_value(pgr_test, "timeline_ids")).not_to be_empty
+      expect(pgr_test.strand.stack[0]["timeline_ids"]).not_to be_empty
     end
 
     it "handles nil read_replica gracefully" do
       refresh_frame(pgr_test, new_values: {"read_replica_id" => nil})
       expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
       expect(@pg_strand.subject.destroy_set?).to be true
-      expect(frame_value(pgr_test, "timeline_ids")).not_to be_empty
+      expect(pgr_test.strand.stack[0]["timeline_ids"]).not_to be_empty
     end
   end
 

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -89,12 +89,12 @@ RSpec.describe Prog::Test::VmGroup do
       vm1 = create_vm(vm_host_id: vm_host.id, cores: 2, name: "test-vm-1")
       create_vm(vm_host_id: vm_host.id, cores: 0, name: "test-vm-2")
       create_vm_host_slice(vm_host_id: vm_host.id)
-      refresh_frame(vg_test, new_values: {"vms" => [vm1.id], "verify_host_capacity" => true})
+      refresh_frame(vg_test, new_values: {"vms" => [vm1.id], "verify_host_capacity?" => true})
       expect { vg_test.verify_host_capacity }.to hop("verify_vm_host_slices")
     end
 
     it "skips if verify_host_capacity is not set" do
-      refresh_frame(vg_test, new_values: {"verify_host_capacity" => false})
+      refresh_frame(vg_test, new_values: {"verify_host_capacity?" => false})
       expect(vg_test).not_to receive(:vm_host)
       expect { vg_test.verify_host_capacity }.to hop("verify_vm_host_slices")
     end
@@ -104,7 +104,7 @@ RSpec.describe Prog::Test::VmGroup do
       vm1 = create_vm(vm_host_id: vm_host.id, cores: 2, name: "test-vm-1")
       create_vm(vm_host_id: vm_host.id, cores: 0, name: "test-vm-2")
       create_vm_host_slice(vm_host_id: vm_host.id)
-      refresh_frame(vg_test, new_values: {"vms" => [vm1.id], "verify_host_capacity" => true})
+      refresh_frame(vg_test, new_values: {"vms" => [vm1.id], "verify_host_capacity?" => true})
 
       expect { vg_test.verify_host_capacity }.to hop("failed")
       expect(st.reload.exitval).to eq({"msg" => "Host used cores does not match the allocated VMs cores (vm_cores=2, slice_cores=1, used_cores=5)"})
@@ -164,7 +164,7 @@ RSpec.describe Prog::Test::VmGroup do
 
     it "hops to destroy_resources if tests are done and reboot is not set" do
       st.retval = {"msg" => "Verified Connected Subnets!"}
-      refresh_frame(vg_test, new_values: {"test_reboot" => false})
+      refresh_frame(vg_test, new_values: {"test_reboot?" => false})
       expect { vg_test.verify_connected_subnets }.to hop("destroy_resources")
     end
   end

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -22,14 +22,12 @@ RSpec.describe Prog::Test::VmGroup do
 
   describe "#setup_vms" do
     it "hops to wait_vms" do
-      expect(vg_test).to receive(:update_stack).and_call_original
       expect { vg_test.setup_vms }.to hop("wait_vms")
       vm_images = vg_test.strand.stack.first["vms"].map { Vm[it].boot_image }
       expect(vm_images).to eq(["ubuntu-noble", "debian-12", "ubuntu-noble"])
     end
 
     it "provisions at least one vm for each boot image" do
-      expect(vg_test).to receive(:update_stack).and_call_original
       refresh_frame(vg_test, new_values: {
         "boot_images" => ["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"],
       })

--- a/spec/prog/test/vm_host_slices_spec.rb
+++ b/spec/prog/test/vm_host_slices_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Prog::Test::VmHostSlices do
 
   describe "slices access method" do
     it "returns slices" do
-      expect(vm_host_slices).to receive(:frame).and_return({"slices" => [slice1.id, slice2.id, slice3.id]})
+      expect(vm_host_slices).to receive(:frame).and_return({"slice_ids" => [slice1.id, slice2.id, slice3.id]})
 
       [slice1, slice2, slice3].each do |slice|
         expect(VmHostSlice).to receive(:[]).with(slice.id).and_return(slice)

--- a/spec/prog/vnet/gcp/nic_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/nic_nexus_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Prog::Vnet::Gcp::NicNexus do
         .and_return(delete_op)
 
       expect { nx.destroy }.to hop("wait_release_ip")
-      expect(st.reload.stack.first.dig("release_ip", "name")).to eq("op-delete-addr")
+      expect(st.stack.first.dig("release_ip", "name")).to eq("op-delete-addr")
     end
 
     it "handles already-deleted static IP" do

--- a/spec/prog/vnet/gcp/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_spec.rb
@@ -525,7 +525,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
       ).and_return(delete_op)
 
       expect { nx.destroy }.to hop("wait_delete_subnet")
-      expect(st.reload.stack.first.dig("delete_subnet", "name")).to eq("op-delete-subnet")
+      expect(st.stack.first.dig("delete_subnet", "name")).to eq("op-delete-subnet")
     end
 
     it "cleans up tag value and tag key (per-subnet)" do

--- a/spec/prog/vnet/gcp/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_nexus_spec.rb
@@ -496,7 +496,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
         Google::Cloud::Compute::V1::FirewallPolicy.new(name: vpc_name, associations: []),
       )
       expect { nx.wait_firewall_policy_associated }.to hop("create_firewall_policy")
-      expect(st.reload.stack.first["associate_fw_policy"]).to be_nil
+      expect(st.stack.first["associate_fw_policy"]).to be_nil
     end
 
     it "hops back to create_firewall_policy when LRO errors and re-fetched policy has nil associations" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -396,7 +396,6 @@ RSpec.configure do |config|
     end
 
     def frame_value(prog, key)
-      prog.strand.reload
       prog.strand.stack.first[key]
     end
   end)


### PR DESCRIPTION
This extends the work started in #5560 for the remaining progs. It then removes `Prog::Base#update_stack`. When doing that, I found I missed `update_stack` removal in `GcpLro` (since it isn't inside `prog/`, but is included in multiple progs), so that is fixed here.

This also removes the persistence from `Prog::Base#delete_from_stack`, so it operates similarly to the `frame_accessor` setter method, and then removes reloading from `frame_value`.

In terms of reviews:

* Burak: Postgres test progs
* Mohi: Kubernetes test prog
* Furkan: Network and GCP test progs
* Enes: Other test progs