### PR TITLE
Delete inline role policies when destroying AWS VMs

### DIFF
--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -367,6 +367,15 @@ class Prog::Vm::Aws::Nexus < Prog::Base
       end
     end
 
+    # Inline policies block delete_role, so drop them before deleting the role.
+    ignore_invalid_entity do
+      iam_client.list_role_policies(role_name:).policy_names.each do |policy_name|
+        ignore_invalid_entity do
+          iam_client.delete_role_policy(role_name:, policy_name:)
+        end
+      end
+    end
+
     ignore_invalid_entity do
       iam_client.delete_role({role_name:})
     end

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -969,5 +969,23 @@ usermod -L ubuntu
           a_hash_including(operation_name: :delete_role, params: {role_name: "testvm"}),
         ))
     end
+
+    it "deletes inline role policies before deleting the role" do
+      iam_client.stub_responses(:list_policies, policies: [])
+      iam_client.stub_responses(:remove_role_from_instance_profile, {})
+      iam_client.stub_responses(:delete_instance_profile, {})
+      iam_client.stub_responses(:list_role_policies, policy_names: ["guardduty-telemetry", "extra-inline"])
+      iam_client.stub_responses(:delete_role_policy, {})
+      iam_client.stub_responses(:delete_role, {})
+
+      expect { nx.cleanup_roles }
+        .to exit({"msg" => "vm destroyed"})
+        .and change(iam_client, :api_requests)
+        .to(include(
+          a_hash_including(operation_name: :delete_role_policy, params: {role_name: "testvm", policy_name: "guardduty-telemetry"}),
+          a_hash_including(operation_name: :delete_role_policy, params: {role_name: "testvm", policy_name: "extra-inline"}),
+          a_hash_including(operation_name: :delete_role, params: {role_name: "testvm"}),
+        ))
+    end
   end
 end


### PR DESCRIPTION
Vm::Aws::Nexus#cleanup_roles detached managed policies and deleted the role, but never removed inline role policies, so delete_role failed with DeleteConflict when a role still had one (e.g. a backfilled guardduty telemetry policy). Delete the role's inline policies first.