### PR TITLE
Revert legacy AWS subnet removal (deployed too early)

### DIFF
--- a/prog/vnet/aws/backfill_aws_subnets.rb
+++ b/prog/vnet/aws/backfill_aws_subnets.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require "aws-sdk-ec2"
+
+class Prog::Vnet::Aws::BackfillAwsSubnets < Prog::Base
+  subject_is :private_subnet
+  frame_accessor :az_subnet_map
+
+  def self.assemble(private_subnet_id)
+    unless (ps = PrivateSubnet[private_subnet_id])
+      fail "No existing private subnet"
+    end
+
+    unless ps.location.aws?
+      fail "Private subnet is not in an AWS location"
+    end
+
+    unless (ps_aws_resource = ps.private_subnet_aws_resource)
+      fail "Private subnet has no AWS resource"
+    end
+
+    unless ps_aws_resource.vpc_id
+      fail "Private subnet AWS resource has no VPC ID"
+    end
+
+    if ps_aws_resource.aws_subnets.any?
+      fail "Private subnet already has AwsSubnet records"
+    end
+
+    Strand.create(
+      prog: "Vnet::Aws::BackfillAwsSubnets",
+      label: "start",
+      stack: [{"subject_id" => private_subnet_id}],
+    )
+  end
+
+  label def start
+    if old_subnet?
+      hop_backfill_old_subnet
+    else
+      hop_fetch_existing_subnets
+    end
+  end
+
+  label def backfill_old_subnet
+    subnets = client.describe_subnets({
+      filters: [{name: "vpc-id", values: [private_subnet_aws_resource.vpc_id]}],
+    }).subnets
+
+    fail "No subnets found in VPC #{private_subnet_aws_resource.vpc_id}" if subnets.empty?
+
+    used_subnet_ids = private_subnet.nics.map { it.nic_aws_resource.subnet_id }.compact.uniq
+    subnets = subnets.select { |subnet| used_subnet_ids.include?(subnet.subnet_id) }
+
+    # this assumes there is only non-ha postgres resources
+    subnet = subnets.min_by(&:cidr_block)
+    az_suffix = subnet.availability_zone.delete_prefix(location.name)
+    location_az = find_location_az(az_suffix)
+
+    AwsSubnet.create(
+      private_subnet_aws_resource_id: private_subnet_aws_resource.id,
+      location_aws_az_id: location_az.id,
+      ipv4_cidr: subnet.cidr_block,
+      ipv6_cidr: subnet.ipv_6_cidr_block_association_set.first.ipv_6_cidr_block,
+      subnet_id: subnet.subnet_id,
+    )
+
+    hop_link_nics
+  end
+
+  label def fetch_existing_subnets
+    subnets = client.describe_subnets({
+      filters: [{name: "vpc-id", values: [private_subnet_aws_resource.vpc_id]}],
+    }).subnets
+
+    # Ensure AZ records exist
+    location.azs
+
+    used_subnet_ids = private_subnet.nics.map { it.nic_aws_resource.subnet_id }.compact.uniq
+    subnets = subnets.select { |subnet| used_subnet_ids.include?(subnet.subnet_id) }
+
+    # Group subnets by AZ suffix, keep only the first per AZ
+    # this assumes there is only non-ha postgres resources
+    az_subnet_map = {}
+    subnets.sort_by(&:cidr_block).each do |subnet|
+      az_suffix = subnet.availability_zone.delete_prefix(location.name)
+      az_subnet_map[az_suffix] ||= {
+        "subnet_id" => subnet.subnet_id,
+        "cidr_block" => subnet.cidr_block,
+        "ipv6_cidr" => subnet.ipv_6_cidr_block_association_set.first.ipv_6_cidr_block,
+      }
+    end
+
+    self.az_subnet_map = az_subnet_map
+    hop_create_records
+  end
+
+  label def create_records
+    azs = location.azs
+    az_subnet_map = self.az_subnet_map
+    vpc_ipv4 = private_subnet.net4
+    ipv4_prefix = 24
+
+    azs.each_with_index do |az, idx|
+      existing = az_subnet_map[az.az]
+      ipv4_cidr = existing ? existing["cidr_block"] : vpc_ipv4.nth_subnet(ipv4_prefix, idx).to_s
+
+      AwsSubnet.create(
+        private_subnet_aws_resource_id: private_subnet_aws_resource.id,
+        location_aws_az_id: az.id,
+        ipv4_cidr:,
+        ipv6_cidr: existing&.dig("ipv6_cidr"),
+        subnet_id: existing&.dig("subnet_id"),
+      )
+    end
+
+    hop_link_nics
+  end
+
+  label def link_nics
+    aws_subnets_by_az = private_subnet_aws_resource.reload.aws_subnets.each_with_object({}) do |aws_subnet, hash|
+      hash[aws_subnet.location_az.az] = aws_subnet
+    end
+
+    private_subnet.nics.each do |nic|
+      next unless nic.nic_aws_resource
+      next if nic.nic_aws_resource.aws_subnet_id
+
+      subnet_az = nic.nic_aws_resource.subnet_az
+      next unless subnet_az
+
+      # subnet_az may be full name ("us-west-2a") or just suffix ("a")
+      az_suffix = subnet_az.delete_prefix(location.name)
+      aws_subnet = aws_subnets_by_az[az_suffix]
+      next unless aws_subnet
+
+      nic.nic_aws_resource.update(aws_subnet_id: aws_subnet.id, subnet_az: az_suffix)
+    end
+
+    if old_subnet?
+      hop_finish
+    else
+      hop_create_missing_az_subnets
+    end
+  end
+
+  label def create_missing_az_subnets
+    vpc = client.describe_vpcs({
+      filters: [{name: "vpc-id", values: [private_subnet_aws_resource.vpc_id]}],
+    }).vpcs[0]
+
+    vpc_ipv6 = NetAddr::IPv6Net.parse(vpc.ipv_6_cidr_block_association_set[0].ipv_6_cidr_block)
+
+    private_subnet_aws_resource.reload.aws_subnets.each_with_index do |aws_subnet, idx|
+      next if aws_subnet.subnet_id
+
+      ipv6_cidr = vpc_ipv6.nth_subnet(64, idx)
+      full_az = location.name + aws_subnet.location_az.az
+
+      subnet = client.create_subnet({
+        vpc_id: private_subnet_aws_resource.vpc_id,
+        cidr_block: aws_subnet.ipv4_cidr.to_s,
+        ipv_6_cidr_block: ipv6_cidr.to_s,
+        availability_zone: full_az,
+        tag_specifications: Util.aws_tag_specifications("subnet", "#{private_subnet.name}-#{aws_subnet.location_az.az}"),
+      }).subnet
+
+      client.modify_subnet_attribute({
+        subnet_id: subnet.subnet_id,
+        assign_ipv_6_address_on_creation: {value: true},
+      })
+
+      # Persist immediately so we skip on retry if associate_route_table fails
+      aws_subnet.update(subnet_id: subnet.subnet_id, ipv6_cidr: ipv6_cidr.to_s)
+    end
+
+    hop_associate_route_tables
+  end
+
+  label def associate_route_tables
+    private_subnet_aws_resource.reload.aws_subnets.each do |aws_subnet|
+      client.associate_route_table({
+        route_table_id: private_subnet_aws_resource.route_table_id,
+        subnet_id: aws_subnet.subnet_id,
+      })
+    rescue Aws::EC2::Errors::ResourceAlreadyAssociated
+    end
+
+    hop_finish
+  end
+
+  label def finish
+    pop "AwsSubnet records backfilled successfully"
+  end
+
+  def location
+    @location ||= private_subnet.location
+  end
+
+  def client
+    @client ||= location.location_credential_aws.client
+  end
+
+  def private_subnet_aws_resource
+    @private_subnet_aws_resource ||= private_subnet.private_subnet_aws_resource
+  end
+
+  private
+
+  def old_subnet?
+    private_subnet.net4.netmask.prefix_len == PrivateSubnet::DEFAULT_SUBNET_PREFIX_LEN
+  end
+
+  def find_location_az(az_suffix)
+    location_az = location.location_azs_dataset.first(az: az_suffix)
+    unless location_az
+      location.azs
+      location_az = location.location_azs_dataset.first(az: az_suffix)
+      fail "Could not find LocationAz for AZ #{az_suffix}" unless location_az
+    end
+    location_az
+  end
+end

--- a/prog/vnet/aws/nic_nexus.rb
+++ b/prog/vnet/aws/nic_nexus.rb
@@ -17,6 +17,13 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
 
     register_deadline("attach_eip_network_interface", 3 * 60)
 
+    # Handle legacy VPCs with per-NIC subnets
+    if old_subnet?
+      subnet = client.describe_subnets({filters: [{name: "vpc-id", values: [vpc_id]}]}).subnets[0]
+      nic.nic_aws_resource.update(subnet_id: subnet.subnet_id, subnet_az: subnet.availability_zone.delete_prefix(private_subnet.location.name))
+      hop_create_network_interface
+    end
+
     # AwsSubnet was selected at assemble time and stored in frame
     aws_subnet = nic.private_subnet.private_subnet_aws_resource.aws_subnets_dataset.first(id: aws_subnet_id)
     fail "No available AWS subnet found" unless aws_subnet
@@ -123,10 +130,21 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
       allocation_id = nic.nic_aws_resource&.eip_allocation_id
       client.release_address({allocation_id:}) if allocation_id
     end
-    hop_destroy_entities
+    hop_delete_subnet
   end
 
   label def delete_subnet
+    # Only delete legacy per-NIC subnets, not shared AZ subnets
+    if old_subnet? || !nic.nic_aws_resource.aws_subnet_id
+      ignore_invalid_nic do
+        client.delete_subnet({subnet_id: nic.nic_aws_resource.subnet_id})
+      rescue Aws::EC2::Errors::DependencyViolation => e
+        raise e if private_subnet.nics.count == 1
+
+        Clog.emit("dependency violation for aws nic", {ignored_aws_nic_failure: Util.exception_to_hash(e, backtrace: nil)})
+      end
+    end
+
     hop_destroy_entities
   end
 
@@ -144,11 +162,19 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
     @private_subnet ||= nic.private_subnet
   end
 
+  def vpc_id
+    @vpc_id ||= private_subnet.private_subnet_aws_resource.vpc_id
+  end
+
   def get_network_interface
     client.describe_network_interfaces({filters: [{name: "network-interface-id", values: [nic.nic_aws_resource.network_interface_id]}, {name: "tag:Ubicloud", values: [Config.provider_resource_tag_value]}]}).network_interfaces[0]
   end
 
   private
+
+  def old_subnet?
+    private_subnet.net4.netmask.prefix_len == PrivateSubnet::DEFAULT_SUBNET_PREFIX_LEN
+  end
 
   def ignore_invalid_nic
     yield

--- a/prog/vnet/aws/nic_nexus.rb
+++ b/prog/vnet/aws/nic_nexus.rb
@@ -126,6 +126,10 @@ class Prog::Vnet::Aws::NicNexus < Prog::Base
     hop_destroy_entities
   end
 
+  label def delete_subnet
+    hop_destroy_entities
+  end
+
   label def destroy_entities
     nic&.nic_aws_resource&.destroy
     nic&.destroy

--- a/spec/model/location_spec.rb
+++ b/spec/model/location_spec.rb
@@ -154,13 +154,7 @@ RSpec.describe Location do
   end
 
   it "fetches aws azs from aws if not present" do
-    LocationCredentialAws.create_with_id(p1_loc.id, access_key: "test-access-key", secret_key: "test-secret-key")
-    client = Aws::EC2::Client.new(stub_responses: true, region: "l1")
-    client.stub_responses(:describe_availability_zones, availability_zones: [
-      {zone_name: "l1a", zone_id: "123"},
-      {zone_name: "l1b", zone_id: "456"},
-    ])
-    expect(Aws::EC2::Client).to receive(:new).with(credentials: anything, region: "l1").and_return(client)
+    expect(p1_loc).to receive(:get_azs_from_aws).and_return([instance_double(Aws::EC2::Types::AvailabilityZone, zone_name: "l1a", zone_id: "123"), instance_double(Aws::EC2::Types::AvailabilityZone, zone_name: "l1b", zone_id: "456")])
     expect(p1_loc.azs).to eq([LocationAz[location_id: p1_loc.id, az: "a", zone_id: "123"], LocationAz[location_id: p1_loc.id, az: "b", zone_id: "456"]])
     expect(LocationAz.count).to eq(2)
   end

--- a/spec/prog/vnet/aws/backfill_aws_subnets_spec.rb
+++ b/spec/prog/vnet/aws/backfill_aws_subnets_spec.rb
@@ -1,0 +1,450 @@
+# frozen_string_literal: true
+
+RSpec.describe Prog::Vnet::Aws::BackfillAwsSubnets do
+  subject(:nx) { described_class.new(st) }
+
+  let(:project) { Project.create(name: "test-prj") }
+  let(:location) {
+    loc = Location.create(name: "us-west-2", provider: "aws", project_id: project.id, display_name: "aws-us-west-2", ui_name: "AWS US West 2", visible: true)
+    LocationCredentialAws.create_with_id(loc.id, access_key: "stubbed-akid", secret_key: "stubbed-secret")
+    loc
+  }
+  let(:az_a) { LocationAz.create(location_id: location.id, az: "a", zone_id: "usw2-az1") }
+  let(:az_b) { LocationAz.create(location_id: location.id, az: "b", zone_id: "usw2-az2") }
+  let(:az_c) { LocationAz.create(location_id: location.id, az: "c", zone_id: "usw2-az3") }
+
+  let(:client) { Aws::EC2::Client.new(stub_responses: true) }
+
+  before do
+    az_a
+    aws_credentials = Aws::Credentials.new("stubbed-akid", "stubbed-secret")
+    allow(Aws::Credentials).to receive(:new).with("stubbed-akid", "stubbed-secret").and_return(aws_credentials)
+    allow(Aws::EC2::Client).to receive(:new).with(credentials: aws_credentials, region: "us-west-2").and_return(client)
+  end
+
+  describe "#assemble" do
+    it "fails if private subnet does not exist" do
+      expect {
+        described_class.assemble("00000000-0000-0000-0000-000000000000")
+      }.to raise_error("No existing private subnet")
+    end
+
+    it "fails if private subnet is not AWS" do
+      metal_loc = Location.create(name: "hetzner-fsn1", provider: "hetzner", project_id: project.id, display_name: "hetzner-fsn1", ui_name: "Hetzner FSN1", visible: true)
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "test-metal", location_id: metal_loc.id).subject
+      expect {
+        described_class.assemble(ps.id)
+      }.to raise_error("Private subnet is not in an AWS location")
+    end
+
+    it "fails if no PrivateSubnetAwsResource exists" do
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "test-ps", location_id: location.id).subject
+      ps.private_subnet_aws_resource.aws_subnets.each(&:destroy)
+      ps.private_subnet_aws_resource.destroy
+      expect {
+        described_class.assemble(ps.id)
+      }.to raise_error("Private subnet has no AWS resource")
+    end
+
+    it "fails if no vpc_id is set" do
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "test-ps", location_id: location.id).subject
+      ps.private_subnet_aws_resource.aws_subnets.each(&:destroy)
+      expect {
+        described_class.assemble(ps.id)
+      }.to raise_error("Private subnet AWS resource has no VPC ID")
+    end
+
+    it "fails if AwsSubnet records already exist" do
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "test-ps", location_id: location.id).subject
+      ps.private_subnet_aws_resource.update(vpc_id: "vpc-123")
+      expect {
+        described_class.assemble(ps.id)
+      }.to raise_error("Private subnet already has AwsSubnet records")
+    end
+
+    it "creates a strand" do
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "test-ps", location_id: location.id).subject
+      ps.private_subnet_aws_resource.update(vpc_id: "vpc-123")
+      ps.private_subnet_aws_resource.aws_subnets.each(&:destroy)
+      st = described_class.assemble(ps.id)
+      expect(st).to be_a(Strand)
+      expect(st.prog).to eq("Vnet::Aws::BackfillAwsSubnets")
+      expect(st.label).to eq("start")
+      expect(st.stack.first["subject_id"]).to eq(ps.id)
+    end
+  end
+
+  describe "old /26 VPCs" do
+    let(:ps) {
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "test-old-ps", location_id: location.id).subject
+      # Simulate old /26 format
+      ps.update(net4: "10.0.0.0/26")
+      ps.private_subnet_aws_resource.update(
+        vpc_id: "vpc-old",
+        route_table_id: "rtb-old",
+        security_group_id: "sg-old",
+        internet_gateway_id: "igw-old",
+      )
+      # Remove AwsSubnet records created by assemble to simulate pre-migration state
+      ps.private_subnet_aws_resource.aws_subnets.each(&:destroy)
+      ps
+    }
+
+    let(:st) {
+      Strand.create(prog: "Vnet::Aws::BackfillAwsSubnets", label: "start", stack: [{"subject_id" => ps.id}])
+    }
+
+    let(:nic) {
+      nic = Prog::Vnet::NicNexus.assemble(ps.id, name: "test-old-nic").subject
+      NicAwsResource.create_with_id(nic.id, subnet_id: "subnet-old", subnet_az: "us-west-2a")
+      nic
+    }
+
+    describe "#start" do
+      it "hops to backfill_old_subnet for /26 VPCs" do
+        expect { nx.start }.to hop("backfill_old_subnet")
+      end
+    end
+
+    describe "#backfill_old_subnet" do
+      before do
+        st.update(label: "backfill_old_subnet")
+        nic
+      end
+
+      it "creates AwsSubnet record for existing subnet" do
+        client.stub_responses(:describe_subnets, subnets: [{
+          subnet_id: "subnet-old",
+          cidr_block: "10.0.0.0/26",
+          availability_zone: "us-west-2a",
+          ipv_6_cidr_block_association_set: [{ipv_6_cidr_block: "2600:1f14::/64"}],
+        }])
+
+        expect { nx.backfill_old_subnet }.to hop("link_nics")
+        aws_subnet = AwsSubnet.where(private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id).first
+        expect(aws_subnet.subnet_id).to eq("subnet-old")
+        expect(aws_subnet.ipv4_cidr.to_s).to eq("10.0.0.0/26")
+        expect(aws_subnet.ipv6_cidr.to_s).to eq("2600:1f14::/64")
+        expect(aws_subnet.location_aws_az_id).to eq(az_a.id)
+      end
+
+      it "fails if no subnets found in VPC" do
+        client.stub_responses(:describe_subnets, subnets: [])
+        expect { nx.backfill_old_subnet }.to raise_error("No subnets found in VPC vpc-old")
+      end
+
+      it "fetches AZs from AWS if LocationAz not cached" do
+        # Remove the existing AZ record
+        LocationAz.where(id: az_a.id).destroy
+
+        client.stub_responses(:describe_subnets, subnets: [{
+          subnet_id: "subnet-old",
+          cidr_block: "10.0.0.0/26",
+          availability_zone: "us-west-2a",
+          ipv_6_cidr_block_association_set: [{ipv_6_cidr_block: "2600:1f14::/64"}],
+        }])
+        client.stub_responses(:describe_availability_zones, availability_zones: [
+          {zone_name: "us-west-2a", zone_id: "usw2-az1"},
+          {zone_name: "us-west-2b", zone_id: "usw2-az2"},
+        ])
+
+        expect { nx.backfill_old_subnet }.to hop("link_nics")
+        expect(LocationAz.where(location_id: location.id).count).to eq(2)
+      end
+
+      it "fails if AZ not found even after fetching from AWS" do
+        LocationAz.where(id: az_a.id).destroy
+
+        client.stub_responses(:describe_subnets, subnets: [{
+          subnet_id: "subnet-old",
+          cidr_block: "10.0.0.0/26",
+          availability_zone: "us-west-2x",
+          ipv_6_cidr_block_association_set: [],
+        }])
+        client.stub_responses(:describe_availability_zones, availability_zones: [
+          {zone_name: "us-west-2b", zone_id: "usw2-az2"},
+        ])
+
+        expect { nx.backfill_old_subnet }.to raise_error("Could not find LocationAz for AZ x")
+      end
+    end
+
+    describe "#link_nics" do
+      before do
+        st.update(label: "link_nics")
+        # Create the AwsSubnet record that would exist after backfill_old_subnet
+        AwsSubnet.create(
+          private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id,
+          location_aws_az_id: az_a.id,
+          ipv4_cidr: "10.0.0.0/26",
+          subnet_id: "subnet-old",
+        )
+        nic  # ensure NIC is created
+      end
+
+      it "links NIC to AwsSubnet and hops to finish for old subnet" do
+        expect { nx.link_nics }.to hop("finish")
+        expect(nic.reload.nic_aws_resource.aws_subnet_id).not_to be_nil
+      end
+
+      it "skips NICs without nic_aws_resource" do
+        nic.nic_aws_resource.destroy
+        expect { nx.link_nics }.to hop("finish")
+      end
+
+      it "skips NICs already linked" do
+        aws_subnet = AwsSubnet.where(private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id).first
+        nic.nic_aws_resource.update(aws_subnet_id: aws_subnet.id)
+        expect { nx.link_nics }.to hop("finish")
+      end
+    end
+  end
+
+  describe "new /16 VPCs" do
+    let(:ps) {
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "test-new-ps", location_id: location.id).subject
+      ps.private_subnet_aws_resource.update(
+        vpc_id: "vpc-new",
+        route_table_id: "rtb-new",
+        security_group_id: "sg-new",
+        internet_gateway_id: "igw-new",
+      )
+      # Remove AwsSubnet records to simulate pre-migration state
+      ps.private_subnet_aws_resource.aws_subnets.each(&:destroy)
+      ps
+    }
+
+    let(:st) {
+      Strand.create(prog: "Vnet::Aws::BackfillAwsSubnets", label: "start", stack: [{"subject_id" => ps.id}])
+    }
+
+    let(:nic_a) {
+      nic = Prog::Vnet::NicNexus.assemble(ps.id, name: "test-nic-a").subject
+      NicAwsResource.create_with_id(nic.id, subnet_id: "subnet-a", subnet_az: "a")
+      nic
+    }
+
+    let(:nic_b) {
+      nic = Prog::Vnet::NicNexus.assemble(ps.id, name: "test-nic-b").subject
+      NicAwsResource.create_with_id(nic.id, subnet_id: "subnet-b", subnet_az: "us-west-2b")
+      nic
+    }
+
+    describe "#start" do
+      it "hops to fetch_existing_subnets for /16 VPCs" do
+        expect { nx.start }.to hop("fetch_existing_subnets")
+      end
+    end
+
+    describe "#fetch_existing_subnets" do
+      before do
+        st.update(label: "fetch_existing_subnets")
+        az_b
+        nic_a
+        nic_b
+      end
+
+      it "groups subnets by AZ and stores in frame" do
+        client.stub_responses(:describe_subnets, subnets: [
+          {subnet_id: "subnet-a", cidr_block: "#{ps.net4.network}/24", availability_zone: "us-west-2a",
+           ipv_6_cidr_block_association_set: [{ipv_6_cidr_block: "2600:1f14:1000::/64"}]},
+          {subnet_id: "subnet-a2", cidr_block: "#{ps.net4.network}/24", availability_zone: "us-west-2a",
+           ipv_6_cidr_block_association_set: [{ipv_6_cidr_block: "2600:1f14:1000:100::/64"}]},
+          {subnet_id: "subnet-b", cidr_block: "#{ps.net4.nth_subnet(24, 1).network}/24", availability_zone: "us-west-2b",
+           ipv_6_cidr_block_association_set: [{ipv_6_cidr_block: "2600:1f14:1000:200::/64"}]},
+        ])
+
+        expect { nx.fetch_existing_subnets }.to hop("create_records")
+        frame = nx.strand.stack.first
+        expect(frame["az_subnet_map"].keys).to contain_exactly("a", "b")
+        expect(frame["az_subnet_map"]["a"]["subnet_id"]).to eq("subnet-a")
+        expect(frame["az_subnet_map"]["b"]["subnet_id"]).to eq("subnet-b")
+      end
+
+      it "handles VPC with no existing subnets" do
+        client.stub_responses(:describe_subnets, subnets: [])
+        expect { nx.fetch_existing_subnets }.to hop("create_records")
+        frame = nx.strand.stack.first
+        expect(frame["az_subnet_map"]).to eq({})
+      end
+    end
+
+    describe "#create_records" do
+      before do
+        az_b
+        az_c
+        st.update(label: "create_records")
+      end
+
+      it "creates AwsSubnet records for each AZ with existing and calculated CIDRs" do
+        st.stack.first["az_subnet_map"] = {
+          "a" => {"subnet_id" => "subnet-a", "cidr_block" => "#{ps.net4.network}/24", "ipv6_cidr" => "2600:1f14:1000::/64"},
+        }
+        st.modified!(:stack)
+        st.save_changes
+
+        expect { nx.create_records }.to hop("link_nics")
+        aws_subnets = AwsSubnet.where(private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id).all
+        expect(aws_subnets.count).to eq(3)
+
+        az_a_subnet = aws_subnets.find { it.location_aws_az_id == az_a.id }
+        expect(az_a_subnet.subnet_id).to eq("subnet-a")
+        expect(az_a_subnet.ipv6_cidr.to_s).to eq("2600:1f14:1000::/64")
+
+        az_b_subnet = aws_subnets.find { it.location_aws_az_id == az_b.id }
+        expect(az_b_subnet.subnet_id).to be_nil
+        expect(az_b_subnet.ipv6_cidr).to be_nil
+
+        az_c_subnet = aws_subnets.find { it.location_aws_az_id == az_c.id }
+        expect(az_c_subnet.subnet_id).to be_nil
+      end
+    end
+
+    describe "#link_nics" do
+      before do
+        az_b
+        st.update(label: "link_nics")
+        # Create AwsSubnet records
+        AwsSubnet.create(
+          private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id,
+          location_aws_az_id: az_a.id,
+          ipv4_cidr: "#{ps.net4.network}/24",
+          subnet_id: "subnet-a",
+        )
+        AwsSubnet.create(
+          private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id,
+          location_aws_az_id: az_b.id,
+          ipv4_cidr: ps.net4.nth_subnet(24, 1).to_s,
+        )
+        nic_a
+        nic_b
+      end
+
+      it "links NICs by AZ suffix and hops to create_missing_az_subnets" do
+        expect { nx.link_nics }.to hop("create_missing_az_subnets")
+        aws_subnet_a = AwsSubnet.where(location_aws_az_id: az_a.id).first
+        aws_subnet_b = AwsSubnet.where(location_aws_az_id: az_b.id).first
+        expect(nic_a.reload.nic_aws_resource.aws_subnet_id).to eq(aws_subnet_a.id)
+        expect(nic_b.reload.nic_aws_resource.aws_subnet_id).to eq(aws_subnet_b.id)
+      end
+
+      it "skips NICs without subnet_az" do
+        nic_a.nic_aws_resource.update(subnet_az: nil)
+        expect { nx.link_nics }.to hop("create_missing_az_subnets")
+        expect(nic_a.reload.nic_aws_resource.aws_subnet_id).to be_nil
+      end
+
+      it "skips NICs with unmatched AZ" do
+        nic_a.nic_aws_resource.update(subnet_az: "us-west-2z")
+        expect { nx.link_nics }.to hop("create_missing_az_subnets")
+        expect(nic_a.reload.nic_aws_resource.aws_subnet_id).to be_nil
+      end
+    end
+
+    describe "#create_missing_az_subnets" do
+      before do
+        az_b
+        st.update(label: "create_missing_az_subnets")
+
+        # AZ a has an existing subnet, AZ b does not
+        AwsSubnet.create(
+          private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id,
+          location_aws_az_id: az_a.id,
+          ipv4_cidr: "#{ps.net4.network}/24",
+          subnet_id: "subnet-existing-a",
+          ipv6_cidr: "2600:1f14:1000::/64",
+        )
+        AwsSubnet.create(
+          private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id,
+          location_aws_az_id: az_b.id,
+          ipv4_cidr: ps.net4.nth_subnet(24, 1).to_s,
+        )
+
+        client.stub_responses(:describe_vpcs, vpcs: [{
+          vpc_id: "vpc-new",
+          ipv_6_cidr_block_association_set: [{ipv_6_cidr_block: "2600:1f14:1000::/56"}],
+        }])
+        client.stub_responses(:create_subnet, ->(context) {
+          az = context.params[:availability_zone]
+          {subnet: {subnet_id: "subnet-#{az}"}}
+        })
+        client.stub_responses(:modify_subnet_attribute)
+      end
+
+      it "creates AWS subnets for AZs without subnet_id and skips existing" do
+        expect(client).to receive(:create_subnet).once.and_call_original
+        expect(client).to receive(:modify_subnet_attribute).once.and_call_original
+        expect { nx.create_missing_az_subnets }.to hop("associate_route_tables")
+
+        az_a_subnet = AwsSubnet.where(location_aws_az_id: az_a.id, private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id).first
+        expect(az_a_subnet.subnet_id).to eq("subnet-existing-a")
+
+        az_b_subnet = AwsSubnet.where(location_aws_az_id: az_b.id, private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id).first
+        expect(az_b_subnet.subnet_id).to eq("subnet-us-west-2b")
+        expect(az_b_subnet.ipv6_cidr).not_to be_nil
+      end
+
+      it "hops to associate_route_tables when all subnets already exist" do
+        AwsSubnet.where(location_aws_az_id: az_b.id, private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id)
+          .update(subnet_id: "subnet-existing-b", ipv6_cidr: "2600:1f14:1000:100::/64")
+        expect(client).not_to receive(:create_subnet)
+        expect { nx.create_missing_az_subnets }.to hop("associate_route_tables")
+      end
+    end
+
+    describe "#associate_route_tables" do
+      before do
+        az_b
+        st.update(label: "associate_route_tables")
+
+        AwsSubnet.create(
+          private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id,
+          location_aws_az_id: az_a.id,
+          ipv4_cidr: "#{ps.net4.network}/24",
+          subnet_id: "subnet-a",
+        )
+        AwsSubnet.create(
+          private_subnet_aws_resource_id: ps.private_subnet_aws_resource.id,
+          location_aws_az_id: az_b.id,
+          ipv4_cidr: ps.net4.nth_subnet(24, 1).to_s,
+          subnet_id: "subnet-b",
+        )
+      end
+
+      it "associates route tables for all subnets and hops to finish" do
+        client.stub_responses(:associate_route_table)
+        expect(client).to receive(:associate_route_table).with({
+          route_table_id: "rtb-new",
+          subnet_id: "subnet-a",
+        }).and_call_original
+        expect(client).to receive(:associate_route_table).with({
+          route_table_id: "rtb-new",
+          subnet_id: "subnet-b",
+        }).and_call_original
+        expect { nx.associate_route_tables }.to hop("finish")
+      end
+
+      it "ignores ResourceAlreadyAssociated errors" do
+        client.stub_responses(:associate_route_table, Aws::EC2::Errors::ResourceAlreadyAssociated.new(nil, nil))
+        expect { nx.associate_route_tables }.to hop("finish")
+      end
+    end
+  end
+
+  describe "#finish" do
+    let(:ps) {
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "test-fin-ps", location_id: location.id).subject
+      ps.private_subnet_aws_resource.update(vpc_id: "vpc-fin")
+      ps.private_subnet_aws_resource.aws_subnets.each(&:destroy)
+      ps
+    }
+
+    let(:st) {
+      Strand.create(prog: "Vnet::Aws::BackfillAwsSubnets", label: "finish", stack: [{"subject_id" => ps.id}])
+    }
+
+    it "pops with success message" do
+      expect { nx.finish }.to exit({"msg" => "AwsSubnet records backfilled successfully"})
+    end
+  end
+end

--- a/spec/prog/vnet/aws/nic_nexus_spec.rb
+++ b/spec/prog/vnet/aws/nic_nexus_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe Prog::Vnet::Aws::NicNexus do
       expect(nx).to receive(:frame).and_return({"aws_subnet_id" => "00000000-0000-0000-0000-000000000000"}).at_least(:once)
       expect { nx.create_subnet }.to raise_error("No available AWS subnet found")
     end
+
+    it "uses existing subnet for old aws subnet" do
+      expect(nx).to receive(:old_subnet?).and_return(true)
+      client.stub_responses(:describe_subnets, subnets: [{subnet_id: "subnet-existing", availability_zone: "a"}])
+      expect(nic.nic_aws_resource).to receive(:update).with(subnet_id: "subnet-existing", subnet_az: "a")
+      expect { nx.create_subnet }.to hop("create_network_interface")
+    end
   end
 
   describe "#create_network_interface" do
@@ -225,33 +232,67 @@ RSpec.describe Prog::Vnet::Aws::NicNexus do
       expect(nic.nic_aws_resource).to receive(:eip_allocation_id).and_return("eip-0123456789abcdefg").at_least(:once)
       client.stub_responses(:release_address)
       expect(client).to receive(:release_address).with({allocation_id: "eip-0123456789abcdefg"}).and_call_original
-      expect { nx.release_eip }.to hop("destroy_entities")
+      expect { nx.release_eip }.to hop("delete_subnet")
     end
 
     it "gracefully continues if the nic is not found" do
       expect(nic.nic_aws_resource).to receive(:eip_allocation_id).and_return(nil).at_least(:once)
-      expect { nx.release_eip }.to hop("destroy_entities")
+      expect { nx.release_eip }.to hop("delete_subnet")
     end
 
     it "gracefully continues if the nic_aws_resource is not found" do
       expect(nic).to receive(:nic_aws_resource).and_return(nil).at_least(:once)
-      expect { nx.release_eip }.to hop("destroy_entities")
+      expect { nx.release_eip }.to hop("delete_subnet")
     end
 
-    it "hops to destroy_entities if the eip_allocation_id is found" do
+    it "hops to delete_subnet if the eip_allocation_id is found" do
       expect(nic.nic_aws_resource).to receive(:eip_allocation_id).and_return("eip-0123456789abcdefg").at_least(:once)
-      expect { nx.release_eip }.to hop("destroy_entities")
+      expect { nx.release_eip }.to hop("delete_subnet")
     end
 
-    it "hops to destroy_entities if the address is already released" do
+    it "hops to delete_subnet if the address is already released" do
       client.stub_responses(:describe_addresses, addresses: [{allocation_id: "eip-0123456789abcdefg"}])
       client.stub_responses(:release_address, Aws::EC2::Errors::InvalidAllocationIDNotFound.new(nil, "The address 'eip-0123456789abcdefg' does not exist."))
-      expect { nx.release_eip }.to hop("destroy_entities")
+      expect { nx.release_eip }.to hop("delete_subnet")
     end
   end
 
   describe "#delete_subnet" do
-    it "hops to destroy_entities" do
+    it "skips deletion for shared subnets (aws_subnet_id set)" do
+      aws_subnet = AwsSubnet.where(private_subnet_aws_resource_id: nic.private_subnet.private_subnet_aws_resource.id).first
+      nic.nic_aws_resource.update(aws_subnet_id: aws_subnet.id)
+      expect(client).not_to receive(:delete_subnet)
+      expect { nx.delete_subnet }.to hop("destroy_entities")
+    end
+
+    it "deletes legacy per-NIC subnet (aws_subnet_id nil)" do
+      client.stub_responses(:delete_subnet)
+      expect(client).to receive(:delete_subnet).with({subnet_id: nic.nic_aws_resource.subnet_id}).and_call_original
+      expect { nx.delete_subnet }.to hop("destroy_entities")
+    end
+
+    it "deletes subnet for old aws subnet" do
+      expect(nx).to receive(:old_subnet?).and_return(true)
+      client.stub_responses(:delete_subnet)
+      expect(client).to receive(:delete_subnet).with({subnet_id: nic.nic_aws_resource.subnet_id}).and_call_original
+      expect { nx.delete_subnet }.to hop("destroy_entities")
+    end
+
+    it "gracefully continues if the nic is not found" do
+      client.stub_responses(:delete_subnet, Aws::EC2::Errors::InvalidSubnetIDNotFound.new(nil, "The subnet 'subnet-0123456789abcdefg' does not exist."))
+      expect(nic.nic_aws_resource).to receive(:subnet_id).and_return(nil).at_least(:once)
+      expect { nx.delete_subnet }.to hop("destroy_entities")
+    end
+
+    it "raises an error if the subnet could not be deleted but we are the only nic" do
+      client.stub_responses(:delete_subnet, Aws::EC2::Errors::DependencyViolation.new(nil, "The subnet 'subnet-0123456789abcdefg' could not be deleted because it is associated with the network interface 'eni-0123456789abcdefg'."))
+      expect(nic.private_subnet).to receive(:nics).and_return([nic]).at_least(:once)
+      expect { nx.delete_subnet }.to raise_error(Aws::EC2::Errors::DependencyViolation)
+    end
+
+    it "gracefully continues if the subnet could not be deleted but we are not the only nic" do
+      client.stub_responses(:delete_subnet, Aws::EC2::Errors::DependencyViolation.new(nil, "The subnet 'subnet-0123456789abcdefg' could not be deleted because it is associated with the network interface 'eni-0123456789abcdefg'."))
+      expect(nic.private_subnet).to receive(:nics).and_return([nic, instance_double(Nic)]).at_least(:once)
       expect { nx.delete_subnet }.to hop("destroy_entities")
     end
   end

--- a/spec/prog/vnet/aws/nic_nexus_spec.rb
+++ b/spec/prog/vnet/aws/nic_nexus_spec.rb
@@ -250,6 +250,12 @@ RSpec.describe Prog::Vnet::Aws::NicNexus do
     end
   end
 
+  describe "#delete_subnet" do
+    it "hops to destroy_entities" do
+      expect { nx.delete_subnet }.to hop("destroy_entities")
+    end
+  end
+
   describe "#destroy_entities" do
     it "refreshes the keys and destroys the nic" do
       expect(nic.nic_aws_resource).to receive(:destroy)


### PR DESCRIPTION
Reverts the last two commits, which removed legacy AWS subnet code and
the `delete_subnet` label:

- `9150eed39` Remove delete_subnet label all together
- `2595530fc` Remove legacy AWS Subnet related code pieces

**Why:** these were deployed too early. We have a couple of more databases waiting failover.
Reverting both restores the tree to exactly its state at `b7e080714`
