### PR TITLE
Delete the S3 bucket when an AWS postgres timeline is destroyed

### DIFF
--- a/model/postgres/aws/postgres_timeline.rb
+++ b/model/postgres/aws/postgres_timeline.rb
@@ -87,6 +87,18 @@ PGDATA=/dat/#{version}/data
     end
 
     def aws_destroy_blob_storage
+      begin
+        s3_client = blob_storage_client
+        loop do
+          objects = s3_client.list_objects_v2(bucket: ubid).contents
+          break if objects.empty?
+          s3_client.delete_objects(bucket: ubid, delete: {objects: objects.map { {key: it.key} }})
+        end
+        s3_client.delete_bucket(bucket: ubid)
+      rescue ::Aws::S3::Errors::NoSuchBucket
+        nil
+      end
+
       iam_client = location.location_credential_aws.iam_client
       if Config.aws_postgres_iam_access
         iam_client.delete_policy(policy_arn: aws_s3_policy_arn)

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -228,6 +228,11 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       aws_location = create_aws_location
       postgres_timeline.update(location_id: aws_location.id)
 
+      s3_client = Aws::S3::Client.new(stub_responses: true)
+      s3_client.stub_responses(:list_objects_v2, {contents: []})
+      s3_client.stub_responses(:delete_bucket)
+      allow(postgres_timeline).to receive(:blob_storage_client).and_return(s3_client)
+
       iam_client = Aws::IAM::Client.new(stub_responses: true)
       expect(postgres_timeline.location.location_credential_aws).to receive(:iam_client).and_return(iam_client).at_least(:once)
       expect(postgres_timeline.location.location_credential_aws).to receive(:aws_iam_account_id).and_return("123456789012")
@@ -240,6 +245,11 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
     it "destroy_blob_storage ignores NoSuchEntity error" do
       aws_location = create_aws_location
       postgres_timeline.update(location_id: aws_location.id)
+
+      s3_client = Aws::S3::Client.new(stub_responses: true)
+      s3_client.stub_responses(:list_objects_v2, {contents: []})
+      s3_client.stub_responses(:delete_bucket)
+      allow(postgres_timeline).to receive(:blob_storage_client).and_return(s3_client)
 
       iam_client = Aws::IAM::Client.new(stub_responses: true)
       expect(postgres_timeline.location.location_credential_aws).to receive(:iam_client).and_return(iam_client).at_least(:once)
@@ -491,12 +501,32 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
         postgres_timeline.update(location_id: aws_location.id)
       end
 
-      it "destroys blob storage and postgres timeline" do
+      it "empties and deletes the bucket, then destroys blob storage and timeline" do
+        s3_client = Aws::S3::Client.new(stub_responses: true)
+        s3_client.stub_responses(:list_objects_v2, {contents: [{key: "basebackups_005/backup"}]}, {contents: []})
+        s3_client.stub_responses(:delete_objects)
+        s3_client.stub_responses(:delete_bucket)
+        allow(nx.postgres_timeline).to receive(:blob_storage_client).and_return(s3_client)
+
         iam_client.stub_responses(:delete_user)
         iam_client.stub_responses(:list_attached_user_policies, attached_policies: [{policy_arn: "arn:aws:iam::aws:policy/AmazonS3FullAccess"}])
         iam_client.stub_responses(:delete_policy)
         iam_client.stub_responses(:list_access_keys, access_key_metadata: [{access_key_id: "access-key"}])
         iam_client.stub_responses(:delete_access_key)
+        expect(nx.postgres_timeline.location.location_credential_aws).to receive(:iam_client).and_return(iam_client).at_least(:once)
+
+        expect { nx.destroy }.to exit({"msg" => "postgres timeline is deleted"})
+        expect(postgres_timeline).not_to exist
+      end
+
+      it "ignores a missing bucket (NoSuchBucket) during teardown" do
+        s3_client = Aws::S3::Client.new(stub_responses: true)
+        s3_client.stub_responses(:list_objects_v2, "NoSuchBucket")
+        allow(nx.postgres_timeline).to receive(:blob_storage_client).and_return(s3_client)
+
+        iam_client.stub_responses(:delete_user)
+        iam_client.stub_responses(:list_attached_user_policies, attached_policies: [])
+        iam_client.stub_responses(:list_access_keys, access_key_metadata: [])
         expect(nx.postgres_timeline.location.location_credential_aws).to receive(:iam_client).and_return(iam_client).at_least(:once)
 
         expect { nx.destroy }.to exit({"msg" => "postgres timeline is deleted"})


### PR DESCRIPTION
aws_destroy_blob_storage only tore down IAM, not the bucket, so every AWS
timeline leaked an S3 bucket.
The gcp variant already deletes its bucket; this makes AWS match.

The destroy path runs at the timeline self-destruct (orphaned + no backups +
>10 days old).

