### PR TITLE
Add admin VmHost usage page

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1352,6 +1352,97 @@ class CloverAdmin < Roda
       view("github_runner_usage")
     end
 
+    r.get "vm-host-usage" do
+      @locations = Location.where(id: VmHost.select(:location_id)).select_order_map([:name, :id]).map { |name, id| [name, UBID.to_ubid(id)] }
+      @archs = %w[x64 arm64]
+      @core_counts = VmHost.exclude(total_cores: nil).distinct.select_order_map(:total_cores)
+      @states = %w[unprepared accepting draining]
+
+      @location_id = typecast_params.ubid("location_id")
+      @arch = typecast_params.nonempty_str("arch")
+      @cores = typecast_params.pos_int("cores")
+      @state = typecast_params.nonempty_str("state")
+
+      unless r.query_string.empty?
+        storage_agg = DB[:storage_device]
+          .select_group(:vm_host_id)
+          .select_append(
+            Sequel.function(:sum, :total_storage_gib).as(:total_storage),
+            Sequel.function(:sum, :available_storage_gib).as(:available_storage),
+          )
+
+        boot_agg = DB[:boot_image]
+          .select_group(:vm_host_id)
+          .select_append(Sequel.function(:count, :name).distinct.as(:image_types))
+
+        vm_agg = DB[:vm]
+          .select_group(:vm_host_id)
+          .select_append(Sequel.function(:count).*.as(:vm_count))
+
+        ip4_agg = DB[:ipv4_address]
+          .join(:address, [:cidr])
+          .left_join(:assigned_vm_address, Sequel[:assigned_vm_address][:ip] => Sequel[:ipv4_address][:ip])
+          .left_join(:assigned_host_address, Sequel[:assigned_host_address][:ip] => Sequel[:ipv4_address][:ip])
+          .select_group(Sequel[:address][:routed_to_host_id])
+          .select_append(
+            Sequel.function(:count).*.as(:total_ip4),
+            Sequel.function(:count).*.filter(Sequel[:assigned_vm_address][:ip] => nil, Sequel[:assigned_host_address][:ip] => nil).as(:available_ip4),
+          )
+
+        vmh = Sequel[:vm_host]
+        vm_host_id = vmh[:id]
+        ds = VmHost
+          .join(Sequel[:location], id: vmh[:location_id])
+          .left_join(storage_agg.as(:sd), vm_host_id:)
+          .left_join(boot_agg.as(:bi), vm_host_id:)
+          .left_join(ip4_agg.as(:ip), routed_to_host_id: vmh[:id])
+          .left_join(vm_agg.as(:vm), vm_host_id:)
+          .select(
+            vmh[:id],
+            Sequel[:location][:name].as(:location),
+            vmh[:allocation_state],
+            vmh[:data_center],
+            vmh[:family],
+            Sequel.function(:coalesce, Sequel[:vm][:vm_count], 0).as(:vm_count),
+            vmh[:used_cores],
+            vmh[:total_cores],
+            vmh[:used_hugepages_1g],
+            vmh[:total_hugepages_1g],
+            Sequel.function(:coalesce, Sequel[:sd][:available_storage], 0).as(:available_storage),
+            Sequel.function(:coalesce, Sequel[:sd][:total_storage], 0).as(:total_storage),
+            Sequel.function(:coalesce, Sequel[:bi][:image_types], 0).as(:image_types),
+            Sequel.function(:coalesce, Sequel[:ip][:available_ip4], 0).as(:available_ip4),
+            Sequel.function(:coalesce, Sequel[:ip][:total_ip4], 0).as(:total_ip4),
+          )
+          .order(Sequel[:location][:name], vmh[:data_center], vmh[:family], vmh[:id])
+
+        ds = ds.where(vmh[:location_id] => UBID.parse(@location_id).to_uuid) if @location_id
+        ds = ds.where(vmh[:arch] => @arch) if @arch
+        ds = ds.where(vmh[:total_cores] => @cores) if @cores
+        ds = ds.where(vmh[:allocation_state] => @state) if @state
+
+        @data = ds.map do |row|
+          used_storage = row[:total_storage] - row[:available_storage]
+          used_ip4 = row[:total_ip4] - row[:available_ip4]
+          {
+            ubid: UBID.to_ubid(row[:id]),
+            location: row[:location],
+            state: row[:allocation_state],
+            datacenter: row[:data_center],
+            family: row[:family],
+            vms: row[:vm_count],
+            cores: "#{row[:used_cores]} / #{row[:total_cores]}",
+            hugepages: "#{row[:used_hugepages_1g]} / #{row[:total_hugepages_1g]}",
+            storage_gib: "#{used_storage} / #{row[:total_storage]}",
+            ip4: "#{used_ip4} / #{row[:total_ip4]}",
+            image_types: row[:image_types],
+          }
+        end
+      end
+
+      view("vm_host_usage")
+    end
+
     r.post "close-admin-account" do
       login = typecast_params.nonempty_str!("login")
 

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -334,3 +334,10 @@ code {
     display: block;
   }
 }
+
+#vm-host-usage-search {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+  align-items: flex-end;
+}

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2838,4 +2838,68 @@ RSpec.describe CloverAdmin do
       expect(audit_log_content).to be_empty
     end
   end
+
+  it "shows VM Host Usage filtered by location" do
+    vm_host = create_vm_host(data_center: "FSN1-DC1", total_cores: 48, used_cores: 4, total_hugepages_1g: 375, used_hugepages_1g: 32)
+    StorageDevice.create(name: "nvme0", total_storage_gib: 1000, available_storage_gib: 600, vm_host_id: vm_host.id)
+    StorageDevice.create(name: "nvme1", total_storage_gib: 500, available_storage_gib: 100, vm_host_id: vm_host.id)
+    BootImage.create(name: "ubuntu-jammy", version: "1", vm_host_id: vm_host.id, size_gib: 14)
+    BootImage.create(name: "ubuntu-jammy", version: "2", vm_host_id: vm_host.id, size_gib: 14)
+    BootImage.create(name: "ubuntu-noble", version: "1", vm_host_id: vm_host.id, size_gib: 14)
+    create_vm(vm_host_id: vm_host.id)
+    create_vm(vm_host_id: vm_host.id)
+
+    # A host in another location that must be excluded by the location filter.
+    create_vm_host(location_id: Location::GITHUB_RUNNERS_ID)
+
+    click_link "VM Host Usage"
+    expect(page.title).to eq "Ubicloud Admin - VM Host Usage"
+
+    # No results are shown until a search is performed.
+    expect(page).to have_no_css(".vm-host-usage-table")
+
+    click_button "Search"
+    headers = page.all(".vm-host-usage-table thead th").map(&:text)
+    expect(headers).to include("location")
+    expect(page.all(".vm-host-usage-table tbody tr").size).to eq 2
+
+    select "hetzner-fsn1", from: "Location"
+    click_button "Search"
+    row = page.all(".vm-host-usage-table tbody tr").map { it.all("td").map(&:text) }
+    expect(row.size).to eq 1
+    expect(row.first).to include(vm_host.ubid, "accepting", "FSN1-DC1", "standard", "2", "4 / 48", "32 / 375", "800 / 1500", "0 / 0", "2")
+  end
+
+  it "filters VM Host Usage by arch, total_cores and state, composing filters" do
+    x64_48 = create_vm_host(arch: "x64", total_cores: 48, allocation_state: "accepting")
+    x64_96 = create_vm_host(arch: "x64", total_cores: 96, allocation_state: "draining")
+    arm_48 = create_vm_host(arch: "arm64", total_cores: 48, allocation_state: "accepting")
+    ubids = lambda { page.all(".vm-host-usage-table tbody tr").map { it.all("td").map(&:text).first } }
+
+    click_link "VM Host Usage"
+    select "arm64", from: "Arch"
+    click_button "Search"
+    expect(ubids.call).to eq([arm_48.ubid])
+
+    visit "/vm-host-usage"
+    select "96", from: "Cores"
+    click_button "Search"
+    expect(ubids.call).to eq([x64_96.ubid])
+
+    visit "/vm-host-usage"
+    select "draining", from: "State"
+    click_button "Search"
+    expect(ubids.call).to eq([x64_96.ubid])
+
+    visit "/vm-host-usage"
+    click_button "Search"
+    expect(ubids.call).to eq([x64_48.ubid, arm_48.ubid, x64_96.ubid].sort)
+
+    # Composed arch + cores + state filter.
+    select "x64", from: "Arch"
+    select "48", from: "Cores"
+    select "accepting", from: "State"
+    click_button "Search"
+    expect(ubids.call).to eq([x64_48.ubid])
+  end
 end

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -50,6 +50,7 @@
     <li><a href="/archived-record-by-id">Find Archived Record by ID</a></li>
     <li><a href="/vm-by-ipv4">Find VM by IPv4 Address</a></li>
     <li><a href="/github-runner-usage">GitHub Runner VM Usage</a></li>
+    <li><a href="/vm-host-usage">VM Host Usage</a></li>
     <li>
       <a href="/audit-log">View Audit Logs</a> |
       <a href="/authentication-audit-log">View Authentication Audit Logs</a> |

--- a/views/admin/vm_host_usage.erb
+++ b/views/admin/vm_host_usage.erb
@@ -1,0 +1,13 @@
+<% @page_title = "VM Host Usage" %>
+
+<% form({id: "vm-host-usage-search"}, wrapper: :div) do |f| %>
+  <%== f.input(:select, key: "location_id", label: "Location", options: @locations, add_blank: "all", value: @location_id) %>
+  <%== f.input(:select, key: "arch", label: "Arch", options: @archs, add_blank: "all", value: @arch) %>
+  <%== f.input(:select, key: "cores", label: "Cores", options: @core_counts, add_blank: "all", value: @cores) %>
+  <%== f.input(:select, key: "state", label: "State", options: @states, add_blank: "all", value: @state) %>
+  <%== f.button("Search") %>
+<% end %>
+
+<% if @data %>
+  <%== part("components/table", title: nil, table_class: "vm-host-usage-table", data: @data, use_admin_label: false) %>
+<% end %>


### PR DESCRIPTION
The admin tools helps to inspect capacity across VM hosts.

Add a "VmHost Usage" page that lists hosts with their allocation state,
location, datacenter, family, VM count, core and hugepage usage, used
storage, used IPv4 addresses, and the number of distinct boot image
types.

Each one-to-many fact (storage devices, boot images, routed IPv4 blocks,
VMs) is pre-aggregated to one row per host and then left-joined, so the
host listing query neither fans out into a cartesian product nor issues
a query per host. The available-IPv4 join mirrors the allocator so the
count matches what scheduling considers usable.

Results are filtered with a select box per location, arch, total cores,
and allocation state, applied with a search button.

<img width="2924" height="1660" alt="CleanShot 2026-06-23 at 09 31 17@2x" src="https://github.com/user-attachments/assets/164f77c3-3fd7-41c7-bb8f-9b9721ceceb7" />
