### PR TITLE
Run the k8s e2e upgrade on its own cluster

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ on:
       test_cases:
         description: 'Comma-separated list of test cases (vm)'
         required: true
-        default: 'vm,github_runner_ubuntu_2404,github_runner_ubuntu_2204,postgres_standard,postgres_ha,postgres_upgrade,postgres_upgrade16,postgres_firewall,kubernetes'
+        default: 'vm,github_runner_ubuntu_2404,github_runner_ubuntu_2204,postgres_standard,postgres_ha,postgres_upgrade,postgres_upgrade16,postgres_firewall,kubernetes,kubernetes_upgrade'
         type: string
       providers:
         description: 'Comma-separated list of providers (metal,aws,gcp)'

--- a/bin/e2e
+++ b/bin/e2e
@@ -28,7 +28,7 @@ def test_metal(options, test_cases)
     wait_until(minio_cluster_st, "wait")
   end
 
-  if options[:test_cases].include?("kubernetes")
+  if options[:test_cases].include?("kubernetes") || options[:test_cases].include?("kubernetes_upgrade")
     Project[Config.kubernetes_service_project_id] ||
       Project.create_with_id(Config.kubernetes_service_project_id, name: "Ubicloud-Kubernetes-Resources")
     Project[Config.load_balancer_service_project_id] ||
@@ -81,7 +81,8 @@ def test_metal(options, test_cases)
   if k8s_dns_zone_st
     wait_until(k8s_dns_zone_st, "wait")
     wait_until(lb_dns_zone_st, "wait")
-    tests_to_wait << Prog::Test::Kubernetes.assemble
+    tests_to_wait << Prog::Test::Kubernetes.assemble if options[:test_cases].include?("kubernetes")
+    tests_to_wait << Prog::Test::KubernetesUpgrade.assemble if options[:test_cases].include?("kubernetes_upgrade")
   end
 
   # Although wait_until will be blocked while checking the first one

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -6,4 +6,5 @@
 - { name: postgres_upgrade,          images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_upgrade16,        images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_firewall,         images: ["postgres-ubuntu-2204"] }
-- { name: kubernetes,                images: ["ubuntu-noble","kubernetes-v1_35", "kubernetes-v1_36"]}
+- { name: kubernetes,                images: ["ubuntu-noble", "kubernetes-v1_35"] }
+- { name: kubernetes_upgrade,        images: ["ubuntu-noble", "kubernetes-v1_35", "kubernetes-v1_36"] }

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -2,7 +2,7 @@
 
 class Prog::Test::Kubernetes < Prog::Test::KubernetesBase
   MIGRATION_TRIES = 1
-  frame_accessor :read_hashes, :normal_pod_restart_test_node,
+  frame_accessor :normal_pod_restart_test_node,
     :rsync_retry_source_node, :chained_migration_source_node, :drain_test_node_name, :reboot_node_id,
     :nat_rules_before_reboot, :pod_access_rules_before_reboot, :migration_number,
     :cert_expire_at_before_renew
@@ -77,14 +77,7 @@ class Prog::Test::Kubernetes < Prog::Test::KubernetesBase
   end
 
   label def test_data_write
-    (1..3).each do |i|
-      unit_name = "csi_data_write_#{i}"
-      kubernetes_cluster.sshable.d_run(
-        unit_name,
-        "bash", "-c",
-        "sudo kubectl --kubeconfig /etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c \"head -c 300M /dev/urandom | tee /etc/data/random-data-#{i} | sha256sum | awk '{print \\$1}'\" > /dev/shm/#{unit_name}.hash",
-      )
-    end
+    write_data_files
     hop_wait_data_write
   end
 
@@ -301,17 +294,5 @@ class Prog::Test::Kubernetes < Prog::Test::KubernetesBase
     true
   rescue
     false
-  end
-
-  def verify_data_hashes(context)
-    expected_hashes = read_hashes
-    expected_hashes.each do |file, expected_hash|
-      command = NetSsh.command("sha256sum /etc/data/:file | awk '{print $1}'", file:)
-      new_hash = kubernetes_cluster.client.kubectl("exec -t ubuntu-statefulset-0 -- sh -c :command", command:).strip
-      if new_hash != expected_hash
-        self.fail_message = "data hash changed after #{context} for #{file}, expected: #{expected_hash}, got: #{new_hash}"
-        hop_destroy_kubernetes
-      end
-    end
   end
 end

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -1,46 +1,22 @@
 # frozen_string_literal: true
 
-class Prog::Test::Kubernetes < Prog::Test::Base
+class Prog::Test::Kubernetes < Prog::Test::KubernetesBase
   MIGRATION_TRIES = 1
-  frame_reader :kubernetes_service_project_id, :kubernetes_test_project_id
-  frame_accessor :fail_message, :kubernetes_cluster_id, :read_hashes, :normal_pod_restart_test_node,
+  frame_accessor :read_hashes, :normal_pod_restart_test_node,
     :rsync_retry_source_node, :chained_migration_source_node, :drain_test_node_name, :reboot_node_id,
     :nat_rules_before_reboot, :pod_access_rules_before_reboot, :migration_number,
     :cert_expire_at_before_renew
 
   def self.assemble
-    kubernetes_test_project = Project.create(name: "Kubernetes-Test-Project")
-    kubernetes_service_project = Project[Config.kubernetes_service_project_id] ||
-      Project.create_with_id(Config.kubernetes_service_project_id, name: "Ubicloud-Kubernetes-Resources")
-    Strand.create(
-      prog: "Test::Kubernetes",
-      label: "start",
-      stack: [{
-        "kubernetes_service_project_id" => kubernetes_service_project.id,
-        "kubernetes_test_project_id" => kubernetes_test_project.id,
-        "migration_number" => 0,
-      }],
-    )
+    st = super(cluster_name: "kubernetes-test-standard", worker_node_count: 3)
+    st.update(stack: [st.stack.first.merge("migration_number" => 0)])
+    st
   end
 
-  label def start
-    kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
-      name: "kubernetes-test-standard",
-      project_id: kubernetes_test_project_id,
-      location_id: Location::HETZNER_FSN1_ID,
-      version: Option.selectable_kubernetes_versions[1],
-      cp_node_count: 1,
-    ).subject
-    Prog::Kubernetes::KubernetesNodepoolNexus.assemble(
-      name: "kubernetes-test-standard-nodepool",
-      node_count: 3,
-      kubernetes_cluster_id: kc.id,
-      target_node_size: "standard-2",
-    )
-
-    self.kubernetes_cluster_id = kc.id
-    hop_wait_for_kubernetes_bootstrap
-  end
+  label :start
+  label :destroy_kubernetes
+  label :finish
+  label :failed
 
   label def wait_for_kubernetes_bootstrap
     hop_trigger_renew_certs if kubernetes_cluster.strand.label == "wait"
@@ -80,36 +56,7 @@ class Prog::Test::Kubernetes < Prog::Test::Base
   end
 
   label def test_csi
-    sts = <<STS
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: ubuntu-statefulset
-spec:
-  serviceName: ubuntu
-  replicas: 1
-  selector:
-    matchLabels: { app: ubuntu }
-  template:
-    metadata:
-      labels: { app: ubuntu }
-    spec:
-      containers:
-      - name: ubuntu
-        image: ubuntu:24.04
-        command: ["/bin/sh", "-c", "sleep infinity"]
-        volumeMounts:
-        - { name: data-volume, mountPath: /etc/data }
-  volumeClaimTemplates:
-  - metadata:
-      name: data-volume
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests: { storage: 5Gi }
-      storageClassName: ubicloud-standard
-STS
-    kubernetes_cluster.sshable.cmd("sudo kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f -", stdin: sts)
+    apply_statefulset
     hop_wait_for_statefulset
   end
 
@@ -344,58 +291,7 @@ STS
     if pod_access_rules != pod_access_rules_before_reboot
       self.fail_message = "ip6 pod_access rules changed after reboot"
     end
-    hop_test_upgrade
-  end
-
-  label def test_upgrade
-    upgrade_candidate = kubernetes_cluster.available_upgrade_version
-    unless upgrade_candidate
-      self.fail_message = "No upgrade candidate available"
-      hop_destroy_kubernetes
-    end
-
-    kubernetes_cluster.update(version: upgrade_candidate)
-    kubernetes_cluster.incr_upgrade
-    nodepool.incr_upgrade
-
-    Clog.emit("waiting for k8s cluster upgrade to #{upgrade_candidate}")
-    hop_wait_for_upgrade
-  end
-
-  label def wait_for_upgrade
-    nap 15 unless kubernetes_cluster.display_state == "running"
-
-    nodes = JSON.parse(kubernetes_cluster.client.kubectl("get nodes -o json"))["items"]
-    unless nodes.size == 3 && nodes.all? { |n| n.dig("status", "nodeInfo", "kubeletVersion").start_with?("#{kubernetes_cluster.version}.") }
-      self.fail_message = "Not all #{nodes.size} nodes upgraded to #{kubernetes_cluster.version}:\n#{kubernetes_cluster.client.kubectl("get nodes")}"
-      hop_destroy_kubernetes
-    end
-
-    hop_verify_data_after_upgrade
-  end
-
-  label def verify_data_after_upgrade
-    nap 5 unless pod_status == "Running"
-    verify_data_hashes("upgrade")
     hop_destroy_kubernetes
-  end
-
-  label def destroy_kubernetes
-    kubernetes_cluster.incr_destroy
-    hop_finish
-  end
-
-  label def finish
-    nap 5 if kubernetes_cluster
-    kubernetes_test_project.destroy
-
-    fail_test(fail_message) if fail_message
-
-    pop "Kubernetes tests are finished!"
-  end
-
-  label def failed
-    nap 15
   end
 
   def vm_ready?(vm)
@@ -405,56 +301,6 @@ STS
     true
   rescue
     false
-  end
-
-  def kubernetes_test_project
-    @kubernetes_test_project ||= Project.with_pk(kubernetes_test_project_id)
-  end
-
-  def kubernetes_cluster
-    @kubernetes_cluster ||= KubernetesCluster.with_pk(kubernetes_cluster_id)
-  end
-
-  def nodepool
-    kubernetes_cluster.nodepools.first
-  end
-
-  def verify_mount
-    lsblk_output = kubernetes_cluster.client.kubectl("exec -t ubuntu-statefulset-0 -- lsblk")
-    lines = lsblk_output.split("\n")[1..]
-    data_mount = lines.find { |line| line.include?("/etc/data") }
-    if data_mount
-      cols = data_mount.split
-      device_name = cols[0]  # e.g. "loop3"
-      size = cols[3]         # e.g. "1G"
-      mountpoint = cols[6]   # e.g. "/etc/data"
-
-      if device_name.start_with?("loop") && size == "5G" && mountpoint == "/etc/data"
-        # no op
-      else
-        raise "/etc/data is mounted incorrectly: #{data_mount}"
-      end
-    else
-      raise "No /etc/data mount found in lsblk output"
-    end
-  end
-
-  # we are not using jsonpath for extracting the status because even though a pod is termination, its phase
-  # from API Server's point of view is Running, in order to detect that using jsonpath, we needed to check for
-  # deletion timestamp, all conditions in status and .status.phase.
-  # to keep the query simple, we let the kubectl do the processing and observe the system from the eyes of a
-  # customer. This also keeps the logic simpler
-  def pod_status
-    status = kubernetes_cluster.client.kubectl("get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").strip
-    if status != "Running"
-      client = kubernetes_cluster.client
-      Clog.emit("pod not running", {
-        pod_status: status,
-        events: begin; client.kubectl("get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp"); rescue => e; e.message; end,
-        pv_pvc: begin; client.kubectl("get pv,pvc"); rescue => e; e.message; end,
-      })
-    end
-    status
   end
 
   def verify_data_hashes(context)

--- a/prog/test/kubernetes_base.rb
+++ b/prog/test/kubernetes_base.rb
@@ -32,7 +32,7 @@ class Prog::Test::KubernetesBase < Prog::Test::Base
   STS
 
   frame_reader :kubernetes_service_project_id, :kubernetes_test_project_id, :cluster_name, :worker_node_count
-  frame_accessor :fail_message, :kubernetes_cluster_id
+  frame_accessor :fail_message, :kubernetes_cluster_id, :read_hashes
 
   def self.assemble(cluster_name:, worker_node_count:)
     kubernetes_test_project = Project.create(name: "Kubernetes-Test-Project")
@@ -101,6 +101,28 @@ class Prog::Test::KubernetesBase < Prog::Test::Base
 
   def apply_statefulset
     kubernetes_cluster.sshable.cmd("sudo kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f -", stdin: STATEFULSET_YAML)
+  end
+
+  def write_data_files
+    (1..3).each do |i|
+      unit_name = "csi_data_write_#{i}"
+      kubernetes_cluster.sshable.d_run(
+        unit_name,
+        "bash", "-c",
+        "sudo kubectl --kubeconfig /etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c \"head -c 300M /dev/urandom | tee /etc/data/random-data-#{i} | sha256sum | awk '{print \\$1}'\" > /dev/shm/#{unit_name}.hash",
+      )
+    end
+  end
+
+  def verify_data_hashes(context)
+    read_hashes.each do |file, expected_hash|
+      command = NetSsh.command("sha256sum /etc/data/:file | awk '{print $1}'", file:)
+      new_hash = kubernetes_cluster.client.kubectl("exec -t ubuntu-statefulset-0 -- sh -c :command", command:).strip
+      if new_hash != expected_hash
+        self.fail_message = "data hash changed after #{context} for #{file}, expected: #{expected_hash}, got: #{new_hash}"
+        hop_destroy_kubernetes
+      end
+    end
   end
 
   def verify_mount

--- a/prog/test/kubernetes_base.rb
+++ b/prog/test/kubernetes_base.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+class Prog::Test::KubernetesBase < Prog::Test::Base
+  STATEFULSET_YAML = <<~STS
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      name: ubuntu-statefulset
+    spec:
+      serviceName: ubuntu
+      replicas: 1
+      selector:
+        matchLabels: { app: ubuntu }
+      template:
+        metadata:
+          labels: { app: ubuntu }
+        spec:
+          containers:
+          - name: ubuntu
+            image: ubuntu:24.04
+            command: ["/bin/sh", "-c", "sleep infinity"]
+            volumeMounts:
+            - { name: data-volume, mountPath: /etc/data }
+      volumeClaimTemplates:
+      - metadata:
+          name: data-volume
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          resources:
+            requests: { storage: 5Gi }
+          storageClassName: ubicloud-standard
+  STS
+
+  frame_reader :kubernetes_service_project_id, :kubernetes_test_project_id, :cluster_name, :worker_node_count
+  frame_accessor :fail_message, :kubernetes_cluster_id
+
+  def self.assemble(cluster_name:, worker_node_count:)
+    kubernetes_test_project = Project.create(name: "Kubernetes-Test-Project")
+    kubernetes_service_project = Project[Config.kubernetes_service_project_id] ||
+      Project.create_with_id(Config.kubernetes_service_project_id, name: "Ubicloud-Kubernetes-Resources")
+    Strand.create(
+      prog: name.delete_prefix("Prog::"),
+      label: "start",
+      stack: [{
+        "kubernetes_service_project_id" => kubernetes_service_project.id,
+        "kubernetes_test_project_id" => kubernetes_test_project.id,
+        "cluster_name" => cluster_name,
+        "worker_node_count" => worker_node_count,
+      }],
+    )
+  end
+
+  def start
+    kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
+      name: cluster_name,
+      project_id: kubernetes_test_project_id,
+      location_id: Location::HETZNER_FSN1_ID,
+      version: Option.selectable_kubernetes_versions[1],
+      cp_node_count: 1,
+    ).subject
+    Prog::Kubernetes::KubernetesNodepoolNexus.assemble(
+      name: "#{cluster_name}-nodepool",
+      node_count: worker_node_count,
+      kubernetes_cluster_id: kc.id,
+      target_node_size: "standard-2",
+    )
+
+    self.kubernetes_cluster_id = kc.id
+    hop_wait_for_kubernetes_bootstrap
+  end
+
+  def destroy_kubernetes
+    kubernetes_cluster.incr_destroy
+    hop_finish
+  end
+
+  def finish
+    nap 5 if kubernetes_cluster
+    kubernetes_test_project.destroy
+
+    fail_test(fail_message) if fail_message
+
+    pop "#{self.class.name.delete_prefix("Prog::Test::")} tests are finished!"
+  end
+
+  def failed
+    nap 15
+  end
+
+  def kubernetes_test_project
+    @kubernetes_test_project ||= Project.with_pk(kubernetes_test_project_id)
+  end
+
+  def kubernetes_cluster
+    @kubernetes_cluster ||= KubernetesCluster.with_pk(kubernetes_cluster_id)
+  end
+
+  def nodepool
+    kubernetes_cluster.nodepools.first
+  end
+
+  def apply_statefulset
+    kubernetes_cluster.sshable.cmd("sudo kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f -", stdin: STATEFULSET_YAML)
+  end
+
+  def verify_mount
+    lsblk_output = kubernetes_cluster.client.kubectl("exec -t ubuntu-statefulset-0 -- lsblk")
+    lines = lsblk_output.split("\n")[1..]
+    data_mount = lines.find { |line| line.include?("/etc/data") }
+    if data_mount
+      cols = data_mount.split
+      device_name = cols[0]  # e.g. "loop3"
+      size = cols[3]         # e.g. "1G"
+      mountpoint = cols[6]   # e.g. "/etc/data"
+
+      if device_name.start_with?("loop") && size == "5G" && mountpoint == "/etc/data"
+        # no op
+      else
+        raise "/etc/data is mounted incorrectly: #{data_mount}"
+      end
+    else
+      raise "No /etc/data mount found in lsblk output"
+    end
+  end
+
+  # we are not using jsonpath for extracting the status because even though a pod is termination, its phase
+  # from API Server's point of view is Running, in order to detect that using jsonpath, we needed to check for
+  # deletion timestamp, all conditions in status and .status.phase.
+  # to keep the query simple, we let the kubectl do the processing and observe the system from the eyes of a
+  # customer. This also keeps the logic simpler
+  def pod_status
+    status = kubernetes_cluster.client.kubectl("get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").strip
+    if status != "Running"
+      client = kubernetes_cluster.client
+      Clog.emit("pod not running", {
+        pod_status: status,
+        events: begin; client.kubectl("get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp"); rescue => e; e.message; end,
+        pv_pvc: begin; client.kubectl("get pv,pvc"); rescue => e; e.message; end,
+      })
+    end
+    status
+  end
+end

--- a/prog/test/kubernetes_upgrade.rb
+++ b/prog/test/kubernetes_upgrade.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Prog::Test::KubernetesUpgrade < Prog::Test::KubernetesBase
-  DATA_CANARY = "ubicloud-upgrade-canary"
-
   def self.assemble
     super(cluster_name: "kubernetes-test-upgrade", worker_node_count: 1)
   end
@@ -25,8 +23,30 @@ class Prog::Test::KubernetesUpgrade < Prog::Test::KubernetesBase
   label def wait_for_statefulset
     nap 5 unless kubernetes_cluster.client.kubectl("get pods ubuntu-statefulset-0 -ojsonpath={.status.phase}").strip == "Running"
 
-    write = NetSsh.command("echo :canary > /etc/data/upgrade-canary", canary: DATA_CANARY)
-    kubernetes_cluster.client.kubectl("exec -t ubuntu-statefulset-0 -- sh -c :write", write:)
+    write_data_files
+    hop_wait_data_write
+  end
+
+  label def wait_data_write
+    (1..3).each do |i|
+      unit_name = "csi_data_write_#{i}"
+      case kubernetes_cluster.sshable.d_check(unit_name)
+      when "InProgress"
+        nap 30
+      when "Failed"
+        self.fail_message = "daemonized write for random-data-#{i} failed"
+        hop_destroy_kubernetes
+      end
+    end
+
+    read_hashes = {}
+    (1..3).each do |i|
+      unit_name = "csi_data_write_#{i}"
+      hash_path = "/dev/shm/#{unit_name}.hash"
+      read_hashes["random-data-#{i}"] = kubernetes_cluster.sshable.cmd("cat :hash_path", hash_path:).strip
+      kubernetes_cluster.sshable.d_clean(unit_name)
+    end
+    self.read_hashes = read_hashes
     hop_trigger_upgrade
   end
 
@@ -62,11 +82,7 @@ class Prog::Test::KubernetesUpgrade < Prog::Test::KubernetesBase
   label def verify_data_after_upgrade
     nap 5 unless pod_status == "Running"
 
-    read = NetSsh.command("cat /etc/data/upgrade-canary")
-    canary = kubernetes_cluster.client.kubectl("exec -t ubuntu-statefulset-0 -- sh -c :read", read:).strip
-    if canary != DATA_CANARY
-      self.fail_message = "data did not survive upgrade, expected: #{DATA_CANARY}, got: #{canary}"
-    end
+    verify_data_hashes("upgrade")
     hop_destroy_kubernetes
   end
 end

--- a/prog/test/kubernetes_upgrade.rb
+++ b/prog/test/kubernetes_upgrade.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class Prog::Test::KubernetesUpgrade < Prog::Test::KubernetesBase
+  DATA_CANARY = "ubicloud-upgrade-canary"
+
+  def self.assemble
+    super(cluster_name: "kubernetes-test-upgrade", worker_node_count: 1)
+  end
+
+  label :start
+  label :destroy_kubernetes
+  label :finish
+  label :failed
+
+  label def wait_for_kubernetes_bootstrap
+    hop_setup_statefulset if kubernetes_cluster.strand.label == "wait"
+    nap 10
+  end
+
+  label def setup_statefulset
+    apply_statefulset
+    hop_wait_for_statefulset
+  end
+
+  label def wait_for_statefulset
+    nap 5 unless kubernetes_cluster.client.kubectl("get pods ubuntu-statefulset-0 -ojsonpath={.status.phase}").strip == "Running"
+
+    write = NetSsh.command("echo :canary > /etc/data/upgrade-canary", canary: DATA_CANARY)
+    kubernetes_cluster.client.kubectl("exec -t ubuntu-statefulset-0 -- sh -c :write", write:)
+    hop_trigger_upgrade
+  end
+
+  label def trigger_upgrade
+    upgrade_candidate = kubernetes_cluster.available_upgrade_version
+    unless upgrade_candidate
+      self.fail_message = "No upgrade candidate available"
+      hop_destroy_kubernetes
+    end
+
+    kubernetes_cluster.update(version: upgrade_candidate)
+    kubernetes_cluster.incr_upgrade
+    nodepool.incr_upgrade
+
+    Clog.emit("waiting for k8s cluster upgrade to #{upgrade_candidate}")
+    hop_wait_for_upgrade
+  end
+
+  label def wait_for_upgrade
+    nap 15 unless kubernetes_cluster.display_state == "running"
+
+    # kubectl reports the control-plane node as well as the workers, so compare
+    # against the cluster's full node count rather than just the worker count.
+    nodes = JSON.parse(kubernetes_cluster.client.kubectl("get nodes -o json"))["items"]
+    unless nodes.size == kubernetes_cluster.all_nodes.count && nodes.all? { |n| n.dig("status", "nodeInfo", "kubeletVersion").start_with?("#{kubernetes_cluster.version}.") }
+      self.fail_message = "Not all #{nodes.size} nodes upgraded to #{kubernetes_cluster.version}:\n#{kubernetes_cluster.client.kubectl("get nodes")}"
+      hop_destroy_kubernetes
+    end
+
+    hop_verify_data_after_upgrade
+  end
+
+  label def verify_data_after_upgrade
+    nap 5 unless pod_status == "Running"
+
+    read = NetSsh.command("cat /etc/data/upgrade-canary")
+    canary = kubernetes_cluster.client.kubectl("exec -t ubuntu-statefulset-0 -- sh -c :read", read:).strip
+    if canary != DATA_CANARY
+      self.fail_message = "data did not survive upgrade, expected: #{DATA_CANARY}, got: #{canary}"
+    end
+    hop_destroy_kubernetes
+  end
+end

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Prog::Test::Kubernetes do
   end
 
   describe "#start" do
-    let(:strand_stack) { [{"kubernetes_test_project_id" => kubernetes_test_project.id}] }
+    let(:strand_stack) { [{"kubernetes_test_project_id" => kubernetes_test_project.id, "cluster_name" => "kubernetes-test-standard", "worker_node_count" => 3}] }
 
     it "assembles kubernetes cluster and hops to wait_for_kubernetes_bootstrap" do
       expect { kubernetes_test.start }.to hop("wait_for_kubernetes_bootstrap")
@@ -600,7 +600,7 @@ RSpec.describe Prog::Test::Kubernetes do
       expect { kubernetes_test.verify_reboot_nftables }.to nap(5)
     end
 
-    it "hops to test_upgrade when rules match" do
+    it "hops to destroy_kubernetes when rules match" do
       refresh_frame(kubernetes_test, new_values: {
         "reboot_node_id" => node.id,
         "nat_rules_before_reboot" => "table ip nat { ... }",
@@ -610,7 +610,7 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(sshable).to receive(:_cmd).with("uptime").and_return("up")
       expect(sshable).to receive(:_cmd).with("sudo nft list chain ip nat postrouting").and_return("table ip nat { ... }")
       expect(sshable).to receive(:_cmd).with("sudo nft list chain ip6 pod_access ingress_egress_control").and_return("table ip6 pod_access { ... }")
-      expect { kubernetes_test.verify_reboot_nftables }.to hop("test_upgrade")
+      expect { kubernetes_test.verify_reboot_nftables }.to hop("destroy_kubernetes")
     end
 
     it "sets fail_message when ip nat rules changed" do
@@ -637,120 +637,8 @@ RSpec.describe Prog::Test::Kubernetes do
       expect(sshable).to receive(:_cmd).with("uptime").and_return("up")
       expect(sshable).to receive(:_cmd).with("sudo nft list chain ip nat postrouting").and_return("table ip nat { ... }")
       expect(sshable).to receive(:_cmd).with("sudo nft list chain ip6 pod_access ingress_egress_control").and_return("different pod_access rules")
-      expect { kubernetes_test.verify_reboot_nftables }.to hop("test_upgrade")
+      expect { kubernetes_test.verify_reboot_nftables }.to hop("destroy_kubernetes")
       expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("ip6 pod_access rules changed after reboot")
-    end
-  end
-
-  describe "#test_upgrade" do
-    it "fails if no upgrade candidate is available" do
-      kubernetes_test.kubernetes_cluster.update(version: Option.selectable_kubernetes_versions.first)
-      expect { kubernetes_test.test_upgrade }.to hop("destroy_kubernetes")
-      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("No upgrade candidate available")
-    end
-
-    it "updates version, increments uprades semaphores, and hops to wait_for_upgrade" do
-      target_version = kubernetes_cluster.available_upgrade_version
-      expect { kubernetes_test.test_upgrade }.to hop("wait_for_upgrade")
-
-      kubernetes_cluster.reload
-      expect(kubernetes_cluster.version).to eq(target_version)
-      expect(kubernetes_cluster.upgrade_set?).to be true
-      expect(kubernetes_cluster.nodepools(reload: true).first.upgrade_set?).to be true
-    end
-  end
-
-  describe "#wait_for_upgrade" do
-    it "naps if the cluster is still upgrading" do
-      expect { kubernetes_test.wait_for_upgrade }.to nap(15)
-    end
-
-    it "fails if some nodes are not upgraded" do
-      kubernetes_test.kubernetes_cluster.strand.update(label: "wait")
-      Strand.where(id: kubernetes_test.kubernetes_cluster.nodepools_dataset.select(:id)).update(label: "wait")
-      kubernetes_test.kubernetes_cluster.update(kubeconfig: "stored")
-
-      nodes_json = {
-        "items" => [
-          {"status" => {"nodeInfo" => {"kubeletVersion" => "#{kubernetes_cluster.version}.1"}}},
-          {"status" => {"nodeInfo" => {"kubeletVersion" => "v1.30.1"}}},
-          {"status" => {"nodeInfo" => {"kubeletVersion" => "#{kubernetes_cluster.version}.1"}}},
-        ],
-      }
-      response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(nodes_json), 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -o json").and_return(response)
-
-      response_raw = Net::SSH::Connection::Session::StringWithExitstatus.new("nodes_raw", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_return(response_raw)
-
-      expect { kubernetes_test.wait_for_upgrade }.to hop("destroy_kubernetes")
-      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("Not all 3 nodes upgraded to #{kubernetes_cluster.version}:\nnodes_raw")
-    end
-
-    it "fails if node count is not 3" do
-      kubernetes_test.kubernetes_cluster.strand.update(label: "wait")
-      Strand.where(id: kubernetes_test.kubernetes_cluster.nodepools_dataset.select(:id)).update(label: "wait")
-      kubernetes_test.kubernetes_cluster.update(kubeconfig: "stored")
-
-      nodes_json = {
-        "items" => [
-          {"status" => {"nodeInfo" => {"kubeletVersion" => "#{kubernetes_test.kubernetes_cluster.version}.1"}}},
-        ],
-      }
-      response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(nodes_json), 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -o json").and_return(response)
-
-      response_raw = Net::SSH::Connection::Session::StringWithExitstatus.new("nodes_raw", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_return(response_raw)
-
-      expect { kubernetes_test.wait_for_upgrade }.to hop("destroy_kubernetes")
-      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("Not all 1 nodes upgraded to #{kubernetes_test.kubernetes_cluster.version}:\nnodes_raw")
-    end
-
-    it "hops to verify_data_after_upgrade if all 3 nodes are upgraded correctly" do
-      kubernetes_test.kubernetes_cluster.strand.update(label: "wait")
-      Strand.where(id: kubernetes_test.kubernetes_cluster.nodepools_dataset.select(:id)).update(label: "wait")
-      kubernetes_test.kubernetes_cluster.update(kubeconfig: "stored")
-
-      nodes_json = {
-        "items" => [{"status" => {"nodeInfo" => {"kubeletVersion" => "#{kubernetes_test.kubernetes_cluster.version}.0"}}}] * 3,
-      }
-      response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(nodes_json), 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -o json").and_return(response)
-
-      expect { kubernetes_test.wait_for_upgrade }.to hop("verify_data_after_upgrade")
-    end
-  end
-
-  describe "#verify_data_after_upgrade" do
-    it "naps until pod is running" do
-      response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv,pvc")
-      expect { kubernetes_test.verify_data_after_upgrade }.to nap(5)
-    end
-
-    it "verifies all data hashes and hops to destroy_kubernetes" do
-      refresh_frame(kubernetes_test, new_values: {"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
-      response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
-      (1..3).each do |i|
-        response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
-        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
-      end
-      expect { kubernetes_test.verify_data_after_upgrade }.to hop("destroy_kubernetes")
-    end
-
-    it "sets fail_message and hops to destroy_kubernetes if a hash is wrong" do
-      refresh_frame(kubernetes_test, new_values: {"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
-      response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
-      response = Net::SSH::Connection::Session::StringWithExitstatus.new("corrupted_hash", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-1\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
-
-      expect { kubernetes_test.verify_data_after_upgrade }.to hop("destroy_kubernetes")
-      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("data hash changed after upgrade for random-data-1, expected: hash1, got: corrupted_hash")
     end
   end
 

--- a/spec/prog/test/kubernetes_upgrade_spec.rb
+++ b/spec/prog/test/kubernetes_upgrade_spec.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Test::KubernetesUpgrade do
+  subject(:kubernetes_test) {
+    described_class.new(Strand.new(prog: "Test::KubernetesUpgrade", label: "start", stack: strand_stack))
+  }
+
+  let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "worker_node_count" => 1}] }
+
+  let(:kubernetes_service_project_id) { "546a1ed8-53e5-86d2-966c-fb782d2ae3aa" }
+  let(:kubernetes_test_project) { Project.create(name: "Kubernetes-Test-Project") }
+  let(:kubernetes_service_project) { Project.create_with_id(kubernetes_service_project_id, name: "Ubicloud-Kubernetes-Resources") }
+  let(:session) { Net::SSH::Connection::Session.allocate }
+  let(:kubernetes_cluster) {
+    kc = Prog::Kubernetes::KubernetesClusterNexus.assemble(
+      name: "test-cluster",
+      version: Option.selectable_kubernetes_versions.last,
+      location_id: Location::HETZNER_FSN1_ID,
+      project_id: kubernetes_test_project.id,
+      cp_node_count: 1,
+      target_node_size: "standard-2",
+    ).subject
+    lb = LoadBalancer.create(private_subnet_id: kc.private_subnet.id, name: "api-lb", health_check_endpoint: "/healthz", project_id: kubernetes_test_project.id)
+    kc.update(api_server_lb_id: lb.id)
+    kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "test-cluster-np", node_count: 1, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
+    Prog::Kubernetes::KubernetesNodeNexus.assemble(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "cp-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-4", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: Option.selectable_kubernetes_versions.first, enable_ip4: true, kubernetes_cluster_id: kc.id)
+    Prog::Kubernetes::KubernetesNodeNexus.assemble(kubernetes_test_project.id, sshable_unix_user: "ubi", name: "w1-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-4", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: Option.selectable_kubernetes_versions.first, enable_ip4: true, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
+    kc
+  }
+  let(:sshable) { kubernetes_test.kubernetes_cluster.sshable }
+
+  before do
+    allow(Config).to receive(:kubernetes_service_project_id).and_return(kubernetes_service_project.id)
+    if (kc = kubernetes_test.kubernetes_cluster)
+      allow(kc.sshable).to receive(:connect).and_return(session)
+    end
+  end
+
+  describe ".assemble" do
+    let(:strand_stack) { [{}] }
+
+    it "creates test and service projects and a strand for the upgrade cluster" do
+      expect(Config).to receive(:kubernetes_service_project_id).at_least(:once).and_return("4fd01c1a-f022-43e8-bd3d-6dbe214df6ed")
+      st = described_class.assemble
+      expect(Project["4fd01c1a-f022-43e8-bd3d-6dbe214df6ed"]).not_to be_nil
+      expect(Project.where(name: "Kubernetes-Test-Project").count).to eq(1)
+      expect(st.prog).to eq("Test::KubernetesUpgrade")
+      expect(st.label).to eq("start")
+      expect(st.stack.first["cluster_name"]).to eq("kubernetes-test-upgrade")
+      expect(st.stack.first["worker_node_count"]).to eq(1)
+    end
+  end
+
+  describe "#start" do
+    let(:strand_stack) { [{"kubernetes_test_project_id" => kubernetes_test_project.id, "cluster_name" => "kubernetes-test-upgrade", "worker_node_count" => 1}] }
+
+    it "assembles a single-worker cluster and hops to wait_for_kubernetes_bootstrap" do
+      expect { kubernetes_test.start }.to hop("wait_for_kubernetes_bootstrap")
+      expect(kubernetes_test.strand.stack[0]["kubernetes_cluster_id"]).to eq KubernetesCluster.get(:id)
+      expect(KubernetesCluster.count).to eq(1)
+      expect(KubernetesNodepool.count).to eq(1)
+      expect(KubernetesNodepool.first.node_count).to eq(1)
+    end
+  end
+
+  describe "#wait_for_kubernetes_bootstrap" do
+    it "hops to setup_statefulset if cluster is ready" do
+      kubernetes_cluster.strand.update(label: "wait")
+      expect { kubernetes_test.wait_for_kubernetes_bootstrap }.to hop("setup_statefulset")
+    end
+
+    it "naps if cluster is not ready" do
+      expect { kubernetes_test.wait_for_kubernetes_bootstrap }.to nap(10)
+    end
+  end
+
+  describe "#setup_statefulset" do
+    it "applies the statefulset and hops to wait_for_statefulset" do
+      expect(sshable).to receive(:_cmd).with("sudo kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f -", stdin: /apiVersion: apps/)
+      expect { kubernetes_test.setup_statefulset }.to hop("wait_for_statefulset")
+    end
+  end
+
+  describe "#wait_for_statefulset" do
+    it "naps if pod is not running yet" do
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.status.phase}").and_return(response)
+      expect { kubernetes_test.wait_for_statefulset }.to nap(5)
+    end
+
+    it "writes the canary and hops to trigger_upgrade once the pod is running" do
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.status.phase}").and_return(response)
+      write_response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c echo\\ ubicloud-upgrade-canary\\ \\>\\ /etc/data/upgrade-canary").and_return(write_response)
+      expect { kubernetes_test.wait_for_statefulset }.to hop("trigger_upgrade")
+    end
+  end
+
+  describe "#trigger_upgrade" do
+    it "fails if no upgrade candidate is available" do
+      kubernetes_test.kubernetes_cluster.update(version: Option.selectable_kubernetes_versions.first)
+      expect { kubernetes_test.trigger_upgrade }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("No upgrade candidate available")
+    end
+
+    it "updates version, increments upgrade semaphores, and hops to wait_for_upgrade" do
+      target_version = kubernetes_cluster.available_upgrade_version
+      expect { kubernetes_test.trigger_upgrade }.to hop("wait_for_upgrade")
+
+      kubernetes_cluster.reload
+      expect(kubernetes_cluster.version).to eq(target_version)
+      expect(kubernetes_cluster.upgrade_set?).to be true
+      expect(kubernetes_cluster.nodepools(reload: true).first.upgrade_set?).to be true
+    end
+  end
+
+  describe "#wait_for_upgrade" do
+    it "naps if the cluster is still upgrading" do
+      expect { kubernetes_test.wait_for_upgrade }.to nap(15)
+    end
+
+    it "fails if a node is not upgraded to the target version" do
+      kubernetes_test.kubernetes_cluster.strand.update(label: "wait")
+      Strand.where(id: kubernetes_test.kubernetes_cluster.nodepools_dataset.select(:id)).update(label: "wait")
+      kubernetes_test.kubernetes_cluster.update(kubeconfig: "stored")
+
+      nodes_json = {
+        "items" => [
+          {"status" => {"nodeInfo" => {"kubeletVersion" => "#{kubernetes_test.kubernetes_cluster.version}.1"}}},
+          {"status" => {"nodeInfo" => {"kubeletVersion" => "v1.30.1"}}},
+        ],
+      }
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(nodes_json), 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -o json").and_return(response)
+
+      response_raw = Net::SSH::Connection::Session::StringWithExitstatus.new("nodes_raw", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_return(response_raw)
+
+      expect { kubernetes_test.wait_for_upgrade }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("Not all 2 nodes upgraded to #{kubernetes_cluster.version}:\nnodes_raw")
+    end
+
+    it "fails if the node count does not match the cluster nodes" do
+      kubernetes_test.kubernetes_cluster.strand.update(label: "wait")
+      Strand.where(id: kubernetes_test.kubernetes_cluster.nodepools_dataset.select(:id)).update(label: "wait")
+      kubernetes_test.kubernetes_cluster.update(kubeconfig: "stored")
+
+      # Cluster has a control-plane node and one worker (2 nodes); only one
+      # reported by kubectl trips the count check.
+      nodes_json = {
+        "items" => [
+          {"status" => {"nodeInfo" => {"kubeletVersion" => "#{kubernetes_test.kubernetes_cluster.version}.1"}}},
+        ],
+      }
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(nodes_json), 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -o json").and_return(response)
+
+      response_raw = Net::SSH::Connection::Session::StringWithExitstatus.new("nodes_raw", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_return(response_raw)
+
+      expect { kubernetes_test.wait_for_upgrade }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("Not all 1 nodes upgraded to #{kubernetes_test.kubernetes_cluster.version}:\nnodes_raw")
+    end
+
+    it "hops to verify_data_after_upgrade when all cluster nodes are upgraded" do
+      kubernetes_test.kubernetes_cluster.strand.update(label: "wait")
+      Strand.where(id: kubernetes_test.kubernetes_cluster.nodepools_dataset.select(:id)).update(label: "wait")
+      kubernetes_test.kubernetes_cluster.update(kubeconfig: "stored")
+
+      nodes_json = {
+        "items" => [{"status" => {"nodeInfo" => {"kubeletVersion" => "#{kubernetes_test.kubernetes_cluster.version}.0"}}}] * 2,
+      }
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(nodes_json), 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -o json").and_return(response)
+
+      expect { kubernetes_test.wait_for_upgrade }.to hop("verify_data_after_upgrade")
+    end
+  end
+
+  describe "#verify_data_after_upgrade" do
+    it "naps until pod is running" do
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get events --field-selector involvedObject.name=ubuntu-statefulset-0 --sort-by=.lastTimestamp")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv,pvc")
+      expect { kubernetes_test.verify_data_after_upgrade }.to nap(5)
+    end
+
+    it "reads the canary and hops to destroy_kubernetes when data survived" do
+      expect(kubernetes_test).to receive(:pod_status).and_return("Running")
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("ubicloud-upgrade-canary", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c cat\\ /etc/data/upgrade-canary").and_return(response)
+      expect { kubernetes_test.verify_data_after_upgrade }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to be_nil
+    end
+
+    it "sets fail_message and hops to destroy_kubernetes when data did not survive" do
+      expect(kubernetes_test).to receive(:pod_status).and_return("Running")
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("garbage", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c cat\\ /etc/data/upgrade-canary").and_return(response)
+      expect { kubernetes_test.verify_data_after_upgrade }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("data did not survive upgrade, expected: ubicloud-upgrade-canary, got: garbage")
+    end
+  end
+
+  describe "#destroy_kubernetes" do
+    it "increments destroy and hops to finish" do
+      expect { kubernetes_test.destroy_kubernetes }.to hop("finish")
+      expect(kubernetes_test.kubernetes_cluster.destroy_set?).to be true
+    end
+  end
+
+  describe "#finish" do
+    it "naps if kubernetes cluster is not destroyed yet" do
+      expect { kubernetes_test.finish }.to nap(5)
+    end
+
+    context "when the kubernetes cluster is destroyed" do
+      let(:strand_stack) { [{"kubernetes_test_project_id" => kubernetes_test_project.id, "fail_message" => fail_message}] }
+      let(:fail_message) { nil }
+
+      it "destroys test project and exits successfully" do
+        expect { kubernetes_test.finish }.to exit({"msg" => "KubernetesUpgrade tests are finished!"})
+          .and change { Project.where(id: kubernetes_test_project.id).count }.from(1).to(0)
+      end
+
+      context "with a fail message" do
+        let(:fail_message) { "Test failed" }
+
+        it "destroys test project and fails the test" do
+          expect { kubernetes_test.finish }.to hop("failed")
+            .and change { Project.where(id: kubernetes_test_project.id).count }.from(1).to(0)
+          expect(kubernetes_test.strand.exitval).to eq({"msg" => "Test failed"})
+        end
+      end
+    end
+  end
+
+  describe "#failed" do
+    it "naps" do
+      expect { kubernetes_test.failed }.to nap(15)
+    end
+  end
+end

--- a/spec/prog/test/kubernetes_upgrade_spec.rb
+++ b/spec/prog/test/kubernetes_upgrade_spec.rb
@@ -90,12 +90,41 @@ RSpec.describe Prog::Test::KubernetesUpgrade do
       expect { kubernetes_test.wait_for_statefulset }.to nap(5)
     end
 
-    it "writes the canary and hops to trigger_upgrade once the pod is running" do
+    it "launches 3 daemonized writes and hops to wait_data_write once the pod is running" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.status.phase}").and_return(response)
-      write_response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c echo\\ ubicloud-upgrade-canary\\ \\>\\ /etc/data/upgrade-canary").and_return(write_response)
-      expect { kubernetes_test.wait_for_statefulset }.to hop("trigger_upgrade")
+      (1..3).each do |i|
+        unit_name = "csi_data_write_#{i}"
+        bash_cmd = "sudo kubectl --kubeconfig /etc/kubernetes/admin.conf exec -t ubuntu-statefulset-0 -- sh -c \"head -c 300M /dev/urandom | tee /etc/data/random-data-#{i} | sha256sum | awk '{print \\$1}'\" > /dev/shm/#{unit_name}.hash"
+        expected_cmd = "common/bin/daemonizer2 run #{unit_name} #{["bash", "-c", bash_cmd].shelljoin}"
+        expect(sshable).to receive(:_cmd).with(expected_cmd, stdin: nil, log: true)
+      end
+      expect { kubernetes_test.wait_for_statefulset }.to hop("wait_data_write")
+    end
+  end
+
+  describe "#wait_data_write" do
+    it "naps if any write is still in progress" do
+      expect(sshable).to receive(:d_check).with("csi_data_write_1").and_return("InProgress")
+      expect { kubernetes_test.wait_data_write }.to nap(30)
+    end
+
+    it "fails if a write has failed" do
+      expect(sshable).to receive(:d_check).with("csi_data_write_1").and_return("Failed")
+      expect { kubernetes_test.wait_data_write }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack[0]["fail_message"]).to eq "daemonized write for random-data-1 failed"
+    end
+
+    it "captures the write hashes and hops to trigger_upgrade when all writes have succeeded" do
+      (1..3).each do |i|
+        expect(sshable).to receive(:d_check).with("csi_data_write_#{i}").and_return("Succeeded")
+      end
+      (1..3).each do |i|
+        expect(sshable).to receive(:_cmd).with("cat /dev/shm/csi_data_write_#{i}.hash").and_return("hash#{i}")
+        expect(sshable).to receive(:d_clean).with("csi_data_write_#{i}")
+      end
+      expect { kubernetes_test.wait_data_write }.to hop("trigger_upgrade")
+      expect(kubernetes_test.strand.stack[0]["read_hashes"]).to eq({"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"})
     end
   end
 
@@ -181,6 +210,10 @@ RSpec.describe Prog::Test::KubernetesUpgrade do
   end
 
   describe "#verify_data_after_upgrade" do
+    before do
+      refresh_frame(kubernetes_test, new_values: {"read_hashes" => {"random-data-1" => "hash1", "random-data-2" => "hash2", "random-data-3" => "hash3"}})
+    end
+
     it "naps until pod is running" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 | grep -v NAME | awk '{print $3}'").and_return(response)
@@ -189,20 +222,22 @@ RSpec.describe Prog::Test::KubernetesUpgrade do
       expect { kubernetes_test.verify_data_after_upgrade }.to nap(5)
     end
 
-    it "reads the canary and hops to destroy_kubernetes when data survived" do
+    it "validates every file hash and hops to destroy_kubernetes when data survived" do
       expect(kubernetes_test).to receive(:pod_status).and_return("Running")
-      response = Net::SSH::Connection::Session::StringWithExitstatus.new("ubicloud-upgrade-canary", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c cat\\ /etc/data/upgrade-canary").and_return(response)
+      (1..3).each do |i|
+        response = Net::SSH::Connection::Session::StringWithExitstatus.new("hash#{i}", 0)
+        expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-#{i}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
+      end
       expect { kubernetes_test.verify_data_after_upgrade }.to hop("destroy_kubernetes")
       expect(kubernetes_test.strand.stack.first["fail_message"]).to be_nil
     end
 
-    it "sets fail_message and hops to destroy_kubernetes when data did not survive" do
+    it "sets fail_message and hops to destroy_kubernetes when a file did not survive" do
       expect(kubernetes_test).to receive(:pod_status).and_return("Running")
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("garbage", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c cat\\ /etc/data/upgrade-canary").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c sha256sum\\ /etc/data/random-data-1\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\}\\'").and_return(response)
       expect { kubernetes_test.verify_data_after_upgrade }.to hop("destroy_kubernetes")
-      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("data did not survive upgrade, expected: ubicloud-upgrade-canary, got: garbage")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("data hash changed after upgrade for random-data-1, expected: hash1, got: garbage")
     end
   end
 


### PR DESCRIPTION
The Kubernetes e2e test upgraded its cluster as the final step, after the functional scenarios. That upgrade is a sequential, node-by-node rolling replacement and took ~12 minutes, all of it on the tail of the metal suite since nothing else ran alongside it.

Split the test the way the Postgres tests are split: a shared Prog::Test::KubernetesBase holds the cluster lifecycle and helpers, while Prog::Test::Kubernetes keeps the functional scenarios and a new Prog::Test::KubernetesUpgrade exercises only the version upgrade on its own minimal single-worker cluster. bin/e2e assembles both, so they run as independent strands and the upgrade proceeds in parallel with the functional tests instead of extending the run.