### PR TITLE
Support patching of VmHost via patch semaphore

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1183,15 +1183,33 @@ class CloverAdmin < Roda
 
       r.post "start", ROLLOUT_PROGS do |prog|
         st = if prog == "RolloutSemaphore"
-          klass, semaphore = typecast_params.nonempty_str!(%w[class semaphore])
+          klass, semaphore, increment = typecast_params.nonempty_str!(%w[class semaphore increment])
           gap = typecast_params.pos_int!("gap")
-          increment = typecast_params.bool!("increment")
+          wait = typecast_params.nonempty_str("wait_label")
+          location_id = typecast_params.ubid_uuid("location_id")
+
           unless semaphore_classes.map(&:name).include?(klass) &&
               (klass = Object.const_get(klass)).semaphore_names.include?(semaphore.to_sym)
             flash["error"] = "invalid semaphore for class"
             r.redirect "/rollouts"
           end
-          Prog.const_get(prog).assemble(semaphore:, ids: klass.select_map(:id), gap:, increment:)
+
+          ds = klass
+          ds = ds.where(location_id:) if location_id && klass.columns.include?(:location_id)
+          ids = ds.select_map(:id)
+
+          case increment
+          when "increment-no-wait"
+            increment = true
+            wait = false
+          when "decrement"
+            increment = false
+          else
+            increment = true
+            wait ||= true
+          end
+
+          Prog.const_get(prog).assemble(semaphore:, ids:, gap:, increment:, wait:)
         elsif prog == "RolloutBootImage"
           image_name, version, arch = typecast_params.nonempty_str!(%w[image_name version arch])
           concurrency = typecast_params.pos_int!("concurrency")

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -26,7 +26,7 @@ class VmHost < Sequel::Model
   plugin :association_dependencies, assigned_host_addresses: :destroy, assigned_subnets: :destroy, provider: :destroy, spdk_installations: :destroy, storage_devices: :destroy, pci_devices: :destroy, boot_images: :destroy, slices: :destroy, cpus: :destroy, vhost_block_backends: :destroy, gpu_partitions: :destroy
 
   plugin ResourceMethods
-  plugin SemaphoreMethods, :checkup, :reboot, :hardware_reset, :destroy, :graceful_reboot, :configure_metrics
+  plugin SemaphoreMethods, :checkup, :reboot, :hardware_reset, :destroy, :graceful_reboot, :configure_metrics, :patch
   include HealthMonitorMethods
   include MetricsTargetMethods
 

--- a/prog/rollout_semaphore.rb
+++ b/prog/rollout_semaphore.rb
@@ -2,8 +2,8 @@
 
 class Prog::RolloutSemaphore < Prog::Base
   semaphore :pause, :destroy
-  frame_reader :semaphore, :gap, :initial_gap, :initial_num, :increment
-  frame_accessor :remaining, :completed, :next_increment_time
+  frame_reader :semaphore, :gap, :initial_gap, :initial_num, :increment, :wait_label
+  frame_accessor :remaining, :completed, :next_increment_time, :current
 
   # semaphore: Name of semaphore to increment.
   # ids: Array of object ids to increment semaphore on.
@@ -15,7 +15,9 @@ class Prog::RolloutSemaphore < Prog::Base
   #                to this range.
   # increment: If true (the default), increments the semaphore. Otherwise, decrements
   #            the semaphore.
-  def self.assemble(semaphore:, ids:, gap: 60, initial_gap: gap * 5, initial_range: 2..15, increment: true)
+  # wait: When incrementing, wait until the semaphore has been decremented. If given a
+  #       string, also wait until the strand is at this label before continuing.
+  def self.assemble(semaphore:, ids:, gap: 60, initial_gap: gap * 5, initial_range: 2..15, increment: true, wait: true)
     classes = ids.map { UBID.class_for_ubid(UBID.to_ubid(it)) }
     classes.uniq!
     classes.delete_if { it.semaphore_names.include?(semaphore.to_sym) }
@@ -36,9 +38,11 @@ class Prog::RolloutSemaphore < Prog::Base
         "initial_gap" => initial_gap,
         "initial_num" => initial_num,
         "remaining" => ids,
+        "current" => nil,
         "completed" => [],
         "next_increment_time" => Time.now.to_i,
         "increment" => increment,
+        "wait_label" => wait,
       }],
     )
   end
@@ -57,18 +61,34 @@ class Prog::RolloutSemaphore < Prog::Base
     time_left = time_int - now
     nap(time_left) if time_left > 0
 
+    nap_time = (completed.size >= initial_num) ? gap : initial_gap
+    # Also handles remaining/completed modifications due to strand.modified!(:stack)
+    self.next_increment_time = now + nap_time
+
     if increment
       Semaphore.incr(next_id, semaphore)
+      if wait_label
+        self.current = next_id
+        hop_wait_current
+      end
     else
       Semaphore.where(strand_id: next_id, name: semaphore).destroy
     end
 
     completed << next_id
-    nap_time = (completed.size >= initial_num) ? gap : initial_gap
-    # Also handles remaining/completed modifications due to strand.modified!(:stack)
-    self.next_increment_time = now + nap_time
-
     nap(nap_time)
+  end
+
+  label def wait_current
+    if Semaphore.where(strand_id: current, name: semaphore).empty? &&
+        (!wait_label.is_a?(String) || !(st = Strand[current]) || st.label == wait_label)
+      completed << current
+      # Also handles completed modifications due to strand.modified!(:stack)
+      self.current = nil
+      hop_start
+    end
+
+    nap((gap / 10).clamp(5, 300))
   end
 
   label def destroy

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -270,8 +270,10 @@ class Prog::Vm::HostNexus < Prog::Base
     when_graceful_reboot_set? do
       fail "BUG: VmHost not in draining state" unless vm_host.allocation_state == "draining"
 
-      vm_host.update(allocation_state: "accepting")
-      decr_graceful_reboot
+      unless vm_host.patch_set?
+        vm_host.update(allocation_state: "accepting")
+        decr_graceful_reboot
+      end
     end
 
     vm_host.update(allocation_state: "accepting") if vm_host.allocation_state == "unprepared"

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -3,6 +3,7 @@
 class Prog::Vm::HostNexus < Prog::Base
   subject_is :sshable, :vm_host
   frame_reader :vhost_block_backend_version, :default_boot_images
+  frame_accessor :accepting_before_patch
 
   def self.assemble(sshable_hostname, location_id: Location::HETZNER_FSN1_ID, family: "standard", net6: nil, ndp_needed: false, provider_name: nil, server_identifier: nil, vhost_block_backend_version: Config.vhost_block_backend_version, default_boot_images: [])
     DB.transaction do
@@ -369,12 +370,15 @@ TIMER
     when_patch_set? do
       unless vm_host.allocation_state == "draining"
         vm_host.update(allocation_state: "draining")
-
-        # Move back to accepting post-reboot
-        incr_graceful_reboot
+        self.accepting_before_patch = true
       end
 
       if vm_host.vms_dataset.empty?
+        if accepting_before_patch
+          # Move back to accepting post-reboot if it was accepting before patch semaphore set
+          incr_graceful_reboot
+          delete_from_stack("accepting_before_patch")
+        end
         decr_patch
         register_deadline("prep_reboot", 10 * 60)
         hop_patch

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -147,7 +147,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def wait_download_boot_images
-    reap(:prep_reboot)
+    reap(:patch)
   end
 
   label def prep_reboot

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -340,7 +340,6 @@ TIMER
   end
 
   label def patch
-    decr_patch
     sshable = vm_host.sshable
 
     case sshable.d_check("apply_patches")
@@ -375,7 +374,12 @@ TIMER
         incr_graceful_reboot
       end
 
-      hop_patch if vm_host.vms_dataset.empty?
+      if vm_host.vms_dataset.empty?
+        decr_patch
+        register_deadline("prep_reboot", 10 * 60)
+        hop_patch
+      end
+
       nap 60
     end
 

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -337,6 +337,21 @@ TIMER
     hop_wait
   end
 
+  label def patch
+    decr_patch
+    sshable = vm_host.sshable
+
+    case sshable.d_check("apply_patches")
+    when "Succeeded"
+      sshable.d_clean("apply_patches")
+      hop_prep_reboot
+    when "Failed", "NotStarted"
+      sshable.d_run("apply_patches", "sudo", "bash", "-c", "apt update && apt full-upgrade -y")
+    end
+
+    nap 60
+  end
+
   label def wait
     hardware_reset_and_reboot_checks
 
@@ -348,6 +363,18 @@ TIMER
     when_configure_metrics_set? do
       decr_configure_metrics
       hop_configure_metrics
+    end
+
+    when_patch_set? do
+      unless vm_host.allocation_state == "draining"
+        vm_host.update(allocation_state: "draining")
+
+        # Move back to accepting post-reboot
+        incr_graceful_reboot
+      end
+
+      hop_patch if vm_host.vms_dataset.empty?
+      nap 60
     end
 
     nap 6 * 60 * 60

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -325,3 +325,12 @@ code {
   flex: 1;
   min-width: 400px;
 }
+
+#start-semaphore-rollout {
+  #wait-label-wrapper {
+    display: none;
+  }
+  &:has(input[name=increment][value=increment]:checked) #wait-label-wrapper {
+    display: block;
+  }
+}

--- a/spec/prog/rollout_semaphore_spec.rb
+++ b/spec/prog/rollout_semaphore_spec.rb
@@ -22,6 +22,25 @@ RSpec.describe Prog::RolloutSemaphore do
       expect(frame["remaining"]).to eq(page_ids)
       expect(frame["next_increment_time"]).to be_within(5).of(Time.now.to_i)
       expect(frame["increment"]).to be true
+      expect(frame.fetch("wait_label")).to be true
+      expect(frame.fetch("current")).to be_nil
+    end
+
+    it "supports gap, initial_gap, initial_range, increment, and wait_label arguments" do
+      st = described_class.assemble(semaphore: "resolve", ids: page_ids, gap: 10, initial_gap: 15, initial_range: 1..5, increment: false, wait: "wait")
+      expect(st.label).to eq("start")
+      expect(st.prog).to eq("RolloutSemaphore")
+
+      frame = st.stack.first
+      expect(frame["semaphore"]).to eq("resolve")
+      expect(frame["gap"]).to eq(10)
+      expect(frame["initial_gap"]).to eq(15)
+      expect(frame["initial_num"]).to eq(1)
+      expect(frame["remaining"]).to eq(page_ids)
+      expect(frame["next_increment_time"]).to be_within(5).of(Time.now.to_i)
+      expect(frame["increment"]).to be false
+      expect(frame["wait_label"]).to eq "wait"
+      expect(frame.fetch("current")).to be_nil
     end
 
     it "raises for invalid semaphore" do
@@ -35,10 +54,23 @@ RSpec.describe Prog::RolloutSemaphore do
       expect { nx.start }.to nap(60 * 60)
     end
 
-    it "increments semaphore on next object and naps" do
+    it "increments semaphore on next object and naps if not waiting" do
+      refresh_frame(nx, new_values: {"wait_label" => false})
       expect { nx.start }.to nap(295...305)
         .and change { pages.first.reload.resolve_set? }.from(false).to(true)
       expect(st.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
+      expect(st.stack[0]["completed"]).to eq [page_ids[0]]
+      expect(st.stack[0].fetch("current")).to be_nil
+      expect(st.stack[0]["remaining"]).to eq page_ids[1..]
+    end
+
+    it "increments semaphore on next object and hops to wait_current" do
+      expect { nx.start }.to hop("wait_current")
+        .and change { pages.first.reload.resolve_set? }.from(false).to(true)
+      expect(st.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
+      expect(st.stack[0]["completed"]).to eq []
+      expect(st.stack[0]["current"]).to eq page_ids[0]
+      expect(st.stack[0]["remaining"]).to eq page_ids[1..]
     end
 
     it "decrements semaphore on next object and naps if increment is not true" do
@@ -47,6 +79,9 @@ RSpec.describe Prog::RolloutSemaphore do
       expect { nx.start }.to nap(295...305)
         .and change { pages.first.reload.resolve_set? }.from(true).to(false)
       expect(st.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
+      expect(st.stack[0]["completed"]).to eq [page_ids[0]]
+      expect(st.stack[0].fetch("current")).to be_nil
+      expect(st.stack[0]["remaining"]).to eq page_ids[1..]
     end
 
     it "hops to destroy if there are no objects remaining" do
@@ -56,14 +91,46 @@ RSpec.describe Prog::RolloutSemaphore do
 
     it "naps using regular gap after passing the initial number of records" do
       refresh_frame(nx, new_values: {"initial_num" => 0})
-      expect { nx.start }.to nap(55...65)
+      expect { nx.start }.to hop("wait_current")
         .and change { pages.first.reload.resolve_set? }.from(false).to(true)
       expect(st.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 60)
+      expect(st.stack[0]["completed"]).to eq []
+      expect(st.stack[0]["current"]).to eq page_ids[0]
+      expect(st.stack[0]["remaining"]).to eq page_ids[1..]
     end
 
     it "naps if not yet at the next increment time" do
       refresh_frame(nx, new_values: {"next_increment_time" => Time.now.to_i + 10})
       expect { nx.start }.to nap(5...15)
+    end
+  end
+
+  describe "#wait_current" do
+    it "naps if semaphore still set for current strand" do
+      Semaphore.incr(page_ids[0], "resolve")
+      refresh_frame(nx, new_values: {"current" => page_ids[0]})
+      expect { nx.wait_current }.to nap(6)
+    end
+
+    it "naps if current strand not at wait_label" do
+      refresh_frame(nx, new_values: {"current" => page_ids[0], "wait_label" => "wait"})
+      expect { nx.wait_current }.to nap(6)
+    end
+
+    it "hops to start if semaphore no longer set and wait label is not a string" do
+      refresh_frame(nx, new_values: {"current" => page_ids[0]})
+      expect { nx.wait_current }.to hop("start")
+    end
+
+    it "hops to start if current strand no longer exists" do
+      Strand.where(id: page_ids[0]).destroy
+      refresh_frame(nx, new_values: {"current" => page_ids[0]})
+      expect { nx.wait_current }.to hop("start")
+    end
+
+    it "hops to start if current strand is at wait label" do
+      refresh_frame(nx, new_values: {"current" => page_ids[0], "wait_label" => "start"})
+      expect { nx.wait_current }.to hop("start")
     end
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -273,6 +273,31 @@ RSpec.describe Prog::Vm::HostNexus do
     end
   end
 
+  describe "#patch" do
+    it "runs apply_patches if not running" do
+      expect(nx.vm_host.sshable).to receive(:d_check).with("apply_patches").and_return("NotStarted")
+      expect(nx.vm_host.sshable).to receive(:d_run).with("apply_patches", "sudo", "bash", "-c", "apt update && apt full-upgrade -y")
+      expect { nx.patch }.to nap(60)
+    end
+
+    it "runs apply_patches if failed" do
+      expect(nx.vm_host.sshable).to receive(:d_check).with("apply_patches").and_return("Failed")
+      expect(nx.vm_host.sshable).to receive(:d_run).with("apply_patches", "sudo", "bash", "-c", "apt update && apt full-upgrade -y")
+      expect { nx.patch }.to nap(60)
+    end
+
+    it "naps if in progress" do
+      expect(nx.vm_host.sshable).to receive(:d_check).with("apply_patches").and_return("InProgress")
+      expect { nx.patch }.to nap(60)
+    end
+
+    it "hops to prep_reboot if apply_patches succeeds" do
+      expect(nx.vm_host.sshable).to receive(:d_check).with("apply_patches").and_return("Succeeded")
+      expect(nx.vm_host.sshable).to receive(:d_clean).with("apply_patches")
+      expect { nx.patch }.to hop("prep_reboot")
+    end
+  end
+
   describe "#wait" do
     it "naps" do
       expect { nx.wait }.to nap(6 * 60 * 60)
@@ -306,6 +331,31 @@ RSpec.describe Prog::Vm::HostNexus do
       nx.incr_checkup
       expect(nx).to receive(:available?).and_return(true)
       expect { nx.wait }.to nap(6 * 60 * 60)
+    end
+
+    context "when patch set" do
+      before { nx.incr_patch }
+
+      it "hops to patch if there are no VMs" do
+        expect { nx.wait }.to hop("patch")
+          .and change { nx.graceful_reboot_set? }.from(false).to(true)
+          .and change { nx.vm_host.allocation_state }.from("unprepared").to("draining")
+      end
+
+      it "naps if there are VMs" do
+        create_vm(vm_host_id: nx.vm_host.id)
+
+        expect { nx.wait }.to nap(60)
+          .and change { nx.graceful_reboot_set? }.from(false).to(true)
+          .and change { nx.vm_host.allocation_state }.from("unprepared").to("draining")
+      end
+
+      it "does not set graceful_reboot if host is already draining" do
+        nx.vm_host.allocation_state = "draining"
+
+        expect { nx.wait }.to hop("patch")
+          .and not_change { nx.graceful_reboot_set? }
+      end
     end
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -263,8 +263,8 @@ RSpec.describe Prog::Vm::HostNexus do
   end
 
   describe "#wait_download_boot_images" do
-    it "hops to prep_reboot if all tasks are done" do
-      expect { nx.wait_download_boot_images }.to hop("prep_reboot")
+    it "hops to patch if all tasks are done" do
+      expect { nx.wait_download_boot_images }.to hop("patch")
     end
 
     it "donates its time if child strands are still running" do

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -338,15 +338,15 @@ RSpec.describe Prog::Vm::HostNexus do
 
       it "hops to patch if there are no VMs" do
         expect { nx.wait }.to hop("patch")
-          .and change { nx.graceful_reboot_set? }.from(false).to(true)
           .and change { nx.vm_host.allocation_state }.from("unprepared").to("draining")
+          .and change { nx.graceful_reboot_set? }.from(false).to(true)
       end
 
       it "naps if there are VMs" do
         create_vm(vm_host_id: nx.vm_host.id)
 
         expect { nx.wait }.to nap(60)
-          .and change { nx.graceful_reboot_set? }.from(false).to(true)
+          .and change { nx.strand.stack[0]["accepting_before_patch"] }.from(nil).to(true)
           .and change { nx.vm_host.allocation_state }.from("unprepared").to("draining")
       end
 
@@ -356,6 +356,17 @@ RSpec.describe Prog::Vm::HostNexus do
         expect { nx.wait }.to hop("patch")
           .and not_change { nx.graceful_reboot_set? }
           .and change { nx.patch_set? }.from(true).to(false)
+          .and change { nx.strand.stack[0]["deadline_target"] }.from(nil).to("prep_reboot")
+        expect(Time.parse(nx.strand.stack[0]["deadline_at"])).to be_within(5).of(Time.now + 600)
+      end
+
+      it "sets graceful_restart semaphore if host was in accepting before patch" do
+        nx.vm_host.allocation_state = "draining"
+        refresh_frame(nx, new_values: {"accepting_before_patch" => true})
+
+        expect { nx.wait }.to hop("patch")
+          .and change { nx.patch_set? }.from(true).to(false)
+          .and change { nx.graceful_reboot_set? }.from(false).to(true)
           .and change { nx.strand.stack[0]["deadline_target"] }.from(nil).to("prep_reboot")
         expect(Time.parse(nx.strand.stack[0]["deadline_at"])).to be_within(5).of(Time.now + 600)
       end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -355,6 +355,9 @@ RSpec.describe Prog::Vm::HostNexus do
 
         expect { nx.wait }.to hop("patch")
           .and not_change { nx.graceful_reboot_set? }
+          .and change { nx.patch_set? }.from(true).to(false)
+          .and change { nx.strand.stack[0]["deadline_target"] }.from(nil).to("prep_reboot")
+        expect(Time.parse(nx.strand.stack[0]["deadline_at"])).to be_within(5).of(Time.now + 600)
       end
     end
   end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -541,6 +541,17 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(vm_host.reload.allocation_state).to eq("accepting")
     end
 
+    it "start_vms starts vms & hops to configure_metrics if was draining and in graceful reboot and not in patch" do
+      vm_host.update(allocation_state: "draining")
+      nx.incr_graceful_reboot
+      nx.incr_patch
+      vm = create_vm(vm_host_id: vm_host.id)
+      Strand.create(id: vm.id, prog: "Vm::Nexus", label: "wait")
+      expect { nx.start_vms }.to hop("configure_metrics")
+      expect(vm_host.reload.allocation_state).to eq("draining")
+      expect(vm_host.graceful_reboot_set?).to be true
+    end
+
     it "start_vms starts vms & raises if not in draining and in graceful reboot" do
       vm_host.update(allocation_state: "accepting")
       nx.incr_graceful_reboot

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1743,6 +1743,64 @@ RSpec.describe CloverAdmin do
       expect(st.stack[0]["remaining"]).to eq [page_st.id]
       expect(st.stack[0]["gap"]).to eq 90
       expect(st.stack[0]["increment"]).to be true
+      expect(st.stack[0]["wait_label"]).to be true
+
+      st.run
+      page.refresh
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "wait_current", "0", st.ubid, "{}", "", "", "increment resolve"]
+
+      Semaphore.where(strand_id: page_st.id, name: "resolve").destroy
+      st.run
+      page.refresh
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{\"remaining\" => 0, \"completed\" => 1}", "", "", "increment resolve"]
+    end
+
+    it "allows creation of semaphore increment rollout strands with locations and wait labels" do
+      select "Page"
+      fill_in "Semaphore", with: "bad"
+      click_button "Start Semaphore Rollout"
+      expect(page).to have_flash_error("invalid semaphore for class")
+
+      fsn1_vm = create_vm
+      hel1_vm = create_vm(location_id: Location::HETZNER_HEL1_ID)
+
+      Strand.create_with_id(fsn1_vm.id, prog: "Vm::Metal::Nexus", label: "start")
+      Strand.create_with_id(hel1_vm.id, prog: "Vm::Metal::Nexus", label: "start")
+
+      select "Vm"
+      select "hetzner-fsn1"
+      fill_in "Semaphore", with: "update_firewall_rules"
+      fill_in "Wait Label", with: "wait"
+      click_button "Start Semaphore Rollout"
+
+      st = Strand.first(prog: "RolloutSemaphore")
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{}", "", "", "increment update_firewall_rules"]
+      expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
+
+      expect(st.stack[0]["semaphore"]).to eq "update_firewall_rules"
+      expect(st.stack[0]["remaining"]).to eq [fsn1_vm.id]
+      expect(st.stack[0]["gap"]).to eq 60
+      expect(st.stack[0]["increment"]).to be true
+      expect(st.stack[0]["wait_label"]).to eq "wait"
+    end
+
+    it "allows creation of semaphore increment without wait rollout strands" do
+      page_st = Prog::PageNexus.assemble("some problem", %w[a], nil)
+
+      select "Page"
+      fill_in "Semaphore", with: "resolve"
+      choose "Increment Without Waiting"
+      click_button "Start Semaphore Rollout"
+
+      st = Strand.first(prog: "RolloutSemaphore")
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{}", "", "", "increment resolve"]
+      expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
+
+      expect(st.stack[0]["semaphore"]).to eq "resolve"
+      expect(st.stack[0]["remaining"]).to eq [page_st.id]
+      expect(st.stack[0]["gap"]).to eq 60
+      expect(st.stack[0]["increment"]).to be true
+      expect(st.stack[0]["wait_label"]).to be false
 
       st.run
       page.refresh

--- a/views/admin/rollouts.erb
+++ b/views/admin/rollouts.erb
@@ -62,11 +62,13 @@ end %>
   <section class="rollout-card">
     <h3>Semaphore</h3>
     <p class="rollout-desc">Increment or decrement a semaphore across every instance of a class, spaced out by a gap.</p>
-    <% form({action: "/rollouts/start/RolloutSemaphore", method: "post", id: "start-local-e2e", class: "rollout-form"}, button: "Start Semaphore Rollout", wrapper: :div) do |f| %>
+    <% form({action: "/rollouts/start/RolloutSemaphore", method: "post", id: "start-semaphore-rollout", class: "rollout-form"}, button: "Start Semaphore Rollout", wrapper: :div) do |f| %>
       <%== f.input(:select, key: :class, label: "Class", required: true, add_blank: true, options: semaphore_classes) %>
+      <%== f.input(:select, key: :location_id, label: "Location", add_blank: true, options: Location.where(project_id: nil).order(:name).select_map([:name, :id]).each { it[1] = UBID.to_ubid(it[1]) }) %>
       <%== f.input(:text, key: :semaphore, label: "Semaphore", required: true) %>
+      <%== f.input(:text, key: :wait_label, label: "Wait Label", wrapper_attr: {id: "wait-label-wrapper"}) %>
       <%== f.input(:number, key: :gap, label: "Gap (seconds)", required: true, attr: {min: 5, max: 3600}, value: 60) %>
-      <%== f.input(:radioset, key: :increment, required: true, options: [["Increment", true], ["Decrement", false]], value: true, wrapper_attr: {class: "rollout-radioset"}) %>
+      <%== f.input(:radioset, key: :increment, required: true, options: [["Increment", "increment"], ["Increment Without Waiting", "increment-no-wait"], ["Decrement", "decrement"]], value: "increment", wrapper_attr: {class: "rollout-radioset"}) %>
     <% end %>
   </section>
 


### PR DESCRIPTION
Setting the patch semaphore will set the host to draining (if not
already in draining), wait until no VMs are running, apply patches, then
reboot. If the host was in accepting before, it sets the host back to
accepting after reboot via use of graceful_reboot semaphore.

This also patches new hosts during setup. This allows the patch process
to be E2E tested by the existing E2E tests. It's also a good general practice
to ensure the host is fully patched before accepting VMs.

As this requires no VMs are running on the host, it's suitable for github
runner hosts only. Other types of VMs on the host will require a different
process, but I think we should get experience with patching github
runner hosts before working on patching other hosts where the stakes
are higher.