### PR TITLE
Keep large runner images off e2e host bootstrap

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -268,9 +268,9 @@ jobs:
       if: always() && matrix.provider == 'metal' && env.METAL_PAUSED != 'true'
       id: extract_download
       run: |
-        download_time="$(grep "VmHost.wait_download_boot_images" foreman.log | cut -d'|' -f2 | tail -1)"
-        echo "### Image downloaded in $download_time" >> $GITHUB_STEP_SUMMARY
-        echo "DOWNLOAD_TIME=$download_time" >> $GITHUB_OUTPUT
+        download_time="$(grep "Boot image download completed" foreman.log | cut -d'|' -f2 | jq -r '.boot_image_download.duration' | sort -nr | head -1)"
+        echo "### Slowest boot image downloaded in ${download_time}s" >> $GITHUB_STEP_SUMMARY
+        echo "DOWNLOAD_TIME=${download_time}s" >> $GITHUB_OUTPUT
 
     - name: Extract last line
       if: always() && env.METAL_PAUSED != 'true'

--- a/bin/e2e
+++ b/bin/e2e
@@ -13,7 +13,11 @@ def main(options)
 end
 
 def test_metal(options, test_cases)
-  default_boot_images = test_cases.values_at(*options[:test_cases]).flat_map { it["images"] }.uniq
+  # The large (~75 GiB each) GitHub runner images dominate the host bootstrap
+  # download wave and gate the entire suite from starting. Skip them here and
+  # let Prog::Test::GithubRunner download them itself, so they fetch in parallel
+  # with the other test cases instead of on the bootstrap critical path.
+  default_boot_images = test_cases.values_at(*options[:test_cases]).flat_map { it["images"] }.uniq.reject { it.start_with?("github") }
   hetzner_server_st = Prog::Test::HetznerServer.assemble(vm_host_id: options[:vm_host_id], default_boot_images:)
   wait_until(hetzner_server_st, "wait")
 
@@ -39,7 +43,8 @@ def test_metal(options, test_cases)
   end
 
   if (gh_test_cases = test_cases.values_at(*options[:test_cases].select { it.include?("github_runner") })).any?
-    tests_to_wait << Prog::Test::GithubRunner.assemble(gh_test_cases)
+    vm_host_id = Strand[hetzner_server_st.id].stack.first["vm_host_id"]
+    tests_to_wait << Prog::Test::GithubRunner.assemble(gh_test_cases, vm_host_id:)
   end
 
   if options[:test_cases].include?("postgres_standard")

--- a/prog/test/github_runner.rb
+++ b/prog/test/github_runner.rb
@@ -10,10 +10,10 @@ class Prog::Test::GithubRunner < Prog::Test::Base
   WORKFLOW_NAME = "test.yml"
   BRANCH_NAME = "main"
 
-  frame_reader :provider, :customer_project_id, :labels
+  frame_reader :provider, :customer_project_id, :labels, :boot_images, :vm_host_id
   frame_accessor :vm_pool_id, :fail_message, :test_run_id
 
-  def self.assemble(test_cases, provider: "metal")
+  def self.assemble(test_cases, provider: "metal", vm_host_id: nil)
     service_project = Project.create_with_id(Config.github_runner_service_project_id, name: "Github-Runner-Service-Project")
     Project.create_with_id(Config.vm_pool_project_id, name: "Vm-Pool-Service-Project")
     customer_project = Project.create(name: "Github-Runner-Customer-Project")
@@ -48,6 +48,8 @@ class Prog::Test::GithubRunner < Prog::Test::Base
       labels << "ubicloud-standard-2-arm-ubuntu-2604" if test_cases.any? { it["name"].include?("2604") }
     end
 
+    boot_images = vm_host_id ? test_cases.flat_map { it["images"] || [] }.uniq : []
+
     Strand.create(
       prog: "Test::GithubRunner",
       label: "start",
@@ -55,12 +57,21 @@ class Prog::Test::GithubRunner < Prog::Test::Base
         "provider" => provider,
         "customer_project_id" => customer_project.id,
         "labels" => labels,
+        "boot_images" => boot_images,
+        "vm_host_id" => vm_host_id,
       }],
     )
   end
 
   label def start
     hop_trigger_test_run if provider == "aws"
+
+    boot_images.each { vm_host.download_boot_image(it) }
+    hop_wait_image_downloads
+  end
+
+  label def wait_image_downloads
+    nap 5 unless boot_images.count == vm_host.boot_images_dataset.where(name: boot_images).exclude(activated_at: nil).count
     hop_create_vm_pool
   end
 
@@ -158,6 +169,10 @@ class Prog::Test::GithubRunner < Prog::Test::Base
 
   label def failed
     nap 15
+  end
+
+  def vm_host
+    @vm_host ||= VmHost[vm_host_id]
   end
 
   def repository_name

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -85,7 +85,7 @@ class Prog::Test::HetznerServer < Prog::Test::Base
       Clog.emit(vm_host.sshable.cmd("ls -lah /var/storage/images").strip.tr("\n", "\t")) if vm_host.strand.label == "wait_download_boot_images"
       nap 15
     end
-    self.available_storage_gib = vm_host.available_storage_gib
+    self.available_storage_gib = vm_host.available_storage_gib + vm_host.boot_images.sum(&:size_gib)
 
     hop_verify_encrypted_swap
   end
@@ -164,7 +164,8 @@ class Prog::Test::HetznerServer < Prog::Test::Base
   label def verify_resources_reclaimed
     fail_test "used_cores is expected to be zero, actual: #{vm_host.used_cores}" unless vm_host.used_cores.zero?
     fail_test "used_hugepages_1g is expected to be zero, actual: #{vm_host.used_hugepages_1g}" unless vm_host.used_hugepages_1g.zero?
-    fail_test "available_storage_gib was not reclaimed as expected: #{available_storage_gib}, actual: #{vm_host.available_storage_gib}" unless available_storage_gib == vm_host.available_storage_gib
+    reclaimed_storage_gib = vm_host.available_storage_gib + vm_host.boot_images.sum(&:size_gib)
+    fail_test "available_storage_gib was not reclaimed as expected: #{available_storage_gib}, actual: #{reclaimed_storage_gib}" unless available_storage_gib == reclaimed_storage_gib
 
     hop_destroy_vm_host
   end

--- a/spec/prog/test/github_runner_spec.rb
+++ b/spec/prog/test/github_runner_spec.rb
@@ -46,6 +46,20 @@ RSpec.describe Prog::Test::GithubRunner do
       expect(strand.stack.first["labels"]).to eq(["ubicloud-standard-2-ubuntu-2204", "ubicloud-standard-2-ubuntu-2404"])
     end
 
+    it "stores boot images and vm host id to download on the metal host" do
+      strand = described_class.assemble([
+        {"name" => "github_runner_ubuntu_2204", "images" => ["github-ubuntu-2204"]},
+        {"name" => "github_runner_ubuntu_2404", "images" => ["github-ubuntu-2404"]},
+      ], vm_host_id: "f3b2d3e0-0000-0000-0000-000000000000")
+      expect(strand.stack.first["boot_images"]).to eq(["github-ubuntu-2204", "github-ubuntu-2404"])
+      expect(strand.stack.first["vm_host_id"]).to eq("f3b2d3e0-0000-0000-0000-000000000000")
+    end
+
+    it "does not store boot images when no vm host id is given" do
+      strand = described_class.assemble([{"name" => "github_runner_ubuntu_2204", "images" => ["github-ubuntu-2204"]}])
+      expect(strand.stack.first["boot_images"]).to eq([])
+    end
+
     it "includes arm64 labels for aws provider" do
       location_id = "5f0db214-de30-8420-8a11-98014b01c5b5"
       expect(Config).to receive(:github_runner_aws_location_id).and_return(location_id)
@@ -62,13 +76,46 @@ RSpec.describe Prog::Test::GithubRunner do
   end
 
   describe "#start" do
-    it "hops to create_vm_pool" do
-      expect { gr_test.start }.to hop("create_vm_pool")
-    end
-
     it "hops to trigger_test_run when provider is aws" do
       expect(gr_test).to receive(:frame).and_return({"provider" => "aws"})
       expect { gr_test.start }.to hop("trigger_test_run")
+    end
+
+    it "hops to wait_image_downloads without downloading when there are no images" do
+      expect { gr_test.start }.to hop("wait_image_downloads")
+      expect(Strand.where(prog: "DownloadBootImage")).to be_empty
+    end
+
+    it "triggers the runner image downloads and hops to wait_image_downloads" do
+      vm_host = create_vm_host
+      refresh_frame(gr_test, new_values: {"vm_host_id" => vm_host.id, "boot_images" => ["github-ubuntu-2204"]})
+      expect { gr_test.start }.to hop("wait_image_downloads")
+      expect(Strand.where(prog: "DownloadBootImage").count).to eq(1)
+    end
+  end
+
+  describe "#wait_image_downloads" do
+    let(:vm_host) { create_vm_host }
+
+    it "hops to create_vm_pool when there are no images to wait for" do
+      refresh_frame(gr_test, new_values: {"vm_host_id" => vm_host.id, "boot_images" => []})
+      expect { gr_test.wait_image_downloads }.to hop("create_vm_pool")
+    end
+
+    context "with runner images on the metal host" do
+      before do
+        refresh_frame(gr_test, new_values: {"vm_host_id" => vm_host.id, "boot_images" => ["github-ubuntu-2204"]})
+      end
+
+      it "naps until the image is activated" do
+        BootImage.create(vm_host_id: vm_host.id, name: "github-ubuntu-2204", version: "1", activated_at: nil, size_gib: 0)
+        expect { gr_test.wait_image_downloads }.to nap(5)
+      end
+
+      it "hops to create_vm_pool once the image is activated" do
+        BootImage.create(vm_host_id: vm_host.id, name: "github-ubuntu-2204", version: "1", activated_at: Time.now, size_gib: 0)
+        expect { gr_test.wait_image_downloads }.to hop("create_vm_pool")
+      end
     end
   end
 

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -255,6 +255,13 @@ RSpec.describe Prog::Test::HetznerServer do
       refresh_frame(hs_test, new_values: {"available_storage_gib" => 860})
       expect { hs_test.verify_resources_reclaimed }.to hop("destroy_vm_host")
     end
+
+    it "counts boot images downloaded after the baseline as reclaimed storage" do
+      vm_host.storage_devices.first.update(available_storage_gib: 710)
+      BootImage.create(vm_host_id: vm_host.id, name: "github-ubuntu-2404", version: "1", activated_at: Time.now, size_gib: 150)
+      refresh_frame(hs_test, new_values: {"available_storage_gib" => 860})
+      expect { hs_test.verify_resources_reclaimed }.to hop("destroy_vm_host")
+    end
   end
 
   describe "#destroy" do


### PR DESCRIPTION
The metal e2e host bootstrap downloaded every boot image required by the selected test cases before any test could start, and the two GitHub runner images (~75 GiB each) dominated that wave: each took 6-9 minutes while every other image finished in under a minute. The whole suite waited on them even though only the GithubRunner test uses them.

Skip the runner images during bootstrap and download them from the GithubRunner test instead, once it is assembled in the parallel phase. The runner VM pool can't be allocated until the images are activated, so the test waits in a dedicated wait_image_downloads label before creating the pool.

This trims the bootstrap critical path by roughly the runner download time. It also makes the suite more robust against slow image downloads: the runner images now have the entire duration of the other parallel tests (notably the ~30 minute Kubernetes case) to finish, rather than blocking the whole run up front.

Current E2E breakdown:
<img width="2526" height="792" alt="CleanShot 2026-06-24 at 15 36 39@2x" src="https://github.com/user-attachments/assets/1aaab5ef-19ad-4381-8e61-4458964bd631" />