### PR TITLE
Cap commit-limit margin at 8 GiB on Postgres VMs

### DIFF
--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -28,8 +28,10 @@ class PostgresSetup
       total_mem_kb = File.read("/proc/meminfo").match(/MemTotal:\s+(\d+)/)[1].to_i
       # 25% of memory is reserved for hugepages, which do not count towards the
       # commit limit, so only the remaining 75% is available for overcommit.
+      # Take the looser of an 80% factor (+ 2 GiB floor) or a flat 8 GiB margin
+      # so the margin doesn't grow unbounded with VM size.
       non_hugepage_mem_kb = total_mem_kb * 0.75
-      overcommit_kbytes = (non_hugepage_mem_kb * 0.8 + 2 * 1048576).round
+      overcommit_kbytes = [non_hugepage_mem_kb * 0.8 + 2 * 1048576, non_hugepage_mem_kb - 8 * 1048576].max.round
       safe_write_to_file("/etc/sysctl.d/99-overcommit.conf", "vm.overcommit_memory=2\nvm.overcommit_kbytes=#{overcommit_kbytes}\n")
     else
       r "sudo rm -f /etc/sysctl.d/99-overcommit.conf"

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe PostgresSetup do
       pg_setup.configure_memory_overcommit(strict: true)
     end
 
+    it "caps the reserve at 8 GiB on large VMs" do
+      # 256 GB = 268435456 KB -> non_hugepage = 201326592 KB; cap branch wins:
+      # 201326592 - 8 * 1048576 = 192937984 (vs 0.8 branch: 163158426)
+      allow(File).to receive(:read).with("/proc/meminfo").and_return("MemTotal:        268435456 kB\n")
+      expect(pg_setup).to receive(:safe_write_to_file).with("/etc/sysctl.d/99-overcommit.conf", "vm.overcommit_memory=2\nvm.overcommit_kbytes=192937984\n")
+      expect(pg_setup).to receive(:r).with("sudo sysctl --system")
+      pg_setup.configure_memory_overcommit(strict: true)
+    end
+
     it "removes overcommit config when strict is false" do
       expect(pg_setup).to receive(:r).with("sudo rm -f /etc/sysctl.d/99-overcommit.conf")
       expect(pg_setup).to receive(:r).with("sudo sysctl --system")


### PR DESCRIPTION
The previous formula set CommitLimit to 80% of non-hugepage RAM with no upper bound on the margin, so the commit budget grew far below physical RAM on large VMs.