### PR TITLE
Wake strands on semaphores arriving mid-run

### DIFF
--- a/lib/sem_snap.rb
+++ b/lib/sem_snap.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
 class SemSnap
+  # Semaphore ids present when this snapshot was taken.
+  attr_reader :original_ids
+
   def initialize(strand_id, deferred: false)
     @deferred = deferred
     @strand_id = strand_id
     @extant = Hash.new { |h, k| h[k.intern] = [] }
     @defer_delete = []
+    @original_ids = []
 
     Semaphore.where(strand_id: @strand_id).each do |sem|
       add_semaphore_instance_to_snapshot(sem)
+      @original_ids << sem.id
     end
   end
 

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -230,8 +230,10 @@ SQL
       modified!(:stack)
     end
 
+    observed_semaphore_ids = nil
     DB.transaction do
       SemSnap.use(id) do |snap|
+        observed_semaphore_ids = snap.original_ids
         prg = load(snap)
         prg.public_send(:before_run)
         prg.public_send(label)
@@ -239,10 +241,14 @@ SQL
     rescue Prog::Base::Nap => e
       save_changes
 
-      scheduled = DB[<<SQL, schedule, e.seconds, id].get
+      # Also stay runnable if a semaphore arrived after this run's snapshot.
+      observed = "{#{observed_semaphore_ids.join(",")}}"
+      scheduled = DB[<<SQL, schedule, observed, e.seconds, id].get
 UPDATE strand
 SET try = 0,
-    schedule = CASE WHEN schedule = ? THEN now() + (? * '1 second'::interval)
+    schedule = CASE WHEN schedule = ?
+                     AND NOT EXISTS (SELECT 1 FROM semaphore WHERE strand_id = strand.id AND NOT (id = ANY(?::uuid[])))
+                    THEN now() + (? * '1 second'::interval)
                     ELSE schedule END
 WHERE id = ?
 RETURNING schedule

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -94,6 +94,11 @@ class Prog::Test < Prog::Base
     nap(123)
   end
 
+  label def late_signal_napper
+    Semaphore.incr(strand.id, "late_signal")
+    nap(123)
+  end
+
   label def popper
     pop({msg: "popped"})
   end

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -110,6 +110,16 @@ RSpec.describe Strand do
     end
   end
 
+  it "stays runnable when a semaphore arrives mid-run on an overdue strand" do
+    st.update(label: "late_signal_napper", schedule: Time.now - 100)
+
+    ret = st.unsynchronized_run
+    expect(ret).to be_a(Prog::Base::Nap)
+
+    expect(st.reload.schedule).to be <= Time.now
+    expect(Semaphore.where(strand_id: st.id, name: "late_signal")).not_to be_empty
+  end
+
   it "logs end of strand if it took long" do
     now = Time.now
     st.label = "napper"


### PR DESCRIPTION
Since b45f37c7d, Semaphore.incr advances schedule with LEAST(schedule, now()), so it only interrupts a running strand while the lease's schedule-forward window is still in the future. That window is ps_sch = least(2**least(try,20), 600) * random(), under a second for a freshly hopped (try=0) strand; once it elapses the schedule is overdue, LEAST is a no-op, and the nap's schedule-equality guard overwrites the schedule, dropping the signal until the nap elapses. With a long nap (wait naps 6h) this stranded a Postgres upgrade's planned failover: the takeover candidate sat in wait holding planned_take_over for hours while the old primary stayed fenced, hanging the upgrade past the e2e timeout.

Keep the strand runnable when a semaphore arrived after this run's SemSnap snapshot, independent of the lease window.