### PR TITLE
Email customers when GitHub runner provisioning hits a known error

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -180,21 +180,60 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     yield
   rescue Octokit::Error => e
     installation_ubid = github_runner.installation.ubid
-    page_args = case e.message
+    page_args, email_body = case e.message
     when /Repository level self-hosted runners are disabled/
-      ["Repository level self-hosted runners are disabled on #{installation_ubid}", ["GithubSelfHostRunnersDisabled", installation_ubid]]
+      [
+        ["Repository level self-hosted runners are disabled on #{installation_ubid}", ["GithubSelfHostRunnersDisabled", installation_ubid]],
+        [
+          "\"Repository level self-hosted runners are disabled on this repository.\"",
+          "To use Ubicloud runners, you need to enable self-hosted runners for this repository in your GitHub organization settings.",
+        ],
+      ]
     when /GitHub Actions is disabled on this repository/
-      ["GitHub Actions is disabled on #{installation_ubid}", ["GithubActionsDisabled", installation_ubid]]
+      [
+        ["GitHub Actions is disabled on #{installation_ubid}", ["GithubActionsDisabled", installation_ubid]],
+        [
+          "\"GitHub Actions is disabled on this repository.\"",
+          "To use Ubicloud runners, you need to enable GitHub Actions for this repository in your GitHub organization settings.",
+        ],
+      ]
     when /your IP address is not permitted to access this resource/
-      ["The organization has an IP allow list enabled on #{installation_ubid}", ["GithubIPAllowlistEnabled", installation_ubid]]
+      [
+        ["The organization has an IP allow list enabled on #{installation_ubid}", ["GithubIPAllowlistEnabled", installation_ubid]],
+        [
+          "\"Although you appear to have the correct authorization credentials, your organization has an IP allow list enabled, and our control plane's IP address is not permitted to access this resource.\"",
+          "To use Ubicloud runners, you need to disable the IP allow list in your GitHub organization settings.",
+        ],
+      ]
     when /Resource not accessible by integration/
       repository_ubid = github_runner.repository.ubid
-      ["Repository #{repository_ubid} not accessible by integration on #{installation_ubid}", ["GithubResourceNotAccessible", installation_ubid, repository_ubid]]
+      [
+        ["Repository #{repository_ubid} not accessible by integration on #{installation_ubid}", ["GithubResourceNotAccessible", installation_ubid, repository_ubid]],
+        [
+          "\"Resource not accessible by integration.\"",
+          "This usually means this repository isn't included in the Ubicloud GitHub App's repository access. To use Ubicloud runners, you need to add this repository to the Ubicloud GitHub App's allowed repository list in your GitHub settings.",
+        ],
+      ]
     end
 
     if page_args
       Clog.emit("Matched a known GitHub API error", {matched_github_api_error: {error_message: e.message, label: github_runner.label, repository_name: github_runner.repository_name}})
-      Prog::PageNexus.assemble(*page_args, installation_ubid, severity: "warning")
+      # Only notify when a new page is created, to avoid duplicate emails.
+      page = Prog::PageNexus.assemble(*page_args, installation_ubid, severity: "warning")
+      receivers = Authorization.allowed_accounts_dataset(project.id, "Project:github", project).select_map(:email)
+      if page && receivers.any?
+        repository_name = github_runner.repository_name
+        Util.send_email(
+          receivers,
+          "Action Required: Couldn't provision Ubicloud runners for the \"#{repository_name}\" repository",
+          greeting: "Hello,",
+          body: [
+            "Our monitoring system detected that we can't provision Ubicloud runners for your \"#{repository_name}\" repository due to the following error:",
+            *email_body,
+            "Please don't hesitate to reach out at support@ubicloud.com if you have any questions or need any help.",
+          ],
+        )
+      end
       github_runner.incr_destroy
       nap 0
     end

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -773,29 +773,75 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(runner.skip_deregistration_set?).to be(true)
     end
 
-    it "destroys the runner if self-hosted runners are disabled" do
+    def add_github_user(email)
+      Account.create(email:).tap do |account|
+        account.add_project(project)
+        AccessControlEntry.create(project_id: project.id, subject_id: account.id, action_id: ActionType::NAME_MAP["Project:github"])
+      end
+    end
+
+    it "destroys the runner and emails project users if self-hosted runners are disabled" do
+      add_github_user("github-user@example.com")
+      add_github_user("another-github-user@example.com")
+      Account.create(email: "billing-only@example.com").tap do |account|
+        account.add_project(project)
+        AccessControlEntry.create(project_id: project.id, subject_id: account.id, action_id: ActionType::NAME_MAP["Project:billing"])
+      end
+
       expect { nx.rescue_common_github_api_errors { raise Octokit::Error.new({body: "Repository level self-hosted runners are disabled"}) } }.to nap(0)
         .and change { Page.count }.by(1)
+        .and change { Mail::TestMailer.deliveries.length }.by(1)
       expect(runner.destroy_set?).to be(true)
+      mail = Mail::TestMailer.deliveries.last
+      expect(mail.to).to contain_exactly("github-user@example.com", "another-github-user@example.com")
+      expect(mail.subject).to eq("Action Required: Couldn't provision Ubicloud runners for the \"test-repo\" repository")
+      expect(mail.html_part.body).to include("Repository level self-hosted runners are disabled on this repository.")
     end
 
-    it "destroys the runner if GitHub Actions are disabled" do
+    it "destroys the runner and emails project users if GitHub Actions are disabled" do
+      add_github_user("github-user@example.com")
       expect { nx.rescue_common_github_api_errors { raise Octokit::Error.new({body: "GitHub Actions is disabled on this repository"}) } }.to nap(0)
         .and change { Page.count }.by(1)
+        .and change { Mail::TestMailer.deliveries.length }.by(1)
       expect(runner.destroy_set?).to be(true)
+      expect(Mail::TestMailer.deliveries.last.html_part.body).to include("GitHub Actions is disabled on this repository.")
     end
 
-    it "destroys the runner if IP allowlist is enabled" do
+    it "destroys the runner and emails project users if IP allowlist is enabled" do
+      add_github_user("github-user@example.com")
       expect { nx.rescue_common_github_api_errors { raise Octokit::Error.new({body: "your IP address is not permitted to access this resource"}) } }.to nap(0)
         .and change { Page.count }.by(1)
+        .and change { Mail::TestMailer.deliveries.length }.by(1)
       expect(runner.destroy_set?).to be(true)
+      expect(Mail::TestMailer.deliveries.last.html_part.body).to include("your organization has an IP allow list enabled")
     end
 
-    it "destroys the runner if resource not accessible by integration" do
+    it "destroys the runner and emails project users if resource not accessible by integration" do
+      add_github_user("github-user@example.com")
       repo = GithubRepository.create(name: "test-repo", installation_id: runner.installation_id)
       runner.update(repository_id: repo.id)
       expect { nx.rescue_common_github_api_errors { raise Octokit::Error.new({body: "Resource not accessible by integration"}) } }.to nap(0)
         .and change { Page.count }.by(1)
+        .and change { Mail::TestMailer.deliveries.length }.by(1)
+      expect(runner.destroy_set?).to be(true)
+      expect(Mail::TestMailer.deliveries.last.html_part.body).to include("Resource not accessible by integration.")
+    end
+
+    it "does not send a duplicate email when an active page already exists" do
+      add_github_user("github-user@example.com")
+      expect { nx.rescue_common_github_api_errors { raise Octokit::Error.new({body: "Repository level self-hosted runners are disabled"}) } }.to nap(0)
+        .and change { Page.count }.by(1)
+        .and change { Mail::TestMailer.deliveries.length }.by(1)
+
+      expect { nx.rescue_common_github_api_errors { raise Octokit::Error.new({body: "Repository level self-hosted runners are disabled"}) } }.to nap(0)
+        .and not_change { Page.count }
+        .and not_change { Mail::TestMailer.deliveries.length }
+    end
+
+    it "creates the page but sends no email when no project user has the github permission" do
+      expect { nx.rescue_common_github_api_errors { raise Octokit::Error.new({body: "Repository level self-hosted runners are disabled"}) } }.to nap(0)
+        .and change { Page.count }.by(1)
+        .and not_change { Mail::TestMailer.deliveries.length }
       expect(runner.destroy_set?).to be(true)
     end
 


### PR DESCRIPTION
When we fail to provision a runner due to a misconfiguration on the customer's side (self-hosted runners disabled, GitHub Actions disabled, an organization IP allow list, or the repository missing from the Ubicloud GitHub App's access), the only signal was an internal page. Someone then had to notice the page, figure out who to contact, and write the explanation email by hand.

Automate that step: alongside the page, email every account with the Project:github permission, describing the specific error and how to resolve it. The email is sent only when PageNexus.assemble actually creates a new page, so an ongoing issue does not generate duplicate mails on every retry.