### PR TITLE
Bound R2 blob storage client timeouts and retries

### DIFF
--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -98,6 +98,16 @@ class GithubRepository < Sequel::Model
       region: Config.github_cache_blob_storage_region,
       request_checksum_calculation: "when_required",
       response_checksum_validation: "when_required",
+      # We only issue small control-plane calls through this client (multipart
+      # create/complete/abort, delete); blob data moves over presigned URLs
+      # directly from the runner. Without explicit timeouts the AWS SDK defaults
+      # (15s open / 60s read, 3 retries) let a hung R2 call exceed the 30s web
+      # request timeout. Bound them so a slow R2 fails fast instead: the
+      # network-hang worst case is (1 + retry_limit) * http_read_timeout = ~24s,
+      # which stays under the 30s web request timeout.
+      http_open_timeout: 5,
+      http_read_timeout: 8,
+      retry_limit: 2,
     )
   end
 end

--- a/spec/model/github/github_repository_spec.rb
+++ b/spec/model/github/github_repository_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe GithubRepository do
     allow(Aws::S3::Client).to receive(:new).and_return(blob_storage_client)
   end
 
+  describe "#blob_storage_client" do
+    it "builds the S3 client with bounded timeouts and retries" do
+      expect(Aws::S3::Client).to receive(:new).with(hash_including(
+        http_open_timeout: 5,
+        http_read_timeout: 8,
+        retry_limit: 2,
+      )).and_return(blob_storage_client)
+
+      expect(github_repository.blob_storage_client).to eq(blob_storage_client)
+    end
+  end
+
   describe ".destroy_blob_storage" do
     let(:uploads) { instance_double(Aws::S3::Types::ListMultipartUploadsOutput, uploads: [instance_double(Aws::S3::Types::MultipartUpload, key: "test-key", upload_id: "test-upload-id")]) }
 


### PR DESCRIPTION
We have seen recurring web request timeouts on POST /runtime/github/caches (reserveCache), surfacing on the Heroku router as H12 "Request timeout" after the full 30s ceiling, e.g.:

  at=error code=H12 desc="Request timeout" method=POST
  path="/runtime/github/caches?runId=..." service=30000ms status=503

The handler talks to Cloudflare R2 through the Aws::S3::Client built in GithubRepository#s3_client (create_multipart_upload and friends). That client was constructed without explicit HTTP timeouts or a retry cap, so it inherited the AWS SDK defaults of a 15s open timeout, a 60s read timeout, and 3 retries. When R2 is slow or a connection hangs, a single create_multipart_upload can therefore block well past the 30s router timeout, and the request is killed mid-flight rather than failing cleanly. The 5s Octokit timeouts in lib/github.rb do not help here: they only govern GitHub API calls, not the S3/R2 client.

Every call we make through this client is a small control-plane operation (multipart create/complete/abort, object and bucket delete, list multipart uploads). The actual cache blob data never flows through it; that moves over presigned URLs directly between the runner and R2. Short timeouts are therefore safe for all operations on this client.

Bound the client to a 5s open timeout, an 8s read timeout, and 2 retries. The worst case for a hung connection becomes (1 + retry_limit) * http_read_timeout = ~24s, which stays under the 30s web request timeout while still allowing two retries to ride out transient throttling or 5xx errors. The retry budget matters for commitCache (complete_multipart_upload), which has no application-level retry of its own, unlike reserveCache.