### PR TITLE
Fix N+1 queries in KubernetesCluster node/vm accessors

### DIFF
--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -93,9 +93,9 @@ class KubernetesCluster < Sequel::Model
   end
 
   def vm_diff_for_lb(load_balancer)
-    worker_vms = nodepools.flat_map(&:vms)
+    worker_vms = nodepools(eager: :vms).flat_map(&:vms)
     worker_vm_ids = worker_vms.map(&:id).to_set
-    lb_vms = load_balancer.load_balancer_vms.map(&:vm)
+    lb_vms = load_balancer.load_balancer_vms(eager: :vm).map(&:vm)
     lb_vm_ids = lb_vms.map(&:id).to_set
 
     extra_vms = lb_vms.reject { |vm| worker_vm_ids.include?(vm.id) }
@@ -127,7 +127,7 @@ class KubernetesCluster < Sequel::Model
   def cluster_health_report
     return unless connectivity_check_target
 
-    nodepools.flat_map(&:nodes).map do |kd|
+    nodepools(eager: :nodes).flat_map(&:nodes).map do |kd|
       pod_name = client.kubectl(
         "get pods -n ubicsi --field-selector spec.nodeName=:nodename -o jsonpath='{.items[*].metadata.name}'",
         nodename: kd.name,
@@ -182,11 +182,11 @@ class KubernetesCluster < Sequel::Model
   end
 
   def all_nodes
-    nodes + nodepools.flat_map(&:nodes)
+    nodes + nodepools(eager: :nodes).flat_map(&:nodes)
   end
 
   def all_functional_nodes
-    functional_nodes + nodepools.flat_map(&:functional_nodes)
+    functional_nodes + nodepools(eager: :functional_nodes).flat_map(&:functional_nodes)
   end
 
   def all_functional_nodes_ready?
@@ -200,15 +200,15 @@ class KubernetesCluster < Sequel::Model
   end
 
   def worker_vms
-    nodepools.flat_map(&:vms)
+    nodepools(eager: :vms).flat_map(&:vms)
   end
 
   def worker_functional_nodes
-    nodepools.flat_map(&:functional_nodes)
+    nodepools(eager: :functional_nodes).flat_map(&:functional_nodes)
   end
 
   def worker_mesh_nodes
-    nodepools.flat_map(&:mesh_nodes)
+    nodepools(eager: :mesh_nodes).flat_map(&:mesh_nodes)
   end
 
   def ready_for_upgrade?

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -691,6 +691,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
     let(:first_ssh_key) { SshKey.generate }
     let(:second_vm) { Prog::Vm::Nexus.assemble_with_sshable(customer_project.id).subject }
     let(:second_ssh_key) { SshKey.generate }
+    let(:worker_mesh_nodes) { kubernetes_cluster.worker_mesh_nodes }
 
     before do
       KubernetesNode.create(vm_id: first_vm.id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id, created_at: Time.now - 1)
@@ -699,8 +700,8 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
     end
 
     it "creates full mesh connectivity on cluster worker nodes" do
-      first_sshable = kubernetes_cluster.worker_mesh_nodes.first.vm.sshable
-      second_sshable = kubernetes_cluster.worker_mesh_nodes.last.vm.sshable
+      first_sshable = worker_mesh_nodes.first.vm.sshable
+      second_sshable = worker_mesh_nodes.last.vm.sshable
 
       expect(first_sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: first_ssh_key.private_key)
       first_vm_authorized_keys = [first_sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n") + "\n"
@@ -716,11 +717,11 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
     it "keeps draining nodes in the mesh so in-flight CSI migrations don't lose ssh access" do
       kubernetes_cluster.nodepools.first.nodes.last.update(state: "draining")
 
-      first_vm = kubernetes_cluster.worker_mesh_nodes.first.vm
-      second_vm = kubernetes_cluster.worker_mesh_nodes.last.vm
+      first_vm = worker_mesh_nodes.first.vm
+      second_vm = worker_mesh_nodes.last.vm
 
       expect(kubernetes_cluster.worker_functional_nodes.map(&:vm)).to eq [first_vm]
-      expect(kubernetes_cluster.worker_mesh_nodes.map(&:vm)).to eq [first_vm, second_vm]
+      expect(worker_mesh_nodes.map(&:vm)).to eq [first_vm, second_vm]
 
       expect(first_vm.sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: first_ssh_key.private_key)
       first_vm_authorized_keys = [first_vm.sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n") + "\n"


### PR DESCRIPTION
The worker_vms, worker_functional_nodes, worker_mesh_nodes, all_nodes, all_functional_nodes, vm_diff_for_lb, and cluster_health_report methods loaded each nodepool's child nodes/vms with a separate query per nodepool. Eager-load the nested association so the children are fetched in a single batch query. Also eager-load the vm for each load_balancer_vm in vm_diff_for_lb.

Cache worker_mesh_nodes in specs.