### PR TITLE
Add ubuntu-resolute and remove ubuntu-jammy from E2E VM tests

### DIFF
--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -1,4 +1,4 @@
-- { name: vm,                        images: ["ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"] }
+- { name: vm,                        images: ["ubuntu-resolute", "ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"] }
 - { name: github_runner_ubuntu_2404, images: ["github-ubuntu-2404"] }
 - { name: github_runner_ubuntu_2204, images: ["github-ubuntu-2204"] }
 - { name: postgres_standard,         images: ["postgres-ubuntu-2204"] }

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -1,4 +1,4 @@
-- { name: vm,                        images: ["ubuntu-resolute", "ubuntu-noble", "ubuntu-jammy", "debian-12", "almalinux-9"] }
+- { name: vm,                        images: ["ubuntu-resolute", "ubuntu-noble", "debian-12", "almalinux-9"] }
 - { name: github_runner_ubuntu_2404, images: ["github-ubuntu-2404"] }
 - { name: github_runner_ubuntu_2204, images: ["github-ubuntu-2204"] }
 - { name: postgres_standard,         images: ["postgres-ubuntu-2204"] }


### PR DESCRIPTION
### Add ubuntu-resolute to E2E VM tests 
We recently added it to the supported boot images.

### Remove ubuntu-jammy from E2E VM tests 
Number of boot images used to run E2E VM tests can impact test runtime since it increases number of VMs created in `VmGroup#setup_vms`. We added ubuntu-resolute in a previous commit and ubuntu-jammy will be deprecated in few months, so removing ubuntu-jammy here to reduce test runtime impact.

Note that the `ubuntu-jammy` image will still be downloaded for some postgres_* tests, since they rely on MinIO cluster which uses ubuntu-jammy. Removing `ubuntu-jammy` here will just reduce number of VMs tested in the `VmGroup` test.