### PR TITLE
Destroy publicly signed postgres cert when destorying postgres resource

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -12,7 +12,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
   extend Forwardable
 
-  def_delegators :postgres_resource, :servers, :representative_server
+  def_delegators :postgres_resource, :representative_server
 
   def self.assemble(project_id:, location_id:, name:, target_vm_size:, target_storage_size_gib:,
     target_version: PostgresResource::DEFAULT_VERSION, flavor: PostgresResource::Flavor::STANDARD,
@@ -377,7 +377,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     reap(nap: 5) do
       postgres_resource.private_subnet.incr_destroy_if_only_used_internally(
         ubid: postgres_resource.ubid,
-        vm_ids: servers.map(&:vm_id),
+        vm_ids: postgres_resource.servers_dataset.select(:vm_id),
       )
 
       postgres_resource.internal_firewall.destroy

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -228,13 +228,13 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     if !use_publicly_signed_certificates? && OpenSSL::X509::Certificate.new(postgres_resource.root_cert_1).not_after < Time.now + 60 * 60 * 24 * 30 * 5
       postgres_resource.root_cert_1, postgres_resource.root_cert_key_1 = postgres_resource.root_cert_2, postgres_resource.root_cert_key_2
       postgres_resource.root_cert_2, postgres_resource.root_cert_key_2 = Util.create_root_certificate(common_name: "#{postgres_resource.ubid} Root Certificate Authority", duration: 60 * 60 * 24 * 365 * 10)
-      servers.each(&:incr_refresh_certificates)
+      PostgresServer.incr_refresh_certificates(server_ids_dataset)
     end
 
     if OpenSSL::X509::Certificate.new(postgres_resource.client_root_cert_1).not_after < Time.now + 60 * 60 * 24 * 30 * 5
       postgres_resource.client_root_cert_1, postgres_resource.client_root_cert_key_1 = postgres_resource.client_root_cert_2, postgres_resource.client_root_cert_key_2
       postgres_resource.client_root_cert_2, postgres_resource.client_root_cert_key_2 = Util.create_root_certificate(common_name: "#{postgres_resource.ubid} Client Certificate Authority", duration: 60 * 60 * 24 * 365 * 10)
-      servers.each(&:incr_refresh_certificates)
+      PostgresServer.incr_refresh_certificates(server_ids_dataset)
     end
 
     refresh = false
@@ -249,7 +249,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         postgres_resource.server_cert, postgres_resource.server_cert_key = create_certificate
       end
       postgres_resource.client_cert, postgres_resource.client_cert_key = create_client_certificate
-      servers.each(&:incr_refresh_certificates)
+      PostgresServer.incr_refresh_certificates(server_ids_dataset)
     end
 
     postgres_resource.certificate_last_checked_at = Time.now
@@ -272,7 +272,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   label def wait_refresh_public_cert
     wait_for_public_cert("refresh_cert_id")
     postgres_resource.save_changes
-    servers.each(&:incr_refresh_certificates)
+    PostgresServer.incr_refresh_certificates(server_ids_dataset)
     decr_refresh_certificates
     hop_wait
   end
@@ -369,7 +369,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
     decr_destroy
 
-    Semaphore.incr(strand.children_dataset.select(:id), "destroy")
+    PostgresResource.incr_destroy(strand.children_dataset.select(:id))
     hop_wait_children_destroyed
   end
 
@@ -389,8 +389,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         client.delete_role(role_name: postgres_resource.ubid)
       end
 
-      servers.each(&:incr_destroy)
-
+      PostgresServer.incr_destroy(server_ids_dataset)
       Cert.incr_destroy(current_cert_id) if current_cert_id
       postgres_resource.dns_zone&.delete_record(record_name: postgres_resource.hostname)
       postgres_resource.destroy
@@ -421,6 +420,10 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       issuer_cert:,
       issuer_key:,
     ).map(&:to_pem)
+  end
+
+  def server_ids_dataset
+    postgres_resource.servers_dataset.select(:id)
   end
 
   def use_publicly_signed_certificates?

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -278,7 +278,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   end
 
   label def wait_servers
-    nap 5 if servers.any? { it.strand.label != "wait" }
+    nap 5 unless Strand.where(id: server_ids_dataset).exclude(label: "wait").empty?
     hop_update_billing_records
   end
 

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -8,7 +8,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   subject_is :postgres_resource
 
   frame_reader :initial_cert_id
-  frame_accessor :refresh_cert_id
+  frame_accessor :refresh_cert_id, :current_cert_id
 
   extend Forwardable
 
@@ -53,7 +53,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       end
 
       if hostname_version == "v3" && Config.acme_email && location.dns_suffix.to_s.empty? && !project.get_ff_postgres_hostname_override
-        strand_args = {stack: ["use_publicly_signed_certificates" => true]}
+        strand_frame = {"use_publicly_signed_certificates" => true}
+        strand_args = {stack: [strand_frame]}
 
         postgres_resource_id, cert_id = DB[:presigned_postgres_cert]
           .where(postgres_resource_id: DB[:presigned_postgres_cert]
@@ -82,7 +83,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
         superuser_password:, ha_type:, target_version:, flavor:, parent_id:, tags:, restore_target:, hostname_version:, user_config:, pgbouncer_user_config:)
 
       if need_initial_cert_id
-        strand_args[:stack][0]["initial_cert_id"] = Prog::Vnet::CertNexus.assemble(
+        strand_frame["current_cert_id"] = strand_frame["initial_cert_id"] = Prog::Vnet::CertNexus.assemble(
           postgres_resource.cert_hostname,
           postgres_resource.dns_zone.id,
           private_hostname: postgres_resource.cert_private_hostname,
@@ -255,7 +256,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     postgres_resource.save_changes
 
     if use_publicly_signed_certificates? && OpenSSL::X509::Certificate.new(postgres_resource.server_cert).not_after < Time.now + 60 * 60 * 24 * 13
-      self.refresh_cert_id = Prog::Vnet::CertNexus.assemble(
+      self.current_cert_id = self.refresh_cert_id = Prog::Vnet::CertNexus.assemble(
         postgres_resource.cert_hostname,
         postgres_resource.dns_zone.id,
         private_hostname: postgres_resource.cert_private_hostname,
@@ -390,6 +391,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
       servers.each(&:incr_destroy)
 
+      Cert.incr_destroy(current_cert_id) if current_cert_id
       postgres_resource.dns_zone&.delete_record(record_name: postgres_resource.hostname)
       postgres_resource.destroy
 

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(pg.server_cert).to be_nil
       expect(pg.server_cert_key).to be_nil
       expect(pg.strand.stack[0]["use_publicly_signed_certificates"]).to be true
+      expect(pg.strand.stack[0]["initial_cert_id"]).to eq pg.strand.stack[0]["current_cert_id"]
       cert = Cert.with_pk!(pg.strand.stack[0]["initial_cert_id"])
       expect(cert.hostname).to eq "*.#{pg.ubid}.pg.ubicloud.app"
       expect(cert.private_hostname).to eq "*.#{pg.ubid}.private.pg.ubicloud.app"
@@ -595,6 +596,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(postgres_resource.server_cert).to eq short_server_cert_pem
       expect(postgres_resource.server_cert_key).to eq short_server_key_pem
       expect(Semaphore.where(strand_id: postgres_server.strand.id, name: "refresh_certificates").first).to exist
+      expect(postgres_resource.strand.stack[0]["refresh_cert_id"]).to eq postgres_resource.strand.stack[0]["current_cert_id"]
       cert = Cert.with_pk!(postgres_resource.strand.stack[0]["refresh_cert_id"])
       expect(cert.hostname).to eq "*.#{postgres_resource.ubid}.pg.ubicloud.app"
       expect(cert.private_hostname).to eq "*.#{postgres_resource.ubid}.private.pg.ubicloud.app"
@@ -814,13 +816,15 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
         Firewall.create(name: "#{postgres_resource.ubid}-internal-firewall", location_id:, project: postgres_project)
       end
 
-      it "triggers server deletion and waits until it is deleted" do
+      it "triggers server and cert deletion and waits until it is deleted" do
         postgres_server
         expect(Config).to receive(:postgres_service_hostname).and_return("pg.example.com").at_least(:once)
-        DnsZone.create(project_id: postgres_project.id, name: "pg.example.com")
+        dns_zone = DnsZone.create(project_id: postgres_project.id, name: "pg.example.com")
+        cert = Prog::Vnet::CertNexus.assemble("test.postgres.exampe.com", dns_zone.id)
+        refresh_frame(nx, new_values: {"current_cert_id" => cert.id})
 
         expect { nx.wait_children_destroyed }.to exit({"msg" => "postgres resource is deleted"})
-        expect(Semaphore.where(strand_id: postgres_server.strand.id, name: "destroy").first).to exist
+        expect(Semaphore.where(name: "destroy").select_order_map(:strand_id)).to eq [postgres_server.id, cert.id].sort
         expect(postgres_resource).not_to exist
       end
 


### PR DESCRIPTION
The previous behavior didn't cause problems, but there is no reason to keep the Cert in the database if the resource has been destroyed.

While here, fix multiple N+1 query issues, and use `Model.incr_*` for to ensure the semaphore name is valid for the resource.