### PR TITLE
Do not return a cached SSH session that is already closed

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -206,9 +206,11 @@ class Sshable < Sequel::Model
   def connect
     Thread.current[:clover_ssh_cache] ||= {}
 
-    # Cache hit.
+    # Cache hit, unless the session was closed underneath us, e.g. by
+    # the server terminating the connection. Then reconnect.
     if (sess = Thread.current[:clover_ssh_cache][[host, unix_user]])
-      return sess
+      return sess unless sess.closed?
+      invalidate_cache_entry
     end
 
     # Cache miss.

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -112,7 +112,7 @@ LOCK
 
     it "can cache SSH connections" do
       expect(Net::SSH).to receive(:start) do
-        instance_double(Net::SSH::Connection::Session, close: nil)
+        instance_double(Net::SSH::Connection::Session, close: nil, closed?: false)
       end
 
       expect(Thread.current[:clover_ssh_cache]).to be_nil
@@ -123,6 +123,17 @@ LOCK
 
       expect(described_class.reset_cache).to eq []
       expect(Thread.current[:clover_ssh_cache]).to be_empty
+    end
+
+    it "reconnects when the cached session was closed underneath it" do
+      closed_sess = instance_double(Net::SSH::Connection::Session, closed?: true)
+      fresh_sess = instance_double(Net::SSH::Connection::Session, closed?: false)
+      expect(Net::SSH).to receive(:start).and_return(closed_sess, fresh_sess)
+
+      expect(sa.connect).to equal(closed_sess)
+      expect(sa.connect).to equal(fresh_sess)
+      expect(sa.connect).to equal(fresh_sess)
+      expect(Thread.current[:clover_ssh_cache]).to eq({["test.localhost", "testuser"] => fresh_sess})
     end
 
     it "does not crash if a cache has never been made" do


### PR DESCRIPTION
Sshable#connect returned cached sessions unconditionally, so once a session was closed underneath us (e.g. the server terminating an idle connection), every subsequent use kept failing with "IOError: closed stream". Sshable#cmd recovers because its rescue invalidates the cache entry, but callers using the session directly, like Kubernetes::Client, were stuck on the dead session with no way to reconnect.

Check closed? on cache hit and reconnect instead, so a retry opens a fresh connection.