### PR TITLE
Use Leaseweb apt mirror for Leaseweb runners

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -462,6 +462,19 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       COMMAND
     end
 
+    # The runner images bake in the Hetzner apt mirror, but runners in Leaseweb
+    # can't reach it. Point them at Leaseweb's own US Ubuntu mirror instead,
+    # falling back to the canonical Ubuntu archive and security mirrors.
+    if vm.location_id == Location::LEASEWEB_WDC02_ID
+      command << NetSsh.command(<<~COMMAND)
+        sudo tee /etc/apt/apt-mirrors.txt > /dev/null <<MIRRORS
+        https://mirror.us.leaseweb.net/ubuntu/	priority:1
+        https://archive.ubuntu.com/ubuntu/	priority:2
+        https://security.ubuntu.com/ubuntu/	priority:3
+        MIRRORS
+      COMMAND
+    end
+
     begin
       # Remove comments and empty lines before sending them to the machine
       vm.sshable.cmd("bash", stdin: NetSsh.combine(*command, joiner: "").gsub(/^(\s*# .*)?\n/, ""))

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -654,6 +654,27 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect { nx.setup_environment }.to hop("register_runner")
     end
 
+    it "hops to register_runner pointing Leaseweb runners at the Leaseweb apt mirror" do
+      expect(vm).to receive(:runtime_token).and_return("my_token")
+      installation.update(use_docker_mirror: false, cache_enabled: false)
+      vm.update(location_id: Location::LEASEWEB_WDC02_ID)
+      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND)
+        set -ueo pipefail
+        echo "image version: $ImageVersion"
+        sudo usermod -a -G sudo,adm runneradmin
+        jq '. += ['\\{\\"group\\":\\"Ubicloud\\ Managed\\ Runner\\",\\"detail\\":\\"Name:\\ #{runner.ubid}\\\\nLabel:\\ ubicloud-standard-4\\\\nVM\\ Family:\\ standard\\\\nArch:\\ x64\\\\nImage:\\ github-ubuntu-2204\\\\nVM\\ Host:\\ #{vm.vm_host.ubid}\\\\nVM\\ Pool:\\ \\\\nLocation:\\ hetzner-fsn1\\\\nDatacenter:\\ FSN1-DC8\\\\nProject:\\ #{project.ubid}\\\\nConsole\\ URL:\\ http://localhost:9292/project/#{project.ubid}/github\\"\\}']' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info > /dev/null
+        echo "UBICLOUD_RUNTIME_TOKEN="my_token"
+        UBICLOUD_CACHE_URL="http://localhost:9292"/runtime/github/" | sudo tee -a /etc/environment > /dev/null
+        sudo tee /etc/apt/apt-mirrors.txt > /dev/null <<MIRRORS
+        https://mirror.us.leaseweb.net/ubuntu/\tpriority:1
+        https://archive.ubuntu.com/ubuntu/\tpriority:2
+        https://security.ubuntu.com/ubuntu/\tpriority:3
+        MIRRORS
+      COMMAND
+
+      expect { nx.setup_environment }.to hop("register_runner")
+    end
+
     it "naps if ssh authentication failed" do
       expect(vm).to receive(:runtime_token).and_return("my_token")
       expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"))]).at_least(:once)


### PR DESCRIPTION
Our runner images bake in the Hetzner apt mirror, but runners running in Leaseweb can't reach it. During setup_environment, rewrite /etc/apt/apt-mirrors.txt for Leaseweb runners to point at Leaseweb's own US Ubuntu mirror, which is close to the leaseweb-wdc02 location, and keep the canonical Ubuntu archive and security mirrors as fallbacks.