### PR TITLE
Do not wait for initial cert id if a presigned cert was available

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -199,7 +199,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     if use_publicly_signed_certificates?
       # Do not generate root certs if we are using publicly signed certificates.
       # We started a CertNexus strand in assemble, nap until the cert is ready.
-      wait_for_public_cert("initial_cert_id")
+      wait_for_public_cert("initial_cert_id") if initial_cert_id
     elsif !postgres_resource.root_cert_1
       # Do not regenerate certificates already present, in case we napped due to a reap.
       postgres_resource.root_cert_1, postgres_resource.root_cert_key_1 = Util.create_root_certificate(common_name: "#{postgres_resource.ubid} Root Certificate Authority", duration: 60 * 60 * 24 * 365 * 5)

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -447,6 +447,12 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(sans).to eq %W[DNS:#{pr.ubid}.pg.ubicloud.app DNS:*.#{pr.ubid}.pg.ubicloud.app DNS:*.#{pr.ubid}.private.pg.ubicloud.app]
     end
 
+    it "hops is using a publicly signed certificate and initial cert is already creted" do
+      nx.postgres_resource.update(hostname_version: "v3")
+      refresh_frame(nx, new_values: {"use_publicly_signed_certificates" => true})
+      expect { nx.initialize_certificates }.to hop("wait_servers")
+    end
+
     it "naps if needing an initial cert and one is not available" do
       nx.postgres_resource.update(hostname_version: "v3")
       refresh_frame(nx, new_values: {"use_publicly_signed_certificates" => true, "initial_cert_id" => Cert.create(hostname: "*.#{postgres_resource.ubid}.pg.example.com").id})


### PR DESCRIPTION
If a presigned cert was available, initial_cert_id will be nil, and wait_for_public_cert will fail as it uses Cert.with_pk!.