### PR TITLE
Update acme-client to 2.0.32 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
-    acme-client (2.0.31)
+    acme-client (2.0.32)
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.0.0)
       faraday-retry (>= 1.0, < 3.0.0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,7 @@ require "webmock/rspec"
 RSpec::Matchers.define_negated_matcher :not_change, :change
 
 def Object.method_added(method)
-  if self == Object && method != :Nokogiri && method != :CSV && method != :valid_ip_address?
+  if self == Object && method != :Nokogiri && method != :CSV
     raise "unexpected Object##{method} defined\n#{caller(1, 3).join("\n")}"
   end
 end


### PR DESCRIPTION
Avoids needs to allow the addition of Object#valid_ip_address?.