### PR TITLE
Skip disk-fill I/O throttle on PG servers in recovery

### DIFF
--- a/rhizome/postgres/lib/io_throttle.rb
+++ b/rhizome/postgres/lib/io_throttle.rb
@@ -116,10 +116,17 @@ class IoThrottle
 
   # descend to 1% of baseline, starting at 91% disk usage
   def calculate_disk_usage_throttle
+    return nil if in_recovery?
     disk_usage_percent = Integer(r("df --output=pcent /dat | tail -n 1").strip.delete_suffix("%"), 10)
     return nil if disk_usage_percent < 91
     ratio = 1.0 - 0.11 * (disk_usage_percent - 91)
     (@disk_throughput_baseline_mbps * ratio).round
+  end
+
+  # Recovery throttles the startup process and walreceiver, which drive
+  # replay, so a near-full disk fills faster instead of slower.
+  def in_recovery?
+    File.exist?("#{@data_dir}/standby.signal") || File.exist?("#{@data_dir}/recovery.signal")
   end
 
   def find_device_id(mount_path)

--- a/rhizome/postgres/spec/io_throttle_spec.rb
+++ b/rhizome/postgres/spec/io_throttle_spec.rb
@@ -138,6 +138,11 @@ RSpec.describe IoThrottle do
   end
 
   describe "#calculate_disk_usage_throttle" do
+    before do
+      allow(File).to receive(:exist?).with("/dat/17/data/standby.signal").and_return(false)
+      allow(File).to receive(:exist?).with("/dat/17/data/recovery.signal").and_return(false)
+    end
+
     it "returns nil when disk usage is below 91%" do
       expect(throttle).to receive(:r).with("df --output=pcent /dat | tail -n 1").and_return("  90%\n")
       expect(throttle.send(:calculate_disk_usage_throttle)).to be_nil
@@ -166,6 +171,18 @@ RSpec.describe IoThrottle do
       expect(throttle_aws).to receive(:r).with("df --output=pcent /dat | tail -n 1").and_return("  97%\n")
       # ratio = 0.34 -> 448 * 0.34 = 152.32 -> 152
       expect(throttle_aws.send(:calculate_disk_usage_throttle)).to eq(152)
+    end
+
+    it "returns nil when standby.signal exists" do
+      allow(File).to receive(:exist?).with("/dat/17/data/standby.signal").and_return(true)
+      expect(throttle).not_to receive(:r)
+      expect(throttle.send(:calculate_disk_usage_throttle)).to be_nil
+    end
+
+    it "returns nil when recovery.signal exists" do
+      allow(File).to receive(:exist?).with("/dat/17/data/recovery.signal").and_return(true)
+      expect(throttle).not_to receive(:r)
+      expect(throttle.send(:calculate_disk_usage_throttle)).to be_nil
     end
   end
 


### PR DESCRIPTION
The throttle clamps the startup process and walreceiver, which drain pg_wal/. Slowing them while the primary keeps producing WAL grows pg_wal locally and fills the disk faster. Detect recovery via standby.signal / recovery.signal, which Postgres removes on promotion.