### PR TITLE
Complete AWS GuardDuty VPC setup

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -188,8 +188,11 @@ class PostgresResource < Sequel::Model
   PG_FIREWALL_RULE_PORT_RANGES = [Sequel.pg_range(5432..5432), Sequel.pg_range(6432..6432)].freeze
 
   def internal_firewall_rules
-    Config.control_plane_outbound_cidrs.map { {cidr: it, port_range: Sequel.pg_range(22..22)} } +
+    rules = Config.control_plane_outbound_cidrs.map { {cidr: it, port_range: Sequel.pg_range(22..22)} } +
       ([private_subnet.net4.to_s, private_subnet.net6.to_s] + Config.postgres_internal_firewall_cidrs).flat_map { |cidr| PG_FIREWALL_RULE_PORT_RANGES.map { |port_range| {cidr:, port_range:} } }
+    # Allow access to GuardDuty endpoint for AWS logs if enabled in project settings
+    rules += [{cidr: private_subnet.net4.to_s, port_range: Sequel.pg_range(443..443)}] if location.aws? && project.get_ff_aws_cloudwatch_logs
+    rules
   end
 
   def pg_firewall_rules(firewall: customer_firewall)

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -58,6 +58,11 @@ class Prog::Vm::Aws::Nexus < Prog::Base
             "arn:aws:logs:*:*:log-group:/#{vm.name}/postgresql:*",
           ],
         },
+        {
+          Effect: "Allow",
+          Action: "guardduty:SendSecurityTelemetry",
+          Resource: "*",
+        },
       ],
     }.to_json
 

--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -146,6 +146,25 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
     rescue Aws::EC2::Errors::ResourceAlreadyAssociated
     end
 
+    hop_create_guardduty_endpoint
+  end
+
+  label def create_guardduty_endpoint
+    hop_wait unless private_subnet.project.get_ff_aws_cloudwatch_logs
+
+    unless guardduty_endpoint
+      client.create_vpc_endpoint({
+        vpc_endpoint_type: "Interface",
+        vpc_id: private_subnet_aws_resource.vpc_id,
+        service_name: guardduty_service_name,
+        subnet_ids: private_subnet_aws_resource.aws_subnets.map(&:subnet_id),
+        security_group_ids: [private_subnet_aws_resource.security_group_id],
+        private_dns_enabled: true,
+        tag_specifications: Util.aws_tag_specifications("vpc-endpoint", private_subnet.name),
+        client_token: private_subnet.id,
+      })
+    end
+
     hop_wait
   end
 
@@ -172,6 +191,10 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
     private_subnet.remove_all_firewalls
 
     hop_finish unless private_subnet_aws_resource
+
+    if (endpoint = guardduty_endpoint)
+      client.delete_vpc_endpoints({vpc_endpoint_ids: [endpoint.vpc_endpoint_id]})
+    end
 
     begin
       ignore_invalid_id do
@@ -266,5 +289,16 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
 
   def private_subnet_aws_resource
     @private_subnet_aws_resource ||= private_subnet.private_subnet_aws_resource
+  end
+
+  def guardduty_service_name
+    "com.amazonaws.#{location.name}.guardduty-data"
+  end
+
+  def guardduty_endpoint
+    client.describe_vpc_endpoints({filters: [
+      {name: "vpc-id", values: [private_subnet_aws_resource.vpc_id]},
+      {name: "service-name", values: [guardduty_service_name]},
+    ]}).vpc_endpoints.first
   end
 end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -84,6 +84,25 @@ RSpec.describe PostgresResource do
     )
   end
 
+  context "when on AWS with the aws_cloudwatch_logs flag" do
+    let(:location_id) {
+      Location.create(name: "us-west-2", provider: "aws", project_id: project.id, display_name: "aws-us-west-2", ui_name: "aws-us-west-2", visible: true).id
+    }
+
+    before { postgres_resource.update(private_subnet_id: private_subnet.id) }
+
+    it "adds a 443 internal rule for the guardduty endpoint when the flag is enabled" do
+      project.set_ff_aws_cloudwatch_logs(true)
+      rendered = postgres_resource.internal_firewall_rules.map { "#{it[:cidr]}:#{it[:port_range].to_range}" }
+      expect(rendered).to include("#{private_subnet.net4}:443..443")
+    end
+
+    it "omits the 443 rule when the flag is disabled" do
+      rendered = postgres_resource.internal_firewall_rules.map { "#{it[:cidr]}:#{it[:port_range].to_range}" }
+      expect(rendered).not_to include("#{private_subnet.net4}:443..443")
+    end
+  end
+
   it "client_ca_certificates is nil while either client_root_cert_1 or client_root_cert_2 also nil" do
     postgres_resource.update(client_root_cert_1: "1", client_root_cert_2: "2")
     expect(postgres_resource.client_ca_certificates).not_to be_nil

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -212,6 +212,11 @@ usermod -L ubuntu
                 "arn:aws:logs:*:*:log-group:/#{vm.name}/postgresql:*",
               ],
             },
+            {
+              Effect: "Allow",
+              Action: "guardduty:SendSecurityTelemetry",
+              Resource: "*",
+            },
           ],
         }.to_json,
         tags: Util.aws_tags("#{vm.name}-cw-agent-policy"),

--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -243,18 +243,53 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
   describe "#associate_az_route_tables" do
     let(:az_a) { location.location_azs_dataset.where(az: "a").first }
 
-    it "associates route tables for all subnets and hops to wait" do
+    it "associates route tables for all subnets and hops to create_guardduty_endpoint" do
       expect(client).to receive(:associate_route_table).with({
         route_table_id: "rtb-0123456789abcdefg",
         subnet_id: "subnet-0123456789abcdefg",
       }).and_call_original
       client.stub_responses(:associate_route_table)
-      expect { nx.associate_az_route_tables }.to hop("wait")
+      expect { nx.associate_az_route_tables }.to hop("create_guardduty_endpoint")
     end
 
     it "ignores ResourceAlreadyAssociated errors" do
       client.stub_responses(:associate_route_table, Aws::EC2::Errors::ResourceAlreadyAssociated.new(nil, nil))
-      expect { nx.associate_az_route_tables }.to hop("wait")
+      expect { nx.associate_az_route_tables }.to hop("create_guardduty_endpoint")
+    end
+  end
+
+  describe "#create_guardduty_endpoint" do
+    it "hops to wait without creating an endpoint when the feature flag is off" do
+      expect(client).not_to receive(:create_vpc_endpoint)
+      expect { nx.create_guardduty_endpoint }.to hop("wait")
+    end
+
+    context "when the aws_cloudwatch_logs feature flag is on" do
+      before { nx.private_subnet.project.set_ff_aws_cloudwatch_logs(true) }
+
+      it "creates the guardduty-data interface endpoint and hops to wait" do
+        client.stub_responses(:describe_vpc_endpoints, vpc_endpoints: [])
+        client.stub_responses(:create_vpc_endpoint, vpc_endpoint: {vpc_endpoint_id: "vpce-0123456789abcdefg"})
+        # 443 ingress is provided via the postgres internal firewall, not added here
+        expect(client).not_to receive(:authorize_security_group_ingress)
+        expect(client).to receive(:create_vpc_endpoint).with({
+          vpc_endpoint_type: "Interface",
+          vpc_id: "vpc-0123456789abcdefg",
+          service_name: "com.amazonaws.us-west-2.guardduty-data",
+          subnet_ids: ["subnet-0123456789abcdefg"],
+          security_group_ids: ["sg-0123456789abcdefg"],
+          private_dns_enabled: true,
+          tag_specifications: Util.aws_tag_specifications("vpc-endpoint", ps.name),
+          client_token: ps.id,
+        }).and_call_original
+        expect { nx.create_guardduty_endpoint }.to hop("wait")
+      end
+
+      it "skips creation when the endpoint already exists" do
+        client.stub_responses(:describe_vpc_endpoints, vpc_endpoints: [{vpc_endpoint_id: "vpce-existing"}])
+        expect(client).not_to receive(:create_vpc_endpoint)
+        expect { nx.create_guardduty_endpoint }.to hop("wait")
+      end
     end
   end
 
@@ -271,6 +306,7 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
   describe "#destroy" do
     before {
       allow(Clog).to receive(:emit).and_call_original
+      client.stub_responses(:describe_vpc_endpoints, vpc_endpoints: [])
     }
 
     it "extends deadline if a vm prevents destroy" do
@@ -300,6 +336,14 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
     it "deletes the security group and hops to delete_internet_gateway" do
       client.stub_responses(:delete_security_group)
       expect(client).to receive(:delete_security_group).with({group_id: "sg-0123456789abcdefg"}).and_call_original
+      expect { nx.destroy }.to hop("delete_internet_gateway")
+    end
+
+    it "deletes the guardduty endpoint before the security group when present" do
+      client.stub_responses(:describe_vpc_endpoints, vpc_endpoints: [{vpc_endpoint_id: "vpce-0123456789abcdefg"}])
+      client.stub_responses(:delete_vpc_endpoints)
+      client.stub_responses(:delete_security_group)
+      expect(client).to receive(:delete_vpc_endpoints).with({vpc_endpoint_ids: ["vpce-0123456789abcdefg"]}).and_call_original
       expect { nx.destroy }.to hop("delete_internet_gateway")
     end
 


### PR DESCRIPTION
## Add guardduty-data VPC endpoint to AWS subnets
GuardDuty Runtime Monitoring needs the agent in the Postgres image to
reach the regional guardduty-data endpoint, which our private subnets
lack. When aws_cloudwatch_logs is set, create the interface endpoint
across the subnet's AZs and delete it on teardown.

## AWS Postgres open 443 to the GuardDuty endpoint
The endpoint shares the subnet security group, and UpdateFirewallRules
revokes any rule not in the firewall definition. Add 443 to the Postgres
internal firewall rules so the reconcile keeps it.

## Grant guardduty:SendSecurityTelemetry to AWS VMs
The runtime agent authenticates to the endpoint with the instance role,
which previously allowed only CloudWatch Logs. Grant it unconditionally
since the permission is inert without GuardDuty.