### PR TITLE
Add admin view to remove boot images

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1246,6 +1246,46 @@ class CloverAdmin < Roda
         additional_semaphores: {"RolloutRhizome" => %w[github_runners_work], "RolloutBootImage" => %w[rollback]})
     end
 
+    r.on "remove-boot-images" do
+      r.get true do
+        @groups = BootImage
+          .left_join(:vm_storage_volume, boot_image_id: Sequel[:boot_image][:id])
+          .select_group(Sequel[:boot_image][:name], Sequel[:boot_image][:version])
+          .select_append(
+            Sequel.function(:count, Sequel[:boot_image][:id]).distinct.as(:image_count),
+            Sequel.function(:count, Sequel[:vm_storage_volume][:id]).as(:volume_count),
+          )
+          .order(Sequel[:boot_image][:name], Sequel[:boot_image][:version])
+          .naked
+          .all
+        view("remove_boot_images")
+      end
+
+      r.is "confirm" do
+        @name, @version = typecast_params.nonempty_str!(%w[name version])
+
+        images_ds = BootImage.where(name: @name, version: @version)
+        # Only images with no active storage volumes (i.e. no active VM) can be removed.
+        removable_ds = images_ds.exclude(id: VmStorageVolume.exclude(boot_image_id: nil).select(:boot_image_id))
+
+        r.get do
+          @total_count = images_ds.count
+          @removable_count = removable_ds.count
+          view("remove_boot_images_confirm")
+        end
+
+        r.post do
+          image_ids = removable_ds.select_map(:id)
+          Strand.import(
+            [:id, :prog, :label, :stack],
+            image_ids.map { [Strand.generate_uuid, "RemoveBootImage", "start", Sequel.pg_jsonb_wrap([{subject_id: it}])] },
+          )
+          flash["notice"] = "Scheduled removal of #{image_ids.length} boot image(s) for #{@name} #{@version}"
+          r.redirect "/remove-boot-images"
+        end
+      end
+    end
+
     r.on "local-e2e" do
       strand_ds = Strand.where(Sequel.like(:prog, "Test::%"))
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1992,6 +1992,47 @@ RSpec.describe CloverAdmin do
     end
   end
 
+  describe "remove boot images" do
+    before do
+      click_link "Remove Boot Images"
+    end
+
+    it "lists boot image groups and removes only unused images" do
+      expect(page.title).to eq "Ubicloud Admin - Remove Boot Images"
+      expect(page).to have_content("No data available for Boot Images")
+
+      remove_path = page.current_path
+      vmh1 = create_vm_host
+      vmh2 = create_vm_host
+      used = BootImage.create(name: "ubuntu-noble", version: "20240101", vm_host_id: vmh1.id, size_gib: 14, activated_at: Time.now)
+      unused = BootImage.create(name: "ubuntu-noble", version: "20240101", vm_host_id: vmh2.id, size_gib: 14, activated_at: Time.now)
+      vm = create_vm(vm_host_id: vmh1.id)
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0, boot_image_id: used.id)
+
+      visit remove_path
+      expect(page.all(".boot-images-table td").map(&:text)).to eq ["ubuntu-noble", "20240101", "2", "1", "Remove"]
+
+      click_link "Remove"
+      expect(page).to have_content("schedule removal of 1 of 2 image(s)")
+
+      click_button "Confirm Remove"
+      expect(page).to have_flash_notice("Scheduled removal of 1 boot image(s) for ubuntu-noble 20240101")
+      expect(Strand.where(prog: "RemoveBootImage").map { it.stack.first["subject_id"] }).to eq [unused.id]
+    end
+
+    it "shows a message and no button when there are no removable images" do
+      vmh = create_vm_host
+      image = BootImage.create(name: "ubuntu-noble", version: "20240101", vm_host_id: vmh.id, size_gib: 14, activated_at: Time.now)
+      vm = create_vm(vm_host_id: vmh.id)
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0, boot_image_id: image.id)
+
+      page.refresh
+      click_link "Remove"
+      expect(page).to have_content("There are no images to remove.")
+      expect(page).to have_no_button("Confirm Remove")
+    end
+  end
+
   describe "local E2E" do
     before do
       project = Project.create(name: "Postgres-Service-Project")

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -56,6 +56,7 @@
       <a href="/authentication-audit-log/admin">View Admin Authentication Audit Logs</a>
     </li>
     <li><a href="/rollouts">Manage Rollouts</a></li>
+    <li><a href="/remove-boot-images">Remove Boot Images</a></li>
     <li><a href="/local-e2e">Manage Local E2E</a></li>
     <li><a href="/admin-list">View Admin List</a></li>
     <li><a href="/autoforme/Strand/search/1?<%= to_query_string(prog: "Vm::Metal::Nexus", label: "unavailable") %>">Show Unavailable VMs</a></li>

--- a/views/admin/remove_boot_images.erb
+++ b/views/admin/remove_boot_images.erb
@@ -1,0 +1,13 @@
+<% @page_title = "Remove Boot Images" %>
+
+<% data = @groups.map do |g|
+  {
+    "name" => g[:name],
+    "version" => g[:version],
+    "images" => g[:image_count],
+    "storage volumes" => g[:volume_count],
+    "action" => table_link("Remove", "/remove-boot-images/confirm?#{to_query_string(name: g[:name], version: g[:version])}")
+  }
+end %>
+
+<%== part("components/table", title: "Boot Images", table_class: "boot-images-table", data:, use_admin_label: false) %>

--- a/views/admin/remove_boot_images_confirm.erb
+++ b/views/admin/remove_boot_images_confirm.erb
@@ -1,0 +1,23 @@
+<% @page_title = "Remove Boot Images" %>
+
+<p>
+  You are about to remove boot image
+  <strong><%= @name %>
+    <%= @version %></strong>.
+</p>
+<p>
+  This will schedule removal of
+  <strong><%= @removable_count %></strong>
+  of
+  <%= @total_count %>
+  image(s) that have no active storage volumes (i.e. no active VM). Images that still have active storage volumes will
+  be kept.
+</p>
+
+<% if @removable_count == 0 %>
+  <p>There are no images to remove.
+    <a href="/remove-boot-images">Back</a></p>
+<% else %>
+  <%== form({action: "/remove-boot-images/confirm?#{to_query_string(name: @name, version: @version)}", method: "post", class: "rollout-form"}, button: "Confirm Remove") %>
+  <p><a href="/remove-boot-images">Cancel</a></p>
+<% end %>


### PR DESCRIPTION
Add a "Remove Boot Images" admin page that lists boot images grouped by name and version, showing the number of images and the total number of storage volumes referencing them.

Each group has a remove action that, after a confirmation step, schedules removal (via remove_boot_image) of only the images that have no active storage volumes. Images still backing an active VM are kept.

<img width="2734" height="1646" alt="CleanShot 2026-06-23 at 17 23 55@2x" src="https://github.com/user-attachments/assets/2b0eeaad-f577-4056-8a7b-02b8cfccbc99" />

<img width="2754" height="1186" alt="CleanShot 2026-06-23 at 17 24 07@2x" src="https://github.com/user-attachments/assets/faadb298-325b-443e-ab4f-fce3193e3ee3" />
