### PR TITLE
Add kubernetes node retire endpoint 

### DIFF
--- a/cli-commands/kc/post/retire-node.rb
+++ b/cli-commands/kc/post/retire-node.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class UbiCli
+  on("kc").run_on("retire-node") do
+    desc "Retire a worker node from a Kubernetes cluster"
+
+    banner "ubi kc (location/kc-name | kc-id) retire-node node-name"
+
+    args 1
+
+    run do |node_name, _, cmd|
+      sdk_object.retire_node(node_name)
+
+      response("Retired node #{node_name}.")
+    end
+  end
+end

--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -141,6 +141,7 @@ class Clover < Roda
     restart
     restore
     restrict
+    retire
     set_maintenance_window
     start
     stop

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -684,6 +684,22 @@ paths:
           $ref: '#/components/responses/Error'
       tags:
         - Kubernetes Cluster
+  /project/{project_id}/location/{location}/kubernetes-cluster/{kubernetes_cluster_reference}/node/{kubernetes_node_name}/retire:
+    parameters:
+      - $ref: '#/components/parameters/project_id'
+      - $ref: '#/components/parameters/location'
+      - $ref: '#/components/parameters/kubernetes_cluster_reference'
+      - $ref: '#/components/parameters/kubernetes_node_name'
+    post:
+      operationId: retireKubernetesNode
+      summary: Retire a worker node from a kubernetes cluster
+      responses:
+        '200':
+          $ref: '#/components/responses/KubernetesNodepool'
+        default:
+          $ref: '#/components/responses/Error'
+      tags:
+        - Kubernetes Cluster
   /project/{project_id}/location/{location}/kubernetes-cluster/{kubernetes_cluster_reference}/nodepool/{kubernetes_nodepool_reference}/resize:
     parameters:
       - $ref: '#/components/parameters/project_id'
@@ -2747,6 +2763,14 @@ components:
           value: kubernetes-cluster-name
       in: path
       name: kubernetes_cluster_reference
+      required: true
+      schema:
+        $ref: '#/components/schemas/Reference'
+    kubernetes_node_name:
+      description: Kubernetes node name
+      example: kubernetes-node-name
+      in: path
+      name: kubernetes_node_name
       required: true
       schema:
         $ref: '#/components/schemas/Reference'

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -162,6 +162,7 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
     kubernetes_node.destroy
     cluster.incr_sync_internal_dns_config
     cluster.incr_sync_worker_mesh
+    cluster.incr_update_billing_records
     pop "kubernetes node is deleted"
   end
 

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -46,7 +46,6 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
 
   label def wait_worker_node
     reap do
-      kubernetes_nodepool.cluster.incr_update_billing_records
       hop_wait
     end
   end

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -268,6 +268,7 @@ CONFIG
     end
     kubernetes_cluster.incr_sync_internal_dns_config
     kubernetes_cluster.incr_sync_worker_mesh
+    kubernetes_cluster.incr_update_billing_records
     pop({node_id: node.id})
   end
 end

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -101,6 +101,33 @@ class Clover
         end
       end
 
+      r.post "node", :object_name, "retire" do |node_name|
+        node = kc.nodepools_dataset.eager(nodes: :vm).all.flat_map(&:nodes).find { it.name == node_name }
+
+        check_found_object(node)
+
+        authorize("KubernetesCluster:edit", kc.id)
+        handle_validation_failure("kubernetes-cluster/show") { @page = "nodes" }
+
+        np = node.kubernetes_nodepool
+        if np.node_count <= 1
+          raise CloverError.new(422, "UnprocessableContent", "You cannot retire the last node of a nodepool")
+        end
+
+        DB.transaction do
+          node.incr_retire
+          np.this.update(node_count: Sequel[:node_count] - 1)
+          audit_log(node, "retire", [kc])
+        end
+
+        if api?
+          Serializers::KubernetesNodepool.serialize(np.reload, {detailed: true})
+        else
+          flash["notice"] = "Node #{node.name} is scheduled to be retired"
+          r.redirect kc
+        end
+      end
+
       r.post "upgrade" do
         authorize("KubernetesCluster:edit", kc)
         upgrade_candidate = kc.available_upgrade_version

--- a/sdk/ruby/lib/ubicloud/model/kubernetes_cluster.rb
+++ b/sdk/ruby/lib/ubicloud/model/kubernetes_cluster.rb
@@ -17,6 +17,10 @@ module Ubicloud
       adapter.post(_path("/nodepool/#{nodepool_ref}/resize"), {node_count:})
     end
 
+    def retire_node(node_name)
+      adapter.post(_path("/node/#{node_name}/retire"))
+    end
+
     # Upgrade the Kubernetes cluster to the latest available version.
     def upgrade
       merge_into_values(adapter.post(_path("/upgrade")))

--- a/serializers/kubernetes_nodepool.rb
+++ b/serializers/kubernetes_nodepool.rb
@@ -10,7 +10,7 @@ class Serializers::KubernetesNodepool < Serializers::Base
       node_size: kn.target_node_size,
     }
     if options[:detailed]
-      base[:vms] = Serializers::Vm.serialize(kn.vms_dataset.all)
+      base[:vms] = Serializers::Vm.serialize(kn.vms_dataset.eager(:strand, :semaphores, :assigned_vm_address, :vm_storage_volumes, :location).all)
     end
     base
   end

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -367,6 +367,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       expect(kd.exists?).to be false
       expect(Semaphore.where(strand_id: kc.id, name: "sync_internal_dns_config").count).to eq(1)
       expect(Semaphore.where(strand_id: kc.id, name: "sync_worker_mesh").count).to eq(1)
+      expect(Semaphore.where(strand_id: kc.id, name: "update_billing_records").count).to eq(1)
     end
   end
 end

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -416,6 +416,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect { prog.approve_new_csr }.to exit({node_id: prog.node.id})
       expect(kubernetes_cluster.reload.sync_internal_dns_config_set?).to be true
       expect(kubernetes_cluster.reload.sync_worker_mesh_set?).to be true
+      expect(kubernetes_cluster.reload.update_billing_records_set?).to be true
     end
 
     it "approves the csr when it is pending" do
@@ -425,6 +426,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect { prog.approve_new_csr }.to exit({node_id: prog.node.id})
       expect(kubernetes_cluster.reload.sync_internal_dns_config_set?).to be true
       expect(kubernetes_cluster.reload.sync_worker_mesh_set?).to be true
+      expect(kubernetes_cluster.reload.update_billing_records_set?).to be true
     end
   end
 end

--- a/spec/routes/api/cli/golden-file-commands/success.txt
+++ b/spec/routes/api/cli/golden-file-commands/success.txt
@@ -66,6 +66,7 @@ kc eu-central-h1/test-kc show -v ip6,ip4-enabled,ip4
 kc kcnzrctjjg4j4g6eqvdsvzthwp show
 kc list
 kc eu-central-h1/test-kc resize-nodepool test-kc-np 8
+kc eu-central-h1/test-kc retire-node kc-np-vm
 kc list -f location
 kc list -l eu-central-h1
 kc list -l eu-central-h1 -f name,id

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -344,6 +344,7 @@ Post Commands:
     kubeconfig         Print kubeconfig.yaml for a Kubernetes cluster
     rename             Rename a Kubernetes cluster
     resize-nodepool    Resize a Kubernetes cluster nodepool
+    retire-node        Retire a worker node from a Kubernetes cluster
     show               Show details for a Kubernetes cluster
     upgrade            Upgrade a Kubernetes cluster to the next supported version
 
@@ -403,6 +404,12 @@ Resize a Kubernetes cluster nodepool
 
 Usage:
     ubi kc (location/kc-name | kc-id) resize-nodepool (np-name | np-id) node-count
+
+
+Retire a worker node from a Kubernetes cluster
+
+Usage:
+    ubi kc (location/kc-name | kc-id) retire-node node-name
 
 
 Show details for a Kubernetes cluster

--- a/spec/routes/api/cli/golden-files/help -ru.txt
+++ b/spec/routes/api/cli/golden-files/help -ru.txt
@@ -41,6 +41,7 @@ ubi kc (location/kc-name | kc-id) destroy [options]
 ubi kc (location/kc-name | kc-id) kubeconfig
 ubi kc (location/kc-name | kc-id) rename new-name
 ubi kc (location/kc-name | kc-id) resize-nodepool (np-name | np-id) node-count
+ubi kc (location/kc-name | kc-id) retire-node node-name
 ubi kc (location/kc-name | kc-id) show [options]
 ubi kc (location/kc-name | kc-id) upgrade
 ubi lb command [...]

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc retire-node kc-np-vm.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc retire-node kc-np-vm.txt
@@ -1,0 +1,1 @@
+Retired node kc-np-vm.

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -f node-size,version,nodepools,cp-vms.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -f node-size,version,nodepools,cp-vms.txt
@@ -3,7 +3,7 @@ version: v1.35
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np
-  node-count: 1
+  node-count: 2
   node-size: standard-2
   vm 1:
     id: vmnwfmjk5k462kkzsfa4n1h4xm
@@ -16,6 +16,17 @@ nodepool 1:
     ip6: bbab:de77:9a94:fa69::2
     ip4-enabled: true
     ip4: 130.0.0.3
+  vm 2:
+    id: vm83agwbp1j60jwakbbmsxmzbe
+    name: kc-np-vm-2
+    state: creating
+    location: eu-central-h1
+    size: standard-2
+    unix-user: ubi
+    storage-size-gib: 40
+    ip6: abab:de77:9a94:fa69::2
+    ip4-enabled: true
+    ip4: 131.0.0.4
 cp-vms 1:
   id: vmgbbazmznfa0mp49nzh5v0z25
   name: kc-cp-vm

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n id,name,node-count.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n id,name,node-count.txt
@@ -8,7 +8,7 @@ version: v1.35
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np
-  node-count: 1
+  node-count: 2
 cp-vms 1:
   id: vmgbbazmznfa0mp49nzh5v0z25
   name: kc-cp-vm

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n node-size,vms.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -n node-size,vms.txt
@@ -18,6 +18,17 @@ nodepool 1:
     ip6: bbab:de77:9a94:fa69::2
     ip4-enabled: true
     ip4: 130.0.0.3
+  vm 2:
+    id: vm83agwbp1j60jwakbbmsxmzbe
+    name: kc-np-vm-2
+    state: creating
+    location: eu-central-h1
+    size: standard-2
+    unix-user: ubi
+    storage-size-gib: 40
+    ip6: abab:de77:9a94:fa69::2
+    ip4-enabled: true
+    ip4: 131.0.0.4
 cp-vms 1:
   id: vmgbbazmznfa0mp49nzh5v0z25
   name: kc-cp-vm

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v id,name,state,location,size,unix-user,storage-size-gib.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v id,name,state,location,size,unix-user,storage-size-gib.txt
@@ -8,11 +8,19 @@ version: v1.35
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np
-  node-count: 1
+  node-count: 2
   node-size: standard-2
   vm 1:
     id: vmnwfmjk5k462kkzsfa4n1h4xm
     name: kc-np-vm
+    state: creating
+    location: eu-central-h1
+    size: standard-2
+    unix-user: ubi
+    storage-size-gib: 40
+  vm 2:
+    id: vm83agwbp1j60jwakbbmsxmzbe
+    name: kc-np-vm-2
     state: creating
     location: eu-central-h1
     size: standard-2

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v ip6,ip4-enabled,ip4.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show -v ip6,ip4-enabled,ip4.txt
@@ -8,12 +8,16 @@ version: v1.35
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np
-  node-count: 1
+  node-count: 2
   node-size: standard-2
   vm 1:
     ip6: bbab:de77:9a94:fa69::2
     ip4-enabled: true
     ip4: 130.0.0.3
+  vm 2:
+    ip6: abab:de77:9a94:fa69::2
+    ip4-enabled: true
+    ip4: 131.0.0.4
 cp-vms 1:
   ip6: ccab:de77:9a94:fa69::2
   ip4-enabled: true

--- a/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show.txt
+++ b/spec/routes/api/cli/golden-files/kc eu-central-h1_test-kc show.txt
@@ -8,7 +8,7 @@ version: v1.35
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np
-  node-count: 1
+  node-count: 2
   node-size: standard-2
   vm 1:
     id: vmnwfmjk5k462kkzsfa4n1h4xm
@@ -21,6 +21,17 @@ nodepool 1:
     ip6: bbab:de77:9a94:fa69::2
     ip4-enabled: true
     ip4: 130.0.0.3
+  vm 2:
+    id: vm83agwbp1j60jwakbbmsxmzbe
+    name: kc-np-vm-2
+    state: creating
+    location: eu-central-h1
+    size: standard-2
+    unix-user: ubi
+    storage-size-gib: 40
+    ip6: abab:de77:9a94:fa69::2
+    ip4-enabled: true
+    ip4: 131.0.0.4
 cp-vms 1:
   id: vmgbbazmznfa0mp49nzh5v0z25
   name: kc-cp-vm

--- a/spec/routes/api/cli/golden-files/kc kcnzrctjjg4j4g6eqvdsvzthwp show.txt
+++ b/spec/routes/api/cli/golden-files/kc kcnzrctjjg4j4g6eqvdsvzthwp show.txt
@@ -8,7 +8,7 @@ version: v1.35
 nodepool 1:
   id: kn4gs7gjswkt4j06xy8w80s1ys
   name: test-kc-np
-  node-count: 1
+  node-count: 2
   node-size: standard-2
   vm 1:
     id: vmnwfmjk5k462kkzsfa4n1h4xm
@@ -21,6 +21,17 @@ nodepool 1:
     ip6: bbab:de77:9a94:fa69::2
     ip4-enabled: true
     ip4: 130.0.0.3
+  vm 2:
+    id: vm83agwbp1j60jwakbbmsxmzbe
+    name: kc-np-vm-2
+    state: creating
+    location: eu-central-h1
+    size: standard-2
+    unix-user: ubi
+    storage-size-gib: 40
+    ip6: abab:de77:9a94:fa69::2
+    ip4-enabled: true
+    ip4: 131.0.0.4
 cp-vms 1:
   id: vmgbbazmznfa0mp49nzh5v0z25
   name: kc-cp-vm

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -75,10 +75,10 @@ RSpec.describe Clover, "cli" do
     expect(PrivateSubnet).to receive(:generate_ubid).and_return(UBID.parse("ps788q81w5w26h900k13ad8bkx"))
     cli(%W[kc eu-central-h1/test-kc create -c 1 -z standard-2 -w 1 -v #{Option.selectable_kubernetes_versions[1]}])
 
-    expect(Vm).to receive(:generate_ubid).and_return(UBID.parse("vmgbbazmznfa0mp49nzh5v0z25"), UBID.parse("vmnwfmjk5k462kkzsfa4n1h4xm"))
-    expect(Nic).to receive(:generate_ubid).and_return(UBID.parse("ncnqx1bbxgra7k8r9k9qwvspwd"), UBID.parse("nc1c3bggqpxt5kqqrdtkym1g03"))
+    expect(Vm).to receive(:generate_ubid).and_return(UBID.parse("vmgbbazmznfa0mp49nzh5v0z25"), UBID.parse("vmnwfmjk5k462kkzsfa4n1h4xm"), UBID.parse("vm83agwbp1j60jwakbbmsxmzbe"))
+    expect(Nic).to receive(:generate_ubid).and_return(UBID.parse("ncnqx1bbxgra7k8r9k9qwvspwd"), UBID.parse("nc1c3bggqpxt5kqqrdtkym1g03"), UBID.parse("ncasemdftr1y2pqrp2qx240tjq"))
     kubernetes_cluster = KubernetesCluster.first
-    vms = ["kc-cp-vm", "kc-np-vm"].map do |vm_name|
+    vms = ["kc-cp-vm", "kc-np-vm", "kc-np-vm-2"].map do |vm_name|
       Prog::Vm::Nexus.assemble_with_sshable(
         Config.kubernetes_service_project_id,
         sshable_unix_user: "ubi",
@@ -95,10 +95,14 @@ RSpec.describe Clover, "cli" do
     PrivateSubnet.first(name: "#{kubernetes_cluster.ubid}-subnet").update(net4: "10.147.206.0/26", net6: "fdab:de77:9a94:fa71::/64")
     vms[0].update(ephemeral_net6: "ccab:de77:9a94:fa69::/64")
     vms[1].update(ephemeral_net6: "bbab:de77:9a94:fa69::/64")
+    vms[2].update(ephemeral_net6: "abab:de77:9a94:fa69::/64")
     add_ipv4_to_vm(vms[0], "129.0.0.2")
     add_ipv4_to_vm(vms[1], "130.0.0.3")
+    add_ipv4_to_vm(vms[2], "131.0.0.4")
     KubernetesNode.create(vm_id: vms[0].id, kubernetes_cluster_id: kubernetes_cluster.id)
     KubernetesNode.create(vm_id: vms[1].id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: KubernetesNodepool.first.id)
+    KubernetesNode.create(vm_id: vms[2].id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: KubernetesNodepool.first.id)
+    KubernetesNodepool.first.update(node_count: 2)
     kubernetes_cluster.update(kubeconfig: "example-kubeconfig")
 
     ie_lb = LoadBalancer.create_with_id("5294a529-4a52-942b-5294-a5294a5294a5", private_subnet_id: @ps.id, name: "ie-lb", health_check_endpoint: "/up", project_id: postgres_project.id)

--- a/spec/routes/api/project/location/kubernetes_cluster_spec.rb
+++ b/spec/routes/api/project/location/kubernetes_cluster_spec.rb
@@ -7,14 +7,12 @@ RSpec.describe Clover, "kubernetes-cluster" do
 
   let(:project) { project_with_default_policy(user) }
   let(:k8s_project) { Project.create(name: "UbicloudKubernetesService") }
-  let(:subnet) { PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id) }
   let(:kc) {
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "cluster",
       version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
       project_id: project.id,
-      private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,
       target_node_size: "standard-2",
     ).subject
@@ -36,6 +34,7 @@ RSpec.describe Clover, "kubernetes-cluster" do
         [:get, "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster"],
         [:post, "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/foo_name"],
         [:post, "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/foo_name/nodepool/bar_name/resize"],
+        [:post, "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/foo_name/node/baz_name/retire"],
         [:delete, "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.name}"],
         [:delete, "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.ubid}"],
         [:get, "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.name}"],
@@ -177,6 +176,43 @@ RSpec.describe Clover, "kubernetes-cluster" do
           expect(last_response.status).to eq(200)
           expect(kn.reload.node_count).to eq(4)
         end
+      end
+    end
+
+    describe "retire node" do
+      let(:kn) { kc.nodepools.first }
+
+      def assemble_worker_node(name)
+        Prog::Kubernetes::KubernetesNodeNexus.assemble(k8s_project.id, sshable_unix_user: "ubi", name:, location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-#{kc.version.tr(".", "_")}", private_subnet_id: kc.private_subnet_id, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id).subject
+      end
+
+      it "retires a worker node by name and decrements node_count" do
+        node = assemble_worker_node("worker-by-name")
+
+        post "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.name}/node/#{node.name}/retire"
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["node_count"]).to eq(1)
+        expect(node.retire_set?).to be true
+        expect(kn.reload.node_count).to eq(1)
+      end
+
+      it "returns 404 when the node does not exist in the cluster" do
+        post "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.name}/node/missing-node/retire"
+
+        expect(last_response.status).to eq(404)
+        expect(kn.reload.node_count).to eq(2)
+      end
+
+      it "does not allow retiring the last node of a nodepool" do
+        kn.update(node_count: 1)
+        node = assemble_worker_node("last-node")
+
+        post "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.name}/node/#{node.name}/retire"
+
+        expect(last_response).to have_api_error(422, "You cannot retire the last node of a nodepool")
+        expect(node.retire_set?).to be false
+        expect(kn.reload.node_count).to eq(1)
       end
     end
 

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Clover, "Kubernetes" do
       name: "myk8s",
       version: Option.selectable_kubernetes_versions.first,
       project_id: project.id,
-      private_subnet_id: PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "mysubnet", location_id: Location::HETZNER_FSN1_ID, project_id: project.id).id,
       location_id: Location::HETZNER_FSN1_ID,
     ).subject
 
@@ -47,7 +46,6 @@ RSpec.describe Clover, "Kubernetes" do
       name: "not-my-k8s",
       version: Option.selectable_kubernetes_versions.first,
       project_id: project_wo_permissions.id,
-      private_subnet_id: PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "othersubnet", location_id: Location::HETZNER_FSN1_ID, project_id: project_wo_permissions.id).id,
       location_id: Location::HETZNER_FSN1_ID,
     ).subject
     Prog::Kubernetes::KubernetesNodepoolNexus.assemble(
@@ -60,6 +58,10 @@ RSpec.describe Clover, "Kubernetes" do
 
   before do
     allow(Config).to receive(:kubernetes_service_project_id).and_return(Project.create(name: "UbicloudKubernetesService").id)
+  end
+
+  def assemble_worker_node(cluster, name)
+    Prog::Kubernetes::KubernetesNodeNexus.assemble(cluster.project_id, sshable_unix_user: "ubi", name:, location_id: cluster.location_id, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-#{cluster.version.tr(".", "_")}", private_subnet_id: cluster.private_subnet_id, enable_ip4: true, kubernetes_cluster_id: cluster.id, kubernetes_nodepool_id: cluster.nodepools.first.id).subject
   end
 
   describe "unauthenticated" do
@@ -247,7 +249,7 @@ RSpec.describe Clover, "Kubernetes" do
 
         kn = kc.nodepools.first
 
-        KubernetesNode.create(vm_id: create_vm(name: "node1").id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
+        assemble_worker_node(kc, "node1")
 
         kc.reload
         expect(kc.display_state).to eq("creating")
@@ -282,7 +284,7 @@ RSpec.describe Clover, "Kubernetes" do
 
       it "shows up on customer private subnet vms page" do
         visit "#{project.path}/location/#{kc.display_location}/private-subnet/#{kc.private_subnet.ubid}/vms"
-        expect(page.title).to eq "Ubicloud - mysubnet"
+        expect(page.title).to eq "Ubicloud - #{kc.private_subnet.name}"
         expect(page.all("#private-subnet-nics h3").map(&:text)).to eq ["Attached VMs", "Other Attached Resources"]
         expect(page.all("#private-subnet-nics td").map(&:text)).to eq ["No VM attached", "Kubernetes Cluster", kc.name, kc.ubid]
         click_link kc.name
@@ -425,6 +427,57 @@ RSpec.describe Clover, "Kubernetes" do
         AccessControlEntry.create(project_id: project_wo_permissions.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
         visit "#{project_wo_permissions.path}#{kc_no_perm.path}/settings"
         expect(page).to have_no_content("Resize")
+      end
+    end
+
+    describe "retire node" do
+      it "can retire a worker node from the nodes tab" do
+        node = assemble_worker_node(kc, "node1")
+        kc.nodepools.first.strand.update(label: "wait")
+
+        visit "#{project.path}#{kc.path}/nodes"
+        expect(page).to have_content("node1")
+
+        click_button "Retire"
+
+        expect(page).to have_flash_notice("Node node1 is scheduled to be retired")
+        expect(node.reload.retire_set?).to be true
+        expect(kc.nodepools.first.reload.node_count).to eq(1)
+      end
+
+      it "does not show a retire button until the nodepool finishes bootstrapping" do
+        assemble_worker_node(kc, "node1")
+
+        visit "#{project.path}#{kc.path}/nodes"
+        expect(page).to have_content("node1")
+        expect(page).to have_no_button("Retire")
+      end
+
+      it "does not show a retire button when the nodepool has a single node" do
+        kc.nodepools.first.update(node_count: 1)
+        assemble_worker_node(kc, "node1")
+        kc.nodepools.first.strand.update(label: "wait")
+
+        visit "#{project.path}#{kc.path}/nodes"
+        expect(page).to have_content("node1")
+        expect(page).to have_no_button("Retire")
+      end
+
+      it "shows a disabled button for a node that is already retiring" do
+        assemble_worker_node(kc, "node1").update(state: "draining")
+
+        visit "#{project.path}#{kc.path}/nodes"
+        expect(page).to have_button("Retiring...", disabled: true)
+        expect(page).to have_no_button("Retire")
+      end
+
+      it "does not show retire option without permissions" do
+        AccessControlEntry.create(project_id: project_wo_permissions.id, subject_id: user.id, action_id: ActionType::NAME_MAP["KubernetesCluster:view"])
+        assemble_worker_node(kc_no_perm, "node1")
+
+        visit "#{project_wo_permissions.path}#{kc_no_perm.path}/nodes"
+        expect(page).to have_content("node1")
+        expect(page).to have_no_button("Retire")
       end
     end
 

--- a/views/kubernetes-cluster/nodes.erb
+++ b/views/kubernetes-cluster/nodes.erb
@@ -1,27 +1,57 @@
 <% @nodes = []
 eager = [:assigned_vm_address, :strand, :semaphores]
+can_edit = has_permission?("KubernetesCluster:edit", @kc)
 
 @nodes +=
   @kc.cp_vms(eager:).map do |vm|
-    { name: vm.name, role: "Control Plane", state: vm.display_state, hostname: vm.ip4_string }
+    { name: vm.name, role: "Control Plane", state: vm.display_state, hostname: vm.ip4_string, retire: nil }
   end
 
 @nodes +=
   @kc
     .nodepools_dataset
-    .eager(vms: eager)
+    .eager(:strand, nodes: { vm: eager })
     .all
     .flat_map do |np|
-      np.vms.map { |vm| { name: vm.name, role: "Worker", state: vm.display_state, hostname: vm.ip4_string } }
-    end %>
+      # A node is only retirable once its nodepool's strand is back in "wait" (every
+      # ProvisionKubernetesNode bud finished bootstrapping) and the pool has more than one
+      # node, since a nodepool must always keep at least one node.
+      node_retirable = np.strand.label == "wait" && np.node_count > 1
+      np.nodes.map do |node|
+        vm = node.vm
+        retire =
+          if can_edit
+            if node.state != "active"
+              part("components/button", text: "Retiring...", type: "danger", attributes: { disabled: "disabled" })
+            elsif node_retirable
+              part(
+                "components/delete_button",
+                url: "#{path(@kc)}/node/#{vm.name}/retire",
+                exact_url: true,
+                text: "Retire",
+                icon: "hero-x-circle",
+                confirmation_message: "Are you sure you want to retire node #{vm.name}? It will be drained and removed from the node pool."
+              )
+            end
+          end
+        { name: vm.name, role: "Worker", state: vm.display_state, hostname: vm.ip4_string, retire: }
+      end
+    end
+
+headers = %w[Name Role State Hostname]
+headers << "Actions" if can_edit %>
 
 <div class="p-6">
   <%== part(
     "components/table_card",
     title: "Nodes",
-    headers: %w[Name Role State Hostname],
+    headers:,
     empty_state: "This cluster doesn't have any nodes yet",
     rows:
-      @nodes.map { |n| [[n[:name], n[:role], n[:state], [n[:hostname], { copyable: true }]], { id: "node-#{n[:name]}" }] }
+      @nodes.map do |n|
+        columns = [n[:name], n[:role], n[:state], [n[:hostname], { copyable: true }]]
+        columns << (n[:retire] ? [n[:retire], { escape: false }] : nil) if can_edit
+        [columns, { id: "node-#{n[:name]}" }]
+      end
   ) %>
 </div>


### PR DESCRIPTION
**Add API endpoint to retire a Kubernetes worker node**
Add POST /project/id/location/loc/kubernetes-cluster/ref/kubernetes-node/ref/retire, which schedules a worker node for retirement by setting its retire semaphore and decrementing the owning nodepool's node_count.

The node is resolved by name or ubid across the cluster's worker nodes, so its nodepool is derived from the node itself rather than the request path; control plane nodes and unknown references return 404. Access requires KubernetesCluster:edit.

Register KubernetesNode in the name-or-ubid route matchers, add
"retire" to the supported audit log actions, and document the endpoint (and kubernetes_node_reference parameter) in the OpenAPI spec.

**Add CLI command and SDK method for retiring a Kubernetes node**

**Add Retire button to the Kubernetes nodes tab**
Render a per-row Retire action for worker nodes on the cluster's Nodes tab, posting to the node retire endpoint. The Actions column is shown only to users with KubernetesCluster:edit.

The button is enabled only once the node's nodepool strand is back in "wait" (i.e. every ProvisionKubernetesNode bud has finished bootstrapping). A node still bootstrapping shows a disabled "Retire", and a node already draining shows a disabled "Retiring...". Control plane nodes have no retire action.