### PR TITLE
Restart PostgreSQL after editing auth config in CI

### DIFF
--- a/.github/actions/setup-clover/action.yml
+++ b/.github/actions/setup-clover/action.yml
@@ -25,7 +25,7 @@ runs:
         runner_map runner clover
         runner_map runner clover_password' | sudo tee -a /etc/postgresql/17/main/pg_ident.conf > /dev/null
         sudo sed -i '1i local   all   all   peer map=runner_map' /etc/postgresql/17/main/pg_hba.conf
-        sudo systemctl start postgresql
+        sudo systemctl restart postgresql
         until pg_isready -q; do sleep 1; done
 
     - name: Set up Ruby


### PR DESCRIPTION
The setup-clover action edited pg_hba.conf and pg_ident.conf to install a peer ident map (runner -> postgres/clover), then ran "systemctl start postgresql". On x64 runners this worked, but on arm64 the same job failed:

```
    createuser -U postgres clover
    createuser: error: connection to server on socket
    "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  Peer
    authentication failed for user "postgres"
```

The difference is the runner image. x64 images ship PostgreSQL pre-installed, while arm64 images do not. On arm64, "apt-get install postgresql-17" creates and auto-starts the 17/main cluster with the default config, before the action writes the ident map. The subsequent "systemctl start postgresql" is then a no-op against the already-running cluster, so the edited pg_hba.conf/pg_ident.conf is never loaded. Without the map, plain peer auth requires the OS user to match the database user, and the runner user is not postgres, so the connection is rejected.

Use "systemctl restart postgresql" so the server reloads the edited auth config regardless of whether installation already started the cluster.