### PR TITLE
Enable track_written for all writeable storage volumes by default

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -100,7 +100,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       size:,
       location_id:,
       boot_image:,
-      storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: true}],
+      storage_volumes: [{size_gib: label_data["storage_size_gib"], encrypted: true, track_written: false}],
       enable_ip4: true,
       arch:,
       swap_size_bytes: 4294963200, # ~4096MB, the same value with GitHub hosted runners

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -35,8 +35,8 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
         name: ubid.to_s,
         size: postgres_resource.target_vm_size.gsub("hobby", "burstable"),
         storage_volumes: [
-          {encrypted: true, size_gib: Config.postgres_boot_disk_size_gib, vring_workers: 1},
-          {encrypted: true, size_gib: postgres_resource.target_storage_size_gib, vring_workers: 1},
+          {encrypted: true, size_gib: Config.postgres_boot_disk_size_gib, vring_workers: 1, track_written: false},
+          {encrypted: true, size_gib: postgres_resource.target_storage_size_gib, vring_workers: 1, track_written: false},
         ],
         boot_image:,
         private_subnet_id: postgres_resource.private_subnet_id,

--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -84,6 +84,15 @@ class Prog::Test::Vm < Prog::Test::Base
       sshable.cmd("sync :test_file", test_file:)
     }
 
+    hop_verify_track_written
+  end
+
+  label def verify_track_written
+    vm.vm_storage_volumes.each do |vol|
+      written = vol.dump_metadata[/^written stripes:[ \t]*(.*)$/, 1]
+      fail_test "no written stripes reported for disk #{vol.disk_index}" if written.nil? || written.empty?
+    end
+
     hop_verify_vm_stats
   end
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -39,8 +39,7 @@ class Prog::Vm::Nexus < Prog::Base
       volume[:vring_workers] ||= vm_size.vring_workers
       volume[:encrypted] = true if !volume.has_key? :encrypted
       if !volume.has_key? :track_written
-        volume[:track_written] = storage_volumes.length == 1 &&
-          volume[:size_gib] <= Config.machine_image_max_size_gib
+        volume[:track_written] = !volume[:read_only]
       end
       volume[:boot] = disk_index == boot_disk_index
 

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -18,7 +18,7 @@ class Prog::Vm::VmPool < Prog::Base
   end
 
   label def create_new_vm
-    storage_params = {size_gib: vm_pool.storage_size_gib}
+    storage_params = {size_gib: vm_pool.storage_size_gib, track_written: false}
     ps = Prog::Vnet::SubnetNexus.assemble(
       Config.vm_pool_project_id,
       location_id: vm_pool.location_id,

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       picked_vm = nx.pick_vm
       expect(vm.id).not_to eq(picked_vm.id)
       expect(picked_vm.pool_id).to be_nil
+      expect(picked_vm.vm_storage_volumes.first.track_written).to be(false)
     end
 
     it "uses alien vms by given ratio" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(postgres_server).not_to be_nil
       expect(postgres_server.vm).not_to be_nil
       expect(postgres_server.vm.sshable).not_to be_nil
+      expect(postgres_server.vm.vm_storage_volumes.map(&:track_written)).to eq([false, false])
 
       st = described_class.assemble(resource_id: postgres_resource.id, timeline_id: postgres_timeline.id, timeline_access: "push")
       expect(st.subject.synchronization_status).to eq("catching_up")

--- a/spec/prog/test/vm_spec.rb
+++ b/spec/prog/test/vm_spec.rb
@@ -25,8 +25,21 @@ RSpec.describe Prog::Test::Vm do
       private_ipv4: "192.168.0.1/32", private_ipv6: "fd01:db8:85a1::/64",
       mac: "00:00:00:00:00:01", state: "active")
     sd = StorageDevice.create(vm_host_id: vm_host.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["sda"])
-    VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, storage_device_id: sd.id)
-    VmStorageVolume.create(vm_id: vm.id, boot: false, size_gib: 20, disk_index: 1, use_bdev_ubi: false, storage_device_id: sd.id)
+    vbb = create_vhost_block_backend(version: "v0.4.2", vm_host_id: vm_host.id)
+    2.times do |i|
+      kek = StorageKeyEncryptionKey.create_random(auth_data: "auth_data_#{i}")
+      VmStorageVolume.create(
+        vm_id: vm.id,
+        boot: i == 0,
+        size_gib: 20,
+        disk_index: i,
+        use_bdev_ubi: false,
+        storage_device_id: sd.id,
+        vhost_block_backend_id: vbb.id,
+        key_encryption_key_1_id: kek.id,
+        vring_workers: 1,
+      )
+    end
     vm
   }
 
@@ -162,7 +175,53 @@ RSpec.describe Prog::Test::Vm do
       expect(sshable).to receive(:_cmd).with("sudo chown ubi #{mount_path}")
       expect(sshable).to receive(:_cmd).with("dd if=/dev/urandom of=#{mount_path}/1.txt bs=512 count=10000")
       expect(sshable).to receive(:_cmd).with("sync #{mount_path}/1.txt")
-      expect { vm_test.verify_extra_disks }.to hop("verify_vm_stats")
+      expect { vm_test.verify_extra_disks }.to hop("verify_track_written")
+    end
+  end
+
+  describe "#verify_track_written" do
+    it "verifies track_written for each disk" do
+      vols = vm_test.vm.vm_storage_volumes
+      expect(vols[0].vm.vm_host.sshable).to receive(:_cmd)
+        .with("sudo host/bin/storage-dump-metadata #{vm.inhost_name} DEFAULT 0 v0.4.2", stdin: /.*/)
+        .and_return(<<~OUT,
+          data file: /var/storage/vmt05cpe/0/disk.raw (42949672960 bytes)
+          source: raw (path: /var/storage/images/ubuntu-noble-20250502.1.raw, size: 3758096384 bytes)
+          metadata version: 2.0
+          stripe size: 1048576 bytes
+          fetched stripes: 0, 5-12, 111, 285, 303, 305
+          written stripes: 0, 5, 6, 12, 111, 285, 303
+          has-source stripes: 0-3583
+        OUT
+                   )
+
+      expect(vols[1].vm.vm_host.sshable).to receive(:_cmd)
+        .with("sudo host/bin/storage-dump-metadata #{vm.inhost_name} DEFAULT 1 v0.4.2", stdin: /.*/)
+        .and_return(<<~OUT,
+          data file: /var/storage/vmt05cpe/1/disk.raw (42949672960 bytes)
+          source: None
+          metadata version: 2.0
+          stripe size: 1048576 bytes
+          fetched stripes:
+          written stripes: 0-4, 36, 128
+          has-source stripes:
+        OUT
+                   )
+
+      expect { vm_test.verify_track_written }.to hop("verify_vm_stats")
+    end
+
+    it "fails if no written stripes reported for a disk" do
+      expect(vm_test.vm.vm_storage_volumes[0].vm.vm_host.sshable).to receive(:_cmd)
+        .with("sudo host/bin/storage-dump-metadata #{vm.inhost_name} DEFAULT 0 v0.4.2", stdin: /.*/)
+        .and_return(<<~OUT,
+          stripe size: 1048576 bytes
+          fetched stripes: 0, 5-12, 111, 285, 303, 305
+          written stripes:
+          has-source stripes: 0-3583
+        OUT
+                   )
+      expect { vm_test.verify_track_written }.to hop("failed")
     end
   end
 

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -94,24 +94,28 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(st.stack.first["storage_volumes"].first["size_gib"]).to eq(40)
     end
 
-    it "sets track_written for single volume within size limit" do
+    it "sets track_written for a single writeable volume" do
       st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: 20}])
       expect(st.stack.first["storage_volumes"].first["track_written"]).to be(true)
     end
 
-    it "does not set track_written if there are multiple storage volumes" do
+    it "sets track_written on every writeable volume when there are multiple" do
       st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: 20}, {size_gib: 10}])
-      expect(st.stack.first["storage_volumes"].first["track_written"]).to be(false)
+      expect(st.stack.first["storage_volumes"].map { it["track_written"] }).to eq([true, true])
     end
 
-    it "does not set track_written if storage volume size exceeds machine image max size" do
-      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: Config.machine_image_max_size_gib + 1}])
-      expect(st.stack.first["storage_volumes"].first["track_written"]).to be(false)
+    it "does not set track_written for a read-only volume" do
+      create_machine_image_version_metal(project_id: project.id)
+      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "test-mi@v1",
+        storage_volumes: [{size_gib: 20}, {size_gib: 10, read_only: true}])
+      _, rov = st.stack.first["storage_volumes"]
+      expect(rov["read_only"]).to be(true)
+      expect(rov["track_written"]).to be(false)
     end
 
     it "preserves an explicitly-provided track_written value" do
-      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: 20, track_written: true}])
-      expect(st.stack.first["storage_volumes"].first["track_written"]).to be(true)
+      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: 20, track_written: false}])
+      expect(st.stack.first["storage_volumes"].first["track_written"]).to be(false)
     end
 
     it "sets machine_image_version_id on boot volume when boot_image is name@version" do

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Prog::Vm::VmPool do
       vm = pool.vms.first
       expect(vm.unix_user).to eq("runneradmin")
       expect(vm.sshable.unix_user).to eq("runneradmin")
+      expect(vm.vm_storage_volumes.first.track_written).to be(false)
     end
   end
 


### PR DESCRIPTION
### Enable track_written for all writeable storage volumes by default 
This will be useful for efficiently moving VMs between hosts. It enables optimizing out stripes to which data hasn't been written to.

VM move support will be implemented in the future, but enabling this now ensures that moves can be efficient for a broader range of VMs once that support exists.

The performance impact is that the first write to each 1MB stripe causes a durable metadata update.

Note that the `track_written` flag was enabled before this change for standard-2 and burstable VMs previously so they can be used as machine image capture sources.

### Don't track writes for github-runner VMs 
Github-runner VMs are ephemeral and we don't need to capture machine images from them or move them between hosts. Tracking writes can impact performance of writes slightly, so disabling them for github-runner VMs.

### Don't track writes for postgres VMs 
We already have a failover mechanism to move postgres VMs. Therefore, we don't need to support efficient VM move for them and we can disable write tracking which has a slight performance cost.
