### PR TITLE
Make machine images publicly available

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -247,7 +247,6 @@ class Project < Sequel::Model
     :free_runner_upgrade_until,
     :gpu_vm,
     :ipv6_disabled,
-    :machine_image,
     :postgres_hostname_override,
     :postgres_init_script,
     :postgres_lantern,

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -39,8 +39,7 @@ class Prog::Vm::Nexus < Prog::Base
       volume[:vring_workers] ||= vm_size.vring_workers
       volume[:encrypted] = true if !volume.has_key? :encrypted
       if !volume.has_key? :track_written
-        volume[:track_written] = !!project.get_ff_machine_image &&
-          storage_volumes.length == 1 &&
+        volume[:track_written] = storage_volumes.length == 1 &&
           volume[:size_gib] <= Config.machine_image_max_size_gib
       end
       volume[:boot] = disk_index == boot_disk_index

--- a/routes/project/location/machine_image.rb
+++ b/routes/project/location/machine_image.rb
@@ -2,8 +2,6 @@
 
 class Clover
   hash_branch(:project_location_prefix, "machine-image") do |r|
-    next unless @project.get_ff_machine_image
-
     r.get api? do
       machine_image_list
     end

--- a/routes/project/machine_image.rb
+++ b/routes/project/machine_image.rb
@@ -2,8 +2,6 @@
 
 class Clover
   hash_branch(:project_prefix, "machine-image") do |r|
-    next unless @project.get_ff_machine_image
-
     r.get api? do
       machine_image_list
     end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -94,25 +94,17 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(st.stack.first["storage_volumes"].first["size_gib"]).to eq(40)
     end
 
-    it "sets track_written when ff_machine_image is set and single volume within size limit" do
-      project.set_ff_machine_image(true)
+    it "sets track_written for single volume within size limit" do
       st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: 20}])
       expect(st.stack.first["storage_volumes"].first["track_written"]).to be(true)
     end
 
-    it "does not set track_written when ff_machine_image is not set" do
-      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: 20}])
-      expect(st.stack.first["storage_volumes"].first["track_written"]).to be(false)
-    end
-
     it "does not set track_written if there are multiple storage volumes" do
-      project.set_ff_machine_image(true)
       st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: 20}, {size_gib: 10}])
       expect(st.stack.first["storage_volumes"].first["track_written"]).to be(false)
     end
 
-    it "does not set track_written if storage volume size exceeds machine image max size even if ff_machine_image is set" do
-      project.set_ff_machine_image(true)
+    it "does not set track_written if storage volume size exceeds machine image max size" do
       st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, storage_volumes: [{size_gib: Config.machine_image_max_size_gib + 1}])
       expect(st.stack.first["storage_volumes"].first["track_written"]).to be(false)
     end

--- a/spec/routes/api/cli/mi/create_spec.rb
+++ b/spec/routes/api/cli/mi/create_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Clover, "cli mi create" do
   let(:location_id) { Location[display_name: TEST_LOCATION].id }
 
   before do
-    @project.set_ff_machine_image(true)
     MachineImageStore.create(project_id: @project.id, location_id:, provider: "r2", region: "auto",
       endpoint: "https://r2.cloudflare.com/", bucket: "test-bucket", access_key: "ak", secret_key: "sk")
     @vm = create_archive_ready_vm(project_id: @project.id, location_id:)

--- a/spec/routes/api/cli/mi/create_version_spec.rb
+++ b/spec/routes/api/cli/mi/create_version_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Clover, "cli mi create-version" do
   let(:location_id) { Location[display_name: TEST_LOCATION].id }
 
   before do
-    @project.set_ff_machine_image(true)
     @mi_metal = create_machine_image_version_metal(project_id: @project.id, location_id:)
     @mi = @mi_metal.machine_image_version.machine_image
     @vm = create_archive_ready_vm(project_id: @project.id, location_id:)

--- a/spec/routes/api/cli/mi/destroy_spec.rb
+++ b/spec/routes/api/cli/mi/destroy_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Clover, "cli mi destroy" do
   let(:location_id) { Location[display_name: TEST_LOCATION].id }
 
   before do
-    @project.set_ff_machine_image(true)
     @mi = MachineImage.create(name: "test-mi", project_id: @project.id, arch: "x64", location_id:)
   end
 

--- a/spec/routes/api/cli/mi/destroy_version_spec.rb
+++ b/spec/routes/api/cli/mi/destroy_version_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Clover, "cli mi destroy-version" do
   let(:extra_metal) { MachineImageVersionMetal[@mi.versions_dataset.first(version: "v2").id] }
 
   before do
-    @project.set_ff_machine_image(true)
     @mi_metal = create_machine_image_version_metal(project_id: @project.id, location_id:)
     @mi = @mi_metal.machine_image_version.machine_image
     extra = MachineImageVersion.create(machine_image_id: @mi.id, version: "v2")

--- a/spec/routes/api/cli/mi/list_spec.rb
+++ b/spec/routes/api/cli/mi/list_spec.rb
@@ -4,7 +4,6 @@ require_relative "../spec_helper"
 
 RSpec.describe Clover, "cli mi list" do
   before do
-    @project.set_ff_machine_image(true)
     @mi = MachineImage.create(name: "test-mi", project_id: @project.id, arch: "x64",
       location_id: Location[display_name: TEST_LOCATION].id)
   end

--- a/spec/routes/api/cli/mi/list_versions_spec.rb
+++ b/spec/routes/api/cli/mi/list_versions_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Clover, "cli mi list-versions" do
   let(:location_id) { Location[display_name: TEST_LOCATION].id }
 
   before do
-    @project.set_ff_machine_image(true)
     @mi_metal = create_machine_image_version_metal(project_id: @project.id, location_id:)
     @mi = @mi_metal.machine_image_version.machine_image
     @miv = @mi_metal.machine_image_version

--- a/spec/routes/api/cli/mi/rename_spec.rb
+++ b/spec/routes/api/cli/mi/rename_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Clover, "cli mi rename" do
   let(:location_id) { Location[display_name: TEST_LOCATION].id }
 
   before do
-    @project.set_ff_machine_image(true)
     @mi = MachineImage.create(name: "old-name", project_id: @project.id, arch: "x64", location_id:)
   end
 

--- a/spec/routes/api/cli/mi/set_latest_spec.rb
+++ b/spec/routes/api/cli/mi/set_latest_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Clover, "cli mi set-latest" do
   let(:location_id) { Location[display_name: TEST_LOCATION].id }
 
   before do
-    @project.set_ff_machine_image(true)
     @mi_metal = create_machine_image_version_metal(project_id: @project.id, location_id:)
     @mi = @mi_metal.machine_image_version.machine_image
     @mi_metal.update(status: "ready")

--- a/spec/routes/api/cli/mi/show_spec.rb
+++ b/spec/routes/api/cli/mi/show_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Clover, "cli mi show" do
   let(:location_id) { Location[display_name: TEST_LOCATION].id }
 
   before do
-    @project.set_ff_machine_image(true)
     @mi_metal = create_machine_image_version_metal(project_id: @project.id, location_id:)
     @mi = @mi_metal.machine_image_version.machine_image
     @mi.update(latest_version_id: @mi_metal.machine_image_version.id)

--- a/spec/routes/api/project/location/machine_image_spec.rb
+++ b/spec/routes/api/project/location/machine_image_spec.rb
@@ -4,11 +4,7 @@ require_relative "../../spec_helper"
 
 RSpec.describe Clover, "machine-image" do
   let(:user) { create_account }
-  let(:project) {
-    p = project_with_default_policy(user)
-    p.set_ff_machine_image(true)
-    p
-  }
+  let(:project) { project_with_default_policy(user) }
   let(:location_id) { Location[display_name: TEST_LOCATION].id }
   let(:mi_version_metal) { create_machine_image_version_metal(project_id: project.id, location_id:) }
   let(:mi) { mi_version_metal.machine_image_version.machine_image }
@@ -17,14 +13,6 @@ RSpec.describe Clover, "machine-image" do
   let(:source_vm) { create_archive_ready_vm(project_id: project.id, location_id:) }
 
   before { login_api }
-
-  describe "feature flag" do
-    it "returns 404 when ff_machine_image is disabled" do
-      project.set_ff_machine_image(false)
-      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/machine-image"
-      expect(last_response.status).to eq(404)
-    end
-  end
 
   describe "list" do
     it "returns images in the location" do

--- a/spec/routes/api/project/machine_image_spec.rb
+++ b/spec/routes/api/project/machine_image_spec.rb
@@ -4,11 +4,7 @@ require_relative "../spec_helper"
 
 RSpec.describe Clover, "project machine-image" do
   let(:user) { create_account }
-  let(:project) {
-    p = project_with_default_policy(user)
-    p.set_ff_machine_image(true)
-    p
-  }
+  let(:project) { project_with_default_policy(user) }
   let(:location_id) { Location[display_name: TEST_LOCATION].id }
 
   before { login_api }
@@ -19,11 +15,5 @@ RSpec.describe Clover, "project machine-image" do
     expect(last_response.status).to eq(200)
     body = JSON.parse(last_response.body)
     expect(body["count"]).to eq(1)
-  end
-
-  it "returns 404 when ff_machine_image is disabled" do
-    project.set_ff_machine_image(false)
-    get "/project/#{project.ubid}/machine-image"
-    expect(last_response.status).to eq(404)
   end
 end

--- a/spec/routes/web/machine_image_spec.rb
+++ b/spec/routes/web/machine_image_spec.rb
@@ -4,11 +4,7 @@ require_relative "spec_helper"
 
 RSpec.describe Clover, "machine-image" do
   let(:user) { create_account }
-  let(:project) {
-    p = user.create_project_with_default_policy("project-1")
-    p.set_ff_machine_image(true)
-    p
-  }
+  let(:project) { user.create_project_with_default_policy("project-1") }
   let(:location_id) { Location[display_name: TEST_LOCATION].id }
   let(:source_vm) { create_archive_ready_vm(project_id: project.id, location_id:) }
   let(:mi_version_metal) { create_machine_image_version_metal(project_id: project.id, location_id:) }
@@ -30,15 +26,6 @@ RSpec.describe Clover, "machine-image" do
   describe "authenticated" do
     before do
       login(user.email)
-    end
-
-    describe "feature flag" do
-      it "returns 404 when ff_machine_image is disabled on the overview page" do
-        project.set_ff_machine_image(false)
-        mi_version_metal
-        visit "#{project.path}/location/#{TEST_LOCATION}/machine-image/#{mi.name}/overview"
-        expect(page.status_code).to eq(404)
-      end
     end
 
     describe "list" do

--- a/views/layouts/sidebar/content.erb
+++ b/views/layouts/sidebar/content.erb
@@ -54,7 +54,6 @@
               is_active: request.path.start_with?("#{@project.path}/kubernetes-cluster"),
               icon: "kubernetes"
             ) %>
-            <% if @project.get_ff_machine_image %>
             <%== part(
               "layouts/sidebar/item",
               name: "Machine Images",
@@ -62,7 +61,6 @@
               is_active: request.path.start_with?("#{@project.path}/machine-image"),
               icon: "hero-rectangle-stack"
             ) %>
-            <% end %>
             <%== part(
               "layouts/sidebar/item",
               name: "Web Shell",


### PR DESCRIPTION
The machine image feature is feature-complete and stable enough to ship to all customers. Drop the `ff_machine_image` gate and the flag entry from Project.