### PR TITLE
Check for fresh servers before maintenance window nap

### DIFF
--- a/prog/postgres/converge_postgres_resource.rb
+++ b/prog/postgres/converge_postgres_resource.rb
@@ -52,6 +52,8 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
   end
 
   label def wait_for_maintenance_window
+    hop_provision_servers unless postgres_resource.has_enough_fresh_servers?
+
     unless postgres_resource.in_maintenance_window? || postgres_resource.bypass_maintenance_window_set?
       ignore_window = begin
         postgres_resource.representative_server.disk_usage_percent >= 95
@@ -61,8 +63,6 @@ class Prog::Postgres::ConvergePostgresResource < Prog::Base
       end
       nap 10 * 60 unless ignore_window
     end
-
-    hop_provision_servers unless postgres_resource.has_enough_fresh_servers?
 
     # Read replicas skip the in-place upgrade process and directly
     # recycle servers, which are provisioned at the target version instead of


### PR DESCRIPTION
In wait_for_maintenance_window, the fresh-servers check now runs before the maintenance window branch. Previously it sat after that branch, so a nap taken while waiting for the maintenance window (or to ignore it) would keep the prog parked and prevent it from hopping back to provision_servers when more servers are needed. Moving the check to the top lets the resource hop to provision servers as soon as it is necessary, regardless of the maintenance window state.