### PR TITLE
Overlap VmGroup post-reboot checks with the rest of the e2e suite

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -30,16 +30,15 @@ def test_metal(options, test_cases)
 
   tests_to_wait = []
   if options[:test_cases].include?("vm") && (test_case = test_cases["vm"])
-    # Testing slices is not parallel with other tests as it requires a specific host state
-
     # This tests encrypted VMs with slices, which will create both standard and
     # burstable VMs. The test will also test host reboot.
     encrypted_vms_st = Prog::Test::VmGroup.assemble(boot_images: test_case["images"], test_reboot: true)
     log(encrypted_vms_st, "storage_encrypted: true")
-    # Not running in parallel but waiting, since host is rebooted during test.
-    # Rebooting makes the next test to test reboot practically as well depending
-    # on when the host is rebooted and can cause flaky issues for github runner tests.
-    wait_until(encrypted_vms_st)
+    # Block only until the in-test host reboot completes; rebooting the shared
+    # host while other tests run would disrupt their VMs. Once the host is back
+    # and VmGroup starts re-verifying its VMs, the rest runs in parallel.
+    wait_until(encrypted_vms_st, "verify_vms_after_reboot")
+    tests_to_wait << encrypted_vms_st
   end
 
   if (gh_test_cases = test_cases.values_at(*options[:test_cases].select { it.include?("github_runner") })).any?

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -57,6 +57,9 @@ class Prog::Test::VmGroup < Prog::Test::Base
 
   label def verify_vms
     vms.each { bud(Prog::Test::Vm, {"subject_id" => it, "first_boot" => first_boot}) }
+    # On the post-reboot pass, reap under a distinct label so bin/e2e can tell
+    # the reboot is done and start the rest of the suite in parallel.
+    hop_verify_vms_after_reboot unless first_boot
     hop_wait_verify_vms
   end
 
@@ -65,12 +68,12 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   label def verify_host_capacity
-    hop_verify_vm_host_slices unless verify_host_capacity?
+    if verify_host_capacity? && first_boot
+      vm_cores = vm_host.vms.sum(&:cores)
+      slice_cores = vm_host.slices.sum(&:cores)
 
-    vm_cores = vm_host.vms.sum(&:cores)
-    slice_cores = vm_host.slices.sum(&:cores)
-
-    fail_test "Host used cores does not match the allocated VMs cores (vm_cores=#{vm_cores}, slice_cores=#{slice_cores}, used_cores=#{vm_host.used_cores})" if vm_cores + slice_cores != vm_host.used_cores
+      fail_test "Host used cores does not match the allocated VMs cores (vm_cores=#{vm_cores}, slice_cores=#{slice_cores}, used_cores=#{vm_host.used_cores})" if vm_cores + slice_cores != vm_host.used_cores
+    end
 
     hop_verify_vm_host_slices
   end
@@ -118,6 +121,10 @@ class Prog::Test::VmGroup < Prog::Test::Base
     end
 
     nap 20
+  end
+
+  label def verify_vms_after_reboot
+    reap(:verify_host_capacity)
   end
 
   label def destroy_resources

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe Prog::Test::VmGroup do
       children = st.children_dataset.where(prog: "Test::Vm").all
       expect(children.map { it.stack.first.values_at("subject_id", "first_boot") }).to contain_exactly([vm1.id, true], [vm2.id, true])
     end
+
+    it "reaps under verify_vms_after_reboot on the post-reboot pass" do
+      vm1 = create_vm(name: "test-vm-1")
+      refresh_frame(vg_test, new_values: {"vms" => [vm1.id], "first_boot" => false})
+      expect { vg_test.verify_vms }.to hop("verify_vms_after_reboot")
+      children = st.children_dataset.where(prog: "Test::Vm").all
+      expect(children.map { it.stack.first.values_at("subject_id", "first_boot") }).to contain_exactly([vm1.id, false])
+    end
   end
 
   describe "#wait_verify_vms" do
@@ -95,6 +103,12 @@ RSpec.describe Prog::Test::VmGroup do
 
     it "skips if verify_host_capacity is not set" do
       refresh_frame(vg_test, new_values: {"verify_host_capacity?" => false})
+      expect(vg_test).not_to receive(:vm_host)
+      expect { vg_test.verify_host_capacity }.to hop("verify_vm_host_slices")
+    end
+
+    it "skips on the post-reboot pass, when other tests may share the host" do
+      refresh_frame(vg_test, new_values: {"verify_host_capacity?" => true, "first_boot" => false})
       expect(vg_test).not_to receive(:vm_host)
       expect { vg_test.verify_host_capacity }.to hop("verify_vm_host_slices")
     end
@@ -191,9 +205,16 @@ RSpec.describe Prog::Test::VmGroup do
       expect { vg_test.wait_reboot }.to nap(20)
     end
 
-    it "runs vm tests if reboot done" do
+    it "re-verifies vms with first_boot false if reboot done" do
       vm_host.strand.update(label: "wait")
       expect { vg_test.wait_reboot }.to hop("verify_vms")
+      expect(vg_test.strand.stack.first["first_boot"]).to be(false)
+    end
+  end
+
+  describe "#verify_vms_after_reboot" do
+    it "reaps and hops to verify_host_capacity" do
+      expect { vg_test.verify_vms_after_reboot }.to hop("verify_host_capacity")
     end
   end
 


### PR DESCRIPTION
The metal e2e ran the VmGroup test fully serialized ahead of the parallel block, because it reboots the shared host and rebooting while other tests run would knock over their VMs. But only the reboot itself needs that exclusivity; VmGroup's post-reboot verification (re-checking the VMs survived, plus slices/firewall/subnets) does not, and it sat on the critical path for ~5 minutes.

Block only until the host reboot completes, then let the post-reboot verification run alongside the github/postgres/kubernetes tests. bin/e2e waits for the new verify_vms_after_reboot label (reached solely after the reboot) instead of the test's full exit, and adds the strand to tests_to_wait so it is still awaited at the end.

The post-reboot pass skips verify_host_capacity: that assertion sums the host's VM and slice cores against used_cores, a host-wide invariant that the now co-resident VMs from the parallel tests would make flaky. It is still checked on the first pass, when this test's VMs are alone on the host.