### PR TITLE
Fix PostgresTimelineNexus#wait_leader stranding timelines forever

### DIFF
--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -53,6 +53,8 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   end
 
   label def wait_leader
+    hop_wait unless PostgresServer[timeline_id: postgres_timeline.id]
+
     leader = postgres_timeline.leader
     nap 5 if leader.nil? || leader.strand.label != "wait" || !leader.walg_credentials_ready?
     hop_wait

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -187,6 +187,16 @@ RSpec.describe PostgresResource do
       expect(new_server.vm.strand.stack[0]["exclude_data_centers"]).to eq([])
     end
 
+    it "reuses the existing timeline rather than creating a new one (HA reprovision keeps a single timeline)" do
+      allow(Config).to receive(:allow_unspread_servers).and_return(true)
+      ps1
+
+      expect { postgres_resource.provision_new_standby }.not_to change(PostgresTimeline, :count)
+      new_server = PostgresServer.exclude(id: ps1.id).first
+      expect(new_server.timeline_id).to eq(timeline.id)
+      expect(new_server.timeline_access).to eq("fetch")
+    end
+
     describe "excludes only active server data centers" do
       before do
         allow(Config).to receive(:allow_unspread_servers).and_return(false)

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -315,6 +315,32 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
 
       expect { nx.wait_leader }.to nap(5)
     end
+
+    it "hops to wait so the GC can run when no server references the timeline (orphaned)" do
+      expect(PostgresServer[timeline_id: postgres_timeline.id]).to be_nil
+
+      expect { nx.wait_leader }.to hop("wait")
+    end
+
+    it "still naps while leaderless if a non-leader (fetch) server references the timeline" do
+      create_minio_cluster
+      resource = create_postgres_resource(project:, location_id:)
+      create_postgres_server(resource:, timeline: postgres_timeline, is_representative: false)
+      expect(nx.postgres_timeline.leader).to be_nil
+      expect(PostgresServer[timeline_id: postgres_timeline.id]).not_to be_nil
+
+      expect { nx.wait_leader }.to nap(5)
+    end
+
+    it "lets a leaderless, backup-less, old timeline reach self-destruct through wait_leader" do
+      create_minio_cluster
+      mock_minio_client(list_objects: [])
+      postgres_timeline.update(created_at: Time.now - 11 * 24 * 60 * 60)
+      expect(PostgresServer[timeline_id: postgres_timeline.id]).to be_nil
+
+      expect { nx.wait_leader }.to hop("wait")
+      expect { nx.wait }.to hop("destroy")
+    end
   end
 
   describe "#wait" do


### PR DESCRIPTION
When a timeline's leader (push) server is destroyed before the timeline
reaches #wait, the timeline is stuck in wait_leader no escape.

The condition occurs when Resource is deleted via API during the
provisioning or replica promote. This is common for automated
provisioning which considers long provisioning as stuck and triggers
deletion to retry later.

