### PR TITLE
Flatten redundant DB.transaction inside metal NicNexus#wait_setup

### DIFF
--- a/prog/vnet/metal/nic_nexus.rb
+++ b/prog/vnet/metal/nic_nexus.rb
@@ -13,11 +13,9 @@ class Prog::Vnet::Metal::NicNexus < Prog::Base
   label def wait_setup
     decr_vm_allocated
     when_setup_nic_set? do
-      DB.transaction do
-        decr_setup_nic
-        nic.private_subnet.incr_refresh_keys
-        nic.update(state: "creating")
-      end
+      decr_setup_nic
+      nic.private_subnet.incr_refresh_keys
+      nic.update(state: "creating")
     end
     when_start_rekey_set? do
       hop_start_rekey


### PR DESCRIPTION
Labels execute inside the strand-level DB.transaction (see Strand#unsynchronized_run), so the nested DB.transaction inside the when_setup_nic_set? block was redundant.