### PR TITLE
Change default `vhost_block_backend_version` to `v0.4.2`

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -165,7 +165,7 @@ module Config
   override :spdk_version, "v23.09-ubi-0.3", string
 
   # Vhost Block Backend
-  override :vhost_block_backend_version, "v0.2.2", string
+  override :vhost_block_backend_version, "v0.4.2", string
 
   # Boot Images
   override :default_boot_image_name, "ubuntu-noble", string


### PR DESCRIPTION
This version has been used in prod for a while now, and it contains features required for UMIs.