### PR TITLE
Upload cli-golden-files.diff on CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,11 @@ jobs:
       with:
         name: code-coverage-report-${{ matrix.runs-on }}
         path: coverage/
+
+    - name: Archive CLI golden-file diff
+      if: failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: cli-golden-files-diff-${{ matrix.runs-on }}
+        path: cli-golden-files.diff
+        if-no-files-found: ignore


### PR DESCRIPTION
The golden_files_spec writes a unified diff to cli-golden-files.diff when the captured CLI output drifts from the checked-in golden files, but the spec output only says "differences are in cli-golden-files.diff" without including the contents. The file lived only on the runner and was lost when the job tore down, leaving intermittent failures undebuggable after the fact.

Upload it as a failure-only artifact with if-no-files-found: ignore so the step is a no-op on unrelated failures.