### PR TITLE
Rollout boot images location by location with UI

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -570,6 +570,7 @@ class CloverAdmin < Roda
   }.freeze
 
   ROLLOUT_PROGS = %w[
+    RolloutBootImage
     RolloutRhizome
     RolloutSemaphore
   ].freeze
@@ -1191,6 +1192,30 @@ class CloverAdmin < Roda
             r.redirect "/rollouts"
           end
           Prog.const_get(prog).assemble(semaphore:, ids: klass.select_map(:id), gap:, increment:)
+        elsif prog == "RolloutBootImage"
+          image_name, version, arch = typecast_params.nonempty_str!(%w[image_name version arch])
+          concurrency = typecast_params.pos_int!("concurrency")
+          exclude_minio_hosts = typecast_params.bool("exclude_minio_hosts")
+          pause_stages = typecast_params.bool("pause_stages")
+
+          unless Prog::DownloadBootImage::BOOT_IMAGE_SHA256.dig(image_name, arch, version)
+            flash["error"] = "invalid version for boot image"
+            r.redirect "/rollouts"
+          end
+
+          exclude_vm_host_ids = typecast_params.str("exclude_vm_host_ids").to_s.split(",").filter_map do |id|
+            id = id.strip
+            next if id.empty?
+            uuid = UUID_REGEXP.match?(id) ? id : UBID.to_uuid(id)
+            unless uuid
+              flash["error"] = "invalid vm host id: #{id}"
+              r.redirect "/rollouts"
+            end
+            uuid
+          end
+
+          Prog.const_get(prog).assemble(image_name:, version:, arch:, concurrency:,
+            exclude_minio_hosts:, exclude_vm_host_ids:, pause_stages:)
         else
           Prog.const_get(prog).assemble
         end
@@ -1200,7 +1225,7 @@ class CloverAdmin < Roda
       end
 
       strand_semaphore_action(strand_ds, ROLLOUT_PROGS,
-        additional_semaphores: {"RolloutRhizome" => %w[github_runners_work]})
+        additional_semaphores: {"RolloutRhizome" => %w[github_runners_work], "RolloutBootImage" => %w[rollback]})
     end
 
     r.on "local-e2e" do

--- a/prog/rollout_boot_image.rb
+++ b/prog/rollout_boot_image.rb
@@ -2,21 +2,45 @@
 
 class Prog::RolloutBootImage < Prog::Base
   semaphore :rollback, :pause
-  frame_reader :concurrency, :image_name, :version, :todo, :in_progress, :completed, :failures
+  frame_reader :concurrency, :image_name, :version, :arch, :todo, :in_progress,
+    :completed, :failures, :stages, :pause_stages
 
-  def self.assemble(vm_hosts:, concurrency:, image_name:, version:)
-    todo = vm_hosts.sort_by(&:created_at).map(&:id)
+  STAGE_LOCATION_IDS = [
+    Location::GITHUB_RUNNERS_ID,
+    Location::HETZNER_FSN1_ID,
+    Location::HETZNER_HEL1_ID,
+    Location::LEASEWEB_WDC02_ID,
+  ].freeze
+
+  def self.assemble(image_name:, version:, concurrency:, arch: "x64",
+    exclude_minio_hosts: true, exclude_vm_host_ids: [], pause_stages: false)
+    fail "Invalid arch: #{arch}" unless ["x64", "arm64"].include?(arch)
+
+    ds = VmHost.where(arch:).exclude(id: exclude_vm_host_ids)
+    if exclude_minio_hosts
+      ds = ds.exclude(id: Vm.where(id: MinioServer.select(:vm_id)).select(:vm_host_id))
+    end
+
+    stages = DB.ignore_duplicate_queries do
+      STAGE_LOCATION_IDS.map { |location_id| ds.where(location_id:).order(:created_at, :id).select_map(:id) }
+    end
+    stages.reject!(&:empty?)
+    todo = stages.shift || []
+
     Strand.create(
       prog: "RolloutBootImage",
       label: "wait",
       stack: [{
         "todo" => todo,
+        "stages" => stages,
         "in_progress" => [],
         "completed" => [],
         "failures" => {},
         "concurrency" => concurrency,
         "image_name" => image_name,
         "version" => version,
+        "arch" => arch,
+        "pause_stages" => pause_stages,
       }],
     )
   end
@@ -43,7 +67,11 @@ class Prog::RolloutBootImage < Prog::Base
     end
 
     reap(fallthrough: true, reaper:) do
-      pop "rollout completed" if todo.empty? && in_progress.empty?
+      if todo.empty? && in_progress.empty?
+        pop "rollout completed" if stages.empty?
+        incr_pause if pause_stages
+        hop_next_stage
+      end
     end
 
     # Fill concurrency slots from the todo queue
@@ -59,6 +87,12 @@ class Prog::RolloutBootImage < Prog::Base
     strand.save_changes
 
     nap 15
+  end
+
+  label def next_stage
+    todo.concat(stages.shift)
+    strand.modified!(:stack)
+    hop_wait
   end
 
   label def rollback

--- a/spec/prog/rollout_boot_image_spec.rb
+++ b/spec/prog/rollout_boot_image_spec.rb
@@ -9,17 +9,18 @@ RSpec.describe Prog::RolloutBootImage do
   let(:vm_host2) { create_vm_host(created_at: Time.utc(2024, 1, 2)) }
   let(:vm_host3) { create_vm_host(created_at: Time.utc(2024, 1, 3)) }
   let(:st) {
+    [vm_host1, vm_host2, vm_host3]
     described_class.assemble(
-      vm_hosts: [vm_host3, vm_host1, vm_host2],
       concurrency: 2,
       image_name: "github-ubuntu-2404",
       version: "20260312.1.0",
     )
   }
 
-  def set_lists(todo: nil, in_progress: nil, completed: nil, failures: nil)
+  def set_lists(todo: nil, stages: nil, in_progress: nil, completed: nil, failures: nil)
     frame = st.stack.first
     frame["todo"] = todo if todo
+    frame["stages"] = stages if stages
     frame["in_progress"] = in_progress if in_progress
     frame["completed"] = completed if completed
     frame["failures"] = failures if failures
@@ -43,26 +44,93 @@ RSpec.describe Prog::RolloutBootImage do
   end
 
   describe ".assemble" do
-    it "creates strand with hosts sorted by created_at in todo" do
-      strand = described_class.assemble(
-        vm_hosts: [vm_host3, vm_host1, vm_host2],
-        concurrency: 2,
-        image_name: "github-ubuntu-2404",
-        version: "20260312.1.0",
-      )
+    it "creates strand with hosts grouped into location stages in rollout order" do
+      github_runner_host = create_vm_host(location_id: Location::GITHUB_RUNNERS_ID)
+      hel1_host = create_vm_host(location_id: Location::HETZNER_HEL1_ID)
+      wdc02_host = create_vm_host(location_id: Location::LEASEWEB_WDC02_ID)
 
-      expect(strand.label).to eq("wait")
-      expect(strand.prog).to eq("RolloutBootImage")
+      expect(st.label).to eq("wait")
+      expect(st.prog).to eq("RolloutBootImage")
 
-      frame = strand.stack.first
+      frame = st.stack.first
       expect(frame["concurrency"]).to eq(2)
       expect(frame["image_name"]).to eq("github-ubuntu-2404")
       expect(frame["version"]).to eq("20260312.1.0")
+      expect(frame["arch"]).to eq("x64")
+      expect(frame["pause_stages"]).to be false
 
-      expect(frame["todo"]).to eq([vm_host1.id, vm_host2.id, vm_host3.id])
+      expect(frame["todo"]).to eq([github_runner_host.id])
+      expect(frame["stages"]).to eq([[vm_host1.id, vm_host2.id, vm_host3.id], [hel1_host.id], [wdc02_host.id]])
       expect(frame["in_progress"]).to eq([])
       expect(frame["completed"]).to eq([])
       expect(frame["failures"]).to eq({})
+    end
+
+    it "sorts hosts by created_at within a stage and drops empty stages" do
+      expect(st.stack.first["todo"]).to eq([vm_host1.id, vm_host2.id, vm_host3.id])
+      expect(st.stack.first["stages"]).to eq([])
+    end
+
+    it "fails for invalid arch" do
+      expect {
+        described_class.assemble(concurrency: 2, image_name: "github-ubuntu-2404", version: "20260312.1.0", arch: "s390x")
+      }.to raise_error(RuntimeError, "Invalid arch: s390x")
+    end
+
+    it "only includes hosts with the given arch" do
+      arm64_host = create_vm_host(arch: "arm64", location_id: Location::GITHUB_RUNNERS_ID)
+      vm_host1
+
+      strand = described_class.assemble(
+        concurrency: 2, image_name: "github-ubuntu-2404", version: "20260312.1.0", arch: "arm64",
+      )
+
+      expect(strand.stack.first["todo"]).to eq([arm64_host.id])
+      expect(strand.stack.first["stages"]).to eq([])
+    end
+
+    it "excludes hosts running minio servers by default, but includes them if requested" do
+      mc = MinioCluster.create(
+        location_id: Location::HETZNER_FSN1_ID,
+        name: "minio-cluster-name",
+        admin_user: "minio-admin",
+        admin_password: "dummy-password",
+        root_cert_1: "dummy-root-cert-1",
+        root_cert_2: "dummy-root-cert-2",
+        project_id: Project.create(name: "test").id,
+      )
+      mp = MinioPool.create(
+        cluster_id: mc.id,
+        start_index: 0,
+        server_count: 1,
+        drive_count: 1,
+        storage_size_gib: 100,
+        vm_size: "standard-2",
+      )
+      minio_host = create_vm_host(created_at: Time.utc(2024, 1, 4))
+      MinioServer.create(
+        minio_pool_id: mp.id,
+        vm_id: create_vm(vm_host_id: minio_host.id).id,
+        index: 0,
+      )
+
+      expect(st.stack.first["todo"]).to eq([vm_host1.id, vm_host2.id, vm_host3.id])
+
+      strand = described_class.assemble(
+        concurrency: 2, image_name: "github-ubuntu-2404", version: "20260312.1.0", exclude_minio_hosts: false,
+      )
+      expect(strand.stack.first["todo"]).to eq([vm_host1.id, vm_host2.id, vm_host3.id, minio_host.id])
+    end
+
+    it "excludes explicitly given host ids" do
+      vm_host1
+
+      strand = described_class.assemble(
+        concurrency: 2, image_name: "github-ubuntu-2404", version: "20260312.1.0",
+        exclude_vm_host_ids: [vm_host2.id, vm_host3.id],
+      )
+
+      expect(strand.stack.first["todo"]).to eq([vm_host1.id])
     end
   end
 
@@ -152,10 +220,27 @@ RSpec.describe Prog::RolloutBootImage do
       expect(st.children_dataset.count).to eq(2)
     end
 
-    it "pops when todo is empty and all children are reaped" do
-      set_lists(todo: [], in_progress: [], completed: [vm_host1.id, vm_host2.id, vm_host3.id])
+    it "pops when all stages are done and all children are reaped" do
+      set_lists(todo: [], stages: [], in_progress: [], completed: [vm_host1.id, vm_host2.id, vm_host3.id])
 
       expect { nx.wait }.to exit({"msg" => "rollout completed"})
+    end
+
+    it "hops to next_stage when the current stage is done" do
+      set_lists(todo: [], stages: [[vm_host3.id]], in_progress: [], completed: [vm_host1.id, vm_host2.id])
+
+      expect { nx.wait }.to hop("next_stage")
+
+      expect(Semaphore.where(strand_id: st.id, name: "pause")).to be_empty
+    end
+
+    it "increments pause before hopping to next_stage when pause_stages is set" do
+      st.stack.first["pause_stages"] = true
+      set_lists(todo: [], stages: [[vm_host3.id]], in_progress: [], completed: [vm_host1.id, vm_host2.id])
+
+      expect { nx.wait }.to hop("next_stage")
+
+      expect(Semaphore.where(strand_id: st.id, name: "pause").count).to eq(1)
     end
 
     it "naps when children are still active" do
@@ -163,6 +248,27 @@ RSpec.describe Prog::RolloutBootImage do
       create_child(vm_host1, lease: Time.now + 100)
 
       expect { nx.wait }.to nap(15)
+    end
+
+    it "does not start the next stage while children are still active" do
+      set_lists(todo: [], stages: [[vm_host3.id]], in_progress: [vm_host1.id], completed: [vm_host2.id])
+      create_child(vm_host1, lease: Time.now + 100)
+
+      expect { nx.wait }.to nap(15)
+
+      expect(reload_frame["stages"]).to eq([[vm_host3.id]])
+    end
+  end
+
+  describe "#next_stage" do
+    it "moves the next stage into todo and hops to wait" do
+      set_lists(todo: [], stages: [[vm_host3.id]], in_progress: [], completed: [vm_host1.id, vm_host2.id])
+
+      expect { nx.next_stage }.to hop("wait")
+
+      frame = st.stack.first
+      expect(frame["todo"]).to eq([vm_host3.id])
+      expect(frame["stages"]).to eq([])
     end
   end
 
@@ -181,14 +287,17 @@ RSpec.describe Prog::RolloutBootImage do
   end
 
   describe "#remove_downloaded_images" do
-    it "removes downloaded images from all hosts and pops" do
+    it "removes downloaded images from started hosts and pops, leaving pending stages untouched" do
+      pending_host = create_vm_host(location_id: Location::HETZNER_HEL1_ID)
       set_lists(
         todo: [vm_host3.id],
+        stages: [[pending_host.id]],
         in_progress: [],
         completed: [vm_host1.id, vm_host2.id],
       )
       BootImage.create(vm_host_id: vm_host1.id, name: "github-ubuntu-2404", version: "20260312.1.0", size_gib: 3, activated_at: Time.now)
       BootImage.create(vm_host_id: vm_host2.id, name: "github-ubuntu-2404", version: "20260312.1.0", size_gib: 3, activated_at: Time.now)
+      BootImage.create(vm_host_id: pending_host.id, name: "github-ubuntu-2404", version: "20260312.1.0", size_gib: 3, activated_at: Time.now)
 
       expect { nx.remove_downloaded_images }.to exit({"msg" => "rollout rolled back"})
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1815,6 +1815,122 @@ RSpec.describe CloverAdmin do
       expect(page).to have_flash_notice("Strand #{st.ubid} updated")
       expect(st.semaphores.map(&:name)).to eq ["github_runners_work"]
     end
+
+    def create_minio_vm_host(**args)
+      vm_host = create_vm_host(**args)
+      cluster = MinioCluster.create(
+        location_id: Location::HETZNER_FSN1_ID,
+        name: "minio-cluster-name",
+        admin_user: "minio-admin",
+        admin_password: "dummy-password",
+        root_cert_1: "dummy-root-cert-1",
+        root_cert_2: "dummy-root-cert-2",
+        project_id: Project.create(name: "minio-project").id,
+      )
+      pool = MinioPool.create(
+        cluster_id: cluster.id,
+        start_index: 0,
+        server_count: 1,
+        drive_count: 1,
+        storage_size_gib: 100,
+        vm_size: "standard-2",
+      )
+      MinioServer.create(
+        minio_pool_id: pool.id,
+        vm_id: create_vm(vm_host_id: vm_host.id).id,
+        index: 0,
+      )
+      vm_host
+    end
+
+    it "allows creation of boot image rollout strands" do
+      vm_host = create_vm_host
+      create_minio_vm_host
+      version = Prog::DownloadBootImage::BOOT_IMAGE_SHA256.dig("ubuntu-noble", "x64").keys.max
+
+      select "ubuntu-noble", from: "Image Name"
+      fill_in "Version", with: version
+      click_button "Start Boot Image Rollout"
+
+      st = Strand.first(prog: "RolloutBootImage")
+      expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
+
+      frame = st.stack[0]
+      expect(frame["image_name"]).to eq "ubuntu-noble"
+      expect(frame["version"]).to eq version
+      expect(frame["arch"]).to eq "x64"
+      expect(frame["concurrency"]).to eq 10
+      expect(frame["pause_stages"]).to be false
+      expect(frame["todo"]).to eq [vm_host.id]
+    end
+
+    it "allows creation of boot image rollout strands with custom options" do
+      vm_host1 = create_vm_host(arch: "arm64", created_at: Time.utc(2024, 1, 1))
+      vm_host2 = create_vm_host(arch: "arm64", created_at: Time.utc(2024, 1, 2))
+      minio_host = create_minio_vm_host(arch: "arm64", created_at: Time.utc(2024, 1, 3))
+      version = Prog::DownloadBootImage::BOOT_IMAGE_SHA256.dig("ubuntu-noble", "arm64").keys.max
+
+      select "ubuntu-noble", from: "Image Name"
+      fill_in "Version", with: version
+      select "arm64", from: "Arch"
+      fill_in "Concurrency", with: "3"
+      uncheck "Exclude Minio Hosts"
+      check "Pause Between Stages"
+      fill_in "Exclude VM Host IDs (comma separated)", with: " #{vm_host1.ubid}, #{vm_host2.id},, "
+      click_button "Start Boot Image Rollout"
+
+      st = Strand.first(prog: "RolloutBootImage")
+      expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
+
+      frame = st.stack[0]
+      expect(frame["arch"]).to eq "arm64"
+      expect(frame["concurrency"]).to eq 3
+      expect(frame["pause_stages"]).to be true
+      expect(frame["todo"]).to eq [minio_host.id]
+    end
+
+    it "shows error when starting boot image rollout with invalid version" do
+      select "ubuntu-noble", from: "Image Name"
+      fill_in "Version", with: "20990101"
+      click_button "Start Boot Image Rollout"
+
+      expect(page).to have_flash_error("invalid version for boot image")
+      expect(Strand.first(prog: "RolloutBootImage")).to be_nil
+    end
+
+    it "shows error when starting boot image rollout with invalid excluded vm host id" do
+      version = Prog::DownloadBootImage::BOOT_IMAGE_SHA256.dig("ubuntu-noble", "x64").keys.max
+
+      select "ubuntu-noble", from: "Image Name"
+      fill_in "Version", with: version
+      fill_in "Exclude VM Host IDs (comma separated)", with: "not-an-id"
+      click_button "Start Boot Image Rollout"
+
+      expect(page).to have_flash_error("invalid vm host id: not-an-id")
+      expect(Strand.first(prog: "RolloutBootImage")).to be_nil
+    end
+
+    it "allows rolling back boot image rollout strands and shows their status" do
+      vm_host = create_vm_host
+      version = Prog::DownloadBootImage::BOOT_IMAGE_SHA256.dig("ubuntu-noble", "x64").keys.max
+      st = Prog::RolloutBootImage.assemble(image_name: "ubuntu-noble", version:, concurrency: 10)
+      page.refresh
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutBootImage", "wait", "0", st.ubid, "{\"image\" => \"ubuntu-noble #{version} x64\"}", "", "", ""]
+
+      frame = st.stack[0]
+      frame["todo"] = []
+      frame["in_progress"] = []
+      frame["stages"] = [[vm_host.id]]
+      frame["completed"] = [vm_host.id]
+      st.modified!(:stack)
+      st.save_changes
+      page.refresh
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutBootImage", "wait", "0", st.ubid, "{\"remaining\" => 1, \"completed\" => 1, \"image\" => \"ubuntu-noble #{version} x64\"}", "", "", ""]
+
+      click_button "Rollback"
+      expect(page).to have_flash_notice("Strand #{st.ubid} updated")
+      expect(st.semaphores.map(&:name)).to eq ["rollback"]
+    end
   end
 
   describe "local E2E" do

--- a/views/admin/rollouts.erb
+++ b/views/admin/rollouts.erb
@@ -11,9 +11,14 @@
       data["monitor_github_runners_until"] = Time.at(time).utc.strftime("%F %T UTC")
     end
   else
-    data["remaining"] = (frame["remaining_host_ids"] || frame["remaining"])&.size
+    data["remaining"] = if strand.prog == "RolloutBootImage"
+      frame["todo"].size + frame["in_progress"].size + frame["stages"].sum(&:size)
+    else
+      (frame["remaining_host_ids"] || frame["remaining"])&.size
+    end
     data["completed"] = frame["completed"]&.size
   end
+  data["image"] = "#{frame["image_name"]} #{frame["version"]} #{frame["arch"]}" if strand.prog == "RolloutBootImage"
   data.compact!
 
   h[:pause] = if strand.semaphores.find { it.name == "pause" }
@@ -28,6 +33,8 @@
     table_form_button("Github Runners Work", action: "/rollouts/#{strand.ubid}/github_runners_work", method: "post")
   elsif strand.prog == "RolloutSemaphore"
     "#{frame["increment"] ? "increment" : "decrement"} #{frame["semaphore"]}"
+  elsif strand.prog == "RolloutBootImage"
+    table_form_button("Rollback", action: "/rollouts/#{strand.ubid}/rollback", method: "post")
   end
 
   h
@@ -46,4 +53,16 @@ end %>
   <%== f.input(:text, key: :semaphore, label: "Semaphore", required: true) %>
   <%== f.input(:number, key: :gap, label: "Gap (seconds)", required: true, attr: {min: 5, max: 3600}, value: 60) %>
   <%== f.input(:radioset, key: :increment, required: true, options: [["Increment", true], ["Decrement", false]], value: true) %>
+<% end %>
+
+<h2>Start Boot Image Rollout</h2>
+
+<% form({action: "/rollouts/start/RolloutBootImage", method: "post", id: "start-rollout"}, button: "Start Boot Image Rollout", wrapper: :div) do |f| %>
+  <%== f.input(:select, key: :image_name, label: "Image Name", required: true, add_blank: true, options: Prog::DownloadBootImage::BOOT_IMAGE_SHA256.keys) %>
+  <%== f.input(:text, key: :version, label: "Version", required: true) %>
+  <%== f.input(:select, key: :arch, label: "Arch", required: true, options: %w[x64 arm64], value: "x64") %>
+  <%== f.input(:number, key: :concurrency, label: "Concurrency", required: true, attr: {min: 1}, value: 10) %>
+  <%== f.input(:checkbox, key: :exclude_minio_hosts, label: "Exclude Minio Hosts", checked: true) %>
+  <%== f.input(:text, key: :exclude_vm_host_ids, label: "Exclude VM Host IDs (comma separated)") %>
+  <%== f.input(:checkbox, key: :pause_stages, label: "Pause Between Stages") %>
 <% end %>


### PR DESCRIPTION
- **Rollout boot images location by location**
  Prog::RolloutBootImage required the operator to enumerate vm hosts by
  hand. Determine them in assemble instead, like RolloutRhizome does,
  and process locations as ordered stages: github-runners, then
  hetzner-fsn1, hetzner-hel1, and leaseweb-wdc02. A stage starts only
  after the previous one fully completes, so problems surface on the
  canary location before the image reaches the rest of the fleet.
  
  Hosts are filtered by arch, since boot image versions are
  arch-specific, and hosts running minio servers are excluded by
  default because their images are managed separately. Operators can
  exclude further hosts explicitly. With pause_stages, the prog
  increments its own pause semaphore at each stage boundary, so the
  operator must unpause to continue with the next location, matching
  the pause convention of the other rollout progs.
  
  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
  

- **Add boot image rollout to admin rollouts page**
  Boot image rollouts could previously only be started from a console.
  Add a form to the Manage Rollouts admin page so operators can start
  them like the rhizome and semaphore rollouts, choosing the image from
  the known boot images, the version, the architecture, the concurrency,
  and the minio/explicit host exclusions and stage pausing options.
  
  The version is validated against BOOT_IMAGE_SHA256 for the chosen
  image and architecture up front, since an unknown version would
  otherwise fail sha256 verification on every host mid-rollout. The
  host exclusion list accepts both ubids and uuids, as operators copy
  ids from different places.
  
  Rollout table rows for boot image rollouts show the image identity,
  the remaining and completed host counts across stages, and a Rollback
  button wired to the prog's rollback semaphore.
  
  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
  