### PR TITLE
Drop 2026 Jan-Apr partitions of archived_record

### DIFF
--- a/migrate/20260615_drop_archived_record_2026_partitions.rb
+++ b/migrate/20260615_drop_archived_record_2026_partitions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  revert do
+    Array.new(4) { |i| Date.new(2026, 1, 1).next_month(i) }.each do |month|
+      create_table("archived_record_#{month.strftime("%Y_%m")}", partition_of: :archived_record) do
+        from month
+        to month.next_month
+      end
+    end
+  end
+end


### PR DESCRIPTION
Drop first four 2026 partitions of the archived_record table:

archived_record_2026_01
archived_record_2026_02
archived_record_2026_03
archived_record_2026_04
