### PR TITLE
Add checksum to pry audit Object Lock puts

### DIFF
--- a/lib/s3_audit_batcher.rb
+++ b/lib/s3_audit_batcher.rb
@@ -42,6 +42,8 @@ class S3AuditBatcher
         object_lock_mode: "COMPLIANCE",
         object_lock_retain_until_date: @retain_until,
         if_none_match: "*",
+        # Object Lock puts require a Content-MD5 or x-amz-checksum-* header.
+        checksum_algorithm: "CRC32",
       )
       @seq += 1
       batch.clear

--- a/spec/lib/s3_audit_batcher_spec.rb
+++ b/spec/lib/s3_audit_batcher_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe S3AuditBatcher do
           object_lock_mode: "COMPLIANCE",
           object_lock_retain_until_date: retain_until,
           if_none_match: "*",
+          checksum_algorithm: "CRC32",
         ),
       )
 


### PR DESCRIPTION
S3 rejects PutObject requests carrying Object Lock parameters unless they include a Content-MD5 or x-amz-checksum-* header. The bin/pry client sets request_checksum_calculation: "when_required", which does not add one for these puts, so every batch failed in staging ("Content-MD5 OR x-amz-checksum- HTTP header is required..."). Request a CRC32 checksum on the put so the requirement holds regardless of client config.