### PR TITLE
Use VM host's location for Leaseweb apt mirrors

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -465,7 +465,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     # The runner images bake in the Hetzner apt mirror, but runners in Leaseweb
     # can't reach it. Point them at Leaseweb's own US Ubuntu mirror instead,
     # falling back to the canonical Ubuntu archive and security mirrors.
-    if vm.location_id == Location::LEASEWEB_WDC02_ID
+    if vm.vm_host&.location_id == Location::LEASEWEB_WDC02_ID
       command << NetSsh.command(<<~COMMAND)
         sudo tee /etc/apt/apt-mirrors.txt > /dev/null <<MIRRORS
         https://mirror.us.leaseweb.net/ubuntu/	priority:1

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -657,12 +657,12 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     it "hops to register_runner pointing Leaseweb runners at the Leaseweb apt mirror" do
       expect(vm).to receive(:runtime_token).and_return("my_token")
       installation.update(use_docker_mirror: false, cache_enabled: false)
-      vm.update(location_id: Location::LEASEWEB_WDC02_ID)
+      vm.vm_host.update(location_id: Location::LEASEWEB_WDC02_ID)
       expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND)
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
-        jq '. += ['\\{\\"group\\":\\"Ubicloud\\ Managed\\ Runner\\",\\"detail\\":\\"Name:\\ #{runner.ubid}\\\\nLabel:\\ ubicloud-standard-4\\\\nVM\\ Family:\\ standard\\\\nArch:\\ x64\\\\nImage:\\ github-ubuntu-2204\\\\nVM\\ Host:\\ #{vm.vm_host.ubid}\\\\nVM\\ Pool:\\ \\\\nLocation:\\ hetzner-fsn1\\\\nDatacenter:\\ FSN1-DC8\\\\nProject:\\ #{project.ubid}\\\\nConsole\\ URL:\\ http://localhost:9292/project/#{project.ubid}/github\\"\\}']' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info > /dev/null
+        jq '. += ['\\{\\"group\\":\\"Ubicloud\\ Managed\\ Runner\\",\\"detail\\":\\"Name:\\ #{runner.ubid}\\\\nLabel:\\ ubicloud-standard-4\\\\nVM\\ Family:\\ standard\\\\nArch:\\ x64\\\\nImage:\\ github-ubuntu-2204\\\\nVM\\ Host:\\ #{vm.vm_host.ubid}\\\\nVM\\ Pool:\\ \\\\nLocation:\\ leaseweb-wdc02\\\\nDatacenter:\\ FSN1-DC8\\\\nProject:\\ #{project.ubid}\\\\nConsole\\ URL:\\ http://localhost:9292/project/#{project.ubid}/github\\"\\}']' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info > /dev/null
         echo "UBICLOUD_RUNTIME_TOKEN="my_token"
         UBICLOUD_CACHE_URL="http://localhost:9292"/runtime/github/" | sudo tee -a /etc/environment > /dev/null
         sudo tee /etc/apt/apt-mirrors.txt > /dev/null <<MIRRORS
@@ -670,6 +670,22 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
         https://archive.ubuntu.com/ubuntu/\tpriority:2
         https://security.ubuntu.com/ubuntu/\tpriority:3
         MIRRORS
+      COMMAND
+
+      expect { nx.setup_environment }.to hop("register_runner")
+    end
+
+    it "hops to register_runner without a vm host" do
+      expect(vm).to receive(:runtime_token).and_return("my_token")
+      installation.update(use_docker_mirror: false, cache_enabled: false)
+      vm.update(vm_host_id: nil)
+      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND)
+        set -ueo pipefail
+        echo "image version: $ImageVersion"
+        sudo usermod -a -G sudo,adm runneradmin
+        jq '. += ['\\{\\"group\\":\\"Ubicloud\\ Managed\\ Runner\\",\\"detail\\":\\"Name:\\ #{runner.ubid}\\\\nLabel:\\ ubicloud-standard-4\\\\nVM\\ Family:\\ standard\\\\nArch:\\ x64\\\\nImage:\\ github-ubuntu-2204\\\\nVM\\ Host:\\ \\\\nVM\\ Pool:\\ \\\\nLocation:\\ \\\\nDatacenter:\\ \\\\nProject:\\ #{project.ubid}\\\\nConsole\\ URL:\\ http://localhost:9292/project/#{project.ubid}/github\\"\\}']' /imagegeneration/imagedata.json | sudo -u runner tee /home/runner/actions-runner/.setup_info > /dev/null
+        echo "UBICLOUD_RUNTIME_TOKEN="my_token"
+        UBICLOUD_CACHE_URL="http://localhost:9292"/runtime/github/" | sudo tee -a /etc/environment > /dev/null
       COMMAND
 
       expect { nx.setup_environment }.to hop("register_runner")


### PR DESCRIPTION
We started setting Leaseweb apt mirrors when a runner is allocated on Leaseweb in commit 6c3394fd2. However, all runner VMs have "github-runners" as their location, so we should check the location of the VM host rather than the VM itself.