### PR TITLE
Stop failed CRM operations from pinning tag creation

### DIFF
--- a/lib/gcp_lro.rb
+++ b/lib/gcp_lro.rb
@@ -16,6 +16,16 @@ module GcpLro
     end
   end
 
+  # On ALREADY_EXISTS (code 6) a concurrent create won the race, typically
+  # a retry recreating the same tag key or value; resolve the existing
+  # name through the block and return it. Otherwise log the failure and
+  # return nil.
+  def crm_op_conflict_name(error, **log)
+    return yield if error.code == 6
+    Clog.emit("CRM operation failed, retrying", {gcp_crm_op_retry: log.merge(error: error.message)})
+    nil
+  end
+
   def save_gcp_op(name, op_name:, scope:, scope_value: nil)
     strand.stack.first[name] = {
       "name" => op_name,

--- a/prog/vnet/gcp/subnet_nexus.rb
+++ b/prog/vnet/gcp/subnet_nexus.rb
@@ -459,15 +459,10 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
     raise unless e.status_code == 409
     lookup.call || raise("#{label} #{short_name} conflict but not found on lookup")
   rescue CrmOperationError => e
-    # google.rpc.Code 6 = ALREADY_EXISTS. The CRM LRO can surface a
-    # conflict via the operation's error Status instead of an HTTP 409,
-    # typically on retries that create the same tag key/value concurrently.
-    if e.code == 6
-      return lookup.call || raise("#{label} #{short_name} conflict but not found on lookup")
+    name = crm_op_conflict_name(e, label:, short_name:) do
+      lookup.call || raise("#{label} #{short_name} conflict but not found on lookup")
     end
-    # A raise would roll back the pending-op clear and pin the strand to the dead op.
-    Clog.emit("CRM operation failed, retrying", {gcp_crm_op_retry: {label:, short_name:, error: e.message}})
-    nap 5
+    name || nap(5)
   end
 
   def lookup_tag_value_name(parent_tag_key_name, short_name)

--- a/prog/vnet/gcp/subnet_nexus.rb
+++ b/prog/vnet/gcp/subnet_nexus.rb
@@ -462,8 +462,12 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
     # google.rpc.Code 6 = ALREADY_EXISTS. The CRM LRO can surface a
     # conflict via the operation's error Status instead of an HTTP 409,
     # typically on retries that create the same tag key/value concurrently.
-    raise unless e.code == 6
-    lookup.call || raise("#{label} #{short_name} conflict but not found on lookup")
+    if e.code == 6
+      return lookup.call || raise("#{label} #{short_name} conflict but not found on lookup")
+    end
+    # A raise would roll back the pending-op clear and pin the strand to the dead op.
+    Clog.emit("CRM operation failed, retrying", {gcp_crm_op_retry: {label:, short_name:, error: e.message}})
+    nap 5
   end
 
   def lookup_tag_value_name(parent_tag_key_name, short_name)

--- a/prog/vnet/gcp/vpc_update_firewall_rules.rb
+++ b/prog/vnet/gcp/vpc_update_firewall_rules.rb
@@ -122,8 +122,12 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
   rescue CrmOperationError => e
     # google.rpc.Code 6 = ALREADY_EXISTS. The CRM LRO can surface a
     # conflict via the operation's error Status instead of an HTTP 409.
-    raise unless e.code == 6
-    lookup_tag_key_name!(short_name, "conflict but not found on lookup")
+    if e.code == 6
+      return lookup_tag_key_name!(short_name, "conflict but not found on lookup")
+    end
+    # A raise would roll back the pending-op clear and pin the strand to the dead op.
+    Clog.emit("CRM operation failed, retrying", {gcp_crm_op_retry: {short_name:, error: e.message}})
+    nap 5
   end
 
   def lookup_tag_key_name(short_name)
@@ -168,8 +172,12 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
   rescue CrmOperationError => e
     # google.rpc.Code 6 = ALREADY_EXISTS. The CRM LRO can surface a
     # conflict via the operation's error Status instead of an HTTP 409.
-    raise unless e.code == 6
-    lookup_tag_value_name!(tag_key_name, short_name, "conflict but not found on lookup")
+    if e.code == 6
+      return lookup_tag_value_name!(tag_key_name, short_name, "conflict but not found on lookup")
+    end
+    # A raise would roll back the pending-op clear and pin the strand to the dead op.
+    Clog.emit("CRM operation failed, retrying", {gcp_crm_op_retry: {short_name:, error: e.message}})
+    nap 5
   end
 
   def lookup_tag_value_name(tag_key_name, short_name)

--- a/prog/vnet/gcp/vpc_update_firewall_rules.rb
+++ b/prog/vnet/gcp/vpc_update_firewall_rules.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
+  include GcpLro
+
   # Per-firewall INGRESS rules start at priority 10000 in the VPC's network
   # firewall policy. These rules target per-firewall secure tags
   # (ubicloud-fw-{firewall.ubid}/active). Tag targeting decides which VMs
@@ -120,14 +122,10 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
     raise unless e.status_code == 409
     lookup_tag_key_name!(short_name, "conflict but not found on lookup")
   rescue CrmOperationError => e
-    # google.rpc.Code 6 = ALREADY_EXISTS. The CRM LRO can surface a
-    # conflict via the operation's error Status instead of an HTTP 409.
-    if e.code == 6
-      return lookup_tag_key_name!(short_name, "conflict but not found on lookup")
+    name = crm_op_conflict_name(e, short_name:) do
+      lookup_tag_key_name!(short_name, "conflict but not found on lookup")
     end
-    # A raise would roll back the pending-op clear and pin the strand to the dead op.
-    Clog.emit("CRM operation failed, retrying", {gcp_crm_op_retry: {short_name:, error: e.message}})
-    nap 5
+    name || nap(5)
   end
 
   def lookup_tag_key_name(short_name)
@@ -170,14 +168,10 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
     raise unless e.status_code == 409
     lookup_tag_value_name!(tag_key_name, short_name, "conflict but not found on lookup")
   rescue CrmOperationError => e
-    # google.rpc.Code 6 = ALREADY_EXISTS. The CRM LRO can surface a
-    # conflict via the operation's error Status instead of an HTTP 409.
-    if e.code == 6
-      return lookup_tag_value_name!(tag_key_name, short_name, "conflict but not found on lookup")
+    name = crm_op_conflict_name(e, short_name:) do
+      lookup_tag_value_name!(tag_key_name, short_name, "conflict but not found on lookup")
     end
-    # A raise would roll back the pending-op clear and pin the strand to the dead op.
-    Clog.emit("CRM operation failed, retrying", {gcp_crm_op_retry: {short_name:, error: e.message}})
-    nap 5
+    name || nap(5)
   end
 
   def lookup_tag_value_name(tag_key_name, short_name)

--- a/spec/prog/vnet/gcp/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_spec.rb
@@ -1292,12 +1292,12 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         expect { nx.send(:ensure_tag_key) }.to raise_error(RuntimeError, /conflict but not found/)
       end
 
-      it "re-raises non-ALREADY_EXISTS CrmOperationError" do
+      it "naps on non-ALREADY_EXISTS CrmOperationError so a fresh create is issued" do
         error = Google::Apis::CloudresourcemanagerV3::Status.new(code: 13, message: "server error")
         op = Google::Apis::CloudresourcemanagerV3::Operation.new(done: true, error:)
         expect(crm_client).to receive(:create_tag_key).and_return(op)
 
-        expect { nx.send(:ensure_tag_key) }.to raise_error(described_class::CrmOperationError, /server error/)
+        expect { nx.send(:ensure_tag_key) }.to nap(5)
       end
 
       it "re-raises non-409 ClientError" do
@@ -1339,7 +1339,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         expect { nx.send(:ensure_tag_key) }.to nap(5)
       end
 
-      it "raises when polled pending op has error" do
+      it "naps with the pending op cleared when the polled op has a terminal error" do
         refresh_frame(nx, new_values: {"pending_tag_key_crm_op" => "operations/tk-error"})
 
         error = Google::Apis::CloudresourcemanagerV3::Status.new(code: 13, message: "server error")
@@ -1348,7 +1348,8 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         )
         expect(crm_client).to receive(:get_operation).with("operations/tk-error").and_return(error_op)
 
-        expect { nx.send(:ensure_tag_key) }.to raise_error(described_class::CrmOperationError, /server error/)
+        expect { nx.send(:ensure_tag_key) }.to nap(5)
+        expect(nx.strand.stack.first["pending_tag_key_crm_op"]).to be_nil
       end
 
       it "falls back to lookup when polled pending op has no name in response" do
@@ -1453,12 +1454,12 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         expect { nx.send(:ensure_tag_value, "tagKeys/123", "active") }.to raise_error(RuntimeError, /conflict but not found/)
       end
 
-      it "re-raises non-ALREADY_EXISTS CrmOperationError" do
+      it "naps on non-ALREADY_EXISTS CrmOperationError so a fresh create is issued" do
         error = Google::Apis::CloudresourcemanagerV3::Status.new(code: 13, message: "server error")
         op = Google::Apis::CloudresourcemanagerV3::Operation.new(done: true, error:)
         expect(crm_client).to receive(:create_tag_value).and_return(op)
 
-        expect { nx.send(:ensure_tag_value, "tagKeys/123", "active") }.to raise_error(described_class::CrmOperationError, /server error/)
+        expect { nx.send(:ensure_tag_value, "tagKeys/123", "active") }.to nap(5)
       end
 
       it "re-raises non-409 ClientError" do
@@ -1532,7 +1533,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         expect { nx.send(:ensure_tag_value, "tagKeys/123", "active") }.to raise_error(RuntimeError, /created but name not found/)
       end
 
-      it "raises when polled pending op has error" do
+      it "naps with the pending op cleared when the polled op has a terminal error" do
         refresh_frame(nx, new_values: {"pending_tag_value_crm_op" => "operations/tv-error"})
 
         error = Google::Apis::CloudresourcemanagerV3::Status.new(code: 13, message: "server error")
@@ -1541,7 +1542,8 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         )
         expect(crm_client).to receive(:get_operation).with("operations/tv-error").and_return(error_op)
 
-        expect { nx.send(:ensure_tag_value, "tagKeys/123", "active") }.to raise_error(described_class::CrmOperationError, /server error/)
+        expect { nx.send(:ensure_tag_value, "tagKeys/123", "active") }.to nap(5)
+        expect(nx.strand.stack.first["pending_tag_value_crm_op"]).to be_nil
       end
     end
   end

--- a/spec/prog/vnet/gcp/vpc_update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_update_firewall_rules_spec.rb
@@ -289,13 +289,12 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       expect(nx.send(:ensure_firewall_tag_key, firewall)).to eq("tagKeys/page2-target")
     end
 
-    it "re-raises non-ALREADY_EXISTS LRO errors" do
+    it "naps on non-ALREADY_EXISTS LRO errors so a fresh create is issued" do
       error = instance_double(Google::Apis::CloudresourcemanagerV3::Status, code: 7, message: "PERMISSION_DENIED")
       op = instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "op-1", error:)
       expect(crm_client).to receive(:create_tag_key).and_return(op)
 
-      expect { nx.send(:ensure_firewall_tag_key, firewall) }
-        .to raise_error(described_class::CrmOperationError, /PERMISSION_DENIED/) { |e| expect(e.code).to eq(7) }
+      expect { nx.send(:ensure_firewall_tag_key, firewall) }.to nap(5)
     end
 
     it "re-raises non-409 client errors" do
@@ -361,7 +360,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       expect(nx.send(:ensure_firewall_tag_key, firewall)).to eq("tagKeys/fresh-1")
     end
 
-    it "raises when polled pending op has error" do
+    it "naps with the pending op cleared when the polled op has a terminal error" do
       refresh_frame(nx, new_values: {
         "pending_tag_key_crm_op" => "operations/tk-error",
         "pending_tag_key_fw_ubid" => firewall.ubid,
@@ -371,8 +370,8 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         done?: true, name: "operations/tk-error", error:)
       expect(crm_client).to receive(:get_operation).with("operations/tk-error").and_return(error_op)
 
-      expect { nx.send(:ensure_firewall_tag_key, firewall) }
-        .to raise_error(described_class::CrmOperationError) { |e| expect(e.code).to eq(13) }
+      expect { nx.send(:ensure_firewall_tag_key, firewall) }.to nap(5)
+      expect(nx.strand.stack.first["pending_tag_key_crm_op"]).to be_nil
     end
 
     it "falls back to lookup when polled op has nil response" do
@@ -481,13 +480,12 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       expect(nx.send(:ensure_tag_value, "tagKeys/123", "active")).to eq("tagValues/page2")
     end
 
-    it "re-raises non-ALREADY_EXISTS LRO errors" do
+    it "naps on non-ALREADY_EXISTS LRO errors so a fresh create is issued" do
       error = instance_double(Google::Apis::CloudresourcemanagerV3::Status, code: 7, message: "PERMISSION_DENIED")
       op = instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "op-1", error:)
       expect(crm_client).to receive(:create_tag_value).and_return(op)
 
-      expect { nx.send(:ensure_tag_value, "tagKeys/123", "active") }
-        .to raise_error(described_class::CrmOperationError) { |e| expect(e.code).to eq(7) }
+      expect { nx.send(:ensure_tag_value, "tagKeys/123", "active") }.to nap(5)
     end
 
     it "naps when op is not done and saves frame state" do
@@ -533,7 +531,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       expect(nx.send(:ensure_tag_value, "tagKeys/123", "active")).to eq("tagValues/fresh-1")
     end
 
-    it "raises when polled pending op has error" do
+    it "naps with the pending op cleared when the polled op has a terminal error" do
       refresh_frame(nx, new_values: {
         "pending_tag_value_crm_op" => "operations/tv-error",
         "pending_tag_value_parent" => "tagKeys/123",
@@ -543,8 +541,8 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         done?: true, name: "operations/tv-error", error:)
       expect(crm_client).to receive(:get_operation).with("operations/tv-error").and_return(error_op)
 
-      expect { nx.send(:ensure_tag_value, "tagKeys/123", "active") }
-        .to raise_error(described_class::CrmOperationError) { |e| expect(e.code).to eq(13) }
+      expect { nx.send(:ensure_tag_value, "tagKeys/123", "active") }.to nap(5)
+      expect(nx.strand.stack.first["pending_tag_value_crm_op"]).to be_nil
     end
 
     it "falls back to lookup when polled op has nil response" do


### PR DESCRIPTION
ensure_crm_resource clears the pending operation slot and then raises
when the polled operation reports a terminal error. The raise rolls
back the label transaction, resurrecting the cleared slot, so every
subsequent run re-polls the same dead operation and raises again,
pinning the strand permanently to the first failure. When the e2e
project hit the 1000 TagKeys cap, the three subnets that had saved a
failing create operation kept replaying it for the rest of the run,
long after the cap was cleared.

Nap instead of raising for terminal errors other than ALREADY_EXISTS:
the nap commits the cleared slot, so the next run issues a fresh
create and recovers as soon as the underlying condition (cap, quota,
permission) clears. Failures keep surfacing via Clog and the chain
deadline still pages if the condition persists. The same
clear-then-raise shape in VpcUpdateFirewallRules tag key and value
creation gets the same fix; the tag binding path in
UpdateFirewallRules keeps raising since it polls inline and saves no
pending state.

