### PR TITLE
Archive pry session logs to S3 with Object Lock

### DIFF
--- a/bin/pry
+++ b/bin/pry
@@ -65,7 +65,7 @@ require "socket"
 
 PRY_SESSION = {
   session_id: SecureRandom.uuid,
-  operator: ENV["SUDO_USER"] || ENV["USER"] || "unknown",
+  operator: [ENV["SUDO_USER"], ENV["USER"]].find { !it.to_s.empty? } || "unknown",
   host: Socket.gethostname,
   pid: Process.pid,
 }.freeze
@@ -83,10 +83,11 @@ PRY_LOGGER = if Config.pry_audit_bucket
     retry_limit: 2,
   }
   client_opts[:endpoint] = Config.pry_audit_endpoint if Config.pry_audit_endpoint
+  key_operator = PRY_SESSION[:operator].gsub(/[^A-Za-z0-9._-]/, "_")[0, 64]
   S3AuditBatcher.new(
     client: Aws::S3::Client.new(**client_opts),
     bucket: Config.pry_audit_bucket,
-    key_prefix: "pry/#{Time.now.utc.strftime("%Y-%m-%d")}/#{PRY_SESSION[:operator]}/#{PRY_SESSION[:session_id]}",
+    key_prefix: "pry/#{Time.now.utc.strftime("%Y-%m-%d")}/#{key_operator}/#{PRY_SESSION[:session_id]}",
     retain_until: Time.now + (Config.pry_audit_retention_years * 366 * 24 * 60 * 60),
   )
 end

--- a/bin/pry
+++ b/bin/pry
@@ -5,8 +5,8 @@ REPL = true
 
 require_relative "../loader"
 
-if Config.production? && !Config.is_e2e && Config.ingest_key.nil? && Config.otel_exporter_otlp_endpoint.nil?
-  puts "INGEST_KEY or OTEL_EXPORTER_OTLP_ENDPOINT is not set in production environment. This is not allowed for auditing purposes."
+if Config.production? && !Config.is_e2e && (Config.pry_audit_bucket.nil? || Config.pry_audit_access_key.nil?)
+  puts "PRY_AUDIT_BUCKET/PRY_AUDIT_ACCESS_KEY is not set in production environment. This is not allowed for auditing purposes."
   exit(1)
 end
 
@@ -60,33 +60,54 @@ if Config.development?
   Pry.prepend(PryReloader)
 end
 
-PRY_LOGGER = if Config.ingest_key
-  LogDnaBatcher.new(Config.ingest_key)
-elsif Config.otel_exporter_otlp_endpoint
-  OtelBatcher.new(Config.otel_exporter_otlp_endpoint, default_resource_attrs: {"service.name" => "pry"})
+require "securerandom"
+require "socket"
+
+PRY_SESSION = {
+  session_id: SecureRandom.uuid,
+  operator: ENV["SUDO_USER"] || ENV["USER"] || "unknown",
+  host: Socket.gethostname,
+  pid: Process.pid,
+}.freeze
+
+PRY_LOGGER = if Config.pry_audit_bucket
+  require "aws-sdk-s3"
+  client_opts = {
+    region: Config.pry_audit_region,
+    access_key_id: Config.pry_audit_access_key,
+    secret_access_key: Config.pry_audit_secret_key,
+    request_checksum_calculation: "when_required",
+    response_checksum_validation: "when_required",
+    http_open_timeout: 5,
+    http_read_timeout: 8,
+    retry_limit: 2,
+  }
+  client_opts[:endpoint] = Config.pry_audit_endpoint if Config.pry_audit_endpoint
+  S3AuditBatcher.new(
+    client: Aws::S3::Client.new(**client_opts),
+    bucket: Config.pry_audit_bucket,
+    key_prefix: "pry/#{Time.now.utc.strftime("%Y-%m-%d")}/#{PRY_SESSION[:operator]}/#{PRY_SESSION[:session_id]}",
+    retain_until: Time.now + (Config.pry_audit_retention_years * 366 * 24 * 60 * 60),
+  )
 end
 
 if PRY_LOGGER
+  PRY_LOGGER.log("pry session opened", app: "pry", level: "info", type: "session_open", ssh_connection: ENV["SSH_CONNECTION"], **PRY_SESSION)
+
   module PryLogger
     def evaluate_ruby(code)
       @counter ||= 0
       @counter += 1
 
-      PRY_LOGGER.log("$> #{code.strip}", app: "pry", level: "info", type: "pry_input", counter: @counter)
+      PRY_LOGGER.log("$> #{code.strip}", app: "pry", level: "info", type: "pry_input", counter: @counter, **PRY_SESSION)
 
-      # Evaluate and capture result
       begin
         result = super
-
-        # Log output
-        output = result.inspect
-        truncate_limit = Config.pry_logger_truncate_limit
-        output = "#{output[0..truncate_limit]}..." if output.length > truncate_limit
-        PRY_LOGGER.log(output, app: "pry", level: "info", type: "pry_output", counter: @counter)
-
+        # Full, untruncated output: this is the compliance system of record.
+        PRY_LOGGER.log(result.inspect, app: "pry", level: "info", type: "pry_output", counter: @counter, **PRY_SESSION)
         result
       rescue => e
-        PRY_LOGGER.log("#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}", app: "pry", level: "error", type: "eval_error", counter: @counter)
+        PRY_LOGGER.log("#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}", app: "pry", level: "error", type: "eval_error", counter: @counter, **PRY_SESSION)
         raise
       end
     end

--- a/config.rb
+++ b/config.rb
@@ -197,7 +197,14 @@ module Config
   optional :database_logger_level, string
   optional :ingest_key, string, clear: true
   optional :otel_exporter_otlp_endpoint, string
-  override :pry_logger_truncate_limit, 500, int
+
+  # Pry audit archive (S3 Object Lock, Compliance mode)
+  optional :pry_audit_bucket, string
+  optional :pry_audit_region, string
+  optional :pry_audit_endpoint, string
+  optional :pry_audit_access_key, string, clear: true
+  optional :pry_audit_secret_key, string, clear: true
+  override :pry_audit_retention_years, 6, int
 
   # Ubicloud Images (Minio)
   override :ubicloud_images_bucket_name, "ubicloud-images", string

--- a/lib/s3_audit_batcher.rb
+++ b/lib/s3_audit_batcher.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "json"
+
+# Ships audit log lines to an S3 bucket with Object Lock (Compliance mode),
+# one immutable, write-once object per flushed batch. Fail-closed: repeated
+# write failures exit the process so no unaudited session can continue.
+class S3AuditBatcher
+  def initialize(client:, bucket:, key_prefix:, retain_until:, flush_interval: 0.5, max_batch_size: 5)
+    @client = client
+    @bucket = bucket
+    @key_prefix = key_prefix
+    @retain_until = retain_until
+    @flush_interval = flush_interval
+    @max_batch_size = max_batch_size
+    @input_queue = Queue.new
+    @seq = 0
+    @batch_send_failure_count = 0
+
+    start_processor
+  end
+
+  def log(line, timestamp: (Time.now.to_f * 1000).to_i, app: nil, level: "info", **meta)
+    @input_queue.push({line:, timestamp:, app:, level:, **meta}.compact)
+  end
+
+  def stop
+    @input_queue.close
+    @processor_thread.join(@flush_interval + 5)
+  end
+
+  def send_batch(batch)
+    return if batch.empty?
+
+    begin
+      @client.put_object(
+        bucket: @bucket,
+        key: "#{@key_prefix}/#{format("%06d", @seq)}.jsonl",
+        body: batch.map { JSON.generate(it) }.join("\n"),
+        content_type: "application/x-ndjson",
+        server_side_encryption: "AES256",
+        object_lock_mode: "COMPLIANCE",
+        object_lock_retain_until_date: @retain_until,
+        if_none_match: "*",
+      )
+      @seq += 1
+      batch.clear
+      @batch_send_failure_count = 0
+    rescue => e
+      @batch_send_failure_count += 1
+      puts "Error sending audit batch: #{e.message}"
+    end
+
+    if @batch_send_failure_count >= 5
+      puts "Too many failures sending audit logs, stopping the batcher."
+      exit(1)
+    end
+  end
+
+  private
+
+  def start_processor
+    @processor_thread = Thread.new do
+      batch = []
+      last_flush_time = Time.now
+
+      loop do
+        if (item = @input_queue.pop(timeout: @flush_interval))
+          batch << item
+        end
+
+        input_queue_is_closed = @input_queue.closed? && @input_queue.empty?
+        flush_interval_is_exceeded = (Time.now - last_flush_time) >= @flush_interval
+        max_batch_size_is_exceeded = batch.size >= @max_batch_size
+
+        if input_queue_is_closed || flush_interval_is_exceeded || max_batch_size_is_exceeded
+          send_batch(batch)
+
+          if batch.empty?
+            last_flush_time = Time.now
+            break if input_queue_is_closed
+          end
+        end
+      rescue => e
+        puts "Error in processor: #{e.message}"
+        puts e.backtrace
+        exit(1)
+      end
+    end
+  end
+end

--- a/spec/lib/s3_audit_batcher_spec.rb
+++ b/spec/lib/s3_audit_batcher_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "aws-sdk-s3"
+
+RSpec.describe S3AuditBatcher do
+  let(:client) { instance_double(Aws::S3::Client) }
+  let(:retain_until) { Time.now + 1000 }
+
+  describe "#send_batch" do
+    let(:batcher) { described_class.new(client:, bucket: "audit", key_prefix: "pry/2026-06-19/op/sess", retain_until:) }
+
+    after { batcher.stop }
+
+    it "exits early if the batch is empty" do
+      expect(client).not_to receive(:put_object)
+
+      batcher.send_batch([])
+    end
+
+    it "writes a write-once, object-locked, encrypted object and clears the batch" do
+      expect(client).to receive(:put_object).with(
+        hash_including(
+          bucket: "audit",
+          key: "pry/2026-06-19/op/sess/000000.jsonl",
+          body: "{\"line\":\"a\"}\n{\"line\":\"b\"}",
+          content_type: "application/x-ndjson",
+          server_side_encryption: "AES256",
+          object_lock_mode: "COMPLIANCE",
+          object_lock_retain_until_date: retain_until,
+          if_none_match: "*",
+        ),
+      )
+
+      batch = [{line: "a"}, {line: "b"}]
+      batcher.send_batch(batch)
+      expect(batch).to be_empty
+    end
+
+    it "increments the object sequence per successful batch" do
+      keys = []
+      allow(client).to receive(:put_object) { |args| keys << args[:key] }
+
+      batcher.send_batch([{line: "a"}])
+      batcher.send_batch([{line: "b"}])
+
+      expect(keys).to eq ["pry/2026-06-19/op/sess/000000.jsonl", "pry/2026-06-19/op/sess/000001.jsonl"]
+    end
+
+    it "prints an error and keeps the batch on failure" do
+      expect(client).to receive(:put_object).and_raise(StandardError, "boom")
+      expect(batcher).to receive(:puts).with("Error sending audit batch: boom")
+
+      batch = [{line: "a"}]
+      batcher.send_batch(batch)
+      expect(batch).not_to be_empty
+    end
+
+    it "exits the process when failures exceed the limit (fail-closed)" do
+      allow(client).to receive(:put_object).and_raise(StandardError, "boom")
+      allow(batcher).to receive(:puts)
+
+      4.times { batcher.send_batch([{line: "a"}]) }
+      expect { batcher.send_batch([{line: "a"}]) }.to raise_error(SystemExit)
+    end
+  end
+
+  describe "#processor thread" do
+    let(:batcher) { described_class.new(client:, bucket: "audit", key_prefix: "p", retain_until:, flush_interval: 10000, max_batch_size: 100) }
+
+    after { batcher.stop }
+
+    before { allow(client).to receive(:put_object) }
+
+    it "sends batch when input queue is closed" do
+      expect(batcher).to receive(:send_batch).exactly(:once)
+      batcher.stop
+    end
+
+    it "adds to batch if not over the limit" do
+      expected = false
+      q = Queue.new
+      batcher.instance_variable_set(:@max_batch_size, 2)
+      batcher.define_singleton_method(:send_batch) do |batch|
+        raise unless expected
+
+        q.push(batch.dup)
+        super(batch)
+      end
+      batcher.log("test log")
+      expected = true
+      batcher.log("test log 2")
+      expect(q.pop.map { it[:line] }).to eq ["test log", "test log 2"]
+    end
+
+    it "sends the batch when flush interval is exceeded" do
+      q = Queue.new
+
+      expect(batcher.instance_variable_get(:@input_queue)).to receive(:closed?).at_least(:once).and_wrap_original do |m, *args|
+        batcher.instance_variable_set(:@flush_interval, -1)
+        q.push(true)
+        m.call(*args)
+      end
+
+      expect(batcher).to receive(:send_batch).at_least(:once).and_wrap_original do |m, *args|
+        batcher.instance_variable_set(:@flush_interval, 10000)
+        q.push(true)
+        m.call(*args)
+      end
+
+      batcher.log("test log")
+
+      2.times { expect(q.pop(timeout: 5)).to be true }
+      expect(q.empty?).to be(true)
+    end
+
+    it "sends the batch when max batch size is exceeded" do
+      q = Queue.new
+
+      expect(batcher.instance_variable_get(:@input_queue)).to receive(:closed?).at_least(:once).and_wrap_original do |m, *args|
+        batcher.instance_variable_set(:@max_batch_size, 1)
+        q.push(true)
+        m.call(*args)
+      end
+
+      first_time = true
+      expect(batcher).to receive(:send_batch).at_least(:once).and_wrap_original do |m, batch|
+        batcher.instance_variable_set(:@max_batch_size, 100)
+        q.push(true)
+        m.call(batch)
+        if first_time
+          first_time = false
+          batch << {line: "test log"}
+        end
+      end
+
+      batcher.log("test log")
+
+      2.times { expect(q.pop(timeout: 5)).to be true }
+      expect(q.empty?).to be(true)
+    end
+
+    it "does not send the batch until one of the pre-conditions are satisfied" do
+      called = false
+      batcher.define_singleton_method(:send_batch) do
+        called = true
+        super(it)
+      end
+      batcher.log("test log")
+      expect(called).to be false
+    end
+
+    it "logs error in case of an exception during batch processing" do
+      q = Queue.new
+
+      expect(batcher.instance_variable_get(:@input_queue)).to receive(:closed?).at_least(:once).and_wrap_original do |m, *args|
+        m.call(*args)
+        true
+      end
+
+      expect(batcher.instance_variable_get(:@input_queue)).to receive(:empty?).and_raise(StandardError, "Unexpected error")
+      expect(batcher).to receive(:puts).with("Error in processor: Unexpected error").ordered
+      expect(batcher).to receive(:puts).with(anything).ordered
+      expect(batcher).to receive(:exit) do |status|
+        expect(status).to eq 1
+        q.push(true)
+        raise StopIteration
+      end
+
+      batcher.log("test log")
+
+      expect(q.pop(timeout: 5)).to be true
+      expect(q.empty?).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
bin/pry already audits every command and result through a pluggable batcher, but it ships only to Mezmo/OTEL, whose retention is too short for the 6-year HIPAA requirement. Add S3AuditBatcher, which writes each flushed batch as an immutable write-once object (Object Lock Compliance mode, SSE, 6yr retention) under pry/<date>/<operator>/<session-id>/, and point bin/pry at it: stamp operator identity, log full untruncated output, and require the S3 config in production instead of INGEST_KEY/OTEL. Fail-closed: repeated write failures abort the session, so there is no unaudited console access.

The bucket must be created with Object Lock and versioning enabled (it cannot be added later); the writer principal needs PutObject and PutObjectRetention and no delete or bypass-governance permission.