### PR TITLE
Default `recovery_init_sync_method` to `syncfs`

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -55,6 +55,7 @@ class PostgresServer < Sequel::Model
       "wal_keep_size" => "96MB",
       "wal_compression" => "lz4",
       "default_toast_compression" => "lz4",
+      "recovery_init_sync_method" => "syncfs",
       "random_page_cost" => "1.1",
       "effective_cache_size" => "#{vm.memory_gib * 1024 * 3 / 4}MB",
       "effective_io_concurrency" => "200",

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -174,6 +174,10 @@ RSpec.describe PostgresServer do
       expect(postgres_server.configure_hash[:configs]).to include("max_wal_size" => "5GB")
     end
 
+    it "sets recovery_init_sync_method to syncfs" do
+      expect(postgres_server.configure_hash[:configs]).to include("recovery_init_sync_method" => "syncfs")
+    end
+
     it "sets strict_overcommit to true by default" do
       expect(postgres_server.configure_hash[:strict_overcommit]).to be true
     end

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show-default-config.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show-default-config.txt
@@ -26,6 +26,7 @@ max_parallel_workers_per_gather=2
 max_wal_size=5GB
 min_wal_size=80MB
 random_page_cost=1.1
+recovery_init_sync_method=syncfs
 shared_buffers=2048MB
 shared_preload_libraries='pg_cron,pg_stat_statements'
 ssl=on


### PR DESCRIPTION
`/dat` is a dedicated ext4 filesystem on AWS, GCP, and metal, so syncfs is equivalent to per-file fsync at recovery start but completes in one syscall per filesystem instead of O(N files). Shortens crash recovery and backup restore on large clusters.