### PR TITLE
Page on standby/read-replica replication lag

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -528,6 +528,7 @@ class PostgresServer < Sequel::Model
       observe_archival_backlog(session)
       observe_io_throttle(session)
       observe_metrics_backlog(session)
+      observe_replica_lag(session)
     end
 
     # Call parent implementation to export actual metrics
@@ -778,7 +779,45 @@ class PostgresServer < Sequel::Model
     Clog.emit("Failed to observe root disk usage", Util.exception_to_hash(ex, into: {postgres_server_id: id}))
   end
 
+  def observe_replica_lag(session)
+    return if primary? || (read_replica? && resource.parent.nil?)
+
+    parent_server = read_replica? ? resource.parent.representative_server : resource.representative_server
+    return unless (primary_lsn = parent_server.last_known_lsn)
+
+    replay_lsn, replay_age = run_query("SELECT pg_last_wal_replay_lsn(), EXTRACT(EPOCH FROM (NOW() - pg_last_xact_replay_timestamp()))::int").split(",")
+    return if replay_lsn.to_s.empty?
+
+    byte_lag = [lsn_diff(primary_lsn, replay_lsn), 0].max
+    previous_replay_lsn = session[:replica_lag_previous_replay_lsn]
+    session[:replica_lag_previous_replay_lsn] = replay_lsn
+    made_progress = previous_replay_lsn.nil? || lsn_diff(replay_lsn, previous_replay_lsn) > 0
+    byte_breach = byte_lag > REPLICA_LAG_HARD_THRESHOLD_BYTES || (byte_lag > REPLICA_LAG_SOFT_THRESHOLD_BYTES && !made_progress)
+
+    # pg_last_xact_replay_timestamp only advances when a transaction is replayed,
+    # so on an idle primary NOW() - pg_last_xact_replay_timestamp grows without bound.
+    # Take it into account only if standby/replica is genuinely behind the primary's LSN
+    # Otherwise everything has been applied and the time lag is zero.
+    time_lag = (byte_lag > 0 && !replay_age.to_s.empty?) ? Integer(replay_age) : 0
+    time_breach = time_lag > REPLICA_LAG_THRESHOLD_SECONDS
+
+    if byte_breach || time_breach
+      session[:replica_lag_breach_count] = (session[:replica_lag_breach_count] || 0) + 1
+      if session[:replica_lag_breach_count] >= 5
+        Prog::PageNexus.assemble("#{ubid} replica lag high", ["PGReplicaLagHigh", id], ubid, severity: "warning", extra_data: {byte_lag:, time_lag:, read_replica: read_replica?})
+      end
+    elsif byte_lag < REPLICA_LAG_SOFT_THRESHOLD_BYTES * 0.1 && time_lag < REPLICA_LAG_THRESHOLD_SECONDS * 0.1
+      session[:replica_lag_breach_count] = 0
+      Page.from_tag_parts("PGReplicaLagHigh", id)&.incr_resolve
+    end
+  rescue => ex
+    Clog.emit("Failed to observe replica lag", Util.exception_to_hash(ex, into: {postgres_server_id: id}))
+  end
+
   METRICS_BACKLOG_THRESHOLD_SECONDS = 300
+  REPLICA_LAG_SOFT_THRESHOLD_BYTES = 1024 * 1024 * 1024
+  REPLICA_LAG_HARD_THRESHOLD_BYTES = 10 * 1024 * 1024 * 1024
+  REPLICA_LAG_THRESHOLD_SECONDS = 15 * 60
   FAILOVER_LABELS = ["prepare_for_unplanned_take_over", "prepare_for_planned_take_over", "wait_fencing_of_old_primary", "taking_over", "lockout", "wait_lockout_attempt", "wait_representative_lockout"].freeze
   MIN_ARCHIVAL_RATE_BYTES_PER_SEC = 10 * 1024 * 1024
   DISK_THROUGHPUT_BASELINE_MBPS = {

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -1143,6 +1143,7 @@ RSpec.describe PostgresServer do
       expect(postgres_server).to receive(:observe_data_disk_usage).with(session)
       expect(postgres_server).to receive(:observe_root_disk_usage).with(session)
       expect(postgres_server).to receive(:observe_io_throttle).with(session)
+      expect(postgres_server).to receive(:observe_replica_lag).with(session)
 
       postgres_server.export_metrics(session:, tsdb_client:)
     end
@@ -1155,6 +1156,7 @@ RSpec.describe PostgresServer do
       expect(postgres_server).not_to receive(:observe_data_disk_usage)
       expect(postgres_server).not_to receive(:observe_root_disk_usage)
       expect(postgres_server).not_to receive(:observe_io_throttle)
+      expect(postgres_server).not_to receive(:observe_replica_lag)
 
       postgres_server.export_metrics(session:, tsdb_client:)
     end
@@ -1165,6 +1167,7 @@ RSpec.describe PostgresServer do
       allow(postgres_server).to receive(:observe_data_disk_usage).with(session)
       allow(postgres_server).to receive(:observe_root_disk_usage).with(session)
       allow(postgres_server).to receive(:observe_io_throttle).with(session)
+      allow(postgres_server).to receive(:observe_replica_lag).with(session)
       allow(postgres_server).to receive(:scrape_endpoints).and_return([])
 
       expect(session[:export_count]).to be_nil
@@ -1483,6 +1486,133 @@ RSpec.describe PostgresServer do
       postgres_server.observe_metrics_backlog(session)
 
       expect(existing_page.reload.semaphores.map(&:name)).not_to include("resolve")
+    end
+  end
+
+  describe "#observe_replica_lag" do
+    let(:session) { {} }
+    # postgres_server (subject) is the representative primary of `resource`;
+    # `standby` is a non-representative standby of the same resource. LSN values
+    # below assume primary at "10/00000000": soft limit 1 GiB, hard limit 10 GiB.
+    #   "10/00000000" => caught up         "F/80000000" =>  2 GiB behind (soft<lag<hard)
+    #   "F/E0000000"  => 512 MiB behind    "D/00000000" => 12 GiB behind (>hard)
+    let(:standby) {
+      described_class.create(
+        timeline:, resource:, vm_id: create_hosted_vm(project, private_subnet, "standby").id,
+        is_representative: false, synchronization_status: "ready", timeline_access: "fetch", version: "16",
+      )
+    }
+
+    replica_lag_query = "SELECT pg_last_wal_replay_lsn(), EXTRACT(EPOCH FROM (NOW() - pg_last_xact_replay_timestamp()))::int"
+
+    def set_primary_lsn(lsn)
+      POSTGRES_MONITOR_DB[:postgres_lsn_monitor].insert(postgres_server_id: postgres_server.id, last_known_lsn: lsn)
+    end
+
+    it "does nothing for a primary" do
+      expect(postgres_server).not_to receive(:_run_query)
+      postgres_server.observe_replica_lag(session)
+    end
+
+    it "does nothing for a read replica whose parent is gone" do
+      resource.update(parent_id: PostgresResource.generate_ubid.to_uuid)
+      expect(standby).not_to receive(:_run_query)
+      standby.observe_replica_lag(session)
+    end
+
+    it "does nothing when the primary has no recorded lsn yet" do
+      postgres_server
+      expect(standby).not_to receive(:_run_query)
+      standby.observe_replica_lag(session)
+    end
+
+    it "does nothing when the replica replay lsn is empty" do
+      set_primary_lsn("10/00000000")
+      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return(",100")
+      standby.observe_replica_lag(session)
+      expect(Page.from_tag_parts("PGReplicaLagHigh", standby.id)).to be_nil
+    end
+
+    it "treats a caught-up replica as zero lag even when the replay timestamp is old" do
+      set_primary_lsn("10/00000000")
+      # Replay caught up to the primary, but replay_age is huge (idle primary).
+      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("10/00000000,100000")
+      session[:replica_lag_breach_count] = 4
+      standby.observe_replica_lag(session)
+      expect(Page.from_tag_parts("PGReplicaLagHigh", standby.id)).to be_nil
+      expect(session[:replica_lag_breach_count]).to eq(0)
+    end
+
+    it "does not page while the replica is past the soft limit but still making progress" do
+      set_primary_lsn("10/00000000")
+      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return(
+        "F/80000000,5", "F/88000000,5", "F/90000000,5", "F/98000000,5", "F/A0000000,5",
+      )
+      5.times { standby.observe_replica_lag(session) }
+      expect(Page.from_tag_parts("PGReplicaLagHigh", standby.id)).to be_nil
+      expect(session[:replica_lag_breach_count]).to be_nil
+    end
+
+    it "pages when the replica is past the soft limit and stalled for the 5th consecutive check" do
+      set_primary_lsn("10/00000000")
+      session[:replica_lag_breach_count] = 3
+      session[:replica_lag_previous_replay_lsn] = "F/80000000"
+      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("F/80000000,5", "F/80000000,5") # same lsn as previous => no progress
+      2.times { standby.observe_replica_lag(session) }
+      expect(Page.from_tag_parts("PGReplicaLagHigh", standby.id)).not_to be_nil
+    end
+
+    it "pages past the hard limit even while the replica is making progress" do
+      set_primary_lsn("10/00000000")
+      session[:replica_lag_breach_count] = 4
+      session[:replica_lag_previous_replay_lsn] = "C/00000000"
+      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("D/00000000,5") # 12 GiB behind, but progressed from C/0
+      standby.observe_replica_lag(session)
+      expect(Page.from_tag_parts("PGReplicaLagHigh", standby.id)).not_to be_nil
+    end
+
+    it "pages on time lag even when byte lag is below the soft limit" do
+      set_primary_lsn("10/00000000")
+      session[:replica_lag_breach_count] = 4
+      session[:replica_lag_previous_replay_lsn] = "F/E0000000"
+      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("F/E0000000,1000") # 512 MiB behind, replay 1000s old
+      standby.observe_replica_lag(session)
+      expect(Page.from_tag_parts("PGReplicaLagHigh", standby.id)).not_to be_nil
+    end
+
+    it "resolves an existing page once lag recovers" do
+      set_primary_lsn("10/00000000")
+      existing_page = Prog::PageNexus.assemble("#{standby.ubid} replica lag high", ["PGReplicaLagHigh", standby.id], standby.ubid, severity: "warning", extra_data: {byte_lag: 0, time_lag: 0, read_replica: false}).subject
+      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("10/00000000,5") # caught up
+      standby.observe_replica_lag(session)
+      expect(existing_page.reload.semaphores.map(&:name)).to include("resolve")
+    end
+
+    it "logs and does not raise when the replica query fails" do
+      set_primary_lsn("10/00000000")
+      expect(standby).to receive(:_run_query).with(replica_lag_query).and_raise("boom")
+      expect(Clog).to receive(:emit).with("Failed to observe replica lag", instance_of(Hash)).and_call_original
+      expect { standby.observe_replica_lag(session) }.not_to raise_error
+    end
+
+    it "for read replicas it uses the parent's primary lsn" do
+      parent_resource = create_postgres_resource(project:, location_id: location.id)
+      parent_primary = described_class.create(
+        timeline:, resource: parent_resource, vm_id: create_hosted_vm(project, private_subnet, "parent-vm").id,
+        is_representative: true, synchronization_status: "ready", timeline_access: "push", version: "16",
+      )
+      resource.update(parent: parent_resource)
+      postgres_server.update(timeline_access: "fetch")
+      POSTGRES_MONITOR_DB[:postgres_lsn_monitor].insert(postgres_server_id: parent_primary.id, last_known_lsn: "10/00000000")
+
+      expect(postgres_server.read_replica?).to be(true)
+      session[:replica_lag_breach_count] = 4
+      session[:replica_lag_previous_replay_lsn] = "C/00000000"
+      expect(postgres_server).to receive(:_run_query).with(replica_lag_query).and_return("D/00000000,5") # 12 GiB behind > hard
+      postgres_server.observe_replica_lag(session)
+      page = Page.from_tag_parts("PGReplicaLagHigh", postgres_server.id)
+      expect(page).not_to be_nil
+      expect(page.details["read_replica"]).to be(true)
     end
   end
 


### PR DESCRIPTION
Add observe_replica_lag to the metrics export path so we get paged when a standby or read replica falls too far behind its primary. The check runs alongside the other observe_ functions and pages only after 5 consecutive breaches, so transient lag doesn't create a page.

Here are few things we paid attention in this design:
- No queries against the primary. The primary's LSN is read from the already-collected last_known_lsn. This ensures that the monitoring of standby is isolated on the standby and doesn't add load to the primary.
- Checking time lag (pg_last_xact_replay_timestamp) alone is not enough to determine if the replica is behind. For example, a primary with low activity can have a large time lag without actually being behind. So, we use it in conjunction with byte lag to get a more accurate picture of the replica's status.
- Similarly, checking byte lag alone can be misleading. A bursty write activity on primary can temporarily cause a large byte lag but it would be transient. We don't want to create page unnecessarily. Therefore we use soft and hard byte thresholds: the soft limit (1 GiB) pages only if the replica is also stalled (no replay progress since the last check), while the hard limit (10 GiB) pages regardless of progress.
- To complement both, we also only page if we are in breach for five consecutive checks. This allows for transient issues to resolve without creating noise.