### PR TITLE
Stop adding AAAA records for Postgres databases by default

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -75,10 +75,8 @@ class PostgresResource < Sequel::Model
     @dns_zone ||= DnsZone[project_id: Config.postgres_service_project_id, name: hostname_suffix]
   end
 
-  AAAA_CUTOFF = Time.utc(2026, 1, 13, 20)
   def can_add_aaaa_record?
     !location.aws? &&
-      created_at < AAAA_CUTOFF &&
       dns_zone &&
       representative_server.vm.ip6_string &&
       dns_zone

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -170,15 +170,16 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         dns_zone.insert_record(record_name:, type: "CNAME", ttl: 10, data: vm.aws_instance.ipv4_dns_name + ".")
       else
         dns_zone.insert_record(record_name:, type: "A", ttl: 10, data: vm.ip4_string)
-        if postgres_resource.created_at >= PostgresResource::AAAA_CUTOFF ||
-            !dns_zone.records_dataset.where(type: "AAAA", name: record_name + ".").empty?
+        unless dns_zone.records_dataset.where(type: "AAAA", name: record_name + ".").empty?
           dns_zone.insert_record(record_name:, type: "AAAA", ttl: 10, data: vm.ip6_string)
         end
 
         record_name = postgres_resource.private_hostname
         dns_zone.delete_record(record_name:)
         dns_zone.insert_record(record_name:, type: "A", ttl: 10, data: vm.private_ipv4_string)
-        dns_zone.insert_record(record_name:, type: "AAAA", ttl: 10, data: vm.private_ipv6_string)
+        unless dns_zone.records_dataset.where(type: "AAAA", name: record_name + ".").empty?
+          dns_zone.insert_record(record_name:, type: "AAAA", ttl: 10, data: vm.private_ipv6_string)
+        end
       end
     end
 

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -169,6 +169,8 @@ class Clover
 
         DB.transaction do
           pg.dns_zone.insert_record(record_name: pg.hostname, type: "AAAA", ttl: 10, data: pg.representative_server.vm.ip6_string)
+          pg.dns_zone.delete_record(record_name: pg.private_hostname, type: "AAAA")
+          pg.dns_zone.insert_record(record_name: pg.private_hostname, type: "AAAA", ttl: 10, data: pg.representative_server.vm.private_ipv6_string)
           pg.incr_refresh_dns_record
           audit_log(pg, "add_aaaa_record")
         end

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -352,7 +352,6 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(DnsRecord.where(dns_zone_id: dns_zone.id).select_order_map([:type, :name])).to eq [
         ["A", "#{name}.pg.example.com."],
         ["A", "private.#{name}.pg.example.com."],
-        ["AAAA", "private.#{name}.pg.example.com."],
       ]
     end
 
@@ -361,6 +360,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com").at_least(:once)
       dns_zone = DnsZone.create(project_id: postgres_project.id, name: "pg.example.com")
       dns_zone.insert_record(record_name: postgres_server.resource.hostname, type: "AAAA", ttl: 10, data: "::1")
+      dns_zone.insert_record(record_name: postgres_server.resource.private_hostname, type: "AAAA", ttl: 10, data: "::1")
       DnsRecord.where(dns_zone_id: dns_zone.id).update(created_at: Time.now - 60)
       nx.incr_initial_provisioning
       expect { nx.refresh_dns_record }.to hop("initialize_certificates")

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -630,9 +630,7 @@ RSpec.describe Clover, "postgres" do
           pg.representative_server.vm.update(ephemeral_net6: "::/64")
         end
 
-        it "can add AAAA record if database was created before cutoff and no AAAA exists" do
-          pg.update(created_at: PostgresResource::AAAA_CUTOFF - 86400)
-
+        it "can add AAAA record if no AAAA exists" do
           visit "#{project.path}#{pg.path}/settings"
 
           expect(page).to have_content "Add IPv6 (AAAA) DNS record"
@@ -644,7 +642,6 @@ RSpec.describe Clover, "postgres" do
         end
 
         it "does not show button if AAAA record already exists" do
-          pg.update(created_at: PostgresResource::AAAA_CUTOFF - 86400)
           @dns_zone.insert_record(record_name: pg.hostname, type: "AAAA", ttl: 10, data: "::1")
 
           visit "#{project.path}#{pg.path}/settings"
@@ -653,8 +650,6 @@ RSpec.describe Clover, "postgres" do
         end
 
         it "handles race condition when AAAA is added between page load and button click" do
-          pg.update(created_at: PostgresResource::AAAA_CUTOFF - 86400)
-
           visit "#{project.path}#{pg.path}/settings"
 
           @dns_zone.insert_record(record_name: pg.hostname, type: "AAAA", ttl: 10, data: "::1")
@@ -664,15 +659,6 @@ RSpec.describe Clover, "postgres" do
           expect(page).to have_flash_error("Cannot add AAAA record for this database")
           expect(page.status_code).to eq(200)
 
-          expect(page).to have_no_content "Add AAAA Record"
-        end
-
-        it "does not show button for databases created after cutoff" do
-          pg.update(created_at: PostgresResource::AAAA_CUTOFF + 86400)
-
-          visit "#{project.path}#{pg.path}/settings"
-
-          expect(page).to have_no_content "Add IPv6 (AAAA) DNS record"
           expect(page).to have_no_content "Add AAAA Record"
         end
 
@@ -690,7 +676,6 @@ RSpec.describe Clover, "postgres" do
             target_storage_size_gib: 128,
             target_version: "16",
           ).subject
-          pg_aws.update(created_at: PostgresResource::AAAA_CUTOFF - 86400)
 
           visit "#{project.path}#{pg_aws.path}/settings"
 
@@ -699,8 +684,6 @@ RSpec.describe Clover, "postgres" do
         end
 
         it "does not show button when user does not have edit permissions" do
-          pg.update(created_at: PostgresResource::AAAA_CUTOFF - 86400)
-
           AccessControlEntry.create(project_id: project_wo_permissions.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
 
           visit "#{project_wo_permissions.path}#{pg_wo_permission.path}/settings"


### PR DESCRIPTION
Apparently some poorly programmed postgres clients in common use do not correctly fallback to IPv4 if there is an AAAA record and there are issues connecting over IPv6. Do to the fault of those few, the many must suffer.

This stops adding both the public and private AAAA records. It removes the AAAA_CUTOFF constant, since it is no longer needed. The "Add IPv6 (AAAA) DNS record" on the PostgreSQL settings page can be used to add the AAAA record, and now it adds both the public and private AAAA records.