### PR TITLE
Do not fail CI if preinstalled PostgreSQL 16 is not found

### DIFF
--- a/.github/actions/setup-clover/action.yml
+++ b/.github/actions/setup-clover/action.yml
@@ -13,8 +13,8 @@ runs:
     - name: Setup PostgreSQL
       shell: bash
       run: |
-        # Remove the default PostgreSQL cluster on the runner
-        sudo -u postgres pg_dropcluster 16 main --stop
+        # Stop the default PostgreSQL cluster on the runner if it exists
+        sudo -u postgres pg_dropcluster 16 main --stop || true
         # Install PostgreSQL
         sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -


### PR DESCRIPTION
We stop the preinstalled PostgreSQL 16 on runners and install PostgreSQL 17 for our tests. Some new images don't have PostgreSQL 16 installed, so CI should not fail if it is not found.