### PR TITLE
Fix missed incr_refresh_certificates for pg servers

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -229,7 +229,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   label def refresh_certificates
     decr_refresh_certificates
 
-    nap 5 if resource.server_cert.nil?
+    nap 5 if resource.server_cert.nil? || resource.client_root_cert_1.nil?
 
     client_ca_bundle = [resource.client_ca_certificates, resource.trusted_ca_certs].compact.join("\n")
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -601,6 +601,9 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "waits for certificate creation by the parent resource" do
       server.resource.update(server_cert: nil)
       expect { nx.refresh_certificates }.to nap(5)
+
+      server.resource.update(server_cert: "1", client_root_cert_1: nil)
+      expect { nx.refresh_certificates }.to nap(5)
     end
 
     it "pushes certificates to vm and hops to configure_prometheus during initial provisioning" do


### PR DESCRIPTION
PostgresResourceNexus#initialize_certificates needs to increment the semaphore, as otherwise the /etc/ssl/certs/ca.crt file can be empty if the server loses the setup race against the resource.