### PR TITLE
Determine root resources for LoadBalancerVm and LoadBalancerVmPort

### DIFF
--- a/model/page.rb
+++ b/model/page.rb
@@ -94,12 +94,14 @@ class Page < Sequel::Model
       [obj.id]
     when Vm, VmHostSlice, VhostBlockBackend, StorageDevice, SpdkInstallation, PciDevice
       [obj.vm_host_id]
-    when VmStorageVolume, VictoriaMetricsServer, Nic, MinioServer, InferenceEndpointReplica, InferenceRouterReplica
+    when VmStorageVolume, VictoriaMetricsServer, Nic, MinioServer, InferenceEndpointReplica, InferenceRouterReplica, LoadBalancerVm
       [obj.vm&.vm_host_id]
     when PostgresServer
       [obj.vm&.vm_host_id, obj.resource_id]
     when PostgresTimeline
       [*(root_resources(obj.leader) if obj.leader)]
+    when LoadBalancerVmPort
+      root_resources(obj.load_balancer_vm)
     when GithubRunner
       [obj.installation_id, obj.vm&.vm_host_id]
     when GithubRepository

--- a/spec/model/page_spec.rb
+++ b/spec/model/page_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe Page do
       pv.refresh
       expect(described_class.root_resources(pv)).to eq [pv.vm.vm_host_id, pg.id]
       expect(described_class.root_resources(pv.timeline)).to eq [pv.vm.vm_host_id, pg.id]
+
+      project = Project.create(name: "test")
+      private_subnet = Prog::Vnet::SubnetNexus.assemble(project.id, name: "test").subject
+      lb = Prog::Vnet::LoadBalancerNexus.assemble(private_subnet.id, name: "test", src_port: 1234, dst_port: 4321).subject
+      lb.add_vm(pv.vm)
+      expect(described_class.root_resources(LoadBalancerVmPort.first)).to eq [pv.vm.vm_host_id]
     end
 
     it "returns empty array for exceptions" do


### PR DESCRIPTION
These use the same root resources as the associated vm.