### PR TITLE
Show association counts on the admin object page

### DIFF
--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -460,6 +460,31 @@ RSpec.describe CloverAdmin do
     ]
   end
 
+  it "shows association count in heading" do
+    project = Project.create(name: "assoc-count-test")
+    SshPublicKey.create(name: "key-0", public_key: "k v", project_id: project.id)
+
+    visit "/model/Project/#{project.ubid}"
+    within(".association", text: "ssh_public_keys") do
+      expect(find("h3").text).to eq "ssh_public_keys"
+      expect(page.all("ul li").length).to eq 1
+    end
+
+    SshPublicKey.create(name: "key-1", public_key: "k v", project_id: project.id)
+    page.refresh
+    within(".association", text: "ssh_public_keys") do
+      expect(find("h3").text).to eq "ssh_public_keys (2)"
+      expect(page.all("ul li").length).to eq 2
+    end
+
+    Array.new(100) { |i| SshPublicKey.create(name: "key-#{i + 2}", public_key: "k v", project_id: project.id) }
+    page.refresh
+    within(".association", text: "ssh_public_keys") do
+      expect(find("h3").text).to eq "ssh_public_keys (100+)"
+      expect(page.all("ul li").length).to eq 101
+    end
+  end
+
   it "handles basic pagination when browsing by class" do
     project_id = Project.create(name: "test").id
     keys = Array.new(101) { |i| SshPublicKey.create(name: "key-#{i}", public_key: "k v", project_id:) }

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -55,16 +55,18 @@
     associated_class = reflection.associated_class
     next unless associated_class.method_defined?(:ubid)
     assoc_objs = if reflection.returns_array?
-      @obj.send(assoc) { it.limit(100) }
+      @obj.send(assoc) { it.limit(101) }
     else
       Array(@obj.send(assoc))
     end
     next if assoc_objs.empty?
+    assoc_count = assoc_objs.count
     %>
 
     <div class="association">
       <h3>
         <%= assoc %>
+        <%= "(#{(assoc_count > 100) ? "100+" : assoc_count})" if assoc_count > 1 %>
         <% if table_param = OBJECT_ASSOC_TABLE_PARAMS[[@klass.name, assoc]] %>
           <a href="/autoforme/<%= associated_class %>/search/1?<%= table_param %>=<%= @obj.id %>">(table)</a>
         <% end %>


### PR DESCRIPTION
The admin object page truncated association lists at 100 entries without saying so, and gave no sense of an association's size without counting the list items by hand.

Show the count next to the association name when there is more than one object. Fetch 101 records so truncation is detectable: the first 100 are rendered and the count is shown as "100+" when the limit is exceeded.

<img width="2554" height="696" alt="CleanShot 2026-06-11 at 20 40 22@2x" src="https://github.com/user-attachments/assets/9f9caeae-0748-41aa-90c0-a80d0a22bd8a" />
