### PR TITLE
Split GCP gems into their own Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,14 +13,19 @@ updates:
       aws-dependencies:
         patterns:
           - "*aws*"
+      gcp-dependencies:
+        patterns:
+          - "google*"
       production-dependencies:
         dependency-type: "production"
         exclude-patterns:
           - "*aws*"
+          - "google*"
       development-dependencies:
         dependency-type: "development"
         exclude-patterns:
           - "*aws*"
+          - "google*"
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:


### PR DESCRIPTION
GCP SDK gems release new versions frequently.

Move any gem whose name starts with "google" into a dedicated gcp-dependencies group similar to what we have for aws gems.

<img width="1354" height="380" alt="CleanShot 2026-06-08 at 20 01 24@2x" src="https://github.com/user-attachments/assets/5547e090-0095-4179-9120-6145caff73f7" />