### PR TITLE
Add require_mfa_or_omniauth project feature flag

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -252,6 +252,7 @@ class Project < Sequel::Model
     :postgres_lantern,
     :postgres_paradedb,
     :private_locations,
+    :require_mfa_or_omniauth,
     :skip_runner_pool,
     :spill_to_alien_runners,
     :visible_locations,

--- a/routes/project.rb
+++ b/routes/project.rb
@@ -104,6 +104,24 @@ class Clover
       @project = Clover.authorized_project(current_account, project_id)
       check_found_object(@project)
 
+      if @project.get_ff_require_mfa_or_omniauth
+        if api?
+          # Only allow API access if the account has MFA setup or does not have a password
+          # (if account doesn't have password, it must have omniauth authentication setup)
+          if DB[:account_webauthn_keys].where(account_id: current_account_id).empty? &&
+              DB[:account_otp_keys].where(id: current_account_id).empty? &&
+              !DB[:account_password_hashes].where(id: current_account_id).empty?
+            no_authorization_needed
+            raise CloverError.new(403, "AccessDenied", "Project #{@project.ubid} requires token's account to have multifactor authentication enabled or login only allowed via external provider")
+          end
+        elsif rodauth.authenticated_by.length < 2 && !rodauth.authenticated_by.include?("omniauth")
+          no_authorization_needed
+          # For web access, only allow access if the current session is MFA authenticated or omniauth authenticated
+          flash["error"] = "Project #{@project.ubid} requires multifactor authentication enabled or login via external provider"
+          r.redirect "/project"
+        end
+      end
+
       @project_permissions = all_permissions(@project.id) if web?
 
       r.get true do

--- a/spec/routes/api/auth_spec.rb
+++ b/spec/routes/api/auth_spec.rb
@@ -18,4 +18,41 @@ RSpec.describe Clover, "auth" do
 
     expect(last_response).to have_api_error(401, "must include personal access token in Authorization header")
   end
+
+  describe "with require_mfa_or_omniauth feature flag" do
+    let(:account) { create_account }
+
+    let(:project) do
+      project = project_with_default_policy(account)
+      project.set_ff_require_mfa_or_omniauth(true)
+      project
+    end
+
+    before do
+      login_api
+    end
+
+    it "allows access if account for token has otp authentication setup" do
+      DB[:account_otp_keys].insert(id: account.id, key: "1")
+      get "/project/#{project.ubid}"
+      expect(last_response.status).to eq(200)
+    end
+
+    it "allows access if account for token has webauthn authentication setup" do
+      DB[:account_webauthn_keys].insert(account_id: account.id, webauthn_id: "1", public_key: "1", name: "1", sign_count: 0)
+      get "/project/#{project.ubid}"
+      expect(last_response.status).to eq(200)
+    end
+
+    it "allows access if account does not have password authentication" do
+      DB[:account_password_hashes].where(id: account.id).delete
+      get "/project/#{project.ubid}"
+      expect(last_response.status).to eq(200)
+    end
+
+    it "denies access if account allows access via password authentication" do
+      get "/project/#{project.ubid}"
+      expect(last_response).to have_api_error(403, "Project #{project.ubid} requires token's account to have multifactor authentication enabled or login only allowed via external provider")
+    end
+  end
 end

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -4,6 +4,18 @@ require_relative "spec_helper"
 require "webauthn/fake_client"
 
 RSpec.describe Clover, "auth" do
+  def mock_provider(provider, email = TEST_USER_EMAIL, name: "John Doe", mock_config: true)
+    expect(Config).to receive("omniauth_#{provider}_id").and_return("12345").at_least(:once) if mock_config
+    OmniAuth.config.add_mock(provider, {
+      provider:,
+      uid: "123456790",
+      info: {
+        name:,
+        email:,
+      },
+    })
+  end
+
   def ip_hash(into = {})
     into["ip"] = "127.0.0.1"
     into
@@ -623,6 +635,56 @@ RSpec.describe Clover, "auth" do
       expect(audit_log_hash).to eq({})
     end
 
+    describe "with require_mfa_or_omniauth feature flag" do
+      let(:account) { Account[email: TEST_USER_EMAIL] }
+      let(:project) do
+        project = account.projects.first
+        project.set_ff_require_mfa_or_omniauth(true)
+        project
+      end
+
+      before do
+        project
+      end
+
+      it "allows access if account is multifactor authenticated" do
+        path = page.current_path
+        visit "/account/multifactor-manage"
+        click_link "Enable"
+        totp = ROTP::TOTP.new(find_by_id("otp-secret").text)
+        fill_in "Authentication Code", with: totp.now
+        click_button "Enable One-Time Password Authentication"
+        visit path
+        expect(page.title).to eq "Ubicloud - Default Dashboard"
+        expect(audit_log_hash).to eq({"otp_setup" => ip_hash})
+      end
+
+      it "allows access if account is logged in via omniauth" do
+        OmniAuth.config.logger = Logger.new(IO::NULL)
+        OmniAuth.config.test_mode = true
+        mock_provider(:google)
+        account.add_identity(provider: "google", uid: "123456790")
+
+        visit "/logout"
+        click_button "Logout"
+
+        visit "/login"
+        click_button "Google"
+        expect(page.title).to eq "Ubicloud - Default Dashboard"
+        expect(audit_log_hash).to eq({
+          "logout" => ip_hash,
+          "login" => ip_hash({"via" => "Google"}),
+        })
+      end
+
+      it "denies access if account is logged in via password without multifactor authentication" do
+        page.refresh
+        expect(page).to have_current_path "/project", ignore_query: true
+        expect(page).to have_flash_error "Project #{project.ubid} requires multifactor authentication enabled or login via external provider"
+        expect(audit_log_hash).to eq({})
+      end
+    end
+
     [true, false].each do |clear_last_password_entry|
       it "allows setting up#{", authenticating with, unlocking," if clear_last_password_entry} and removing OTP authentication when password entry is #{"not " unless clear_last_password_entry}required" do
         visit "/clear-last-password-entry" if clear_last_password_entry
@@ -840,18 +902,6 @@ RSpec.describe Clover, "auth" do
   end
 
   describe "social login" do
-    def mock_provider(provider, email = TEST_USER_EMAIL, name: "John Doe", mock_config: true)
-      expect(Config).to receive("omniauth_#{provider}_id").and_return("12345").at_least(:once) if mock_config
-      OmniAuth.config.add_mock(provider, {
-        provider:,
-        uid: "123456790",
-        info: {
-          name:,
-          email:,
-        },
-      })
-    end
-
     let(:oidc_provider) do
       op = OidcProvider.create(
         display_name: "TestOIDC",


### PR DESCRIPTION
If this flag is set for a project, deny access to the project if the request is not multifactor authenticated or omniauth authenticated.

For api requests, tokens themselves are not authenticated through either method, so check whether the token's account has multifactor authentication enabled or does not have password authentication enabled. If an account doesn't have a password, it must have omniauth authentication enabled.