### PR TITLE
Don't fail daemonizer2 clean if state is NotStarted

### DIFF
--- a/rhizome/common/bin/daemonizer2
+++ b/rhizome/common/bin/daemonizer2
@@ -25,7 +25,7 @@ def clean(name, stdin_path)
   state = get_state(name)
   begin
     case state
-    when "InProgress", "Unknown", "NotStarted"
+    when "InProgress", "Unknown"
       fail "Cleanup is only allowed when the service is in a Succeeded, Failed, or NotStarted state"
     when "Succeeded"
       r "sudo systemctl stop #{name}.service"


### PR DESCRIPTION
This makes d_clean idempotent and is useful for cases where a label is retried for other reasons.

Also, the failure message said clean is allowed when state is NotStarted, which didn't match the previous behaviour.