### PR TITLE
Qualify created_at order on admin BillingInfo browse

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -661,7 +661,7 @@ class CloverAdmin < Roda
     end
 
     model BillingInfo do
-      order Sequel.desc(:created_at)
+      order Sequel.desc(Sequel[:billing_info][:created_at])
       eager_graph [:project]
       columns do |type_symbol, request|
         cs = [:stripe_id, :project, :valid_vat, :created_at]

--- a/spec/routes/web/admin/model/billing_info_spec.rb
+++ b/spec/routes/web/admin/model/billing_info_spec.rb
@@ -19,4 +19,13 @@ RSpec.describe CloverAdmin, "BillingInfo" do
     expect(page.status_code).to eq 200
     expect(page.title).to eq "Ubicloud Admin - BillingInfo #{@instance.ubid}"
   end
+
+  it "paginates the browse page" do
+    oldest = Array.new(25) { |i| BillingInfo.create(stripe_id: "cus_test#{i}", created_at: Time.now - i - 1) }.last
+    click_link "BillingInfo"
+    click_link "Next"
+    expect(page.status_code).to eq 200
+    expect(page.title).to eq "Ubicloud Admin - BillingInfo - Browse"
+    expect(page).to have_content oldest.ubid
+  end
 end


### PR DESCRIPTION
The BillingInfo autoforme model uses eager_graph [:project], which left-joins the project table. Both billing_info and project have a created_at column, and the filter pagination strategy builds the next-page condition directly from the configured order expression. With an unqualified order, paging past the first page generated WHERE ("created_at" < ...), which PostgreSQL rejected with PG::AmbiguousColumn.

Qualify the order with the billing_info table, matching what the Account model already does for its eager_graph [:identities].