### PR TITLE
Preload jemalloc in the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,11 @@ FROM docker.io/library/ruby:4.0.5-alpine3.23
 # - postgresql-client: Required for postgresql gem at runtime
 # - gcompat: Required for nokogiri gem at runtime. https://nokogiri.org/tutorials/installing_nokogiri.html#linux-musl-error-loading-shared-library
 # - foreman: Helps to start different parts of app based on Procfile
+# - jemalloc: Reduces memory fragmentation; arch-independent path on Alpine
+ENV JEMALLOC_PATH=/usr/lib/libjemalloc.so.2
 RUN apk update --no-cache && \
-    apk add tzdata curl postgresql-client gcompat libffi --no-cache && \
+    apk add tzdata curl postgresql-client gcompat libffi jemalloc --no-cache && \
+    test -f "$JEMALLOC_PATH" && \
     gem install foreman
 
 RUN adduser -D ubicloud && \
@@ -45,6 +48,7 @@ COPY --chown=ubicloud . /app
 
 ENV RACK_ENV=production
 ENV PORT=3000
+ENV LD_PRELOAD=${JEMALLOC_PATH}
 
 EXPOSE 3000
 


### PR DESCRIPTION
Install the jemalloc package and preload it via LD_PRELOAD so the app uses jemalloc to reduce memory fragmentation. The path is defined once via JEMALLOC_PATH and asserted to exist at build time, so the build fails loudly if a future Alpine release moves the library. Alpine ships libjemalloc.so.2 at /usr/lib on both x86_64 and aarch64, so the preload path is architecture-independent.