### PR TITLE
Remove CertNexus#before_run

### DIFF
--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -22,14 +22,6 @@ class Prog::Vnet::CertNexus < Prog::Base
     end
   end
 
-  def before_run
-    if add_private
-      delete_from_stack("add_private")
-      cert.update(private_hostname: "private.#{cert.hostname}")
-    end
-    super
-  end
-
   label def start
     register_deadline("wait", 10 * 60)
 

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -83,20 +83,6 @@ RSpec.describe Prog::Vnet::CertNexus do
     end
   end
 
-  describe "#before_run" do
-    it "adds private_hostname to cert if add_private is in frame" do
-      refresh_frame(nx, new_values: {"add_private" => true})
-      nx.before_run
-      expect(st.subject.private_hostname).to eq "private.cert-hostname.test-dns-zone.com"
-      expect(nx.strand.stack[0].has_key?("add_private")).to be false
-    end
-
-    it "does nothing if add_private is not in frame" do
-      nx.before_run
-      expect(st.subject.private_hostname).to be_nil
-    end
-  end
-
   describe "#start" do
     it "registers a deadline and starts the certificate creation process" do
       identifiers = [cert.hostname]


### PR DESCRIPTION
This was used to adjust existing strands to the new private_hostname support. That support was merged on May 21 (#5462). The longest nap in the CertNexus is 30 days, so by now, all strands should have switched, and we can remove this backwards compatibility.