### PR TITLE
Allow `Object#valid_ip_address?` added by acme-client gem

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,7 @@ require "webmock/rspec"
 RSpec::Matchers.define_negated_matcher :not_change, :change
 
 def Object.method_added(method)
-  if self == Object && method != :Nokogiri && method != :CSV
+  if self == Object && method != :Nokogiri && method != :CSV && method != :valid_ip_address?
     raise "unexpected Object##{method} defined\n#{caller(1, 3).join("\n")}"
   end
 end


### PR DESCRIPTION
This is to workaround the following exception when running specs that is caused by a bug in acme-client:

```
RuntimeError:
  unexpected Object#valid_ip_address? defined
  .../gems/acme-client-2.0.31/lib/acme/client/certificate_request.rb:126:in
'<top (required)>'
  .../ruby/4.0.5/lib/ruby/4.0.0/bundled_gems.rb:60:in
'Kernel.require'
  .../4.0.5/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in
Kernel#replace_require'
```