### PR TITLE
Make MaintainPresignedCerts prog automatically handle stuck certs

### DIFF
--- a/prog/vnet/maintain_presigned_certs.rb
+++ b/prog/vnet/maintain_presigned_certs.rb
@@ -37,23 +37,25 @@ class Prog::Vnet::MaintainPresignedCerts < Prog::Base
       waiting_strand_id: strand.id)
     self.resource_id = ubid.to_uuid
     self.cert_id = st.id
-    register_deadline("wait", MAX_WAIT_SIGNING_SECONDS)
+    self.last_cert_created = now
+    register_deadline("wait", MAX_WAIT_SIGNING_SECONDS + 15 * 60)
     hop_wait_for_signed_cert
   end
 
   def wait_for_signed_cert
     if (cert_strand = Strand[cert_id])
-      nap(10 * 60) unless cert_strand.label == "wait"
-      ds.insert(id_key.to_sym => resource_id, :cert_id => cert_id)
+      if cert_strand.label == "wait"
+        ds.insert(id_key.to_sym => resource_id, :cert_id => cert_id)
+      elsif now - last_cert_created < MAX_WAIT_SIGNING_SECONDS
+        nap(10 * 60)
+      else
+        Clog.emit("Strand for presigned cert not finished in time, destroying", {"presigned_cert_strand_destroyed" => UBID.to_ubid(cert_id)})
+        cert_strand.subject.incr_destroy
+      end
     else
-      # Info page for visibility, as this indicates a problem in the code or a manual deletion of the strand.
-      # There isn't anything that can be done in this case, and we want to keep the table populated, so hop back to wait.
-      # Purposely do not resolve this page automatically, since an operator should be looking into the problem.
-      cert_ubid = UBID.to_ubid(cert_id)
-      Prog::PageNexus.assemble("Strand for presigned cert deleted: #{cert_ubid}",
-        [strand.prog.split("::").last, cert_id],
-        cert_ubid,
-        severity: "info")
+      # There isn't anything that can be done in this case, and we want to keep the table populated,
+      # so hop back to wait. Emit so it's possible to track cases where this has happened.
+      Clog.emit("Strand for presigned cert deleted", {"presigned_cert_strand_deleted" => UBID.to_ubid(cert_id)})
     end
 
     self.resource_id = nil

--- a/spec/prog/vnet/maintain_presigned_load_balancer_certs_spec.rb
+++ b/spec/prog/vnet/maintain_presigned_load_balancer_certs_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Prog::Vnet::MaintainPresignedLoadBalancerCerts do
       dns_zone
       expect { prog.request_cert }.to hop("wait_for_signed_cert")
       frame = prog.strand.stack[0]
-      load_balancer_id, cert_id = frame.values_at("load_balancer_id", "cert_id")
+      load_balancer_id, cert_id, last_cert_created = frame.values_at("load_balancer_id", "cert_id", "last_cert_created")
       expect(Cert.count).to eq 1
       cert = Cert.first
       lb_ubid = UBID.to_ubid(load_balancer_id)
@@ -69,7 +69,8 @@ RSpec.describe Prog::Vnet::MaintainPresignedLoadBalancerCerts do
       expect(cert.private_hostname).to eq "*.#{lb_ubid}.private.lb2.ubicloud.com"
       expect(cert.dns_zone_id).to eq dns_zone.id
       expect(frame["deadline_target"]).to eq "wait"
-      expect(Time.parse(frame["deadline_at"])).to be_within(5).of(Time.now + 60 * 30)
+      expect(Time.parse(frame["deadline_at"])).to be_within(5).of(Time.now + 60 * 45)
+      expect(last_cert_created).to be_within(5).of(Time.now.to_i)
     end
   end
 
@@ -81,9 +82,9 @@ RSpec.describe Prog::Vnet::MaintainPresignedLoadBalancerCerts do
       })
     end
 
-    it "info pages and hops if cert strand does not exist" do
+    it "emits and hops if cert strand does not exist" do
+      expect(Clog).to receive(:emit).with("Strand for presigned cert deleted", {"presigned_cert_strand_deleted" => UBID.to_ubid(prog.strand.stack[0]["cert_id"])}).and_call_original
       expect { prog.wait_for_signed_cert }.to hop("wait")
-        .and change { Page.where(severity: "info").count }.from(0).to(1)
         .and not_change { DB[:presigned_load_balancer_cert].count }
       frame = prog.strand.stack[0]
       expect(frame.fetch("load_balancer_id")).to be_nil
@@ -91,14 +92,29 @@ RSpec.describe Prog::Vnet::MaintainPresignedLoadBalancerCerts do
       expect(frame.fetch("last_cert_created")).to be_within(5).of(Time.now.to_i)
     end
 
-    it "naps if cert strand is not in wait" do
+    it "naps if cert strand is not in wait and it has not been too lon" do
       frame = prog.strand.stack[0]
       Strand.create_with_id(frame.fetch("cert_id"), prog: "Vnet::CertNexus", label: "start")
       refresh_frame(prog, new_values: {"last_cert_created" => Time.now.to_i - 50})
       expect { prog.wait_for_signed_cert }.to nap(600)
     end
 
-    it "hops if cert strand is in wait" do
+    it "destroys cert and hops if cert strand is not in wait and it has been too long" do
+      frame = prog.strand.stack[0]
+      Strand.create_with_id(frame.fetch("cert_id"), prog: "Vnet::CertNexus", label: "start")
+      cert = Cert.create_with_id(frame.fetch("cert_id"), hostname: "test")
+      refresh_frame(prog, new_values: {"last_cert_created" => Time.now.to_i - 35 * 60})
+      expect(Clog).to receive(:emit).with("Strand for presigned cert not finished in time, destroying", {"presigned_cert_strand_destroyed" => UBID.to_ubid(prog.strand.stack[0]["cert_id"])}).and_call_original
+      expect { prog.wait_for_signed_cert }.to hop("wait")
+        .and not_change { DB[:presigned_load_balancer_cert].count }
+        .and change { cert.reload.destroy_set? }.from(false).to(true)
+      frame = prog.strand.stack[0]
+      expect(frame.fetch("load_balancer_id")).to be_nil
+      expect(frame.fetch("cert_id")).to be_nil
+      expect(frame.fetch("last_cert_created")).to be_within(5).of(Time.now.to_i)
+    end
+
+    it "adds cert to presigned certs table and hops if cert strand is in wait" do
       frame = prog.strand.stack[0]
       expect_load_balancer_id = frame.fetch("load_balancer_id")
       expect_cert_id = frame.fetch("cert_id")
@@ -106,7 +122,6 @@ RSpec.describe Prog::Vnet::MaintainPresignedLoadBalancerCerts do
       Cert.create_with_id(expect_cert_id, hostname: "*.#{UBID.to_ubid(expect_load_balancer_id)}.lb2.ubicloud.com")
 
       expect { prog.wait_for_signed_cert }.to hop("wait")
-        .and not_change { Page.where(severity: "info").count }
         .and change { DB[:presigned_load_balancer_cert].count }.from(0).to(1)
       load_balancer_id, cert_id, created_at = DB[:presigned_load_balancer_cert].get([:load_balancer_id, :cert_id, :created_at])
       expect(load_balancer_id).to eq expect_load_balancer_id

--- a/spec/prog/vnet/maintain_presigned_postgres_certs_spec.rb
+++ b/spec/prog/vnet/maintain_presigned_postgres_certs_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Prog::Vnet::MaintainPresignedPostgresCerts do
       dns_zone
       expect { prog.request_cert }.to hop("wait_for_signed_cert")
       frame = prog.strand.stack[0]
-      postgres_resource_id, cert_id = frame.values_at("postgres_resource_id", "cert_id")
+      postgres_resource_id, cert_id, last_cert_created = frame.values_at("postgres_resource_id", "cert_id", "last_cert_created")
       expect(Cert.count).to eq 1
       cert = Cert.first
       pg_ubid = UBID.to_ubid(postgres_resource_id)
@@ -66,7 +66,8 @@ RSpec.describe Prog::Vnet::MaintainPresignedPostgresCerts do
       expect(cert.private_hostname).to eq "*.#{pg_ubid}.private.pg.ubicloud.app"
       expect(cert.dns_zone_id).to eq dns_zone.id
       expect(frame["deadline_target"]).to eq "wait"
-      expect(Time.parse(frame["deadline_at"])).to be_within(5).of(Time.now + 60 * 30)
+      expect(Time.parse(frame["deadline_at"])).to be_within(5).of(Time.now + 60 * 45)
+      expect(last_cert_created).to be_within(5).of(Time.now.to_i)
     end
   end
 
@@ -78,9 +79,9 @@ RSpec.describe Prog::Vnet::MaintainPresignedPostgresCerts do
       })
     end
 
-    it "info pages and hops if cert strand does not exist" do
+    it "emits and hops if cert strand does not exist" do
+      expect(Clog).to receive(:emit).with("Strand for presigned cert deleted", {"presigned_cert_strand_deleted" => UBID.to_ubid(prog.strand.stack[0]["cert_id"])}).and_call_original
       expect { prog.wait_for_signed_cert }.to hop("wait")
-        .and change { Page.where(severity: "info").count }.from(0).to(1)
         .and not_change { DB[:presigned_postgres_cert].count }
       frame = prog.strand.stack[0]
       expect(frame.fetch("postgres_resource_id")).to be_nil
@@ -88,14 +89,29 @@ RSpec.describe Prog::Vnet::MaintainPresignedPostgresCerts do
       expect(frame.fetch("last_cert_created")).to be_within(5).of(Time.now.to_i)
     end
 
-    it "naps if cert strand is not in wait" do
+    it "naps if cert strand is not in wait and it has not been too long" do
       frame = prog.strand.stack[0]
       Strand.create_with_id(frame.fetch("cert_id"), prog: "Vnet::CertNexus", label: "start")
       refresh_frame(prog, new_values: {"last_cert_created" => Time.now.to_i - 50})
       expect { prog.wait_for_signed_cert }.to nap(600)
     end
 
-    it "hops if cert strand is in wait" do
+    it "destroys cert and hops if cert strand is not in wait and it has been too long" do
+      frame = prog.strand.stack[0]
+      Strand.create_with_id(frame.fetch("cert_id"), prog: "Vnet::CertNexus", label: "start")
+      cert = Cert.create_with_id(frame.fetch("cert_id"), hostname: "test")
+      refresh_frame(prog, new_values: {"last_cert_created" => Time.now.to_i - 35 * 60})
+      expect(Clog).to receive(:emit).with("Strand for presigned cert not finished in time, destroying", {"presigned_cert_strand_destroyed" => UBID.to_ubid(prog.strand.stack[0]["cert_id"])}).and_call_original
+      expect { prog.wait_for_signed_cert }.to hop("wait")
+        .and not_change { DB[:presigned_postgres_cert].count }
+        .and change { cert.reload.destroy_set? }.from(false).to(true)
+      frame = prog.strand.stack[0]
+      expect(frame.fetch("postgres_resource_id")).to be_nil
+      expect(frame.fetch("cert_id")).to be_nil
+      expect(frame.fetch("last_cert_created")).to be_within(5).of(Time.now.to_i)
+    end
+
+    it "adds cert to presigned certs table and hops if cert strand is in wait" do
       frame = prog.strand.stack[0]
       expect_postgres_resource_id = frame.fetch("postgres_resource_id")
       expect_cert_id = frame.fetch("cert_id")
@@ -103,7 +119,6 @@ RSpec.describe Prog::Vnet::MaintainPresignedPostgresCerts do
       Cert.create_with_id(expect_cert_id, hostname: "*.#{UBID.to_ubid(expect_postgres_resource_id)}.pg.ubicloud.app")
 
       expect { prog.wait_for_signed_cert }.to hop("wait")
-        .and not_change { Page.where(severity: "info").count }
         .and change { DB[:presigned_postgres_cert].count }.from(0).to(1)
       postgres_resource_id, cert_id, created_at = DB[:presigned_postgres_cert].get([:postgres_resource_id, :cert_id, :created_at])
       expect(postgres_resource_id).to eq expect_postgres_resource_id


### PR DESCRIPTION
If a cert is stuck, MaintainPresignedCerts can just ignore it and try another cert, since the cert isn't tied to anything that is currently used.

When creating the cert, this tracks when the cert is created. If more than 30 minutes have passed and the cert is still not ready, mark it for destruction and try again. No longer page if the cert strand was deleted by something else either. Just Clog emit for both of these cases, so we can track them if necessary.

Previously, there was a deadline page if the cert wasn't ready in 30 minutes. Now, that is the deadline for automatically destroying the strand. There is still a deadline, but now it is 45 minutes, but it should never be hit, since sometime between 30-40 minutes, it should destroy the cert if it is not yet ready.