### PR TITLE
Remove free 7-day premium runner trial for new users

### DIFF
--- a/model/github/github_installation.rb
+++ b/model/github/github_installation.rb
@@ -23,15 +23,13 @@ class GithubInstallation < Sequel::Model
   end
 
   def free_runner_upgrade?(at = Time.now)
-    free_runner_upgrade_expires_at > at
+    free_runner_upgrade_expires_at&.>(at)
   end
 
   def free_runner_upgrade_expires_at
-    dates = [created_at + 7 * 24 * 60 * 60]
     if (upgrade_until = project.get_ff_free_runner_upgrade_until)
-      dates.push(Time.parse(upgrade_until))
+      Time.parse(upgrade_until)
     end
-    dates.max
   end
 
   def standard_runner_allowed?

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -225,8 +225,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     it "uses the original billing rate for runners who were upgraded for free based on runner creation time" do
       vm.update(family: "premium")
       runner.update(label: "ubicloud-standard-2", ready_at: now - 5 * 60, created_at: now - 100)
-
-      expect(installation).to receive(:free_runner_upgrade_expires_at).and_return(now - 50)
+      project.set_ff_free_runner_upgrade_until(now - 50).reload
       expect(BillingRecord).to receive(:create).and_call_original
       nx.update_billing_record
 

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Clover, "github" do
     it "shows badge for free premium runner upgrade" do
       now = Time.utc(2026, 6, 1)
       allow(Time).to receive(:now).and_return(now)
-      installation.update(created_at: now - 1)
+      project.set_ff_free_runner_upgrade_until(now + 100)
 
       visit "#{project.path}/github/#{installation.ubid}/setting"
       expect(page.status_code).to eq(200)
@@ -344,7 +344,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "shows badge for free premium runner upgrade" do
-      installation.update(created_at: Time.now)
+      project.set_ff_free_runner_upgrade_until(Time.now + 100)
 
       visit "#{project.path}/github/#{installation.ubid}/runner"
       expect(page.status_code).to eq(200)


### PR DESCRIPTION
Previously, we offered new users a free 7-day trial of premium runners to try out our high-performance runners. Since premium runners are now the default and standard runners are no longer available to new users, this trial is no longer meaningful.

We're keeping the `free_runner_upgrade_until` feature flag in case we want to offer free upgrades to existing users to encourage them to switch to premium runners.