### PR TITLE
Add a tracked SQL migration runner for postgres and ubi_admin databases

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -18,7 +18,7 @@ class PostgresServer < Sequel::Model
     :restart, :configure, :fence, :unfence, :planned_take_over, :unplanned_take_over, :configure_metrics,
     :destroy, :recycle, :recycle_lagging_read_replica, :recycle_unavailable_server, :recycle_by_user_request,
     :promote_read_replica, :refresh_walg_credentials, :configure_s3_new_timeline, :lockout, :use_physical_slot,
-    :configure_logs, :ignore_instance_size_mismatch
+    :configure_logs, :ignore_instance_size_mismatch, :install_rhizome
   include HealthMonitorMethods
   include MetricsTargetMethods
 

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -535,6 +535,28 @@ SQL
     nap 1
   end
 
+  label def install_rhizome
+    bud Prog::InstallRhizome, {"target_folder" => "postgres", "subject_id" => vm.id}
+    hop_wait_install_rhizome
+  end
+
+  label def wait_install_rhizome
+    reap(:run_migrations, nap: 5)
+  end
+
+  label def run_migrations
+    hop_wait if postgres_server.read_replica? || !postgres_server.primary?
+
+    case vm.sshable.d_check("migrate")
+    when "Succeeded"
+      hop_wait
+    when "Failed", "NotStarted"
+      vm.sshable.d_run("migrate", "sudo", "postgres/bin/migrate")
+    end
+
+    nap 5
+  end
+
   label def wait_catch_up
     # The monitor starts running against servers that are not in the initial provisioning state.
     # So, we need to decrement the initial provisioning counter to avoid the monitor from
@@ -668,6 +690,12 @@ SQL
       decr_configure_logs
       register_deadline("wait", 3 * 60)
       hop_configure_logs
+    end
+
+    when_install_rhizome_set? do
+      decr_install_rhizome
+      register_deadline("wait", 10 * 60)
+      hop_install_rhizome
     end
 
     when_promote_read_replica_set? do

--- a/rhizome/postgres/bin/migrate
+++ b/rhizome/postgres/bin/migrate
@@ -1,0 +1,31 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+# Applied migrations are tracked ubi_admin database, keyed by folder-qualified path.
+migrate_root = File.expand_path("../migrate", __dir__)
+exit 0 unless File.directory?(migrate_root)
+
+r "sudo -u postgres psql -d ubi_admin -v 'ON_ERROR_STOP=1'", stdin: <<~SQL
+  CREATE TABLE IF NOT EXISTS public.migrations (
+    filename   text PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now()
+  );
+SQL
+applied = r("sudo -u postgres psql -d ubi_admin -tAc 'SELECT filename FROM public.migrations'").split("\n").map(&:strip)
+
+# postgres db first, then every other database directory in name order
+ordered_dbs = (["postgres"] + Dir.children(migrate_root).sort).uniq
+
+ordered_dbs.each do |db|
+  dir = File.join(migrate_root, db)
+  next unless File.directory?(dir)
+  Dir.children(dir).select { |f| f.end_with?(".sql") }.sort.each do |name|
+    key = "/#{db}/#{name}"
+    next if applied.include?(key)
+    # Apply the migration against its own database, then register it centrally in ubi_admin.
+    r "sudo -u postgres psql -d #{db} -v 'ON_ERROR_STOP=1' --single-transaction", stdin: File.read(File.join(dir, name))
+    r "sudo -u postgres psql -d ubi_admin -v 'ON_ERROR_STOP=1' -c \"INSERT INTO public.migrations (filename) VALUES ('#{key}') ON CONFLICT (filename) DO NOTHING\""
+  end
+end

--- a/rhizome/postgres/bin/post-installation-script
+++ b/rhizome/postgres/bin/post-installation-script
@@ -3,52 +3,13 @@
 
 require_relative "../../common/lib/util"
 
-role_creation_queries = <<~ROLE_CREATION
-  /**
-    * Create system roles.
-    */
-  DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ubi_replication') THEN CREATE ROLE ubi_replication WITH REPLICATION LOGIN; END IF; END $$;
-  DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ubi_monitoring') THEN CREATE ROLE ubi_monitoring WITH LOGIN IN ROLE pg_monitor; END IF; END $$;
-  DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgbouncer') THEN CREATE ROLE pgbouncer LOGIN; END IF; END $$;
-ROLE_CREATION
-
-ubi_admin_init_queries = <<~UBI_ADMIN_INIT
-  /**
-    * Lock down the privileges of the pgbouncer role.
-    */
-  REVOKE ALL PRIVILEGES ON SCHEMA public FROM pgbouncer;
-
-  /**
-    * Create the pgbouncer schema if it does not exist. All of the
-    * administrative functions for pgbouncer will live in its own schema.
-    */
-  CREATE SCHEMA IF NOT EXISTS pgbouncer;
-
-  /**
-    * Lock down the privileges of the pgbouncer schema.
-    */
-  REVOKE ALL PRIVILEGES ON SCHEMA pgbouncer FROM pgbouncer;
-  GRANT USAGE ON SCHEMA pgbouncer TO pgbouncer;
-
-  /**
-    * The "get_auth" function is used by pgbouncer to authenticate users.
-    * See: https://www.pgbouncer.org/config.html#auth_query
-    */
-  CREATE OR REPLACE FUNCTION pgbouncer.get_auth (
-    INOUT p_user     name,
-    OUT   p_password text
-  ) RETURNS record
-    LANGUAGE sql SECURITY DEFINER SET search_path = pg_catalog AS
-  $$SELECT usename, passwd FROM pg_shadow WHERE usename = p_user$$;
-
-  REVOKE ALL ON FUNCTION pgbouncer.get_auth(name) FROM PUBLIC, pgbouncer;
-  GRANT EXECUTE ON FUNCTION pgbouncer.get_auth(name) TO pgbouncer;
-UBI_ADMIN_INIT
-
-r "sudo -u postgres psql -v 'ON_ERROR_STOP=1'", stdin: role_creation_queries
 r "sudo -u postgres createdb ubi_admin"
-r "sudo -u postgres psql -d ubi_admin -v 'ON_ERROR_STOP=1'", stdin: ubi_admin_init_queries
 
+# Initial execution of migration scripts
+r "sudo postgres/bin/migrate"
+
+# Cached init scripts are for backward compatibility.
+# All new database scripts should use migration instead.
 Dir.glob("/var/cache/postgresql-init/*.sql").sort.each do |sql_file|
   r "sudo -u postgres psql -v 'ON_ERROR_STOP=1'", stdin: File.read(sql_file)
 end

--- a/rhizome/postgres/migrate/postgres/20260616_system_roles.sql
+++ b/rhizome/postgres/migrate/postgres/20260616_system_roles.sql
@@ -1,0 +1,6 @@
+  /**
+    * Create system roles.
+    */
+DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ubi_replication') THEN CREATE ROLE ubi_replication WITH REPLICATION LOGIN; END IF; END $$;
+DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'ubi_monitoring') THEN CREATE ROLE ubi_monitoring WITH LOGIN IN ROLE pg_monitor; END IF; END $$;
+DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgbouncer') THEN CREATE ROLE pgbouncer LOGIN; END IF; END $$;

--- a/rhizome/postgres/migrate/ubi_admin/20260616_pgbouncer_auth.sql
+++ b/rhizome/postgres/migrate/ubi_admin/20260616_pgbouncer_auth.sql
@@ -1,0 +1,30 @@
+  /**
+    * Lock down the privileges of the pgbouncer role.
+    */
+  REVOKE ALL PRIVILEGES ON SCHEMA public FROM pgbouncer;
+
+  /**
+    * Create the pgbouncer schema if it does not exist. All of the
+    * administrative functions for pgbouncer will live in its own schema.
+    */
+  CREATE SCHEMA IF NOT EXISTS pgbouncer;
+
+  /**
+    * Lock down the privileges of the pgbouncer schema.
+    */
+  REVOKE ALL PRIVILEGES ON SCHEMA pgbouncer FROM pgbouncer;
+  GRANT USAGE ON SCHEMA pgbouncer TO pgbouncer;
+
+  /**
+    * The "get_auth" function is used by pgbouncer to authenticate users.
+    * See: https://www.pgbouncer.org/config.html#auth_query
+    */
+  CREATE OR REPLACE FUNCTION pgbouncer.get_auth (
+    INOUT p_user     name,
+    OUT   p_password text
+  ) RETURNS record
+    LANGUAGE sql SECURITY DEFINER SET search_path = pg_catalog AS
+  $$SELECT usename, passwd FROM pg_shadow WHERE usename = p_user$$;
+
+  REVOKE ALL ON FUNCTION pgbouncer.get_auth(name) FROM PUBLIC, pgbouncer;
+  GRANT EXECUTE ON FUNCTION pgbouncer.get_auth(name) TO pgbouncer;

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -245,6 +245,61 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
   end
 
+  describe "#install_rhizome" do
+    it "buds an install rhizome process and waits" do
+      expect(nx).to receive(:bud).with(Prog::InstallRhizome, {"target_folder" => "postgres", "subject_id" => postgres_server.vm.id})
+      expect { nx.install_rhizome }.to hop("wait_install_rhizome")
+    end
+  end
+
+  describe "#wait_install_rhizome" do
+    it "hops to run_migrations if there are no sub-programs running" do
+      expect { nx.wait_install_rhizome }.to hop("run_migrations")
+    end
+
+    it "donates if there are sub-programs running" do
+      Strand.create(parent: st, prog: "InstallRhizome", label: "start", stack: [{}], lease: Time.now + 10)
+      expect { nx.wait_install_rhizome }.to nap(5)
+    end
+  end
+
+  describe "#run_migrations" do
+    it "skips the migrator and returns to wait on a read replica" do
+      expect(server).to receive(:read_replica?).and_return(true)
+      expect(sshable).not_to receive(:d_check)
+      expect { nx.run_migrations }.to hop("wait")
+    end
+
+    it "skips the migrator and returns to wait on a standby" do
+      expect(server).to receive(:read_replica?).and_return(false)
+      expect(server).to receive(:primary?).and_return(false)
+      expect(sshable).not_to receive(:d_check)
+      expect { nx.run_migrations }.to hop("wait")
+    end
+
+    it "launches the migrator on the primary if not started" do
+      expect(server).to receive(:read_replica?).and_return(false)
+      expect(server).to receive(:primary?).and_return(true)
+      expect(sshable).to receive(:d_check).with("migrate").and_return("NotStarted")
+      expect(sshable).to receive(:d_run).with("migrate", "sudo", "postgres/bin/migrate")
+      expect { nx.run_migrations }.to nap(5)
+    end
+
+    it "naps while the migrator is in progress on the primary" do
+      expect(server).to receive(:read_replica?).and_return(false)
+      expect(server).to receive(:primary?).and_return(true)
+      expect(sshable).to receive(:d_check).with("migrate").and_return("InProgress")
+      expect { nx.run_migrations }.to nap(5)
+    end
+
+    it "hops to wait once the migrator succeeds on the primary" do
+      expect(server).to receive(:read_replica?).and_return(false)
+      expect(server).to receive(:primary?).and_return(true)
+      expect(sshable).to receive(:d_check).with("migrate").and_return("Succeeded")
+      expect { nx.run_migrations }.to hop("wait")
+    end
+  end
+
   describe "#mount_data_disk" do
     it "formats data disk if format command is not sent yet or failed" do
       expect(server).to receive(:storage_device_paths).and_return(["/dev/vdb"])
@@ -1271,6 +1326,12 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       nx.incr_configure_logs
       expect(nx).to receive(:register_deadline).with("wait", 3 * 60)
       expect { nx.wait }.to hop("configure_logs")
+    end
+
+    it "hops to install_rhizome if install_rhizome is set" do
+      nx.incr_install_rhizome
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60)
+      expect { nx.wait }.to hop("install_rhizome")
     end
 
     it "hops to configure if configure is set" do


### PR DESCRIPTION
Introduces a tracked SQL migration framework for managed Postgres servers, in two commits.

### 1. Add a tracked SQL migration runner for postgres and ubi_admin databases.

Solves 2 problems:
- Organizes growing number of one-off scripts run against postgres and
  ubi_admin databases from post-installation-script and OS image.
- Enables systematic upgrade of system database objects as a part of
  rhizome installation.

Migration scripts are organized by database (`/postgres`, `/ubi_admin`)
with the same naming conventions as metadata db migrations. Applied
migrations are tracked centrally in `ubi_admin.public.migrations`, keyed
by folder-qualified path. `post-installation-script` applies them once
during provisioning.

### 2. Trigger rhizome upgrade and database migrations via a PostgresServer semaphore.

`Prog::InstallRhizome` stays a generic dataplane primitive; the migration
step lives in `PostgresServerNexus`. An `install_rhizome` semaphore buds
`Prog::InstallRhizome` to re-ship the rhizome bundle (which carries the
migrate runner and any new migration files), and once that completes the
migrator runs — only on the writable primary. Standbys and read replicas
are read-only and receive the same objects through streaming replication.

Upgrade and migrations can be triggered for a single server or rolled out
across many with `Prog::RolloutSemaphore`.
