### PR TITLE
Add Ubuntu 26.04 runner support

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -214,8 +214,10 @@ module Config
 
   override :github_ubuntu_2204_x64_aws_ami_version, "ami-027521b1fcdfb2d1d", string
   override :github_ubuntu_2404_x64_aws_ami_version, "ami-00053ab2c8f2e7a3f", string
+  override :github_ubuntu_2604_x64_aws_ami_version, "ami-05a5aaba660346f42", string
   override :github_ubuntu_2204_arm64_aws_ami_version, "ami-057b1610e577ebfa5", string
   override :github_ubuntu_2404_arm64_aws_ami_version, "ami-005e84aaf5eab2384", string
+  override :github_ubuntu_2604_arm64_aws_ami_version, "ami-0695161c7269e474e", string
   override :postgres_gce_image_gcp_project_id, "ubicloud-images", string
 
   # Allocator

--- a/config/github_runner_labels.yml
+++ b/config/github_runner_labels.yml
@@ -5,6 +5,12 @@
 - { name: ubicloud-standard-16,                 alias_for: ubicloud-standard-16-ubuntu-2404 }
 - { name: ubicloud-standard-30,                 alias_for: ubicloud-standard-30-ubuntu-2404 }
 - { name: ubicloud-standard-60,                 alias_for: ubicloud-standard-60-ubuntu-2404 }
+- { name: ubicloud-standard-2-ubuntu-2604,      family: standard,     vcpus: 2,     arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2604 }
+- { name: ubicloud-standard-4-ubuntu-2604,      family: standard,     vcpus: 4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2604 }
+- { name: ubicloud-standard-8-ubuntu-2604,      family: standard,     vcpus: 8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2604 }
+- { name: ubicloud-standard-16-ubuntu-2604,     family: standard,     vcpus: 16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2604 }
+- { name: ubicloud-standard-30-ubuntu-2604,     family: standard,     vcpus: 30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2604 }
+- { name: ubicloud-standard-60-ubuntu-2604,     family: standard,     vcpus: 60,    arch: x64,   storage_size_gib: 600, boot_image: github-ubuntu-2604 }
 - { name: ubicloud-standard-2-ubuntu-2404,      family: standard,     vcpus: 2,     arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404 }
 - { name: ubicloud-standard-4-ubuntu-2404,      family: standard,     vcpus: 4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404 }
 - { name: ubicloud-standard-8-ubuntu-2404,      family: standard,     vcpus: 8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404 }
@@ -22,6 +28,11 @@
 - { name: ubicloud-premium-8,                   alias_for: ubicloud-premium-8-ubuntu-2404 }
 - { name: ubicloud-premium-16,                  alias_for: ubicloud-premium-16-ubuntu-2404 }
 - { name: ubicloud-premium-30,                  alias_for: ubicloud-premium-30-ubuntu-2404 }
+- { name: ubicloud-premium-2-ubuntu-2604,       family: premium,      vcpus: 2,     arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2604 }
+- { name: ubicloud-premium-4-ubuntu-2604,       family: premium,      vcpus: 4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2604 }
+- { name: ubicloud-premium-8-ubuntu-2604,       family: premium,      vcpus: 8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2604 }
+- { name: ubicloud-premium-16-ubuntu-2604,      family: premium,      vcpus: 16,    arch: x64,   storage_size_gib: 300, boot_image: github-ubuntu-2604 }
+- { name: ubicloud-premium-30-ubuntu-2604,      family: premium,      vcpus: 30,    arch: x64,   storage_size_gib: 400, boot_image: github-ubuntu-2604 }
 - { name: ubicloud-premium-2-ubuntu-2404,       family: premium,      vcpus: 2,     arch: x64,   storage_size_gib: 75,  boot_image: github-ubuntu-2404 }
 - { name: ubicloud-premium-4-ubuntu-2404,       family: premium,      vcpus: 4,     arch: x64,   storage_size_gib: 150, boot_image: github-ubuntu-2404 }
 - { name: ubicloud-premium-8-ubuntu-2404,       family: premium,      vcpus: 8,     arch: x64,   storage_size_gib: 200, boot_image: github-ubuntu-2404 }
@@ -39,6 +50,12 @@
 - { name: ubicloud-standard-16-arm,             alias_for: ubicloud-standard-16-arm-ubuntu-2404 }
 - { name: ubicloud-standard-30-arm,             alias_for: ubicloud-standard-30-arm-ubuntu-2404 }
 - { name: ubicloud-standard-60-arm,             alias_for: ubicloud-standard-60-arm-ubuntu-2404 }
+- { name: ubicloud-standard-2-arm-ubuntu-2604,  family: standard,     vcpus: 2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2604 }
+- { name: ubicloud-standard-4-arm-ubuntu-2604,  family: standard,     vcpus: 4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2604 }
+- { name: ubicloud-standard-8-arm-ubuntu-2604,  family: standard,     vcpus: 8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2604 }
+- { name: ubicloud-standard-16-arm-ubuntu-2604, family: standard,     vcpus: 16,    arch: arm64, storage_size_gib: 300, boot_image: github-ubuntu-2604 }
+- { name: ubicloud-standard-30-arm-ubuntu-2604, family: standard,     vcpus: 30,    arch: arm64, storage_size_gib: 400, boot_image: github-ubuntu-2604 }
+- { name: ubicloud-standard-60-arm-ubuntu-2604, family: standard,     vcpus: 60,    arch: arm64, storage_size_gib: 600, boot_image: github-ubuntu-2604 }
 - { name: ubicloud-standard-2-arm-ubuntu-2404,  family: standard,     vcpus: 2,     arch: arm64, storage_size_gib: 86,  boot_image: github-ubuntu-2404 }
 - { name: ubicloud-standard-4-arm-ubuntu-2404,  family: standard,     vcpus: 4,     arch: arm64, storage_size_gib: 150, boot_image: github-ubuntu-2404 }
 - { name: ubicloud-standard-8-arm-ubuntu-2404,  family: standard,     vcpus: 8,     arch: arm64, storage_size_gib: 200, boot_image: github-ubuntu-2404 }

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -139,6 +139,14 @@ class Prog::DownloadBootImage < Prog::Base
         "9.7-20251118" => "c6c09af3b5be62e0ca82ccfafe0b1de9be90890fa8fddbd6118fa8b76b36de2d",
       },
     },
+    "github-ubuntu-2604" => {
+      "x64" => {
+        "20260615.1.0" => "c156d88596f161cade8bbfadb82cb9435a316e36903280a56a0eee37f2b0e1aa",
+      },
+      "arm64" => {
+        "20260615.1.0" => "308c1f3f8770829cd21b4b7362fdee93d2a370ce9f5837932d5a81957a4f7e1a",
+      },
+    },
     "github-ubuntu-2404" => {
       "x64" => {
         "20260508.1.0" => "5ad16e9ad7128b4390c910e95fbcfc1c7d1920857d5facbb892b4afcfb1022ea",

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -14,8 +14,10 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
   AWS_AMI_VERSIONS = [
     Config.github_ubuntu_2204_x64_aws_ami_version,
     Config.github_ubuntu_2404_x64_aws_ami_version,
+    Config.github_ubuntu_2604_x64_aws_ami_version,
     Config.github_ubuntu_2204_arm64_aws_ami_version,
     Config.github_ubuntu_2404_arm64_aws_ami_version,
+    Config.github_ubuntu_2604_arm64_aws_ami_version,
   ].freeze
 
   def self.assemble(installation, repository_name:, label:, actual_label: nil, default_branch: nil)

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -40,10 +40,12 @@ class Prog::Test::GithubRunner < Prog::Test::Base
     labels = []
     labels << "ubicloud-standard-2-ubuntu-2204" if test_cases.any? { it["name"].include?("2204") }
     labels << "ubicloud-standard-2-ubuntu-2404" if test_cases.any? { it["name"].include?("2404") }
+    labels << "ubicloud-standard-2-ubuntu-2604" if test_cases.any? { it["name"].include?("2604") }
 
     if provider == "aws"
       labels << "ubicloud-standard-2-arm-ubuntu-2204" if test_cases.any? { it["name"].include?("2204") }
       labels << "ubicloud-standard-2-arm-ubuntu-2404" if test_cases.any? { it["name"].include?("2404") }
+      labels << "ubicloud-standard-2-arm-ubuntu-2604" if test_cases.any? { it["name"].include?("2604") }
     end
 
     Strand.create(

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -53,10 +53,10 @@ RSpec.describe Prog::Test::GithubRunner do
       expect(Config).to receive(:e2e_aws_access_key).and_return("access_key")
       expect(Config).to receive(:e2e_aws_secret_key).and_return("secret_key")
       expect(Config).to receive(:e2e_cache_proxy_download_url).and_return("")
-      strand = described_class.assemble([{"name" => "github_runner_ubuntu_2204"}, {"name" => "github_runner_ubuntu_2404"}], provider: "aws")
+      strand = described_class.assemble([{"name" => "github_runner_ubuntu_2204"}, {"name" => "github_runner_ubuntu_2404"}, {"name" => "github_runner_ubuntu_2604"}], provider: "aws")
       expect(strand.stack.first["labels"]).to eq([
-        "ubicloud-standard-2-ubuntu-2204", "ubicloud-standard-2-ubuntu-2404",
-        "ubicloud-standard-2-arm-ubuntu-2204", "ubicloud-standard-2-arm-ubuntu-2404",
+        "ubicloud-standard-2-ubuntu-2204", "ubicloud-standard-2-ubuntu-2404", "ubicloud-standard-2-ubuntu-2604",
+        "ubicloud-standard-2-arm-ubuntu-2204", "ubicloud-standard-2-arm-ubuntu-2404", "ubicloud-standard-2-arm-ubuntu-2604",
       ])
     end
   end


### PR DESCRIPTION
GitHub recently launched Ubuntu 26.04 support in public preview and published the runner image template. We can add support for it as well.

https://github.com/actions/runner-images/issues/14226