### PR TITLE
Add table links for Strand children and VmHost vms

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -562,7 +562,9 @@ class CloverAdmin < Roda
     ["Project", :postgres_resources] => "project",
     ["Project", :invoices] => "project",
     ["PostgresResource", :servers] => "resource",
+    ["Strand", :children] => "parent",
     ["VmHost", :boot_images] => "vm_host",
+    ["VmHost", :vms] => "vm_host",
   }.freeze
 
   ROLLOUT_PROGS = %w[
@@ -626,6 +628,8 @@ class CloverAdmin < Roda
         column_grep.call(ds, :created_at, value)
       when :project
         ubid_uuid_grep.call(ds, :project_id, value)
+      when :vm_host
+        ubid_uuid_grep.call(ds, :vm_host_id, value)
       end
     end
 
@@ -862,12 +866,19 @@ class CloverAdmin < Roda
       order Sequel.desc(:try)
       columns do |type_symbol, request|
         if type_symbol == :search_form
-          [:prog, :label, :try]
+          [:prog, :label, :try, :parent]
         else
           [:ubid, :prog, :label, :schedule, :try]
         end
       end
-      column_options try: {type: "number", value: nil}
+      column_options try: {type: "number", value: nil},
+        parent: ubid_input.call("Parent")
+
+      column_search_filter do |ds, column, value|
+        if column == :parent
+          ubid_uuid_grep.call(ds, :parent_id, value)
+        end
+      end
     end
 
     model Vm do
@@ -881,7 +892,8 @@ class CloverAdmin < Roda
         family: {type: "select", options: Option::VmFamilies.map(&:name), add_blank: true},
         vcpus: {type: "number"},
         created_at: {type: "text"},
-        project: ubid_input.call("Project")
+        project: ubid_input.call("Project"),
+        vm_host: ubid_input.call("VmHost")
     end
 
     model BootImage do
@@ -894,8 +906,6 @@ class CloverAdmin < Roda
 
       column_search_filter do |ds, column, value|
         case column
-        when :vm_host
-          ubid_uuid_grep.call(ds, :vm_host_id, value)
         when :activated_at
           column_grep.call(ds, :activated_at, value)
         else

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -458,6 +458,23 @@ RSpec.describe CloverAdmin do
     expect(page.all("#autoforme_content td").map(&:text)).to eq [
       "ubuntu-jammy", "20220202", vm_host.ubid, "14", "", boot_image.created_at.to_s,
     ]
+
+    vm.update(vm_host_id: vm_host.id)
+    visit "/model/VmHost/#{vm_host.ubid}"
+    within(".association", text: "vms") { click_link "(table)" }
+    expect(page.title).to eq "Ubicloud Admin - Vm - Search"
+    expect(page.all("#autoforme_content td").map(&:text)).to eq [
+      "assoc-table-vm", "creating", "assoc-table-test", vm_host.ubid, "hetzner-fsn1", "x64", "ubuntu-noble", "standard", "2", vm.created_at.to_s,
+    ]
+
+    strand = vm.strand
+    child_strand = Strand.create(prog: "Test", label: "start", parent_id: strand.id)
+    visit "/model/Strand/#{strand.ubid}"
+    within(".association", text: "children") { click_link "(table)" }
+    expect(page.title).to eq "Ubicloud Admin - Strand - Search"
+    expect(page.all("#autoforme_content td").map(&:text)).to eq [
+      child_strand.ubid, "Test", "start", child_strand.schedule.to_s, "0",
+    ]
   end
 
   it "handles basic pagination when browsing by class" do


### PR DESCRIPTION
The admin object page shows a (table) link next to an association when it is registered in OBJECT_ASSOC_TABLE_PARAMS, leading to the autoforme search page filtered to the associated objects. Register Strand children and VmHost vms so both large associations can be browsed as tables.

To back the links, give the Strand search form a parent filter and the Vm search form a vm_host filter, both accepting UBID or UUID like the existing association filters. Since both Vm and BootImage search by vm_host, handle it in the framework-level filter next to project instead of duplicating it per model.