### PR TITLE
Clog and nap when the LocationNexus doesn't have enough permissions

### DIFF
--- a/prog/location_nexus.rb
+++ b/prog/location_nexus.rb
@@ -28,7 +28,13 @@ class Prog::LocationNexus < Prog::Base
         server.resource.incr_bypass_maintenance_window
       end
     end
+
     nap 3600
+  rescue Aws::EC2::Errors::UnauthorizedOperation => e
+    Clog.emit("AWS UnauthorizedOperation error when checking for scheduled maintenance events", Util.exception_to_hash(e, into: {location_id: location.id}))
+    # This is a known issue with AWS accounts that don't have the right permissions to describe maintenance events.
+    Prog::PageNexus.assemble("aws_unauthorized_operation", ["AwsUnauthorizedOperation", location.ubid], location.ubid, severity: "warning", extra_data: {project: location.project.ubid})
+    nap 3600 * 24 * 31
   end
 
   label def destroy

--- a/spec/prog/location_nexus_spec.rb
+++ b/spec/prog/location_nexus_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe Prog::LocationNexus do
       expect { nx.wait }.to nap(3600)
       expect(Semaphore.where(name: "recycle").count).to eq(0)
     end
+
+    it "naps for 24h if AWS returns UnauthorizedOperation" do
+      expect(nx.location).to receive(:scheduled_maintenance_events).and_raise(Aws::EC2::Errors::UnauthorizedOperation.new(nil, "test"))
+      expect(Prog::PageNexus).to receive(:assemble).with("aws_unauthorized_operation", ["AwsUnauthorizedOperation", location.ubid], location.ubid, severity: "warning", extra_data: {project: location.project.ubid})
+      expect { nx.wait }.to nap(3600 * 24 * 31)
+    end
   end
 
   describe "#before_run" do


### PR DESCRIPTION
We recently started checking scheduled_maintenance_events for AWS
locations. This causes failures when the BYOC locations don't have the
permissions.