### PR TITLE
Halve metal Postgres e2e storage to ease host allocation

### DIFF
--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -43,7 +43,7 @@ class Prog::Test::PostgresBase < Prog::Test::Base
       vcpus = Option::GCP_STORAGE_SIZE_OPTIONS[family].keys.first
       [location.id, "#{family}-#{vcpus}", Option::GCP_STORAGE_SIZE_OPTIONS[family][vcpus].first.to_i]
     else
-      [Location::HETZNER_FSN1_ID, "standard-2", 128]
+      [Location::HETZNER_FSN1_ID, "standard-2", 64]
     end
   end
 


### PR DESCRIPTION
The metal e2e tail is the postgres_upgrade test, and profiling the host showed why: its new read-replica VM spent ~5 minutes queued in the allocator (created -> allocated) before it could be placed. The host was not short on cores or memory at the time (peak ~18/32 cores and 144/245 hugepages, both ~40% free); the binding constraint was storage. The allocator's base filter requires available_storage_gib >= the request, and the metal Postgres servers each ask for 128 GiB. With the standard + HA + two upgrade resources (each with primary, standby, read replica, and their v+1 replacements coexisting mid-upgrade), that is ~13 servers x 128 GiB ~= 1.6 TB competing for the single host's storage, so a new 128 GiB replica cannot land until older servers are torn down.

The e2e database is a handful of rows, so 128 GiB is wildly oversized. Drop it to 64 GiB (a valid POSTGRES_STORAGE_SIZE_OPTIONS value), halving the peak Postgres storage footprint to ~830 GiB and letting upgrade replicas allocate immediately. Cores and memory have ample headroom, so this trades nothing for the contention relief. aws/gcp sizing is unchanged.