### PR TITLE
Lay out admin rollout forms as structured cards

### DIFF
--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -34,8 +34,54 @@ input[type=submit] {
   #ubid_form & { font-size: 0.9em; }
 }
 
-#start-local-e2e, #start-rollout {
-  > div { margin-top: 10px; }
+.rollout-forms {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+  align-items: start;
+  margin-top: 8px;
+}
+.rollout-card {
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 16px 20px 20px;
+  background-color: #fafafa;
+}
+.rollout-card h3 {
+  margin: 0;
+}
+.rollout-card .rollout-desc {
+  margin: 4px 0 0;
+  color: #666;
+  font-size: 0.9em;
+}
+.rollout-form > div {
+  margin-top: 12px;
+}
+/* Stacked text/number/select fields: label above a full-width control */
+.rollout-form > div:has(> input[type=text]),
+.rollout-form > div:has(> input[type=number]),
+.rollout-form > div:has(> select) {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  > label { font-weight: 600; }
+  > input, > select { width: 100%; box-sizing: border-box; }
+}
+/* Checkbox and radio rows: control inline with its label */
+.rollout-form > div:has(> input[type=checkbox]),
+.rollout-form .rollout-radioset {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.rollout-form .rollout-radioset {
+  gap: 4px 12px;
+  flex-wrap: wrap;
+}
+.rollout-form input[type=submit] {
+  margin-top: 16px;
 }
 span.label {
   display: block;

--- a/views/admin/rollouts.erb
+++ b/views/admin/rollouts.erb
@@ -42,27 +42,37 @@ end %>
 
 <%== part("components/table", title: "Active Rollouts", table_class: "rollouts-table", data:) %>
 
-<h2>Start Rhizome Rollout</h2>
+<h2>Start Rollout</h2>
 
-<%== form({action: "/rollouts/start/RolloutRhizome", method: "post"}, button: "Start Rhizome Rollout") %>
+<div class="rollout-forms">
+  <section class="rollout-card">
+    <h3>Boot Image</h3>
+    <p class="rollout-desc">Download a boot image version to hosts, a few at a time.</p>
+    <% form({action: "/rollouts/start/RolloutBootImage", method: "post", id: "start-rollout", class: "rollout-form"}, button: "Start Boot Image Rollout", wrapper: :div) do |f| %>
+      <%== f.input(:select, key: :image_name, label: "Image Name", required: true, add_blank: true, options: Prog::DownloadBootImage::BOOT_IMAGE_SHA256.keys) %>
+      <%== f.input(:text, key: :version, label: "Version", required: true) %>
+      <%== f.input(:select, key: :arch, label: "Arch", required: true, options: %w[x64 arm64], value: "x64") %>
+      <%== f.input(:number, key: :concurrency, label: "Concurrency", required: true, attr: {min: 1}, value: 10) %>
+      <%== f.input(:text, key: :exclude_vm_host_ids, label: "Exclude VM Host IDs (comma separated)") %>
+      <%== f.input(:checkbox, key: :exclude_minio_hosts, label: "Exclude Minio Hosts", checked: true) %>
+      <%== f.input(:checkbox, key: :pause_stages, label: "Pause Between Stages") %>
+    <% end %>
+  </section>
 
-<h2>Start Semaphore Rollout</h2>
+  <section class="rollout-card">
+    <h3>Semaphore</h3>
+    <p class="rollout-desc">Increment or decrement a semaphore across every instance of a class, spaced out by a gap.</p>
+    <% form({action: "/rollouts/start/RolloutSemaphore", method: "post", id: "start-local-e2e", class: "rollout-form"}, button: "Start Semaphore Rollout", wrapper: :div) do |f| %>
+      <%== f.input(:select, key: :class, label: "Class", required: true, add_blank: true, options: semaphore_classes) %>
+      <%== f.input(:text, key: :semaphore, label: "Semaphore", required: true) %>
+      <%== f.input(:number, key: :gap, label: "Gap (seconds)", required: true, attr: {min: 5, max: 3600}, value: 60) %>
+      <%== f.input(:radioset, key: :increment, required: true, options: [["Increment", true], ["Decrement", false]], value: true, wrapper_attr: {class: "rollout-radioset"}) %>
+    <% end %>
+  </section>
 
-<% form({action: "/rollouts/start/RolloutSemaphore", method: "post", id: "start-local-e2e"}, button: "Start Semaphore Rollout", wrapper: :div) do |f| %>
-  <%== f.input(:select, key: :class, label: "Class", required: true, add_blank: true, options: semaphore_classes) %>
-  <%== f.input(:text, key: :semaphore, label: "Semaphore", required: true) %>
-  <%== f.input(:number, key: :gap, label: "Gap (seconds)", required: true, attr: {min: 5, max: 3600}, value: 60) %>
-  <%== f.input(:radioset, key: :increment, required: true, options: [["Increment", true], ["Decrement", false]], value: true) %>
-<% end %>
-
-<h2>Start Boot Image Rollout</h2>
-
-<% form({action: "/rollouts/start/RolloutBootImage", method: "post", id: "start-rollout"}, button: "Start Boot Image Rollout", wrapper: :div) do |f| %>
-  <%== f.input(:select, key: :image_name, label: "Image Name", required: true, add_blank: true, options: Prog::DownloadBootImage::BOOT_IMAGE_SHA256.keys) %>
-  <%== f.input(:text, key: :version, label: "Version", required: true) %>
-  <%== f.input(:select, key: :arch, label: "Arch", required: true, options: %w[x64 arm64], value: "x64") %>
-  <%== f.input(:number, key: :concurrency, label: "Concurrency", required: true, attr: {min: 1}, value: 10) %>
-  <%== f.input(:checkbox, key: :exclude_minio_hosts, label: "Exclude Minio Hosts", checked: true) %>
-  <%== f.input(:text, key: :exclude_vm_host_ids, label: "Exclude VM Host IDs (comma separated)") %>
-  <%== f.input(:checkbox, key: :pause_stages, label: "Pause Between Stages") %>
-<% end %>
+  <section class="rollout-card">
+    <h3>Rhizome</h3>
+    <p class="rollout-desc">Deploy the latest rhizome code to all hosts.</p>
+    <%== form({action: "/rollouts/start/RolloutRhizome", method: "post", class: "rollout-form"}, button: "Start Rhizome Rollout") %>
+  </section>
+</div>


### PR DESCRIPTION
The Start Rollout forms were a single cluttered column of mixed field widths, making them hard to scan and use. Group each rollout into its own card in a responsive grid, with a short description, stacked labels over full-width inputs, and inline checkboxes and radios.

| Before | After |
|--------|-------|
| <img width="2732" height="2606" alt="CleanShot 2026-06-16 at 19 47 18@2x" src="https://github.com/user-attachments/assets/8473642b-eeba-4559-a35f-efa04b99ff73" /> | <img width="2690" height="2598" alt="CleanShot 2026-06-16 at 19 50 09@2x" src="https://github.com/user-attachments/assets/87dd1e10-ef1a-4494-8aa5-2a090a171847" /> |