### PR TITLE
Fix flaky test when second rounding is unlucky

### DIFF
--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -91,7 +91,8 @@ RSpec.describe Prog::Test::Kubernetes do
   end
 
   describe "#wait_for_renew_certs" do
-    let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "cert_expire_at_before_renew" => (Time.now + 365 * 24 * 60 * 60).to_s}] }
+    let(:cert_expiry) { Time.now + 365 * 24 * 60 * 60 }
+    let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "cert_expire_at_before_renew" => cert_expiry.to_s}] }
 
     it "naps while the CP node is still renewing its certs" do
       cp_node.update(state: "renewing_certs")
@@ -101,7 +102,7 @@ RSpec.describe Prog::Test::Kubernetes do
 
     it "naps when the renewal flow finished but the cert expiry has not advanced" do
       cp_node.strand.update(label: "wait")
-      expect(cp_node.sshable).to receive(:_cmd).with("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").and_return("notAfter=#{(Time.now + 365 * 24 * 60 * 60).utc.strftime("%b %e %H:%M:%S %Y")} GMT\n")
+      expect(cp_node.sshable).to receive(:_cmd).with("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").and_return("notAfter=#{cert_expiry.utc.strftime("%b %e %H:%M:%S %Y")} GMT\n")
       expect { kubernetes_test.wait_for_renew_certs }.to nap(10)
     end
 


### PR DESCRIPTION
The verbatim failure follows.  This is likely the result of being unlucky with spanning a second in-between expression evaluation in test execution.

Failures:

     1) Prog::Test::Kubernetes#wait_for_renew_certs naps when the renewal flow finished but the cert expiry has not advanced
     Failure/Error: Unable to find matching line from backtrace
     Prog::Base::Hop:
     hop Test::Kubernetes#start -> Test::Kubernetes#test_nodes
    Finished in 1 minute 1.94 seconds (files took 5.24 seconds to load)
    6925 examples, 1 failure
    Failed examples:
    rspec ./spec/prog/test/kubernetes_spec.rb:102 # Prog::Test::Kubernetes#wait_for_renew_certs naps when the renewal flow finished but the cert expiry has not advanced
    rake aborted!
    Command failed with status (1): [CLOVER_FREEZE=true RUBYOPT=-w RACK_ENV=test FORCE_AUTOLOAD=1 bundle exec turbo_tests -n 8]