### PR TITLE
Configure parseable log stream retention instead of bucket lifecycle

### DIFF
--- a/lib/parseable/client.rb
+++ b/lib/parseable/client.rb
@@ -48,6 +48,15 @@ class Parseable::Client
     send_request("DELETE", "/api/v1/logstream/#{stream_name}", accepted_statuses: [200, 404])
   end
 
+  def set_retention(stream_name:, duration_days:)
+    body = JSON.generate([{
+      description: "Delete logs older than #{duration_days} days",
+      action: "delete",
+      duration: "#{duration_days}d",
+    }])
+    send_request("PUT", "/api/v1/logstream/#{stream_name}/retention", body, {"Content-Type" => "application/json"})
+  end
+
   def create_role(role_name:, privileges:)
     body = JSON.generate(privileges)
     send_request("PUT", "/api/v1/role/#{role_name}", body, {"Content-Type" => "application/json"})

--- a/model/parseable_resource.rb
+++ b/model/parseable_resource.rb
@@ -13,7 +13,7 @@ class ParseableResource < Sequel::Model
     encrypted_columns: [:admin_password, :root_cert_key_1, :root_cert_key_2, :secret_key]
   plugin SemaphoreMethods, :destroy, :reconfigure
 
-  LOG_BUCKET_EXPIRATION_DAYS = 7
+  LOG_RETENTION_DAYS = 7
 
   def self.for_project(project_id)
     ParseableResource.where(

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -559,6 +559,7 @@ class PostgresResource < Sequel::Model
     return unless (client = ParseableResource.client_for_project(Config.postgres_service_project_id))
 
     client.create_stream(stream_name: ubid)
+    client.set_retention(stream_name: ubid, duration_days: ParseableResource::LOG_RETENTION_DAYS)
     client.create_role(role_name: ubid, privileges: [{privilege: "ingestor", resource: {stream: ubid}}])
     password = client.create_user(user_id: ubid, roles: [ubid])
     update(parseable_password: password)

--- a/prog/parseable/parseable_resource_nexus.rb
+++ b/prog/parseable/parseable_resource_nexus.rb
@@ -62,11 +62,6 @@ class Prog::Parseable::ParseableResourceNexus < Prog::Base
     admin_client.admin_policy_set(parseable_resource.ubid, parseable_resource.blob_storage_access_key)
 
     parseable_resource.blob_storage_client.create_bucket(parseable_resource.bucket_name)
-    parseable_resource.blob_storage_client.set_lifecycle_policy(
-      parseable_resource.bucket_name,
-      parseable_resource.ubid,
-      ParseableResource::LOG_BUCKET_EXPIRATION_DAYS,
-    )
 
     hop_wait_servers
   end

--- a/spec/lib/parseable/client_spec.rb
+++ b/spec/lib/parseable/client_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe Parseable::Client do
     end
   end
 
+  describe "#set_retention" do
+    it "sends a PUT request with the retention policy" do
+      stub_request(:put, "#{endpoint}/api/v1/logstream/mystream/retention")
+        .with(body: JSON.generate([{description: "Delete logs older than 7 days", action: "delete", duration: "7d"}]))
+        .to_return(status: 200)
+      expect { client.set_retention(stream_name: "mystream", duration_days: 7) }.not_to raise_error
+    end
+
+    it "raises Client::Error on non-success status" do
+      stub_request(:put, "#{endpoint}/api/v1/logstream/mystream/retention").to_return(status: 500)
+      expect { client.set_retention(stream_name: "mystream", duration_days: 7) }.to raise_error(Parseable::Client::Error)
+    end
+  end
+
   describe "#delete_stream" do
     it "sends a DELETE request for the stream" do
       stub_request(:delete, "#{endpoint}/api/v1/logstream/mystream").to_return(status: 200)

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -1391,6 +1391,7 @@ RSpec.describe PostgresResource do
       client = instance_double(Parseable::Client)
       expect(ParseableResource).to receive(:client_for_project).and_return(client)
       expect(client).to receive_messages(create_stream: "test-stream", create_role: "test-role", create_user: "test-parseable-pass")
+      expect(client).to receive(:set_retention).with(stream_name: postgres_resource.ubid, duration_days: ParseableResource::LOG_RETENTION_DAYS)
       postgres_resource.setup_log_aggregation
       expect(postgres_resource.parseable_password).to eq("test-parseable-pass")
     end

--- a/spec/prog/parseable/parseable_resource_nexus_spec.rb
+++ b/spec/prog/parseable/parseable_resource_nexus_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe Prog::Parseable::ParseableResourceNexus do
       expect(admin_client).to receive(:admin_policy_add).with(pr.ubid, pr.blob_storage_policy)
       expect(admin_client).to receive(:admin_policy_set).with(pr.ubid, pr.blob_storage_access_key)
       expect(blob_client).to receive(:create_bucket).with(pr.bucket_name)
-      expect(blob_client).to receive(:set_lifecycle_policy).with(pr.bucket_name, pr.ubid, ParseableResource::LOG_BUCKET_EXPIRATION_DAYS)
 
       expect { nx.configure_blob_storage }.to hop("wait_servers")
     end

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -228,6 +228,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       client = instance_double(Parseable::Client)
       expect(ParseableResource).to receive(:client_for_project).and_return(client)
       expect(client).to receive_messages(create_stream: "test-stream", create_role: "test-role", create_user: "test-parseable-pass")
+      expect(client).to receive(:set_retention).with(stream_name: postgres_resource.ubid, duration_days: ParseableResource::LOG_RETENTION_DAYS)
       postgres_server
       expect { nx.start }.to nap(5)
     end


### PR DESCRIPTION
Setting the retention using a blanket bucket lifecycle rule causes issues, where parseable metadata files can be deleted causing unnecessary retries/corruption. Instead, setup retention using the parseable API, to only clean up data files once the log retention period expires. This also allows for custom retention per-stream.