### PR TITLE
Add basic Leaseweb provider API client

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -106,6 +106,8 @@ module Config
   optional :hetzner_user, string, clear: true
   optional :hetzner_password, string, clear: true
   override :hetzner_connection_string, "https://robot-ws.your-server.de", string
+  optional :leaseweb_api_key, string, clear: true
+  override :leaseweb_connection_string, "https://api.leaseweb.com", string
   override :managed_service, false, bool
   override :sanctioned_countries, "CU,IR,KP,SY", array(string)
   override :hetzner_ssh_public_key, nil, string

--- a/lib/hosting/leaseweb_apis.rb
+++ b/lib/hosting/leaseweb_apis.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "excon"
+class Hosting::LeasewebApis < Hosting::ProviderApis
+  def hardware_reset
+    create_connection.post(path: "/bareMetals/v2/servers/#{@provider.server_identifier}/powerCycle", expects: 204)
+    nil
+  end
+
+  def set_server_name(server_name)
+    create_connection.put(path: "/bareMetals/v2/servers/#{@provider.server_identifier}",
+      body: JSON.generate(reference: server_name),
+      expects: 204)
+    nil
+  end
+
+  def pull_data_center
+    response = create_connection.get(path: "/bareMetals/v2/servers/#{@provider.server_identifier}", expects: 200)
+    location = JSON.parse(response.body).fetch("location")
+    [location["site"], location["suite"], location["rack"]].compact.join("-")
+  end
+
+  private
+
+  def create_connection
+    Excon.new(Config.leaseweb_connection_string,
+      headers: {"X-Lsw-Auth" => Config.leaseweb_api_key, "Content-Type" => "application/json"})
+  end
+end

--- a/spec/lib/hosting/leaseweb_apis_spec.rb
+++ b/spec/lib/hosting/leaseweb_apis_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Hosting::LeasewebApis do
+  let(:leaseweb_apis) do
+    vmh = create_vm_host
+    provider = HostProvider.create do
+      it.id = vmh.id
+      it.server_identifier = "123"
+      it.provider_name = HostProvider::LEASEWEB_PROVIDER_NAME
+    end
+    described_class.new(provider)
+  end
+
+  before do
+    allow(Config).to receive_messages(
+      leaseweb_connection_string: "https://api.leaseweb.com",
+      leaseweb_api_key: "key123",
+    )
+  end
+
+  describe "hardware_reset" do
+    it "can power cycle a server" do
+      Excon.stub({path: "/bareMetals/v2/servers/123/powerCycle", method: :post}, {status: 204, body: ""})
+      expect(leaseweb_apis.hardware_reset).to be_nil
+    end
+  end
+
+  describe "set_server_name" do
+    it "updates the server reference" do
+      Excon.stub({path: "/bareMetals/v2/servers/123", method: :put, body: JSON.generate(reference: "vh123")}, {status: 204, body: ""})
+      expect(leaseweb_apis.set_server_name("vh123")).to be_nil
+    end
+  end
+
+  describe "pull_data_center" do
+    it "returns the site and suite" do
+      Excon.stub({path: "/bareMetals/v2/servers/123", method: :get}, {status: 200, body: JSON.generate(location: {site: "WDC-02", suite: "SC03.03A", rack: "F10"})})
+      expect(leaseweb_apis.pull_data_center).to eq "WDC-02-SC03.03A-F10"
+    end
+  end
+
+  describe "unimplemented operations" do
+    it "does not respond to operations leaseweb does not implement" do
+      [:pull_ips, :reimage, :get_main_ip4].each do |operation|
+        expect(leaseweb_apis).not_to respond_to(operation)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is not full Leaseweb support, nor the complete Leaseweb API.

It's a basic, initial client covering a few operations. It allows
on-call engineers to perform hardware resets without having to access
the Leaseweb portal, since not all on-call engineers have portal access.

Hosting::LeasewebApis subclasses Hosting::ProviderApis and implements a
basic subset of operations as a starting point. Operations it does not
support are simply left undefined, so callers can detect them with
respond_to?, showing that a provider need not support every operation.
Leaseweb's Dedicated Server API offers many more operations, which can
be added later.

The implemented operations map to the bareMetals v2 API
(https://developer.leaseweb.com/docs):

```
  hardware_reset    -> POST /bareMetals/v2/servers/{id}/powerCycle
  set_server_name   -> PUT  /bareMetals/v2/servers/{id}  {reference}
  pull_data_center  -> GET  /bareMetals/v2/servers/{id}, joining the
                       location site, suite, and rack
```

I used the combination of site, suite, and rack as the datacenter
identifier, since we allocate PG standbys in a different rack which is
different from how Hetzner datacenters work.
