### PR TITLE
Add 100% line/branch coverage for rhizome

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -206,7 +206,7 @@ end
 
 desc "Run rhizome (data plane) tests"
 task "rhizome_spec" do
-  sh "COVERAGE=rhizome bundle exec rspec -O /dev/null rhizome"
+  sh "COVERAGE=rhizome RUBYOPT=-r./spec/coverage_helper.rb bundle exec rspec -O /dev/null rhizome"
 end
 
 desc "Run CSI tests"

--- a/rhizome/common/lib/arch_class.rb
+++ b/rhizome/common/lib/arch_class.rb
@@ -3,8 +3,12 @@
 require "rbconfig"
 
 ArchClass = Struct.new(:sym) {
+  def self.target_cpu
+    RbConfig::CONFIG.fetch("target_cpu")
+  end
+
   def self.from_system
-    new case RbConfig::CONFIG.fetch("target_cpu")
+    new case target_cpu
     when /arm64|aarch64/i
       :arm64
     when /amd64|x86_64|x64/i

--- a/rhizome/common/lib/network.rb
+++ b/rhizome/common/lib/network.rb
@@ -2,7 +2,7 @@
 
 # By reading the mac address from an interface, compute its ipv6
 # link local address that it would have if its device state were set
-# to up.
+# to up. From RFC 4291 Section 2.5.1 & Appendix A.
 def mac_to_ipv6_link_local(mac)
   eui = mac.split(":").map(&:hex)
   eui.insert(3, 0xff, 0xfe)

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -62,7 +62,7 @@ def sync_parent_dir(f)
 end
 
 def safe_write_to_file(filename, content = nil)
-  raise ArgumentError, "must provide either content or block" if (content.nil? && !block_given?) || (!content.nil? && block_given?)
+  raise ArgumentError, "must provide either content or block" if content.nil? ^ block_given?
 
   temp_filename = filename + ".tmp"
   lock_filename = "/tmp/#{OpenSSL::Digest::SHA256.hexdigest(temp_filename)}.lock"

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -37,6 +37,7 @@ def rm_if_exists(path)
   FileUtils.rm_r(path)
 rescue Errno::ENOENT
   # ignore if path doesn't exist, otherwise raise error
+  nil
 end
 
 def fsync_or_fail(f)

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+# :nocov:
 require "bundler/setup" if File.directory?(File.expand_path("../../host", __dir__))
+# :nocov:
 require "open3"
 require "shellwords"
 require "openssl"

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -80,7 +80,8 @@ def safe_write_to_file(filename, content = nil)
 end
 
 def curl_file(url, path)
-  r("bash -c 'curl -f -L3 #{url.shellescape} | tee >(openssl dgst -sha256) > #{path.shellescape}'").split(" ").last
+  cmd = "curl -f -L3 #{url.shellescape} | tee >(openssl dgst -sha256) > #{path.shellescape}"
+  r("bash -c #{cmd.shellescape}").split(" ").last
 end
 
 def validate_keys(context, required_keys, optional_keys, hash)

--- a/rhizome/common/spec/arch_class_spec.rb
+++ b/rhizome/common/spec/arch_class_spec.rb
@@ -9,4 +9,51 @@ RSpec.describe ArchClass do
       expect(described_class.new(:arm64).render(x64: "test-x64", arm64: "test-arm64")).to eq("test-arm64")
     end
   end
+
+  describe "#arm64?" do
+    it "returns true for arm64" do
+      expect(described_class.new(:arm64).arm64?).to be true
+    end
+
+    it "returns false for x64" do
+      expect(described_class.new(:x64).arm64?).to be false
+    end
+  end
+
+  describe "#x64?" do
+    it "returns true for x64" do
+      expect(described_class.new(:x64).x64?).to be true
+    end
+
+    it "returns false for arm64" do
+      expect(described_class.new(:arm64).x64?).to be false
+    end
+  end
+
+  describe ".from_system" do
+    it "detects x64 from amd64 target_cpu" do
+      allow(RbConfig::CONFIG).to receive(:fetch).with("target_cpu").and_return("x86_64")
+      expect(described_class.from_system.sym).to eq(:x64)
+    end
+
+    it "detects x64 from x64 target_cpu" do
+      allow(RbConfig::CONFIG).to receive(:fetch).with("target_cpu").and_return("x64")
+      expect(described_class.from_system.sym).to eq(:x64)
+    end
+
+    it "detects arm64 from aarch64 target_cpu" do
+      allow(RbConfig::CONFIG).to receive(:fetch).with("target_cpu").and_return("aarch64")
+      expect(described_class.from_system.sym).to eq(:arm64)
+    end
+
+    it "detects arm64 from arm64 target_cpu" do
+      allow(RbConfig::CONFIG).to receive(:fetch).with("target_cpu").and_return("arm64")
+      expect(described_class.from_system.sym).to eq(:arm64)
+    end
+
+    it "raises an error for an unsupported architecture" do
+      allow(RbConfig::CONFIG).to receive(:fetch).with("target_cpu").and_return("riscv64")
+      expect { described_class.from_system }.to raise_error(/BUG: could not detect architecture/)
+    end
+  end
 end

--- a/rhizome/common/spec/arch_class_spec.rb
+++ b/rhizome/common/spec/arch_class_spec.rb
@@ -30,29 +30,40 @@ RSpec.describe ArchClass do
     end
   end
 
+  describe ".target_cpu" do
+    it "returns a supported CPU string" do
+      expect(described_class.target_cpu).to match(/amd64|x86_64|x64|arm64|aarch64/)
+    end
+  end
+
   describe ".from_system" do
     it "detects x64 from amd64 target_cpu" do
-      allow(RbConfig::CONFIG).to receive(:fetch).with("target_cpu").and_return("x86_64")
+      allow(described_class).to receive(:target_cpu).and_return("amd64")
+      expect(described_class.from_system.sym).to eq(:x64)
+    end
+
+    it "detects x64 from x86_64 target_cpu" do
+      allow(described_class).to receive(:target_cpu).and_return("x86_64")
       expect(described_class.from_system.sym).to eq(:x64)
     end
 
     it "detects x64 from x64 target_cpu" do
-      allow(RbConfig::CONFIG).to receive(:fetch).with("target_cpu").and_return("x64")
+      allow(described_class).to receive(:target_cpu).and_return("x64")
       expect(described_class.from_system.sym).to eq(:x64)
     end
 
     it "detects arm64 from aarch64 target_cpu" do
-      allow(RbConfig::CONFIG).to receive(:fetch).with("target_cpu").and_return("aarch64")
+      allow(described_class).to receive(:target_cpu).and_return("aarch64")
       expect(described_class.from_system.sym).to eq(:arm64)
     end
 
     it "detects arm64 from arm64 target_cpu" do
-      allow(RbConfig::CONFIG).to receive(:fetch).with("target_cpu").and_return("arm64")
+      allow(described_class).to receive(:target_cpu).and_return("arm64")
       expect(described_class.from_system.sym).to eq(:arm64)
     end
 
     it "raises an error for an unsupported architecture" do
-      allow(RbConfig::CONFIG).to receive(:fetch).with("target_cpu").and_return("riscv64")
+      allow(described_class).to receive(:target_cpu).and_return("riscv64")
       expect { described_class.from_system }.to raise_error(/BUG: could not detect architecture/)
     end
   end

--- a/rhizome/common/spec/network_spec.rb
+++ b/rhizome/common/spec/network_spec.rb
@@ -7,11 +7,12 @@ RSpec.describe "network" do
   # rubocop:enable RSpec/DescribeClass
   describe "mac_to_ipv6_link_local" do
     it "converts a MAC address to an IPv6 link local address" do
+      # 0x3e ^ 0x02 -> 0x3c
       expect(mac_to_ipv6_link_local("3e:bd:a5:96:f7:b9")).to eq("fe80::3cbd:a5ff:fe96:f7b9")
     end
 
-    it "sets the universal/local bit (bit 1) in the first octet" do
-      # 00 -> 02, 02 -> 00
+    it "sets the universal/local bit in the first octet" do
+      # 0x00 ^ 0x02 -> 0x02
       expect(mac_to_ipv6_link_local("00:00:00:00:00:00")).to eq("fe80::0200:00ff:fe00:0000")
     end
   end

--- a/rhizome/common/spec/network_spec.rb
+++ b/rhizome/common/spec/network_spec.rb
@@ -2,7 +2,9 @@
 
 require_relative "../lib/network"
 
+# rubocop:disable RSpec/DescribeClass
 RSpec.describe "network" do
+  # rubocop:enable RSpec/DescribeClass
   describe "mac_to_ipv6_link_local" do
     it "converts a MAC address to an IPv6 link local address" do
       expect(mac_to_ipv6_link_local("3e:bd:a5:96:f7:b9")).to eq("fe80::3cbd:a5ff:fe96:f7b9")

--- a/rhizome/common/spec/network_spec.rb
+++ b/rhizome/common/spec/network_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "../lib/network"
+
+RSpec.describe "network" do
+  describe "mac_to_ipv6_link_local" do
+    it "converts a MAC address to an IPv6 link local address" do
+      expect(mac_to_ipv6_link_local("3e:bd:a5:96:f7:b9")).to eq("fe80::3cbd:a5ff:fe96:f7b9")
+    end
+
+    it "sets the universal/local bit (bit 1) in the first octet" do
+      # 00 -> 02, 02 -> 00
+      expect(mac_to_ipv6_link_local("00:00:00:00:00:00")).to eq("fe80::0200:00ff:fe00:0000")
+    end
+  end
+
+  describe "gen_mac" do
+    it "generates a MAC address with the local bit set and multicast bit cleared" do
+      100.times do
+        mac = gen_mac
+        expect(mac).to match(/\A[0-9a-f]{2}(?::[0-9a-f]{2}){5}\z/)
+        first_byte = mac.split(":").first.to_i(16)
+        expect(first_byte & 0x02).to eq(0x02), "local bit must be set, got: #{mac}"
+        expect(first_byte & 0x01).to eq(0x00), "multicast bit must be cleared, got: #{mac}"
+      end
+    end
+  end
+end

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -5,7 +5,9 @@ require "tmpdir"
 require "fileutils"
 require "openssl"
 
+# rubocop:disable RSpec/DescribeClass
 RSpec.describe "util" do
+  # rubocop:enable RSpec/DescribeClass
   describe "fsync_or_fail" do
     it "calls fsync on the given file" do
       f = instance_double(File)
@@ -91,9 +93,9 @@ RSpec.describe "util" do
       Dir.mktmpdir do |dir|
         path = "#{dir}/test_file"
         FileUtils.touch(path)
-        expect(File).to be_exist(path)
+        expect(File).to exist(path)
         rm_if_exists(path)
-        expect(File).not_to be_exist(path)
+        expect(File).not_to exist(path)
       end
     end
 

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -41,7 +41,15 @@ RSpec.describe "util" do
       expect { safe_write_to_file("test", "content") {} }.to raise_error(ArgumentError, /must provide either content or block/)
     end
 
-    it "supports the block form for writing" do
+    it "supports passing a string for file content" do
+      Dir.mktmpdir do |dir|
+        path = "#{dir}/test.txt"
+        safe_write_to_file(path, "string content")
+        expect(File.read(path)).to eq("string content")
+      end
+    end
+
+    it "passes File to the block" do
       Dir.mktmpdir do |dir|
         path = "#{dir}/test.txt"
         safe_write_to_file(path) do |f|

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -33,15 +33,11 @@ RSpec.describe "util" do
 
   describe "safe_write_to_file" do
     it "raises ArgumentError when neither content nor block is provided" do
-      Dir.mktmpdir do |dir|
-        expect { safe_write_to_file("#{dir}/test") }.to raise_error(ArgumentError, /must provide either content or block/)
-      end
+      expect { safe_write_to_file("test") }.to raise_error(ArgumentError, /must provide either content or block/)
     end
 
     it "raises ArgumentError when both content and block are provided" do
-      Dir.mktmpdir do |dir|
-        expect { safe_write_to_file("#{dir}/test", "content") { |f| } }.to raise_error(ArgumentError, /must provide either content or block/)
-      end
+      expect { safe_write_to_file("test", "content") {} }.to raise_error(ArgumentError, /must provide either content or block/)
     end
 
     it "supports the block form for writing" do

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "util" do
     end
 
     it "does nothing if the path does not exist" do
-      expect { rm_if_exists("/nonexistent/path/that/does/not/exist") }.not_to raise_error
+      expect(rm_if_exists("/nonexistent/path/that/does/not/exist")).to be_nil
     end
   end
 end

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -91,6 +91,15 @@ RSpec.describe "util" do
     it "raises CommandFail when command exits with non-zero status" do
       expect { r("false") }.to raise_error(CommandFail, /command failed: false/)
     end
+
+    it "executes command as a string using a shell" do
+      expect(r("echo -n a")).to eq "a"
+      expect(r("true && echo -n a")).to eq "a"
+    end
+
+    it "executes program directly without a shell when given multiple arguments" do
+      expect(r("echo", "-n", "$$")).to eq "$$"
+    end
   end
 
   describe "rm_if_exists" do

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require_relative "../lib/util"
+require "tmpdir"
+require "fileutils"
+require "openssl"
+
+RSpec.describe "util" do
+  describe "fsync_or_fail" do
+    it "calls fsync on the given file" do
+      f = instance_double(File)
+      expect(f).to receive(:fsync)
+      fsync_or_fail(f)
+    end
+
+    it "raises FsyncFail when fsync raises SystemCallError" do
+      f = instance_double(File)
+      expect(f).to receive(:fsync).and_raise(Errno::EIO, "fsync error")
+      expect { fsync_or_fail(f) }.to raise_error(FsyncFail, /fsync error/)
+    end
+  end
+
+  describe "sync_parent_dir" do
+    it "fsyncs the parent directory of the given path" do
+      dir_file = instance_double(File)
+      expect(File).to receive(:open).with("/some/dir").and_yield(dir_file)
+      expect(dir_file).to receive(:fsync)
+      sync_parent_dir("/some/dir/file.txt")
+    end
+  end
+
+  describe "safe_write_to_file" do
+    it "raises ArgumentError when neither content nor block is provided" do
+      Dir.mktmpdir do |dir|
+        expect { safe_write_to_file("#{dir}/test") }.to raise_error(ArgumentError, /must provide either content or block/)
+      end
+    end
+
+    it "raises ArgumentError when both content and block are provided" do
+      Dir.mktmpdir do |dir|
+        expect { safe_write_to_file("#{dir}/test", "content") { |f| } }.to raise_error(ArgumentError, /must provide either content or block/)
+      end
+    end
+
+    it "supports the block form for writing" do
+      Dir.mktmpdir do |dir|
+        path = "#{dir}/test.txt"
+        safe_write_to_file(path) do |f|
+          f.write("block content")
+        end
+        expect(File.read(path)).to eq("block content")
+      end
+    end
+  end
+
+  describe "validate_keys" do
+    it "accepts a hash with all required and no extra keys" do
+      expect { validate_keys("ctx", [:a, :b], [:c], {a: 1, b: 2}) }.not_to raise_error
+    end
+
+    it "accepts a hash with required keys and allowed optional keys" do
+      expect { validate_keys("ctx", [:a], [:b], {a: 1, b: 2}) }.not_to raise_error
+    end
+
+    it "raises ArgumentError for missing required keys" do
+      expect { validate_keys("ctx", [:a, :b], [], {a: 1}) }.to raise_error(ArgumentError, /Missing required keys in ctx: b/)
+    end
+
+    it "raises ArgumentError for unexpected extra keys" do
+      expect { validate_keys("ctx", [:a], [], {a: 1, z: 99}) }.to raise_error(ArgumentError, /Unexpected keys in ctx: z/)
+    end
+  end
+
+  describe "curl_file" do
+    it "calls r with curl command and returns the sha256 hash" do
+      url = "https://example.com/file.gz"
+      path = "/tmp/file.gz"
+      expect(self).to receive(:r).with("bash -c 'curl -f -L3 #{url.shellescape} | tee >(openssl dgst -sha256) > #{path.shellescape}'").and_return("SHA2-256(stdin)= #{"a" * 64}")
+      expect(curl_file(url, path)).to eq("a" * 64)
+    end
+  end
+
+  describe "r" do
+    it "raises CommandFail when command exits with non-zero status" do
+      expect { r("false") }.to raise_error(CommandFail, /command failed: false/)
+    end
+  end
+
+  describe "rm_if_exists" do
+    it "removes an existing path" do
+      Dir.mktmpdir do |dir|
+        path = "#{dir}/test_file"
+        FileUtils.touch(path)
+        expect(File).to be_exist(path)
+        rm_if_exists(path)
+        expect(File).not_to be_exist(path)
+      end
+    end
+
+    it "does nothing if the path does not exist" do
+      expect { rm_if_exists("/nonexistent/path/that/does/not/exist") }.not_to raise_error
+    end
+  end
+end

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe "util" do
   # rubocop:enable RSpec/DescribeClass
   describe "fsync_or_fail" do
     it "calls fsync on the given file" do
-      f = instance_double(File)
-      expect(f).to receive(:fsync)
-      fsync_or_fail(f)
+      Dir.mktmpdir do |dir|
+        File.open(dir) do |f|
+          expect(fsync_or_fail(f)).to eq 0
+        end
+      end
     end
 
     it "raises FsyncFail when fsync raises SystemCallError" do
@@ -24,10 +26,9 @@ RSpec.describe "util" do
 
   describe "sync_parent_dir" do
     it "fsyncs the parent directory of the given path" do
-      dir_file = instance_double(File)
-      expect(File).to receive(:open).with("/some/dir").and_yield(dir_file)
-      expect(dir_file).to receive(:fsync)
-      sync_parent_dir("/some/dir/file.txt")
+      Dir.mktmpdir do |dir|
+        expect(sync_parent_dir("#{dir}/nonexistant")).to eq 0
+      end
     end
   end
 

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "util" do
     it "calls r with curl command and returns the sha256 hash" do
       url = "https://example.com/file.gz"
       path = "/tmp/file.gz"
-      expect(self).to receive(:r).with("bash -c 'curl -f -L3 #{url.shellescape} | tee >(openssl dgst -sha256) > #{path.shellescape}'").and_return("SHA2-256(stdin)= #{"a" * 64}")
+      expect(self).to receive(:r).with("bash -c curl\\ -f\\ -L3\\ https://example.com/file.gz\\ \\|\\ tee\\ \\>\\(openssl\\ dgst\\ -sha256\\)\\ \\>\\ /tmp/file.gz").and_return("SHA2-256(stdin)= #{"a" * 64}")
       expect(curl_file(url, path)).to eq("a" * 64)
     end
   end

--- a/rhizome/host/lib/cert_server_setup.rb
+++ b/rhizome/host/lib/cert_server_setup.rb
@@ -137,6 +137,7 @@ CERT_SERVICE
   def create_cert_folder
     FileUtils.mkdir(cert_folder)
   rescue Errno::EEXIST
+    nil
   end
 
   def put_certificate(cert_payload, cert_key_payload)

--- a/rhizome/host/lib/cloud_hypervisor.rb
+++ b/rhizome/host/lib/cloud_hypervisor.rb
@@ -46,7 +46,9 @@ module CloudHypervisor
     )
     SUPPORTED = {default.version => default}.freeze
     INSTALLED = SUPPORTED.select { _2.downloaded? }
+    # :nocov:
     INSTALLED.default = default if default.downloaded?
+    # :nocov:
     INSTALLED.freeze
 
     def self.[](version)
@@ -116,6 +118,7 @@ module CloudHypervisor
     )}
     default = SUPPORTED["35.1"]
 
+    # :nocov:
     if ubuntu_version >= 24
       SUPPORTED["46.0"] = Arch.render(
         x64: new("46.0", "00b5cf2976847d2f21d2b7266038c8fc40bd14f2a542115055e9e214867edc9e", "526c91cf6b2d30b24af6eb39511f4f562f7bbc50a4dfb17d486274057a162445"),
@@ -123,12 +126,15 @@ module CloudHypervisor
       )
       default = SUPPORTED["46.0"]
     end
+    # :nocov:
 
     SUPPORTED.freeze
 
     INSTALLED = SUPPORTED.select { _2.downloaded? }
     INSTALLED.default = if default.downloaded?
+      # :nocov:
       default
+      # :nocov:
     else
       INSTALLED.values.first
     end

--- a/rhizome/host/lib/kek_pipe.rb
+++ b/rhizome/host/lib/kek_pipe.rb
@@ -37,11 +37,10 @@ module KekPipe
             stdin_w.write(stdin)
           rescue Errno::EPIPE
             # Child exited before consuming all stdin
+            nil
           rescue IOError => e
             # Another possible error if child exited before consuming all stdin
-            # :nocov:
             raise unless e.message.include?("stream closed")
-            # :nocov:
           ensure
             stdin_w.close
           end
@@ -55,7 +54,7 @@ module KekPipe
           begin
             Process.kill("TERM", pid)
           rescue Errno::ESRCH
-            # Child has already exited.
+            nil
           end
           Process.waitpid(pid)
         end

--- a/rhizome/host/lib/kek_pipe.rb
+++ b/rhizome/host/lib/kek_pipe.rb
@@ -54,6 +54,7 @@ module KekPipe
           begin
             Process.kill("TERM", pid)
           rescue Errno::ESRCH
+            # Child has already exited.
             nil
           end
           Process.waitpid(pid)

--- a/rhizome/host/lib/kek_pipe.rb
+++ b/rhizome/host/lib/kek_pipe.rb
@@ -39,7 +39,9 @@ module KekPipe
             # Child exited before consuming all stdin
           rescue IOError => e
             # Another possible error if child exited before consuming all stdin
+            # :nocov:
             raise unless e.message.include?("stream closed")
+            # :nocov:
           ensure
             stdin_w.close
           end

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -59,7 +59,9 @@ class VmPath
     cert
   ].each do |file_name|
     method_name = file_name.tr(".-", "_")
+    # :nocov:
     fail "BUG" if method_defined?(method_name)
+    # :nocov:
 
     # Method producing a path, e.g. #user_data
     define_method method_name do
@@ -68,7 +70,9 @@ class VmPath
 
     # Method producing a shell-quoted path, e.g. #q_user_data.
     quoted_method_name = "q_" + method_name
+    # :nocov:
     fail "BUG" if method_defined?(quoted_method_name)
+    # :nocov:
 
     define_method quoted_method_name do
       home(file_name).shellescape
@@ -78,7 +82,9 @@ class VmPath
     #
     # Trailing newlines are removed.
     read_method_name = "read_" + method_name
+    # :nocov:
     fail "BUG" if method_defined?(read_method_name)
+    # :nocov:
 
     define_method read_method_name do
       read(home(file_name))
@@ -86,7 +92,9 @@ class VmPath
 
     # Method overwriting the file's contents, e.g. #write_user_data
     write_method_name = "write_" + method_name
+    # :nocov:
     fail "BUG" if method_defined?(write_method_name)
+    # :nocov:
 
     define_method write_method_name do |s|
       write(home(file_name), s)
@@ -94,7 +102,9 @@ class VmPath
 
     # Method serializing data to YAML and writing, e.g. #write_yaml_user_data
     yaml_write_method_name = "write_yaml_" + method_name
+    # :nocov:
     fail "BUG" if method_defined?(yaml_write_method_name)
+    # :nocov:
 
     define_method yaml_write_method_name do |data, prefix: nil|
       s = YAML.dump(data, line_width: -1)

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -40,6 +40,11 @@ class VmPath
     File.join("", "vm", @vm_name, n)
   end
 
+  def self.define_new_method(m, &block)
+    fail "BUG" if method_defined?(m)
+    define_method(m, &block)
+  end
+
   # Define path, q_path, read, write methods for files in
   # `/vm/#{vm_name}`
   %w[
@@ -59,54 +64,32 @@ class VmPath
     cert
   ].each do |file_name|
     method_name = file_name.tr(".-", "_")
-    # :nocov:
-    fail "BUG" if method_defined?(method_name)
-    # :nocov:
 
     # Method producing a path, e.g. #user_data
-    define_method method_name do
+    define_new_method method_name do
       home(file_name)
     end
 
     # Method producing a shell-quoted path, e.g. #q_user_data.
-    quoted_method_name = "q_" + method_name
-    # :nocov:
-    fail "BUG" if method_defined?(quoted_method_name)
-    # :nocov:
-
-    define_method quoted_method_name do
+    define_new_method("q_" + method_name) do
       home(file_name).shellescape
     end
 
     # Method reading the file's contents, e.g. #read_user_data
     #
     # Trailing newlines are removed.
-    read_method_name = "read_" + method_name
-    # :nocov:
-    fail "BUG" if method_defined?(read_method_name)
-    # :nocov:
-
-    define_method read_method_name do
+    define_new_method("read_" + method_name) do
       read(home(file_name))
     end
 
     # Method overwriting the file's contents, e.g. #write_user_data
     write_method_name = "write_" + method_name
-    # :nocov:
-    fail "BUG" if method_defined?(write_method_name)
-    # :nocov:
-
-    define_method write_method_name do |s|
+    define_new_method(write_method_name) do |s|
       write(home(file_name), s)
     end
 
     # Method serializing data to YAML and writing, e.g. #write_yaml_user_data
-    yaml_write_method_name = "write_yaml_" + method_name
-    # :nocov:
-    fail "BUG" if method_defined?(yaml_write_method_name)
-    # :nocov:
-
-    define_method yaml_write_method_name do |data, prefix: nil|
+    define_method("write_yaml_" + method_name) do |data, prefix: nil|
       s = YAML.dump(data, line_width: -1)
       s.sub!(/\A---/, prefix) if prefix
       send(write_method_name, s)

--- a/rhizome/host/spec/boot_image_spec.rb
+++ b/rhizome/host/spec/boot_image_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe BootImage do
       bi.download(url: "url", ca_path: "ca_path", sha256sum: "sha256sum")
     end
 
+    it "can download an unversioned image" do
+      bi_no_version = described_class.new("ubuntu-jammy", nil)
+      expect(File).to receive(:exist?).with("/var/storage/images/ubuntu-jammy.raw").and_return(false)
+      expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images")
+      expect(bi_no_version).to receive(:image_ext).with("url").and_return(".img")
+      tmp_path = "/var/storage/images/ubuntu-jammy.img.tmp"
+      expect(bi_no_version).to receive(:curl_image).with("url", tmp_path, nil).and_return("sha256sum")
+      expect(bi_no_version).to receive(:verify_sha256sum).with("sha256sum", nil)
+      expect(bi_no_version).to receive(:convert_image).with(tmp_path, "qcow2")
+      expect(FileUtils).to receive(:rm_r).with(tmp_path)
+      bi_no_version.download(url: "url")
+    end
+
     it "can download an image with htcat" do
       expect(File).to receive(:exist?).with("/var/storage/images/ubuntu-jammy-20240110.raw").and_return(false)
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/images")
@@ -53,9 +66,33 @@ RSpec.describe BootImage do
     end
   end
 
+  describe "#image_path" do
+    it "returns path with version when version is set" do
+      expect(bi.image_path).to eq("/var/storage/images/ubuntu-jammy-20240110.raw")
+    end
+
+    it "returns path without version when version is nil" do
+      bi_no_version = described_class.new("ubuntu-jammy", nil)
+      expect(bi_no_version.image_path).to eq("/var/storage/images/ubuntu-jammy.raw")
+    end
+
+    it "uses custom image_root when provided" do
+      bi_custom = described_class.new("ubuntu-jammy", "20240110", image_root: "/custom/images")
+      expect(bi_custom.image_path).to eq("/custom/images/ubuntu-jammy-20240110.raw")
+    end
+  end
+
   describe "#initial_format" do
     it "fails if initial image has unsupported format" do
       expect { bi.initial_format(".iso") }.to raise_error RuntimeError, "Unsupported boot_image format: .iso"
+    end
+
+    it "returns raw for .raw extension" do
+      expect(bi.initial_format(".raw")).to eq("raw")
+    end
+
+    it "returns vpc for .vhd extension" do
+      expect(bi.initial_format(".vhd")).to eq("vpc")
     end
   end
 

--- a/rhizome/host/spec/boot_image_spec.rb
+++ b/rhizome/host/spec/boot_image_spec.rb
@@ -94,6 +94,11 @@ RSpec.describe BootImage do
     it "returns vpc for .vhd extension" do
       expect(bi.initial_format(".vhd")).to eq("vpc")
     end
+
+    it "returns qcow2 for .qcow2 and .img extensions" do
+      expect(bi.initial_format(".qcow2")).to eq("qcow2")
+      expect(bi.initial_format(".img")).to eq("qcow2")
+    end
   end
 
   describe "#curl_image" do

--- a/rhizome/host/spec/cert_server_setup_spec.rb
+++ b/rhizome/host/spec/cert_server_setup_spec.rb
@@ -60,7 +60,8 @@ RSpec.describe CertServerSetup do
       expect(Arch).to receive(:render).with(x64: "x86_64", arm64: "arm64").and_return("arm64")
       expect(cert_server_setup).to receive(:r).with("curl -L3 -o /tmp/metadata-endpoint-0.1.6.tar.gz https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_arm64.tar.gz")
       expect(FileUtils).to receive(:mkdir_p).with("/opt/metadata-endpoint-0.1.6")
-      expect(FileUtils).to receive(:cd).with("/opt/metadata-endpoint-0.1.6")
+      expect(FileUtils).to receive(:cd).with("/opt/metadata-endpoint-0.1.6").and_yield
+      expect(cert_server_setup).to receive(:r).with("tar -xzf /tmp/metadata-endpoint-0.1.6.tar.gz")
       expect(FileUtils).to receive(:rm_f).with("/tmp/metadata-endpoint-0.1.6.tar.gz")
       expect { cert_server_setup.download_server }.not_to raise_error
     end
@@ -69,7 +70,8 @@ RSpec.describe CertServerSetup do
       expect(Arch).to receive(:render).with(x64: "x86_64", arm64: "arm64").and_return("x86_64")
       expect(cert_server_setup).to receive(:r).with("curl -L3 -o /tmp/metadata-endpoint-0.1.6.tar.gz https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_x86_64.tar.gz")
       expect(FileUtils).to receive(:mkdir_p).with("/opt/metadata-endpoint-0.1.6")
-      expect(FileUtils).to receive(:cd).with("/opt/metadata-endpoint-0.1.6")
+      expect(FileUtils).to receive(:cd).with("/opt/metadata-endpoint-0.1.6").and_yield
+      expect(cert_server_setup).to receive(:r).with("tar -xzf /tmp/metadata-endpoint-0.1.6.tar.gz")
       expect(FileUtils).to receive(:rm_f).with("/tmp/metadata-endpoint-0.1.6.tar.gz")
       expect { cert_server_setup.download_server }.not_to raise_error
     end
@@ -135,6 +137,13 @@ MemoryLimit=10M
       expect(cert_server_setup).to receive(:r).with("systemctl daemon-reload")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-vm-metadata-endpoint.service")
       expect { cert_server_setup.stop_and_remove_service }.not_to raise_error
+    end
+  end
+
+  describe "#create_cert_folder" do
+    it "silently ignores Errno::EEXIST if the folder already exists" do
+      expect(FileUtils).to receive(:mkdir).with("/vm/test-vm/cert").and_raise(Errno::EEXIST)
+      expect { cert_server_setup.create_cert_folder }.not_to raise_error
     end
   end
 

--- a/rhizome/host/spec/cert_server_setup_spec.rb
+++ b/rhizome/host/spec/cert_server_setup_spec.rb
@@ -143,7 +143,7 @@ MemoryLimit=10M
   describe "#create_cert_folder" do
     it "silently ignores Errno::EEXIST if the folder already exists" do
       expect(FileUtils).to receive(:mkdir).with("/vm/test-vm/cert").and_raise(Errno::EEXIST)
-      expect { cert_server_setup.create_cert_folder }.not_to raise_error
+      expect(cert_server_setup.create_cert_folder).to be_nil
     end
   end
 

--- a/rhizome/host/spec/cloud_hypervisor_spec.rb
+++ b/rhizome/host/spec/cloud_hypervisor_spec.rb
@@ -40,6 +40,41 @@ RSpec.describe CloudHypervisor do
     end
   end
 
+  describe "CloudHypervisor::Version.ubuntu_version" do
+    it "parses ubuntu version from os-release" do
+      expect(File).to receive(:read).with("/etc/os-release").and_return('ID=ubuntu\nVERSION_ID="22"\n')
+      expect(CloudHypervisor::Version.ubuntu_version).to eq(22)
+    end
+
+    it "parses ubuntu version without quotes" do
+      expect(File).to receive(:read).with("/etc/os-release").and_return("VERSION_ID=24\n")
+      expect(CloudHypervisor::Version.ubuntu_version).to eq(24)
+    end
+
+    it "raises when version cannot be determined" do
+      expect(File).to receive(:read).with("/etc/os-release").and_return("ID=debian\n")
+      expect { CloudHypervisor::Version.ubuntu_version }.to raise_error("unable to determine Ubuntu version")
+    end
+  end
+
+  describe "CloudHypervisor::Firmware.download" do
+    it "calls download on each supported firmware version" do
+      CloudHypervisor::Firmware::SUPPORTED.each_value do |fw|
+        expect(fw).to receive(:download)
+      end
+      CloudHypervisor::Firmware.download
+    end
+  end
+
+  describe "CloudHypervisor::Version.download" do
+    it "calls download on each supported version" do
+      CloudHypervisor::Version::SUPPORTED.each_value do |v|
+        expect(v).to receive(:download)
+      end
+      CloudHypervisor::Version.download
+    end
+  end
+
   context "when downloading cloud-hypervisor" do
     subject(:ch) { CloudHypervisor::Version.new("35.1", "sha_ch", "sha_remote") }
 

--- a/rhizome/host/spec/crypt_swap_setup_spec.rb
+++ b/rhizome/host/spec/crypt_swap_setup_spec.rb
@@ -58,5 +58,59 @@ RSpec.describe CryptSwapSetup do
 
       expect { described_class.run }.to output(/skipping cryptswap setup/).to_stdout
     end
+
+    it "skips if cryptswap is already configured in fstab" do
+      already_configured_fstab = <<~FSTAB
+        /dev/mapper/cryptswap none swap sw 0 0
+      FSTAB
+      expect(File).to receive(:read).with(CryptSwapSetup::FSTAB).and_return(already_configured_fstab)
+      expect { described_class.run }.to output(/already configured/).to_stdout
+    end
+
+    it "fails if no swap entry is found in fstab" do
+      no_swap_fstab = <<~FSTAB
+        UUID=52ad6a6b-7eae-4ebe-ae19-6aab35d7f2fa / ext4 defaults 0 0
+      FSTAB
+      expect(File).to receive(:read).with(CryptSwapSetup::FSTAB).and_return(no_swap_fstab)
+      expect { described_class.run }.to raise_error("No swap entry found in /etc/fstab")
+    end
+  end
+
+  describe ".add_crypttab_entry" do
+    it "creates a new crypttab when it does not exist" do
+      expect(File).to receive(:exist?).with(CryptSwapSetup::CRYPTTAB).and_return(false)
+      expect(described_class).to receive(:safe_write_to_file).with(CryptSwapSetup::CRYPTTAB, "new entry\n")
+      described_class.add_crypttab_entry("new entry\n")
+    end
+
+    it "backs up and replaces existing cryptswap entry when crypttab exists" do
+      existing = "cryptswap /dev/old /dev/urandom old-opts\nother entry\n"
+      expect(File).to receive(:exist?).with(CryptSwapSetup::CRYPTTAB).and_return(true)
+      expect(Time).to receive(:now).and_return(Time.at(1_700_000_001))
+      expect(FileUtils).to receive(:cp).with(CryptSwapSetup::CRYPTTAB, "#{CryptSwapSetup::CRYPTTAB}.bak.1700000001")
+      expect(File).to receive(:read).with(CryptSwapSetup::CRYPTTAB).and_return(existing)
+      expect(described_class).to receive(:safe_write_to_file).with(CryptSwapSetup::CRYPTTAB, "other entry\nnew entry\n")
+      described_class.add_crypttab_entry("new entry\n")
+    end
+  end
+
+  describe ".resolve_swap_device" do
+    it "resolves a UUID-based swap entry" do
+      swap_line = "UUID=4c4fe278-d132-4136-8073-b1242eacf5eb none swap sw 0 0"
+      expect(File).to receive(:realpath).with("/dev/disk/by-uuid/4c4fe278-d132-4136-8073-b1242eacf5eb").and_return("/dev/nvme0n1p2")
+      expect(described_class.resolve_swap_device(swap_line)).to eq("/dev/nvme0n1p2")
+    end
+
+    it "resolves a LABEL-based swap entry" do
+      swap_line = "LABEL=swap none swap sw 0 0"
+      expect(File).to receive(:realpath).with("/dev/disk/by-label/swap").and_return("/dev/sda1")
+      expect(described_class.resolve_swap_device(swap_line)).to eq("/dev/sda1")
+    end
+
+    it "resolves a direct device path swap entry" do
+      swap_line = "/dev/sda2 none swap sw 0 0"
+      expect(File).to receive(:realpath).with("/dev/sda2").and_return("/dev/sda2")
+      expect(described_class.resolve_swap_device(swap_line)).to eq("/dev/sda2")
+    end
   end
 end

--- a/rhizome/host/spec/crypt_swap_setup_spec.rb
+++ b/rhizome/host/spec/crypt_swap_setup_spec.rb
@@ -48,11 +48,10 @@ RSpec.describe CryptSwapSetup do
     end
 
     it "skips cryptswap setup when swap is a swapfile" do
-      swapfile_fstab = <<~FSTAB
+      expect(File).to receive(:read).with(CryptSwapSetup::FSTAB).and_return(<<~FSTAB)
             UUID=52ad6a6b-7eae-4ebe-ae19-6aab35d7f2fa / ext4 defaults 0 0
             /swap.img none swap sw 0 0
       FSTAB
-      expect(File).to receive(:read).with(CryptSwapSetup::FSTAB).and_return(swapfile_fstab.dup)
       expect(File).to receive(:realpath).with("/swap.img").and_return("/swap.img")
       expect(File).to receive(:blockdev?).with("/swap.img").and_return(false)
 
@@ -60,18 +59,16 @@ RSpec.describe CryptSwapSetup do
     end
 
     it "skips if cryptswap is already configured in fstab" do
-      already_configured_fstab = <<~FSTAB
+      expect(File).to receive(:read).with(CryptSwapSetup::FSTAB).and_return(<<~FSTAB)
         /dev/mapper/cryptswap none swap sw 0 0
       FSTAB
-      expect(File).to receive(:read).with(CryptSwapSetup::FSTAB).and_return(already_configured_fstab)
       expect { described_class.run }.to output(/already configured/).to_stdout
     end
 
     it "fails if no swap entry is found in fstab" do
-      no_swap_fstab = <<~FSTAB
+      expect(File).to receive(:read).with(CryptSwapSetup::FSTAB).and_return(<<~FSTAB)
         UUID=52ad6a6b-7eae-4ebe-ae19-6aab35d7f2fa / ext4 defaults 0 0
       FSTAB
-      expect(File).to receive(:read).with(CryptSwapSetup::FSTAB).and_return(no_swap_fstab)
       expect { described_class.run }.to raise_error("No swap entry found in /etc/fstab")
     end
   end

--- a/rhizome/host/spec/kek_pipe_spec.rb
+++ b/rhizome/host/spec/kek_pipe_spec.rb
@@ -95,10 +95,28 @@ RSpec.describe KekPipe do
     it "handles errors when Process.spawn fails before pid is assigned" do
       Dir.mktmpdir do |dir|
         kek_pipe = File.join(dir, "kek.pipe")
-        allow(Process).to receive(:spawn).and_raise(Errno::ENOENT, "No such file or directory")
+        expect(Process).to receive(:spawn).and_raise(Errno::ENOENT, "No such file or directory")
         expect {
           kp.run_with_kek_pipe(
             ["nonexistent_command"],
+            kek_pipe: kek_pipe,
+            kek_content: "kek",
+          )
+        }.to raise_error(RuntimeError, /error writing KEK to pipe/)
+      end
+    end
+
+    it "handles errors when Process.kill fails before pid is assigned" do
+      Dir.mktmpdir do |dir|
+        kek_pipe = File.join(dir, "kek.pipe")
+        expect(kp).to receive(:write_kek_to_pipe).and_raise
+        expect(Process).to receive(:kill).and_wrap_original do |m, *args|
+          m.call(*args)
+          raise Errno::ESRCH, "No such process"
+        end
+        expect {
+          kp.run_with_kek_pipe(
+            ["true"],
             kek_pipe: kek_pipe,
             kek_content: "kek",
           )
@@ -131,6 +149,102 @@ RSpec.describe KekPipe do
         )
 
         expect(File.read(output_file)).to eq("env-early-exit|kek-content-early-exit|line1\n")
+      end
+    end
+
+    it "works even if child process exits with EPIPE" do
+      Dir.mktmpdir do |dir|
+        output_file = File.join(dir, "output-early-exit")
+        kek_pipe = File.join(dir, "kek.pipe")
+        script = <<~RUBY
+          line = STDIN.gets
+          kek = File.read(ARGV[0])
+          File.write(ARGV[1], [ENV.fetch("TEST_KEK_ENV"), kek, line].join("|"))
+          exit 0
+        RUBY
+
+        large_stdin = "line1\nline2\nline3\n" * 10000
+
+        expect(IO).to receive(:pipe).and_wrap_original do |m|
+          _, w = ary = m.call
+          expect(w).to receive(:write).and_raise(Errno::EPIPE, "stream closed")
+          ary
+        end
+
+        kp.run_with_kek_pipe(
+          ["ruby", "-e", script, kek_pipe, output_file],
+          kek_pipe: kek_pipe,
+          kek_content: "kek-content-early-exit",
+          stdin: large_stdin,
+          env: {"TEST_KEK_ENV" => "env-early-exit"},
+        )
+
+        expect(File.read(output_file)).to eq("env-early-exit|kek-content-early-exit|")
+      end
+    end
+
+    it "works even if child process exits with stream closed IOError" do
+      Dir.mktmpdir do |dir|
+        output_file = File.join(dir, "output-early-exit")
+        kek_pipe = File.join(dir, "kek.pipe")
+        script = <<~RUBY
+          line = STDIN.gets
+          kek = File.read(ARGV[0])
+          File.write(ARGV[1], [ENV.fetch("TEST_KEK_ENV"), kek, line].join("|"))
+          exit 0
+        RUBY
+
+        large_stdin = "line1\nline2\nline3\n" * 10000
+
+        expect(IO).to receive(:pipe).and_wrap_original do |m|
+          _, w = ary = m.call
+          expect(w).to receive(:write).and_raise(IOError, "stream closed")
+          ary
+        end
+
+        kp.run_with_kek_pipe(
+          ["ruby", "-e", script, kek_pipe, output_file],
+          kek_pipe: kek_pipe,
+          kek_content: "kek-content-early-exit",
+          stdin: large_stdin,
+          env: {"TEST_KEK_ENV" => "env-early-exit"},
+        )
+
+        expect(File.read(output_file)).to eq("env-early-exit|kek-content-early-exit|")
+      end
+    end
+
+    it "fails if child process exits with non-stream closed IOError" do
+      Dir.mktmpdir do |dir|
+        output_file = File.join(dir, "output-early-exit")
+        kek_pipe = File.join(dir, "kek.pipe")
+        script = <<~RUBY
+          line = STDIN.gets
+          kek = File.read(ARGV[0])
+          File.write(ARGV[1], [ENV.fetch("TEST_KEK_ENV"), kek, line].join("|"))
+          exit 0
+        RUBY
+
+        large_stdin = "line1\nline2\nline3\n" * 10000
+
+        expect(IO).to receive(:pipe).and_wrap_original do |m|
+          _, w = ary = m.call
+          expect(w).to receive(:write) do
+            Thread.current.report_on_exception = false
+            raise IOError, "other error"
+          end
+          ary
+        end
+
+        expect do
+          kp.run_with_kek_pipe(
+            ["ruby", "-e", script, kek_pipe, output_file],
+            kek_pipe: kek_pipe,
+            kek_content: "kek-content-early-exit",
+            stdin: large_stdin,
+            env: {"TEST_KEK_ENV" => "env-early-exit"},
+          )
+        end.to raise_error(IOError, "other error")
       end
     end
   end

--- a/rhizome/host/spec/kek_pipe_spec.rb
+++ b/rhizome/host/spec/kek_pipe_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe KekPipe do
       end
     end
 
-    it "handles errors when Process.kill fails before pid is assigned" do
+    it "handles errors when Process.kill fails with Errno::ESRCH" do
       Dir.mktmpdir do |dir|
         kek_pipe = File.join(dir, "kek.pipe")
         expect(kp).to receive(:write_kek_to_pipe).and_raise
@@ -152,7 +152,7 @@ RSpec.describe KekPipe do
       end
     end
 
-    it "works even if child process exits with EPIPE" do
+    it "works even if writing to pipe fails with EPIPE" do
       Dir.mktmpdir do |dir|
         output_file = File.join(dir, "output-early-exit")
         kek_pipe = File.join(dir, "kek.pipe")
@@ -183,7 +183,7 @@ RSpec.describe KekPipe do
       end
     end
 
-    it "works even if child process exits with stream closed IOError" do
+    it "works even if writing to pipe fails with stream closed IOError" do
       Dir.mktmpdir do |dir|
         output_file = File.join(dir, "output-early-exit")
         kek_pipe = File.join(dir, "kek.pipe")
@@ -214,7 +214,7 @@ RSpec.describe KekPipe do
       end
     end
 
-    it "fails if child process exits with non-stream closed IOError" do
+    it "fails if writing to pipe fails with non-stream closed IOError" do
       Dir.mktmpdir do |dir|
         output_file = File.join(dir, "output-early-exit")
         kek_pipe = File.join(dir, "kek.pipe")

--- a/rhizome/host/spec/kek_pipe_spec.rb
+++ b/rhizome/host/spec/kek_pipe_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe KekPipe do
       Dir.mktmpdir do |dir|
         kek_pipe = File.join(dir, "kek.pipe")
         expect(FileUtils).to receive(:chown).with("spdk", "spdk", kek_pipe)
-        kp.with_kek_pipe(kek_pipe, owner: "spdk") { }
+        kp.with_kek_pipe(kek_pipe, owner: "spdk") {}
       end
     end
   end

--- a/rhizome/host/spec/kek_pipe_spec.rb
+++ b/rhizome/host/spec/kek_pipe_spec.rb
@@ -6,6 +6,16 @@ require "tmpdir"
 RSpec.describe KekPipe do
   let(:kp) { Class.new { extend KekPipe } }
 
+  describe ".with_kek_pipe" do
+    it "calls FileUtils.chown when owner is given" do
+      Dir.mktmpdir do |dir|
+        kek_pipe = File.join(dir, "kek.pipe")
+        expect(FileUtils).to receive(:chown).with("spdk", "spdk", kek_pipe)
+        kp.with_kek_pipe(kek_pipe, owner: "spdk") { }
+      end
+    end
+  end
+
   describe ".run_with_kek_pipe" do
     it "passes kek via pipe; with stdin" do
       Dir.mktmpdir do |dir|
@@ -64,6 +74,35 @@ RSpec.describe KekPipe do
             kek_write_timeout_sec: 0.1,
           )
         }.to raise_error RuntimeError, "error writing KEK to pipe: execution expired"
+      end
+    end
+
+    it "raises CommandFail when command exits with non-zero status" do
+      Dir.mktmpdir do |dir|
+        kek_pipe = File.join(dir, "kek.pipe")
+        script = "File.read(ARGV[0]); exit 1"
+
+        expect {
+          kp.run_with_kek_pipe(
+            ["ruby", "-e", script, kek_pipe],
+            kek_pipe: kek_pipe,
+            kek_content: "kek-content",
+          )
+        }.to raise_error(CommandFail, /command failed/)
+      end
+    end
+
+    it "handles errors when Process.spawn fails before pid is assigned" do
+      Dir.mktmpdir do |dir|
+        kek_pipe = File.join(dir, "kek.pipe")
+        allow(Process).to receive(:spawn).and_raise(Errno::ENOENT, "No such file or directory")
+        expect {
+          kp.run_with_kek_pipe(
+            ["nonexistent_command"],
+            kek_pipe: kek_pipe,
+            kek_content: "kek",
+          )
+        }.to raise_error(RuntimeError, /error writing KEK to pipe/)
       end
     end
 

--- a/rhizome/host/spec/slice_setup_spec.rb
+++ b/rhizome/host/spec/slice_setup_spec.rb
@@ -63,6 +63,11 @@ RSpec.describe SliceSetup do
       expect { slice_setup.install_systemd_unit("3-4") }.to raise_error("BUG: we cannot create system units")
     end
 
+    it "raises an error if the slice name contains a dash" do
+      slice_setup = described_class.new("slice-name.slice")
+      expect { slice_setup.install_systemd_unit("3-4") }.to raise_error("BUG: unit name cannot contain a dash")
+    end
+
     it "raises an error if allowed_cpus is nil" do
       expect { slice_setup.install_systemd_unit(nil) }.to raise_error("BUG: invalid allowed_cpus")
     end

--- a/rhizome/host/spec/spdk_rpc_spec.rb
+++ b/rhizome/host/spec/spdk_rpc_spec.rb
@@ -184,6 +184,53 @@ RSpec.describe SpdkRpc do
     end
   end
 
+  describe "#bdev_ubi_create" do
+    it "can create a bdev_ubi bdev with default params" do
+      expect(sr).to receive(:call).with("bdev_ubi_create", {
+        name: "name",
+        base_bdev: "base",
+        image_path: "/path/to/image",
+        stripe_size_kb: 1024,
+        no_sync: false,
+        copy_on_read: false,
+        directio: true,
+      })
+      sr.bdev_ubi_create("name", "base", "/path/to/image")
+    end
+
+    it "can create a bdev_ubi bdev with copy_on_read" do
+      expect(sr).to receive(:call).with("bdev_ubi_create", {
+        name: "name",
+        base_bdev: "base",
+        image_path: "/path/to/image",
+        stripe_size_kb: 1024,
+        no_sync: false,
+        copy_on_read: true,
+        directio: true,
+      })
+      sr.bdev_ubi_create("name", "base", "/path/to/image", 1024, true)
+    end
+  end
+
+  describe "#bdev_ubi_delete" do
+    it "can delete a bdev_ubi bdev" do
+      expect(sr).to receive(:call).with("bdev_ubi_delete", {name: "name"})
+      sr.bdev_ubi_delete("name")
+    end
+
+    it "ignores exception if bdev doesn't exist and if_exists=true" do
+      expect(sr).to receive(:call).with("bdev_ubi_delete", {name: "name"})
+        .and_raise SpdkRpcError.build("No such device", -19)
+      sr.bdev_ubi_delete("name")
+    end
+
+    it "raises exception if bdev doesn't exist and if_exists=false" do
+      expect(sr).to receive(:call).with("bdev_ubi_delete", {name: "name"})
+        .and_raise SpdkRpcError.build("No such device", -19)
+      expect { sr.bdev_ubi_delete("name", false) }.to raise_error SpdkNotFound
+    end
+  end
+
   describe "#bdev_set_qos_limit" do
     it "can set qos limits" do
       expect(sr).to receive(:call).with("bdev_set_qos_limit", {
@@ -286,6 +333,13 @@ RSpec.describe SpdkRpc do
         ->(_) { response[6..] },
       )
       expect(sr.read_response(unix_socket)).to eq(response)
+    end
+  end
+
+  describe "SpdkRpcError.build" do
+    it "returns SpdkExists for direct EEXIST errno code" do
+      result = SpdkRpcError.build("File exists", -Errno::EEXIST::Errno)
+      expect(result).to be_a(SpdkExists)
     end
   end
 

--- a/rhizome/host/spec/spdk_setup_spec.rb
+++ b/rhizome/host/spec/spdk_setup_spec.rb
@@ -8,33 +8,36 @@ RSpec.describe SpdkSetup do
   let(:spdk_version) { DEFAULT_SPDK_VERSION }
 
   describe "#prep" do
+    before do
+      expect(described_class).to receive(:r).with("apt-get -y install libaio-dev libssl-dev libnuma-dev libjson-c-dev uuid-dev libiscsi-dev")
+    end
+
     it "can prep host for spdk" do
-      expect(described_class).to receive(:r).with(/apt-get -y .*/)
-      expect(described_class).to receive(:r).with(/adduser .*/)
+      expect(described_class).to receive(:r).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
       expect(FileUtils).to receive(:mkdir_p).with(SpdkPath.vhost_dir)
       expect(FileUtils).to receive(:chown).with("spdk", "spdk", SpdkPath.vhost_dir)
-      expect { described_class.prep }.not_to raise_error
+      described_class.prep
     end
 
     it "continues if user already exists (ubuntu 22.04)" do
-      expect(described_class).to receive(:r).with(/apt-get -y .*/)
-      expect(described_class).to receive(:r).with(/adduser .*/).and_raise CommandFail.new("Warning: The home dir /home/spdk you specified already exists.\nadduser: The user `spdk' already exists.", "", "")
+      expect(described_class).to receive(:r).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
+        .and_raise CommandFail.new("Warning: The home dir /home/spdk you specified already exists.\nadduser: The user `spdk' already exists.", "", "")
       expect(FileUtils).to receive(:mkdir_p).with(SpdkPath.vhost_dir)
       expect(FileUtils).to receive(:chown).with("spdk", "spdk", SpdkPath.vhost_dir)
-      expect { described_class.prep }.not_to raise_error
+      described_class.prep
     end
 
     it "continues if user already exists (ubuntu 24.04)" do
-      expect(described_class).to receive(:r).with(/apt-get -y .*/)
-      expect(described_class).to receive(:r).with(/adduser .*/).and_raise CommandFail.new("info: The home dir /home/spdk you specified already exists.\n\nfatal: The user `spdk' already exists.", "", "")
+      expect(described_class).to receive(:r).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
+        .and_raise CommandFail.new("info: The home dir /home/spdk you specified already exists.\n\nfatal: The user `spdk' already exists.", "", "")
       expect(FileUtils).to receive(:mkdir_p).with(SpdkPath.vhost_dir)
       expect(FileUtils).to receive(:chown).with("spdk", "spdk", SpdkPath.vhost_dir)
-      expect { described_class.prep }.not_to raise_error
+      described_class.prep
     end
 
     it "fails if adduser fails with an unexpected error" do
-      expect(described_class).to receive(:r).with(/apt-get -y .*/)
-      expect(described_class).to receive(:r).with(/adduser .*/).and_raise CommandFail.new("adduser: some other error.", "", "")
+      expect(described_class).to receive(:r).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
+        .and_raise CommandFail.new("adduser: some other error.", "", "")
       expect { described_class.prep }.to raise_error CommandFail
     end
   end
@@ -61,11 +64,11 @@ RSpec.describe SpdkSetup do
       expect(spdk_setup).to receive(:package_url).and_return("package_url")
       expect(spdk_setup).to receive(:puts).with("Downloading SPDK package from package_url")
       expect(spdk_setup).to receive(:install_path).and_return("install_path").at_least(:once)
-      expect(spdk_setup).to receive(:r).with(/curl -L3 -o .* package_url/)
+      expect(spdk_setup).to receive(:r).with("curl -L3 -o /tmp/spdk.tar.gz package_url")
       expect(FileUtils).to receive(:mkdir_p).with("install_path")
       expect(FileUtils).to receive(:cd).with("install_path").and_yield
       expect(spdk_setup).to receive(:r).with("tar -xzf /tmp/spdk.tar.gz --strip-components=1")
-      expect { spdk_setup.install_package(os_version: "ubuntu-22.04") }.not_to raise_error
+      spdk_setup.install_package(os_version: "ubuntu-22.04")
     end
   end
 
@@ -80,7 +83,7 @@ RSpec.describe SpdkSetup do
     it "creates the hugepages mount" do
       expect(spdk_setup).to receive(:r).with("sudo --user=spdk mkdir -p /home/spdk/hugepages.#{spdk_version.tr("-", ".")}")
       expect(File).to receive(:write).with("/lib/systemd/system/home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount", /.*/)
-      expect { spdk_setup.create_hugepages_mount(cpu_count: 4) }.not_to raise_error
+      spdk_setup.create_hugepages_mount(cpu_count: 4)
     end
   end
 

--- a/rhizome/host/spec/spdk_setup_spec.rb
+++ b/rhizome/host/spec/spdk_setup_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe SpdkSetup do
       expect(spdk_setup).to receive(:r).with(/curl -L3 -o .* package_url/)
       expect(FileUtils).to receive(:mkdir_p).with("install_path")
       expect(FileUtils).to receive(:cd).with("install_path").and_yield
-      expect(spdk_setup).to receive(:r).with(/tar -xzf.*--strip-components=1/)
+      expect(spdk_setup).to receive(:r).with("tar -xzf /tmp/spdk.tar.gz --strip-components=1")
       expect { spdk_setup.install_package(os_version: "ubuntu-22.04") }.not_to raise_error
     end
   end

--- a/rhizome/host/spec/spdk_setup_spec.rb
+++ b/rhizome/host/spec/spdk_setup_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe SpdkSetup do
       expect(Arch).to receive(:sym).and_return(:arm64)
       expect(spdk_setup.package_url(os_version: "ubuntu-22.04")).to match(/https.*arm64.*tar.gz/)
     end
+
+    it "raises for an unsupported SPDK version" do
+      setup = described_class.new("unknown-version")
+      expect { setup.package_url(os_version: "ubuntu-22.04") }.to raise_error("BUG: unsupported SPDK version")
+    end
   end
 
   describe "#install_package" do
@@ -58,7 +63,8 @@ RSpec.describe SpdkSetup do
       expect(spdk_setup).to receive(:install_path).and_return("install_path").at_least(:once)
       expect(spdk_setup).to receive(:r).with(/curl -L3 -o .* package_url/)
       expect(FileUtils).to receive(:mkdir_p).with("install_path")
-      expect(FileUtils).to receive(:cd).with("install_path")
+      expect(FileUtils).to receive(:cd).with("install_path").and_yield
+      expect(spdk_setup).to receive(:r).with(/tar -xzf.*--strip-components=1/)
       expect { spdk_setup.install_package(os_version: "ubuntu-22.04") }.not_to raise_error
     end
   end
@@ -78,6 +84,41 @@ RSpec.describe SpdkSetup do
     end
   end
 
+  describe "#create_conf" do
+    it "writes json config with correct subsystems" do
+      expect(spdk_setup).to receive(:safe_write_to_file).with(
+        SpdkPath.conf_path(spdk_version),
+        satisfy { |content|
+          parsed = JSON.parse(content)
+          subsystems = parsed["subsystems"].map { _1["subsystem"] }
+          subsystems == ["iobuf", "accel", "bdev"]
+        },
+      )
+      spdk_setup.create_conf(cpu_count: 4)
+    end
+  end
+
+  describe "#stop_and_remove_services" do
+    it "stops and removes services and unit files" do
+      expect(spdk_setup).to receive(:r).with("systemctl stop spdk-#{spdk_version}.service")
+      expect(spdk_setup).to receive(:r).with("systemctl stop home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
+      expect(spdk_setup).to receive(:r).with("systemctl disable spdk-#{spdk_version}.service")
+      expect(spdk_setup).to receive(:r).with("systemctl disable home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
+      expect(FileUtils).to receive(:rm_f).with("/lib/systemd/system/spdk-#{spdk_version}.service")
+      expect(FileUtils).to receive(:rm_f).with("/lib/systemd/system/home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
+      spdk_setup.stop_and_remove_services
+    end
+  end
+
+  describe "#remove_paths" do
+    it "removes conf, hugepages dir, and install path" do
+      expect(FileUtils).to receive(:rm_f).with(SpdkPath.conf_path(spdk_version))
+      expect(FileUtils).to receive(:rm_rf).with(spdk_setup.hugepages_dir)
+      expect(FileUtils).to receive(:rm_rf).with(spdk_setup.install_path)
+      spdk_setup.remove_paths
+    end
+  end
+
   describe "#enable_services" do
     it "enables services" do
       expect(spdk_setup).to receive(:r).with("systemctl enable spdk-#{spdk_version}.service")
@@ -91,6 +132,17 @@ RSpec.describe SpdkSetup do
       expect(spdk_setup).to receive(:r).with("systemctl start spdk-#{spdk_version}.service")
       expect(spdk_setup).to receive(:r).with("systemctl start home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
       expect { spdk_setup.start_services }.not_to raise_error
+    end
+  end
+
+  describe "#vhost_target" do
+    it "returns 'vhost_ubi' for a ubi spdk version" do
+      expect(spdk_setup.vhost_target).to eq("vhost_ubi")
+    end
+
+    it "returns 'vhost' for a non-ubi spdk version" do
+      non_ubi_setup = described_class.new("v24.01.0")
+      expect(non_ubi_setup.vhost_target).to eq("vhost")
     end
   end
 

--- a/rhizome/host/spec/storage_archive_spec.rb
+++ b/rhizome/host/spec/storage_archive_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe StorageArchive do
       }.to raise_error(RuntimeError, "unsupported key encryption algorithm rsa for disk_kek")
     end
 
+    it "fails when disk KEK key is missing" do
+      invalid_disk_kek = {"algorithm" => "aes-256-gcm"}
+
+      expect {
+        described_class.new(disk_config_path, disk_kek_path, invalid_disk_kek, target_conf, "v0.4.0", "/path/to/stats.json")
+      }.to raise_error(RuntimeError, "missing key for disk_kek")
+    end
+
     it "does not require disk KEK" do
       expect {
         described_class.new(disk_config_path, nil, nil, target_conf, "v0.4.0", "/path/to/stats.json")

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -81,6 +81,47 @@ RSpec.describe StorageVolume do
     expect { described_class.new("test", {"encrypted" => false, "read_only" => true}) }.not_to raise_error
   end
 
+  describe "#prep with bdev_ubi and no image" do
+    it "fails if bdev_ubi is set but no image is provided" do
+      sv = described_class.new("test", {
+        "disk_index" => 2,
+        "device_id" => "xyz01",
+        "encrypted" => true,
+        "size_gib" => 12,
+        "use_bdev_ubi" => true,
+      })
+      expect(File).to receive(:exist?).with("/var/storage").and_return(true)
+      expect(FileUtils).to receive(:mkdir_p).with("/var/storage/test/2")
+      expect(FileUtils).to receive(:chown).with("test", "test", "/var/storage/test/2")
+      expect(sv).to receive(:generate_data_encryption_key).and_return({cipher: "AES_XTS", key: "k1", key2: "k2"})
+      expect(sv).to receive(:store_spdk_data_encryption_key)
+      expect { sv.prep("kws") }.to raise_error("bdev_ubi requires a base image")
+    end
+  end
+
+  describe "#prep with bdev_ubi" do
+    it "calls create_ubi_writespace for bdev_ubi volumes" do
+      sv = described_class.new("test", {
+        "disk_index" => 2,
+        "device_id" => "xyz01",
+        "encrypted" => true,
+        "size_gib" => 12,
+        "image" => "kubuntu",
+        "use_bdev_ubi" => true,
+      })
+      encryption_key = {cipher: "AES_XTS", key: "k1", key2: "k2"}
+      allow(sv).to receive(:rpc_client).and_return(rpc_client)
+      expect(FileUtils).to receive(:mkdir_p).with("/var/storage/test/2")
+      expect(FileUtils).to receive(:chown).with("test", "test", "/var/storage/test/2")
+      expect(File).to receive(:exist?).with("/var/storage").and_return(true)
+      expect(sv).to receive(:verify_imaged_disk_size)
+      expect(sv).to receive(:generate_data_encryption_key).and_return(encryption_key)
+      expect(sv).to receive(:store_spdk_data_encryption_key).with(encryption_key, "kws")
+      expect(sv).to receive(:create_ubi_writespace).with(encryption_key)
+      sv.prep("kws")
+    end
+  end
+
   describe "#prep" do
     it "can prep a non-imaged encrypted disk" do
       key_wrapping_secrets = "key_wrapping_secrets"
@@ -195,6 +236,36 @@ RSpec.describe StorageVolume do
 
       encrypted_sv.purge_spdk_artifacts
     end
+
+    it "can purge a bdev_ubi disk" do
+      sv = described_class.new("test", {
+        "disk_index" => 2,
+        "device_id" => "xyz01",
+        "encrypted" => true,
+        "use_bdev_ubi" => true,
+        "image" => "kubuntu",
+      })
+      rpc = instance_double(SpdkRpc)
+      allow(sv).to receive(:rpc_client).and_return(rpc)
+      expect(rpc).to receive(:vhost_delete_controller).with("test_2")
+      expect(rpc).to receive(:bdev_ubi_delete).with("xyz01")
+      expect(rpc).to receive(:bdev_crypto_delete).with("xyz01_base")
+      expect(rpc).to receive(:bdev_aio_delete).with("xyz01_aio")
+      expect(rpc).to receive(:accel_crypto_key_destroy).with("xyz01_key")
+      expect(FileUtils).to receive(:rm_r).with("/var/storage/vhost/test_2")
+
+      sv.purge_spdk_artifacts
+    end
+
+    it "can purge a vhost backend service" do
+      allow(encrypted_vhost_sv).to receive(:stop_service_if_loaded)
+      allow(encrypted_vhost_sv).to receive(:rm_if_exists)
+      expect(encrypted_vhost_sv).to receive(:stop_service_if_loaded).with("test-2-storage.service")
+      expect(encrypted_vhost_sv).to receive(:rm_if_exists).with("/etc/systemd/system/test-2-storage.service")
+      expect(encrypted_vhost_sv).to receive(:rm_if_exists).with("/var/storage/test/2/vhost.sock")
+
+      encrypted_vhost_sv.purge_spdk_artifacts
+    end
   end
 
   describe "#generate_data_encryption_key" do
@@ -252,6 +323,24 @@ RSpec.describe StorageVolume do
       expect(encrypted_sv).to receive(:r).with(/spdk_dd.*--if #{image_path} --ob crypt0 --bs=[0-9]+\s*\z/, stdin: /{.*}/)
       encrypted_sv.encrypted_image_copy(encryption_key, image_path)
     end
+
+    it "includes count parameter when specified" do
+      encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
+      expect(encrypted_sv).to receive(:r).with(/--count 4/, stdin: /{.*}/)
+      encrypted_sv.encrypted_image_copy(encryption_key, image_path, count: 4)
+    end
+  end
+
+  describe "#spdk_service" do
+    it "returns spdk service name when spdk_version is set" do
+      sv = described_class.new("test", {
+        "disk_index" => 2,
+        "device_id" => "xyz01",
+        "encrypted" => true,
+        "spdk_version" => "v23.09-ubi-0.3",
+      })
+      expect(sv.send(:spdk_service)).to eq("spdk-v23.09-ubi-0.3.service")
+    end
   end
 
   describe "#create_empty_disk_file" do
@@ -282,6 +371,24 @@ RSpec.describe StorageVolume do
       expect(rpc_client).to receive(:bdev_aio_create).with("#{bdev}_aio", disk_file, 512)
       expect(rpc_client).to receive(:bdev_crypto_create).with(bdev, "#{bdev}_aio", "#{bdev}_key")
       encrypted_sv.setup_spdk_bdev(encryption_key)
+    end
+
+    it "can setup bdev_ubi spdk bdev" do
+      sv = described_class.new("test", {
+        "disk_index" => 2,
+        "device_id" => "xyz01",
+        "encrypted" => true,
+        "use_bdev_ubi" => true,
+        "image" => "kubuntu",
+      })
+      rpc = instance_double(SpdkRpc)
+      allow(sv).to receive(:rpc_client).and_return(rpc)
+      encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
+      expect(rpc).to receive(:accel_crypto_key_create).with("xyz01_key", "aes_xts", "key1value", "key2value")
+      expect(rpc).to receive(:bdev_aio_create).with("xyz01_aio", disk_file, 512)
+      expect(rpc).to receive(:bdev_crypto_create).with("xyz01_base", "xyz01_aio", "xyz01_key")
+      expect(rpc).to receive(:bdev_ubi_create).with("xyz01", "xyz01_base", "/var/storage/images/kubuntu.raw")
+      sv.setup_spdk_bdev(encryption_key)
     end
   end
 
@@ -370,6 +477,22 @@ RSpec.describe StorageVolume do
       expect(encrypted_vhost_sv).to receive(:vhost_backend_create_service_file)
       encrypted_vhost_sv.prep_vhost_backend(encryption_key, key_wrapping_secrets)
     end
+
+    it "skips metadata creation when not required" do
+      sv = described_class.new("test", {
+        "disk_index" => 2,
+        "device_id" => "xyz01",
+        "encrypted" => true,
+        "size_gib" => 12,
+        "vhost_block_backend_version" => "v0.1-5",
+      })
+      encryption_key = "encryption_key"
+      key_wrapping_secrets = "key_wrapping_secrets"
+      expect(sv).to receive(:vhost_backend_create_config).with(encryption_key, key_wrapping_secrets)
+      expect(sv).not_to receive(:vhost_backend_create_metadata)
+      expect(sv).to receive(:vhost_backend_create_service_file)
+      sv.prep_vhost_backend(encryption_key, key_wrapping_secrets)
+    end
   end
 
   describe "#vhost_backend_create_config" do
@@ -402,6 +525,62 @@ RSpec.describe StorageVolume do
       expect(encrypted_vhost_sv).to receive(:sync_parent_dir).with(config_path)
       expect(encrypted_vhost_sv).to receive(:write_through_device?).and_return(true)
       encrypted_vhost_sv.vhost_backend_create_config(encryption_key, key_wrapping_secrets)
+    end
+
+    it "creates v1 config without image_path when no image is set" do
+      sv = described_class.new("test", {
+        "disk_index" => 2,
+        "device_id" => "xyz01",
+        "encrypted" => true,
+        "size_gib" => 12,
+        "vhost_block_backend_version" => "v0.1-5",
+      })
+      allow(sv).to receive(:write_through_device?).and_return(false)
+      expect(sv).to receive(:write_config_file) do |_path, content|
+        parsed = YAML.safe_load(content)
+        expect(parsed).not_to have_key("image_path")
+      end
+      sv.vhost_backend_create_config(encryption_key, key_wrapping_secrets)
+    end
+
+    it "creates v2 config without stripe source when no image or archive source" do
+      sv = described_class.new("test", {
+        "disk_index" => 2,
+        "device_id" => "xyz01",
+        "encrypted" => true,
+        "size_gib" => 12,
+        "vhost_block_backend_version" => "v0.4.0",
+      })
+      expect(sv).to receive(:write_through_device?).and_return(false)
+      expect(sv).not_to receive(:write_config_file).with("/var/storage/test/2/vhost-backend-stripe-source.conf", anything)
+      expect(sv).to receive(:write_config_file).with("/var/storage/test/2/vhost-backend-secrets.conf", anything)
+      expect(sv).to receive(:write_config_file).with("/var/storage/test/2/vhost-backend.conf", satisfy { |content|
+        !content.include?("vhost-backend-stripe-source.conf") &&
+          !content.include?("metadata_path")
+      })
+      sv.vhost_backend_create_config(encryption_key, key_wrapping_secrets)
+    end
+
+    it "includes cpus and num_queues in v1 config when cpus are set" do
+      sv = described_class.new("test", {
+        "disk_index" => 2,
+        "device_id" => "xyz01",
+        "encrypted" => true,
+        "size_gib" => 12,
+        "image" => "kubuntu",
+        "vhost_block_backend_version" => "v0.1-5",
+        "num_queues" => 4,
+        "queue_size" => 128,
+        "cpus" => [0, 1],
+      })
+      allow(sv).to receive(:write_through_device?).and_return(false)
+      # v1 config uses write_config_file with YAML content
+      expect(sv).to receive(:write_config_file) do |_path, content|
+        parsed = YAML.safe_load(content)
+        expect(parsed["cpus"]).to eq([0, 1])
+        expect(parsed["num_queues"]).to eq(2)
+      end
+      sv.vhost_backend_create_config(encryption_key, key_wrapping_secrets)
     end
 
     it "creates v2 config files for v0.4.0" do
@@ -556,6 +735,69 @@ RSpec.describe StorageVolume do
 
       encrypted_vhost_v2_sv.vhost_backend_create_service_file
     end
+
+    it "uses broader network access restrictions when archive_source is set" do
+      sv = described_class.new("test", {
+        "disk_index" => 2,
+        "device_id" => "xyz01",
+        "encrypted" => true,
+        "size_gib" => 12,
+        "vhost_block_backend_version" => "v0.4.0",
+        "archive_source" => {"bucket" => "b", "region" => "r", "endpoint" => "e"},
+      })
+      service_file = "/etc/systemd/system/test-2-storage.service"
+      expect(File).to receive(:write).with(service_file, satisfy { |content|
+        content.include?("AF_UNIX AF_INET AF_INET6") &&
+          content.include?("PrivateNetwork=no")
+      })
+      sv.vhost_backend_create_service_file
+    end
+  end
+
+  describe "#vhost_backend_create_encrypted_metadata" do
+    it "builds and runs the init-metadata command with --kek for v1 config" do
+      allow(encrypted_vhost_sv).to receive(:vhost_backend_kek).and_return("kek_content")
+      expect(encrypted_vhost_sv).to receive(:run_with_kek_pipe) do |cmd, **_kwargs|
+        expect(cmd).to include("sudo")
+        expect(cmd).to include("--kek")
+      end
+      encrypted_vhost_sv.vhost_backend_create_encrypted_metadata({})
+    end
+
+    it "builds and runs the init-metadata command without --kek for v2 config" do
+      allow(encrypted_vhost_v2_sv).to receive(:vhost_backend_kek).and_return("kek_content")
+      expect(encrypted_vhost_v2_sv).to receive(:run_with_kek_pipe) do |cmd, **_kwargs|
+        expect(cmd).not_to include("--kek")
+      end
+      encrypted_vhost_v2_sv.vhost_backend_create_encrypted_metadata({})
+    end
+  end
+
+  describe "#vp accessor" do
+    it "returns a VmPath instance for the vm" do
+      sv = described_class.new("myvm", {"disk_index" => 0, "encrypted" => true})
+      expect(sv.send(:vp)).to be_a(VmPath)
+      expect(sv.send(:vp).instance_variable_get(:@vm_name)).to eq("myvm")
+    end
+  end
+
+  describe "#rpc_client accessor" do
+    it "returns a SpdkRpc instance" do
+      sv = described_class.new("myvm", {"disk_index" => 0, "encrypted" => true})
+      expect(SpdkRpc).to receive(:new).and_call_original
+      expect(sv.send(:rpc_client)).to be_a(SpdkRpc)
+    end
+  end
+
+  describe "#q_vhost_user_block_service" do
+    it "returns the shellescape-safe service name" do
+      expect(encrypted_vhost_sv.send(:q_vhost_user_block_service)).to eq("test-2-storage.service")
+    end
+
+    it "returns nil when there is no vhost backend version" do
+      sv = described_class.new("test", {"disk_index" => 0, "encrypted" => true})
+      expect(sv.send(:q_vhost_user_block_service)).to be_nil
+    end
   end
 
   describe "#vhost_backend_start" do
@@ -661,6 +903,27 @@ RSpec.describe StorageVolume do
       expect(Dir).to receive(:[]).with("/dev/disk/by-id/*").and_return([])
       expect(File).to receive(:stat).with("storage_path").and_return(instance_double(File::Stat, dev_major: 8, dev_minor: 0))
       expect { encrypted_sv.persistent_device_id("storage_path") }.to raise_error RuntimeError, "No persistent device ID found for storage path: storage_path"
+    end
+  end
+
+  describe "#create_ubi_writespace" do
+    it "creates larger disk and clears metadata section" do
+      encryption_key = {cipher: "AES_XTS", key: "k1", key2: "k2"}
+      expect(encrypted_sv).to receive(:create_empty_disk_file).with(disk_size_mib: 12 * 1024 + 16)
+      expect(encrypted_sv).to receive(:encrypted_image_copy).with(encryption_key, "/dev/zero", block_size: 2097152, count: 4)
+      encrypted_sv.create_ubi_writespace(encryption_key)
+    end
+  end
+
+  describe "#dump_metadata" do
+    it "raises error for non-v2 vhost backend" do
+      expect { encrypted_vhost_sv.dump_metadata({}) }.to raise_error(/does not support dump-metadata/)
+    end
+
+    it "runs dump-metadata command for v2 backend" do
+      key_wrapping_secrets = {"key" => Base64.strict_encode64("a" * 32)}
+      expect(encrypted_vhost_v2_sv).to receive(:run_with_kek_pipe)
+      encrypted_vhost_v2_sv.dump_metadata(key_wrapping_secrets)
     end
   end
 

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe StorageVolume do
     expect { described_class.new("test", {"encrypted" => false, "read_only" => true}) }.not_to raise_error
   end
 
-  describe "#prep with bdev_ubi and no image" do
+  describe "#prep" do
     it "fails if bdev_ubi is set but no image is provided" do
       sv = described_class.new("test", {
         "disk_index" => 2,
@@ -97,9 +97,7 @@ RSpec.describe StorageVolume do
       expect(sv).to receive(:store_spdk_data_encryption_key)
       expect { sv.prep("kws") }.to raise_error("bdev_ubi requires a base image")
     end
-  end
 
-  describe "#prep with bdev_ubi" do
     it "calls create_ubi_writespace for bdev_ubi volumes" do
       sv = described_class.new("test", {
         "disk_index" => 2,
@@ -119,9 +117,7 @@ RSpec.describe StorageVolume do
       expect(sv).to receive(:create_ubi_writespace).with(encryption_key)
       sv.prep("kws")
     end
-  end
 
-  describe "#prep" do
     it "can prep a non-imaged encrypted disk" do
       key_wrapping_secrets = "key_wrapping_secrets"
       encryption_key = {cipher: "AES_XTS", key: "k1", key2: "k2"}
@@ -788,7 +784,12 @@ RSpec.describe StorageVolume do
 
   describe "#q_vhost_user_block_service" do
     it "returns the shellescape-safe service name" do
-      expect(encrypted_vhost_sv.send(:q_vhost_user_block_service)).to eq("test-2-storage.service")
+      sv = described_class.new("a'b", {
+        "disk_index" => 2,
+        "encrypted" => true,
+        "vhost_block_backend_version" => "v0.4.0",
+      })
+      expect(sv.send(:q_vhost_user_block_service)).to eq("a\\'b-2-storage.service")
     end
 
     it "returns nil when there is no vhost backend version" do

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -110,7 +110,6 @@ RSpec.describe StorageVolume do
         "use_bdev_ubi" => true,
       })
       encryption_key = {cipher: "AES_XTS", key: "k1", key2: "k2"}
-      allow(sv).to receive(:rpc_client).and_return(rpc_client)
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/test/2")
       expect(FileUtils).to receive(:chown).with("test", "test", "/var/storage/test/2")
       expect(File).to receive(:exist?).with("/var/storage").and_return(true)
@@ -246,7 +245,7 @@ RSpec.describe StorageVolume do
         "image" => "kubuntu",
       })
       rpc = instance_double(SpdkRpc)
-      allow(sv).to receive(:rpc_client).and_return(rpc)
+      expect(sv).to receive(:rpc_client).and_return(rpc).at_least(:once)
       expect(rpc).to receive(:vhost_delete_controller).with("test_2")
       expect(rpc).to receive(:bdev_ubi_delete).with("xyz01")
       expect(rpc).to receive(:bdev_crypto_delete).with("xyz01_base")
@@ -258,9 +257,7 @@ RSpec.describe StorageVolume do
     end
 
     it "can purge a vhost backend service" do
-      allow(encrypted_vhost_sv).to receive(:stop_service_if_loaded)
-      allow(encrypted_vhost_sv).to receive(:rm_if_exists)
-      expect(encrypted_vhost_sv).to receive(:stop_service_if_loaded).with("test-2-storage.service")
+      expect(encrypted_vhost_sv).to receive(:stop_service_if_loaded).with("test-2-storage.service").at_least(:once)
       expect(encrypted_vhost_sv).to receive(:rm_if_exists).with("/etc/systemd/system/test-2-storage.service")
       expect(encrypted_vhost_sv).to receive(:rm_if_exists).with("/var/storage/test/2/vhost.sock")
 
@@ -320,13 +317,13 @@ RSpec.describe StorageVolume do
   describe "#encrypted_image_copy" do
     it "can copy an image to an encrypted volume" do
       encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
-      expect(encrypted_sv).to receive(:r).with(/spdk_dd.*--if #{image_path} --ob crypt0 --bs=[0-9]+\s*\z/, stdin: /{.*}/)
+      expect(encrypted_sv).to receive(:r).with("/opt/spdk-/bin/spdk_dd --config /dev/stdin --disable-cpumask-locks --rpc-socket /var/tmp/spdk_dd.sock.test --if /var/storage/images/kubuntu.raw --ob crypt0 --bs=2097152 ", stdin: /{.*}/)
       encrypted_sv.encrypted_image_copy(encryption_key, image_path)
     end
 
     it "includes count parameter when specified" do
       encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
-      expect(encrypted_sv).to receive(:r).with(/--count 4/, stdin: /{.*}/)
+      expect(encrypted_sv).to receive(:r).with("/opt/spdk-/bin/spdk_dd --config /dev/stdin --disable-cpumask-locks --rpc-socket /var/tmp/spdk_dd.sock.test --if /var/storage/images/kubuntu.raw --ob crypt0 --bs=2097152 --count 4", stdin: /{.*}/)
       encrypted_sv.encrypted_image_copy(encryption_key, image_path, count: 4)
     end
   end
@@ -357,7 +354,7 @@ RSpec.describe StorageVolume do
     it "can set disk file permissions" do
       expect(FileUtils).to receive(:chown).with("test", "test", disk_file)
       expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", disk_file)
-      expect(encrypted_sv).to receive(:r).with(/setfacl.*#{disk_file}/)
+      expect(encrypted_sv).to receive(:r).with("setfacl -m u:spdk:rw /var/storage/test/2/disk.raw")
 
       encrypted_sv.set_disk_file_permissions
     end
@@ -382,7 +379,7 @@ RSpec.describe StorageVolume do
         "image" => "kubuntu",
       })
       rpc = instance_double(SpdkRpc)
-      allow(sv).to receive(:rpc_client).and_return(rpc)
+      expect(sv).to receive(:rpc_client).and_return(rpc).at_least(:once)
       encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
       expect(rpc).to receive(:accel_crypto_key_create).with("xyz01_key", "aes_xts", "key1value", "key2value")
       expect(rpc).to receive(:bdev_aio_create).with("xyz01_aio", disk_file, 512)
@@ -402,7 +399,7 @@ RSpec.describe StorageVolume do
         "encrypted" => true,
       })
       rpc_client = instance_double(SpdkRpc)
-      allow(sv).to receive(:rpc_client).and_return(rpc_client)
+      expect(sv).to receive(:rpc_client).and_return(rpc_client)
       expect(rpc_client).to receive(:bdev_set_qos_limit).with(
         "xyz01", r_mbytes_per_sec: 200, w_mbytes_per_sec: 300,
       )
@@ -426,11 +423,11 @@ RSpec.describe StorageVolume do
       spdk_vhost_sock = "/var/storage/vhost/test_2"
       vm_vhost_sock = "/var/storage/test/2/vhost.sock"
 
-      expect(rpc_client).to receive(:vhost_create_blk_controller).with("test_2", device_id)
+      expect(rpc_client).to receive(:vhost_create_blk_controller).with("test_2", device_id).at_least(:once)
       expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", spdk_vhost_sock)
       expect(FileUtils).to receive(:ln_s).with(spdk_vhost_sock, vm_vhost_sock)
       expect(FileUtils).to receive(:chown).with("test", "test", vm_vhost_sock)
-      expect(encrypted_sv).to receive(:r).with(/setfacl.*#{spdk_vhost_sock}/)
+      expect(encrypted_sv).to receive(:r).with("setfacl -m u:test:rw /var/storage/vhost/test_2")
 
       encrypted_sv.setup_spdk_vhost
     end
@@ -516,7 +513,7 @@ RSpec.describe StorageVolume do
     it "can create vhost backend config" do
       config_path = "/var/storage/test/2/vhost-backend.conf"
       f = instance_double(File)
-      allow(f).to receive(:path).and_return(config_path)
+      expect(f).to receive(:path).and_return(config_path).at_least(:once)
       expect(encrypted_vhost_sv).to receive(:safe_write_to_file).with(config_path).and_yield(f)
       expect(FileUtils).to receive(:chown).with("test", "test", config_path)
       expect(File).to receive(:chmod).with(0o600, config_path)
@@ -535,7 +532,7 @@ RSpec.describe StorageVolume do
         "size_gib" => 12,
         "vhost_block_backend_version" => "v0.1-5",
       })
-      allow(sv).to receive(:write_through_device?).and_return(false)
+      expect(sv).to receive(:write_through_device?).and_return(false)
       expect(sv).to receive(:write_config_file) do |_path, content|
         parsed = YAML.safe_load(content)
         expect(parsed).not_to have_key("image_path")
@@ -573,7 +570,7 @@ RSpec.describe StorageVolume do
         "queue_size" => 128,
         "cpus" => [0, 1],
       })
-      allow(sv).to receive(:write_through_device?).and_return(false)
+      expect(sv).to receive(:write_through_device?).and_return(false)
       # v1 config uses write_config_file with YAML content
       expect(sv).to receive(:write_config_file) do |_path, content|
         parsed = YAML.safe_load(content)
@@ -710,14 +707,14 @@ RSpec.describe StorageVolume do
       }
       metadata_path = "/var/storage/test/2/metadata"
       f = instance_double(File)
-      allow(f).to receive(:path).and_return(metadata_path)
+      expect(f).to receive(:path).and_return(metadata_path).at_least(:once)
       expect(encrypted_vhost_sv).to receive(:rm_if_exists).with(metadata_path)
       expect(encrypted_vhost_sv).to receive(:safe_write_to_file).with(metadata_path).and_yield(f)
       expect(FileUtils).to receive(:chown).with("test", "test", metadata_path)
       expect(File).to receive(:chmod).with(0o600, metadata_path)
       expect(f).to receive(:truncate).with(8 * 1024 * 1024)
       expect(encrypted_vhost_sv).to receive(:vhost_backend_create_encrypted_metadata).with(key_wrapping_secrets)
-      allow(encrypted_vhost_sv).to receive(:sync_parent_dir).with(metadata_path)
+      expect(encrypted_vhost_sv).to receive(:sync_parent_dir).with(metadata_path).at_least(:once)
       encrypted_vhost_sv.vhost_backend_create_metadata(key_wrapping_secrets)
     end
   end
@@ -756,7 +753,7 @@ RSpec.describe StorageVolume do
 
   describe "#vhost_backend_create_encrypted_metadata" do
     it "builds and runs the init-metadata command with --kek for v1 config" do
-      allow(encrypted_vhost_sv).to receive(:vhost_backend_kek).and_return("kek_content")
+      expect(encrypted_vhost_sv).to receive(:vhost_backend_kek).and_return("kek_content")
       expect(encrypted_vhost_sv).to receive(:run_with_kek_pipe) do |cmd, **_kwargs|
         expect(cmd).to include("sudo")
         expect(cmd).to include("--kek")
@@ -765,7 +762,7 @@ RSpec.describe StorageVolume do
     end
 
     it "builds and runs the init-metadata command without --kek for v2 config" do
-      allow(encrypted_vhost_v2_sv).to receive(:vhost_backend_kek).and_return("kek_content")
+      expect(encrypted_vhost_v2_sv).to receive(:vhost_backend_kek).and_return("kek_content")
       expect(encrypted_vhost_v2_sv).to receive(:run_with_kek_pipe) do |cmd, **_kwargs|
         expect(cmd).not_to include("--kek")
       end
@@ -934,12 +931,14 @@ RSpec.describe StorageVolume do
     end
 
     it "does nothing if the service is not loaded" do
-      allow(encrypted_vhost_sv).to receive(:r).and_raise(CommandFail.new("error", "", "Unit test-2-storage.service not loaded."))
-      expect { encrypted_vhost_sv.stop_service_if_loaded("test-2-storage.service") }.not_to raise_error
+      expect(encrypted_vhost_sv).to receive(:r).with("systemctl", "stop", "test-2-storage.service")
+        .and_raise(CommandFail.new("error", "", "Unit test-2-storage.service not loaded."))
+      encrypted_vhost_sv.stop_service_if_loaded("test-2-storage.service")
     end
 
     it "raises an error for unexpected command failures" do
-      allow(encrypted_vhost_sv).to receive(:r).and_raise(CommandFail.new("unexpected error", "some output", "Some error"))
+      expect(encrypted_vhost_sv).to receive(:r).with("systemctl", "stop", "test-2-storage.service")
+        .and_raise(CommandFail.new("unexpected error", "some output", "Some error"))
       expect { encrypted_vhost_sv.stop_service_if_loaded("test-2-storage.service") }.to raise_error(CommandFail, /unexpected error/)
     end
   end

--- a/rhizome/host/spec/vhost_block_backend_spec.rb
+++ b/rhizome/host/spec/vhost_block_backend_spec.rb
@@ -3,39 +3,38 @@
 require_relative "../lib/vhost_block_backend"
 
 RSpec.describe VhostBlockBackend do
+  let(:v031) { described_class.new("v0.3.1") }
+  let(:v042) { described_class.new("v0.4.2") }
+
   describe "#config_v2?" do
     it "returns true for v0.4.0 and later" do
-      expect(described_class.new("v0.4.0").config_v2?).to be true
-      expect(described_class.new("v0.4.2").config_v2?).to be true
+      expect(v042.config_v2?).to be true
     end
 
     it "returns false for versions before v0.4.0" do
-      expect(described_class.new("v0.3.1").config_v2?).to be false
-      expect(described_class.new("v0.2.2").config_v2?).to be false
+      expect(v031.config_v2?).to be false
     end
   end
 
   describe "#supports_archive?" do
     it "returns true for v0.4.0 and later" do
-      expect(described_class.new("v0.4.2").supports_archive?).to be true
+      expect(v042.supports_archive?).to be true
     end
 
     it "returns false for versions before v0.4.0" do
-      expect(described_class.new("v0.3.1").supports_archive?).to be false
+      expect(v031.supports_archive?).to be false
     end
   end
 
   describe "#sha256" do
     it "returns the sha256 for a known version and arch" do
       allow(Arch).to receive(:sym).and_return(:x64)
-      backend = described_class.new("v0.4.2")
-      expect(backend.sha256).to eq("e7e430f2e722a2d5d7c18a4f609360e003798d481e26da6db380e698ccb079eb")
+      expect(v042.sha256).to eq("e7e430f2e722a2d5d7c18a4f609360e003798d481e26da6db380e698ccb079eb")
     end
 
     it "returns the sha256 for arm64" do
       allow(Arch).to receive(:sym).and_return(:arm64)
-      backend = described_class.new("v0.4.2")
-      expect(backend.sha256).to eq("ada92fe076e49f731f5d343d445b1e80d7685b811c33cde7fe88918e93649093")
+      expect(v042.sha256).to eq("ada92fe076e49f731f5d343d445b1e80d7685b811c33cde7fe88918e93649093")
     end
 
     it "fails for an unsupported version" do
@@ -48,84 +47,77 @@ RSpec.describe VhostBlockBackend do
   describe "#url" do
     it "returns a tar.gz URL with ubiblk prefix for v0.4.0 and later" do
       allow(Arch).to receive(:sym).and_return(:x64)
-      backend = described_class.new("v0.4.2")
-      expect(backend.url).to eq("https://github.com/ubicloud/ubiblk/releases/download/v0.4.2/ubiblk-x64.tar.gz")
+      expect(v042.url).to eq("https://github.com/ubicloud/ubiblk/releases/download/v0.4.2/ubiblk-x64.tar.gz")
     end
 
     it "returns a vhost-backend URL for versions before v0.4.0" do
       allow(Arch).to receive(:sym).and_return(:x64)
-      backend = described_class.new("v0.3.1")
-      expect(backend.url).to eq("https://github.com/ubicloud/ubiblk/releases/download/v0.3.1/vhost-backend-x64.tar.gz")
+      expect(v031.url).to eq("https://github.com/ubicloud/ubiblk/releases/download/v0.3.1/vhost-backend-x64.tar.gz")
     end
 
     it "uses the correct arch in the URL" do
       allow(Arch).to receive(:sym).and_return(:arm64)
-      backend = described_class.new("v0.4.2")
-      expect(backend.url).to include("arm64")
+      expect(v042.url).to eq("https://github.com/ubicloud/ubiblk/releases/download/v0.4.2/ubiblk-arm64.tar.gz")
     end
   end
 
   describe "#dir" do
     it "returns the versioned install directory" do
-      backend = described_class.new("v0.4.2")
-      expect(backend.dir).to eq("/opt/vhost-block-backend/v0.4.2")
+      expect(v042.dir).to eq("/opt/vhost-block-backend/v0.4.2")
     end
   end
 
   describe "#bin_path" do
     it "returns path to vhost-backend binary" do
-      backend = described_class.new("v0.4.2")
-      expect(backend.bin_path).to eq("/opt/vhost-block-backend/v0.4.2/vhost-backend")
+      expect(v042.bin_path).to eq("/opt/vhost-block-backend/v0.4.2/vhost-backend")
     end
   end
 
   describe "#init_metadata_path" do
     it "returns path to init-metadata binary" do
-      backend = described_class.new("v0.4.2")
-      expect(backend.init_metadata_path).to eq("/opt/vhost-block-backend/v0.4.2/init-metadata")
+      expect(v042.init_metadata_path).to eq("/opt/vhost-block-backend/v0.4.2/init-metadata")
     end
   end
 
   describe "#archive_path" do
     it "returns path to archive binary" do
-      backend = described_class.new("v0.4.2")
-      expect(backend.archive_path).to eq("/opt/vhost-block-backend/v0.4.2/archive")
+      expect(v042.archive_path).to eq("/opt/vhost-block-backend/v0.4.2/archive")
     end
   end
 
   describe "#dump_metadata_path" do
     it "returns path to dump-metadata binary" do
-      backend = described_class.new("v0.4.2")
-      expect(backend.dump_metadata_path).to eq("/opt/vhost-block-backend/v0.4.2/dump-metadata")
+      expect(v042.dump_metadata_path).to eq("/opt/vhost-block-backend/v0.4.2/dump-metadata")
     end
   end
 
   describe "#download" do
-    let(:backend) { described_class.new("v0.4.2") }
     let(:dir) { "/opt/vhost-block-backend/v0.4.2" }
     let(:temp_tarball) { "/tmp/vhost-backend-v0.4.2.tar.gz" }
 
     before do
       allow(Arch).to receive(:sym).and_return(:x64)
+      expect(v042).to receive(:puts)
+        .with("Downloading ubiblk package from https://github.com/ubicloud/ubiblk/releases/download/v0.4.2/ubiblk-x64.tar.gz")
     end
 
     it "downloads, extracts, and removes the tarball" do
-      expect(backend).to receive(:curl_file)
+      expect(v042).to receive(:curl_file)
         .with("https://github.com/ubicloud/ubiblk/releases/download/v0.4.2/ubiblk-x64.tar.gz", temp_tarball)
         .and_return("e7e430f2e722a2d5d7c18a4f609360e003798d481e26da6db380e698ccb079eb")
       expect(FileUtils).to receive(:mkdir_p).with(dir)
       expect(FileUtils).to receive(:cd).with(dir).and_yield
-      expect(backend).to receive(:r).with("tar -xzf #{temp_tarball}")
+      expect(v042).to receive(:r).with("tar -xzf #{temp_tarball}")
       expect(FileUtils).to receive(:rm_f).with(temp_tarball)
 
-      backend.download
+      v042.download
     end
 
     it "raises an error if the SHA-256 digest is incorrect" do
-      expect(backend).to receive(:curl_file).and_return("wrongsha256")
+      expect(v042).to receive(:curl_file).and_return("wrongsha256")
       # mkdir_p, cd, r are NOT called when sha256 fails immediately after download
       expect(FileUtils).not_to receive(:mkdir_p)
-      expect { backend.download }.to raise_error("Invalid SHA-256 digest")
+      expect { v042.download }.to raise_error("Invalid SHA-256 digest")
     end
   end
 end

--- a/rhizome/host/spec/vhost_block_backend_spec.rb
+++ b/rhizome/host/spec/vhost_block_backend_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require_relative "../lib/vhost_block_backend"
+
+RSpec.describe VhostBlockBackend do
+  describe "#config_v2?" do
+    it "returns true for v0.4.0 and later" do
+      expect(described_class.new("v0.4.0").config_v2?).to be true
+      expect(described_class.new("v0.4.2").config_v2?).to be true
+    end
+
+    it "returns false for versions before v0.4.0" do
+      expect(described_class.new("v0.3.1").config_v2?).to be false
+      expect(described_class.new("v0.2.2").config_v2?).to be false
+    end
+  end
+
+  describe "#supports_archive?" do
+    it "returns true for v0.4.0 and later" do
+      expect(described_class.new("v0.4.2").supports_archive?).to be true
+    end
+
+    it "returns false for versions before v0.4.0" do
+      expect(described_class.new("v0.3.1").supports_archive?).to be false
+    end
+  end
+
+  describe "#sha256" do
+    it "returns the sha256 for a known version and arch" do
+      allow(Arch).to receive(:sym).and_return(:x64)
+      backend = described_class.new("v0.4.2")
+      expect(backend.sha256).to eq("e7e430f2e722a2d5d7c18a4f609360e003798d481e26da6db380e698ccb079eb")
+    end
+
+    it "returns the sha256 for arm64" do
+      allow(Arch).to receive(:sym).and_return(:arm64)
+      backend = described_class.new("v0.4.2")
+      expect(backend.sha256).to eq("ada92fe076e49f731f5d343d445b1e80d7685b811c33cde7fe88918e93649093")
+    end
+
+    it "fails for an unsupported version" do
+      allow(Arch).to receive(:sym).and_return(:x64)
+      backend = described_class.new("v9.9.9")
+      expect { backend.sha256 }.to raise_error(/Unsupported version/)
+    end
+  end
+
+  describe "#url" do
+    it "returns a tar.gz URL with ubiblk prefix for v0.4.0 and later" do
+      allow(Arch).to receive(:sym).and_return(:x64)
+      backend = described_class.new("v0.4.2")
+      expect(backend.url).to eq("https://github.com/ubicloud/ubiblk/releases/download/v0.4.2/ubiblk-x64.tar.gz")
+    end
+
+    it "returns a vhost-backend URL for versions before v0.4.0" do
+      allow(Arch).to receive(:sym).and_return(:x64)
+      backend = described_class.new("v0.3.1")
+      expect(backend.url).to eq("https://github.com/ubicloud/ubiblk/releases/download/v0.3.1/vhost-backend-x64.tar.gz")
+    end
+
+    it "uses the correct arch in the URL" do
+      allow(Arch).to receive(:sym).and_return(:arm64)
+      backend = described_class.new("v0.4.2")
+      expect(backend.url).to include("arm64")
+    end
+  end
+
+  describe "#dir" do
+    it "returns the versioned install directory" do
+      backend = described_class.new("v0.4.2")
+      expect(backend.dir).to eq("/opt/vhost-block-backend/v0.4.2")
+    end
+  end
+
+  describe "#bin_path" do
+    it "returns path to vhost-backend binary" do
+      backend = described_class.new("v0.4.2")
+      expect(backend.bin_path).to eq("/opt/vhost-block-backend/v0.4.2/vhost-backend")
+    end
+  end
+
+  describe "#init_metadata_path" do
+    it "returns path to init-metadata binary" do
+      backend = described_class.new("v0.4.2")
+      expect(backend.init_metadata_path).to eq("/opt/vhost-block-backend/v0.4.2/init-metadata")
+    end
+  end
+
+  describe "#archive_path" do
+    it "returns path to archive binary" do
+      backend = described_class.new("v0.4.2")
+      expect(backend.archive_path).to eq("/opt/vhost-block-backend/v0.4.2/archive")
+    end
+  end
+
+  describe "#dump_metadata_path" do
+    it "returns path to dump-metadata binary" do
+      backend = described_class.new("v0.4.2")
+      expect(backend.dump_metadata_path).to eq("/opt/vhost-block-backend/v0.4.2/dump-metadata")
+    end
+  end
+
+  describe "#download" do
+    let(:backend) { described_class.new("v0.4.2") }
+    let(:dir) { "/opt/vhost-block-backend/v0.4.2" }
+    let(:temp_tarball) { "/tmp/vhost-backend-v0.4.2.tar.gz" }
+
+    before do
+      allow(Arch).to receive(:sym).and_return(:x64)
+    end
+
+    it "downloads, extracts, and removes the tarball" do
+      expect(backend).to receive(:curl_file)
+        .with("https://github.com/ubicloud/ubiblk/releases/download/v0.4.2/ubiblk-x64.tar.gz", temp_tarball)
+        .and_return("e7e430f2e722a2d5d7c18a4f609360e003798d481e26da6db380e698ccb079eb")
+      expect(FileUtils).to receive(:mkdir_p).with(dir)
+      expect(FileUtils).to receive(:cd).with(dir).and_yield
+      expect(backend).to receive(:r).with("tar -xzf #{temp_tarball}")
+      expect(FileUtils).to receive(:rm_f).with(temp_tarball)
+
+      backend.download
+    end
+
+    it "raises an error if the SHA-256 digest is incorrect" do
+      expect(backend).to receive(:curl_file).and_return("wrongsha256")
+      # mkdir_p, cd, r are NOT called when sha256 fails immediately after download
+      expect(FileUtils).not_to receive(:mkdir_p)
+      expect { backend.download }.to raise_error("Invalid SHA-256 digest")
+    end
+  end
+end

--- a/rhizome/host/spec/vm_path_spec.rb
+++ b/rhizome/host/spec/vm_path_spec.rb
@@ -5,6 +5,10 @@ require_relative "../lib/vm_path"
 RSpec.describe VmPath do
   subject(:vp) { described_class.new("test'vm") }
 
+  it ".define_new_method raises if the method is already defined" do
+    expect { described_class.define_new_method(:inspect) {} }.to raise_error(RuntimeError, "BUG")
+  end
+
   it "can compute a path" do
     expect(vp.guest_ephemeral).to eq("/vm/test'vm/guest_ephemeral")
   end

--- a/rhizome/host/spec/vm_path_spec.rb
+++ b/rhizome/host/spec/vm_path_spec.rb
@@ -33,4 +33,44 @@ RSpec.describe VmPath do
       vp.write_serial_log("test content\n")
     end
   end
+
+  describe "#systemd_service" do
+    it "returns escaped systemd service path" do
+      expect(IO).to receive(:popen).with(["systemd-escape", "test'vm.service"]).and_yield(StringIO.new("test\\x27vm.service\n"))
+      expect(vp.systemd_service).to eq("/etc/systemd/system/test\\x27vm.service")
+    end
+  end
+
+  describe "#write_systemd_service" do
+    it "writes to the escaped systemd service path" do
+      expect(IO).to receive(:popen).with(["systemd-escape", "test'vm.service"]).and_yield(StringIO.new("test\\x27vm.service\n"))
+      expect(File).to receive(:write).with("/etc/systemd/system/test\\x27vm.service", "unit content\n")
+      vp.write_systemd_service("unit content")
+    end
+  end
+
+  describe "#dnsmasq_service" do
+    it "returns dnsmasq service path" do
+      expect(vp.dnsmasq_service).to eq("/etc/systemd/system/test'vm-dnsmasq.service")
+    end
+  end
+
+  describe "#write_dnsmasq_service" do
+    it "writes to the dnsmasq service path" do
+      expect(File).to receive(:write).with("/etc/systemd/system/test'vm-dnsmasq.service", "dnsmasq content\n")
+      vp.write_dnsmasq_service("dnsmasq content")
+    end
+  end
+
+  describe "#write_yaml_*" do
+    it "serializes data to YAML and writes it" do
+      expect(File).to receive(:write).with(vp.meta_data, satisfy { |s| s.include?("key: value") })
+      vp.write_yaml_meta_data({"key" => "value"})
+    end
+
+    it "replaces the leading --- with the given prefix" do
+      expect(File).to receive(:write).with(vp.user_data, satisfy { |s| s.start_with?("#cloud-config\n") })
+      vp.write_yaml_user_data({"key" => "value"}, prefix: "#cloud-config")
+    end
+  end
 end

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -256,63 +256,6 @@ RSpec.describe VmSetup do
     end
   end
 
-  describe "#purge_storage" do
-    let(:vol_1_params) {
-      {
-        "size_gib" => 20,
-        "device_id" => "test_0",
-        "disk_index" => 0,
-        "encrypted" => false,
-        "spdk_version" => "some-version",
-      }
-    }
-    let(:vol_2_params) {
-      {
-        "size_gib" => 20,
-        "device_id" => "test_1",
-        "disk_index" => 1,
-        "encrypted" => true,
-        "spdk_version" => "some-version",
-      }
-    }
-    let(:vol_3_params) {
-      {
-        "size_gib" => 0,
-        "device_id" => "test_2",
-        "disk_index" => 2,
-        "encrypted" => false,
-        "read_only" => true,
-      }
-    }
-    let(:params) {
-      JSON.generate({storage_volumes: [vol_1_params, vol_2_params, vol_3_params]})
-    }
-
-    it "can purge storage" do
-      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
-      expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
-
-      # delete the unencrypted volume
-      sv_1 = instance_double(StorageVolume)
-      expect(StorageVolume).to receive(:new).with("test", vol_1_params).and_return(sv_1)
-      expect(sv_1).to receive(:purge_spdk_artifacts)
-      expect(sv_1).to receive(:storage_root).and_return("/var/storage/test")
-
-      # delete the encrypted volume
-      sv_2 = instance_double(StorageVolume)
-      expect(StorageVolume).to receive(:new).with("test", vol_2_params).and_return(sv_2)
-      expect(sv_2).to receive(:purge_spdk_artifacts)
-      expect(sv_2).to receive(:storage_root).and_return("/var/storage/test")
-
-      vs.purge_storage
-    end
-
-    it "exits silently if vm hasn't been created yet" do
-      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(false)
-      expect { vs.purge_storage }.not_to raise_error
-    end
-  end
-
   describe "#purge" do
     it "can purge" do
       expect(vs).to receive(:r).with("ip netns del test")
@@ -859,6 +802,61 @@ NFTABLES_CONF
   end
 
   describe "#purge_storage" do
+    let(:vol_1_params) {
+      {
+        "size_gib" => 20,
+        "device_id" => "test_0",
+        "disk_index" => 0,
+        "encrypted" => false,
+        "spdk_version" => "some-version",
+      }
+    }
+    let(:vol_2_params) {
+      {
+        "size_gib" => 20,
+        "device_id" => "test_1",
+        "disk_index" => 1,
+        "encrypted" => true,
+        "spdk_version" => "some-version",
+      }
+    }
+    let(:vol_3_params) {
+      {
+        "size_gib" => 0,
+        "device_id" => "test_2",
+        "disk_index" => 2,
+        "encrypted" => false,
+        "read_only" => true,
+      }
+    }
+    let(:params) {
+      JSON.generate({storage_volumes: [vol_1_params, vol_2_params, vol_3_params]})
+    }
+
+    it "can purge storage" do
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
+      expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
+
+      # delete the unencrypted volume
+      sv_1 = instance_double(StorageVolume)
+      expect(StorageVolume).to receive(:new).with("test", vol_1_params).and_return(sv_1)
+      expect(sv_1).to receive(:purge_spdk_artifacts)
+      expect(sv_1).to receive(:storage_root).and_return("/var/storage/test")
+
+      # delete the encrypted volume
+      sv_2 = instance_double(StorageVolume)
+      expect(StorageVolume).to receive(:new).with("test", vol_2_params).and_return(sv_2)
+      expect(sv_2).to receive(:purge_spdk_artifacts)
+      expect(sv_2).to receive(:storage_root).and_return("/var/storage/test")
+
+      vs.purge_storage
+    end
+
+    it "exits silently if vm hasn't been created yet" do
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(false)
+      expect { vs.purge_storage }.not_to raise_error
+    end
+
     it "calls fmpm when gpu_partition_id is present" do
       params = JSON.generate({
         "gpu_partition_id" => "gpu-partition-123",
@@ -993,7 +991,7 @@ NFTABLES_CONF
 
   describe "#no_valid_ch_version / #no_valid_firmware_version" do
     it "raises when no valid cloud hypervisor version is given" do
-      expect { VmSetup.new("test", ch_version: "nonexistent-version") }.to raise_error("no valid cloud hypervisor version")
+      expect { described_class.new("test", ch_version: "nonexistent-version") }.to raise_error("no valid cloud hypervisor version")
     end
 
     it "raises when no valid firmware version is given" do

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../lib/vm_setup"
-require "openssl"
-require "base64"
 
 RSpec.describe VmSetup do
   mock_vm_path = Class.new(VmPath) do
@@ -29,17 +27,6 @@ RSpec.describe VmSetup do
       end
     end.new("test")
   }
-
-  def key_wrapping_secrets
-    key_wrapping_algorithm = "aes-256-gcm"
-    cipher = OpenSSL::Cipher.new(key_wrapping_algorithm)
-    {
-      "key" => Base64.encode64(cipher.random_key),
-      "init_vector" => Base64.encode64(cipher.random_iv),
-      "algorithm" => key_wrapping_algorithm,
-      "auth_data" => "Ubicloud-Test-Auth",
-    }
-  end
 
   it "can halve an IPv6 network" do
     lower, upper = vs.subdivide_network(NetAddr.parse_net("2a01:4f9:2b:35b:7e40::/79"))
@@ -260,6 +247,13 @@ RSpec.describe VmSetup do
       config = YAML.safe_load(vps.writes["network-config"])
       expect(config["ethernets"].keys).to contain_exactly("enx3ebda596f7b9", "enxfb55ddba210a")
     end
+
+    it "uses nth(1) for DHCP range when nic net4 is not /32" do
+      non_slash32_nics = [VmSetup::Nic.new("fd48:666c:a296:ce4b:2cc6::/79", "192.168.1.0/24", "nctest", "3e:bd:a5:96:f7:b9", "10.0.0.254/32")]
+      vs.cloudinit("user", ["key"], "fddf:53d2:4c89:2305:46a0::/79", non_slash32_nics, nil, "ubuntu-noble", "10.0.0.2", ipv6_disabled: false)
+      dnsmasq_conf = vps.writes["dnsmasq.conf"]
+      expect(dnsmasq_conf).to include("dhcp-range=nctest,192.168.1.1,192.168.1.1,6h")
+    end
   end
 
   describe "#purge_storage" do
@@ -336,6 +330,12 @@ RSpec.describe VmSetup do
   end
 
   describe "#unmount_hugepages" do
+    it "returns early when hugepages is disabled" do
+      vs.instance_variable_set(:@hugepages, false)
+      expect(vs).not_to receive(:r)
+      vs.unmount_hugepages
+    end
+
     it "can unmount hugepages" do
       expect(vs).to receive(:r).with("umount /vm/test/hugepages")
       vs.unmount_hugepages
@@ -510,6 +510,10 @@ RSpec.describe VmSetup do
       }
     end
 
+    it "raises BUG when cpu_topology contains special characters" do
+      expect { vs.send(:install_systemd_unit, 2, '"1:1:1:2"', 2, [], [], [], "system.slice", 0) }.to raise_error("BUG")
+    end
+
     it "adds topoext when CPU vendor is AMD" do
       vs.instance_variable_set(:@hypervisor, "qemu")
 
@@ -539,6 +543,13 @@ RSpec.describe VmSetup do
       expect(vs).to receive(:enable_bursting).with("some_slice.slice", 50)
 
       vs.restart("some_slice.slice", 50)
+    end
+
+    it "skips enable_bursting when cpu_burst_percent_limit is 0" do
+      expect(vs).to receive(:restart_systemd_unit)
+      expect(vs).not_to receive(:enable_bursting)
+
+      vs.restart("some_slice.slice", 0)
     end
   end
 
@@ -626,6 +637,40 @@ RSpec.describe VmSetup do
       vs.setup_networking(true, gua, "", "local_ip4", [], false, "10.0.0.2", multiqueue: false)
     end
 
+    it "writes ephemeral addresses when not skip_persisted and ip4 is empty" do
+      vps = mock_vm_path.new("test")
+      allow(vs).to receive(:vp).and_return(vps)
+      gua = "fddf:53d2:4c89:2305:46a0::"
+
+      expect(vs).to receive(:interfaces).with([], false)
+      expect(vs).to receive(:setup_veths_6)
+      expect(vs).to receive(:setup_taps_6).with(gua, [], "10.0.0.2")
+      expect(vs).to receive(:routes4).with(nil, "local_ip4", [])
+      expect(vs).to receive(:forwarding)
+      expect(vs).to receive(:write_nftables_conf)
+
+      vs.setup_networking(false, gua, "", "local_ip4", [], false, "10.0.0.2", multiqueue: false)
+
+      expect(vps.writes["guest_ephemeral"]).to eq("fddf:53d2:4c89:2305::/65\n")
+      expect(vps.writes["clover_ephemeral"]).to eq("fddf:53d2:4c89:2305:8000::/65\n")
+    end
+
+    it "skips unblock_ip4 when not skip_persisted but ip4 is empty" do
+      vps = instance_spy(VmPath)
+      allow(vs).to receive(:vp).and_return(vps)
+      gua = "fddf:53d2:4c89:2305:46a0::"
+
+      expect(vs).not_to receive(:unblock_ip4)
+      expect(vs).to receive(:interfaces).with([], false)
+      expect(vs).to receive(:setup_veths_6)
+      expect(vs).to receive(:setup_taps_6).with(gua, [], "10.0.0.2")
+      expect(vs).to receive(:routes4).with(nil, "local_ip4", [])
+      expect(vs).to receive(:forwarding)
+      expect(vs).to receive(:write_nftables_conf)
+
+      vs.setup_networking(false, gua, "", "local_ip4", [], false, "10.0.0.2", multiqueue: false)
+    end
+
     it "can generate nftables config" do
       vps = instance_spy(VmPath)
       expect(vs).to receive(:vp).and_return(vps).at_least(:once)
@@ -698,6 +743,12 @@ NFTABLES_CONF
   end
 
   describe "#hugepages" do
+    it "returns early when hugepages is disabled" do
+      vs.instance_variable_set(:@hugepages, false)
+      expect(FileUtils).not_to receive(:mkdir_p)
+      vs.hugepages(2)
+    end
+
     it "can setup hugepages" do
       expect(FileUtils).to receive(:mkdir_p).with("/vm/test/hugepages")
       expect(FileUtils).to receive(:chown).with("test", "test", "/vm/test/hugepages")
@@ -749,6 +800,525 @@ NFTABLES_CONF
     end
   end
 
+  describe "#parse_routes" do
+    it "returns the device of the default route" do
+      routes = JSON.generate([{"dst" => "default", "dev" => "eth0"}, {"dst" => "10.0.0.0/8", "dev" => "eth1"}])
+      expect(vs.parse_routes(routes)).to eq("eth0")
+    end
+
+    it "raises when no default route is found" do
+      routes = JSON.generate([{"dst" => "10.0.0.0/8", "dev" => "eth1"}])
+      expect { vs.parse_routes(routes) }.to raise_error(/No default route found/)
+    end
+  end
+
+  describe "#purge_network" do
+    it "ignores 'no such file or directory' error when deleting netns" do
+      expect(vs).to receive(:block_ip4)
+      expect(vs).to receive(:r).with("ip netns del test").and_raise(
+        CommandFail.new("err", "", 'Cannot remove namespace file "/var/run/netns/test": No such file or directory'),
+      )
+      expect { vs.purge_network }.not_to raise_error
+    end
+
+    it "re-raises unexpected errors when deleting netns" do
+      expect(vs).to receive(:block_ip4)
+      expect(vs).to receive(:r).with("ip netns del test").and_raise(
+        CommandFail.new("err", "", "some unexpected error"),
+      )
+      expect { vs.purge_network }.to raise_error(CommandFail)
+    end
+  end
+
+  describe "#purge_without_network" do
+    it "removes service files, reloads daemon, purges storage and hugepages" do
+      expect(IO).to receive(:popen).with(["systemd-escape", "test.service"]).and_yield(StringIO.new("test.service\n"))
+      expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test.service")
+      expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-dnsmasq.service")
+      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:purge_storage)
+      expect(vs).to receive(:unmount_hugepages)
+      vs.purge_without_network
+    end
+  end
+
+  describe "#purge_user" do
+    it "silently ignores 'user does not exist' error" do
+      expect(vs).to receive(:r).with("deluser --remove-home test").and_raise(
+        CommandFail.new("err", "", "The user `test' does not exist."),
+      )
+      expect { vs.purge_user }.not_to raise_error
+    end
+
+    it "re-raises unexpected deluser errors" do
+      expect(vs).to receive(:r).with("deluser --remove-home test").and_raise(
+        CommandFail.new("err", "", "some unexpected error"),
+      )
+      expect { vs.purge_user }.to raise_error(CommandFail)
+    end
+  end
+
+  describe "#purge_storage" do
+    it "calls fmpm when gpu_partition_id is present" do
+      params = JSON.generate({
+        "gpu_partition_id" => "gpu-partition-123",
+        "storage_volumes" => [],
+      })
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
+      expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
+      expect(vs).to receive(:r).with("/usr/bin/fmpm -d gpu-partition-123", expect: [0, 238])
+      vs.purge_storage
+    end
+  end
+
+  describe "#setup_veths_6" do
+    let(:guest_ephemeral) { NetAddr.parse_net("fddf:53d2:4c89:2305::/65") }
+    let(:clover_ephemeral) { NetAddr.parse_net("fddf:53d2:4c89:2305:8000::/65") }
+    let(:gua) { "fddf:53d2:4c89:2305:46a0::/79" }
+
+    before do
+      allow(vs).to receive(:r).and_return("")
+      allow(File).to receive(:read).and_call_original
+    end
+
+    it "sets up veths without ndp" do
+      expect(vs).to receive(:r).with("ip netns exec test cat /sys/class/net/vethitest/address").and_return("3e:bd:a5:96:f7:b9\n")
+      expect(File).to receive(:read).with("/sys/class/net/vethotest/address").and_return("3e:bd:a5:96:f7:b9\n")
+      expect(vs).to receive(:r).with("ip link set dev vethotest up")
+      expect(vs).to receive(:r).with(/ip route replace .*vethotest/)
+      expect(vs).to receive(:r).with(/ip -n test addr replace.*vethitest/)
+      expect(vs).to receive(:r).with("ip -n test link set dev vethitest up")
+      expect(vs).to receive(:r).with(/ip -n test route replace 2000::\/3.*vethitest/)
+      vs.setup_veths_6(guest_ephemeral, clover_ephemeral, gua, false)
+    end
+
+    it "sets up ndp proxy routes when ndp_needed is true" do
+      expect(vs).to receive(:r).with("ip netns exec test cat /sys/class/net/vethitest/address").and_return("3e:bd:a5:96:f7:b9\n")
+      expect(File).to receive(:read).with("/sys/class/net/vethotest/address").and_return("3e:bd:a5:96:f7:b9\n")
+      allow(vs).to receive(:r).and_return("")
+      routes = JSON.generate([{"dst" => "default", "dev" => "eth0"}])
+      expect(vs).to receive(:r).with("ip -j route").and_return(routes)
+      expect(vs).to receive(:r).with(/ip -6 neigh add proxy.*eth0/)
+      vs.setup_veths_6(guest_ephemeral, clover_ephemeral, gua, true)
+    end
+  end
+
+  describe "#setup_taps_6" do
+    it "sets up tap routes for each NIC" do
+      gua = "fddf:53d2:4c89:2305:46a0::/79"
+      nics = [VmSetup::Nic.new("fd48:666c:a296:ce4b:2cc6::/79", "192.168.5.50/32", "nctest", "3e:bd:a5:96:f7:b9", "10.0.0.254/32")]
+      allow(vs).to receive(:r).and_return("")
+      expect(vs).to receive(:r).with(/ip -n test addr replace.*nctest/).at_least(:once)
+      expect(vs).to receive(:r).with(/ip -n test link set dev nctest up/)
+      vs.setup_taps_6(gua, nics, "10.0.0.2")
+    end
+  end
+
+  describe "#routes4" do
+    let(:nics) { [VmSetup::Nic.new(nil, nil, "nctest", nil, nil)] }
+
+    it "sets up routes with ip4" do
+      # With ip4="10.0.0.2/32" and ip4_local="10.0.0.0/31":
+      #   vm = "10.0.0.2/32", vetho = "10.0.0.0", vethi = "10.0.0.2"
+      allow(vs).to receive(:r).and_return("")
+      expect(vs).to receive(:r).with("ip addr replace 10.0.0.0/32 dev vethotest")
+      expect(vs).to receive(:r).with("ip route replace 10.0.0.2/32 dev vethotest")
+      expect(vs).to receive(:r).with("echo 1 > /proc/sys/net/ipv4/conf/vethotest/proxy_arp")
+      expect(vs).to receive(:r).with("ip -n test addr replace 10.0.0.2/32 dev vethitest")
+      expect(vs).to receive(:r).with("ip -n test route replace 10.0.0.0 dev vethitest")
+      expect(vs).to receive(:r).with("ip -n test route replace 10.0.0.2/32 dev nctest")
+      expect(vs).to receive(:r).with("ip -n test route replace default via 10.0.0.0 dev vethitest")
+      expect(vs).to receive(:r).with(/ip netns exec test.*proxy_arp/).twice
+      vs.routes4("10.0.0.2/32", "10.0.0.0/31", nics)
+    end
+
+    it "skips ip4 route when ip4 is nil" do
+      allow(vs).to receive(:r).and_return("")
+      expect(vs).not_to receive(:r).with(/ip route replace .* dev vethotest/)
+      vs.routes4(nil, "10.0.0.1/31", nics)
+    end
+  end
+
+  describe "#update_via_routes" do
+    it "returns immediately for /32 prefix nics" do
+      nics = [VmSetup::Nic.new(nil, "10.0.0.1/32", "nctest", nil, nil)]
+      expect(vs).not_to receive(:r)
+      vs.update_via_routes(nics)
+    end
+
+    it "updates routes for non-/32 nics when tap is ready" do
+      nics = [VmSetup::Nic.new(nil, "10.0.0.0/30", "nctest", nil, nil)]
+      expect(vs).to receive(:r).with(/ip -n test link | grep.*UP.*echo UP || echo DOWN/).and_return("UP\n")
+      expect(vs).to receive(:r).with(/ip -n test route replace.*10.0.0.0\/30.*10.0.0.1.*nctest/)
+      vs.update_via_routes(nics)
+    end
+
+    it "raises when tap never becomes ready" do
+      nics = [VmSetup::Nic.new(nil, "10.0.0.0/30", "nctest", nil, nil)]
+      allow(vs).to receive(:r).and_return("DOWN\n")
+      allow(vs).to receive(:sleep)
+      expect { vs.update_via_routes(nics) }.to raise_error(/tap device not ready/)
+    end
+
+    it "skips route update for /32 nics when mixed with non-/32 nics" do
+      nics = [
+        VmSetup::Nic.new(nil, "10.0.0.0/30", "nctest1", nil, nil),
+        VmSetup::Nic.new(nil, "10.0.0.5/32", "nctest2", nil, nil),
+      ]
+      allow(vs).to receive(:r).with(/ip -n test link/).and_return("UP\n")
+      expect(vs).to receive(:r).with(/ip -n test route replace 10.0.0.0\/30/)
+      expect(vs).not_to receive(:r).with(/ip -n test route replace 10.0.0.5/)
+      vs.update_via_routes(nics)
+    end
+  end
+
+  describe "#prepare_gpus" do
+    it "resets PCI devices ending in .0 and chowns vfio groups" do
+      pci_devices = [["00:00.0", "1"], ["00:00.1", "2"]]
+      expect(vs).to receive(:r).with("echo 1 > /sys/bus/pci/devices/0000:00:00.0/reset")
+      expect(vs).to receive(:r).with("chown test:test /sys/kernel/iommu_groups/1 /dev/vfio/1")
+      vs.prepare_gpus(pci_devices, nil)
+    end
+
+    it "calls fmpm with gpu_partition_id when present" do
+      expect(vs).to receive(:r).with("/usr/bin/fmpm -a gp1", expect: [0, 239])
+      vs.prepare_gpus([], "gp1")
+    end
+
+    it "does nothing when pci_devices is empty and no gpu_partition_id" do
+      expect(vs).not_to receive(:r)
+      vs.prepare_gpus([], nil)
+    end
+  end
+
+  describe "#no_valid_ch_version / #no_valid_firmware_version" do
+    it "raises when no valid cloud hypervisor version is given" do
+      expect { VmSetup.new("test", ch_version: "nonexistent-version") }.to raise_error("no valid cloud hypervisor version")
+    end
+
+    it "raises when no valid firmware version is given" do
+      # Bypass ch_version check by overriding no_valid_ch_version to return nil
+      klass = Class.new(VmSetup) do
+        def no_valid_ch_version
+          nil
+        end
+      end
+      expect { klass.new("test", firmware_version: "nonexistent-fw") }.to raise_error("no valid cloud hypervisor firmware version")
+    end
+  end
+
+  describe "#prep" do
+    it "calls all setup steps in parallel threads" do
+      expect(vs).to receive(:cloudinit)
+      expect(vs).to receive(:setup_networking)
+      expect(vs).to receive(:storage)
+      expect(vs).to receive(:hugepages)
+      expect(vs).to receive(:prepare_gpus)
+      expect(vs).to receive(:install_systemd_unit)
+      expect(vs).to receive(:start_systemd_unit)
+      expect(vs).to receive(:update_via_routes)
+      expect(vs).to receive(:enable_bursting).with("some.slice", 100)
+
+      vs.prep(
+        "user", ["key"],
+        [VmSetup::Nic.new("fd00::/64", "10.0.0.1/32", "tap0", "02:aa:bb:cc:dd:01", "10.0.0.254/32")],
+        "fddf::/79", "10.0.0.1/32", "10.0.0.0/31", 2, "1:1:1:2", 4,
+        false, [], {}, nil, [], "ubuntu-noble", "10.0.0.2", "some.slice", 50, 100, nil, false, nil,
+      )
+    end
+
+    it "skips enable_bursting when cpu_burst_percent_limit is 0" do
+      expect(vs).to receive(:cloudinit)
+      expect(vs).to receive(:setup_networking)
+      expect(vs).to receive(:storage)
+      expect(vs).to receive(:hugepages)
+      expect(vs).to receive(:prepare_gpus)
+      expect(vs).to receive(:install_systemd_unit)
+      expect(vs).to receive(:start_systemd_unit)
+      expect(vs).to receive(:update_via_routes)
+      expect(vs).not_to receive(:enable_bursting)
+
+      vs.prep(
+        "user", ["key"],
+        [VmSetup::Nic.new("fd00::/64", "10.0.0.1/32", "tap0", "02:aa:bb:cc:dd:01", "10.0.0.254/32")],
+        "fddf::/79", "10.0.0.1/32", "10.0.0.0/31", 2, "1:1:1:2", 4,
+        false, [], {}, nil, [], "ubuntu-noble", "10.0.0.2", "some.slice", 50, 0, nil, false, nil,
+      )
+    end
+  end
+
+  describe "#reassign_ip6" do
+    it "calls all setup steps sequentially" do
+      expect(vs).to receive(:cloudinit)
+      expect(vs).to receive(:setup_networking)
+      expect(vs).to receive(:hugepages)
+      expect(vs).to receive(:storage)
+      expect(vs).to receive(:install_systemd_unit)
+      expect(vs).to receive(:start_systemd_unit)
+      expect(vs).to receive(:update_via_routes)
+      expect(vs).to receive(:enable_bursting).with("s.slice", 50)
+
+      vs.reassign_ip6(
+        "user", ["key"],
+        [VmSetup::Nic.new("fd00::/64", "10.0.0.1/32", "tap0", "02:aa:bb:cc:dd:01", "10.0.0.254/32")],
+        "fddf::/79", "10.0.0.1/32", "10.0.0.0/31", 2, "1:1:1:2", 4,
+        false, [], {}, nil, [], "ubuntu-noble", "10.0.0.2", "s.slice", 50, 50, false, nil,
+      )
+    end
+
+    it "skips enable_bursting when cpu_burst_percent_limit is 0" do
+      expect(vs).to receive(:cloudinit)
+      expect(vs).to receive(:setup_networking)
+      expect(vs).to receive(:hugepages)
+      expect(vs).to receive(:storage)
+      expect(vs).to receive(:install_systemd_unit)
+      expect(vs).to receive(:start_systemd_unit)
+      expect(vs).to receive(:update_via_routes)
+      expect(vs).not_to receive(:enable_bursting)
+
+      vs.reassign_ip6(
+        "user", ["key"],
+        [VmSetup::Nic.new("fd00::/64", "10.0.0.1/32", "tap0", "02:aa:bb:cc:dd:01", "10.0.0.254/32")],
+        "fddf::/79", "10.0.0.1/32", "10.0.0.0/31", 2, "1:1:1:2", 4,
+        false, [], {}, nil, [], "ubuntu-noble", "10.0.0.2", "s.slice", 50, 0, false, nil,
+      )
+    end
+  end
+
+  describe "#generate_nat4_rules" do
+    it "returns nil when ip4 is nil" do
+      expect(vs.send(:generate_nat4_rules, nil, "10.0.0.1/24")).to be_nil
+    end
+
+    it "uses nth(1) for non-/32 private_ip" do
+      result = vs.send(:generate_nat4_rules, "1.2.3.4/32", "192.168.1.0/24")
+      expect(result).to include("dnat to 192.168.1.1")
+    end
+  end
+
+  describe "#apply_nftables" do
+    it "flushes and reloads nftables in the vm netns" do
+      expect(vs).to receive(:r).with("ip netns exec test nft flush ruleset")
+      vps = instance_spy(VmPath, q_nftables_conf: "/vm/test/nftables.conf")
+      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:r).with("ip netns exec test nft -f /vm/test/nftables.conf")
+      vs.send(:apply_nftables)
+    end
+  end
+
+  describe "#forwarding" do
+    it "enables forwarding in the vm netns" do
+      expect(vs).to receive(:r).with("ip netns exec test sysctl -w net.ipv6.conf.all.forwarding=1")
+      expect(vs).to receive(:r).with("ip netns exec test sysctl -w net.ipv4.conf.all.forwarding=1")
+      expect(vs).to receive(:r).with("ip netns exec test sysctl -w net.ipv4.ip_forward=1")
+      vs.send(:forwarding)
+    end
+  end
+
+  describe "#cloudinit with special cases" do
+    let(:vps) { mock_vm_path.new("test") }
+    let(:nics) { [VmSetup::Nic.new("fd48:666c:a296:ce4b:2cc6::/79", "192.168.5.50/32", "nctest", "3e:bd:a5:96:f7:b9", "10.0.0.254/32")] }
+
+    before do
+      allow(vs).to receive(:vp).and_return(vps)
+      allow(vs).to receive(:write_user_data)
+      allow(vs).to receive(:r)
+      allow(FileUtils).to receive(:rm_rf)
+      allow(FileUtils).to receive(:chmod)
+      allow(FileUtils).to receive(:chown)
+    end
+
+    it "includes github runner dnsmasq address entries for github boot images" do
+      vs.cloudinit("user", ["key"], "fddf:53d2:4c89:2305:46a0::/79", nics, nil, "github-ubuntu-noble", "10.0.0.2", ipv6_disabled: false)
+      dnsmasq_conf = vps.writes["dnsmasq.conf"]
+      expect(dnsmasq_conf).to include("address=/ubicloudhostplaceholder.blob.core.windows.net/")
+      expect(dnsmasq_conf).to include("address=/.docker.io/::")
+    end
+
+    it "uses dhcp-option=6 dns config when ipv6 is disabled" do
+      vs.cloudinit("user", ["key"], "fddf:53d2:4c89:2305:46a0::/79", nics, nil, "ubuntu-noble", "10.0.0.2", ipv6_disabled: true)
+      dnsmasq_conf = vps.writes["dnsmasq.conf"]
+      expect(dnsmasq_conf).to include("dhcp-option=6,8.8.8.8")
+      expect(dnsmasq_conf).not_to include("server=2001:4860:4860::8888")
+    end
+  end
+
+  describe "#install_systemd_unit with unsupported hypervisor" do
+    it "raises on unsupported hypervisor" do
+      vs.instance_variable_set(:@hypervisor, "kvm")
+      vps = instance_spy(VmPath)
+      allow(vs).to receive(:vp).and_return(vps)
+      expect { vs.send(:install_systemd_unit, 2, "1:1:1:2", 2, [], [], [], "system.slice", 0) }.to raise_error(/unsupported hypervisor kvm/)
+    end
+  end
+
+  describe "#build_ch_service with version < 36 and pci devices" do
+    it "uses separate --device flags for each pci device" do
+      vps = instance_spy(VmPath,
+        ch_api_sock: "/tmp/ch.sock",
+        serial_log: "/vm/test/serial.log",
+        cloudinit_img: "/vm/test/cloudinit.img")
+      allow(vs).to receive(:vp).and_return(vps)
+
+      vs.instance_variable_set(:@ch_version,
+        CloudHypervisor::Version.new("35.1", "sha256_ch_bin", "sha256_ch_remote"))
+      vs.instance_variable_set(:@firmware_version,
+        CloudHypervisor::Firmware.new("202311", "sha256"))
+
+      storage_params = []
+      args = [2, "1:1:1:2", 2, storage_params, [], [["00:01.0", "1"], ["00:02.0", "2"]], "system.slice", 0]
+
+      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      vs.send(:install_systemd_unit, *args)
+
+      expect(vps).to have_received(:write_systemd_service) { |content|
+        # v < 36: each device gets its own --device prefix
+        expect(content).to include("--device path=/sys/bus/pci/devices/0000:00:01.0/ --device path=/sys/bus/pci/devices/0000:00:02.0/")
+      }
+    end
+  end
+
+  describe "#build_ch_service with version >= 36" do
+    it "joins all disk params with a single --disk flag" do
+      vps = instance_spy(VmPath,
+        ch_api_sock: "/tmp/ch.sock",
+        serial_log: "/vm/test/serial.log",
+        cloudinit_img: "/vm/test/cloudinit.img")
+      allow(vs).to receive(:vp).and_return(vps)
+
+      vs.instance_variable_set(:@ch_version,
+        CloudHypervisor::Version.new("36.0", "sha256_ch_bin", "sha256_ch_remote"))
+      vs.instance_variable_set(:@firmware_version,
+        CloudHypervisor::Firmware.new("202311", "sha256"))
+
+      storage_params = [
+        {"disk_index" => 0, "device_id" => "vol_0", "encrypted" => true, "vhost_block_backend_version" => "v0.4.0"},
+      ]
+      args = [2, "1:1:1:2", 2, storage_params, [VmSetup::Nic.new("fd00::/64", "10.0.0.1/32", "tap0", "02:aa:bb:cc:dd:01", "10.0.0.254/32")], [["00:01.0", "1"]], "system.slice", 0]
+
+      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      vs.send(:install_systemd_unit, *args)
+
+      expect(vps).to have_received(:write_systemd_service) { |content|
+        expect(content).to include("--disk ")
+        expect(content).to include("--device path=/sys/bus/pci/devices/0000:00:01.0/")
+        expect(content).not_to include("--device path=\n")
+      }
+    end
+  end
+
+  describe "#build_ch_service with hugepages disabled" do
+    it "uses shared=on instead of hugepages when hugepages is false" do
+      vs.instance_variable_set(:@hugepages, false)
+
+      vps = instance_spy(VmPath,
+        ch_api_sock: "/tmp/ch.sock",
+        serial_log: "/vm/test/serial.log",
+        cloudinit_img: "/vm/test/cloudinit.img")
+      allow(vs).to receive(:vp).and_return(vps)
+
+      vs.instance_variable_set(:@ch_version,
+        CloudHypervisor::Version.new("36.0", "sha256_ch_bin", "sha256_ch_remote"))
+      vs.instance_variable_set(:@firmware_version,
+        CloudHypervisor::Firmware.new("202311", "sha256"))
+
+      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      vs.send(:install_systemd_unit, 2, "1:1:1:2", 2, [], [], [], "system.slice", 0)
+
+      expect(vps).to have_received(:write_systemd_service) { |content|
+        expect(content).to include("shared=on")
+        expect(content).not_to include("hugepages=on")
+      }
+    end
+  end
+
+  describe "#install_systemd_unit with non-zero cpu_percent_limit" do
+    it "includes CPUQuota when cpu_percent_limit is non-zero" do
+      vps = instance_spy(VmPath,
+        ch_api_sock: "/tmp/ch.sock",
+        serial_log: "/vm/test/serial.log",
+        cloudinit_img: "/vm/test/cloudinit.img")
+      allow(vs).to receive(:vp).and_return(vps)
+
+      vs.instance_variable_set(:@ch_version,
+        CloudHypervisor::Version.new("36.0", "sha256_ch_bin", "sha256_ch_remote"))
+      vs.instance_variable_set(:@firmware_version,
+        CloudHypervisor::Firmware.new("202311", "sha256"))
+
+      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      vs.send(:install_systemd_unit, 2, "1:1:1:2", 2, [], [], [], "system.slice", 50)
+
+      expect(vps).to have_received(:write_systemd_service) { |content|
+        expect(content).to include("CPUQuota=50%")
+      }
+    end
+  end
+
+  describe "#build_qemu_service without hugepages" do
+    it "uses -m flag instead of memory-backend-memfd when hugepages is false" do
+      vs.instance_variable_set(:@hypervisor, "qemu")
+      vs.instance_variable_set(:@hugepages, false)
+
+      vps = instance_spy(VmPath,
+        serial_log: "/vm/test/serial.log",
+        cloudinit_img: "/vm/test/cloudinit.img")
+      allow(vs).to receive(:vp).and_return(vps)
+      vs.instance_variable_set(:@firmware_version,
+        CloudHypervisor::Firmware.new("202311", "sha256"))
+
+      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:cpu_vendor).and_return("GenuineIntel")
+
+      storage_params = []
+      args = [2, "1:1:1:2", 2, storage_params, [], [], "system.slice", 0]
+      vs.send(:install_systemd_unit, *args)
+
+      expect(vps).to have_received(:write_systemd_service) { |content|
+        expect(content).to include("-m 2G")
+        expect(content).not_to include("memory-backend-memfd")
+      }
+    end
+  end
+
+  describe "#build_qemu_service with pci devices" do
+    it "adds pcie-root-port and vfio-pci devices" do
+      vs.instance_variable_set(:@hypervisor, "qemu")
+
+      vps = instance_spy(VmPath,
+        serial_log: "/vm/test/serial.log",
+        cloudinit_img: "/vm/test/cloudinit.img")
+      allow(vs).to receive(:vp).and_return(vps)
+      vs.instance_variable_set(:@firmware_version,
+        CloudHypervisor::Firmware.new("202311", "sha256"))
+
+      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:cpu_vendor).and_return("GenuineIntel")
+
+      storage_params = []
+      pci_devices = [["00:01.0", "1"], ["00:02.0", "2"]]
+      args = [2, "1:1:1:2", 2, storage_params, [], pci_devices, "system.slice", 0]
+      vs.send(:install_systemd_unit, *args)
+
+      expect(vps).to have_received(:write_systemd_service) { |content|
+        expect(content).to include("-device pcie-root-port,id=rp1,slot=1,chassis=1,bus=pcie.0,hotplug=off")
+        expect(content).to include("-device vfio-pci,host=0000:00:01.0,bus=rp1,addr=0x0")
+      }
+    end
+  end
+
+  describe "#qemu_smp" do
+    it "warns when max_vcpus does not match topology product" do
+      expect { vs.send(:qemu_smp, "1:1:1:2", 3) }.to output(/Warning: max_vcpus=3 does not match topology product=2/).to_stderr
+    end
+  end
+
+  describe "#cpu_vendor" do
+    it "strips the output of lscpu vendor id" do
+      expect(vs).to receive(:r).with("/usr/bin/lscpu | grep -m1 \"Vendor ID\" | cut -d: -f2").and_return("  AuthenticAMD  \n")
+      expect(vs.send(:cpu_vendor)).to eq("AuthenticAMD")
+    end
+  end
+
   describe "#interfaces" do
     it "can setup interfaces without multiqueue" do
       expect(vs).to receive(:r).with("ip netns del test")
@@ -780,6 +1350,17 @@ NFTABLES_CONF
     it "fails if network namespace can not be deleted" do
       expect(vs).to receive(:r).with("ip netns del test").and_raise(CommandFail.new("", "", "error"))
       expect { vs.interfaces([VmSetup::Nic.new(nil, nil, "nctest", nil, "1.1.1.1")], false) }.to raise_error(CommandFail)
+    end
+
+    it "ignores 'No such file or directory' error when deleting netns" do
+      expect(vs).to receive(:r).with("ip netns del test").and_raise(
+        CommandFail.new("", "", 'Cannot remove namespace file "/var/run/netns/test": No such file or directory'),
+      )
+      expect(File).to receive(:exist?).with("/sys/class/net/vethotest").and_return(false)
+      expect(vs).to receive(:r).with("ip netns add test")
+      expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
+      expect(vs).to receive(:r).with("ip link add vethotest addr 00:00:00:00:00:00 type veth peer name vethitest addr 00:00:00:00:00:00 netns test")
+      vs.interfaces([], false)
     end
   end
 end

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe VmSetup do
 
     it "uses cloud-hypervisor by default" do
       vps = instance_spy(VmPath)
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
       expect(vs).to receive(:build_ch_service).and_return("CH_SERVICE")
       expect(vs).to receive(:r).with("systemctl daemon-reload")
 
@@ -351,7 +351,7 @@ RSpec.describe VmSetup do
       vs.instance_variable_set(:@hypervisor, "qemu")
 
       vps = instance_spy(VmPath)
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
       expect(vs).to receive(:build_qemu_service).and_return("QEMU_SERVICE")
       expect(vs).to receive(:r).with("systemctl daemon-reload")
 
@@ -365,7 +365,7 @@ RSpec.describe VmSetup do
         ch_api_sock: "/tmp/ch.sock",
         serial_log: "/vm/test/serial.log",
         cloudinit_img: "/vm/test/cloudinit.img")
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
 
       vs.instance_variable_set(:@ch_version,
         CloudHypervisor::Version.new("35.1", "sha256_ch_bin", "sha256_ch_remote"))
@@ -411,7 +411,7 @@ RSpec.describe VmSetup do
       vps = instance_spy(VmPath,
         serial_log: "/vm/test/serial.log",
         cloudinit_img: "/vm/test/cloudinit.img")
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
 
       vs.instance_variable_set(:@firmware_version,
         CloudHypervisor::Firmware.new("202311", "sha256"))
@@ -463,7 +463,7 @@ RSpec.describe VmSetup do
       vps = instance_spy(VmPath,
         serial_log: "/vm/test/serial.log",
         cloudinit_img: "/vm/test/cloudinit.img")
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
 
       vs.instance_variable_set(:@firmware_version,
         CloudHypervisor::Firmware.new("202311", "sha256"))
@@ -582,7 +582,7 @@ RSpec.describe VmSetup do
 
     it "writes ephemeral addresses when not skip_persisted and ip4 is empty" do
       vps = mock_vm_path.new("test")
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
       gua = "fddf:53d2:4c89:2305:46a0::"
 
       expect(vs).to receive(:interfaces).with([], false)
@@ -600,7 +600,7 @@ RSpec.describe VmSetup do
 
     it "skips unblock_ip4 when not skip_persisted but ip4 is empty" do
       vps = instance_spy(VmPath)
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
       gua = "fddf:53d2:4c89:2305:46a0::"
 
       expect(vs).not_to receive(:unblock_ip4)
@@ -874,29 +874,29 @@ NFTABLES_CONF
     let(:clover_ephemeral) { NetAddr.parse_net("fddf:53d2:4c89:2305:8000::/65") }
     let(:gua) { "fddf:53d2:4c89:2305:46a0::/79" }
 
-    before do
-      allow(vs).to receive(:r).and_return("")
-      allow(File).to receive(:read).and_call_original
-    end
-
     it "sets up veths without ndp" do
       expect(vs).to receive(:r).with("ip netns exec test cat /sys/class/net/vethitest/address").and_return("3e:bd:a5:96:f7:b9\n")
       expect(File).to receive(:read).with("/sys/class/net/vethotest/address").and_return("3e:bd:a5:96:f7:b9\n")
       expect(vs).to receive(:r).with("ip link set dev vethotest up")
-      expect(vs).to receive(:r).with(/ip route replace .*vethotest/)
-      expect(vs).to receive(:r).with(/ip -n test addr replace.*vethitest/)
+      expect(vs).to receive(:r).with("ip route replace fddf:53d2:4c89:2305:46a0::/79 via fe80::3cbd:a5ff:fe96:f7b9 dev vethotest")
+      expect(vs).to receive(:r).with("ip -n test addr replace fddf:53d2:4c89:2305:8000::/65 dev vethitest")
       expect(vs).to receive(:r).with("ip -n test link set dev vethitest up")
-      expect(vs).to receive(:r).with(/ip -n test route replace 2000::\/3.*vethitest/)
+      expect(vs).to receive(:r).with("ip -n test route replace 2000::/3 via fe80::3cbd:a5ff:fe96:f7b9 dev vethitest")
       vs.setup_veths_6(guest_ephemeral, clover_ephemeral, gua, false)
     end
 
     it "sets up ndp proxy routes when ndp_needed is true" do
       expect(vs).to receive(:r).with("ip netns exec test cat /sys/class/net/vethitest/address").and_return("3e:bd:a5:96:f7:b9\n")
       expect(File).to receive(:read).with("/sys/class/net/vethotest/address").and_return("3e:bd:a5:96:f7:b9\n")
-      allow(vs).to receive(:r).and_return("")
+      expect(vs).to receive(:r).with("ip -6 neigh add proxy fddf:53d2:4c89:2305::2 dev eth0")
+      expect(vs).to receive(:r).with("ip -6 neigh add proxy fddf:53d2:4c89:2305:8000:: dev eth0")
+      expect(vs).to receive(:r).with("ip -n test addr replace fddf:53d2:4c89:2305:8000::/65 dev vethitest")
+      expect(vs).to receive(:r).with("ip -n test link set dev vethitest up")
+      expect(vs).to receive(:r).with("ip -n test route replace 2000::/3 via fe80::3cbd:a5ff:fe96:f7b9 dev vethitest")
+      expect(vs).to receive(:r).with("ip link set dev vethotest up")
       routes = JSON.generate([{"dst" => "default", "dev" => "eth0"}])
       expect(vs).to receive(:r).with("ip -j route").and_return(routes)
-      expect(vs).to receive(:r).with(/ip -6 neigh add proxy.*eth0/)
+      expect(vs).to receive(:r).with("ip route replace fddf:53d2:4c89:2305:46a0::/79 via fe80::3cbd:a5ff:fe96:f7b9 dev vethotest")
       vs.setup_veths_6(guest_ephemeral, clover_ephemeral, gua, true)
     end
   end
@@ -905,9 +905,15 @@ NFTABLES_CONF
     it "sets up tap routes for each NIC" do
       gua = "fddf:53d2:4c89:2305:46a0::/79"
       nics = [VmSetup::Nic.new("fd48:666c:a296:ce4b:2cc6::/79", "192.168.5.50/32", "nctest", "3e:bd:a5:96:f7:b9", "10.0.0.254/32")]
-      allow(vs).to receive(:r).and_return("")
-      expect(vs).to receive(:r).with(/ip -n test addr replace.*nctest/).at_least(:once)
-      expect(vs).to receive(:r).with(/ip -n test link set dev nctest up/)
+      expect(vs).to receive(:r).with("ip -n test addr replace fddf:53d2:4c89:2305:46a0::1/80 dev nctest")
+      expect(vs).to receive(:r).with("ip -n test addr replace 10.0.0.2 dev nctest")
+      expect(vs).to receive(:r).with("ip -n test route replace fddf:53d2:4c89:2305:46a0::/80 via fe80::3cbd:a5ff:fe96:f7b9 dev nctest")
+      expect(vs).to receive(:r).with("ip -n test route del fddf:53d2:4c89:2305:46a0::/80 dev nctest")
+      expect(vs).to receive(:r).with("ip -n test link set dev nctest up")
+      expect(vs).to receive(:r).with("ip -n test addr replace fd48:666c:a296:ce4b:2cc6::1/79 dev nctest noprefixroute")
+      expect(vs).to receive(:r).with("ip -n test route replace fd48:666c:a296:ce4b:2cc6::/79 via fe80::3cbd:a5ff:fe96:f7b9 dev nctest")
+      expect(vs).to receive(:r).with("ip -n test addr replace fd00:0b1c:100d:5AFE:CE:: dev nctest")
+      expect(vs).to receive(:r).with("ip -n test addr replace fd00:0b1c:100d:53:: dev nctest")
       vs.setup_taps_6(gua, nics, "10.0.0.2")
     end
   end
@@ -918,7 +924,6 @@ NFTABLES_CONF
     it "sets up routes with ip4" do
       # With ip4="10.0.0.2/32" and ip4_local="10.0.0.0/31":
       #   vm = "10.0.0.2/32", vetho = "10.0.0.0", vethi = "10.0.0.2"
-      allow(vs).to receive(:r).and_return("")
       expect(vs).to receive(:r).with("ip addr replace 10.0.0.0/32 dev vethotest")
       expect(vs).to receive(:r).with("ip route replace 10.0.0.2/32 dev vethotest")
       expect(vs).to receive(:r).with("echo 1 > /proc/sys/net/ipv4/conf/vethotest/proxy_arp")
@@ -926,13 +931,19 @@ NFTABLES_CONF
       expect(vs).to receive(:r).with("ip -n test route replace 10.0.0.0 dev vethitest")
       expect(vs).to receive(:r).with("ip -n test route replace 10.0.0.2/32 dev nctest")
       expect(vs).to receive(:r).with("ip -n test route replace default via 10.0.0.0 dev vethitest")
-      expect(vs).to receive(:r).with(/ip netns exec test.*proxy_arp/).twice
+      expect(vs).to receive(:r).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/nctest/proxy_arp'")
+      expect(vs).to receive(:r).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethitest/proxy_arp'")
       vs.routes4("10.0.0.2/32", "10.0.0.0/31", nics)
     end
 
     it "skips ip4 route when ip4 is nil" do
-      allow(vs).to receive(:r).and_return("")
-      expect(vs).not_to receive(:r).with(/ip route replace .* dev vethotest/)
+      expect(vs).to receive(:r).with("ip addr replace 10.0.0.0/32 dev vethotest")
+      expect(vs).to receive(:r).with("echo 1 > /proc/sys/net/ipv4/conf/vethotest/proxy_arp")
+      expect(vs).to receive(:r).with("ip -n test addr replace 10.0.0.2/32 dev vethitest")
+      expect(vs).to receive(:r).with("ip -n test route replace 10.0.0.0 dev vethitest")
+      expect(vs).to receive(:r).with("ip -n test route replace default via 10.0.0.0 dev vethitest")
+      expect(vs).to receive(:r).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethitest/proxy_arp'")
+      expect(vs).to receive(:r).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/nctest/proxy_arp'")
       vs.routes4(nil, "10.0.0.1/31", nics)
     end
   end
@@ -946,15 +957,15 @@ NFTABLES_CONF
 
     it "updates routes for non-/32 nics when tap is ready" do
       nics = [VmSetup::Nic.new(nil, "10.0.0.0/30", "nctest", nil, nil)]
-      expect(vs).to receive(:r).with(/ip -n test link | grep.*UP.*echo UP || echo DOWN/).and_return("UP\n")
-      expect(vs).to receive(:r).with(/ip -n test route replace.*10.0.0.0\/30.*10.0.0.1.*nctest/)
+      expect(vs).to receive(:r).with("ip -n test link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN").and_return("UP\n")
+      expect(vs).to receive(:r).with("ip -n test route replace 10.0.0.0/30 via 10.0.0.1 dev nctest")
       vs.update_via_routes(nics)
     end
 
     it "raises when tap never becomes ready" do
       nics = [VmSetup::Nic.new(nil, "10.0.0.0/30", "nctest", nil, nil)]
-      allow(vs).to receive(:r).and_return("DOWN\n")
-      allow(vs).to receive(:sleep)
+      expect(vs).to receive(:r).with("ip -n test link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN").and_return("DOWN\n").at_least(:once)
+      expect(vs).to receive(:sleep).at_least(:once)
       expect { vs.update_via_routes(nics) }.to raise_error(/tap device not ready/)
     end
 
@@ -963,9 +974,8 @@ NFTABLES_CONF
         VmSetup::Nic.new(nil, "10.0.0.0/30", "nctest1", nil, nil),
         VmSetup::Nic.new(nil, "10.0.0.5/32", "nctest2", nil, nil),
       ]
-      allow(vs).to receive(:r).with(/ip -n test link/).and_return("UP\n")
-      expect(vs).to receive(:r).with(/ip -n test route replace 10.0.0.0\/30/)
-      expect(vs).not_to receive(:r).with(/ip -n test route replace 10.0.0.5/)
+      expect(vs).to receive(:r).with("ip -n test link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN").and_return("UP\n")
+      expect(vs).to receive(:r).with("ip -n test route replace 10.0.0.0/30 via 10.0.0.1 dev nctest1")
       vs.update_via_routes(nics)
     end
   end
@@ -1098,7 +1108,7 @@ NFTABLES_CONF
     it "flushes and reloads nftables in the vm netns" do
       expect(vs).to receive(:r).with("ip netns exec test nft flush ruleset")
       vps = instance_spy(VmPath, q_nftables_conf: "/vm/test/nftables.conf")
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps)
       expect(vs).to receive(:r).with("ip netns exec test nft -f /vm/test/nftables.conf")
       vs.send(:apply_nftables)
     end
@@ -1145,7 +1155,7 @@ NFTABLES_CONF
     it "raises on unsupported hypervisor" do
       vs.instance_variable_set(:@hypervisor, "kvm")
       vps = instance_spy(VmPath)
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps)
       expect { vs.send(:install_systemd_unit, 2, "1:1:1:2", 2, [], [], [], "system.slice", 0) }.to raise_error(/unsupported hypervisor kvm/)
     end
   end
@@ -1156,7 +1166,7 @@ NFTABLES_CONF
         ch_api_sock: "/tmp/ch.sock",
         serial_log: "/vm/test/serial.log",
         cloudinit_img: "/vm/test/cloudinit.img")
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
 
       vs.instance_variable_set(:@ch_version,
         CloudHypervisor::Version.new("35.1", "sha256_ch_bin", "sha256_ch_remote"))
@@ -1182,7 +1192,7 @@ NFTABLES_CONF
         ch_api_sock: "/tmp/ch.sock",
         serial_log: "/vm/test/serial.log",
         cloudinit_img: "/vm/test/cloudinit.img")
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
 
       vs.instance_variable_set(:@ch_version,
         CloudHypervisor::Version.new("36.0", "sha256_ch_bin", "sha256_ch_remote"))
@@ -1213,7 +1223,7 @@ NFTABLES_CONF
         ch_api_sock: "/tmp/ch.sock",
         serial_log: "/vm/test/serial.log",
         cloudinit_img: "/vm/test/cloudinit.img")
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
 
       vs.instance_variable_set(:@ch_version,
         CloudHypervisor::Version.new("36.0", "sha256_ch_bin", "sha256_ch_remote"))
@@ -1236,7 +1246,7 @@ NFTABLES_CONF
         ch_api_sock: "/tmp/ch.sock",
         serial_log: "/vm/test/serial.log",
         cloudinit_img: "/vm/test/cloudinit.img")
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
 
       vs.instance_variable_set(:@ch_version,
         CloudHypervisor::Version.new("36.0", "sha256_ch_bin", "sha256_ch_remote"))
@@ -1260,7 +1270,7 @@ NFTABLES_CONF
       vps = instance_spy(VmPath,
         serial_log: "/vm/test/serial.log",
         cloudinit_img: "/vm/test/cloudinit.img")
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
       vs.instance_variable_set(:@firmware_version,
         CloudHypervisor::Firmware.new("202311", "sha256"))
 
@@ -1285,7 +1295,7 @@ NFTABLES_CONF
       vps = instance_spy(VmPath,
         serial_log: "/vm/test/serial.log",
         cloudinit_img: "/vm/test/cloudinit.img")
-      allow(vs).to receive(:vp).and_return(vps)
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
       vs.instance_variable_set(:@firmware_version,
         CloudHypervisor::Firmware.new("202311", "sha256"))
 

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -199,7 +199,10 @@ RSpec.describe VmSetup do
     before do
       allow(vs).to receive(:vp).and_return(vps)
       allow(vs).to receive(:write_user_data)
-      allow(vs).to receive(:r)
+      expect(vs).to receive(:r).with("mkdosfs -n CIDATA -C /vm/test/cloudinit.img 128")
+      expect(vs).to receive(:r).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/user-data ::")
+      expect(vs).to receive(:r).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/meta-data ::")
+      expect(vs).to receive(:r).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/network-config ::")
       allow(FileUtils).to receive(:rm_rf)
       allow(FileUtils).to receive(:chmod)
       allow(FileUtils).to receive(:chown)
@@ -1130,7 +1133,10 @@ NFTABLES_CONF
     before do
       allow(vs).to receive(:vp).and_return(vps)
       allow(vs).to receive(:write_user_data)
-      allow(vs).to receive(:r)
+      expect(vs).to receive(:r).with("mkdosfs -n CIDATA -C /vm/test/cloudinit.img 128")
+      expect(vs).to receive(:r).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/user-data ::")
+      expect(vs).to receive(:r).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/meta-data ::")
+      expect(vs).to receive(:r).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/network-config ::")
       allow(FileUtils).to receive(:rm_rf)
       allow(FileUtils).to receive(:chmod)
       allow(FileUtils).to receive(:chown)

--- a/rhizome/host/spec/vm_stats_spec.rb
+++ b/rhizome/host/spec/vm_stats_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe VmStats do
       stub_unit_property("vmh6b1sz-0-storage", "MemoryPeak", "51892224")
       stub_unit_property("vmh6b1sz-0-storage", "MemorySwapPeak", "123879")
       stub_unit_property("vmh6b1sz-0-storage", "ActiveEnterTimestampMonotonic", "31534196")
-      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(1616.0)
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(1616.0).at_least(:once)
       expect(File).to receive(:read).with("/proc/3373/stat").and_return("3373 (cloud-hyperviso) S 1 3373 3373 0 -1 4194560 1163 0 0 0 95143 16431 0 0 20 0 13 0 3364 8618754048 960 18446744073709551615 135770696667136 135770699811150 140729095742720 0 0 0 134234114 69632 1073759298 0 0 0 17 7 0 0 0 89566 0 135770700348320 135770700898816 93826017284096 140729095744653 140729095745099 140729095745099 140729095745483 0")
       expect(File).to receive(:read).with("/proc/3350/stat").and_return("3350 (vhost-backend) S 1 3350 3350 0 -1 4194560 15183 45 31 0 16602 733 0 0 20 0 7 0 3351 17248038912 10371 18446744073709551615 140535920156672 140535933113610 140725366025408 0 0 0 0 4096 1088 0 0 0 17 7 0 0 0 0 0 140535936046520 140535939797664 93825003057152 140725366033855 140725366033953 140725366033953 140725366034378 0")
       expect(File).to receive(:foreach).with("/proc/3350/io")
@@ -97,7 +97,7 @@ RSpec.describe VmStats do
   describe "#unit_active_age_ms" do
     it "returns nil when ActiveEnterTimestampMonotonic is zero" do
       stub_unit_property("my-unit", "ActiveEnterTimestampMonotonic", "0")
-      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0)
+      expect(Process).not_to receive(:clock_gettime)
       expect(vm_stats.send(:unit_active_age_ms, "my-unit")).to be_nil
     end
   end

--- a/rhizome/host/spec/vm_stats_spec.rb
+++ b/rhizome/host/spec/vm_stats_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe VmStats do
     end
   end
 
+  describe "#unit_active_age_ms" do
+    it "returns nil when ActiveEnterTimestampMonotonic is zero" do
+      stub_unit_property("my-unit", "ActiveEnterTimestampMonotonic", "0")
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0)
+      expect(vm_stats.send(:unit_active_age_ms, "my-unit")).to be_nil
+    end
+  end
+
   describe "#unit_property" do
     it "returns the value of the specified property for the given systemd unit" do
       stub_unit_property("my-unit", "MainPID", "1234")

--- a/rhizome/inference_endpoint/spec/replica_setup_spec.rb
+++ b/rhizome/inference_endpoint/spec/replica_setup_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../lib/replica_setup"
+require "tmpdir"
 
 RSpec.describe ReplicaSetup do
   subject(:rs) { described_class.new }
@@ -40,10 +41,11 @@ RSpec.describe ReplicaSetup do
 
   describe "#write" do
     it "writes content to a file" do
-      f = instance_double(File)
-      expect(File).to receive(:open).with("/some/path", "w").and_yield(f)
-      expect(f).to receive(:puts).with("content")
-      rs.write("/some/path", "content")
+      Dir.mktmpdir do |dir|
+        file = File.join(dir, "file")
+        rs.write(file, "content")
+        expect(File.read(file)).to eq "content\n"
+      end
     end
   end
 

--- a/rhizome/inference_endpoint/spec/replica_setup_spec.rb
+++ b/rhizome/inference_endpoint/spec/replica_setup_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require_relative "../lib/replica_setup"
+
+RSpec.describe ReplicaSetup do
+  subject(:rs) { described_class.new }
+
+  describe "#inference_gateway_service" do
+    it "returns the correct path" do
+      expect(rs.inference_gateway_service).to eq("/etc/systemd/system/inference-gateway.service")
+    end
+  end
+
+  describe "#inference_engine_service" do
+    it "returns the correct path" do
+      expect(rs.inference_engine_service).to eq("/etc/systemd/system/inference-engine.service")
+    end
+  end
+
+  describe "#lb_cert_download_service" do
+    it "returns the correct path" do
+      expect(rs.lb_cert_download_service).to eq("/etc/systemd/system/lb-cert-download.service")
+    end
+  end
+
+  describe "#lb_cert_download_timer" do
+    it "returns the correct path" do
+      expect(rs.lb_cert_download_timer).to eq("/etc/systemd/system/lb-cert-download.timer")
+    end
+  end
+
+  describe "#common_systemd_settings" do
+    it "includes key security settings" do
+      settings = rs.common_systemd_settings
+      expect(settings).to include("NoNewPrivileges=yes")
+      expect(settings).to include("ProtectKernelTunables=yes")
+      expect(settings).to include("PrivateNetwork=no")
+    end
+  end
+
+  describe "#write" do
+    it "writes content to a file" do
+      f = instance_double(File)
+      expect(File).to receive(:open).with("/some/path", "w").and_yield(f)
+      expect(f).to receive(:puts).with("content")
+      rs.write("/some/path", "content")
+    end
+  end
+
+  describe "#write_inference_gateway_service" do
+    it "writes to the inference gateway service path" do
+      expect(rs).to receive(:write).with("/etc/systemd/system/inference-gateway.service", "content")
+      rs.write_inference_gateway_service("content")
+    end
+  end
+
+  describe "#write_inference_engine_service" do
+    it "writes to the inference engine service path" do
+      expect(rs).to receive(:write).with("/etc/systemd/system/inference-engine.service", "content")
+      rs.write_inference_engine_service("content")
+    end
+  end
+
+  describe "#write_lb_cert_download_service" do
+    it "writes to the cert download service path" do
+      expect(rs).to receive(:write).with("/etc/systemd/system/lb-cert-download.service", "content")
+      rs.write_lb_cert_download_service("content")
+    end
+  end
+
+  describe "#write_lb_cert_download_timer" do
+    it "writes to the cert download timer path" do
+      expect(rs).to receive(:write).with("/etc/systemd/system/lb-cert-download.timer", "content")
+      rs.write_lb_cert_download_timer("content")
+    end
+  end
+
+  describe "#write_config_files" do
+    it "writes the inference gateway config file" do
+      expect(rs).to receive(:safe_write_to_file).with(
+        "/ie/workdir/inference-gateway.conf",
+        satisfy { |content|
+          content.include?("IG_LISTEN_ADDRESS=\"0.0.0.0:8080\"") &&
+            content.include?("IG_REPLICA_UBID=replica-123") &&
+            content.include?("IG_MAX_REQUESTS=100") &&
+            content.include?("IG_SSL_CRT_PATH=/certs/server.crt") &&
+            content.include?("IG_SSL_KEY_PATH=/certs/server.key")
+        },
+      )
+      rs.write_config_files("replica-123", "/certs/server.crt", "/certs/server.key", 8080, 100)
+    end
+  end
+
+  describe "#install_systemd_units" do
+    it "writes all systemd unit files and reloads daemon" do
+      expect(rs).to receive(:write_lb_cert_download_service).with(satisfy { |s|
+        s.include?("download-lb-cert") && s.include?("NoNewPrivileges=yes")
+      })
+      expect(rs).to receive(:write_lb_cert_download_timer).with(satisfy { |s|
+        s.include?("OnActiveSec=1h") && s.include?("timers.target")
+      })
+      expect(rs).to receive(:write_inference_gateway_service).with(satisfy { |s|
+        s.include?("inference-gateway") && s.include?("KillSignal=SIGINT")
+      })
+      expect(rs).to receive(:write_inference_engine_service).with(satisfy { |s|
+        s.include?("/usr/bin/start-engine") && s.include?("multi-user.target")
+      })
+      expect(rs).to receive(:r).with("systemctl daemon-reload")
+
+      rs.install_systemd_units("/usr/bin/start-engine")
+    end
+  end
+
+  describe "#start_systemd_units" do
+    it "enables and starts the required systemd units" do
+      expect(rs).to receive(:r).with("systemctl enable --now lb-cert-download.timer")
+      expect(rs).to receive(:r).with("systemctl enable --now inference-engine.service")
+      rs.start_systemd_units
+    end
+  end
+
+  describe "#prep" do
+    it "calls write_config_files, install_systemd_units, and start_systemd_units in order" do
+      expect(rs).to receive(:write_config_files).with("rep-ubid", "/c.crt", "/k.key", 9000, 50).ordered
+      expect(rs).to receive(:install_systemd_units).with("/bin/engine").ordered
+      expect(rs).to receive(:start_systemd_units).ordered
+
+      rs.prep(
+        engine_start_cmd: "/bin/engine",
+        replica_ubid: "rep-ubid",
+        ssl_crt_path: "/c.crt",
+        ssl_key_path: "/k.key",
+        gateway_port: 9000,
+        max_requests: 50,
+      )
+    end
+  end
+end

--- a/rhizome/postgres/lib/io_throttle.rb
+++ b/rhizome/postgres/lib/io_throttle.rb
@@ -87,6 +87,7 @@ class IoThrottle
       immune_pids << pid if IMMUNE_PATTERNS.any? { |pattern| cmdline.include?(pattern) }
     rescue Errno::ENOENT
       # Process exited between enumeration and read
+      nil
     end
     immune_pids
   end
@@ -101,6 +102,7 @@ class IoThrottle
     File.write("#{cgroup_path}/cgroup.procs", pid.to_s)
   rescue Errno::ESRCH
     # Process no longer exists
+    nil
   end
 
   private

--- a/rhizome/postgres/spec/disk_full_check_spec.rb
+++ b/rhizome/postgres/spec/disk_full_check_spec.rb
@@ -89,6 +89,17 @@ RSpec.describe "disk-full-check" do
     File.read(auto_conf)
   end
 
+  describe "when the script fails" do
+    before do
+      fake_df(99, 1)
+      FileUtils.rm_rf(File.join(dat, "16", "data"))
+    end
+
+    it "raises an error" do
+      expect { run_check }.to raise_error(/disk-full-check failed/)
+    end
+  end
+
   describe "recovery, >7GB available" do
     before { fake_df(50, 53_687_091_200) }
 

--- a/rhizome/postgres/spec/hugepages_setup_spec.rb
+++ b/rhizome/postgres/spec/hugepages_setup_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../lib/hugepages_setup"
 
 RSpec.describe HugepagesSetup do
-  let(:logger) { instance_double(Logger, warn: nil) }
+  let(:logger) { instance_double(Logger, warn: nil, info: nil) }
   let(:hugepages_setup) { described_class.new("17-main", logger) }
 
   describe "#setup_postgres_hugepages" do
@@ -42,6 +42,70 @@ RSpec.describe HugepagesSetup do
       expect(hugepages_setup).not_to receive(:update_postgres_hugepages_conf)
       expect(logger).to receive(:warn).with("No hugepages configured, skipping setup.")
       expect { hugepages_setup.setup_postgres_hugepages }.not_to raise_error
+    end
+  end
+
+  describe "#hugepage_info" do
+    it "parses hugepage count and size from /proc/meminfo" do
+      meminfo = "HugePages_Total:     512\nHugepagesize:       2048 kB\n"
+      expect(File).to receive(:read).with("/proc/meminfo").and_return(meminfo)
+      count, size = hugepages_setup.hugepage_info
+      expect(count).to eq(512)
+      expect(size).to eq(2048)
+    end
+  end
+
+  describe "#get_postgres_param" do
+    it "returns the integer value of a postgres parameter" do
+      expect(hugepages_setup).to receive(:r).with(
+        "sudo -u postgres /usr/lib/postgresql/17/bin/postgres -D /dat/17/data -c config_file=/etc/postgresql/17/main/postgresql.conf -C shared_buffers",
+      ).and_return("131072\n")
+      expect(hugepages_setup.get_postgres_param("shared_buffers")).to eq(131072)
+    end
+  end
+
+  describe "#stop_postgres_cluster" do
+    it "stops the postgres cluster (exit 0 or 2)" do
+      expect(hugepages_setup).to receive(:r).with("sudo pg_ctlcluster stop 17 main", expect: [0, 2])
+      hugepages_setup.stop_postgres_cluster
+    end
+  end
+
+  describe "#update_postgres_hugepages_conf" do
+    it "writes the hugepages configuration file" do
+      expect(hugepages_setup).to receive(:safe_write_to_file).with(
+        "/etc/postgresql/17/main/conf.d/002-hugepages.conf",
+        satisfy { |s| s.include?("huge_pages = 'on'") && s.include?("524288kB") },
+      )
+      hugepages_setup.update_postgres_hugepages_conf(524288)
+    end
+  end
+
+  describe "#postgres_running?" do
+    it "returns false when postgres is not running (exit 3)" do
+      expect(hugepages_setup).to receive(:r).with("sudo pg_ctlcluster status 17 main", expect: [3]).and_return("")
+      expect(hugepages_setup.postgres_running?).to be false
+    end
+
+    it "returns true when postgres is running (r raises CommandFail)" do
+      expect(hugepages_setup).to receive(:r).with("sudo pg_ctlcluster status 17 main", expect: [3]).and_raise(CommandFail.new("error", "", ""))
+      expect(hugepages_setup.postgres_running?).to be true
+    end
+  end
+
+  describe "#setup" do
+    it "stops postgres and runs hugepages setup when postgres is not running" do
+      expect(hugepages_setup).to receive(:postgres_running?).and_return(false)
+      expect(hugepages_setup).to receive(:stop_postgres_cluster)
+      expect(hugepages_setup).to receive(:setup_postgres_hugepages)
+      hugepages_setup.setup
+    end
+
+    it "does nothing when postgres is already running" do
+      expect(hugepages_setup).to receive(:postgres_running?).and_return(true)
+      expect(hugepages_setup).not_to receive(:stop_postgres_cluster)
+      expect(hugepages_setup).not_to receive(:setup_postgres_hugepages)
+      hugepages_setup.setup
     end
   end
 end

--- a/rhizome/postgres/spec/io_throttle_spec.rb
+++ b/rhizome/postgres/spec/io_throttle_spec.rb
@@ -130,6 +130,13 @@ RSpec.describe IoThrottle do
 
       throttle.apply_throttle(100)
     end
+
+    it "returns early without throttling when enable_io_controller is false" do
+      allow(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_raise(Errno::ENOENT)
+      allow(logger).to receive(:warn)
+      expect(throttle).not_to receive(:set_io_limit)
+      throttle.apply_throttle(100)
+    end
   end
 
   describe "#calculate_disk_usage_throttle" do
@@ -161,6 +168,93 @@ RSpec.describe IoThrottle do
       expect(throttle_aws).to receive(:r).with("df --output=pcent /dat | tail -n 1").and_return("  97%\n")
       # ratio = 0.34 -> 448 * 0.34 = 152.32 -> 152
       expect(throttle_aws.send(:calculate_disk_usage_throttle)).to eq(152)
+    end
+  end
+
+  describe "#classify_processes" do
+    before do
+      allow(File).to receive(:write)
+    end
+
+    it "moves non-immune cgroup pids to throttled cgroup" do
+      # pid 1001 is in service_cgroup but not immune → move to throttled
+      allow(throttle).to receive(:find_immune_pids).and_return([1000])
+      allow(throttle).to receive(:get_cgroup_pids).with(service_cgroup).and_return([1001])
+      allow(throttle).to receive(:get_cgroup_pids).with(immune_cgroup).and_return([])
+      allow(throttle).to receive(:get_cgroup_pids).with(throttled_cgroup).and_return([])
+      expect(File).to receive(:write).with("#{throttled_cgroup}/cgroup.procs", "1001")
+      throttle.send(:classify_processes)
+    end
+
+    it "skips immune pids when iterating service+immune cgroups" do
+      # pid 1000 is in immune_cgroup AND in immune_pids → next (skip it, don't move to throttled)
+      allow(throttle).to receive(:find_immune_pids).and_return([1000])
+      allow(throttle).to receive(:get_cgroup_pids).with(service_cgroup).and_return([])
+      allow(throttle).to receive(:get_cgroup_pids).with(immune_cgroup).and_return([1000])
+      allow(throttle).to receive(:get_cgroup_pids).with(throttled_cgroup).and_return([])
+      expect(File).not_to receive(:write).with("#{throttled_cgroup}/cgroup.procs", anything)
+      throttle.send(:classify_processes)
+    end
+
+    it "moves immune pids from throttled cgroup back to immune cgroup" do
+      # pid 1000 ended up in throttled_cgroup but is actually immune → move to immune
+      allow(throttle).to receive(:find_immune_pids).and_return([1000])
+      allow(throttle).to receive(:get_cgroup_pids).with(service_cgroup).and_return([])
+      allow(throttle).to receive(:get_cgroup_pids).with(immune_cgroup).and_return([])
+      allow(throttle).to receive(:get_cgroup_pids).with(throttled_cgroup).and_return([1000])
+      expect(File).to receive(:write).with("#{immune_cgroup}/cgroup.procs", "1000")
+      throttle.send(:classify_processes)
+    end
+
+    it "does not move non-immune throttled pids back to immune" do
+      # No immune pids; pid 1001 is in throttled_cgroup but not immune → stays there (else branch)
+      allow(throttle).to receive(:find_immune_pids).and_return([])
+      allow(throttle).to receive(:get_cgroup_pids).with(service_cgroup).and_return([])
+      allow(throttle).to receive(:get_cgroup_pids).with(immune_cgroup).and_return([])
+      allow(throttle).to receive(:get_cgroup_pids).with(throttled_cgroup).and_return([1001])
+      expect(File).not_to receive(:write).with("#{immune_cgroup}/cgroup.procs", anything)
+      throttle.send(:classify_processes)
+    end
+  end
+
+  describe "#find_device_id" do
+    it "finds the device major:minor from mount path" do
+      expect(throttle).to receive(:r).with("findmnt -n -o SOURCE /dat").and_return("/dev/sda\n")
+      expect(File).to receive(:realpath).with("/dev/sda").and_return("/dev/sda")
+      stat = instance_double(File::Stat, rdev_major: 8, rdev_minor: 0)
+      expect(File).to receive(:stat).with("/dev/sda").and_return(stat)
+      expect(throttle.send(:find_device_id, "/dat")).to eq("8:0")
+    end
+  end
+
+  describe "#enable_io_controller" do
+    it "returns true immediately when io is already enabled" do
+      expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
+      expect(throttle.send(:enable_io_controller)).to be true
+    end
+
+    it "enables io controller by creating cgroups and writing +io" do
+      expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("")
+      expect(FileUtils).to receive(:mkdir_p).with(throttled_cgroup)
+      expect(FileUtils).to receive(:mkdir_p).with(immune_cgroup)
+      expect(File).to receive(:read).with("#{service_cgroup}/cgroup.procs").and_return("1001\n1002\n")
+      expect(File).to receive(:write).with("#{throttled_cgroup}/cgroup.procs", "1001")
+      expect(File).to receive(:write).with("#{throttled_cgroup}/cgroup.procs", "1002")
+      expect(File).to receive(:write).with("#{service_cgroup}/cgroup.subtree_control", "+io")
+      expect(throttle.send(:enable_io_controller)).to be true
+    end
+
+    it "returns false and logs warning when cgroup operation fails" do
+      expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_raise(Errno::ENOENT)
+      expect(logger).to receive(:warn).with(/Cannot enable I\/O controller/)
+      expect(throttle.send(:enable_io_controller)).to be false
+    end
+
+    it "returns false and logs warning when permission is denied" do
+      expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("")
+      expect(FileUtils).to receive(:mkdir_p).with(throttled_cgroup).and_raise(Errno::EPERM)
+      expect(logger).to receive(:warn).with(/Cannot enable I\/O controller/)
+      expect(throttle.send(:enable_io_controller)).to be false
     end
   end
 

--- a/rhizome/postgres/spec/io_throttle_spec.rb
+++ b/rhizome/postgres/spec/io_throttle_spec.rb
@@ -99,41 +99,39 @@ RSpec.describe IoThrottle do
   end
 
   describe "#apply" do
-    before do
-      allow(File).to receive(:directory?).with(service_cgroup).and_return(true)
-      allow(throttle).to receive(:find_device_id).and_return("8:0")
-    end
-
     it "removes throttle when throttle_mbps is nil" do
+      expect(File).to receive(:directory?).with(service_cgroup).and_return(true)
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=max")
+      expect(throttle).to receive(:find_device_id).and_return("8:0")
       throttle.apply(nil)
     end
 
     it "fails if service cgroup doesn't exist" do
-      allow(File).to receive(:directory?).with(service_cgroup).and_return(false)
+      expect(File).to receive(:directory?).with(service_cgroup).and_return(false)
+      expect(throttle).not_to receive(:find_device_id)
       expect { throttle.apply(100) }.to raise_error(/Service cgroup not found/)
     end
   end
 
   describe "#apply_throttle" do
     before do
-      allow(File).to receive_messages(directory?: true, read: "")
-      allow(File).to receive(:write)
-      allow(Dir).to receive(:mkdir)
       throttle.instance_variable_set(:@dev_id, "8:0")
     end
 
     it "sets io.max with correct wbps value" do
-      allow(throttle).to receive_messages(find_immune_pids: [1000], get_cgroup_pids: [])
+      expect(File).to receive_messages(directory?: true, read: "")
+      expect(throttle).to receive_messages(find_immune_pids: [1000], get_cgroup_pids: [])
 
+      expect(File).to receive(:write).with("/sys/fs/cgroup/system.slice/system-postgresql.slice/postgresql@17-main.service/cgroup.subtree_control", "+io")
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=104857600")
+      expect(File).to receive(:write).with("/sys/fs/cgroup/system.slice/system-postgresql.slice/postgresql@17-main.service/immune/cgroup.procs", "1000")
 
       throttle.apply_throttle(100)
     end
 
     it "returns early without throttling when enable_io_controller is false" do
-      allow(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_raise(Errno::ENOENT)
-      allow(logger).to receive(:warn)
+      expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_raise(Errno::ENOENT)
+      expect(logger).to receive(:warn)
       expect(throttle).not_to receive(:set_io_limit)
       throttle.apply_throttle(100)
     end
@@ -172,46 +170,43 @@ RSpec.describe IoThrottle do
   end
 
   describe "#classify_processes" do
-    before do
-      allow(File).to receive(:write)
-    end
-
     it "moves non-immune cgroup pids to throttled cgroup" do
       # pid 1001 is in service_cgroup but not immune → move to throttled
-      allow(throttle).to receive(:find_immune_pids).and_return([1000])
-      allow(throttle).to receive(:get_cgroup_pids).with(service_cgroup).and_return([1001])
-      allow(throttle).to receive(:get_cgroup_pids).with(immune_cgroup).and_return([])
-      allow(throttle).to receive(:get_cgroup_pids).with(throttled_cgroup).and_return([])
+      expect(throttle).to receive(:find_immune_pids).and_return([1000])
+      expect(throttle).to receive(:get_cgroup_pids).with(service_cgroup).and_return([1001])
+      expect(throttle).to receive(:get_cgroup_pids).with(immune_cgroup).and_return([])
+      expect(throttle).to receive(:get_cgroup_pids).with(throttled_cgroup).and_return([])
       expect(File).to receive(:write).with("#{throttled_cgroup}/cgroup.procs", "1001")
+      expect(File).to receive(:write).with("/sys/fs/cgroup/system.slice/system-postgresql.slice/postgresql@17-main.service/immune/cgroup.procs", "1000")
       throttle.send(:classify_processes)
     end
 
     it "skips immune pids when iterating service+immune cgroups" do
       # pid 1000 is in immune_cgroup AND in immune_pids → next (skip it, don't move to throttled)
-      allow(throttle).to receive(:find_immune_pids).and_return([1000])
-      allow(throttle).to receive(:get_cgroup_pids).with(service_cgroup).and_return([])
-      allow(throttle).to receive(:get_cgroup_pids).with(immune_cgroup).and_return([1000])
-      allow(throttle).to receive(:get_cgroup_pids).with(throttled_cgroup).and_return([])
+      expect(throttle).to receive(:find_immune_pids).and_return([1000])
+      expect(throttle).to receive(:get_cgroup_pids).with(service_cgroup).and_return([])
+      expect(throttle).to receive(:get_cgroup_pids).with(immune_cgroup).and_return([1000])
+      expect(throttle).to receive(:get_cgroup_pids).with(throttled_cgroup).and_return([])
       expect(File).not_to receive(:write).with("#{throttled_cgroup}/cgroup.procs", anything)
       throttle.send(:classify_processes)
     end
 
     it "moves immune pids from throttled cgroup back to immune cgroup" do
       # pid 1000 ended up in throttled_cgroup but is actually immune → move to immune
-      allow(throttle).to receive(:find_immune_pids).and_return([1000])
-      allow(throttle).to receive(:get_cgroup_pids).with(service_cgroup).and_return([])
-      allow(throttle).to receive(:get_cgroup_pids).with(immune_cgroup).and_return([])
-      allow(throttle).to receive(:get_cgroup_pids).with(throttled_cgroup).and_return([1000])
-      expect(File).to receive(:write).with("#{immune_cgroup}/cgroup.procs", "1000")
+      expect(throttle).to receive(:find_immune_pids).and_return([1000])
+      expect(throttle).to receive(:get_cgroup_pids).with(service_cgroup).and_return([])
+      expect(throttle).to receive(:get_cgroup_pids).with(immune_cgroup).and_return([])
+      expect(throttle).to receive(:get_cgroup_pids).with(throttled_cgroup).and_return([1000])
+      expect(File).to receive(:write).with("#{immune_cgroup}/cgroup.procs", "1000").twice
       throttle.send(:classify_processes)
     end
 
     it "does not move non-immune throttled pids back to immune" do
       # No immune pids; pid 1001 is in throttled_cgroup but not immune → stays there (else branch)
-      allow(throttle).to receive(:find_immune_pids).and_return([])
-      allow(throttle).to receive(:get_cgroup_pids).with(service_cgroup).and_return([])
-      allow(throttle).to receive(:get_cgroup_pids).with(immune_cgroup).and_return([])
-      allow(throttle).to receive(:get_cgroup_pids).with(throttled_cgroup).and_return([1001])
+      expect(throttle).to receive(:find_immune_pids).and_return([])
+      expect(throttle).to receive(:get_cgroup_pids).with(service_cgroup).and_return([])
+      expect(throttle).to receive(:get_cgroup_pids).with(immune_cgroup).and_return([])
+      expect(throttle).to receive(:get_cgroup_pids).with(throttled_cgroup).and_return([1001])
       expect(File).not_to receive(:write).with("#{immune_cgroup}/cgroup.procs", anything)
       throttle.send(:classify_processes)
     end
@@ -261,23 +256,22 @@ RSpec.describe IoThrottle do
   describe "#run" do
     let(:data_dir) { "/dat/17/data" }
 
-    before do
-      allow(File).to receive(:directory?).with(service_cgroup).and_return(true)
-      allow(throttle).to receive_messages(find_device_id: "8:0", calculate_disk_usage_throttle: nil)
-    end
-
     it "applies no throttle when backlog is below threshold and no disk usage throttle" do
-      allow(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return([])
+      expect(File).to receive(:directory?).with(service_cgroup).and_return(true)
+      expect(throttle).to receive_messages(find_device_id: "8:0", calculate_disk_usage_throttle: nil)
+      expect(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return([])
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=max")
 
       throttle.run
     end
 
     it "applies throttle tier based on backlog count" do
+      expect(File).to receive(:directory?).with(service_cgroup).and_return(true)
+      expect(throttle).to receive_messages(find_device_id: "8:0", calculate_disk_usage_throttle: nil)
       ready_files = Array.new(150) { |i| "#{data_dir}/pg_wal/archive_status/#{i.to_s.rjust(8, "0")}.ready" }
-      allow(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return(ready_files)
-      allow(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
-      allow(throttle).to receive_messages(find_immune_pids: [], get_cgroup_pids: [])
+      expect(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return(ready_files)
+      expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
+      expect(throttle).to receive_messages(find_immune_pids: [], get_cgroup_pids: [])
 
       # 150 files hits moderate tier (100+): 80% of baseline 100 MB/s = 80 MB/s
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=#{80 * 1024 * 1024}")
@@ -287,13 +281,13 @@ RSpec.describe IoThrottle do
 
     it "scales throttle values with the disk throughput baseline" do
       throttle_leaseweb = described_class.new("17-main", logger, 35)
-      allow(File).to receive(:directory?).with(service_cgroup).and_return(true)
-      allow(throttle_leaseweb).to receive_messages(find_device_id: "8:0", calculate_disk_usage_throttle: nil)
+      expect(File).to receive(:directory?).with(service_cgroup).and_return(true)
+      expect(throttle_leaseweb).to receive_messages(find_device_id: "8:0", calculate_disk_usage_throttle: nil)
 
       ready_files = Array.new(150) { |i| "#{data_dir}/pg_wal/archive_status/#{i.to_s.rjust(8, "0")}.ready" }
-      allow(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return(ready_files)
-      allow(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
-      allow(throttle_leaseweb).to receive_messages(find_immune_pids: [], get_cgroup_pids: [])
+      expect(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return(ready_files)
+      expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
+      expect(throttle_leaseweb).to receive_messages(find_immune_pids: [], get_cgroup_pids: [])
 
       # 150 files hits moderate tier (100+): 80% of baseline 35 MB/s = 28 MB/s
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=#{28 * 1024 * 1024}")
@@ -302,6 +296,8 @@ RSpec.describe IoThrottle do
     end
 
     it "applies disk usage throttle when disk is high and no archival backlog" do
+      expect(File).to receive(:directory?).with(service_cgroup).and_return(true)
+      expect(throttle).to receive_messages(find_device_id: "8:0")
       expect(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return([])
       expect(throttle).to receive(:calculate_disk_usage_throttle).and_return(55)
       expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
@@ -314,6 +310,8 @@ RSpec.describe IoThrottle do
     end
 
     it "uses more restrictive throttle when both apply" do
+      expect(File).to receive(:directory?).with(service_cgroup).and_return(true)
+      expect(throttle).to receive_messages(find_device_id: "8:0")
       ready_files = Array.new(150) { |i| "#{data_dir}/pg_wal/archive_status/#{i.to_s.rjust(8, "0")}.ready" }
       expect(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return(ready_files)
       # Archival: 80 MB/s, disk usage: 55 MB/s -> pick 55

--- a/rhizome/postgres/spec/otel_log_config_spec.rb
+++ b/rhizome/postgres/spec/otel_log_config_spec.rb
@@ -387,6 +387,17 @@ RSpec.describe OtelLogConfig do
       end
     end
 
+    context "with an unknown destination type" do
+      let(:log_destinations) do
+        [{"type" => "unknown", "url" => "tcp://logs.example.com:514"}]
+      end
+
+      it "creates a transform processor with nil statements" do
+        transform = parsed["processors"]["transform/dest0"]
+        expect(transform["log_statements"].first["statements"]).to be_nil
+      end
+    end
+
     context "with mixed otlp and syslog destinations" do
       let(:log_destinations) do
         [

--- a/rhizome/postgres/spec/pg_bouncer_setup_spec.rb
+++ b/rhizome/postgres/spec/pg_bouncer_setup_spec.rb
@@ -106,4 +106,58 @@ RSpec.describe PgBouncerSetup do
       expect(config).to include("2 = host=/tmp/.s.PGSQL.50002")
     end
   end
+
+  describe "#pgbouncer_service_file_path" do
+    it "returns the correct service template path" do
+      expect(pgbouncer_setup.pgbouncer_service_file_path).to eq("/etc/systemd/system/pgbouncer@.service")
+    end
+  end
+
+  describe "#socket_service_file_path" do
+    it "returns the correct socket template path" do
+      expect(pgbouncer_setup.socket_service_file_path).to eq("/etc/systemd/system/pgbouncer@.socket")
+    end
+  end
+
+  describe "#create_service_templates" do
+    it "writes service and socket templates and reloads systemd" do
+      expect(File).to receive(:write).with("/etc/systemd/system/pgbouncer@.service", pgbouncer_setup.service_template_content)
+      expect(File).to receive(:write).with("/etc/systemd/system/pgbouncer@.socket", pgbouncer_setup.socket_template_content)
+      expect(pgbouncer_setup).to receive(:r).with("systemctl daemon-reload")
+      pgbouncer_setup.create_service_templates
+    end
+  end
+
+  describe "#create_pgbouncer_config" do
+    it "writes config files for each instance" do
+      expect(File).to receive(:write).with("/etc/pgbouncer/pgbouncer_50001.ini", pgbouncer_setup.pgbouncer_ini_content(1))
+      expect(File).to receive(:write).with("/etc/pgbouncer/pgbouncer_50002.ini", pgbouncer_setup.pgbouncer_ini_content(2))
+      pgbouncer_setup.create_pgbouncer_config
+    end
+  end
+
+  describe "#disable_default_pgbouncer" do
+    it "disables and stops the default pgbouncer service" do
+      expect(pgbouncer_setup).to receive(:r).with("systemctl disable --now pgbouncer")
+      pgbouncer_setup.disable_default_pgbouncer
+    end
+  end
+
+  describe "#enable_and_start_service" do
+    it "reloads or enables and starts each pgbouncer instance" do
+      expect(pgbouncer_setup).to receive(:r).with("systemctl reload pgbouncer@50001 || systemctl enable --now pgbouncer@50001")
+      expect(pgbouncer_setup).to receive(:r).with("systemctl reload pgbouncer@50002 || systemctl enable --now pgbouncer@50002")
+      pgbouncer_setup.enable_and_start_service
+    end
+  end
+
+  describe "#setup" do
+    it "creates service templates, config, disables default, and enables instances" do
+      expect(pgbouncer_setup).to receive(:create_service_templates).ordered
+      expect(pgbouncer_setup).to receive(:create_pgbouncer_config).ordered
+      expect(pgbouncer_setup).to receive(:disable_default_pgbouncer).ordered
+      expect(pgbouncer_setup).to receive(:enable_and_start_service).ordered
+      pgbouncer_setup.setup
+    end
+  end
 end

--- a/rhizome/postgres/spec/postgres_lockout_spec.rb
+++ b/rhizome/postgres/spec/postgres_lockout_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe PostgresLockout do
     it "writes the lockout pg_hba config and reloads postgres" do
       expect(lockout).to receive(:safe_write_to_file).with(
         "/etc/postgresql/17/main/pg_hba.conf",
-        PostgresLockout.lockout_pg_hba,
+        described_class.lockout_pg_hba,
       )
       expect(logger).to receive(:info).with("Written lockout pg_hba.conf for PostgreSQL 17")
       expect(lockout).to receive(:r).with("sudo pg_ctlcluster 17 main reload")

--- a/rhizome/postgres/spec/postgres_lockout_spec.rb
+++ b/rhizome/postgres/spec/postgres_lockout_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe PostgresLockout do
   let(:logger) { instance_double(Logger, info: nil, warn: nil) }
   let(:lockout) { described_class.new("17", logger) }
 
-  before do
-    allow(lockout).to receive(:r)
-  end
-
   describe ".lockout_pg_hba" do
     it "returns restrictive pg_hba configuration" do
       config = described_class.lockout_pg_hba

--- a/rhizome/postgres/spec/postgres_lockout_spec.rb
+++ b/rhizome/postgres/spec/postgres_lockout_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe PostgresLockout do
     end
   end
 
+  describe "#write_lockout_pg_hba" do
+    it "writes the lockout pg_hba config and reloads postgres" do
+      expect(lockout).to receive(:safe_write_to_file).with(
+        "/etc/postgresql/17/main/pg_hba.conf",
+        PostgresLockout.lockout_pg_hba,
+      )
+      expect(logger).to receive(:info).with("Written lockout pg_hba.conf for PostgreSQL 17")
+      expect(lockout).to receive(:r).with("sudo pg_ctlcluster 17 main reload")
+      expect(logger).to receive(:info).with("Reloaded PostgreSQL 17 configuration to apply lockout pg_hba.conf")
+      lockout.write_lockout_pg_hba
+    end
+  end
+
   describe "#lockout" do
     it "writes lockout pg_hba and terminates connections in order" do
       expect(lockout).to receive(:write_lockout_pg_hba).ordered

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -50,8 +50,47 @@ RSpec.describe PostgresSetup do
         m = s.match(/\A(\d+)(MiB|GiB)\z/) or raise "unrecognized unit in #{s}"
         Integer(m[1], 10) * ((m[2] == "GiB") ? 1024**3 : 1024**2)
       }
+      expect(to_bytes.("1GiB")).to eq(1024**3)
       sum = PostgresSetup::GO_SERVICES.values.sum(&to_bytes)
       expect(sum).to be <= 2 * 1024**3 # MemoryHigh=2G on system-go_services.slice
+    end
+  end
+
+  describe "#install_packages" do
+    it "installs packages when the cache directory exists" do
+      expect(File).to receive(:exist?).with("/var/cache/postgresql-packages/17").and_return(true)
+      expect(pg_setup).to receive(:r).with("sudo install-postgresql-packages 17")
+      pg_setup.install_packages
+    end
+
+    it "does nothing when the cache directory does not exist" do
+      expect(File).to receive(:exist?).with("/var/cache/postgresql-packages/17").and_return(false)
+      expect(pg_setup).not_to receive(:r)
+      pg_setup.install_packages
+    end
+  end
+
+  describe "#setup_data_directory" do
+    it "sets up data directory with correct structure" do
+      expect(pg_setup).to receive(:r).with("chown postgres /dat")
+      expect(pg_setup).to receive(:r).with("rm -rf /dat/17")
+      expect(pg_setup).to receive(:r).with("rm -rf /etc/postgresql/17")
+      expect(pg_setup).to receive(:r).with("echo \"data_directory = '/dat/17/data'\" | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf")
+      expect(pg_setup).to receive(:r).with(/install -m 0755.*disk-full-check.*\/usr\/local\/sbin\/disk-full-check/)
+      expect(pg_setup).to receive(:r).with("install -d -m 0755 /etc/postgresql-common/pg-logs-throttle")
+      expect(pg_setup).to receive(:r).with(/install -m 0644.*991-pg-logs-throttle\.conf.*/)
+      expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/disk-full-check@.service", satisfy { |s| s.include?("disk-full-check") })
+      expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/disk-full-check@.timer", satisfy { |s| s.include?("OnBootSec=30s") })
+      expect(pg_setup).to receive(:r).with("sudo systemctl daemon-reload")
+      expect(pg_setup).to receive(:r).with("sudo systemctl enable --now disk-full-check@17.timer")
+      pg_setup.setup_data_directory
+    end
+  end
+
+  describe "#create_cluster" do
+    it "creates a postgres cluster" do
+      expect(pg_setup).to receive(:r).with("pg_createcluster 17 main --port=5432 --locale=C.UTF8")
+      pg_setup.create_cluster
     end
   end
 

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe PostgresSetup do
   let(:pg_setup) { described_class.new("17") }
 
   before do
-    allow(pg_setup).to receive(:r)
     allow(pg_setup).to receive(:safe_write_to_file)
   end
 
@@ -76,9 +75,9 @@ RSpec.describe PostgresSetup do
       expect(pg_setup).to receive(:r).with("rm -rf /dat/17")
       expect(pg_setup).to receive(:r).with("rm -rf /etc/postgresql/17")
       expect(pg_setup).to receive(:r).with("echo \"data_directory = '/dat/17/data'\" | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf")
-      expect(pg_setup).to receive(:r).with(/install -m 0755.*disk-full-check.*\/usr\/local\/sbin\/disk-full-check/)
+      expect(pg_setup).to receive(:r).with("install -m 0755 #{File.expand_path("../bin/disk-full-check", __dir__).shellescape} /usr/local/sbin/disk-full-check")
       expect(pg_setup).to receive(:r).with("install -d -m 0755 /etc/postgresql-common/pg-logs-throttle")
-      expect(pg_setup).to receive(:r).with(/install -m 0644.*991-pg-logs-throttle\.conf.*/)
+      expect(pg_setup).to receive(:r).with("install -m 0644 #{File.expand_path("../lib/pg-logs-throttle/991-pg-logs-throttle.conf", __dir__).shellescape} /etc/postgresql-common/pg-logs-throttle/991-pg-logs-throttle.conf")
       expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/disk-full-check@.service", satisfy { |s| s.include?("disk-full-check") })
       expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/disk-full-check@.timer", satisfy { |s| s.include?("OnBootSec=30s") })
       expect(pg_setup).to receive(:r).with("sudo systemctl daemon-reload")

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe PostgresSetup do
         m = s.match(/\A(\d+)(MiB|GiB)\z/) or raise "unrecognized unit in #{s}"
         Integer(m[1], 10) * ((m[2] == "GiB") ? 1024**3 : 1024**2)
       }
-      expect(to_bytes.("1GiB")).to eq(1024**3)
+      expect(to_bytes.call("1GiB")).to eq(1024**3)
       sum = PostgresSetup::GO_SERVICES.values.sum(&to_bytes)
       expect(sum).to be <= 2 * 1024**3 # MemoryHigh=2G on system-go_services.slice
     end

--- a/rhizome/postgres/spec/postgres_upgrade_spec.rb
+++ b/rhizome/postgres/spec/postgres_upgrade_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe PostgresUpgrade do
 
   before do
     # Mock the util methods from common/lib/util
-    allow(postgres_upgrade).to receive(:r)
     stub_const("EXTENSION_UPGRADE_SCRIPTS", {
       17 => {
         "postgis" => "SELECT postgis_extensions_upgrade();",
@@ -84,6 +83,7 @@ RSpec.describe PostgresUpgrade do
   describe "#disable_previous_version" do
     it "disables and stops previous version service" do
       expect(postgres_upgrade).to receive(:r).with("sudo systemctl disable --now postgresql@16-main")
+      expect(postgres_upgrade).to receive(:r).with("sudo systemctl disable --now disk-full-check@17.timer")
       postgres_upgrade.disable_previous_version
     end
   end
@@ -95,6 +95,8 @@ RSpec.describe PostgresUpgrade do
       expect(pg_setup).to receive(:install_packages)
       expect(pg_setup).to receive(:setup_data_directory)
       expect(pg_setup).to receive(:create_cluster)
+      expect(postgres_upgrade).to receive(:r).with("sudo systemctl disable --now postgresql@16-main")
+      expect(postgres_upgrade).to receive(:r).with("sudo systemctl disable --now disk-full-check@17.timer")
       postgres_upgrade.initialize_new_version
     end
   end
@@ -128,6 +130,7 @@ RSpec.describe PostgresUpgrade do
   describe "#enable_new_version" do
     it "enables and starts new version service" do
       expect(postgres_upgrade).to receive(:r).with("sudo systemctl enable --now postgresql@17-main")
+      expect(postgres_upgrade).to receive(:r).with("sudo systemctl enable --now disk-full-check@17.timer")
       postgres_upgrade.enable_new_version
     end
   end
@@ -142,9 +145,8 @@ RSpec.describe PostgresUpgrade do
     end
 
     it "raises when postgres fails to start before deadline" do
-      allow(postgres_upgrade).to receive(:r).with("sudo -u postgres pg_isready").and_raise(StandardError)
-      allow(postgres_upgrade).to receive(:sleep)
-      allow(Time).to receive(:now).and_return(Time.at(0), Time.at(61))
+      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres pg_isready").and_raise(StandardError)
+      expect(Time).to receive(:now).and_return(Time.at(0), Time.at(61))
       expect { postgres_upgrade.wait_for_postgres_to_start }.to raise_error("Postgres failed to start")
     end
   end
@@ -229,9 +231,6 @@ RSpec.describe PostgresUpgrade do
       expect(postgres_upgrade).to receive(:wait_for_postgres_to_start).ordered
       expect(postgres_upgrade).to receive(:run_post_upgrade_scripts).ordered
       expect(postgres_upgrade).to receive(:run_post_upgrade_extension_update).ordered
-
-      allow(postgres_upgrade).to receive(:puts)
-
       postgres_upgrade.upgrade({"user_config" => user_config})
     end
   end

--- a/rhizome/postgres/spec/postgres_upgrade_spec.rb
+++ b/rhizome/postgres/spec/postgres_upgrade_spec.rb
@@ -140,6 +140,13 @@ RSpec.describe PostgresUpgrade do
 
       postgres_upgrade.wait_for_postgres_to_start
     end
+
+    it "raises when postgres fails to start before deadline" do
+      allow(postgres_upgrade).to receive(:r).with("sudo -u postgres pg_isready").and_raise(StandardError)
+      allow(postgres_upgrade).to receive(:sleep)
+      allow(Time).to receive(:now).and_return(Time.at(0), Time.at(61))
+      expect { postgres_upgrade.wait_for_postgres_to_start }.to raise_error("Postgres failed to start")
+    end
   end
 
   describe "#run_post_upgrade_scripts" do

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -15,13 +15,9 @@ elsif (suite = ENV.delete("COVERAGE"))
     command_name "#{suite}#{ENV["TEST_ENV_NUMBER"]}"
 
     if suite == "rhizome"
-      require "pathname"
-      LOCKED_FILES = ["rhizome/kubernetes/lib/ubi_cni.rb"].map do |file|
-        Pathname.new(File.expand_path("..", __dir__)).join(file).to_s
-      end
-
       add_filter do |file|
-        !LOCKED_FILES.include?(file.filename)
+        path = file.filename.delete_prefix(File.dirname(__dir__))
+        !path.start_with?("/rhizome/") || !path.include?("/lib/")
       end
     else
       add_filter do |file|


### PR DESCRIPTION
The new tests were written by Claude, but I went through all added specs, and also made changes to existing specs, making many small changes:

* Test full argument(s) given to `r`, where previously they weren't tested at all or used regexps.
* Convert `allow` to `expect` in many cases.
* Removing unnecessary `not_to raise_error`.
* Adding explicit `nil` to rescue blocks.
* Avoiding unnecessary `before` blocks in specs.
* Reducing mocking in the specs.
* Fixing improper shell escaping in `curl_file`.
* Adding `VmPath.define_new_method` to DRY up code.

In terms of reviews:

Hadi: rhizome/host
Ben: rhizome/inference_endpoint
Burak: rhizome/postgres
Enes: rhizome/common, Rakefile, spec/coverage_helper.rb
