### PR TITLE
Fix handling of removing last payment method for project

### DIFF
--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -153,8 +153,8 @@ class Clover
           next unless (payment_method = @project.payment_methods_dataset.with_pk(id))
 
           unless payment_method.billing_info.payment_methods_dataset.count > 1
-            response.status = 400
-            next {error: {message: "You can't delete the last payment method of a project."}}
+            flash["error"] = "You can't delete the last payment method of a project."
+            r.redirect @project, "/billing"
           end
 
           DB.transaction do

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -318,17 +318,24 @@ RSpec.describe Clover, "billing" do
     end
 
     it "can't delete last payment method" do
-      expect(customers_service).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"country" => "NL"}, "metadata" => {"company_name" => "Foo Company Name"}})
-      expect(payment_methods_service).to receive(:retrieve).with(payment_method.stripe_id).and_return(stripe_object("card" => {"brand" => "visa"}))
+      expect(customers_service).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"country" => "NL"}, "metadata" => {"company_name" => "Foo Company Name"}}).at_least(:once)
+      expect(payment_methods_service).to receive(:retrieve).with(payment_method.stripe_id).and_return(stripe_object("card" => {"brand" => "visa"})).at_least(:once)
 
       visit "#{project.path}/billing"
 
       within("#payment-method-#{payment_method.ubid}") do
+        expect(page).to have_no_content("Delete")
+      end
+
+      pm2 = PaymentMethod.create(billing_info_id: billing_info.id, stripe_id: "pm_1234567891")
+      expect(payment_methods_service).to receive(:retrieve).with("pm_1234567891").and_return(stripe_object("card" => {"brand" => "visa"}))
+      page.refresh
+      pm2.this.delete(force: true)
+      within("#payment-method-#{payment_method.ubid}") do
         click_button "Delete"
       end
 
-      expect(page.status_code).to eq(400)
-      expect(page.body).to eq({error: {message: "You can't delete the last payment method of a project."}}.to_json)
+      expect(page).to have_flash_error("You can't delete the last payment method of a project.")
       expect(billing_info.reload.payment_methods.count).to eq(1)
     end
 
@@ -351,6 +358,8 @@ RSpec.describe Clover, "billing" do
     it "returns 404 if payment method does not exist" do
       expect(customers_service).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"country" => "NL"}, "metadata" => {"company_name" => "Foo Company Name"}})
       expect(payment_methods_service).to receive(:retrieve).with(payment_method.stripe_id).and_return(stripe_object("card" => {"brand" => "visa"}))
+      payment_method_2 = PaymentMethod.create(billing_info_id: billing_info.id, stripe_id: "pm_2222222222")
+      expect(payment_methods_service).to receive(:retrieve).with(payment_method_2.stripe_id).and_return(stripe_object("card" => {"brand" => "mastercard"})).at_least(:once)
       visit "#{project.path}/billing"
       payment_method.this.delete(force: true)
 

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -160,6 +160,7 @@ end
       <% end %>
     </div>
     <!-- Payment Methods Card -->
+    <% allow_delete = billing_info.payment_methods.size > 1 %>
     <%== part(
       "components/table_card",
       title: "Payment Methods",
@@ -173,17 +174,21 @@ end
               "#{pm.stripe_data["brand"].capitalize} ending in #{pm.stripe_data["last4"]}",
               "Expires #{pm.stripe_data["exp_month"]}/#{pm.stripe_data["exp_year"]}",
               "Added on #{pm.created_at.strftime("%B %d, %Y")}",
-              [
-                "delete_button",
-                {
-                  component: {
-                    url: path(pm),
-                    hidden_inputs: { project_id: @project.ubid },
-                    confirmation: pm.stripe_data["last4"]
-                  },
-                  extra_class: "flex justify-end"
-                }
-              ]
+              if allow_delete
+                [
+                  "delete_button",
+                  {
+                    component: {
+                      url: path(pm),
+                      hidden_inputs: { project_id: @project.ubid },
+                      confirmation: pm.stripe_data["last4"]
+                    },
+                    extra_class: "flex justify-end"
+                  }
+                ]
+              else
+                []
+              end
             ],
             { id: "payment-method-#{pm.ubid}" }
           ]


### PR DESCRIPTION
Use a flash error instead of a JSON response.

When displaying the form, do not show a delete button if there is only one payment method.