### PR TITLE
Spill 30 vCPU runners to alien runners as 32 vCPUs

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -68,11 +68,14 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     if github_runner.spill_over_set? || (support_alien? && rand < alien_ratio)
       boot_image = Config.send(:"#{boot_image.tr("-", "_")}_#{arch}_aws_ami_version")
       location_id = Config.github_runner_aws_location_id
+      # AWS has no 30 vCPU instance size, so 30 vCPU runners get a 32 vCPU
+      # instance, but the customer is still billed for 30 vCPUs.
+      vcpus = (label_data["vcpus"] == 30) ? 32 : label_data["vcpus"]
       if x64?
-        size = Option.aws_instance_type_name("m7a", label_data["vcpus"])
+        size = Option.aws_instance_type_name("m7a", vcpus)
         alternative_families << "m7i" << "m6a"
       else
-        size = Option.aws_instance_type_name("m8g", label_data["vcpus"])
+        size = Option.aws_instance_type_name("m8g", vcpus)
         alternative_families << "m7g"
       end
       # eu-central-1a is usually give capacity errors
@@ -115,7 +118,9 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       # the customer for the label's VM size instead of the effective VM size.
       label_data["vm_size"]
     elsif vm.location.aws?
-      "standard-#{vm.vcpus}"
+      # Alien runners are billed by the label's vCPU count, not the instance's;
+      # 30 vCPU labels run on 32 vCPU instances but are still billed for 30.
+      "standard-#{label_data["vcpus"]}"
     else
       "#{vm.family}-#{vm.vcpus}"
     end

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -146,6 +146,19 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(picked_vm.boot_image).to eq(Config.github_ubuntu_2404_x64_aws_ami_version)
     end
 
+    it "uses a 32 vCPU alien vm for 30 vCPU runners if spilled over" do
+      runner.update(label: "ubicloud-standard-30")
+      runner.incr_spill_over
+      location = Location.create(name: "eu-central-1", provider: "aws", project_id: vm.project_id, display_name: "aws-eu-central-1", ui_name: "AWS Frankfurt", visible: true)
+      LocationCredentialAws.create(access_key: "test-access-key", secret_key: "test-secret-key") { it.id = location.id }
+      LocationAz.create(location_id: location.id, az: "b", zone_id: "euc1-az1")
+      expect(Config).to receive(:github_runner_aws_location_id).and_return(location.id)
+      picked_vm = nx.pick_vm
+      expect(picked_vm.family).to eq("m7a")
+      expect(picked_vm.vcpus).to eq(32)
+      expect(picked_vm.location.aws?).to be(true)
+    end
+
     it "uses alien arm64 vms if spilled over" do
       runner.update(label: "ubicloud-arm")
       runner.incr_spill_over
@@ -237,6 +250,21 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(br.duration(now, now)).to eq(1)
       expect(br.billing_rate["resource_family"]).to eq("standard-2")
       expect(runner.billed_vm_size).to eq("standard-2")
+    end
+
+    it "bills 30 vCPUs for alien runners running on 32 vCPU instances" do
+      runner.update(label: "ubicloud-standard-30", ready_at: now - 5 * 60)
+      location = Location.create(name: "eu-central-1", provider: "aws", project_id: vm.project_id, display_name: "aws-eu-central-1", ui_name: "AWS Frankfurt", visible: true)
+      vm.update(location_id: location.id, family: "m7a", vcpus: 32)
+      expect(vm.location.aws?).to be(true)
+      expect(BillingRecord).to receive(:create).and_call_original
+      nx.update_billing_record
+
+      br = BillingRecord[resource_id: project.id]
+      expect(br.amount).to eq(5)
+      expect(br.duration(now, now)).to eq(1)
+      expect(br.billing_rate["resource_family"]).to eq("standard-30")
+      expect(runner.billed_vm_size).to eq("standard-30")
     end
 
     it "updates the amount of existing billing record" do


### PR DESCRIPTION
Runners spill over to alien (AWS) instances only up to 16 vCPUs, because the smaller runner sizes (2, 4, 8, 16) match AWS instance sizes exactly. The 30 vCPU label has no AWS equivalent; the closest size is 32 vCPUs.

Map 30 vCPU labels to 32 vCPU instances (m7a.8xlarge/m8g.8xlarge) when picking an alien VM. Since the extra two vCPUs are an artifact of AWS sizing rather than something the customer asked for, bill alien runners by the label's vCPU count instead of the instance's, so a spilled 30 vCPU runner is still charged as standard-30. For all other alien runners the two counts are equal, so billing is unchanged.

This is not enabled yet: support_alien? still caps eligibility at 16 vCPUs, so 30 vCPU runners only take this path if the spill_over semaphore is set manually. Enabling it later is a one-line change to support_alien?.