### PR TITLE
Qualify MachineImage admin label with its location

### DIFF
--- a/model/machine_image/machine_image.rb
+++ b/model/machine_image/machine_image.rb
@@ -12,6 +12,10 @@ class MachineImage < Sequel::Model
 
   dataset_module Pagination
 
+  def admin_label
+    "#{name} (#{display_location})"
+  end
+
   def display_location
     location.display_name
   end

--- a/spec/model/machine_image/machine_image_spec.rb
+++ b/spec/model/machine_image/machine_image_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe MachineImage do
+  describe "#admin_label" do
+    it "qualifies the name with the location's display name" do
+      project = Project.create(name: "p")
+      mi = described_class.create(name: "ubuntu-noble", arch: "x64", project_id: project.id, location_id: Location::HETZNER_FSN1_ID)
+      expect(mi.admin_label).to eq("ubuntu-noble (#{Location[Location::HETZNER_FSN1_ID].display_name})")
+    end
+  end
+end


### PR DESCRIPTION
Machine image names are only unique per (project, location), so a list of machine images in the admin UI can show two rows with the same label. Override admin_label to render "name (location_display_name)" so operators can tell them apart.