### PR TITLE
Fix GitHub runner tests that depend on the current date

### DIFF
--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "toggles premium runners for installation" do
-      installation.update(allocator_preferences: {})
+      installation.update(allocator_preferences: {}, created_at: Time.utc(2026, 5, 1))
 
       # enable
       visit "#{project.path}/github/#{installation.ubid}/setting"
@@ -155,7 +155,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "does not allow toggling premium when standard runner is not allowed" do
-      installation.update(allocator_preferences: {})
+      installation.update(allocator_preferences: {}, created_at: Time.utc(2026, 5, 1))
 
       visit "#{project.path}/github/#{installation.ubid}/setting"
       installation.update(created_at: Time.utc(2026, 6, 6))


### PR DESCRIPTION
We disallow switching the runner type for installations created after June 1, 2026. So to test the runner type toggle, we need to set the creation date to an earlier date.