### PR TITLE
Add PolymorphicForeignKeyChecker

### DIFF
--- a/lib/polymorphic_foreign_key_checker.rb
+++ b/lib/polymorphic_foreign_key_checker.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module PolymorphicForeignKeyChecker
+  DEFAULT_CHECKS = [
+    [:access_control_entry, :subject_id, :action_id, :object_id],
+    [:api_key, :owner_id],
+    [:applied_action_tag, :action_id],
+    [:applied_object_tag, :object_id],
+    [:applied_subject_tag, :subject_id],
+    [:github_runner, :vm_id],
+    [:page_root_resource, :root_resource_id],
+    [:postgres_resource, :project_id, :parent_id],
+    [:postgres_server, :resource_id, :physical_slot_ready_id],
+    [:postgres_timeline, :parent_id],
+    [:project_quota, :quota_id],
+    [:resource_discount, :resource_id],
+  ].freeze.each(&:freeze)
+
+  def self.check_all
+    DEFAULT_CHECKS.flat_map { check(*it) }
+  end
+
+  def self.check(table, *columns)
+    ds = DB[table].distinct.skip_locked
+    columns.filter_map do |column|
+      uuid_hash = ds.exclude(column => nil).select_hash(column, Sequel[nil].as(:v))
+      UBID.resolve_map(uuid_hash)
+      uuid_hash.delete_if { |_, v| v }
+      unless uuid_hash.empty?
+        [table, column, uuid_hash.keys.map { UBID.to_ubid(it) }]
+      end
+    end
+  end
+end

--- a/spec/lib/polymorphic_foreign_key_checker_spec.rb
+++ b/spec/lib/polymorphic_foreign_key_checker_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe PolymorphicForeignKeyChecker do
+  it "checks polymorphic foreign keys and reports invalid references" do
+    expect(described_class.check_all).to be_empty
+    account = Account.create(email: "test@example.com")
+    project_id = account.create_project_with_default_policy("Default").id
+    expect(described_class.check_all).to be_empty
+    account.remove_project(project_id)
+    account.this.delete(force: true)
+    expect(described_class.check_all).to eq [[:applied_subject_tag, :subject_id, [account.ubid]]]
+  end
+end


### PR DESCRIPTION
This class will check that polymorphic foreign keys are still valid. While it's possible to implement referential integrity checks for polymorphic foreign keys with database triggers, this is a simpler approach that doesn't prevent issues, but can still make us aware of them.

Potential polymorphic foreign keys to consider were taken from the results of this code:

```
DB.tables.sort.each do |t|
  next if /_\d{4}_\d{2}\z/.match(t)
  fks = Set.new
  DB.foreign_key_list(t).each do |fk|
    fks.add(fk[:columns])
  end
  sch = DB.schema(t)
  composite_pk = sch.count { |_, opts| opts[:primary_key] } > 1
  cols = sch.filter_map { |c, opts| c if (composite_pk || !opts[:primary_key]) && opts[:db_type] == "uuid" && !fks.include?([c]) }
  p [t, cols] unless cols.empty?
end
```

This resulted in

```ruby
[:access_control_entry, [:subject_id, :action_id, :object_id]]
[:account_authentication_audit_log, [:id, :account_id]]
[:admin_account_authentication_audit_log, [:id, :account_id]]
[:api_key, [:owner_id]]
[:applied_action_tag, [:action_id]]
[:applied_object_tag, [:object_id]]
[:applied_subject_tag, [:subject_id]]
[:audit_log, [:id, :project_id, :subject_id]]
[:billing_record, [:project_id, :resource_id, :billing_rate_id]]
[:github_cache_entry, [:created_by, :last_accessed_by]]
[:github_runner, [:vm_id]]
[:invoice, [:project_id]]
[:page_root_resource, [:root_resource_id]]
[:postgres_resource, [:project_id, :parent_id]]
[:postgres_server, [:resource_id, :physical_slot_ready_id]]
[:postgres_timeline, [:parent_id]]
[:project_quota, [:quota_id]]
[:resource_discount, [:resource_id]]
```

Some of these tables should not be checked:

* account_authentication_audit_log: Expected to reference deleted accounts
* admin_account_authentication_audit_log: same
* audit_log: same
* billing_record: Expected to reference deleted projects, resources, and billing rates
* github_cache_entry: Expected to reference deleted runners
* invoice: Expected to reference deleted projects

This checks the remaining tables.

Currently, this is designed to be run manually in pry. We could potentially run it from a prog later. It uses SKIP LOCKED, so it shouldn't block, though it probably requires a sequential scan per column checked.