### PR TITLE
Make Location.postgres_locations use a deterministic order

### DIFF
--- a/model/location.rb
+++ b/model/location.rb
@@ -38,6 +38,7 @@ class Location < Sequel::Model
     where(project_id: nil, name: ["hetzner-fsn1", "leaseweb-wdc02"])
       .or(provider: "aws", project_id: nil)
       .or(provider: "gcp", project_id: nil, name: visible_gcp_names || [])
+      .order(:display_name)
       .all
   end
 

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Clover, "postgres" do
           ha_type: "sync",
         }.to_json
 
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: location", {"location" => "Invalid location. Available options: eu-central-h1, us-east-a2, us-east-1, us-west-2"})
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: location", {"location" => "Invalid location. Available options: eu-central-h1, us-east-1, us-east-a2, us-west-2"})
       end
 
       it "location not exist" do


### PR DESCRIPTION
Fixes the following nondeterministic CI error:

```
  1) Clover postgres authenticated create invalid location
     Failure/Error: expect(last_response).to have_api_error(400, "Validation failed for following fields: location", {"location" => "Invalid location. Available options: eu-central-h1, us-east-a2, us-east-1, us-west-2"})

             expected: 400 - Validation failed for following fields: location - {"location" => "Invalid location. Available options: eu-central-h1, us-east-a2, us-east-1, us-west-2"}
                  got: 400 - Validation failed for following fields: location - {"location" => "Invalid location. Available options: eu-central-h1, us-west-2, us-east-a2, us-east-1"}
     # ./spec/routes/api/project/location/postgres_spec.rb:196:in 'block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:66:in 'block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.103.0/lib/sequel/database/transactions.rb:257:in 'Sequel::Database#_transaction'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.103.0/lib/sequel/database/transactions.rb:239:in 'block in Sequel::Database#transaction'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.103.0/lib/sequel/connection_pool/timed_queue.rb:92:in 'Sequel::TimedQueueConnectionPool#hold'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.103.0/lib/sequel/database/connecting.rb:283:in 'Sequel::Database#synchronize'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.103.0/lib/sequel/database/transactions.rb:197:in 'Sequel::Database#transaction'
     # ./spec/spec_helper.rb:65:in 'block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/4.0.0/gems/webmock-3.26.2/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
```