### PR TITLE
Do not add a private_hostname for load balancers with a custom hostname

### DIFF
--- a/model/load_balancer.rb
+++ b/model/load_balancer.rb
@@ -175,14 +175,20 @@ class LoadBalancer < Sequel::Model
   end
 
   def cert_hostname
+    if (hostname = custom_hostname)
+      return hostname
+    end
+
     if hostname_version == 2
       "*.#{ubid}.#{domain}"
     else
-      hostname
+      self.hostname
     end
   end
 
   def private_hostname
+    return if custom_hostname
+
     if hostname_version == 2
       "#{name}.#{ubid}.private.#{domain}"
     else
@@ -191,6 +197,8 @@ class LoadBalancer < Sequel::Model
   end
 
   def cert_private_hostname
+    return if custom_hostname
+
     if hostname_version == 2
       "*.#{ubid}.private.#{domain}"
     else

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -179,35 +179,36 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
         # Insert IPv4 record if stack is ipv4 or dual, and vm has IPv4
         if load_balancer.ipv4_enabled?
           if vm.ip4_string
-            ip_info << [vm.ip4_string, "A", hostname]
+            ip_info << [vm.ip4_string, "A", hostname, dns_zone]
           elsif vm.ip4_enabled
             # VM will have a public IPv4 address, but it is not assigned yet
             nap 5
           end
-          ip_info << [vm.private_ipv4_string, "A", private_hostname]
+          ip_info << [vm.private_ipv4_string, "A", private_hostname, private_dns_zone]
         end
 
         if load_balancer.ipv6_enabled?
           if vm.ip6_string
-            ip_info << [vm.ip6_string, "AAAA", hostname]
+            ip_info << [vm.ip6_string, "AAAA", hostname, dns_zone]
           else
             # VM public IPv6 address not assigned yet
             nap 5
           end
-          ip_info << [vm.private_ipv6_string, "AAAA", private_hostname]
+          ip_info << [vm.private_ipv6_string, "AAAA", private_hostname, private_dns_zone]
         end
       end
 
       dns_zone.delete_record(record_name: hostname)
-      private_dns_zone.delete_record(record_name: private_hostname)
-      ip_info.each do |data, type, record_name|
-        zone = (record_name == private_hostname) ? private_dns_zone : dns_zone
-        zone.insert_record(
-          record_name:,
-          type:,
-          ttl: 10,
-          data:,
-        )
+      private_dns_zone.delete_record(record_name: private_hostname) if private_hostname
+      ip_info.each do |data, type, record_name, zone|
+        if record_name
+          zone.insert_record(
+            record_name:,
+            type:,
+            ttl: 10,
+            data:,
+          )
+        end
       end
     end
 

--- a/spec/model/load_balancer_spec.rb
+++ b/spec/model/load_balancer_spec.rb
@@ -61,9 +61,8 @@ RSpec.describe LoadBalancer do
       )
     end
 
-    it "uses custom_hostname if available for v1 certs" do
+    it "uses custom_hostname if available" do
       lb.custom_hostname = "foo.example.com"
-      lb.hostname_version = 1
       expect(lb.cert_hostname).to eq "foo.example.com"
     end
 
@@ -83,10 +82,10 @@ RSpec.describe LoadBalancer do
       )
     end
 
-    it "ignores custom_hostname" do
+    it "nil for custom_hostname" do
       lb.custom_hostname = "foo.example.com"
       lb.hostname_version = 1
-      expect(lb.private_hostname).to eq("private.test-lb.#{lb.private_subnet.ubid[-5...]}.lb.ubicloud.com")
+      expect(lb.private_hostname).to be_nil
     end
 
     it "based on hostname version" do
@@ -105,10 +104,9 @@ RSpec.describe LoadBalancer do
       )
     end
 
-    it "ignores custom_hostname if available for v1 certs" do
+    it "nil for custom_hostname" do
       lb.custom_hostname = "foo.example.com"
-      lb.hostname_version = 1
-      expect(lb.cert_private_hostname).to eq("private.test-lb.#{lb.private_subnet.ubid[-5...]}.lb.ubicloud.com")
+      expect(lb.cert_private_hostname).to be_nil
     end
 
     it "based on hostname version" do

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -309,38 +309,41 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
     ["ipv4", "ipv6", "dual"].each do |stack|
       bools.each do |has_pub4|
         bools.each do |has_pub6|
-          # If ipv6 is enabled for this stack but no public ipv6 assigned, code naps
-          expects_nap = ipv6_on[stack] && !has_pub6
+          bools.each do |has_private|
+            # If ipv6 is enabled for this stack but no public ipv6 assigned, code naps
+            expects_nap = ipv6_on[stack] && !has_pub6
 
-          it "#{stack} stack, pub4=#{has_pub4}, pub6=#{has_pub6}" do
-            vm_args = {name: "vm", private_ipv4: "10.0.0.1/32", private_ipv6: "fd10:9b0b:6b4b:8fb2::/64"}
-            vm_args[:public_ipv4] = "203.0.113.1/32" if has_pub4
-            vm_args[:public_ipv6] = "2001:db8:1::/64" if has_pub6
-            add_lb_vm(stack:, **vm_args)
-
-            if expects_nap
-              expect { nx.rewrite_dns_records }.to nap(5)
-              expect(DnsRecord.where(dns_zone_id: dns_zone.id, tombstoned: false).all).to be_empty
-            else
-              expect { nx.rewrite_dns_records }.to hop("wait")
-
-              expected = []
-              if ipv4_on[stack]
-                expected << [:pub, "A", "203.0.113.1"] if has_pub4
-                expected << [:priv, "A", "10.0.0.1"]
-              end
-              if ipv6_on[stack]
-                expected << [:pub, "AAAA", "2001:db8:1::2"] if has_pub6
-                expected << [:priv, "AAAA", "fd10:9b0b:6b4b:8fb2::2"]
-              end
-
+            it "#{stack} stack, pub4=#{has_pub4}, pub6=#{has_pub6}, private=#{has_private}" do
+              vm_args = {name: "vm", private_ipv4: "10.0.0.1/32", private_ipv6: "fd10:9b0b:6b4b:8fb2::/64"}
+              vm_args[:public_ipv4] = "203.0.113.1/32" if has_pub4
+              vm_args[:public_ipv6] = "2001:db8:1::/64" if has_pub6
+              add_lb_vm(stack:, **vm_args)
               hostname = nx.load_balancer.hostname
-              expected_records = expected.map { |prefix, type, data|
-                name = (prefix == :pub) ? hostname : "private.#{hostname}"
-                [name, type, data]
-              }
-              records = dns_records_for(hostname).map { [it.name.chomp("."), it.type, it.data] }.uniq
-              expect(records).to match_array(expected_records)
+              nx.load_balancer.custom_hostname = hostname unless has_private
+
+              if expects_nap
+                expect { nx.rewrite_dns_records }.to nap(5)
+                expect(DnsRecord.where(dns_zone_id: dns_zone.id, tombstoned: false).all).to be_empty
+              else
+                expect { nx.rewrite_dns_records }.to hop("wait")
+
+                expected = []
+                if ipv4_on[stack]
+                  expected << [:pub, "A", "203.0.113.1"] if has_pub4
+                  expected << [:priv, "A", "10.0.0.1"] if has_private
+                end
+                if ipv6_on[stack]
+                  expected << [:pub, "AAAA", "2001:db8:1::2"] if has_pub6
+                  expected << [:priv, "AAAA", "fd10:9b0b:6b4b:8fb2::2"] if has_private
+                end
+
+                expected_records = expected.map { |prefix, type, data|
+                  name = (prefix == :pub) ? hostname : "private.#{hostname}"
+                  [name, type, data]
+                }
+                records = dns_records_for(hostname).map { [it.name.chomp("."), it.type, it.data] }.uniq
+                expect(records).to match_array(expected_records)
+              end
             end
           end
         end
@@ -390,7 +393,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       expect(dns_zone.reload.records.count).to eq(804) # 4 records to tombstone the previous ones and 4 records to add
     end
 
-    it "writes public records to the custom zone and private records to the service zone" do
+    it "writes public records to the custom zone and does not write private records when a custom hostname is used" do
       dns_zone
       custom_zone = DnsZone.create(project_id: ps.project_id, name: "k8s.ubicloud.com")
       lb = described_class.assemble(ps.id, name: "custom-lb", src_port: 80, dst_port: 8080,
@@ -402,7 +405,7 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       expect { custom_nx.rewrite_dns_records }.to hop("wait")
 
       expect(custom_zone.reload.records.map(&:name).uniq).to eq(["apiserver.k8s.ubicloud.com."])
-      expect(dns_zone.reload.records.map(&:name).uniq).to eq(["#{lb.private_hostname}."])
+      expect(dns_zone.reload.records.map(&:name).uniq).to eq([])
     end
   end
 end


### PR DESCRIPTION
Attempting to add a private hostname for load balancers with a custom hostname fails when creating the cert, since it can try to insert the private hostname into the DnsZone for the custom hostname, which does not work.

If we want to support private hostnames for load balancers with custom hostnames, instead of this, we would need to have the CertNexus accept the private dns zone in addition to the public dns zone, and insert the challenge records into the correct zone.

This should fix load balancer setup for AI inference endpoints, which Mohi found was broken after the recent change to add support for hostname version 2 for load balancers.

Best viewed ignoring whitespace.