### PR TITLE
Guard against missing installation in workflow_job webhook

### DIFF
--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -51,7 +51,8 @@ class Clover
   end
 
   def handle_workflow_job(data)
-    unless (installation = GithubInstallation.with_github_installation_id(data["installation"]["id"]))
+    unless (installation_id = data.dig("installation", "id")) && (installation = GithubInstallation.with_github_installation_id(installation_id))
+      Clog.emit("Unregistered installation", {unregistered_installation: {installation_id:, repository_name: data.dig("repository", "full_name")}})
       return error("Unregistered installation")
     end
 

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -67,7 +67,16 @@ RSpec.describe Clover, "github" do
 
   context "when workflow_job event" do
     it "fails if installation not exists" do
+      expect(Clog).to receive(:emit).with("Unregistered installation", instance_of(Hash)).and_call_original
       send_webhook("workflow_job", workflow_job_payload(action: "queued", installation_id: 789))
+
+      expect(page.status_code).to eq(200)
+      expect(page.body).to eq({error: {message: "Unregistered installation"}}.to_json)
+    end
+
+    it "fails if installation is missing from the payload" do
+      expect(Clog).to receive(:emit).with("Unregistered installation", instance_of(Hash)).and_call_original
+      send_webhook("workflow_job", workflow_job_payload(action: "queued").except(:installation))
 
       expect(page.status_code).to eq(200)
       expect(page.body).to eq({error: {message: "Unregistered installation"}}.to_json)


### PR DESCRIPTION
A workflow_job payload can arrive without an installation key, which made data["installation"]["id"] raise NoMethodError. The resulting 500 is recorded by GitHub as a failed delivery, so Prog::RedeliverGithubFailures keeps re-posting it every cycle, amplifying the exceptions instead of letting them die out.

Read the id with dig so a missing key yields nil, short-circuit before the lookup to avoid a needless query on a nil id, and log the unregistered installation with its repository name for triage. The request now returns 200, so the delivery is no longer redelivered.