### PR TITLE
Remove Prog::LearnCpu::CpuTopology

### DIFF
--- a/prog/learn_cpu.rb
+++ b/prog/learn_cpu.rb
@@ -2,7 +2,6 @@
 
 class Prog::LearnCpu < Prog::Base
   subject_is :sshable
-  CpuTopology = Struct.new(:total_cpus, :total_cores, :total_dies, :total_sockets, keyword_init: true)
 
   def get_arch
     arch = sshable.cmd("common/bin/arch").strip
@@ -19,8 +18,7 @@ class Prog::LearnCpu < Prog::Base
     sockets = parsed.map { |socket, _| socket }.uniq.count
     cores = parsed.uniq.count
 
-    CpuTopology.new(total_cpus: cpus, total_cores: cores, total_dies: 0,
-      total_sockets: sockets)
+    {total_cpus: cpus, total_cores: cores, total_sockets: sockets}
   end
 
   def count_dies(arch:, total_sockets:)
@@ -34,7 +32,7 @@ class Prog::LearnCpu < Prog::Base
   label def start
     arch = get_arch
     topo = get_topology
-    topo.total_dies = count_dies(total_sockets: topo.total_sockets, arch:)
-    pop(arch:, **topo.to_h)
+    total_dies = count_dies(total_sockets: topo[:total_sockets], arch:)
+    pop(arch:, **topo, total_dies:)
   end
 end

--- a/spec/prog/learn_cpu_spec.rb
+++ b/spec/prog/learn_cpu_spec.rb
@@ -67,7 +67,7 @@ JSON
       expect(lc.sshable).to receive(:_cmd).with("/usr/bin/lscpu -Jye").and_return(
         eight_thread_four_core_four_numa_two_socket,
       )
-      expect(lc.get_topology).to eq(Prog::LearnCpu::CpuTopology.new(total_cpus: 8, total_cores: 4, total_dies: 0, total_sockets: 2))
+      expect(lc.get_topology).to eq({total_cpus: 8, total_cores: 4, total_sockets: 2})
     end
   end
 
@@ -86,7 +86,7 @@ JSON
     it "pops with cpu info" do
       allow(lc).to receive_messages(
         get_arch: "x64",
-        get_topology: Prog::LearnCpu::CpuTopology.new(total_cpus: 8, total_cores: 4, total_dies: 0, total_sockets: 2),
+        get_topology: {total_cpus: 8, total_cores: 4, total_sockets: 2},
         count_dies: 2,
       )
       expect { lc.start }.to exit(arch: "x64", total_cpus: 8, total_cores: 4, total_dies: 2, total_sockets: 2)


### PR DESCRIPTION
I don't think the conceptual overhead of the Struct is worth it in this case. The values are self contained in this prog, it is only used to pass data from get_topology to start, and start converts it into a hash. It seems simpler to switch to a hash.