### PR TITLE
Add MachineImageVersion quota

### DIFF
--- a/config/default_quotas.yml
+++ b/config/default_quotas.yml
@@ -4,3 +4,4 @@
 - { id: 0ac764de-48c5-4432-876d-389878da0885, resource_type: GithubRunnerCacheStorage, limited_value: 30,  new_value: 30,   verified_value: 30  }
 - { id: 91d616ea-a15b-4d54-90b7-aaa1e1bd2f19, resource_type: PostgresVCpu,             limited_value: 16,  new_value: 128,  verified_value: 256 }
 - { id: 3acfffdb-37d6-42ff-8d1f-78a1915c7912, resource_type: KubernetesVCpu,           limited_value: 16,  new_value: 32,   verified_value: 256 }
+- { id: b33f53ec-338a-4936-afd0-4b650a195e4e, resource_type: MachineImageVersion,      limited_value: 8,   new_value: 16,   verified_value: 128 }

--- a/helpers/machine_image.rb
+++ b/helpers/machine_image.rb
@@ -19,6 +19,11 @@ class Clover
   # Resolves the image store for @location, reads destroy_source, and kicks
   # off VersionMetalNexus. Returns the new MachineImageVersion.
   def assemble_machine_image_version(mi, version, source_vm)
+    unless @project.quota_available?("MachineImageVersion", 1)
+      requested = @project.current_resource_usage("MachineImageVersion") + 1
+      limit = @project.effective_quota_value("MachineImageVersion")
+      fail Validation::ValidationFailed.new(version: "Insufficient quota for machine image versions. Requested: #{requested}, maximum allowed: #{limit}")
+    end
     store = @project.machine_image_store_for(@location.id)
     raise CloverError.new(400, "InvalidRequest", "No machine image store configured for this location") unless store
     destroy_source = typecast_params.bool("destroy_source")

--- a/model/project.rb
+++ b/model/project.rb
@@ -171,6 +171,7 @@ class Project < Sequel::Model
     when "KubernetesVCpu" then kubernetes_clusters_dataset.select(Sequel[:kubernetes_cluster][:cp_node_count].as(:node_count), Sequel[:kubernetes_cluster][:target_node_size])
       .union(kubernetes_clusters_dataset.association_join(:nodepools).select(:node_count, Sequel[:nodepools][:target_node_size]), all: true)
       .all.sum { it[:node_count] * Validation.validate_vm_size(it[:target_node_size], "x64").vcpus } || 0
+    when "MachineImageVersion" then MachineImageVersion.where(machine_image_id: machine_images_dataset.select(:id)).count
     else
       raise "Unknown resource type: #{resource_type}"
     end

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -210,6 +210,13 @@ RSpec.describe Project do
       Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "a-np", node_count: 3, kubernetes_cluster_id: cluster.id, target_node_size: "standard-4").subject
     }.to change { project.current_resource_usage("KubernetesVCpu") }.from(2).to(14)
 
+    expect(project.current_resource_usage("MachineImageVersion")).to eq 0
+    mi = MachineImage.create(name: "img", arch: "x64", project_id: project.id, location_id: Location::HETZNER_FSN1_ID)
+    expect {
+      MachineImageVersion.create(machine_image_id: mi.id, version: "1.0", actual_size_mib: 100)
+      MachineImageVersion.create(machine_image_id: mi.id, version: "1.1", actual_size_mib: 100)
+    }.to change { project.current_resource_usage("MachineImageVersion") }.from(0).to(2)
+
     expect { project.current_resource_usage("UnknownResource") }.to raise_error(RuntimeError)
   end
 

--- a/spec/routes/api/project/location/machine_image_spec.rb
+++ b/spec/routes/api/project/location/machine_image_spec.rb
@@ -164,6 +164,18 @@ RSpec.describe Clover, "machine-image" do
       expect(JSON.parse(last_response.body)["error"]["message"]).to match(/^version must start with a letter or number/)
     end
 
+    it "returns 400 and does not create a MachineImage when the version quota is exhausted" do
+      store
+      mi_version_metal  # consumes the only slot
+      project.add_quota(quota_id: ProjectQuota.default_quotas["MachineImageVersion"]["id"], value: 1)
+      expect {
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/machine-image/new-mi",
+          {vm: source_vm.ubid}.to_json
+      }.not_to change { MachineImage.count }
+      expect(last_response).to have_api_error(400, "Validation failed for following fields: version",
+        {"version" => "Insufficient quota for machine image versions. Requested: 2, maximum allowed: 1"})
+    end
+
     it "rejects POST with a UBID in the path (create is name-only)" do
       store
       ubid = "m1n30gjk1d1e2jj34v9x0dq4rp"
@@ -405,6 +417,15 @@ RSpec.describe Clover, "machine-image" do
       post "/project/#{project.ubid}/location/#{TEST_LOCATION}/machine-image/#{mi.name}/version/#{mi_version.version}",
         {vm: source_vm.ubid}.to_json
       expect(last_response).to have_api_error(400, "Version #{mi_version.version} already exists for this machine image")
+    end
+
+    it "returns 400 when the MachineImageVersion quota is exhausted" do
+      mi_version_metal
+      project.add_quota(quota_id: ProjectQuota.default_quotas["MachineImageVersion"]["id"], value: 1)
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/machine-image/#{mi.name}/version/v2",
+        {vm: source_vm.ubid}.to_json
+      expect(last_response).to have_api_error(400, "Validation failed for following fields: version",
+        {"version" => "Insufficient quota for machine image versions. Requested: 2, maximum allowed: 1"})
     end
   end
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -755,6 +755,7 @@ RSpec.describe CloverAdmin do
       ["GithubRunnerVCpuArm", "100", "0"],
       ["PostgresVCpu", "128", "0"],
       ["KubernetesVCpu", "32", "0"],
+      ["MachineImageVersion", "16", "0"],
     ]
   end
 

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -387,6 +387,9 @@ RSpec.describe Clover, "project" do
         find_by_id("desktop-menu").click_link "Settings"
 
         expect(page.title).to eq("Ubicloud - #{project.name}")
+        %w[VmVCpu PostgresVCpu KubernetesVCpu MachineImageVersion].each do |resource_type|
+          expect(page).to have_content(resource_type)
+        end
       end
 
       it "raises forbidden when does not have permissions" do

--- a/views/admin/extras/Project.erb
+++ b/views/admin/extras/Project.erb
@@ -3,7 +3,7 @@
 <%== part("components/collapsible_table",
   title: "Quotas",
   table_class: "project-quota-table",
-  data: ["VmVCpu", "GithubRunnerVCpu", "GithubRunnerVCpuArm", "PostgresVCpu", "KubernetesVCpu"].map {
+  data: ["VmVCpu", "GithubRunnerVCpu", "GithubRunnerVCpuArm", "PostgresVCpu", "KubernetesVCpu", "MachineImageVersion"].map {
     {
       "Resource" => it,
       "Quota" => obj.effective_quota_value(it),

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -1,5 +1,5 @@
 <% @page_title = @project.name
-@quotas = ["VmVCpu", "PostgresVCpu", "KubernetesVCpu"].map {
+@quotas = ["VmVCpu", "PostgresVCpu", "KubernetesVCpu", "MachineImageVersion"].map {
   {
     resource_type: it,
     current_resource_usage: @project.current_resource_usage(it),


### PR DESCRIPTION
### Add MachineImageVersion quota 
Cap how many machine image versions a project can hold (across all its machine images). Defaults: limited=8, new=16, verified=128. Enforced synchronously at the version-create endpoint so the user gets a 400 before any strand or storage work happens.

This is primarily accident prevention. A misconfigured script, CI loop, or cron job could otherwise silently create thousands of versions that we would then have to operate around. A hard cap turns that failure mode into an immediate 400 on the user's first unintended request.

We also considered quotaing total archive size, which more directly tracks resource usage. However, we do not currently have a fixed total capacity limit across all customers, and "total archive size" is harder for customers to understand and predict. A version-count quota achieves the accident-prevention goal with a simpler model. We may reconsider a size-based quota later.

### Surface MachineImageVersion quota on the project settings page 
Add the new resource type to the quota tiles on the user-facing project settings page so users hitting the 400 can see remaining capacity. Extends the existing "can show project details" spec to also assert each quota tile renders.

### Surface MachineImageVersion quota in the admin quota table 
Add the new resource type to the admin Project extras table so operators can see usage and quota from the admin page.
