### PR TITLE
Stop rolling out IPv6 DNS records for new PG DBs

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -74,10 +74,11 @@ class PostgresResource < Sequel::Model
     @dns_zone ||= DnsZone[project_id: Config.postgres_service_project_id, name: hostname_suffix]
   end
 
-  AAAA_CUTOFF = Time.utc(2026, 1, 13, 20)
+  AAAA_CUTOFF_BEGIN = Time.utc(2026, 1, 13, 20)
+  AAAA_CUTOFF_END = Time.utc(2026, 6, 23)
   def can_add_aaaa_record?
     !location.aws? &&
-      created_at < AAAA_CUTOFF &&
+      (created_at < AAAA_CUTOFF_BEGIN || created_at >= AAAA_CUTOFF_END) &&
       dns_zone &&
       representative_server.vm.ip6_string &&
       dns_zone

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -135,7 +135,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         dns_zone.insert_record(record_name:, type: "CNAME", ttl: 10, data: vm.aws_instance.ipv4_dns_name + ".")
       else
         dns_zone.insert_record(record_name:, type: "A", ttl: 10, data: vm.ip4_string)
-        if postgres_resource.created_at >= PostgresResource::AAAA_CUTOFF ||
+        if (postgres_resource.created_at >= PostgresResource::AAAA_CUTOFF_BEGIN && postgres_resource.created_at < PostgresResource::AAAA_CUTOFF_END) ||
             !dns_zone.records_dataset.where(type: "AAAA", name: record_name + ".").empty?
           dns_zone.insert_record(record_name:, type: "AAAA", ttl: 10, data: vm.ip6_string)
         end

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     let(:name) { postgres_resource.name }
 
     it "creates dns records and hops" do
-      postgres_server
+      postgres_server.resource.update(created_at: PostgresResource::AAAA_CUTOFF_BEGIN + 86400)
       expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com").at_least(:once)
       dns_zone = DnsZone.create(project_id: postgres_project.id, name: "pg.example.com")
       nx.incr_initial_provisioning
@@ -325,6 +325,19 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
         ["A", "#{name}.pg.example.com."],
         ["A", "private.#{name}.pg.example.com."],
         ["AAAA", "#{name}.pg.example.com."],
+        ["AAAA", "private.#{name}.pg.example.com."],
+      ]
+    end
+
+    it "does not create public AAAA record for resources created after the cutoff window" do
+      postgres_server.resource.update(created_at: PostgresResource::AAAA_CUTOFF_END + 86400)
+      expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com").at_least(:once)
+      dns_zone = DnsZone.create(project_id: postgres_project.id, name: "pg.example.com")
+      nx.incr_initial_provisioning
+      expect { nx.refresh_dns_record }.to hop("initialize_certificates")
+      expect(DnsRecord.where(dns_zone_id: dns_zone.id).select_order_map([:type, :name])).to eq [
+        ["A", "#{name}.pg.example.com."],
+        ["A", "private.#{name}.pg.example.com."],
         ["AAAA", "private.#{name}.pg.example.com."],
       ]
     end

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -631,7 +631,7 @@ RSpec.describe Clover, "postgres" do
         end
 
         it "can add AAAA record if database was created before cutoff and no AAAA exists" do
-          pg.update(created_at: PostgresResource::AAAA_CUTOFF - 86400)
+          pg.update(created_at: PostgresResource::AAAA_CUTOFF_BEGIN - 86400)
 
           visit "#{project.path}#{pg.path}/settings"
 
@@ -644,7 +644,7 @@ RSpec.describe Clover, "postgres" do
         end
 
         it "does not show button if AAAA record already exists" do
-          pg.update(created_at: PostgresResource::AAAA_CUTOFF - 86400)
+          pg.update(created_at: PostgresResource::AAAA_CUTOFF_BEGIN - 86400)
           @dns_zone.insert_record(record_name: pg.hostname, type: "AAAA", ttl: 10, data: "::1")
 
           visit "#{project.path}#{pg.path}/settings"
@@ -653,7 +653,7 @@ RSpec.describe Clover, "postgres" do
         end
 
         it "handles race condition when AAAA is added between page load and button click" do
-          pg.update(created_at: PostgresResource::AAAA_CUTOFF - 86400)
+          pg.update(created_at: PostgresResource::AAAA_CUTOFF_BEGIN - 86400)
 
           visit "#{project.path}#{pg.path}/settings"
 
@@ -667,13 +667,25 @@ RSpec.describe Clover, "postgres" do
           expect(page).to have_no_content "Add AAAA Record"
         end
 
-        it "does not show button for databases created after cutoff" do
-          pg.update(created_at: PostgresResource::AAAA_CUTOFF + 86400)
+        it "does not show button for databases created within the cutoff window" do
+          pg.update(created_at: PostgresResource::AAAA_CUTOFF_BEGIN + 86400)
 
           visit "#{project.path}#{pg.path}/settings"
 
           expect(page).to have_no_content "Add IPv6 (AAAA) DNS record"
           expect(page).to have_no_content "Add AAAA Record"
+        end
+
+        it "can add AAAA record if database was created after the end cutoff and no AAAA exists" do
+          pg.update(created_at: PostgresResource::AAAA_CUTOFF_END + 86400)
+
+          visit "#{project.path}#{pg.path}/settings"
+
+          expect(page).to have_content "Add IPv6 (AAAA) DNS record"
+          click_button "Add AAAA Record"
+
+          expect(page).to have_flash_notice("The AAAA DNS record will be added in a few seconds")
+          expect(pg.dns_zone.records_dataset.where(type: "AAAA").get(:name)).to eq(pg.hostname + ".")
         end
 
         it "does not show button for AWS instances" do
@@ -690,7 +702,7 @@ RSpec.describe Clover, "postgres" do
             target_storage_size_gib: 128,
             target_version: "16",
           ).subject
-          pg_aws.update(created_at: PostgresResource::AAAA_CUTOFF - 86400)
+          pg_aws.update(created_at: PostgresResource::AAAA_CUTOFF_BEGIN - 86400)
 
           visit "#{project.path}#{pg_aws.path}/settings"
 
@@ -699,7 +711,7 @@ RSpec.describe Clover, "postgres" do
         end
 
         it "does not show button when user does not have edit permissions" do
-          pg.update(created_at: PostgresResource::AAAA_CUTOFF - 86400)
+          pg.update(created_at: PostgresResource::AAAA_CUTOFF_BEGIN - 86400)
 
           AccessControlEntry.create(project_id: project_wo_permissions.id, subject_id: user.id, action_id: ActionType::NAME_MAP["Postgres:view"])
 


### PR DESCRIPTION
Returning both A and AAAA records for a database hostname triggers problematic behavior in Node.js v20+ clients. Their Happy Eyeballs implementation does not race IPv4 and IPv6 per the standard; it may abandon a working IPv4 connection after ~250ms and fall back to an IPv6 address that is unusable for clients without IPv6 connectivity, causing connections to fail or time out. This is widespread in modern Node versions and very hard for users to diagnose.

To stop introducing these subtle connectivity issues, cap the AAAA rollout window: rename AAAA_CUTOFF to AAAA_CUTOFF_BEGIN and add AAAA_CUTOFF_END so databases created on or after the end cutoff no longer get an AAAA record automatically. Existing AAAA records are left untouched, and users who explicitly want IPv6 can still opt in via the "Add AAAA Record" button, which now also covers these newer databases.