### PR TITLE
Always add private AAAA records for Postgres databases

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -177,9 +177,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         record_name = postgres_resource.private_hostname
         dns_zone.delete_record(record_name:)
         dns_zone.insert_record(record_name:, type: "A", ttl: 10, data: vm.private_ipv4_string)
-        unless dns_zone.records_dataset.where(type: "AAAA", name: record_name + ".").empty?
-          dns_zone.insert_record(record_name:, type: "AAAA", ttl: 10, data: vm.private_ipv6_string)
-        end
+        dns_zone.insert_record(record_name:, type: "AAAA", ttl: 10, data: vm.private_ipv6_string)
       end
     end
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -352,6 +352,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(DnsRecord.where(dns_zone_id: dns_zone.id).select_order_map([:type, :name])).to eq [
         ["A", "#{name}.pg.example.com."],
         ["A", "private.#{name}.pg.example.com."],
+        ["AAAA", "private.#{name}.pg.example.com."],
       ]
     end
 


### PR DESCRIPTION
We initially stopped publishing AAAA records because some poorly programmed postgres clients do not correctly fall back to IPv4 if there is an AAAA record and there are issues connecting over IPv6.

However, that concern does not apply to the private networking case: our VMs already support IPv6 over the private network, so there is no fallback-to-IPv4 problem there. Add the private hostname AAAA record unconditionally again. The public hostname AAAA record remains conditional.