### PR TITLE
Remove private subnet id from k8s assemble

### DIFF
--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -462,7 +462,6 @@ class RegenScreenshots
         size: k8s_cluster.target_node_size,
         storage_volumes: nil,
         boot_image: "kubernetes-v1_35",
-        private_subnet_id: k8s_cluster.private_subnet_id,
         enable_ip4: true,
         kubernetes_cluster_id: k8s_cluster.id,
       )
@@ -477,7 +476,6 @@ class RegenScreenshots
         size: k8s_nodepool.target_node_size,
         storage_volumes: nil,
         boot_image: "kubernetes-v1_35",
-        private_subnet_id: k8s_cluster.private_subnet_id,
         enable_ip4: true,
         kubernetes_cluster_id: k8s_cluster.id,
         kubernetes_nodepool_id: k8s_nodepool.id,

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -3,7 +3,7 @@
 class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   subject_is :kubernetes_cluster
 
-  def self.assemble(name:, project_id:, location_id:, version: Option.selectable_kubernetes_versions.first, private_subnet_id: nil, cp_node_count: 3, target_node_size: "standard-2", target_node_storage_size_gib: nil)
+  def self.assemble(name:, project_id:, location_id:, version: Option.selectable_kubernetes_versions.first, cp_node_count: 3, target_node_size: "standard-2", target_node_storage_size_gib: nil)
     DB.transaction do
       unless (project = Project[project_id])
         fail "No existing project"
@@ -15,18 +15,14 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       Validation.validate_kubernetes_location(location_id)
 
       ubid = KubernetesCluster.generate_ubid
-      subnet = if private_subnet_id
-        PrivateSubnet[id: private_subnet_id, project_id:] || fail("Given subnet is not available in the project")
-      else
-        # Will create customer private subnet with customer firewall
-        Prog::Vnet::SubnetNexus.assemble(
-          project_id,
-          name: "#{ubid}-subnet",
-          location_id:,
-          firewall_name: "#{ubid}-firewall",
-          ipv4_range_size: 16,
-        ).subject
-      end
+      # Will create customer private subnet with customer firewall
+      subnet = Prog::Vnet::SubnetNexus.assemble(
+        project_id,
+        name: "#{ubid}-subnet",
+        location_id:,
+        firewall_name: "#{ubid}-firewall",
+        ipv4_range_size: 16,
+      ).subject
 
       # Internal control plane node firewall, will be directly attached to kubernetes control plane VMs
       internal_cp_vm_firewall = Firewall.create(name: "#{ubid}-cp-vm-firewall", location_id:, description: "Kubernetes control plane node internal firewall", project_id: Config.kubernetes_service_project_id)

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -3,7 +3,7 @@
 class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
   subject_is :kubernetes_node
 
-  def self.assemble(project_id, sshable_unix_user:, name:, location_id:, size:, storage_volumes:, boot_image:, private_subnet_id:, enable_ip4:, kubernetes_cluster_id:, kubernetes_nodepool_id: nil)
+  def self.assemble(project_id, sshable_unix_user:, name:, location_id:, size:, storage_volumes:, boot_image:, enable_ip4:, kubernetes_cluster_id:, kubernetes_nodepool_id: nil)
     DB.transaction do
       id = KubernetesNode.generate_uuid
       cluster = KubernetesCluster[kubernetes_cluster_id]
@@ -19,7 +19,7 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
       end
 
       vm = Prog::Vm::Nexus.assemble_with_sshable(project_id, sshable_unix_user:, name:, location_id:,
-        size:, storage_volumes:, boot_image:, private_subnet_id:, enable_ip4:,
+        size:, storage_volumes:, boot_image:, private_subnet_id: cluster.private_subnet_id, enable_ip4:,
         allow_private_subnet_in_other_project: true,
         exclude_host_ids:).subject
 

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -67,7 +67,6 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
       size: vm_size,
       storage_volumes:,
       boot_image:,
-      private_subnet_id: kubernetes_cluster.private_subnet_id,
       enable_ip4: true,
       kubernetes_cluster_id: kubernetes_cluster.id,
       kubernetes_nodepool_id: kubernetes_nodepool&.id,

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -10,13 +10,11 @@ RSpec.describe KubernetesCluster do
       location_id: Location::HETZNER_FSN1_ID,
       cp_node_count: 3,
       project_id: project.id,
-      private_subnet_id: private_subnet.id,
       target_node_size: "standard-2",
     ).subject
   }
 
   let(:project) { Project.create(name: "test") }
-  let(:private_subnet) { PrivateSubnet.create(project_id: project.id, name: "test", location_id: Location::HETZNER_FSN1_ID, net6: "fe80::/64", net4: "192.168.0.0/24") }
 
   before {
     allow(Config).to receive(:kubernetes_service_project_id).and_return(project.id)
@@ -458,7 +456,6 @@ RSpec.describe KubernetesCluster do
         size: kc.target_node_size,
         storage_volumes: [{encrypted: true, size_gib: 40}],
         boot_image: "kubernetes-#{kc.version.tr(".", "_")}",
-        private_subnet_id: kc.private_subnet_id,
         enable_ip4: true,
         kubernetes_cluster_id: kc.id,
       ).subject

--- a/spec/model/kubernetes/kubernetes_etcd_backup_spec.rb
+++ b/spec/model/kubernetes/kubernetes_etcd_backup_spec.rb
@@ -14,14 +14,12 @@ RSpec.describe KubernetesEtcdBackup do
 
   let(:project) { Project.create(name: "test") }
   let(:location) { Location[Location::HETZNER_FSN1_ID] }
-  let(:private_subnet) { PrivateSubnet.create(project_id: project.id, name: "test", location_id: location.id, net6: "fe80::/64", net4: "192.168.0.0/24") }
   let(:kc) {
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "test-cluster",
       version: Option.selectable_kubernetes_versions.first,
       location_id: location.id,
       project_id: project.id,
-      private_subnet_id: private_subnet.id,
       cp_node_count: 1,
       target_node_size: "standard-2",
     ).subject

--- a/spec/model/kubernetes/kubernetes_node_spec.rb
+++ b/spec/model/kubernetes/kubernetes_node_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe KubernetesNode do
       Config.kubernetes_service_project_id,
       sshable_unix_user: "ubi", name: "test-node", location_id: Location::HETZNER_FSN1_ID,
       size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}],
-      boot_image: "kubernetes-v1.33", private_subnet_id: subnet.id, enable_ip4: true,
+      boot_image: "kubernetes-v1.33", enable_ip4: true,
       kubernetes_cluster_id: kc.id,
     ).subject
   }

--- a/spec/prog/kubernetes/etcd_backup_nexus_spec.rb
+++ b/spec/prog/kubernetes/etcd_backup_nexus_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Prog::Kubernetes::EtcdBackupNexus do
 
   let(:project) { Project.create(name: "test") }
   let(:location) { Location[Location::HETZNER_FSN1_ID] }
-  let(:private_subnet) { PrivateSubnet.create(project_id: project.id, name: "test", location_id: location.id, net6: "fe80::/64", net4: "192.168.0.0/24") }
   let(:kc) {
     MinioCluster.create(project_id: project.id, location_id: location.id, name: "minio-cluster", admin_user: "admin", admin_password: "password", root_cert_1: "certs")
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
@@ -15,7 +14,6 @@ RSpec.describe Prog::Kubernetes::EtcdBackupNexus do
       version: Option.selectable_kubernetes_versions.first,
       location_id: location.id,
       project_id: project.id,
-      private_subnet_id: private_subnet.id,
       cp_node_count: 1,
       target_node_size: "standard-2",
     ).subject

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
         size: kc.target_node_size,
         storage_volumes: [{encrypted: true, size_gib: kc.target_node_storage_size_gib}],
         boot_image: "kubernetes-#{kc.version.tr(".", "_")}",
-        private_subnet_id: kc.private_subnet_id,
         enable_ip4: true,
         kubernetes_cluster_id: kc.id,
       )
@@ -72,42 +71,36 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
   describe ".assemble" do
     it "validates input" do
       expect {
-        described_class.assemble(project_id: "88c8beda-0718-82d2-9948-7569acc26b80", name: "k8stest", location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3, private_subnet_id: subnet.id)
+        described_class.assemble(project_id: "88c8beda-0718-82d2-9948-7569acc26b80", name: "k8stest", location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3)
       }.to raise_error RuntimeError, "No existing project"
 
       expect {
-        described_class.assemble(version: "v1.30", project_id: customer_project.id, name: "k8stest", location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3, private_subnet_id: subnet.id)
+        described_class.assemble(version: "v1.30", project_id: customer_project.id, name: "k8stest", location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: version"
 
       expect {
-        described_class.assemble(name: "Uppercase", project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3, private_subnet_id: subnet.id)
+        described_class.assemble(name: "Uppercase", project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: name"
 
       expect {
-        described_class.assemble(name: "hyph_en", project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3, private_subnet_id: subnet.id)
+        described_class.assemble(name: "hyph_en", project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: name"
 
       expect {
-        described_class.assemble(name: "onetoolongnameforatestkubernetesclustername", project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3, private_subnet_id: subnet.id)
+        described_class.assemble(name: "onetoolongnameforatestkubernetesclustername", project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: name"
 
       expect {
-        described_class.assemble(name: "somename", project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 2, private_subnet_id: subnet.id)
+        described_class.assemble(name: "somename", project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 2)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: control_plane_node_count"
 
       expect {
-        described_class.assemble(name: "somename", project_id: customer_project.id, location_id: Location::HETZNER_HEL1_ID, cp_node_count: 3, private_subnet_id: subnet.id)
+        described_class.assemble(name: "somename", project_id: customer_project.id, location_id: Location::HETZNER_HEL1_ID, cp_node_count: 3)
       }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: location"
-
-      p = Project.create(name: "another")
-      subnet.update(project_id: p.id)
-      expect {
-        described_class.assemble(name: "normalname", project_id: Project.create(name: "t").id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3, private_subnet_id: subnet.id)
-      }.to raise_error RuntimeError, "Given subnet is not available in the project"
     end
 
     it "creates a kubernetes cluster" do
-      st = described_class.assemble(name: "k8stest", version: Option.selectable_kubernetes_versions.first, private_subnet_id: subnet.id, project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3, target_node_size: "standard-8", target_node_storage_size_gib: 100)
+      st = described_class.assemble(name: "k8stest", version: Option.selectable_kubernetes_versions.first, project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3, target_node_size: "standard-8", target_node_storage_size_gib: 100)
 
       kc = st.subject
       expect(kc.name).to eq "k8stest"
@@ -115,7 +108,6 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(kc.version).to eq Option.selectable_kubernetes_versions.first
       expect(kc.location_id).to eq Location::HETZNER_FSN1_ID
       expect(kc.cp_node_count).to eq 3
-      expect(kc.private_subnet.id).to eq subnet.id
       expect(kc.project.id).to eq customer_project.id
       expect(kc.strand.label).to eq "start"
       expect(kc.target_node_size).to eq "standard-8"
@@ -254,7 +246,6 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
         size: kubernetes_cluster.target_node_size,
         storage_volumes: [{encrypted: true, size_gib: kubernetes_cluster.target_node_storage_size_gib}],
         boot_image: "kubernetes-#{kubernetes_cluster.version.tr(".", "_")}",
-        private_subnet_id: kubernetes_cluster.private_subnet_id,
         enable_ip4: true,
         kubernetes_cluster_id: kubernetes_cluster.id,
       )
@@ -343,7 +334,6 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
         size: @nodepool.target_node_size,
         storage_volumes: [{encrypted: true, size_gib: @nodepool.target_node_storage_size_gib}],
         boot_image: "kubernetes-#{kubernetes_cluster.version.tr(".", "_")}",
-        private_subnet_id: kubernetes_cluster.private_subnet_id,
         enable_ip4: true,
         kubernetes_cluster_id: kubernetes_cluster.id,
         kubernetes_nodepool_id: @nodepool.id,
@@ -962,7 +952,6 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
         size: kubernetes_nodepool.target_node_size,
         storage_volumes: [{encrypted: true, size_gib: kubernetes_nodepool.target_node_storage_size_gib}],
         boot_image: "kubernetes-#{kubernetes_cluster.version.tr(".", "_")}",
-        private_subnet_id: kubernetes_cluster.private_subnet_id,
         enable_ip4: true,
         kubernetes_cluster_id: kubernetes_cluster.id,
         kubernetes_nodepool_id: kubernetes_nodepool.id,

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -6,29 +6,27 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
   subject(:nx) { described_class.new(kd.strand) }
 
   let(:project) { Project.create(name: "default") }
-  let(:subnet) { Prog::Vnet::SubnetNexus.assemble(project.id, name: "test", ipv4_range_size: 16, ipv6_range: "fd40:1a0a:8d48:182a::/64").subject }
   let(:kc) {
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "cluster",
       version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
-      private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,
       project_id: project.id,
       target_node_size: "standard-2",
     ).subject
 
-    lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "lb", health_check_endpoint: "/", project_id: project.id)
+    lb = LoadBalancer.create(private_subnet_id: kc.private_subnet_id, name: "lb", health_check_endpoint: "/", project_id: project.id)
     LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 123, dst_port: 456)
     kc.update(api_server_lb_id: lb.id)
 
-    services_lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "services_lb", health_check_endpoint: "/", project_id: project.id)
+    services_lb = LoadBalancer.create(private_subnet_id: kc.private_subnet_id, name: "services_lb", health_check_endpoint: "/", project_id: project.id)
     LoadBalancerPort.create(load_balancer_id: services_lb.id, src_port: 123, dst_port: 456)
     kc.update(services_lb_id: services_lb.id)
 
     kc
   }
-  let(:kd) { described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "vm", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", private_subnet_id: subnet.id, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: nil).subject }
+  let(:kd) { described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "vm", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: nil).subject }
 
   before do
     allow(Config).to receive(:kubernetes_service_project_id).and_return(Project.create(name: "UbicloudKubernetesService").id)
@@ -36,7 +34,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
 
   describe ".assemble" do
     it "creates a kubernetes node" do
-      st = described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "vm2", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", private_subnet_id: subnet.id, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: nil)
+      st = described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "vm2", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: nil)
       kd = st.subject
 
       expect(kd.vm.name).to eq "vm2"
@@ -47,13 +45,13 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
     end
 
     it "attaches internal cp vm firewall to control plane node" do
-      node = described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "vm2", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", private_subnet_id: subnet.id, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: nil).subject
+      node = described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "vm2", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: nil).subject
       expect(node.vm.vm_firewalls).to eq [kc.internal_cp_vm_firewall]
     end
 
     it "attaches internal worker vm firewall to nodepool node" do
       kn = KubernetesNodepool.create(name: "np", node_count: 1, kubernetes_cluster_id: kc.id, target_node_size: "standard-2")
-      node = described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "vm2", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", private_subnet_id: subnet.id, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id).subject
+      node = described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "vm2", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id).subject
       expect(node.vm.vm_firewalls).to eq [kc.internal_worker_vm_firewall]
     end
 
@@ -68,11 +66,11 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       existing_hosts = [vm.vm_host_id]
 
       expect(Config).to receive(:allow_unspread_servers).and_return(false)
-      node = described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "node3", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", private_subnet_id: subnet.id, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: nil).subject
+      node = described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "node3", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: nil).subject
       expect(node.vm.strand.stack[0]["exclude_host_ids"]).to eq existing_hosts
 
       expect(Config).to receive(:allow_unspread_servers).and_return(true)
-      node = described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "node4", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", private_subnet_id: subnet.id, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: nil).subject
+      node = described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "node4", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: nil).subject
       expect(node.vm.strand.stack[0]["exclude_host_ids"]).to eq []
     end
 
@@ -82,7 +80,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       vm = create_vm(vm_host: host)
       KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
 
-      node = described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "vm3", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", private_subnet_id: subnet.id, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id).subject
+      node = described_class.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "vm3", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-v1.33", enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id).subject
       expect(node.kubernetes_nodepool).to eq kn
       expect(node.vm.strand.stack[0]["exclude_host_ids"]).to eq []
     end

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -6,19 +6,17 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
   subject(:nx) { described_class.new(kn.strand) }
 
   let(:project) { Project.create(name: "default") }
-  let(:subnet) { PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id) }
   let(:kc) {
     kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "k8scluster",
       version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
-      private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,
       project_id: project.id,
       target_node_size: "standard-2",
     ).subject
 
-    lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "somelb", health_check_endpoint: "/foo", project_id: project.id)
+    lb = LoadBalancer.create(private_subnet_id: kc.private_subnet_id, name: "somelb", health_check_endpoint: "/foo", project_id: project.id)
     LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 123, dst_port: 456)
     [create_vm, create_vm].each do |vm|
       KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kc.id)

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -12,9 +12,6 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   let(:project) {
     Project.create(name: "default")
   }
-  let(:subnet) {
-    Prog::Vnet::SubnetNexus.assemble(project.id, name: "test", ipv4_range: "172.19.0.0/16", ipv6_range: "fd40:1a0a:8d48:182a::/64").subject
-  }
 
   let(:kubernetes_cluster) { prog.kubernetes_cluster }
 
@@ -23,14 +20,13 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       name: "k8scluster",
       version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
-      private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,
       project_id: project.id,
       target_node_size: "standard-4",
       target_node_storage_size_gib: 37,
     ).subject
 
-    lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "somelb", health_check_endpoint: "/foo", project_id: Config.kubernetes_service_project_id)
+    lb = LoadBalancer.create(private_subnet_id: kc.private_subnet_id, name: "somelb", health_check_endpoint: "/foo", project_id: Config.kubernetes_service_project_id)
     LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 123, dst_port: 456)
     Prog::Kubernetes::KubernetesNodeNexus.assemble(
       project.id,
@@ -40,7 +36,6 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       size: "standard-4",
       storage_volumes: [{encrypted: true, size_gib: 40}],
       boot_image: Option.selectable_kubernetes_versions.first,
-      private_subnet_id: subnet.id,
       enable_ip4: true,
       kubernetes_cluster_id: kc.id,
     )
@@ -48,8 +43,8 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   }
 
   let(:node) {
-    nic = Prog::Vnet::NicNexus.assemble(subnet.id, ipv4_addr: "172.19.145.64/26", ipv6_addr: "fd40:1a0a:8d48:182a::/79").subject
-    vm = Prog::Vm::Nexus.assemble_with_sshable(Config.kubernetes_service_project_id, name: "test-vm", private_subnet_id: subnet.id, nic_id: nic.id).subject
+    nic = Prog::Vnet::NicNexus.assemble(_kubernetes_cluster.private_subnet_id, ipv4_addr: "172.19.145.64/26", ipv6_addr: "fd40:1a0a:8d48:182a::/79").subject
+    vm = Prog::Vm::Nexus.assemble_with_sshable(Config.kubernetes_service_project_id, name: "test-vm", private_subnet_id: _kubernetes_cluster.private_subnet_id, nic_id: nic.id).subject
     vm.update(ephemeral_net6: "2001:db8:85a3:73f2:1c4a::/79", created_at: Time.now - 1)
     KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: _kubernetes_cluster.id)
   }
@@ -164,8 +159,8 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
           s.include?("ip6 saddr 2001:db8:85a3:73f2:1c4a::2 ct state established,related,new counter accept") &&
           s.include?("ip6 daddr 2001:db8:85a3:73f2:1c4a::/79 ct state established,related counter accept") &&
           s.include?("ip6 saddr 2001:db8:85a3:73f2:1c4a::/79 ct state established,related,new counter accept") &&
-          s.include?("ip6 saddr fd40:1a0a:8d48:182a::/64 ct state established,related,new counter accept") &&
-          s.include?("ip6 daddr fd40:1a0a:8d48:182a::/64 ct state established,related,new counter accept")
+          s.include?("ip6 saddr #{kubernetes_cluster.private_subnet.net6} ct state established,related,new counter accept") &&
+          s.include?("ip6 daddr #{kubernetes_cluster.private_subnet.net6} ct state established,related,new counter accept")
         },
       ).ordered
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now nftables").ordered
@@ -217,7 +212,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(prog.vm.sshable).to receive(:d_check).with("init_kubernetes_cluster").and_return("NotStarted")
       expect(prog.vm.sshable).to receive(:d_run).with(
         "init_kubernetes_cluster", "/home/ubi/kubernetes/bin/init-cluster",
-        stdin: /{"node_name":"test-vm","cluster_name":"k8scluster","lb_hostname":"somelb\..*","port":"443","private_subnet_cidr4":"172.19.0.0\/16","private_subnet_cidr6":"fd40:1a0a:8d48:182a::\/64","node_ipv4":"172.19.145.65","node_ipv6":"2001:db8:85a3:73f2:1c4a::2"/, log: false,
+        stdin: /{"node_name":"test-vm","cluster_name":"k8scluster","lb_hostname":"somelb\..*","port":"443","private_subnet_cidr4":"#{kubernetes_cluster.private_subnet.net4}","private_subnet_cidr6":"#{kubernetes_cluster.private_subnet.net6}","node_ipv4":"172.19.145.65","node_ipv6":"2001:db8:85a3:73f2:1c4a::2"/, log: false,
       )
 
       expect { prog.init_cluster }.to nap(30)

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -147,21 +147,37 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     it "enables kubelet and buds a bootstrap rhizome process" do
       prog.node.vm.strand.update(label: "wait")
       sshable = prog.vm.sshable
+      expected_nft_rules = <<~NFT
+        #!/usr/sbin/nft -f
+        flush ruleset
+
+        table ip nat {
+          chain postrouting {
+            type nat hook postrouting priority 100;
+            ip saddr 172.19.145.64/26 oifname "ens3" masquerade
+          }
+        }
+
+        table ip6 pod_access {
+          chain ingress_egress_control {
+            type filter hook forward priority filter; policy drop;
+            # allow access to the vm itself in order to not break the normal functionality of Clover and SSH
+            ip6 daddr 2001:db8:85a3:73f2:1c4a::2 ct state established,related,new counter accept
+            ip6 saddr 2001:db8:85a3:73f2:1c4a::2 ct state established,related,new counter accept
+
+            # not allow new connections from internet but allow new connections from inside
+            ip6 daddr 2001:db8:85a3:73f2:1c4a::/79 ct state established,related counter accept
+            ip6 saddr 2001:db8:85a3:73f2:1c4a::/79 ct state established,related,new counter accept
+
+            # used for internal private ipv6 communication between pods
+            ip6 saddr #{kubernetes_cluster.private_subnet.net6} ct state established,related,new counter accept
+            ip6 daddr #{kubernetes_cluster.private_subnet.net6} ct state established,related,new counter accept
+          }
+        }
+      NFT
       expect(sshable).to receive(:_cmd).with(
         "sudo tee /etc/nftables.conf > /dev/null",
-        stdin: satisfy { |s|
-          s.include?("#!/usr/sbin/nft -f") &&
-          s.include?("flush ruleset") &&
-          s.include?("table ip nat") &&
-          s.include?("ip saddr 172.19.145.64/26 oifname \"ens3\" masquerade") &&
-          s.include?("table ip6 pod_access") &&
-          s.include?("ip6 daddr 2001:db8:85a3:73f2:1c4a::2 ct state established,related,new counter accept") &&
-          s.include?("ip6 saddr 2001:db8:85a3:73f2:1c4a::2 ct state established,related,new counter accept") &&
-          s.include?("ip6 daddr 2001:db8:85a3:73f2:1c4a::/79 ct state established,related counter accept") &&
-          s.include?("ip6 saddr 2001:db8:85a3:73f2:1c4a::/79 ct state established,related,new counter accept") &&
-          s.include?("ip6 saddr #{kubernetes_cluster.private_subnet.net6} ct state established,related,new counter accept") &&
-          s.include?("ip6 daddr #{kubernetes_cluster.private_subnet.net6} ct state established,related,new counter accept")
-        },
+        stdin: expected_nft_rules,
       ).ordered
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now nftables").ordered
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now kubelet").ordered

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -10,23 +10,19 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
   let(:project) {
     Project.create(name: "default")
   }
-  let(:subnet) {
-    Prog::Vnet::SubnetNexus.assemble(Config.kubernetes_service_project_id, name: "test", ipv4_range: "172.19.0.0/16", ipv6_range: "fd40:1a0a:8d48:182a::/64").subject
-  }
 
   let(:kubernetes_cluster) {
-    kc = KubernetesCluster.create(
+    kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
       name: "k8scluster",
       version: Option.selectable_kubernetes_versions.first,
       cp_node_count: 3,
-      private_subnet_id: subnet.id,
       location_id: Location::HETZNER_FSN1_ID,
       project_id: project.id,
       target_node_size: "standard-4",
       target_node_storage_size_gib: 37,
-    )
+    ).subject
 
-    lb = LoadBalancer.create(private_subnet_id: subnet.id, name: "somelb", health_check_endpoint: "/foo", project_id: Config.kubernetes_service_project_id)
+    lb = LoadBalancer.create(private_subnet_id: kc.private_subnet_id, name: "somelb", health_check_endpoint: "/foo", project_id: Config.kubernetes_service_project_id)
     LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 123, dst_port: 456)
     kc.update(api_server_lb_id: lb.id)
   }
@@ -41,7 +37,7 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
 
   describe "#before_run" do
     before do
-      Strand.create(id: kubernetes_cluster.id, label: "wait", prog: "KubernetesClusterNexus")
+      kubernetes_cluster.strand.update(label: "wait")
     end
 
     it "exits when kubernetes cluster is deleted and has no children itself" do
@@ -92,7 +88,6 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
   describe "#wait_node_ready" do
     let(:session) { Net::SSH::Connection::Session.allocate }
     let(:new_node) {
-      Firewall.create(name: "#{kubernetes_cluster.ubid}-cp-vm-firewall", project_id: Config.kubernetes_service_project_id, location_id: kubernetes_cluster.location_id)
       Prog::Kubernetes::KubernetesNodeNexus.assemble(
         Config.kubernetes_service_project_id,
         sshable_unix_user: "ubi",
@@ -101,7 +96,6 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
         size: kubernetes_cluster.target_node_size,
         storage_volumes: [{encrypted: true, size_gib: 40}],
         boot_image: "kubernetes-#{kubernetes_cluster.version.tr(".", "_")}",
-        private_subnet_id: kubernetes_cluster.private_subnet_id,
         enable_ip4: true,
         kubernetes_cluster_id: kubernetes_cluster.id,
       ).subject

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe Prog::Test::Kubernetes do
     lb = LoadBalancer.create(private_subnet_id: kc.private_subnet.id, name: "api-lb", health_check_endpoint: "/healthz", project_id: kubernetes_test_project.id)
     kc.update(api_server_lb_id: lb.id)
     kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "test-cluster-np", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
-    Prog::Kubernetes::KubernetesNodeNexus.assemble(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "cp-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-4", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: Option.selectable_kubernetes_versions.first, private_subnet_id: kc.private_subnet.id, enable_ip4: true, kubernetes_cluster_id: kc.id)
-    Prog::Kubernetes::KubernetesNodeNexus.assemble(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "w1-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-4", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: Option.selectable_kubernetes_versions.first, private_subnet_id: kc.private_subnet.id, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
-    Prog::Kubernetes::KubernetesNodeNexus.assemble(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "w2-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-4", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: Option.selectable_kubernetes_versions.first, private_subnet_id: kc.private_subnet.id, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
+    Prog::Kubernetes::KubernetesNodeNexus.assemble(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "cp-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-4", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: Option.selectable_kubernetes_versions.first, enable_ip4: true, kubernetes_cluster_id: kc.id)
+    Prog::Kubernetes::KubernetesNodeNexus.assemble(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "w1-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-4", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: Option.selectable_kubernetes_versions.first, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
+    Prog::Kubernetes::KubernetesNodeNexus.assemble(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "w2-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-4", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: Option.selectable_kubernetes_versions.first, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
     kc
   }
   let(:sshable) { kubernetes_test.kubernetes_cluster.sshable }
@@ -397,7 +397,7 @@ RSpec.describe Prog::Test::Kubernetes do
     before do
       nodepool = kubernetes_cluster.nodepools.first
       nodepool.update(node_count: 3)
-      Prog::Kubernetes::KubernetesNodeNexus.assemble(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "w3-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-4", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: Option.selectable_kubernetes_versions.first, private_subnet_id: kubernetes_cluster.private_subnet.id, enable_ip4: true, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: nodepool.id)
+      Prog::Kubernetes::KubernetesNodeNexus.assemble(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "w3-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-4", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: Option.selectable_kubernetes_versions.first, enable_ip4: true, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: nodepool.id)
     end
 
     it "uncordons all, cordons pod node, deletes pod and hops to cordon_chained_target" do

--- a/spec/routes/api/project/location/kubernetes_cluster_spec.rb
+++ b/spec/routes/api/project/location/kubernetes_cluster_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Clover, "kubernetes-cluster" do
       let(:kn) { kc.nodepools.first }
 
       def assemble_worker_node(name)
-        Prog::Kubernetes::KubernetesNodeNexus.assemble(k8s_project.id, sshable_unix_user: "ubi", name:, location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-#{kc.version.tr(".", "_")}", private_subnet_id: kc.private_subnet_id, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id).subject
+        Prog::Kubernetes::KubernetesNodeNexus.assemble(k8s_project.id, sshable_unix_user: "ubi", name:, location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-#{kc.version.tr(".", "_")}", enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id).subject
       end
 
       it "retires a worker node by name and decrements node_count" do

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Clover, "Kubernetes" do
   end
 
   def assemble_worker_node(cluster, name)
-    Prog::Kubernetes::KubernetesNodeNexus.assemble(cluster.project_id, sshable_unix_user: "ubi", name:, location_id: cluster.location_id, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-#{cluster.version.tr(".", "_")}", private_subnet_id: cluster.private_subnet_id, enable_ip4: true, kubernetes_cluster_id: cluster.id, kubernetes_nodepool_id: cluster.nodepools.first.id).subject
+    Prog::Kubernetes::KubernetesNodeNexus.assemble(cluster.project_id, sshable_unix_user: "ubi", name:, location_id: cluster.location_id, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-#{cluster.version.tr(".", "_")}", enable_ip4: true, kubernetes_cluster_id: cluster.id, kubernetes_nodepool_id: cluster.nodepools.first.id).subject
   end
 
   describe "unauthenticated" do

--- a/spec/serializers/kubernetes_cluster_spec.rb
+++ b/spec/serializers/kubernetes_cluster_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Serializers::KubernetesCluster do
   describe ".serialize_internal" do
     it "serializes a KubernetesCluster without the detailed option" do
       project = Project.create(name: "default")
-      subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
-      kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.selectable_kubernetes_versions.first, private_subnet_id: subnet.id).subject
+      kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.selectable_kubernetes_versions.first).subject
       kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
       KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
 
@@ -30,8 +29,7 @@ RSpec.describe Serializers::KubernetesCluster do
 
     it "serializes a KubernetesNodepool without the detailed option" do
       project = Project.create(name: "default")
-      subnet = PrivateSubnet.create(net6: "0::0", net4: "127.0.0.1", name: "x", location_id: Location::HETZNER_FSN1_ID, project_id: project.id)
-      kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.selectable_kubernetes_versions.first, private_subnet_id: subnet.id).subject
+      kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.selectable_kubernetes_versions.first).subject
       kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
       cp_vm = create_vm
       KubernetesNode.create(vm_id: cp_vm.id, kubernetes_cluster_id: kc.id)


### PR DESCRIPTION
**Remove private_subnet_id from Kubernetes prog assembles**
Drop the bring-your-own private subnet option from KubernetesClusterNexus.assemble and KubernetesNodeNexus.assemble. The cluster now always creates its own subnet, and the node derives the subnet from its cluster instead of taking it as an argument.

Two reasons for the change:

1. Production never used custom private subnets; every caller relied on the cluster creating its own.
2. We don't expose any API that lets customers create subnets with the larger IPv4 CIDRs that Kubernetes needs, so a customer-supplied subnet could never be a valid fit anyway.

Update the specs accordingly, dropping the now-unused standalone subnets and the obsolete "Given subnet is not available in the project" validation case.

**Assert full nftables config in ProvisionKubernetesNode spec**