### PR TITLE
Close shared GCP VPC attach/destroy race

### DIFF
--- a/prog/vnet/gcp/subnet_nexus.rb
+++ b/prog/vnet/gcp/subnet_nexus.rb
@@ -112,7 +112,7 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   label def wait_create_subnet
     poll_and_clear_gcp_op("create_subnet") do |op|
       begin
-        credential.subnetworks_client.get(project: gcp_project_id, region: gcp_region, subnetwork: subnet_name)
+        get_gce_subnet
       rescue Google::Cloud::NotFoundError
         raise "GCP subnet #{subnet_name} creation failed: #{op_error_message(op)}"
       end
@@ -219,7 +219,7 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   label def wait_delete_subnet
     poll_and_clear_gcp_op("delete_subnet") do |op|
       begin
-        credential.subnetworks_client.get(project: gcp_project_id, region: gcp_region, subnetwork: subnet_name)
+        get_gce_subnet
       rescue Google::Cloud::NotFoundError
         Clog.emit("GCP subnet already gone despite LRO error; proceeding",
           {gcp_subnet_already_gone: {subnet: subnet_name, lro_error: op_error_message(op)}})
@@ -253,6 +253,14 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
       nap 5
     end
 
+    # Hold the row until GCE stops resolving the deleted subnet.
+    begin
+      get_gce_subnet
+      nap 10
+    rescue Google::Cloud::NotFoundError
+      nil
+    end
+
     private_subnet.destroy
 
     if gcp_vpc && gcp_vpc.private_subnets_dataset.empty?
@@ -263,6 +271,10 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   end
 
   private
+
+  def get_gce_subnet
+    credential.subnetworks_client.get(project: gcp_project_id, region: gcp_region, subnetwork: subnet_name)
+  end
 
   def firewall_policy_name
     private_subnet.gcp_vpc.name

--- a/prog/vnet/gcp/subnet_nexus.rb
+++ b/prog/vnet/gcp/subnet_nexus.rb
@@ -45,15 +45,23 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
         # The dedicated_for_subnet_id: nil filter is load-bearing:
         # without it, once the project has any dedicated VPCs, this
         # lookup could grab another subnet's dedicated row.
-        GcpVpc.where(
+        #
+        # finish_destroy takes the same row lock before the
+        # last-subnet-out incr_destroy.
+        vpc = GcpVpc.where(
           project_id: private_subnet.project_id,
           location_id: private_subnet.location_id,
           dedicated_for_subnet_id: nil,
-        ).first ||
-          Prog::Vnet::Gcp::VpcNexus.assemble(
-            private_subnet.project_id,
-            private_subnet.location_id,
-          ).subject
+        ).for_no_key_update.first
+        if vpc && (vpc.destroy_set? || vpc.destroying_set?)
+          Clog.emit("Waiting for draining GCP VPC before attaching subnet",
+            {gcp_vpc_draining: {vpc: vpc.name, label: vpc.strand.label}})
+          nap 5
+        end
+        vpc || Prog::Vnet::Gcp::VpcNexus.assemble(
+          private_subnet.project_id,
+          private_subnet.location_id,
+        ).subject
       end
     unless private_subnet.gcp_vpc
       gcp_vpc.add_private_subnet(private_subnet)

--- a/prog/vnet/gcp/subnet_nexus.rb
+++ b/prog/vnet/gcp/subnet_nexus.rb
@@ -30,39 +30,7 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
     register_deadline("wait", 5 * 60)
 
     gcp_vpc = private_subnet.gcp_vpc ||
-      if private_subnet.project.gcp_dedicated_subnet_vpcs
-        # Look up by dedicated_for_subnet_id (not the join row) so
-        # a label re-entry that left the assemble committed but the
-        # join row not yet inserted can still find its dedicated VPC
-        # instead of leaking a second one.
-        GcpVpc.first(dedicated_for_subnet_id: private_subnet.id) ||
-          Prog::Vnet::Gcp::VpcNexus.assemble(
-            private_subnet.project_id,
-            private_subnet.location_id,
-            dedicated_for_subnet_id: private_subnet.id,
-          ).subject
-      else
-        # The dedicated_for_subnet_id: nil filter is load-bearing:
-        # without it, once the project has any dedicated VPCs, this
-        # lookup could grab another subnet's dedicated row.
-        #
-        # finish_destroy takes the same row lock before the
-        # last-subnet-out incr_destroy.
-        vpc = GcpVpc.where(
-          project_id: private_subnet.project_id,
-          location_id: private_subnet.location_id,
-          dedicated_for_subnet_id: nil,
-        ).for_no_key_update.first
-        if vpc && (vpc.destroy_set? || vpc.destroying_set?)
-          Clog.emit("Waiting for draining GCP VPC before attaching subnet",
-            {gcp_vpc_draining: {vpc: vpc.name, label: vpc.strand.label}})
-          nap 5
-        end
-        vpc || Prog::Vnet::Gcp::VpcNexus.assemble(
-          private_subnet.project_id,
-          private_subnet.location_id,
-        ).subject
-      end
+      (private_subnet.project.gcp_dedicated_subnet_vpcs ? ensure_dedicated_vpc : ensure_shared_vpc)
     unless private_subnet.gcp_vpc
       gcp_vpc.add_private_subnet(private_subnet)
       # Firewalls attached to this subnet (or to VMs whose NICs live in
@@ -271,6 +239,40 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   end
 
   private
+
+  # Look up by dedicated_for_subnet_id (not the join row) so a label
+  # re-entry that left the assemble committed but the join row not yet
+  # inserted can still find its dedicated VPC instead of leaking a
+  # second one.
+  def ensure_dedicated_vpc
+    GcpVpc.first(dedicated_for_subnet_id: private_subnet.id) ||
+      Prog::Vnet::Gcp::VpcNexus.assemble(
+        private_subnet.project_id,
+        private_subnet.location_id,
+        dedicated_for_subnet_id: private_subnet.id,
+      ).subject
+  end
+
+  # The dedicated_for_subnet_id: nil filter is load-bearing: without
+  # it, once the project has any dedicated VPCs, this lookup could
+  # grab another subnet's dedicated row. finish_destroy takes the same
+  # row lock before the last-subnet-out incr_destroy.
+  def ensure_shared_vpc
+    vpc = GcpVpc.where(
+      project_id: private_subnet.project_id,
+      location_id: private_subnet.location_id,
+      dedicated_for_subnet_id: nil,
+    ).for_no_key_update.first
+    if vpc && (vpc.destroy_set? || vpc.destroying_set?)
+      Clog.emit("Waiting for draining GCP VPC before attaching subnet",
+        {gcp_vpc_draining: {vpc: vpc.name, label: vpc.strand.label}})
+      nap 5
+    end
+    vpc || Prog::Vnet::Gcp::VpcNexus.assemble(
+      private_subnet.project_id,
+      private_subnet.location_id,
+    ).subject
+  end
 
   def get_gce_subnet
     credential.subnetworks_client.get(project: gcp_project_id, region: gcp_region, subnetwork: subnet_name)

--- a/prog/vnet/gcp/vpc_nexus.rb
+++ b/prog/vnet/gcp/vpc_nexus.rb
@@ -487,7 +487,7 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
   label def wait_vpc_network_deleted
     poll_and_clear_gcp_op("delete_vpc") do |err_op|
       begin
-        credential.networks_client.get(project: gcp_project_id, network: gcp_vpc.name)
+        get_vpc_network
       rescue Google::Cloud::NotFoundError
         Clog.emit("GCP VPC network already gone despite LRO error; proceeding",
           {gcp_vpc_already_gone: {network: gcp_vpc.name, lro_error: op_error_message(err_op)}})
@@ -500,11 +500,20 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
   end
 
   label def finalize_destroy
-    gcp_vpc.destroy
-    pop "vpc destroyed"
+    begin
+      get_vpc_network
+    rescue Google::Cloud::NotFoundError
+      gcp_vpc.destroy
+      pop "vpc destroyed"
+    end
+    nap 10
   end
 
   private
+
+  def get_vpc_network
+    credential.networks_client.get(project: gcp_project_id, network: gcp_vpc.name)
+  end
 
   def get_firewall_policy
     credential.network_firewall_policies_client.get(

--- a/prog/vnet/gcp/vpc_nexus.rb
+++ b/prog/vnet/gcp/vpc_nexus.rb
@@ -210,14 +210,18 @@ class Prog::Vnet::Gcp::VpcNexus < Prog::Base
   end
 
   label def destroy
-    register_deadline("destroy", 10 * 60)
     decr_destroy
 
-    unless gcp_vpc.private_subnets.empty?
-      Clog.emit("Cannot destroy VPC with active subnets", gcp_vpc)
-      nap 10
+    # Serializes with the attach decision in SubnetNexus#start.
+    gcp_vpc.lock!(:no_key_update)
+
+    unless gcp_vpc.private_subnets_dataset.empty?
+      Clog.emit("Dropping VPC destroy, subnets are attached", gcp_vpc)
+      decr_destroying
+      hop_wait
     end
 
+    register_deadline("destroy", 10 * 60)
     hop_enumerate_destroy_state
   end
 

--- a/spec/prog/vnet/gcp/subnet_nexus_concurrency_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_concurrency_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus, :no_db_transaction do
     Location.create(name: "vpc-race-gcp-#{tag}", provider: "gcp", project_id: project.id,
       display_name: "VPC Race GCP", ui_name: "VPC Race GCP", visible: true)
   }
+  let(:credential) {
+    LocationCredentialGcp.create_with_id(location,
+      project_id: "test-gcp-project",
+      service_account_email: "vpc-race@test-gcp-project.iam.gserviceaccount.com",
+      credentials_json: "{}")
+  }
   let(:gcp_vpc) {
     vpc = GcpVpc.create(
       project_id: project.id,
@@ -45,6 +51,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus, :no_db_transaction do
       DB[:strand].where(id: strand_ids).delete
       DB[:private_subnet].where(id: created_subnet_ids).delete
       DB[:gcp_vpc].where(id: gcp_vpc.id).delete
+      DB[:location_credential_gcp].where(id: location.id).delete
       DB[:location].where(id: location.id).delete
       DB[:project].where(id: project.id).delete
     end
@@ -140,7 +147,13 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus, :no_db_transaction do
     expect(t1_error).to be_nil
     expect(DB[:private_subnet_gcp_vpc].where(private_subnet_id: attacher.id).count).to eq(1)
 
-    expect { described_class.new(destroyer.strand).finish_destroy }.to exit({"msg" => "subnet destroyed"})
+    credential
+    nx_destroyer = described_class.new(destroyer.strand)
+    subnetworks = instance_double(Google::Cloud::Compute::V1::Subnetworks::Rest::Client)
+    expect(subnetworks).to receive(:get).and_raise(Google::Cloud::NotFoundError.new("not found"))
+    allow(nx_destroyer.send(:credential)).to receive(:subnetworks_client).and_return(subnetworks)
+
+    expect { nx_destroyer.finish_destroy }.to exit({"msg" => "subnet destroyed"})
     expect(gcp_vpc.destroy_set?).to be(false)
     expect(destroyer).not_to exist
     expect(DB[:private_subnet_gcp_vpc].where(private_subnet_id: attacher.id).count).to eq(1)

--- a/spec/prog/vnet/gcp/subnet_nexus_concurrency_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_concurrency_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require_relative "../../../spec_helper"
+
+# Two-connection specs for the shared GCP VPC attach/destroy race:
+# single-connection specs cannot catch a silently dropped gcp_vpc row
+# lock, so these drive real concurrent transactions through both commit
+# orders, outside the wrapping rollback-only transaction.
+RSpec.describe Prog::Vnet::Gcp::SubnetNexus, :no_db_transaction do
+  let(:tag) { SecureRandom.hex(4) }
+  let(:created_subnet_ids) { [] }
+  let(:project) { Project.create(name: "vpc-race-#{tag}") }
+  let(:location) {
+    Location.create(name: "vpc-race-gcp-#{tag}", provider: "gcp", project_id: project.id,
+      display_name: "VPC Race GCP", ui_name: "VPC Race GCP", visible: true)
+  }
+  let(:gcp_vpc) {
+    vpc = GcpVpc.create(
+      project_id: project.id,
+      location_id: location.id,
+      name: "ubicloud-#{project.ubid}-#{location.ubid}",
+    )
+    Strand.create_with_id(vpc, prog: "Vnet::Gcp::VpcNexus", label: "wait")
+    vpc
+  }
+
+  def make_subnet(idx)
+    subnet = PrivateSubnet.create(
+      name: "vpc-race-ps-#{tag}-#{idx}",
+      location_id: location.id, project_id: project.id,
+      net6: "fd10:dd#{format("%02x", idx)}::/64",
+      net4: "10.#{200 + idx}.0.0/26",
+      state: "waiting",
+    )
+    Strand.create_with_id(subnet, prog: "Vnet::Gcp::SubnetNexus", label: "start")
+    created_subnet_ids << subnet.id
+    subnet
+  end
+
+  after do
+    DB.transaction do
+      strand_ids = created_subnet_ids + [gcp_vpc.id]
+      DB[:semaphore].where(strand_id: strand_ids).delete
+      DB[:private_subnet_gcp_vpc].where(gcp_vpc_id: gcp_vpc.id).delete
+      DB[:strand].where(id: strand_ids).delete
+      DB[:private_subnet].where(id: created_subnet_ids).delete
+      DB[:gcp_vpc].where(id: gcp_vpc.id).delete
+      DB[:location].where(id: location.id).delete
+      DB[:project].where(id: project.id).delete
+    end
+  end
+
+  it "blocks start on the held vpc row lock until the incr_destroy commits, then naps without attaching" do
+    # Commit the lets on the main connection before the threads start.
+    vpc_id = gcp_vpc.id
+    subnet = make_subnet(1)
+    nx = described_class.new(subnet.strand)
+
+    t1_has_lock = Queue.new
+    t1_may_release = Queue.new
+    t1_error = nil
+    t2_result = nil
+
+    # Simulates finish_destroy: hold the row lock across the incr,
+    # releasing only at commit.
+    t1 = Thread.new do
+      DB.transaction do
+        GcpVpc.where(id: vpc_id).for_no_key_update.first
+        t1_has_lock.push(DB.get(Sequel.function(:pg_backend_pid)))
+        gcp_vpc.incr_destroy
+        expect(t1_may_release.pop(timeout: 5)).to be true
+      end
+    rescue => e
+      t1_error = e
+    end
+
+    begin
+      t1_pid = t1_has_lock.pop(timeout: 5)
+      expect(t1_pid).to be_a(Integer)
+
+      t2_pid_queue = Queue.new
+      t2 = Thread.new do
+        DB.synchronize do
+          t2_pid_queue.push(DB.get(Sequel.function(:pg_backend_pid)))
+          nx.start
+        end
+        t2_result = :proceeded
+      rescue Prog::Base::Nap => e
+        t2_result = [:napped, e.seconds]
+      rescue Prog::Base::Hop
+        t2_result = :hopped
+      rescue => e
+        t2_result = [:error, e.class.name, e.message]
+      end
+
+      # Wait until T2's backend is blocked by T1's; without the lock
+      # it would attach and finish as :hopped instead.
+      t2_pid = t2_pid_queue.pop(timeout: 5)
+      expect(t2_pid).to be_a(Integer)
+      blocking = lambda { DB.get(Sequel.function(:pg_blocking_pids, t2_pid)).to_a }
+      500.times do
+        break if blocking.call == [t1_pid]
+        sleep 0.01
+      end
+      expect(blocking.call).to eq([t1_pid])
+      expect(t2_result).to be_nil
+
+      t1_may_release.push(true)
+      expect(t1.join(5)).to eq(t1)
+      expect(t2.join(5)).to eq(t2)
+    ensure
+      t1_may_release.push(true) if t1.alive?
+      [t1, t2].each do |t|
+        next unless t&.alive?
+        t.kill
+        t.join
+      end
+    end
+
+    expect(t1_error).to be_nil
+    expect(t2_result).to eq([:napped, 5])
+    expect(DB[:private_subnet_gcp_vpc].where(private_subnet_id: subnet.id).count).to eq(0)
+    expect(gcp_vpc.destroy_set?).to be(true)
+  end
+
+  it "makes finish_destroy's locked recount observe a committed attach and skip incr_destroy" do
+    attacher = make_subnet(1)
+    destroyer = make_subnet(2)
+    DB[:private_subnet_gcp_vpc].insert(private_subnet_id: destroyer.id, gcp_vpc_id: gcp_vpc.id)
+
+    t1_error = nil
+    t1 = Thread.new do
+      described_class.new(attacher.strand).start
+    rescue Prog::Base::Hop
+      # expected: attach committed, hop to wait_vpc_ready
+    rescue => e
+      t1_error = e
+    end
+    expect(t1.join(5)).to eq(t1)
+    expect(t1_error).to be_nil
+    expect(DB[:private_subnet_gcp_vpc].where(private_subnet_id: attacher.id).count).to eq(1)
+
+    expect { described_class.new(destroyer.strand).finish_destroy }.to exit({"msg" => "subnet destroyed"})
+    expect(gcp_vpc.destroy_set?).to be(false)
+    expect(destroyer).not_to exist
+    expect(DB[:private_subnet_gcp_vpc].where(private_subnet_id: attacher.id).count).to eq(1)
+  ensure
+    if t1&.alive?
+      t1.kill
+      t1.join
+    end
+  end
+end

--- a/spec/prog/vnet/gcp/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_spec.rb
@@ -97,6 +97,31 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
       expect(GcpVpc[linked_id].dedicated_for_subnet_id).to be_nil
     end
 
+    it "naps without attaching while the shared VPC has destroy requested" do
+      DB[:private_subnet_gcp_vpc].where(private_subnet_id: ps.id).delete
+      gcp_vpc.incr_destroy
+
+      expect { nx.start }.to nap(5)
+      expect(DB[:private_subnet_gcp_vpc].where(private_subnet_id: ps.id).count).to eq(0)
+    end
+
+    it "naps without attaching while the shared VPC is mid-teardown (destroying set, destroy already consumed)" do
+      DB[:private_subnet_gcp_vpc].where(private_subnet_id: ps.id).delete
+      gcp_vpc.incr_destroying
+      gcp_vpc.strand.update(label: "wait_vpc_network_deleted")
+
+      expect { nx.start }.to nap(5)
+      expect(DB[:private_subnet_gcp_vpc].where(private_subnet_id: ps.id).count).to eq(0)
+    end
+
+    it "attaches while the shared VPC is still being created" do
+      DB[:private_subnet_gcp_vpc].where(private_subnet_id: ps.id).delete
+      gcp_vpc.strand.update(label: "wait_create_vpc")
+
+      expect { nx.start }.to hop("wait_vpc_ready")
+      expect(DB[:private_subnet_gcp_vpc].where(private_subnet_id: ps.id).get(:gcp_vpc_id)).to eq(gcp_vpc.id)
+    end
+
     context "when project.gcp_dedicated_subnet_vpcs is true" do
       before { project.update(gcp_dedicated_subnet_vpcs: true) }
 

--- a/spec/prog/vnet/gcp/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_spec.rb
@@ -741,6 +741,19 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
   end
 
   describe "#finish_destroy" do
+    before do
+      allow(subnetworks_client).to receive(:get).and_raise(Google::Cloud::NotFoundError.new("not found"))
+    end
+
+    it "naps while the deleted GCE subnet still resolves" do
+      expect(subnetworks_client).to receive(:get)
+        .with(project: "test-gcp-project", region: "us-central1", subnetwork: "ubicloud-#{ps.ubid}")
+        .and_return(Google::Cloud::Compute::V1::Subnetwork.new(name: "ubicloud-#{ps.ubid}"))
+
+      expect { nx.finish_destroy }.to nap(10)
+      expect(ps).to exist
+    end
+
     it "destroys the subnet and pops" do
       # Create another subnet so gcp_vpc is not the last
       ps2 = PrivateSubnet.create(name: "ps2", location_id: location.id, net6: "fd10:9b0b:6b4b:8fbc::/64",

--- a/spec/prog/vnet/gcp/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_nexus_spec.rb
@@ -1298,10 +1298,23 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
   end
 
   describe "#finalize_destroy" do
-    it "destroys GcpVpc row and pops" do
+    it "destroys GcpVpc row and pops once the network no longer resolves" do
       vpc_id = gcp_vpc.id
+      expect(networks_client).to receive(:get)
+        .with(project: "test-gcp-project", network: vpc_name)
+        .and_raise(Google::Cloud::NotFoundError.new("not found"))
+
       expect { nx.finalize_destroy }.to exit({"msg" => "vpc destroyed"})
       expect(GcpVpc[vpc_id]).to be_nil
+    end
+
+    it "naps while the deleted network still resolves" do
+      expect(networks_client).to receive(:get)
+        .with(project: "test-gcp-project", network: vpc_name)
+        .and_return(Google::Cloud::Compute::V1::Network.new(name: vpc_name))
+
+      expect { nx.finalize_destroy }.to nap(10)
+      expect(gcp_vpc).to exist
     end
   end
 

--- a/spec/prog/vnet/gcp/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_nexus_spec.rb
@@ -660,14 +660,24 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
       expect(nx.strand.stack.first["deadline_target"]).to eq("destroy")
     end
 
-    it "naps when subnets still exist" do
+    it "drops the destroy, clears destroying, and hops back to wait when subnets are attached" do
+      # Semaphore.incr inserts nothing if the strand row does not exist yet.
+      st
       ps = PrivateSubnet.create(
         name: "ps", location_id: location.id, project_id: project.id,
         net6: "fd10:9b0b:6b4b:8fbb::/64", net4: "10.0.0.0/26", state: "waiting",
       )
       DB[:private_subnet_gcp_vpc].insert(private_subnet_id: ps.id, gcp_vpc_id: gcp_vpc.id)
+      gcp_vpc.incr_destroy
+      gcp_vpc.incr_destroying
+      expect(gcp_vpc.destroying_set?).to be(true)
 
-      expect { nx.destroy }.to nap(10)
+      expect(nx.gcp_vpc).to receive(:lock!).with(:no_key_update).and_call_original
+
+      expect { nx.destroy }.to hop("wait")
+      expect(gcp_vpc.reload.destroy_set?).to be(false)
+      expect(gcp_vpc.reload.destroying_set?).to be(false)
+      expect(nx.strand.stack.first["deadline_target"]).to be_nil
     end
   end
 


### PR DESCRIPTION
Destroying the last private subnet of a shared GCP VPC fires
incr_destroy on the VPC from SubnetNexus#finish_destroy.
VpcNexus#destroy checked for attached subnets only once, at entry,
before walking a fourteen-label teardown chain of GCP LROs that takes
minutes and ends with the network and the gcp_vpc row being deleted. A
subnet created in that window found the still-present row, attached to
it, and parked in wait_vpc_ready; when finalize_destroy removed the
row, the join cascaded away and the new subnet's gcp_vpc lookup
returned nil, crashing the strand mid-provisioning. If the attach
landed before the entry check instead, the VPC napped forever on
"Cannot destroy VPC with active subnets" while the subnet napped
forever waiting for the wait label, a mutual stall.

The FOR NO KEY UPDATE lock taken by finish_destroy (fbbdc260f) was
chosen deliberately to permit concurrent attach, assuming the destroy
entry check would catch late attaches; it only catches those landing
before that single check.

Close the window from the attach side: SubnetNexus#start now takes the
same row lock for the attach decision and refuses to attach while the
VPC has destroy requested or destroying set. The destroying semaphore
is set in the same transaction as the hop into the destroy label and
outlives the destroy decr until the strand pops, so it covers the
whole teardown chain without depending on a label list, and stays
correct while the strand runs pushed child progs. Locking both sides
makes the interleavings safe: if the attach commits first,
finish_destroy's recount sees the new join and skips incr_destroy; if
the incr commits first, the subnet observes it and naps until
finalize_destroy removes the row, then assembles a fresh VPC.

Deleting the row is what releases the deterministic name to a
successor VPC, and GCE reads can briefly resolve a network after its
delete LRO completes, so finalize_destroy keeps the row until a direct
get returns NotFound: a fresh assemble cannot collide with, or adopt
via create_vpc's AlreadyExists rescue, the dying network.

VpcNexus#destroy now locks the gcp_vpc row before its emptiness check,
serializing with the attach decision so even destroy requests fired
without the row lock (e.g. the admin panel's generic semaphore incr)
cannot interleave with an in-flight attach. When subnets are attached
it drops the obsolete request and returns to wait instead of napping
forever: in-band, finish_destroy only fires incr_destroy when the
locked recount sees zero subnets, so a non-empty VPC at destroy entry
means the request came out of band, and the next last-subnet-out will
re-request destroy. The drop path clears the destroying semaphore that
the hop into destroy set, and the destroy deadline is only registered
on the proceed path so the drop does not page.

A real two-connection concurrency spec drives start and a simulated
finish_destroy through the race window and asserts both permitted
outcomes; dropping the lock from the attach lookup reintroduces the
race and turns the spec red.


wait_delete_subnet trusts a clean delete LRO, but GCE reads can
briefly resolve a subnet after its delete LRO completes, the same
read-after-delete gap finalize_destroy closes for networks. Deleting
the private_subnet row is what the shared VPC's last-subnet-out
recount keys on, so releasing it early lets the VPC teardown reach
the network delete while GCE still sees the subnet, failing it with
"resource in use" until reads catch up. finish_destroy now verifies
with a direct get and naps until NotFound before deleting the row,
mirroring the network gate.
