### PR TITLE
Guard against PV data loss when retiring an unresponsive k8s node

### DIFF
--- a/lib/kubernetes/client.rb
+++ b/lib/kubernetes/client.rb
@@ -45,6 +45,11 @@ class Kubernetes::Client
     kubectl("delete node :node_name", node_name:)
   end
 
+  def retain_pv(pv_name)
+    patch_data = JSON.generate({"spec" => {"persistentVolumeReclaimPolicy" => "Retain"}})
+    kubectl("patch pv :pv_name --type=merge -p :patch_data", pv_name:, patch_data:)
+  end
+
   def get_csr(node_name, csr_status:)
     kubectl("get csr --sort-by=.metadata.creationTimestamp | awk /:csr_status/' && /kubelet-serving/ && /':node_name'/ {print $1}' | tail -1", node_name:, csr_status:).chomp
   end

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -94,7 +94,19 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
   end
 
   label def retire
+    register_deadline("destroy", 6 * 60 * 60)
     kubernetes_node.update(state: "draining")
+    hop_retain_volumes
+  end
+
+  # Retain every PV pinned to this node before draining, driven from the control
+  # plane so the data survives even when this node's own CSI pod is down.
+  label def retain_volumes
+    node_pvs.each do |pv|
+      next unless pv.dig("status", "phase") == "Bound"
+      next if pv.dig("spec", "persistentVolumeReclaimPolicy") == "Retain"
+      cluster.client.retain_pv(pv.dig("metadata", "name"))
+    end
     hop_drain
   end
 
@@ -132,9 +144,15 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
   end
 
   label def wait_for_copy
-    pending = kubernetes_node.pending_pvs
-    if pending.any?
-      pv_names = pending.map { |pv| pv.dig("metadata", "name") }
+    # Block while any PV's data still lives on this node: Bound means migration
+    # never started, Retain means the copy is still in flight.
+    unmigrated = node_pvs.select do |pv|
+      pv.dig("status", "phase") == "Bound" ||
+        pv.dig("spec", "persistentVolumeReclaimPolicy") == "Retain"
+    end
+
+    if unmigrated.any?
+      pv_names = unmigrated.map { |pv| pv.dig("metadata", "name") }
       Clog.emit("Waiting for CSI data copy to complete", {pending_pvs: {ubid: kubernetes_node.ubid, name: kubernetes_node.name, pvs: pv_names}})
       nap 15
     end
@@ -168,5 +186,13 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
 
   def available?
     kubernetes_node.available?
+  end
+
+  def node_pvs
+    pvs = JSON.parse(cluster.client.kubectl("get pv -ojson"))["items"]
+    pvs.select do |pv|
+      pv.dig("spec", "csi", "driver") == "csi.ubicloud.com" &&
+        pv.dig("spec", "nodeAffinity", "required", "nodeSelectorTerms", 0, "matchExpressions", 0, "values", 0) == kubernetes_node.name
+    end
   end
 end

--- a/spec/lib/kubernetes/client_spec.rb
+++ b/spec/lib/kubernetes/client_spec.rb
@@ -229,6 +229,14 @@ RSpec.describe Kubernetes::Client do
     end
   end
 
+  describe "retain_pv" do
+    it "patches the PV reclaim policy to Retain" do
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("persistentvolume/my-pv patched", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s patch pv my-pv --type=merge -p \\{\\\"spec\\\":\\{\\\"persistentVolumeReclaimPolicy\\\":\\\"Retain\\\"\\}\\}").and_return(response)
+      kubernetes_client.retain_pv("my-pv")
+    end
+  end
+
   describe "get_csr" do
     it "returns the pending csr name for the node" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("csr-abc123\n", 0)

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -276,10 +276,25 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       expect(nx.cluster).to receive(:client).and_return(client)
     end
 
+    it "naps when a Bound PV without a migration annotation still lives on this node" do
+      pv_list = {"items" => [{
+        "metadata" => {"name" => "pv-1"},
+        "status" => {"phase" => "Bound"},
+        "spec" => {
+          "csi" => {"driver" => "csi.ubicloud.com"},
+          "persistentVolumeReclaimPolicy" => "Delete",
+          "nodeAffinity" => {"required" => {"nodeSelectorTerms" => [{"matchExpressions" => [{"values" => [nx.kubernetes_node.name]}]}]}},
+        },
+      }]}
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(success_response.replace(JSON.generate(pv_list)))
+      expect { nx.wait_for_copy }.to nap(15)
+    end
+
     it "naps when a PV with old-pvc-object annotation references this node" do
       pv_list = {"items" => [{
         "metadata" => {"annotations" => {"csi.ubicloud.com/old-pvc-object" => "some-data"}},
         "spec" => {
+          "csi" => {"driver" => "csi.ubicloud.com"},
           "persistentVolumeReclaimPolicy" => "Retain",
           "nodeAffinity" => {"required" => {"nodeSelectorTerms" => [{"matchExpressions" => [{"values" => [nx.kubernetes_node.name]}]}]}},
         },
@@ -297,7 +312,24 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
     it "hops to remove_node_from_cluster when PVs reference a different node" do
       pv_list = {"items" => [{
         "metadata" => {"annotations" => {"csi.ubicloud.com/old-pvc-object" => "some-data"}},
-        "spec" => {"nodeAffinity" => {"required" => {"nodeSelectorTerms" => [{"matchExpressions" => [{"values" => ["other-node"]}]}]}}},
+        "spec" => {
+          "csi" => {"driver" => "csi.ubicloud.com"},
+          "nodeAffinity" => {"required" => {"nodeSelectorTerms" => [{"matchExpressions" => [{"values" => ["other-node"]}]}]}},
+        },
+      }]}
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(success_response.replace(JSON.generate(pv_list)))
+      expect { nx.wait_for_copy }.to hop("remove_node_from_cluster")
+    end
+
+    it "hops to remove_node_from_cluster when a Bound PV on this node belongs to another driver" do
+      pv_list = {"items" => [{
+        "metadata" => {"name" => "pv-foreign"},
+        "status" => {"phase" => "Bound"},
+        "spec" => {
+          "csi" => {"driver" => "other-csi-driver"},
+          "persistentVolumeReclaimPolicy" => "Delete",
+          "nodeAffinity" => {"required" => {"nodeSelectorTerms" => [{"matchExpressions" => [{"values" => [nx.kubernetes_node.name]}]}]}},
+        },
       }]}
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(success_response.replace(JSON.generate(pv_list)))
       expect { nx.wait_for_copy }.to hop("remove_node_from_cluster")
@@ -307,6 +339,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       pv_list = {"items" => [{
         "metadata" => {"annotations" => {"csi.ubicloud.com/old-pvc-object" => "some-data"}},
         "spec" => {
+          "csi" => {"driver" => "csi.ubicloud.com"},
           "persistentVolumeReclaimPolicy" => "Delete",
           "nodeAffinity" => {"required" => {"nodeSelectorTerms" => [{"matchExpressions" => [{"values" => [nx.kubernetes_node.name]}]}]}},
         },
@@ -317,9 +350,52 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
   end
 
   describe "#retire" do
-    it "updates the state and hops to drain" do
-      expect { nx.retire }.to hop("drain")
+    it "registers a destroy deadline, updates the state and hops to retain_volumes" do
+      expect { nx.retire }.to hop("retain_volumes")
       expect(kd.reload.state).to eq("draining")
+      expect(nx.strand.stack.first["deadline_target"]).to eq("destroy")
+    end
+  end
+
+  describe "#retain_volumes" do
+    let(:session) { Net::SSH::Connection::Session.allocate }
+    let(:client) { Kubernetes::Client.new(nx.cluster, session) }
+    let(:success_response) { Net::SSH::Connection::Session::StringWithExitstatus.new("", 0) }
+
+    before do
+      allow(nx.cluster).to receive(:client).and_return(client)
+    end
+
+    def pv(name:, phase:, policy:, node:, driver: "csi.ubicloud.com")
+      {
+        "metadata" => {"name" => name},
+        "status" => {"phase" => phase},
+        "spec" => {
+          "csi" => {"driver" => driver},
+          "persistentVolumeReclaimPolicy" => policy,
+          "nodeAffinity" => {"required" => {"nodeSelectorTerms" => [{"matchExpressions" => [{"values" => [node]}]}]}},
+        },
+      }
+    end
+
+    it "retains bound Delete PVs pinned to this node and hops to drain" do
+      pv_list = {"items" => [pv(name: "pv-bound", phase: "Bound", policy: "Delete", node: nx.kubernetes_node.name)]}
+      get_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate(pv_list), 0)
+      patch_response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(get_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s patch pv pv-bound --type=merge -p \\{\\\"spec\\\":\\{\\\"persistentVolumeReclaimPolicy\\\":\\\"Retain\\\"\\}\\}").and_return(patch_response)
+      expect { nx.retain_volumes }.to hop("drain")
+    end
+
+    it "skips PVs that are already Retain, not Bound, on another node, or from another driver" do
+      pv_list = {"items" => [
+        pv(name: "pv-retain", phase: "Bound", policy: "Retain", node: nx.kubernetes_node.name),
+        pv(name: "pv-released", phase: "Released", policy: "Delete", node: nx.kubernetes_node.name),
+        pv(name: "pv-other", phase: "Bound", policy: "Delete", node: "other-node"),
+        pv(name: "pv-foreign", phase: "Bound", policy: "Delete", node: nx.kubernetes_node.name, driver: "other-csi-driver"),
+      ]}
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(success_response.replace(JSON.generate(pv_list)))
+      expect { nx.retain_volumes }.to hop("drain")
     end
   end
 


### PR DESCRIPTION
The node retire flow could destroy a node's VM while it still held the only copy of a PV's data. Migration prep (Retain + old-pvc-object annotation) is set only by NodeUnstageVolume on the source node, but an unreachable node gets force-detached, which skips unstage. wait_for_detach saw no VolumeAttachment and wait_for_copy saw no annotation, so both gates passed and the node sailed into destroy, wiping the backing file.

Close the window:
- retire registers a destroy deadline and hops to a new retain_volumes step that flips every Bound PV pinned to the node to Retain. This is driven from the control plane, so the data is protected even when the node's own CSI pod is down.
- wait_for_copy now gates on live PV state instead of the migration annotation: block while any pinned PV is still Bound (migration never started) or Retain (copy in flight), and only proceed once it is gone or rolled back to Delete (copy finished).

Converts silent data loss into a recoverable, pageable stuck state.