### PR TITLE
Increase GCP VPC destroy deadline to 10 mins

### DIFF
--- a/prog/vnet/gcp/vpc_nexus.rb
+++ b/prog/vnet/gcp/vpc_nexus.rb
@@ -208,7 +208,7 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
   end
 
   label def destroy
-    register_deadline("destroy", 5 * 60)
+    register_deadline("destroy", 10 * 60)
     decr_destroy
 
     unless gcp_vpc.private_subnets.empty?

--- a/spec/prog/vnet/gcp/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_nexus_spec.rb
@@ -656,7 +656,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
   describe "#destroy" do
     it "registers deadline and hops to enumerate_destroy_state when no subnets remain" do
       expect { nx.destroy }.to hop("enumerate_destroy_state")
-      expect(Time.parse(nx.strand.stack.first["deadline_at"])).to be_within(5).of(Time.now + 5 * 60)
+      expect(Time.parse(nx.strand.stack.first["deadline_at"])).to be_within(10).of(Time.now + 10 * 60)
       expect(nx.strand.stack.first["deadline_target"]).to eq("destroy")
     end
 


### PR DESCRIPTION
GCP VPC entities are quite heavy resources to destroy. In staging
environment we have seen a few times that the destroy operation took
longer than 5 minutes. So, we're increasing the deadline here.