### PR TITLE
Add class-level incr_ methods to SemaphoreMethods

### DIFF
--- a/lib/semaphore_methods.rb
+++ b/lib/semaphore_methods.rb
@@ -21,6 +21,10 @@ module SemaphoreMethods
         define_method :"#{name}_set?" do
           semaphores.any? { it.name == name }
         end
+
+        define_singleton_method :"incr_#{name}" do
+          Semaphore.incr(it, sym)
+        end
       end
     end
   end

--- a/model/dns_zone/dns_server.rb
+++ b/model/dns_zone/dns_server.rb
@@ -13,7 +13,7 @@ class DnsServer < Sequel::Model
       raise "Cannot retire the only VM of DnsServer #{name}" if !force && vms_dataset.count <= 1
       deleted = DB[:dns_servers_vms].where(dns_server_id: id, vm_id:).delete
       raise "VM #{UBID.to_ubid(vm_id)} is not associated with DnsServer #{name}" if deleted.zero?
-      Semaphore.incr(vm_id, "destroy")
+      Vm.incr_destroy(vm_id)
     end
   end
 

--- a/model/gcp/private_subnet.rb
+++ b/model/gcp/private_subnet.rb
@@ -34,7 +34,7 @@ class PrivateSubnet < Sequel::Model
     # semaphore here directly.
     def gcp_apply_firewalls
       gcp_vpc.incr_update_firewall_rules
-      Semaphore.incr(vms_dataset.select(Sequel[:vm][:id]), :update_firewall_rules)
+      Vm.incr_update_firewall_rules(vms_dataset.select(Sequel[:vm][:id]))
     end
 
     # GCP reserves the network and default gateway (first two) and the

--- a/prog/parseable/parseable_resource_nexus.rb
+++ b/prog/parseable/parseable_resource_nexus.rb
@@ -92,7 +92,7 @@ class Prog::Parseable::ParseableResourceNexus < Prog::Base
     if OpenSSL::X509::Certificate.new(parseable_resource.root_cert_1).not_after < Time.now + 60 * 60 * 24 * 30 * 5
       parseable_resource.root_cert_1, parseable_resource.root_cert_key_1 = parseable_resource.root_cert_2, parseable_resource.root_cert_key_2
       parseable_resource.root_cert_2, parseable_resource.root_cert_key_2 = Util.create_root_certificate(common_name: "#{parseable_resource.ubid} Root Certificate Authority", duration: 60 * 60 * 24 * 365 * 10)
-      Semaphore.incr(parseable_resource.servers_dataset.select(:id), "reconfigure")
+      ParseableServer.incr_reconfigure(parseable_resource.servers_dataset.select(:id))
     end
 
     parseable_resource.certificate_last_checked_at = Time.now
@@ -116,7 +116,7 @@ class Prog::Parseable::ParseableResourceNexus < Prog::Base
     firewall&.destroy
     parseable_resource.private_subnet.incr_destroy
 
-    Semaphore.incr(parseable_resource.servers_dataset.select(:id), "destroy")
+    ParseableServer.incr_destroy(parseable_resource.servers_dataset.select(:id))
     hop_wait_servers_destroyed
   end
 

--- a/prog/rollout_rhizome.rb
+++ b/prog/rollout_rhizome.rb
@@ -110,7 +110,7 @@ class Prog::RolloutRhizome < Prog::Base
   end
 
   label def destroy_vms_on_initial_hosts
-    Semaphore.incr(initial_vm_ids, "destroy")
+    Vm.incr_destroy(initial_vm_ids)
     delete_from_stack("initial_vm_ids", "initial_vms_keypair")
 
     if initial_github_runner_host_ids.empty?


### PR DESCRIPTION
Allow Model.incr_<name>(id) without loading the model instance.  This offers a more typo-safe way to increment semaphores when an `id` is closer at hand or easy to project from a dataset, as compared to the free-handed `Semaphore.incr`.

Convert a some sites to demonstrate the notation and get the code some exercise in the test suite.