### PR TITLE
Add Config.*_hostname_version_default

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -255,6 +255,7 @@ module Config
   optional :load_balancer_service_project_id, uuid
   optional :load_balancer_service_hostname, string
   override :load_balancer_service_hostname_v2, Config.load_balancer_service_hostname, string
+  override :load_balancer_hostname_version_default, 1, int
 
   # ACME
   # The following are optional because they are only needed in production.

--- a/config.rb
+++ b/config.rb
@@ -187,6 +187,7 @@ module Config
   override :postgres_boot_disk_size_gib, 16, int
   override :postgres_service_hostname, "postgres.ubicloud.com", string
   override :postgres_service_hostname_v3, "pg.ubicloud.app", string
+  override :postgres_hostname_version_default, "v2", string
   override :postgres_monitor_database_url, Config.clover_database_url, string
   optional :postgres_monitor_database_root_certs, string
   optional :postgres_paradedb_notification_email, string

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -17,7 +17,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   def self.assemble(project_id:, location_id:, name:, target_vm_size:, target_storage_size_gib:,
     target_version: PostgresResource::DEFAULT_VERSION, flavor: PostgresResource::Flavor::STANDARD,
     ha_type: PostgresResource::HaType::NONE, parent_id: nil, tags: [], restore_target: nil, with_firewall_rules: true,
-    user_config: {}, pgbouncer_user_config: {}, private_subnet_name: nil, init_script: nil, hostname_version: "v2")
+    user_config: {}, pgbouncer_user_config: {}, private_subnet_name: nil, init_script: nil,
+    hostname_version: Config.postgres_hostname_version_default)
 
     unless (project = Project[project_id])
       fail "No existing project"

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -12,7 +12,9 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
   def self.assemble_with_multiple_ports(private_subnet_id, ports:, name: nil, algorithm: "round_robin",
     health_check_endpoint: DEFAULT_HEALTH_CHECK_ENDPOINT, health_check_interval: 30, health_check_timeout: 15,
     health_check_up_threshold: 3, health_check_down_threshold: 2, health_check_protocol: "http",
-    custom_hostname_prefix: nil, custom_hostname_dns_zone_id: nil, stack: LoadBalancer::Stack::DUAL, cert_enabled: health_check_protocol == "https", hostname_version: 1)
+    custom_hostname_prefix: nil, custom_hostname_dns_zone_id: nil, stack: LoadBalancer::Stack::DUAL,
+    cert_enabled: health_check_protocol == "https",
+    hostname_version: Config.load_balancer_hostname_version_default)
 
     unless (ps = PrivateSubnet[private_subnet_id])
       fail "Given subnet doesn't exist with the id #{private_subnet_id}"
@@ -62,7 +64,9 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
   def self.assemble(private_subnet_id, name: nil, algorithm: "round_robin",
     health_check_endpoint: DEFAULT_HEALTH_CHECK_ENDPOINT, health_check_interval: 30, health_check_timeout: 15,
     health_check_up_threshold: 3, health_check_down_threshold: 2, health_check_protocol: "http", src_port: nil, dst_port: nil,
-    custom_hostname_prefix: nil, custom_hostname_dns_zone_id: nil, stack: LoadBalancer::Stack::DUAL, cert_enabled: health_check_protocol == "https", hostname_version: 1)
+    custom_hostname_prefix: nil, custom_hostname_dns_zone_id: nil, stack: LoadBalancer::Stack::DUAL,
+    cert_enabled: health_check_protocol == "https",
+    hostname_version: Config.load_balancer_hostname_version_default)
 
     assemble_with_multiple_ports(private_subnet_id, name:, algorithm:, health_check_endpoint:, health_check_interval:, health_check_timeout:,
       health_check_up_threshold:, health_check_down_threshold:, health_check_protocol:, ports: [[src_port, dst_port]], custom_hostname_prefix:, custom_hostname_dns_zone_id:, stack:, cert_enabled:, hostname_version:)


### PR DESCRIPTION
This allows for configuring the hostname version to use by default for postgres and load balancers. This allows for early testing of the new hostname versions, as well as to keep the old default after we switch to the new version.