### PR TITLE
Filter source-VM dropdown to machine-image-eligible VMs only

### DIFF
--- a/helpers/machine_image.rb
+++ b/helpers/machine_image.rb
@@ -26,15 +26,21 @@ class Clover
     Prog::MachineImage::CreateVersionMetal.assemble(mi, version, source_vm, store, destroy_source_after: !!destroy_source).subject
   end
 
-  def stopped_vms_for_machine_image(location_id: nil)
+  def stopped_vms_for_machine_image(location_id: nil, arch: nil)
     dataset = dataset_authorize(@project.vms_dataset, "Vm:view")
       .association_join(:strand)
       .where(Sequel[:strand][:label] => "stopped")
+      .exclude(Sequel[:vm][:vm_host_id] => nil)
       .select_all(:vm)
-      .eager(:location)
+      .eager(:location, :vm_storage_volumes)
       .order(:name)
     dataset = dataset.where(Sequel[:vm][:location_id] => location_id) if location_id
-    dataset.all
+    dataset = dataset.where(Sequel[:vm][:arch] => arch) if arch
+    dataset.all.select do |vm|
+      next false unless vm.vm_storage_volumes.size == 1
+      sv = vm.vm_storage_volumes.first
+      sv.track_written && sv.key_encryption_key_1_id && sv.size_gib <= Config.machine_image_max_size_gib
+    end
   end
 
   def generate_machine_image_options
@@ -54,7 +60,7 @@ class Clover
   end
 
   def generate_machine_image_version_options(mi)
-    vm_values = stopped_vms_for_machine_image(location_id: mi.location_id).map {
+    vm_values = stopped_vms_for_machine_image(location_id: mi.location_id, arch: mi.arch).map {
       {value: it.ubid, display_name: it.name}
     }
 

--- a/prog/machine_image/create_version_metal.rb
+++ b/prog/machine_image/create_version_metal.rb
@@ -16,6 +16,7 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
     sv = source_vm.vm_storage_volumes.first
     fail MachineImageError, "Source VM's storage volume doesn't support machine images" unless sv.track_written
     fail MachineImageError, "Source VM's storage volume must be encrypted" unless sv.key_encryption_key_1
+    fail MachineImageError, "Source VM's storage volume is larger than #{Config.machine_image_max_size_gib} GiB" if sv.size_gib > Config.machine_image_max_size_gib
 
     DB.transaction do
       miv = MachineImageVersion.create(

--- a/spec/prog/machine_image/create_version_metal_spec.rb
+++ b/spec/prog/machine_image/create_version_metal_spec.rb
@@ -137,6 +137,14 @@ RSpec.describe Prog::MachineImage::CreateVersionMetal do
       }.to raise_error("Source VM's storage volume must be encrypted")
     end
 
+    it "fails when source VM's storage volume is larger than machine_image_max_size_gib" do
+      source_vol.update(size_gib: Config.machine_image_max_size_gib + 1)
+
+      expect {
+        described_class.assemble(machine_image, "1.0", source_vm, store)
+      }.to raise_error("Source VM's storage volume is larger than #{Config.machine_image_max_size_gib} GiB")
+    end
+
     it "creates a machine image version, its metal instance & archive_kek, and strand" do
       strand = described_class.assemble(machine_image, "2.0", source_vm, store, destroy_source_after: true)
 

--- a/spec/routes/web/machine_image_spec.rb
+++ b/spec/routes/web/machine_image_spec.rb
@@ -176,6 +176,37 @@ RSpec.describe Clover, "machine-image" do
         click_button "Create"
         expect(page).to have_flash_error("Machine image with this name already exists in this location")
       end
+
+      it "excludes ineligible VMs from the source VM dropdown" do
+        source_vm
+
+        non_metal_vm = create_vm(project_id: project.id, location_id:, name: "non-metal-vm")
+        Strand.create_with_id(non_metal_vm, prog: "Vm::Nexus", label: "stopped")
+
+        multi_volume_vm = create_archive_ready_vm(project_id: project.id, location_id:, name: "multi-volume-vm")
+        sv = multi_volume_vm.vm_storage_volumes.first
+        VmStorageVolume.create(
+          vm_id: multi_volume_vm.id, boot: false, size_gib: 5, disk_index: 1,
+          storage_device_id: sv.storage_device_id, vhost_block_backend_id: sv.vhost_block_backend_id,
+          key_encryption_key_1_id: StorageKeyEncryptionKey.create_random(auth_data: "extra").id,
+          vring_workers: 1, track_written: true,
+        )
+
+        untracked_vm = create_archive_ready_vm(project_id: project.id, location_id:, name: "untracked-vm")
+        untracked_vm.vm_storage_volumes.first.update(track_written: false)
+
+        unencrypted_vm = create_archive_ready_vm(project_id: project.id, location_id:, name: "unencrypted-vm")
+        unencrypted_vm.vm_storage_volumes.first.update(key_encryption_key_1_id: nil)
+
+        oversized_vm = create_archive_ready_vm(project_id: project.id, location_id:, name: "oversized-vm")
+        oversized_vm.vm_storage_volumes.first.update(size_gib: Config.machine_image_max_size_gib + 1)
+
+        visit "#{project.path}/machine-image/create"
+        expect(page).to have_select("vm", with_options: [source_vm.name])
+        [non_metal_vm, multi_volume_vm, untracked_vm, unencrypted_vm, oversized_vm].each do |ineligible|
+          expect(page).to have_no_select("vm", with_options: [ineligible.name])
+        end
+      end
     end
 
     describe "create version" do
@@ -191,6 +222,15 @@ RSpec.describe Clover, "machine-image" do
         miv = mi.versions_dataset.first(version: "v2")
         expect(miv).not_to be_nil
         expect(miv.strand.stack.first["destroy_source_after"]).to be false
+      end
+
+      it "excludes VMs whose arch differs from the machine image from the source VM dropdown" do
+        mi_version_metal
+        source_vm
+        wrong_arch_vm = create_archive_ready_vm(project_id: project.id, location_id:, name: "arm64-vm", arch: "arm64")
+        visit "#{project.path}/location/#{TEST_LOCATION}/machine-image/#{mi.name}/create-version"
+        expect(page).to have_select("vm", with_options: [source_vm.name])
+        expect(page).to have_no_select("vm", with_options: [wrong_arch_vm.name])
       end
     end
 


### PR DESCRIPTION
### Assert source VM size_gib in CreateVersionMetal.assemble 

The size constraint was previously verified only implicitly: a VM's storage volume is given track_written=true at create time only when its size_gib is at or below Config.machine_image_max_size_gib, so the existing "doesn't support machine images" guard caught oversized VMs as a side effect.

That coupling is fragile. We may decide in future to enable track_written for VMs of any size for unrelated reasons (e.g. VM migration between hosts), at which point the size cap would silently stop being enforced here. Assert it explicitly so the contract is clear regardless of how track_written is decided.

### Filter source-VM dropdown to machine-image-eligible VMs only 

stopped_vms_for_machine_image (used by the create-MI and create-version UI dropdowns) now additionally requires:

- vm_host_id present (metal VM)
- exactly one storage volume
- track_written on that volume
- the volume is encrypted (key_encryption_key_1_id present)
- size_gib <= Config.machine_image_max_size_gib
- arch matches the target machine image (create-version only)

These match the assertions CreateVersionMetal.assemble would fail on if the user picked an ineligible source. Removing them from the dropdown prevents the failure mode entirely.