### PR TITLE
Clear R2 credentials when destroying blob storage fails

### DIFF
--- a/model/github/github_repository.rb
+++ b/model/github/github_repository.rb
@@ -57,10 +57,11 @@ class GithubRepository < Sequel::Model
 
     begin
       CloudflareClient.new(Config.github_cache_blob_storage_api_key).delete_token(access_key)
-      this.update(access_key: nil, secret_key: nil)
     rescue Excon::Error::HTTPStatus
       Clog.emit("Repository credentials failed to delete Cloudflare token", {failed_cloudflare_token_delete: {bucket_name:}})
     end
+
+    this.update(access_key: nil, secret_key: nil)
   end
 
   def setup_blob_storage

--- a/spec/model/github/github_repository_spec.rb
+++ b/spec/model/github/github_repository_spec.rb
@@ -58,13 +58,13 @@ RSpec.describe GithubRepository do
       expect(github_repository.reload.access_key).to be_nil
     end
 
-    it "succeed if can not delete token" do
+    it "clears the credentials even if it can not delete the token" do
       expect(blob_storage_client).to receive(:list_multipart_uploads).and_return(uploads)
       expect(blob_storage_client).to receive(:abort_multipart_upload).with(bucket: github_repository.bucket_name, key: "test-key", upload_id: "test-upload-id")
       expect(blob_storage_client).to receive(:delete_bucket).with(bucket: github_repository.bucket_name)
       expect(cloudflare_client).to receive(:delete_token).with(github_repository.access_key).and_raise(Excon::Error::HTTPStatus.new("Expected(200) <=> Actual(520 Unknown)", nil, Excon::Response.new(body: "foo")))
       github_repository.destroy_blob_storage
-      expect(github_repository.reload.access_key).to eq("my-token-id")
+      expect(github_repository.reload.access_key).to be_nil
     end
   end
 


### PR DESCRIPTION
We have seen recurring ~3s 503s on POST /runtime/github/caches (reserveCache) for specific repositories. The cache action returns "Could not authorize multipart upload" after exhausting its retry loop, and it repeats on every job for the affected repository.

The cause is a desync between the credentials stored on the repository and the actual state in Cloudflare R2.
GithubRepository#destroy_blob_storage is called from cleanup_cache to reclaim a bucket that has been empty for seven days; the repository row lives on afterwards. It deletes the bucket, then deletes the Cloudflare token and clears access_key/secret_key:

  begin
    CloudflareClient.new(...).delete_token(access_key)
    this.update(access_key: nil, secret_key: nil)
  rescue Excon::Error::HTTPStatus
    Clog.emit("Repository credentials failed to delete ...")
  end

When delete_token raises (a Cloudflare hiccup, 5xx, or rate limit), the rescue swallows it and the update is skipped, leaving access_key set even though the bucket is already gone. On the next job, reserveCache runs "setup_blob_storage unless access_key", so it skips re-provisioning and calls create_multipart_upload against the missing bucket, which fails with NoSuchBucket/Unauthorized. Nothing ever clears access_key, so the repository is stuck failing every cache request until it is destroyed.

Clear the credentials unconditionally once the bucket teardown has been attempted. The stored credentials are dead at that point, so leaving them set is strictly worse than dropping them: the next job re-provisions a fresh bucket and token. An orphaned Cloudflare token is a minor, logged leak by comparison.

This prevents new occurrences but does not retroactively clear repositories already stuck in this state; those are handled by a separate one-off cleanup.