### PR TITLE
Only delete created subnet and VPC in postgres test progs

### DIFF
--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -106,8 +106,8 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
 
   label def wait_resources_destroyed
     nap 5 if postgres_resource
-    nap_if_private_subnet
     nap_if_gcp_vpc
+    nap_if_private_subnet
     verify_timelines_destroyed(timeline_ids) if timeline_ids
     hop_finish
   end

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -4,7 +4,7 @@ class Prog::Test::PostgresBase < Prog::Test::Base
   frame_reader :provider, :family, :aws_location_name, :gcp_location_name, :postgres_test_project_id, :local_e2e
   frame_accessor :postgres_resource_id, :private_subnet_id, :location_id, :fail_message, :timeline_ids
 
-  def self.assemble(provider:, project_name:, family: nil, aws_location_name: "us-west-2", gcp_location_name: "gcp-us-central1", local_e2e: false, gcp_dedicated_subnet_vpcs: false)
+  def self.assemble(provider:, project_name:, family: nil, aws_location_name: "us-west-2", gcp_location_name: "gcp-us-central1", local_e2e: false, gcp_dedicated_subnet_vpcs: true)
     postgres_test_project = if Config.local_e2e_postgres_test_project_id
       Project.with_pk!(Config.local_e2e_postgres_test_project_id)
     else
@@ -99,14 +99,20 @@ class Prog::Test::PostgresBase < Prog::Test::Base
   end
 
   def nap_if_private_subnet
-    if PrivateSubnet[project_id: postgres_test_project_id]
+    if private_subnet_id && PrivateSubnet[private_subnet_id]
       Clog.emit("Waiting for private subnet to be destroyed")
       nap 5
     end
   end
 
   def nap_if_gcp_vpc
-    if GcpVpc[project_id: postgres_test_project_id]
+    has_gcp_vpc = if postgres_test_project.gcp_dedicated_subnet_vpcs
+      private_subnet_id && GcpVpc[dedicated_for_subnet_id: private_subnet_id]
+    else
+      GcpVpc[project_id: postgres_test_project_id]
+    end
+
+    if has_gcp_vpc
       Clog.emit("Waiting for GCP VPC to be destroyed")
       nap 5
     end

--- a/prog/test/postgres_firewall.rb
+++ b/prog/test/postgres_firewall.rb
@@ -121,8 +121,8 @@ class Prog::Test::PostgresFirewall < Prog::Test::PostgresBase
 
   label def wait_resources_destroyed
     nap 5 if postgres_resource
-    nap_if_private_subnet
     nap_if_gcp_vpc
+    nap_if_private_subnet
     verify_timelines_destroyed(timeline_ids) if timeline_ids
     hop_destroy
   end

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -36,8 +36,8 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
 
   label def wait_resources_destroyed
     nap 5 if postgres_resource
-    nap_if_private_subnet
     nap_if_gcp_vpc
+    nap_if_private_subnet
     verify_timelines_destroyed(timeline_ids) if timeline_ids
 
     hop_finish

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -2,6 +2,7 @@
 
 class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   semaphore :pause, :destroy
+  frame_reader :start_version
   frame_accessor :pre_upgrade_postgres_timeline_id, :read_replica_id
 
   def self.assemble(provider: "metal", start_version: "17", **)
@@ -284,10 +285,6 @@ SQL
 
   def read_replica
     @read_replica ||= PostgresResource[read_replica_id]
-  end
-
-  def start_version
-    frame["start_version"]
   end
 
   def target_version

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -273,8 +273,8 @@ SQL
 
   label def wait_resources_destroyed
     nap 5 if read_replica || postgres_resource
-    nap_if_private_subnet
     nap_if_gcp_vpc
+    nap_if_private_subnet
     verify_timelines_destroyed(timeline_ids) if timeline_ids
     hop_finish
   end

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -306,18 +306,22 @@ RSpec.describe Prog::Test::HaPostgresResource do
 
     it "naps if private subnet still exists" do
       project_id = pgr_test.frame["postgres_test_project_id"]
-      refresh_frame(pgr_test, new_values: {"postgres_resource_id" => nil})
-      PrivateSubnet.create(
+      ps = PrivateSubnet.create(
         name: "ha-test-subnet", project_id:, location_id: Location::HETZNER_FSN1_ID,
         net4: "10.0.0.0/26", net6: "fd00::/64",
       )
+      refresh_frame(pgr_test, new_values: {"private_subnet_id" => ps.id})
       expect { pgr_test.wait_resources_destroyed }.to nap(5)
     end
 
     it "naps if GCP VPC still exists" do
       project_id = pgr_test.frame["postgres_test_project_id"]
-      refresh_frame(pgr_test, new_values: {"postgres_resource_id" => nil})
-      GcpVpc.create(project_id:, location_id: Location::HETZNER_FSN1_ID, name: "ha-test-vpc")
+      ps = PrivateSubnet.create(
+        name: "ha-test-subnet", project_id:, location_id: Location::HETZNER_FSN1_ID,
+        net4: "10.0.0.0/26", net6: "fd00::/64",
+      )
+      refresh_frame(pgr_test, new_values: {"private_subnet_id" => ps.id})
+      GcpVpc.create(project_id:, location_id: Location::HETZNER_FSN1_ID, name: "ha-test-vpc", dedicated_for_subnet_id: ps.id)
       expect { pgr_test.wait_resources_destroyed }.to nap(5)
     end
 

--- a/spec/prog/test/postgres_firewall_spec.rb
+++ b/spec/prog/test/postgres_firewall_spec.rb
@@ -394,14 +394,17 @@ RSpec.describe Prog::Test::PostgresFirewall do
     end
 
     it "naps if the private subnet isn't deleted yet" do
-      project_id = pg_fw_test.strand.stack.first["postgres_test_project_id"]
-      PrivateSubnet.create(name: "subnet", project_id:, location_id:, net4: "10.0.0.0/26", net6: "fd00::/64")
+      project_id = pg_fw_test.frame["postgres_test_project_id"]
+      ps = PrivateSubnet.create(name: "subnet", project_id:, location_id:, net4: "10.0.0.0/26", net6: "fd00::/64")
+      refresh_frame(pg_fw_test, new_values: {"private_subnet_id" => ps.id})
       expect { pg_fw_test.wait_resources_destroyed }.to nap(5)
     end
 
     it "naps if the GCP VPC isn't deleted yet" do
       project_id = pg_fw_test.strand.stack.first["postgres_test_project_id"]
-      GcpVpc.create(project_id:, location_id:, name: "vpc")
+      ps = PrivateSubnet.create(name: "subnet", project_id:, location_id:, net4: "10.0.0.0/26", net6: "fd00::/64")
+      refresh_frame(pg_fw_test, new_values: {"private_subnet_id" => ps.id})
+      GcpVpc.create(project_id:, location_id:, name: "vpc", dedicated_for_subnet_id: ps.id)
       expect { pg_fw_test.wait_resources_destroyed }.to nap(5)
     end
 

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Prog::Test::PostgresResource do
     end
 
     it "naps if the private subnet isn't deleted yet" do
-      project_id = pgr_test.strand.stack.first["postgres_test_project_id"]
+      project_id = pgr_test.frame["postgres_test_project_id"]
       ps = PrivateSubnet.create(name: "subnet", project_id:, location_id:, net4: "10.0.0.0/26", net6: "fd00::/64")
       refresh_frame(pgr_test, new_values: {"private_subnet_id" => ps.id})
       expect { pgr_test.wait_resources_destroyed }.to nap(5)
@@ -283,6 +283,15 @@ RSpec.describe Prog::Test::PostgresResource do
 
     it "naps if the GCP VPC isn't deleted yet" do
       project_id = pgr_test.strand.stack.first["postgres_test_project_id"]
+      ps = PrivateSubnet.create(name: "subnet", project_id:, location_id:, net4: "10.0.0.0/26", net6: "fd00::/64")
+      refresh_frame(pgr_test, new_values: {"private_subnet_id" => ps.id})
+      GcpVpc.create(project_id:, location_id:, name: "vpc", dedicated_for_subnet_id: ps.id)
+      expect { pgr_test.wait_resources_destroyed }.to nap(5)
+    end
+
+    it "naps if the GCP VPC isn't deleted yet when not dedicating VPCs to subnets" do
+      project_id = pgr_test.strand.stack.first["postgres_test_project_id"]
+      Project[project_id].update(gcp_dedicated_subnet_vpcs: false)
       GcpVpc.create(project_id:, location_id:, name: "vpc")
       expect { pgr_test.wait_resources_destroyed }.to nap(5)
     end

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../../model/spec_helper"
+require "aws-sdk-ec2"
 
 RSpec.describe Prog::Test::UpgradePostgresResource do
   subject(:pgr_test) { described_class.new(pgr_strand) }

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -559,18 +559,22 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
 
     it "naps if private subnet still exists" do
       project_id = pgr_test.frame["postgres_test_project_id"]
-      refresh_frame(pgr_test, new_values: {"postgres_resource_id" => nil, "read_replica_id" => nil})
-      PrivateSubnet.create(
+      ps = PrivateSubnet.create(
         name: "upgrade-test-subnet", project_id:, location_id: Location::HETZNER_FSN1_ID,
         net4: "10.0.0.0/26", net6: "fd00::/64",
       )
+      refresh_frame(pgr_test, new_values: {"private_subnet_id" => ps.id, "read_replica_id" => nil})
       expect { pgr_test.wait_resources_destroyed }.to nap(5)
     end
 
     it "naps if GCP VPC still exists" do
       project_id = pgr_test.frame["postgres_test_project_id"]
-      refresh_frame(pgr_test, new_values: {"postgres_resource_id" => nil, "read_replica_id" => nil})
-      GcpVpc.create(project_id:, location_id: Location::HETZNER_FSN1_ID, name: "upgrade-test-vpc")
+      ps = PrivateSubnet.create(
+        name: "upgrade-test-subnet", project_id:, location_id: Location::HETZNER_FSN1_ID,
+        net4: "10.0.0.0/26", net6: "fd00::/64",
+      )
+      refresh_frame(pgr_test, new_values: {"postgres_resource_id" => nil, "read_replica_id" => nil, "private_subnet_id" => ps.id})
+      GcpVpc.create(project_id:, location_id: Location::HETZNER_FSN1_ID, name: "upgrade-test-vpc", dedicated_for_subnet_id: ps.id)
       expect { pgr_test.wait_resources_destroyed }.to nap(5)
     end
 


### PR DESCRIPTION
Previously, this assumed any subnet or GCP VPC in the project was
related to the test, which isn't correct if a shared project is used, as
it is for local E2E tests. The prog keeps track of the created subnet,
so it knows which subnet was created, and can delete that subnet
specifically. For GCP VPC, it can know the specific VPC if a VPC is
created per subnet. Make that the default behavior, and change the code
to look for the specific VPC in that case.

Change the progs from calling nap_if_gcp_vpc before
nap_if_private_subnet, because when dedicated GCP VPCs are used, the
private subnet cannot be deleted until after the GCP VPC is deleted,
since the GCP VPC references the private subnet.

Make a couple of minor improvements while here.