### PR TITLE
Make Postgres boot disk size configurable

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -184,6 +184,7 @@ module Config
 
   # Postgres
   optional :postgres_service_project_id, uuid
+  override :postgres_boot_disk_size_gib, 16, int
   override :postgres_service_hostname, "postgres.ubicloud.com", string
   override :postgres_service_hostname_v3, "pg.ubicloud.app", string
   override :postgres_monitor_database_url, Config.clover_database_url, string

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -35,7 +35,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
         name: ubid.to_s,
         size: postgres_resource.target_vm_size.gsub("hobby", "burstable"),
         storage_volumes: [
-          {encrypted: true, size_gib: 16, vring_workers: 1},
+          {encrypted: true, size_gib: Config.postgres_boot_disk_size_gib, vring_workers: 1},
           {encrypted: true, size_gib: postgres_resource.target_storage_size_gib, vring_workers: 1},
         ],
         boot_image:,


### PR DESCRIPTION
Replace the hardcoded 16 GiB Postgres boot disk size with a new Config.postgres_boot_disk_size_gib setting (default 16 GiB), so the boot disk size can be tuned per deployment without code changes.