### PR TITLE
Use container-based slim runners for chores

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,7 +11,7 @@ permissions:
   statuses: write
 jobs:
   CLAAssistant:
-    runs-on: ubicloud
+    runs-on: ubuntu-slim
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/.github/workflows/trigger-e2e.yml
+++ b/.github/workflows/trigger-e2e.yml
@@ -12,7 +12,7 @@ on:
 jobs:
     pr_comment:
       if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/run-e2e')
-      runs-on: ubicloud
+      runs-on: ubuntu-slim
       steps:
         - name: Trigger E2E tests
           uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
These jobs are triggered on every commit and are very short-lived. They don't need much power or a full runner.

"ubuntu-slim" is a container-based runner optimized for speed and efficiency.