### PR TITLE
Make MI version list auto-refresh conditional and less frequent

### DIFF
--- a/views/machine_image/versions.erb
+++ b/views/machine_image/versions.erb
@@ -1,10 +1,13 @@
-<div class="auto-refresh hidden" data-interval="10"></div>
-
 <% @versions = @machine_image.versions_dataset.eager(:metal).reverse(:created_at).all
   can_edit = has_permission?("MachineImage:edit", @machine_image)
   latest_version_id = @machine_image.latest_version_id
   version_headers = ["Version", "State", "Size", "Archive Size", "Created"]
-  version_headers << "" if can_edit %>
+  version_headers << "" if can_edit
+  in_flight_states = %w[creating destroying] %>
+
+<% if @versions.any? { |v| in_flight_states.include?(v.metal&.status) } %>
+  <div class="auto-refresh hidden" data-interval="60"></div>
+<% end %>
 
 <div class="p-6">
   <%== part(


### PR DESCRIPTION
Auto-refresh the machine image versions page only when a version is being created or destroyed, and reduce the refresh interval from 10s to 60s.

Previously, the page refreshed unconditionally every 10s. This made the destroy flow confusing: the user clicks the trash icon, enters the version name to confirm, and if the refresh deadline passes during that confirmation step, the page refreshes immediately after confirmation. The version the user just confirmed may then no longer be scheduled for destruction.

This change refreshes only when it is useful and does so less frequently, which reduces the chance of interrupting the destroy confirmation flow.