### PR TITLE
Relax NVMe SMART checks for github runner hosts 

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -298,8 +298,23 @@ class VmHost < Sequel::Model
 
   def check_storage_nvme(ssh_session, devices)
     devices.reject { |device_name| !device_name.start_with?("nvme") }.map do |device_name|
-      passed = ssh_session.exec!("sudo nvme smart-log /dev/:device_name | grep \"critical_warning\" | awk '{print $3}'", device_name:).strip == "0"
-      Clog.emit("Device #{device_name} failed nvme smart-log check on VmHost #{ubid}", {}) unless passed
+      smart = JSON.parse(ssh_session.exec!("sudo nvme smart-log -o json /dev/:device_name", device_name:))
+      cw = Integer(smart["critical_warning"])
+      avail_spare = Integer(smart["avail_spare"])
+      spare_thresh = Integer(smart["spare_thresh"])
+
+      # For github runner hosts, allow critical warning 0x4 (reliability
+      # degraded, end of warranty) and no warning 0x0. For other hosts, we will
+      # page on 0x4 so that we can proactively move workloads off the host
+      # before they experience failures.
+      allowed_cw = if location_id == Location::GITHUB_RUNNERS_ID
+        [0, 4]
+      else
+        [0]
+      end
+
+      passed = allowed_cw.include?(cw) && avail_spare > spare_thresh
+      Clog.emit("Device #{device_name} failed nvme smart-log check on VmHost #{ubid}", {critical_warning: cw, avail_spare:, spare_thresh:}) unless passed
       passed
     end.all?(true)
   end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -284,8 +284,8 @@ class VmHost < Sequel::Model
     Hosting::Apis.hardware_reset_server(self)
   end
 
-  def check_storage_smartctl(ssh_session, devices)
-    devices.map do |device_name|
+  def check_storage_non_nvme(ssh_session, devices)
+    devices.reject { |device_name| device_name.start_with?("nvme") }.map do |device_name|
       command = ["sudo smartctl -j -H /dev/:device_name"]
       command << "-d scsi" if device_name.start_with?("sd")
       command << "| jq .smart_status.passed"
@@ -395,7 +395,7 @@ class VmHost < Sequel::Model
 
   def perform_health_checks(ssh_session, test_file_suffix: "monitor")
     device_names = disk_device_names(ssh_session)
-    check_storage_smartctl(ssh_session, device_names) &&
+    check_storage_non_nvme(ssh_session, device_names) &&
       check_storage_nvme(ssh_session, device_names) &&
       check_storage_read_write(ssh_session, device_names, test_file_suffix:) &&
       check_storage_kernel_logs(ssh_session, device_names) &&

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -422,21 +422,88 @@ RSpec.describe VmHost do
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
+    it "skips smartctl for nvme devices and only runs it on the others" do
+      # readlink resolves wwn-random-id1 to sda, wwn-random-id2 to vda, and
+      # nvme-eui-random-id to nvme0n1.
+      StorageDevice.create(vm_host_id: vm_host.id, name: "EXTRA", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["wwn-random-id2", "nvme-eui-random-id"])
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id2").and_return("vda")
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/nvme-eui-random-id").and_return("nvme0n1")
+      # sda and vda go through smartctl; nvme0n1 is skipped here and handled by
+      # check_storage_nvme. sd-prefixed devices add -d scsi; others (vda) don't.
+      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/sda -d scsi | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("true\n", 0))
+      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/vda | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("true\n", 0))
+      stub_nvme_smart_log(critical_warning: 0)
+      stub_remaining_health_checks_pass
+      expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
+    end
+
+    def stub_nvme_smart_log(critical_warning:, avail_spare: 100, spare_thresh: 10)
+      payload = JSON.generate(
+        critical_warning:,
+        avail_spare:,
+        spare_thresh:,
+      )
+      expect(ssh_session).to receive(:_exec!).with("sudo nvme smart-log -o json /dev/nvme0n1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(payload, 0))
+    end
+
+    # Mocks the remaining (non-storage-smart) health checks to pass via ssh_session
+    # only, without stubbing the check_storage_* methods themselves. An empty
+    # lsblk leaves check_storage_read_write with no mount points to test.
+    def stub_remaining_health_checks_pass
+      expect(ssh_session).to receive(:_exec!).with("lsblk --json").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new('{"blockdevices":[]}', 0))
+      expect(ssh_session).to receive(:_exec!).with("journalctl -kS -1min --no-pager").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))
+      expect(ssh_session).to receive(:_exec!).with("cat /sys/devices/system/clocksource/clocksource0/available_clocksource").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("tsc\n", 0))
+    end
+
     it "checks pulse with nvme errors" do
       expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
       expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
-      expect(ssh_session).to receive(:_exec!).with("sudo nvme smart-log /dev/nvme0n1 | grep \"critical_warning\" | awk '{print $3}'").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("1\n", 0))
+      stub_nvme_smart_log(critical_warning: 1)
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse with no nvme errors" do
       expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
       expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
-      expect(ssh_session).to receive(:_exec!).with("sudo nvme smart-log /dev/nvme0n1 | grep \"critical_warning\" | awk '{print $3}'").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("0\n", 0))
+      stub_nvme_smart_log(critical_warning: 0)
       expect(vm_host).to receive(:check_storage_read_write).and_return(true)
       expect(vm_host).to receive(:check_storage_kernel_logs).and_return(true)
       expect(vm_host).to receive(:check_clock_source).and_return(true)
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
+    end
+
+    it "fails non-github-runner hosts on critical_warning 4" do
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
+      stub_nvme_smart_log(critical_warning: 4)
+      expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
+    end
+
+    it "fails when avail_spare is at or below spare_thresh even without a critical warning" do
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
+      stub_nvme_smart_log(critical_warning: 0, avail_spare: 10, spare_thresh: 10)
+      expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
+    end
+
+    it "passes github-runner hosts on critical_warning 4 when spare is above threshold" do
+      vm_host.update(location_id: Location::GITHUB_RUNNERS_ID)
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
+      stub_nvme_smart_log(critical_warning: 4, avail_spare: 99, spare_thresh: 10)
+      stub_remaining_health_checks_pass
+      expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
+    end
+
+    it "fails github-runner hosts on critical_warning 4 when spare is at or below threshold" do
+      vm_host.update(location_id: Location::GITHUB_RUNNERS_ID)
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
+      stub_nvme_smart_log(critical_warning: 4, avail_spare: 10, spare_thresh: 10)
+      expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
+    end
+
+    it "fails github-runner hosts on critical_warning 1" do
+      vm_host.update(location_id: Location::GITHUB_RUNNERS_ID)
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
+      stub_nvme_smart_log(critical_warning: 1)
+      expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse on a non-default mountpoint with faulty read/write on disk" do

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -393,14 +393,14 @@ RSpec.describe VmHost do
     end
 
     it "checks pulse on a non-default mountpoint with kernel errors" do
-      expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
-      expect(vm_host).to receive(:check_storage_read_write).and_return(true)
+      stub_smartctl_sda_passes
+      expect(ssh_session).to receive(:_exec!).with("lsblk --json").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new('{"blockdevices":[]}', 0))
       expect(ssh_session).to receive(:_exec!).with("journalctl -kS -1min --no-pager").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("Nov 04 12:18:04 ubuntu kernel: Buffer I/O error on dev sda, logical block 1032, lost async page write", 0))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse on a with read/write errors" do
-      expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
+      stub_smartctl_sda_passes
       expect(ssh_session).to receive(:_exec!).with("lsblk --json").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new('{"blockdevices": [{"name": "fd0","maj:min": "2:0","rm": true,"size": "4K","ro": false,"type": "disk","mountpoints": [null]},{"name": "sda","maj:min": "8:0","rm": false,"size": "2.2G","ro": false,"type": "disk","mountpoints": [null],"children": [{"name": "sda1","maj:min": "8:1","rm": false,"size": "2.1G","ro": false,"type": "part","mountpoints": ["/"]},{"name": "sda14","maj:min": "8:14","rm": false,"size": "4M","ro": false,"type": "part","mountpoints": [null]}]}]}', 0))
       file_path = "/test-file-monitor"
       expect(ssh_session).to receive(:_exec!).with("sudo bash -c head\\ -c\\ 1M\\ \\</dev/zero\\ \\>\\ #{file_path}").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("failed to write file", 1))
@@ -410,9 +410,8 @@ RSpec.describe VmHost do
     end
 
     it "checks pulse with kernel errors" do
-      expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
-      expect(vm_host).to receive(:check_storage_nvme).and_return(true)
-      expect(vm_host).to receive(:check_storage_read_write).and_return(true)
+      stub_smartctl_sda_passes
+      expect(ssh_session).to receive(:_exec!).with("lsblk --json").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new('{"blockdevices":[]}', 0))
       expect(ssh_session).to receive(:_exec!).with("journalctl -kS -1min --no-pager").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("exit code 1", 1))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
@@ -455,20 +454,20 @@ RSpec.describe VmHost do
       expect(ssh_session).to receive(:_exec!).with("cat /sys/devices/system/clocksource/clocksource0/available_clocksource").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("tsc\n", 0))
     end
 
+    def stub_smartctl_sda_passes
+      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/sda -d scsi | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("true\n", 0))
+    end
+
     it "checks pulse with nvme errors" do
       expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
-      expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
       stub_nvme_smart_log(critical_warning: 1)
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse with no nvme errors" do
       expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
-      expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
       stub_nvme_smart_log(critical_warning: 0)
-      expect(vm_host).to receive(:check_storage_read_write).and_return(true)
-      expect(vm_host).to receive(:check_storage_kernel_logs).and_return(true)
-      expect(vm_host).to receive(:check_clock_source).and_return(true)
+      stub_remaining_health_checks_pass
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
     end
 
@@ -507,8 +506,7 @@ RSpec.describe VmHost do
     end
 
     it "checks pulse on a non-default mountpoint with faulty read/write on disk" do
-      expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
-      expect(vm_host).to receive(:check_storage_nvme).and_return(true)
+      stub_smartctl_sda_passes
       expect(ssh_session).to receive(:_exec!).with("lsblk --json").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new('{"blockdevices": [{"name": "fd0","maj:min": "2:0","rm": true,"size": "4K","ro": false,"type": "disk","mountpoints": [null]},{"name": "sda","maj:min": "8:0","rm": false,"size": "2.2G","ro": false,"type": "disk","mountpoints": [null],"children": [{"name": "sda1","maj:min": "8:1","rm": false,"size": "2.1G","ro": false,"type": "part","mountpoints": ["/random-mountpoint"]},{"name": "sda14","maj:min": "8:14","rm": false,"size": "4M","ro": false,"type": "part","mountpoints": [null]}]}]}', 0))
       file_path = "/random-mountpoint/test-file-monitor"
       expect(ssh_session).to receive(:_exec!).with("sudo bash -c head\\ -c\\ 1M\\ \\</dev/zero\\ \\>\\ #{file_path}").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -393,14 +393,14 @@ RSpec.describe VmHost do
     end
 
     it "checks pulse on a non-default mountpoint with kernel errors" do
-      expect(vm_host).to receive(:check_storage_smartctl).and_return(true)
+      expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
       expect(vm_host).to receive(:check_storage_read_write).and_return(true)
       expect(ssh_session).to receive(:_exec!).with("journalctl -kS -1min --no-pager").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("Nov 04 12:18:04 ubuntu kernel: Buffer I/O error on dev sda, logical block 1032, lost async page write", 0))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse on a with read/write errors" do
-      expect(vm_host).to receive(:check_storage_smartctl).and_return(true)
+      expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
       expect(ssh_session).to receive(:_exec!).with("lsblk --json").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new('{"blockdevices": [{"name": "fd0","maj:min": "2:0","rm": true,"size": "4K","ro": false,"type": "disk","mountpoints": [null]},{"name": "sda","maj:min": "8:0","rm": false,"size": "2.2G","ro": false,"type": "disk","mountpoints": [null],"children": [{"name": "sda1","maj:min": "8:1","rm": false,"size": "2.1G","ro": false,"type": "part","mountpoints": ["/"]},{"name": "sda14","maj:min": "8:14","rm": false,"size": "4M","ro": false,"type": "part","mountpoints": [null]}]}]}', 0))
       file_path = "/test-file-monitor"
       expect(ssh_session).to receive(:_exec!).with("sudo bash -c head\\ -c\\ 1M\\ \\</dev/zero\\ \\>\\ #{file_path}").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("failed to write file", 1))
@@ -410,29 +410,28 @@ RSpec.describe VmHost do
     end
 
     it "checks pulse with kernel errors" do
-      expect(vm_host).to receive(:check_storage_smartctl).and_return(true)
+      expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
       expect(vm_host).to receive(:check_storage_nvme).and_return(true)
       expect(vm_host).to receive(:check_storage_read_write).and_return(true)
       expect(ssh_session).to receive(:_exec!).with("journalctl -kS -1min --no-pager").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("exit code 1", 1))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
-    it "checks pulse with smartctl errors" do
-      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
-      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/nvme0n1 | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("false\n", 0))
+    it "checks pulse with smartctl errors on a non-nvme device" do
+      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/sda -d scsi | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("false\n", 0))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse with nvme errors" do
       expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
-      expect(vm_host).to receive(:check_storage_smartctl).and_return(true)
+      expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
       expect(ssh_session).to receive(:_exec!).with("sudo nvme smart-log /dev/nvme0n1 | grep \"critical_warning\" | awk '{print $3}'").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("1\n", 0))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse with no nvme errors" do
       expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
-      expect(vm_host).to receive(:check_storage_smartctl).and_return(true)
+      expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
       expect(ssh_session).to receive(:_exec!).with("sudo nvme smart-log /dev/nvme0n1 | grep \"critical_warning\" | awk '{print $3}'").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("0\n", 0))
       expect(vm_host).to receive(:check_storage_read_write).and_return(true)
       expect(vm_host).to receive(:check_storage_kernel_logs).and_return(true)
@@ -441,7 +440,7 @@ RSpec.describe VmHost do
     end
 
     it "checks pulse on a non-default mountpoint with faulty read/write on disk" do
-      expect(vm_host).to receive(:check_storage_smartctl).and_return(true)
+      expect(vm_host).to receive(:check_storage_non_nvme).and_return(true)
       expect(vm_host).to receive(:check_storage_nvme).and_return(true)
       expect(ssh_session).to receive(:_exec!).with("lsblk --json").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new('{"blockdevices": [{"name": "fd0","maj:min": "2:0","rm": true,"size": "4K","ro": false,"type": "disk","mountpoints": [null]},{"name": "sda","maj:min": "8:0","rm": false,"size": "2.2G","ro": false,"type": "disk","mountpoints": [null],"children": [{"name": "sda1","maj:min": "8:1","rm": false,"size": "2.1G","ro": false,"type": "part","mountpoints": ["/random-mountpoint"]},{"name": "sda14","maj:min": "8:14","rm": false,"size": "4M","ro": false,"type": "part","mountpoints": [null]}]}]}', 0))
       file_path = "/random-mountpoint/test-file-monitor"


### PR DESCRIPTION
### Relax NVMe SMART checks for github runner hosts

Previously `check_storage_nvme` failed whenever the disk's warning flag was non-zero.

This included the warning flag 0x4 which is documented as the following in the NVM Express Base Specs:

> The NVM subsystem reliability has been degraded due to significant
> media related errors or any internal error that degrades NVM subsystem
> reliability.

However, based on the 3 cases we've experienced in prod so far and from Hetzner's communication with disk manufacturers, this warning is activated when disk "Percentage Used" reaches 100%. The primary factor in "Percentage Used" is data written (the correlation between these two values in our production hosts is 0.97). This doesn't necessarily mean disk has error: all our prod disks which have this warning has 0 media errors. Based on Hetzner's comments, this just means that the disk is no longer under warranty.

For this reason, we change how we interpret SMART results for NVMe disks:

- Fail if available spare below spare threshold or if any media errors  happen.
- For github runner hosts, allow warning 0x04.
- For other hosts, page on warning 0x04 so we proactively start moving  off the VMs from that host.

Note that since the reasoning above is not based on manufacturer official docs, this is a temporary solution and we'll revisit this in future.

### Change check_storage_smartctl to check_storage_non_nvme 

NVMe SMART checks are already covered in `check_storage_nvme`. Change `check_storage_smartctl` to `check_storage_non_nvme` and only check non-NVMe devices there.