### PR TITLE
Relax NVMe SMART checks for github runner hosts 

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -305,8 +305,23 @@ class VmHost < Sequel::Model
   end
 
   def check_nvme_smart(ssh_session, device_name)
-    passed = ssh_session.exec!("sudo nvme smart-log /dev/:device_name | grep \"critical_warning\" | awk '{print $3}'", device_name:).strip == "0"
-    Clog.emit("Device #{device_name} failed nvme smart-log check on VmHost #{ubid}", {}) unless passed
+    smart = JSON.parse(ssh_session.exec!("sudo nvme smart-log -o json /dev/:device_name", device_name:))
+    cw = Integer(smart["critical_warning"])
+    avail_spare = Integer(smart["avail_spare"])
+    spare_thresh = Integer(smart["spare_thresh"])
+
+    # For github runner hosts, allow critical warning 0x4 (reliability
+    # degraded, end of warranty) and no warning 0x0. For other hosts, we will
+    # page on 0x4 so that we can proactively move workloads off the host
+    # before they experience failures.
+    allowed_cw = if location_id == Location::GITHUB_RUNNERS_ID
+      [0, 4]
+    else
+      [0]
+    end
+
+    passed = allowed_cw.include?(cw) && avail_spare > spare_thresh
+    Clog.emit("Device #{device_name} failed nvme smart-log check on VmHost #{ubid}", {critical_warning: cw, avail_spare:, spare_thresh:}) unless passed
     passed
   end
 

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -284,24 +284,30 @@ class VmHost < Sequel::Model
     Hosting::Apis.hardware_reset_server(self)
   end
 
-  def check_storage_smartctl(ssh_session, devices)
-    devices.map do |device_name|
-      command = ["sudo smartctl -j -H /dev/:device_name"]
-      command << "-d scsi" if device_name.start_with?("sd")
-      command << "| jq .smart_status.passed"
-      command = NetSsh.combine(*command)
-      passed = ssh_session.exec!(command, device_name:).strip == "true"
-      Clog.emit("Device #{device_name} failed smartctl check on VmHost #{ubid}", {}) unless passed
-      passed
-    end.all?(true)
+  def check_storage_smart(ssh_session, devices)
+    devices.map { |device_name|
+      if device_name.start_with?("nvme")
+        check_nvme_smart(ssh_session, device_name)
+      else
+        check_non_nvme_smart(ssh_session, device_name)
+      end
+    }.all?(true)
   end
 
-  def check_storage_nvme(ssh_session, devices)
-    devices.reject { |device_name| !device_name.start_with?("nvme") }.map do |device_name|
-      passed = ssh_session.exec!("sudo nvme smart-log /dev/:device_name | grep \"critical_warning\" | awk '{print $3}'", device_name:).strip == "0"
-      Clog.emit("Device #{device_name} failed nvme smart-log check on VmHost #{ubid}", {}) unless passed
-      passed
-    end.all?(true)
+  def check_non_nvme_smart(ssh_session, device_name)
+    command = ["sudo smartctl -j -H /dev/:device_name"]
+    command << "-d scsi" if device_name.start_with?("sd")
+    command << "| jq .smart_status.passed"
+    command = NetSsh.combine(*command)
+    passed = ssh_session.exec!(command, device_name:).strip == "true"
+    Clog.emit("Device #{device_name} failed smartctl check on VmHost #{ubid}", {}) unless passed
+    passed
+  end
+
+  def check_nvme_smart(ssh_session, device_name)
+    passed = ssh_session.exec!("sudo nvme smart-log /dev/:device_name | grep \"critical_warning\" | awk '{print $3}'", device_name:).strip == "0"
+    Clog.emit("Device #{device_name} failed nvme smart-log check on VmHost #{ubid}", {}) unless passed
+    passed
   end
 
   def check_storage_read_write(ssh_session, devices, test_file_suffix:)
@@ -395,8 +401,7 @@ class VmHost < Sequel::Model
 
   def perform_health_checks(ssh_session, test_file_suffix: "monitor")
     device_names = disk_device_names(ssh_session)
-    check_storage_smartctl(ssh_session, device_names) &&
-      check_storage_nvme(ssh_session, device_names) &&
+    check_storage_smart(ssh_session, device_names) &&
       check_storage_read_write(ssh_session, device_names, test_file_suffix:) &&
       check_storage_kernel_logs(ssh_session, device_names) &&
       check_clock_source(ssh_session)

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -437,19 +437,66 @@ RSpec.describe VmHost do
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
+    def stub_nvme_smart_log(critical_warning:, avail_spare: 100, spare_thresh: 10)
+      payload = JSON.generate(
+        critical_warning:,
+        avail_spare:,
+        spare_thresh:,
+      )
+      expect(ssh_session).to receive(:_exec!).with("sudo nvme smart-log -o json /dev/nvme0n1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(payload, 0))
+    end
+
+    def stub_remaining_health_checks_pass
+      stub_empty_lsblk
+      expect(ssh_session).to receive(:_exec!).with("journalctl -kS -1min --no-pager").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))
+      expect(ssh_session).to receive(:_exec!).with("cat /sys/devices/system/clocksource/clocksource0/available_clocksource").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("tsc\n", 0))
+    end
+
     it "checks pulse with nvme errors" do
       expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
-      expect(ssh_session).to receive(:_exec!).with("sudo nvme smart-log /dev/nvme0n1 | grep \"critical_warning\" | awk '{print $3}'").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("1\n", 0))
+      stub_nvme_smart_log(critical_warning: 1)
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse with no nvme errors" do
       expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
-      expect(ssh_session).to receive(:_exec!).with("sudo nvme smart-log /dev/nvme0n1 | grep \"critical_warning\" | awk '{print $3}'").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("0\n", 0))
-      stub_empty_lsblk
-      expect(ssh_session).to receive(:_exec!).with("journalctl -kS -1min --no-pager").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))
-      expect(ssh_session).to receive(:_exec!).with("cat /sys/devices/system/clocksource/clocksource0/available_clocksource").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("tsc\n", 0))
+      stub_nvme_smart_log(critical_warning: 0)
+      stub_remaining_health_checks_pass
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
+    end
+
+    it "fails non-github-runner hosts on critical_warning 4" do
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
+      stub_nvme_smart_log(critical_warning: 4)
+      expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
+    end
+
+    it "fails when avail_spare is at or below spare_thresh even without a critical warning" do
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
+      stub_nvme_smart_log(critical_warning: 0, avail_spare: 10, spare_thresh: 10)
+      expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
+    end
+
+    it "passes github-runner hosts on critical_warning 4 when spare is above threshold" do
+      vm_host.update(location_id: Location::GITHUB_RUNNERS_ID)
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
+      stub_nvme_smart_log(critical_warning: 4, avail_spare: 99, spare_thresh: 10)
+      stub_remaining_health_checks_pass
+      expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
+    end
+
+    it "fails github-runner hosts on critical_warning 4 when spare is at or below threshold" do
+      vm_host.update(location_id: Location::GITHUB_RUNNERS_ID)
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
+      stub_nvme_smart_log(critical_warning: 4, avail_spare: 10, spare_thresh: 10)
+      expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
+    end
+
+    it "fails github-runner hosts on critical_warning 1" do
+      vm_host.update(location_id: Location::GITHUB_RUNNERS_ID)
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
+      stub_nvme_smart_log(critical_warning: 1)
+      expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse on a non-default mountpoint with faulty read/write on disk" do

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -392,15 +392,23 @@ RSpec.describe VmHost do
       expect(Semaphore.where(strand_id: vm_host.id, name: "checkup").count).to eq(1)
     end
 
+    def stub_smartctl_sda_passes
+      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/sda -d scsi | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("true\n", 0))
+    end
+
+    def stub_empty_lsblk
+      expect(ssh_session).to receive(:_exec!).with("lsblk --json").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new('{"blockdevices":[]}', 0))
+    end
+
     it "checks pulse on a non-default mountpoint with kernel errors" do
-      expect(vm_host).to receive(:check_storage_smartctl).and_return(true)
-      expect(vm_host).to receive(:check_storage_read_write).and_return(true)
+      stub_smartctl_sda_passes
+      stub_empty_lsblk
       expect(ssh_session).to receive(:_exec!).with("journalctl -kS -1min --no-pager").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("Nov 04 12:18:04 ubuntu kernel: Buffer I/O error on dev sda, logical block 1032, lost async page write", 0))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse on a with read/write errors" do
-      expect(vm_host).to receive(:check_storage_smartctl).and_return(true)
+      stub_smartctl_sda_passes
       expect(ssh_session).to receive(:_exec!).with("lsblk --json").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new('{"blockdevices": [{"name": "fd0","maj:min": "2:0","rm": true,"size": "4K","ro": false,"type": "disk","mountpoints": [null]},{"name": "sda","maj:min": "8:0","rm": false,"size": "2.2G","ro": false,"type": "disk","mountpoints": [null],"children": [{"name": "sda1","maj:min": "8:1","rm": false,"size": "2.1G","ro": false,"type": "part","mountpoints": ["/"]},{"name": "sda14","maj:min": "8:14","rm": false,"size": "4M","ro": false,"type": "part","mountpoints": [null]}]}]}', 0))
       file_path = "/test-file-monitor"
       expect(ssh_session).to receive(:_exec!).with("sudo bash -c head\\ -c\\ 1M\\ \\</dev/zero\\ \\>\\ #{file_path}").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("failed to write file", 1))
@@ -410,9 +418,8 @@ RSpec.describe VmHost do
     end
 
     it "checks pulse with kernel errors" do
-      expect(vm_host).to receive(:check_storage_smartctl).and_return(true)
-      expect(vm_host).to receive(:check_storage_nvme).and_return(true)
-      expect(vm_host).to receive(:check_storage_read_write).and_return(true)
+      stub_smartctl_sda_passes
+      stub_empty_lsblk
       expect(ssh_session).to receive(:_exec!).with("journalctl -kS -1min --no-pager").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("exit code 1", 1))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
@@ -425,24 +432,23 @@ RSpec.describe VmHost do
 
     it "checks pulse with nvme errors" do
       expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
-      expect(vm_host).to receive(:check_storage_smartctl).and_return(true)
+      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/nvme0n1 | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("true\n", 0))
       expect(ssh_session).to receive(:_exec!).with("sudo nvme smart-log /dev/nvme0n1 | grep \"critical_warning\" | awk '{print $3}'").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("1\n", 0))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse with no nvme errors" do
       expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
-      expect(vm_host).to receive(:check_storage_smartctl).and_return(true)
+      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/nvme0n1 | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("true\n", 0))
       expect(ssh_session).to receive(:_exec!).with("sudo nvme smart-log /dev/nvme0n1 | grep \"critical_warning\" | awk '{print $3}'").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("0\n", 0))
-      expect(vm_host).to receive(:check_storage_read_write).and_return(true)
-      expect(vm_host).to receive(:check_storage_kernel_logs).and_return(true)
-      expect(vm_host).to receive(:check_clock_source).and_return(true)
+      stub_empty_lsblk
+      expect(ssh_session).to receive(:_exec!).with("journalctl -kS -1min --no-pager").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))
+      expect(ssh_session).to receive(:_exec!).with("cat /sys/devices/system/clocksource/clocksource0/available_clocksource").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("tsc\n", 0))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
     end
 
     it "checks pulse on a non-default mountpoint with faulty read/write on disk" do
-      expect(vm_host).to receive(:check_storage_smartctl).and_return(true)
-      expect(vm_host).to receive(:check_storage_nvme).and_return(true)
+      stub_smartctl_sda_passes
       expect(ssh_session).to receive(:_exec!).with("lsblk --json").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new('{"blockdevices": [{"name": "fd0","maj:min": "2:0","rm": true,"size": "4K","ro": false,"type": "disk","mountpoints": [null]},{"name": "sda","maj:min": "8:0","rm": false,"size": "2.2G","ro": false,"type": "disk","mountpoints": [null],"children": [{"name": "sda1","maj:min": "8:1","rm": false,"size": "2.1G","ro": false,"type": "part","mountpoints": ["/random-mountpoint"]},{"name": "sda14","maj:min": "8:14","rm": false,"size": "4M","ro": false,"type": "part","mountpoints": [null]}]}]}', 0))
       file_path = "/random-mountpoint/test-file-monitor"
       expect(ssh_session).to receive(:_exec!).with("sudo bash -c head\\ -c\\ 1M\\ \\</dev/zero\\ \\>\\ #{file_path}").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -425,21 +425,26 @@ RSpec.describe VmHost do
     end
 
     it "checks pulse with smartctl errors" do
-      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
-      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/nvme0n1 | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("false\n", 0))
+      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/sda -d scsi | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("false\n", 0))
+      expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
+    end
+
+    it "runs smartctl without -d scsi on non-sd, non-nvme devices" do
+      StorageDevice.create(vm_host_id: vm_host.id, name: "EXTRA", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["wwn-random-id2"])
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id2").and_return("vda")
+      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/sda -d scsi | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("true\n", 0))
+      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/vda | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("false\n", 0))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse with nvme errors" do
       expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
-      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/nvme0n1 | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("true\n", 0))
       expect(ssh_session).to receive(:_exec!).with("sudo nvme smart-log /dev/nvme0n1 | grep \"critical_warning\" | awk '{print $3}'").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("1\n", 0))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "checks pulse with no nvme errors" do
       expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("nvme0n1")
-      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/nvme0n1 | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("true\n", 0))
       expect(ssh_session).to receive(:_exec!).with("sudo nvme smart-log /dev/nvme0n1 | grep \"critical_warning\" | awk '{print $3}'").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("0\n", 0))
       stub_empty_lsblk
       expect(ssh_session).to receive(:_exec!).with("journalctl -kS -1min --no-pager").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))


### PR DESCRIPTION
### Demock pre-existing #check_pulse specs 

Replace every check_storage_* / check_clock_source method stub with the ssh_session._exec! command those methods actually issue. Adds two small helpers (stub_smartctl_sda_passes, stub_empty_lsblk) used across multiple examples.

### Refactor check_storage_smartctl/check_storage_nvme into one dispatcher 

Single check_storage_smart method dispatches per device: nvme* to check_nvme_smart, everything else to check_non_nvme_smart. Bodies are unchanged.

`smartctl -H` on an NVMe drive only inspects the critical_warning byte to decide pass/fail, which check_storage_nvme already does itself. So routing NVMe straight to nvme-cli skips a call whose result is fully covered by the existing nvme-cli check, and this refactor does not change behavior.

### Relax NVMe SMART checks for github runner hosts 

Previously check_nvme_smart failed whenever the disk's warning flag was non-zero.

This included the warning flag 0x4 which is documented as the following in the NVM Express Base Specs:

> The NVM subsystem reliability has been degraded due to significant
> media related errors or any internal error that degrades NVM subsystem
> reliability.

However, based on Hetzner's comments:

> The message 'Critical Warning: 0x04' is caused by "Percentage Used"
> being above 100%. This only means that the drive's warranty from the
> manufacturer is over. But as long as 'Available Spare' is greater
> than 'Available Spare Threshold', you can safely ignore this message.
>
> We have investigated and analyzed this topic with the manufacturers
> for a very long time.

Our own data in prod supports some of these claims:

- This is turned on when "Percentage Used" reaches 100%.
- Percentage Used is mostly determined by data written: the correlation between these two values in our production hosts is 0.97. We also know from manufacturer's website that disk's warranty expires after written amount passes a threshold.
- All our prod disks which have this warning has 0 media errors and all of them have available spare 100%.
- All disks without warning have 0 media errors. One has 97% spare, rest have 100% spare.

For this reason, as a temporary solution until we look into this in more detail, we change how we interpret SMART results for NVMe disks:

- Fail if available spare below spare threshold or we have media errors.
- For github runner hosts, allow warning 0x04.
- For other hosts, page on warning 0x04 so we proactively start moving off the VMs from that host.

Note that since the reasoning above is not based on manufacturer official docs, this is a temporary solution and we'll revisit this in future.