### PR TITLE
Sort available options in validation error message

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -397,7 +397,7 @@ module Validation
 
       if subtree[key][value].nil?
         display_key = key.tr("_", " ")
-        available_options = subtree[key].keys.map! { it.is_a?(Location) ? it.display_name : it.to_s }.join(", ")
+        available_options = subtree[key].keys.map! { it.is_a?(Location) ? it.display_name : it.to_s }.sort.join(", ")
         fail ValidationFailed.new({key.to_sym => "Invalid #{display_key}. Available options: #{available_options}"})
       end
     end

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Clover, "postgres" do
           ha_type: "sync",
         }.to_json
 
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: location", {"location" => "Invalid location. Available options: eu-central-h1, us-east-a2, us-east-1, us-west-2"})
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: location", {"location" => "Invalid location. Available options: eu-central-h1, us-east-1, us-east-a2, us-west-2"})
       end
 
       it "location not exist" do


### PR DESCRIPTION
The "Clover postgres authenticated create invalid location" was flaky and failed on origin/main.

This change tries to fix it by sorting available options to get consistent order across runs.