### PR TITLE
Revert "Use LEAST for Semaphore.incr and child exit scheduling"

### DIFF
--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -19,7 +19,7 @@ class Semaphore < Sequel::Model
       Strand
         .where(id:)
         .returning(:id)
-        .with_sql(:update_sql, schedule: Sequel.function(:least, Sequel[:schedule], Sequel::CURRENT_TIMESTAMP)))
+        .with_sql(:update_sql, schedule: Sequel::CURRENT_TIMESTAMP))
       .insert([:id, :strand_id, :name],
         DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
   end

--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -19,7 +19,7 @@ class Semaphore < Sequel::Model
       Strand
         .where(id:)
         .returning(:id)
-        .with_sql(:update_sql, schedule: Strand::SCHEDULE_NO_LATER_THAN_NOW))
+        .with_sql(:update_sql, schedule: Sequel.function(:least, Sequel[:schedule], Sequel::CURRENT_TIMESTAMP)))
       .insert([:id, :strand_id, :name],
         DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
   end

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -154,7 +154,7 @@ SQL
             Strand
               .where(id: parent_id)
               .exclude(active_siblings_ds.exists)
-              .update(schedule: Sequel.function(:least, Sequel[:schedule], Sequel::CURRENT_TIMESTAMP))
+              .update(schedule: Sequel::CURRENT_TIMESTAMP)
           end
         end
       end

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -94,11 +94,6 @@ class Strand < Sequel::Model
     Sequel.function(:least, Sequel[2]**Sequel.function(:least, :try, 20), 600) * Sequel.function(:random)
   end
 
-  # Advance a strand's schedule to now() only when it is not already
-  # scheduled for an earlier time, so an overdue schedule is never
-  # pushed later. Outlined to a constant to avoid extra allocations.
-  SCHEDULE_NO_LATER_THAN_NOW = Sequel.function(:least, Sequel[:schedule], Sequel::CURRENT_TIMESTAMP)
-
   TAKE_LEASE_PS = DB[:strand]
     .returning
     .where(
@@ -159,7 +154,7 @@ SQL
             Strand
               .where(id: parent_id)
               .exclude(active_siblings_ds.exists)
-              .update(schedule: SCHEDULE_NO_LATER_THAN_NOW)
+              .update(schedule: Sequel.function(:least, Sequel[:schedule], Sequel::CURRENT_TIMESTAMP))
           end
         end
       end


### PR DESCRIPTION
## Revert "Avoid some allocation by outlining a Sequel expression"
This reverts commit https://github.com/ubicloud/ubicloud/commit/b151911ffbc1da7152981db14d60c0104b8501c1.

## Revert "Use LEAST for Semaphore.incr and child exit scheduling"
This reverts commit https://github.com/ubicloud/ubicloud/commit/b45f37c7dc890331f7903c3e6f63e0fcc94d57d9.