### PR TITLE
Keep draining worker nodes in the SSH mesh during upgrades

### DIFF
--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -207,6 +207,10 @@ class KubernetesCluster < Sequel::Model
     nodepools.flat_map(&:functional_nodes)
   end
 
+  def worker_mesh_nodes
+    nodepools.flat_map(&:mesh_nodes)
+  end
+
   def ready_for_upgrade?
     !upgrading? && available_upgrade_version && strand.label == "wait" \
     && !nodepools.empty? && nodepools.first.strand.label == "wait"

--- a/model/kubernetes/kubernetes_nodepool.rb
+++ b/model/kubernetes/kubernetes_nodepool.rb
@@ -8,6 +8,7 @@ class KubernetesNodepool < Sequel::Model
   many_to_many :vms, join_table: :kubernetes_node, order: :created_at, read_only: true
   one_to_many :nodes, class: :KubernetesNode, order: :created_at, read_only: true
   one_to_many :functional_nodes, class: :KubernetesNode, order: :created_at, conditions: {state: "active"}, read_only: true
+  one_to_many :mesh_nodes, class: :KubernetesNode, order: :created_at, conditions: {state: ["active", "renewing_certs", "draining"]}, read_only: true
 
   plugin ResourceMethods
   plugin SemaphoreMethods, :destroy, :start_bootstrapping, :upgrade, :scale_worker_count

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -324,7 +324,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   label def sync_worker_mesh
     decr_sync_worker_mesh
 
-    key_pairs = kubernetes_cluster.worker_functional_nodes.map do |node|
+    key_pairs = kubernetes_cluster.worker_mesh_nodes.map do |node|
       {vm: node.vm, ssh_key: SshKey.generate}
     end
 

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -699,13 +699,36 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
     end
 
     it "creates full mesh connectivity on cluster worker nodes" do
-      expect(kubernetes_cluster.worker_functional_nodes.first.vm.sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: first_ssh_key.private_key)
-      first_vm_authorized_keys = [first_vm.sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n") + "\n"
-      expect(kubernetes_cluster.worker_functional_nodes.first.vm.sshable).to receive(:_cmd).with("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: first_vm_authorized_keys)
+      first_sshable = kubernetes_cluster.worker_mesh_nodes.first.vm.sshable
+      second_sshable = kubernetes_cluster.worker_mesh_nodes.last.vm.sshable
 
-      expect(kubernetes_cluster.worker_functional_nodes.last.vm.sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: second_ssh_key.private_key)
+      expect(first_sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: first_ssh_key.private_key)
+      first_vm_authorized_keys = [first_sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n") + "\n"
+      expect(first_sshable).to receive(:_cmd).with("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: first_vm_authorized_keys)
+
+      expect(second_sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: second_ssh_key.private_key)
+      second_vm_authorized_keys = [second_sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n") + "\n"
+      expect(second_sshable).to receive(:_cmd).with("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: second_vm_authorized_keys)
+
+      expect { nx.sync_worker_mesh }.to hop("wait")
+    end
+
+    it "keeps draining nodes in the mesh so in-flight CSI migrations don't lose ssh access" do
+      kubernetes_cluster.nodepools.first.nodes.last.update(state: "draining")
+
+      first_vm = kubernetes_cluster.worker_mesh_nodes.first.vm
+      second_vm = kubernetes_cluster.worker_mesh_nodes.last.vm
+
+      expect(kubernetes_cluster.worker_functional_nodes.map(&:vm)).to eq [first_vm]
+      expect(kubernetes_cluster.worker_mesh_nodes.map(&:vm)).to eq [first_vm, second_vm]
+
+      expect(first_vm.sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: first_ssh_key.private_key)
+      first_vm_authorized_keys = [first_vm.sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n") + "\n"
+      expect(first_vm.sshable).to receive(:_cmd).with("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: first_vm_authorized_keys)
+
+      expect(second_vm.sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: second_ssh_key.private_key)
       second_vm_authorized_keys = [second_vm.sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n") + "\n"
-      expect(kubernetes_cluster.worker_functional_nodes.last.vm.sshable).to receive(:_cmd).with("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: second_vm_authorized_keys)
+      expect(second_vm.sshable).to receive(:_cmd).with("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: second_vm_authorized_keys)
 
       expect { nx.sync_worker_mesh }.to hop("wait")
     end


### PR DESCRIPTION
ProvisionKubernetesNode#approve_new_csr queues incr_sync_worker_mesh when the new node joins. UpgradeKubernetesNode then races forward to drain_old_node, which flips the old node's state to "draining". If the cluster nexus only gets around to running sync_worker_mesh after that state flip, worker_functional_nodes (filtered by state="active") excludes the draining node: the new node writes a freshly generated private key to disk, but the draining node never receives the matching public key in its authorized_keys. The CSI rsync from the new node to the draining node then fails authentication and the PV migration cannot proceed.

Add a mesh_nodes association that also includes draining (and renewing_certs) nodes and use it in sync_worker_mesh, so the draining node continues to receive mesh updates until it is actually destroyed. functional_nodes is left unchanged so readiness checks and nodepool scaling still exclude draining nodes.