### PR TITLE
Use LEAST for Semaphore.incr and child exit scheduling

### DIFF
--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -19,7 +19,7 @@ class Semaphore < Sequel::Model
       Strand
         .where(id:)
         .returning(:id)
-        .with_sql(:update_sql, schedule: Sequel::CURRENT_TIMESTAMP))
+        .with_sql(:update_sql, schedule: Sequel.function(:least, Sequel[:schedule], Sequel::CURRENT_TIMESTAMP)))
       .insert([:id, :strand_id, :name],
         DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
   end

--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -19,7 +19,7 @@ class Semaphore < Sequel::Model
       Strand
         .where(id:)
         .returning(:id)
-        .with_sql(:update_sql, schedule: Sequel.function(:least, Sequel[:schedule], Sequel::CURRENT_TIMESTAMP)))
+        .with_sql(:update_sql, schedule: Strand::SCHEDULE_NO_LATER_THAN_NOW))
       .insert([:id, :strand_id, :name],
         DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
   end

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -154,7 +154,7 @@ SQL
             Strand
               .where(id: parent_id)
               .exclude(active_siblings_ds.exists)
-              .update(schedule: Sequel::CURRENT_TIMESTAMP)
+              .update(schedule: Sequel.function(:least, Sequel[:schedule], Sequel::CURRENT_TIMESTAMP))
           end
         end
       end

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -94,6 +94,11 @@ class Strand < Sequel::Model
     Sequel.function(:least, Sequel[2]**Sequel.function(:least, :try, 20), 600) * Sequel.function(:random)
   end
 
+  # Advance a strand's schedule to now() only when it is not already
+  # scheduled for an earlier time, so an overdue schedule is never
+  # pushed later. Outlined to a constant to avoid extra allocations.
+  SCHEDULE_NO_LATER_THAN_NOW = Sequel.function(:least, Sequel[:schedule], Sequel::CURRENT_TIMESTAMP)
+
   TAKE_LEASE_PS = DB[:strand]
     .returning
     .where(
@@ -154,7 +159,7 @@ SQL
             Strand
               .where(id: parent_id)
               .exclude(active_siblings_ds.exists)
-              .update(schedule: Sequel.function(:least, Sequel[:schedule], Sequel::CURRENT_TIMESTAMP))
+              .update(schedule: SCHEDULE_NO_LATER_THAN_NOW)
           end
         end
       end


### PR DESCRIPTION
A semaphore increment or child-exit notification overwrites the target strand's schedule with now(). If the schedule already held an earlier scheduled time, the write pushes the schedule later.

This effect can be especially troublesome with distant future-dated schedules in a gradual attempt to make the system more event-oriented/edge triggered rather than polling-oriented/level triggered.