### PR TITLE
Allow non-GPU VMs on GPU hosts

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -102,6 +102,11 @@ module Scheduling::Allocator
       adjusted_vcpus = (vcpus.odd? && threads_per_core == 1) ? vcpus + 1 : vcpus
       (Float(adjusted_vcpus) / threads_per_core).ceil
     end
+
+    def single_ubicloud_location?
+      return false unless location_filter.one?
+      Location[location_filter.first].provider == "ubicloud"
+    end
   end
 
   class Allocation
@@ -240,7 +245,7 @@ module Scheduling::Allocator
       ds = ds.where(location_id: request.location_filter) unless request.location_filter.empty?
       ds = ds.where(allocation_state: request.allocation_state_filter) unless request.allocation_state_filter.empty?
       ds = ds.where(Sequel[:vm_host][:family] => request.family_filter) unless request.family_filter.empty?
-      ds = ds.exclude { Sequel.function(:coalesce, num_gpus, 0) > 0 } unless request.gpu_count > 0 || request.host_filter.any?
+      ds = ds.exclude { Sequel.function(:coalesce, num_gpus, 0) > 0 } unless request.gpu_count > 0 || request.host_filter.any? || request.single_ubicloud_location?
 
       if request.minimum_vhost_block_backend_version
         ds = ds.where(

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -457,6 +457,19 @@ RSpec.describe Al do
         a_hash_including("iommu_group" => 9, "numa_node" => 0),
       )
     end
+
+    it "retrieves candidates with gpu if gpu_count is zero but host is in a ubicloud provided location" do
+      loc = Location.first(provider: "ubicloud")
+      vmh = create_vm_host(location_id: loc.id, total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      PciDevice.create(vm_host_id: vmh.id, slot: "01:00.0", device_class: "0300", vendor: "vd", device: "dv1", numa_node: 0, iommu_group: 3)
+      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
+      req.location_filter = [loc.id]
+      cand = Al::Allocation.candidate_hosts(req)
+      expect(req).to be_single_ubicloud_location
+      expect(cand.size).to eq(1)
+    end
   end
 
   describe "Allocation" do


### PR DESCRIPTION
We currently prevent standard (non-GPU) VMs from being provisioned on
GPU hosts to avoid consuming scarce GPU-host capacity with regular
workloads. This is the right default for larger locations with many
hosts without GPU.

In smaller `ubicloud` locations this restriction is counterproductive,
GPU hosts may be the only available capacity. This change lifts the
restriction when the request targets one such location.
