### PR TITLE
Add daemonizer2 stop 

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -187,6 +187,10 @@ class Sshable < Sequel::Model
     cmd("common/bin/daemonizer2 restart :unit_name", unit_name:)
   end
 
+  def d_stop(unit_name)
+    cmd("common/bin/daemonizer2 stop :unit_name", unit_name:)
+  end
+
   def d_logs(unit_name)
     cmd("sudo journalctl -u :unit_name --no-pager", unit_name:)
   end

--- a/rhizome/common/bin/daemonizer2
+++ b/rhizome/common/bin/daemonizer2
@@ -44,6 +44,10 @@ def restart(name)
   r "sudo systemctl restart #{name}"
 end
 
+def stop(name)
+  r "sudo systemctl stop #{name}"
+end
+
 command = ARGV[0]
 name = ARGV[1]
 stdin_path = "/dev/shm/#{name}.stdin"
@@ -55,6 +59,8 @@ when "clean"
   clean(name, stdin_path)
 when "restart"
   restart(name)
+when "stop"
+  stop(name)
 when "run"
   command_parts = ARGV[2..]
   state = get_state(name)

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -301,6 +301,11 @@ LOCK
       sa.d_restart(unit_name)
     end
 
+    it "calls cmd with the correct stop command" do
+      expect(sa).to receive(:_cmd).with("common/bin/daemonizer2 stop test_unit")
+      sa.d_stop(unit_name)
+    end
+
     it "calls cmd with the correct run command and no stdin" do
       expect(sa).to receive(:_cmd).with("common/bin/daemonizer2 run test_unit sudo\\ host/bin/setup-vm\\ prep\\ test_unit", stdin: nil, log: true)
       sa.d_run(unit_name, run_command)


### PR DESCRIPTION
### Add daemonizer2 stop 

Some of the progs need to be able to cancel an in-flight daemon unit. For example, when switching directly from creating to destroying state of machine image versions. For these cases, we add support for a `stop` action in daemonizer2.

### Add Sshable#d_stop 

Convenience method to call daemonizer2's stop action which was added in the previous commit.