### PR TITLE
Show total active pages on admin site index page

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1541,6 +1541,7 @@ class CloverAdmin < Roda
         .exclude(severity: "info")
         .left_join(:page_root_resource, page_id: :id)
         .to_hash_groups(:root_resource_id)
+      @total_pages = @grouped_pages.flat_map(&:last).map!(&:id).uniq.size
       @classes = available_classes
       @info_pages = Page.active.where(severity: "info").reverse(:created_at).all
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -807,7 +807,7 @@ RSpec.describe CloverAdmin do
 
     page1 = Prog::PageNexus.assemble("some problem", %w[a], nil).subject
     page.refresh
-    expect(page).to have_content "Active Pages"
+    expect(page).to have_content "1 Active Pages"
     expect(page_data).to eq [
       ["", "some problem", "[]", "{}"],
     ]
@@ -816,6 +816,7 @@ RSpec.describe CloverAdmin do
 
     Prog::PageNexus.assemble("another problem", %w[b], vm_pool.ubid).subject
     visit "/"
+    expect(page).to have_content "2 Active Pages"
     expect(page_data).to eq [
       ["", "some problem", "[]", "{}"],
       ["another problem", "[\"#{vm_pool.ubid}\"]", "{}"],
@@ -829,6 +830,7 @@ RSpec.describe CloverAdmin do
     vm.update(vm_host_id: vmh.id)
     Prog::PageNexus.assemble("third problem", %w[c], vm.ubid).subject
     visit "/"
+    expect(page).to have_content "3 Active Pages"
     expect(page_data).to eq [
       [vmh.ubid, "third problem", "[\"#{vm.ubid}\"]", "{}"],
       ["", "some problem", "[]", "{}"],

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -3,7 +3,7 @@
 <div class="container">
   <% unless @grouped_pages.empty? %>
     <table class="page-table">
-      <caption>Active Pages</caption>
+      <caption><%= @total_pages %> Active Pages</caption>
       <thead>
         <tr>
           <th>Root Resource</th>


### PR DESCRIPTION
This isn't the same as the number of table rows, because pages with multiple root resources have multiple rows.