### PR TITLE
Fix nondeterministic failure in Prog::Test::Kubernetes spec

### DIFF
--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Prog::Test::Kubernetes do
   end
 
   describe "#wait_for_renew_certs" do
-    let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "cert_expire_at_before_renew" => (Time.now + 365 * 24 * 60 * 60).to_s}] }
+    let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "cert_expire_at_before_renew" => (Time.now + 366 * 24 * 60 * 60).to_s}] }
 
     it "naps while the CP node is still renewing its certs" do
       cp_node.update(state: "renewing_certs")


### PR DESCRIPTION
It's a bad idea to have the spec try to use the exact same second as the deadline, as if the spec is started near the end of the second, it can fail.

Passed 100 runs locally with this change, where it previously failed without.