### PR TITLE
Do not include vm ssh or pg psql in recursive help output for old ubi

### DIFF
--- a/cli-commands/help.rb
+++ b/cli-commands/help.rb
@@ -11,6 +11,8 @@ class UbiCli
 
     args(0..)
 
+    interactive_commands = [%w[vm ssh], %w[pg psql]].freeze.each(&:freeze)
+
     run do |argv, opts|
       orig_command = command = UbiCli.command
 
@@ -23,8 +25,11 @@ class UbiCli
       usage = opts[:usage]
       if command
         if opts[:recursive]
+          skip_interactive_commands = comparable_client_version < MIN_PGPASSWORD_VERSION
           body = []
           command.each_subcommand do |_, cmd|
+            next if skip_interactive_commands && interactive_commands.include?(cmd.command_path)
+
             if usage
               cmd.each_banner do |banner|
                 body << banner << "\n"

--- a/spec/routes/api/cli/golden_files_spec.rb
+++ b/spec/routes/api/cli/golden_files_spec.rb
@@ -167,7 +167,8 @@ RSpec.describe Clover, "cli" do
 
       cli_commands_hash[lowercase_cmd] = cmd
       body = DB.transaction(savepoint: true, rollback: :always) do
-        cli(cmd.shellsplit, **kws)
+        args = cmd.shellsplit
+        cli(args, ubi_version: args.include?("help") ? "1.1.0" : "1.0.0", **kws)
       end
       File.write(File.join(output_dir, "#{cmd.tr("/", "_")}.txt"), body)
     end

--- a/spec/routes/api/cli/help_spec.rb
+++ b/spec/routes/api/cli/help_spec.rb
@@ -59,6 +59,13 @@ RSpec.describe Clover, "cli help" do
     OUTPUT
   end
 
+  it "does not include interactive commands for old ubi versions" do
+    expect(cli(%w[help -ru vm])).not_to include " ssh "
+    expect(cli(%w[help -ru vm], ubi_version: "1.1.0")).to include " ssh "
+    expect(cli(%w[help -ru pg])).not_to include " psql "
+    expect(cli(%w[help -ru pg], ubi_version: "1.1.0")).to include " psql "
+  end
+
   it "shows error and help for nested command if there is a partial match" do
     expect(cli(%w[help vm ssh foo], status: 400)).to eq <<~OUTPUT
       ! Invalid command: vm ssh foo

--- a/spec/routes/api/cli/spec_helper.rb
+++ b/spec/routes/api/cli/spec_helper.rb
@@ -4,7 +4,7 @@ require_relative "../spec_helper"
 
 RSpec.configure do |config|
   config.include(Module.new do
-    def cli(argv, status: 200, env: {"HTTP_X_UBI_VERSION" => "1.0.0"}, confirm_prompt: nil, command_execute: nil)
+    def cli(argv, status: 200, ubi_version: "1.0.0", env: {"HTTP_X_UBI_VERSION" => ubi_version}, confirm_prompt: nil, command_execute: nil)
       post("/cli", {"argv" => argv}.to_json, env)
       expect(last_response.status).to eq(status), "status is #{last_response.status} not #{status}, body for failing status: #{last_response.body}"
       if status == 400


### PR DESCRIPTION
These commands do not work correctly in ineractive mode in ubi 1.0.0. They can work for non-interactive use in ubi 1.0.0 use, so we don't want to prevent their use, but hiding their output in recursive help reduces their discoverability and the chance a user will attempt to them when they may not work.