### PR TITLE
Redirect to the versions tab after creating a machine image

### DIFF
--- a/helpers/machine_image.rb
+++ b/helpers/machine_image.rb
@@ -145,7 +145,7 @@ class Clover
       Serializers::MachineImage.serialize(mi)
     else
       flash["notice"] = "'#{name}' is being created"
-      request.redirect mi
+      request.redirect mi, "/versions"
     end
   end
 end

--- a/spec/routes/web/machine_image_spec.rb
+++ b/spec/routes/web/machine_image_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Clover, "machine-image" do
         expect(page.status_code).to eq(200)
         new_mi = MachineImage[name: "new-mi"]
         expect(new_mi).not_to be_nil
-        expect(page).to have_current_path("#{project.path}/location/#{TEST_LOCATION}/machine-image/new-mi/overview")
+        expect(page).to have_current_path("#{project.path}/location/#{TEST_LOCATION}/machine-image/new-mi/versions")
         expect(new_mi.versions.count).to eq(1)
         expect(new_mi.versions.first.strand.prog).to eq("MachineImage::VersionMetalNexus")
       end


### PR DESCRIPTION
When a user creates a new machine image via the web UI, redirect to the freshly-created image's versions tab instead of overview. The overview at that moment has nothing useful to show (the only version is still mid-archive), while the versions tab surfaces the in-flight capture's progress.

The version-create handler already redirected to the versions tab; this aligns the image-create handler with it.