### PR TITLE
Allow OTEL as a pry audit sink alongside S3

### DIFF
--- a/bin/pry
+++ b/bin/pry
@@ -5,8 +5,8 @@ REPL = true
 
 require_relative "../loader"
 
-if Config.production? && !Config.is_e2e && (Config.pry_audit_bucket.nil? || Config.pry_audit_access_key.nil?)
-  puts "PRY_AUDIT_BUCKET/PRY_AUDIT_ACCESS_KEY is not set in production environment. This is not allowed for auditing purposes."
+if Config.production? && !Config.is_e2e && Config.pry_audit_bucket.nil? && Config.otel_exporter_otlp_endpoint.nil?
+  puts "PRY_AUDIT_BUCKET or OTEL_EXPORTER_OTLP_ENDPOINT is not set in production environment. This is not allowed for auditing purposes."
   exit(1)
 end
 
@@ -90,6 +90,8 @@ PRY_LOGGER = if Config.pry_audit_bucket
     key_prefix: "pry/#{Time.now.utc.strftime("%Y-%m-%d")}/#{key_operator}/#{PRY_SESSION[:session_id]}",
     retain_until: Time.now + (Config.pry_audit_retention_years * 366 * 24 * 60 * 60),
   )
+elsif Config.otel_exporter_otlp_endpoint
+  OtelBatcher.new(Config.otel_exporter_otlp_endpoint, default_resource_attrs: {"service.name" => "pry"})
 end
 
 if PRY_LOGGER


### PR DESCRIPTION
Ubicloud deployers who don't want to run an S3 Object Lock bucket can point the pry audit log at their own OTEL collector instead. Restore the OtelBatcher path (dropped when S3 became the sole sink) as an alternative, and accept either PRY_AUDIT_BUCKET or OTEL_EXPORTER_OTLP_ENDPOINT as the production audit sink.