### PR TITLE
Scale default max_wal_size to 4% of storage size with 5GB minimum and 256GB maximum.

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -51,7 +51,7 @@ class PostgresServer < Sequel::Model
       "max_parallel_workers_per_gather" => "2",
       "max_parallel_maintenance_workers" => "2",
       "min_wal_size" => "80MB",
-      "max_wal_size" => "5GB",
+      "max_wal_size" => "#{(storage_size_gib * 4 / 100).clamp(5, 256)}GB",
       "wal_keep_size" => "96MB",
       "wal_compression" => "lz4",
       "default_toast_compression" => "lz4",

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -159,6 +159,21 @@ RSpec.describe PostgresServer do
       expect(postgres_server.configure_hash[:configs]).to include("wal_compression" => "lz4", "default_toast_compression" => "lz4")
     end
 
+    it "sets max_wal_size to 4% of storage" do
+      allow(postgres_server).to receive(:storage_size_gib).and_return(1875)
+      expect(postgres_server.configure_hash[:configs]).to include("max_wal_size" => "75GB")
+    end
+
+    it "caps max_wal_size at 256GB for large-storage instances" do
+      allow(postgres_server).to receive(:storage_size_gib).and_return(7500)
+      expect(postgres_server.configure_hash[:configs]).to include("max_wal_size" => "256GB")
+    end
+
+    it "floors max_wal_size at 5GB for small-storage instances" do
+      allow(postgres_server).to receive(:storage_size_gib).and_return(32)
+      expect(postgres_server.configure_hash[:configs]).to include("max_wal_size" => "5GB")
+    end
+
     it "sets strict_overcommit to true by default" do
       expect(postgres_server.configure_hash[:strict_overcommit]).to be true
     end


### PR DESCRIPTION
Small max_wal_size with full_page_write triggers checkpoints spiral
under heavy workload. More frequent checkpoints cause more full page
writes, which hit max_wal_size faster and trigger even more checkpoints.

This change shows 25-35% max throughput increase for TPC-C and pgbench
with sync HA enabled and high cache hit ratio.