### PR TITLE
Fix non-determinism and N+1 query issues in KubernetesCluster serializer

### DIFF
--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -12,7 +12,7 @@ class KubernetesCluster < Sequel::Model
   many_to_many :cp_vms, join_table: :kubernetes_node, right_key: :vm_id, class: :Vm, order: :created_at, conditions: {kubernetes_nodepool_id: nil}, read_only: true
   one_to_many :nodes, class: :KubernetesNode, order: :created_at, conditions: {kubernetes_nodepool_id: nil}, read_only: true
   one_to_many :functional_nodes, class: :KubernetesNode, order: :created_at, conditions: {kubernetes_nodepool_id: nil, state: ["active", "renewing_certs"]}, read_only: true
-  one_to_many :nodepools, class: :KubernetesNodepool, read_only: true
+  one_to_many :nodepools, class: :KubernetesNodepool, read_only: true, order: :name
   one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id, read_only: true, &:active
   many_to_one :location, read_only: true
   one_to_one :kubernetes_etcd_backup, read_only: true

--- a/model/kubernetes/kubernetes_nodepool.rb
+++ b/model/kubernetes/kubernetes_nodepool.rb
@@ -5,7 +5,7 @@ require_relative "../../model"
 class KubernetesNodepool < Sequel::Model
   one_to_one :strand, key: :id, read_only: true
   many_to_one :cluster, key: :kubernetes_cluster_id, class: :KubernetesCluster, read_only: true
-  many_to_many :vms, join_table: :kubernetes_node, order: :created_at, read_only: true
+  many_to_many :vms, join_table: :kubernetes_node, order: [:created_at, :name], read_only: true
   one_to_many :nodes, class: :KubernetesNode, order: :created_at, read_only: true
   one_to_many :functional_nodes, class: :KubernetesNode, order: :created_at, conditions: {state: "active"}, read_only: true
   one_to_many :mesh_nodes, class: :KubernetesNode, order: :created_at, conditions: {state: ["active", "renewing_certs", "draining"]}, read_only: true

--- a/serializers/kubernetes_cluster.rb
+++ b/serializers/kubernetes_cluster.rb
@@ -13,7 +13,7 @@ class Serializers::KubernetesCluster < Serializers::Base
     }
     if options[:detailed]
       base[:cp_vms] = Serializers::Vm.serialize(kc.cp_vms_dataset.all)
-      base[:nodepools] = Serializers::KubernetesNodepool.serialize(kc.nodepools_dataset.all, {detailed: true})
+      base[:nodepools] = Serializers::KubernetesNodepool.serialize(kc.nodepools(eager: {vms: Serializers::KubernetesNodepool::VMS_EAGER}, reload: true), {detailed: true})
     end
     base
   end

--- a/serializers/kubernetes_nodepool.rb
+++ b/serializers/kubernetes_nodepool.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Serializers::KubernetesNodepool < Serializers::Base
+  VMS_EAGER = [:strand, :semaphores, :assigned_vm_address, :vm_storage_volumes, :location].freeze
+
   def self.serialize_internal(kn, options = {})
     base = {
       id: kn.ubid,
@@ -10,7 +12,7 @@ class Serializers::KubernetesNodepool < Serializers::Base
       node_size: kn.target_node_size,
     }
     if options[:detailed]
-      base[:vms] = Serializers::Vm.serialize(kn.vms_dataset.eager(:strand, :semaphores, :assigned_vm_address, :vm_storage_volumes, :location).all)
+      base[:vms] = Serializers::Vm.serialize(kn.vms(eager: VMS_EAGER))
     end
     base
   end

--- a/spec/serializers/kubernetes_cluster_spec.rb
+++ b/spec/serializers/kubernetes_cluster_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Serializers::KubernetesCluster do
       expect(described_class.serialize_internal(kc)).to eq(expected_result)
     end
 
-    it "serializes a KubernetesNodepool without the detailed option" do
+    it "serializes a KubernetesCluster with the detailed option" do
       project = Project.create(name: "default")
       kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "cluster", project_id: project.id, location_id: Location::HETZNER_FSN1_ID, version: Option.selectable_kubernetes_versions.first).subject
       kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "nodepool", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject


### PR DESCRIPTION
The KubernetesCluster in detailed mode used nodepools_dataset.all,
and passed the result to the KubernetesNodepool serializer, which
did vms_dataset.all, which results in an N+1 query issue. Additionally,
the nodepools and vms were not ordered, causing nondeterministic
failures in the CLI golden files specs.

Fix the N+1 query issue by calling the association method instead of
the association dataset method, and using the :eager option to eagerly
load. When eagerly loading the nodepools for the cluster, also eagerly
load the associations for the vm that the nodepool serializer needs.

Fix the nondeterminism by adding an order on the related associations.
The KubernetesNodepool.vms association was ordered on created_at, but
that doesn't result in a non-deterministic order in the specs (due to
transactions), so also order on name.

This reloads the nodepools association in the serializer. Without the
forced reload, if the nodepools association is already reloaded, the
:eager will be ignored (by design). This could be removed if the
related code is audited and adjustments were made (either ensuring
the nodepools assocation was not loaded, or ensuring the necessary
associations were eager loaded if it was), but I'm not sure it's worth
doing that.

The first commit fixes a typo in a spec description.

Thanks to @pykello for #5743, which allowed me to get access to the
output for the nondeterministic golden files failures and determine that
this was the cause.