### PR TITLE
Tolerate runner images without a preinstalled PostgreSQL

### DIFF
--- a/.github/actions/setup-clover/action.yml
+++ b/.github/actions/setup-clover/action.yml
@@ -13,8 +13,10 @@ runs:
     - name: Setup PostgreSQL
       shell: bash
       run: |
-        # Remove the default PostgreSQL cluster on the runner
-        sudo -u postgres pg_dropcluster 16 main --stop
+        # Remove the default PostgreSQL cluster, if the runner image ships one
+        if id postgres >/dev/null 2>&1; then
+          sudo -u postgres pg_dropcluster 16 main --stop || true
+        fi
         # Install PostgreSQL
         sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -


### PR DESCRIPTION
setup-clover starts by dropping the runner image's default PostgreSQL
16 cluster with sudo -u postgres, which fails with "unknown user
postgres" when the image ships no PostgreSQL at all. The arm runner
image ubuntu24-arm64/20260609.1 dropped the preinstalled PostgreSQL,
so every arm CI job on every branch dies in Set up Clover before
apt-get runs, while x86 images still carry PG 16 and pass.

Guard the cluster drop on the postgres user existing and tolerate a
missing cluster, so the action works on images with and without a
preinstalled PostgreSQL.

