### PR TITLE
Remove unused `pinned_source_vm` association

### DIFF
--- a/model/machine_image/machine_image_version_metal.rb
+++ b/model/machine_image/machine_image_version_metal.rb
@@ -6,7 +6,6 @@ class MachineImageVersionMetal < Sequel::Model
   many_to_one :machine_image_version, key: :id, read_only: true, is_used: true
   many_to_one :store, class: :MachineImageStore, read_only: true
   many_to_one :archive_kek, class: :StorageKeyEncryptionKey, read_only: true
-  many_to_one :pinned_source_vm, class: :Vm, read_only: true
   one_to_many :vm_storage_volumes, key: :machine_image_version_id, read_only: true
   one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id, read_only: true, &:active
 


### PR DESCRIPTION
This was never used and broke Daily CI when running `unused_associations_check`.

In the code we either use the `pinned_source_vm_id` column directly (when updating in the nexus or asserting in specs), or the inverse association `Vm.pinning_machine_image_version_metal`.