### PR TITLE
Add GCP CloudSQL IAM passwordless authentication for the catalog DB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,10 @@ group :aws_rds_iam do
   gem "pg-aws_rds_iam", github: "haines/pg-aws_rds_iam", ref: "fb91b9232837e350aa9c8440b7340346adae845e"
 end
 
+group :gcp_cloudsql_iam do
+  gem "google-apis-iamcredentials_v1"
+end
+
 group :development do
   gem "awesome_print"
   gem "by", ">= 1.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -607,6 +607,7 @@ DEPENDENCIES
   forme
   google-apis-cloudresourcemanager_v3
   google-apis-iam_v1
+  google-apis-iamcredentials_v1
   google-cloud-compute-v1 (~> 3.4)
   google-cloud-storage (~> 1.58)
   jwt

--- a/bin/rake-task-runner
+++ b/bin/rake-task-runner
@@ -61,10 +61,18 @@ SQL
     user = DB.get(Sequel.lit("current_user"))
     ph_user = "#{user}_password"
 
+    ph_connect_opts_proc = DB.opts[:connect_opts_proc]
+    if Config.clover_database_gcp_iam_auth_enabled
+      require_relative "../lib/gcp_database_auth"
+      ph_sa = Config.clover_database_gcp_clover_password_login_sa ||
+        fail("clover_database_gcp_clover_password_login_sa must be set to run ph migrations under GCP IAM auth")
+      ph_connect_opts_proc = GcpDatabaseAuth.connect_opts_proc(ph_user => ph_sa)
+    end
+
     # NB: this grant/revoke cannot be transaction-isolated, so, in
     # sensitive settings, it would be good to check role access.
     DB["GRANT CREATE ON SCHEMA public TO ?", ph_user.to_sym].get
-    Sequel.postgres(**DB.opts, user: ph_user) do |ph_db|
+    Sequel.postgres(**DB.opts, user: ph_user, connect_opts_proc: ph_connect_opts_proc) do |ph_db|
       ph_db.loggers << Logger.new($stdout) if ph_db.loggers.empty?
       Sequel::Migrator.run(ph_db, "migrate/ph", table: "schema_migrations_password")
     end

--- a/config.rb
+++ b/config.rb
@@ -58,6 +58,9 @@ module Config
   optional :kms_decrypt_clover_column_encryption_key_with_arn, string
   optional :heartbeat_url, string
   optional :clover_database_root_certs, string
+  override :clover_database_gcp_iam_auth_enabled, false, bool
+  optional :clover_database_gcp_clover_login_sa, string
+  optional :clover_database_gcp_clover_password_login_sa, string
   override :max_health_monitor_threads, 32, int
   override :max_metrics_export_threads, 32, int
   optional :omniauth_github_id, string, clear: true

--- a/db.rb
+++ b/db.rb
@@ -4,9 +4,15 @@ require "netaddr"
 require "sequel/core"
 require_relative "config"
 require_relative "lib/util"
+connect_opts_proc = nil
 if Config.clover_database_rds_iam_auth_enabled
   require "pg/aws_rds_iam"
   driver_options = {aws_rds_iam_auth_token_generator: "default"}
+elsif Config.clover_database_gcp_iam_auth_enabled
+  require_relative "lib/gcp_database_auth"   # loaded only on the GCP path
+  role = GcpDatabaseAuth.url_user(Config.clover_database_url)
+  connect_opts_proc = GcpDatabaseAuth.connect_opts_proc(role => Config.clover_database_gcp_clover_login_sa)
+  driver_options = {}
 else
   driver_options = {}
 end
@@ -25,11 +31,11 @@ max_connections ||= Config.db_pool - 1
 pool_timeout ||= Config.database_timeout
 
 pg_auto_parameterize_min_array_size = 1 if Config.frozen_test?
-DB = Sequel.connect(Config.clover_database_url, max_connections:, pool_timeout:, treat_string_list_as_untyped_array: true, pg_auto_parameterize_min_array_size:, driver_options:)
+DB = Sequel.connect(Config.clover_database_url, max_connections:, pool_timeout:, treat_string_list_as_untyped_array: true, pg_auto_parameterize_min_array_size:, driver_options:, connect_opts_proc:)
 
 postgres_monitor_db_ca_bundle_filename = File.join(Dir.pwd, "var", "ca_bundles", "postgres_monitor_db.crt")
 Util.safe_write_to_file(postgres_monitor_db_ca_bundle_filename, Config.postgres_monitor_database_root_certs)
-POSTGRES_MONITOR_DB = Sequel.connect(Config.postgres_monitor_database_url, max_connections: Config.db_pool_monitor, pool_timeout: Config.database_timeout, driver_options:, test: false)
+POSTGRES_MONITOR_DB = Sequel.connect(Config.postgres_monitor_database_url, max_connections: Config.db_pool_monitor, pool_timeout: Config.database_timeout, driver_options:, connect_opts_proc:, test: false)
 
 # Load Sequel Database/Global extensions here
 # DB.extension :date_arithmetic

--- a/lib/gcp_database_auth.rb
+++ b/lib/gcp_database_auth.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "googleauth"
+require "google/apis/iamcredentials_v1"
+
+module GcpDatabaseAuth
+  class Error < StandardError; end
+
+  @mutex = Mutex.new
+  @cache = {} # sa_email => [token, refresh_deadline_monotonic]
+
+  class << self
+    def connect_opts_proc(sa_by_role)
+      lambda do |opts|
+        role = opts[:user]
+        service_account = sa_by_role[role]
+        raise Error, "no CloudSQL IAM SA mapped for role #{role.inspect}" unless service_account
+        # The CloudSQL IAM db username is the SA email minus its .gserviceaccount.com suffix.
+        opts[:user] = service_account.delete_suffix(".gserviceaccount.com")
+        opts[:password] = access_token(service_account)
+        opts[:driver_options] = opts[:driver_options].merge(options: role_connect_option(role))
+      end
+    end
+
+    def url_user(url)
+      Sequel::Database.send(:options_from_uri, URI.parse(url))[:user]
+    end
+
+    private
+
+    def reset_cache!
+      @mutex.synchronize { @cache.clear }
+    end
+
+    # A cached token for the SA while it stays more than 5 minutes from expiry,
+    # else a freshly minted one. Minting holds the lock: a refresh happens about
+    # once an hour per SA, and holding the lock across it keeps concurrent
+    # connections from minting twice.
+    def access_token(service_account)
+      @mutex.synchronize do
+        token, refresh_deadline = @cache[service_account]
+        unless token && Process.clock_gettime(Process::CLOCK_MONOTONIC) < refresh_deadline
+          token, ttl = mint_impersonated(service_account)
+          @cache[service_account] = [token, Process.clock_gettime(Process::CLOCK_MONOTONIC) + ttl - 300]
+        end
+        token
+      end
+    end
+
+    # libpq options value that SETs the active role at connection startup. nil for
+    # a blank role; a bare identifier is validated (fail-closed) otherwise.
+    def role_connect_option(role)
+      return nil if role.nil? || role.empty?
+      raise ArgumentError, "invalid role identifier: #{role.inspect}" unless role.match?(/\A[a-z_][a-z0-9_]*\z/)
+      "-c role=#{role}"
+    end
+
+    def mint_impersonated(sa_email)
+      svc = Google::Apis::IamcredentialsV1::IAMCredentialsService.new
+      svc.authorization = Google::Auth.get_application_default(["https://www.googleapis.com/auth/cloud-platform"])
+      req = Google::Apis::IamcredentialsV1::GenerateAccessTokenRequest.new(scope: ["https://www.googleapis.com/auth/sqlservice.login"], lifetime: "3600s")
+      resp = svc.generate_service_account_access_token("projects/-/serviceAccounts/#{sa_email}", req)
+      [resp.access_token, Time.new(resp.expire_time) - Time.now]
+    rescue Google::Apis::Error => e
+      # The top-line message ("Invalid request") hides the real reason; the
+      # response body carries the INVALID_ARGUMENT/PERMISSION detail. Surface
+      # both, plus the SA we tried to impersonate, while preserving the original
+      # backtrace so the failing call site stays visible in production.
+      raise Error, "generateAccessToken for #{sa_email.inspect} failed with #{e.class.name}: #{e.message}: #{e.body}", e.backtrace
+    end
+  end
+end

--- a/lib/gcp_database_auth.rb
+++ b/lib/gcp_database_auth.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "googleauth"
+require "google/apis/iamcredentials_v1"
+
+module GcpDatabaseAuth
+  class Error < StandardError; end
+
+  @mutex = Mutex.new
+  @cache = {} # sa_email => [token, refresh_deadline_monotonic]
+
+  class << self
+    def connect_opts_proc(sa_by_role)
+      lambda do |opts|
+        role = opts[:user]
+        service_account = sa_by_role[role]
+        raise Error, "no CloudSQL IAM SA mapped for role #{role.inspect}" unless service_account
+        # The CloudSQL IAM db username is the SA email minus its .gserviceaccount.com suffix.
+        opts[:user] = service_account.delete_suffix(".gserviceaccount.com")
+        opts[:password] = access_token(service_account)
+        opts[:driver_options] = opts[:driver_options].merge(options: role_connect_option(role))
+      end
+    end
+
+    # The Postgres role from the connection URL. Delegates to Sequel's own parser
+    # so the result always matches opts[:user] — userinfo or ?user= query param,
+    # percent-decoded. options_from_uri is a private class method (Sequel exposes
+    # no public URI->options parser), hence send.
+    def url_user(url)
+      Sequel::Database.send(:options_from_uri, URI.parse(url))[:user]
+    end
+
+    private
+
+    def reset_cache!
+      @mutex.synchronize { @cache.clear }
+    end
+
+    # A cached token for the SA while it stays more than 5 minutes from expiry,
+    # else a freshly minted one. Minting holds the lock: a refresh happens about
+    # once an hour per SA, and holding the lock across it keeps concurrent
+    # connections from minting twice.
+    def access_token(service_account)
+      @mutex.synchronize do
+        token, refresh_deadline = @cache[service_account]
+        unless token && Process.clock_gettime(Process::CLOCK_MONOTONIC) < refresh_deadline
+          token, ttl = mint_impersonated(service_account)
+          @cache[service_account] = [token, Process.clock_gettime(Process::CLOCK_MONOTONIC) + ttl - 300]
+        end
+        token
+      end
+    end
+
+    # libpq options value that SETs the active role at connection startup. nil for
+    # a blank role; a bare identifier is validated (fail-closed) otherwise.
+    def role_connect_option(role)
+      return nil if role.nil? || role.empty?
+      raise ArgumentError, "invalid role identifier: #{role.inspect}" unless role.match?(/\A[a-z_][a-z0-9_]*\z/)
+      "-c role=#{role}"
+    end
+
+    def mint_impersonated(sa_email)
+      svc = Google::Apis::IamcredentialsV1::IAMCredentialsService.new
+      svc.authorization = Google::Auth.get_application_default(["https://www.googleapis.com/auth/cloud-platform"])
+      req = Google::Apis::IamcredentialsV1::GenerateAccessTokenRequest.new(scope: ["https://www.googleapis.com/auth/sqlservice.login"], lifetime: "3600s")
+      resp = svc.generate_service_account_access_token("projects/-/serviceAccounts/#{sa_email}", req)
+      [resp.access_token, Time.parse(resp.expire_time) - Time.now]
+    rescue Google::Apis::Error => e
+      # The top-line message ("Invalid request") hides the real reason; the
+      # response body carries the INVALID_ARGUMENT/PERMISSION detail. Surface
+      # both, plus the SA we tried to impersonate, while preserving the original
+      # backtrace so the failing call site stays visible in production.
+      raise e.class, "generateAccessToken for #{sa_email.inspect} failed: #{e.message}: #{e.body}", e.backtrace
+    end
+  end
+end

--- a/spec/db_spec.rb
+++ b/spec/db_spec.rb
@@ -184,4 +184,14 @@ RSpec.describe "Database" do
       expect(host.valid?).to be false
     end
   end
+
+  describe "Rodauth password-hash isolation invariant" do
+    it "app role cannot SELECT account_password_hashes" do
+      expect(DB["SELECT has_table_privilege('clover', 'account_password_hashes', 'SELECT')"].get).to be(false)
+    end
+
+    it "app role is not a member of clover_password" do
+      expect(DB["SELECT pg_has_role('clover', 'clover_password', 'MEMBER')"].get).to be(false)
+    end
+  end
 end

--- a/spec/gcp_database_auth_spec.rb
+++ b/spec/gcp_database_auth_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require_relative "../lib/gcp_database_auth"
+require "googleauth"
+require "google/apis/iamcredentials_v1"
+
+RSpec.describe GcpDatabaseAuth do
+  # Stub the real GCP IAM Credentials boundary instead of any test seam in the
+  # module itself. The lib (and with it the google gems) is only loaded by
+  # db.rb's GCP branch, never at app boot, so these classes load AFTER
+  # Refrigerator.freeze_core and remain unfrozen — which is what lets RSpec
+  # stub them even in frozen tests. The block receives the resource path
+  # ("projects/-/serviceAccounts/<sa-email>") and returns the token string the
+  # API should hand back.
+  def stub_iam_credentials(expire_time: (Time.now + 3600).utc.iso8601)
+    adc = Object.new
+    svc = instance_double(Google::Apis::IamcredentialsV1::IAMCredentialsService)
+    allow(svc).to receive(:authorization=).with(adc)
+    allow(svc).to receive(:generate_service_account_access_token) do |resource, _req|
+      Struct.new(:access_token, :expire_time).new(yield(resource), expire_time)
+    end
+    allow(Google::Apis::IamcredentialsV1::IAMCredentialsService).to receive(:new).with(no_args).and_return(svc)
+    allow(Google::Auth).to receive(:get_application_default).with(["https://www.googleapis.com/auth/cloud-platform"]).and_return(adc)
+    svc
+  end
+
+  describe ".url_user" do
+    it "extracts the userinfo from a connection URL" do
+      expect(described_class.url_user("postgres://clover@10.0.0.5/clover?sslmode=require")).to eq("clover")
+    end
+
+    it "percent-decodes the user, matching Sequel" do
+      expect(described_class.url_user("postgres://clover-sa%40p.iam@h/db")).to eq("clover-sa@p.iam")
+    end
+
+    it "reads the role from a ?user= query parameter (Clover's standard URL form)" do
+      expect(described_class.url_user("postgres:///clover_test?user=clover")).to eq("clover")
+    end
+
+    it "lets a ?user= query parameter override userinfo (matches Sequel)" do
+      expect(described_class.url_user("postgres://ignored@h/db?user=clover")).to eq("clover")
+    end
+
+    it "returns nil when the URL carries no user" do
+      expect(described_class.url_user("postgres://h/clover")).to be_nil
+    end
+  end
+
+  describe ".connect_opts_proc" do
+    before { described_class.send(:reset_cache!) }
+
+    let(:sa) { "clover-sa@my-project.iam.gserviceaccount.com" }
+    let(:opts_proc) { described_class.connect_opts_proc({"clover" => sa}) }
+
+    def call_proc(opts_proc, user: "clover")
+      opts = {user:, driver_options: {}}
+      opts_proc.call(opts)
+      opts
+    end
+
+    it "rewrites opts with the SA login user (email minus its .gserviceaccount.com suffix), minted-token password, and role option" do
+      stub_iam_credentials { |_resource| "minted-token" }
+      opts = call_proc(opts_proc)
+      expect(opts[:user]).to eq("clover-sa@my-project.iam")
+      expect(opts[:password]).to eq("minted-token")
+      expect(opts[:driver_options][:options]).to eq("-c role=clover")
+    end
+
+    it "leaves a bare SA db username (no suffix) unchanged" do
+      stub_iam_credentials { |_resource| "minted-token" }
+      opts_proc = described_class.connect_opts_proc({"clover" => "clover-sa@my-project.iam"})
+      expect(call_proc(opts_proc)[:user]).to eq("clover-sa@my-project.iam")
+    end
+
+    it "raises a GcpDatabaseAuth::Error for a role not in the map" do
+      expect { opts_proc.call({user: "nope", driver_options: {}}) }
+        .to raise_error(GcpDatabaseAuth::Error, /no CloudSQL IAM SA mapped for role "nope"/)
+    end
+
+    it "sets no role option when the mapped role is blank" do
+      stub_iam_credentials { |_resource| "minted-token" }
+      opts_proc = described_class.connect_opts_proc({nil => sa, "" => sa})
+      expect(call_proc(opts_proc, user: nil)[:driver_options][:options]).to be_nil
+      expect(call_proc(opts_proc, user: "")[:driver_options][:options]).to be_nil
+    end
+
+    it "rejects a role that is not a bare identifier (fail-closed)" do
+      stub_iam_credentials { |_resource| "minted-token" }
+      opts_proc = described_class.connect_opts_proc({"a; DROP" => sa})
+      expect { call_proc(opts_proc, user: "a; DROP") }.to raise_error(ArgumentError, /invalid role identifier/)
+    end
+
+    it "does not mutate the caller's existing driver_options hash" do
+      stub_iam_credentials { |_resource| "minted-token" }
+      driver_options = {}
+      opts_proc.call({user: "clover", driver_options:})
+      expect(driver_options).to eq({})
+    end
+
+    it "mints by impersonation, targeting the mapped SA" do
+      svc = stub_iam_credentials { |_resource| "minted-token" }
+      call_proc(opts_proc)
+      expect(svc).to have_received(:generate_service_account_access_token)
+        .with("projects/-/serviceAccounts/clover-sa@my-project.iam.gserviceaccount.com", anything)
+    end
+
+    it "surfaces the SA and body, preserving the original backtrace, when generateAccessToken is rejected" do
+      adc = Object.new
+      svc = instance_double(Google::Apis::IamcredentialsV1::IAMCredentialsService)
+      allow(svc).to receive(:authorization=).with(adc)
+      allow(svc).to receive(:generate_service_account_access_token)
+        .with("projects/-/serviceAccounts/#{sa}", anything)
+        .and_raise(Google::Apis::ClientError.new("Invalid request", body: '{"error":{"status":"INVALID_ARGUMENT"}}'))
+      allow(Google::Apis::IamcredentialsV1::IAMCredentialsService).to receive(:new).with(no_args).and_return(svc)
+      allow(Google::Auth).to receive(:get_application_default).with(["https://www.googleapis.com/auth/cloud-platform"]).and_return(adc)
+
+      expect { call_proc(opts_proc) }
+        .to raise_error(Google::Apis::ClientError, /clover-sa@my-project\.iam\.gserviceaccount\.com.*INVALID_ARGUMENT/m) do |error|
+          expect(error.backtrace).to eq(error.cause.backtrace) # original backtrace kept, not reset to the rescue line
+        end
+    end
+
+    it "caches a minted token per SA and reuses it until near expiry" do
+      calls = 0
+      stub_iam_credentials { |_resource| "tok-#{calls += 1}" }
+      t1 = call_proc(opts_proc)[:password]
+      t2 = call_proc(opts_proc)[:password]
+      expect([t1, t2, calls]).to eq(["tok-1", "tok-1", 1])
+    end
+
+    it "derives the cache lifetime from the response's expire_time (not a fixed 3600)" do
+      calls = 0
+      # expire_time inside the 5-minute refresh buffer => the second call must
+      # re-mint; a hardcoded 3600 lifetime would wrongly reuse the first token.
+      stub_iam_credentials(expire_time: (Time.now + 30).utc.iso8601) { |_resource| "tok-#{calls += 1}" }
+      call_proc(opts_proc)
+      call_proc(opts_proc)
+      expect(calls).to eq(2)
+    end
+
+    it "keys the cache by SA (each SA gets its own token)" do
+      stub_iam_credentials { |resource| "tok:#{resource}" }
+      opts_proc = described_class.connect_opts_proc({
+        "clover" => sa,
+        "clover_password" => "clover-sa-ph@my-project.iam.gserviceaccount.com",
+      })
+      a = call_proc(opts_proc)[:password]
+      b = call_proc(opts_proc, user: "clover_password")[:password]
+      expect(a).not_to eq(b)
+    end
+
+    # Stubs the (unfrozen) IAM client rather than GcpDatabaseAuth itself, so it
+    # also runs under frozen tests where the module can't be stubbed.
+    it "holds the lock while minting so a concurrent fetch reuses the token instead of minting twice" do
+      proceed = Queue.new
+      mints = 0
+      adc = Object.new
+      svc = instance_double(Google::Apis::IamcredentialsV1::IAMCredentialsService)
+      allow(svc).to receive(:authorization=).with(adc)
+      allow(svc).to receive(:generate_service_account_access_token) do
+        mints += 1
+        proceed.pop if mints == 1 # hold the lock until the second caller is waiting
+        Struct.new(:access_token, :expire_time).new("tok-#{mints}", (Time.now + 3600).utc.iso8601)
+      end
+      allow(Google::Apis::IamcredentialsV1::IAMCredentialsService).to receive(:new).with(no_args).and_return(svc)
+      allow(Google::Auth).to receive(:get_application_default).with(["https://www.googleapis.com/auth/cloud-platform"]).and_return(adc)
+
+      first = Thread.new { call_proc(opts_proc)[:password] }
+      Thread.pass until mints == 1               # first holds the lock, inside the blocked mint
+      second = Thread.new { call_proc(opts_proc)[:password] }
+      Thread.pass until second.status == "sleep" # second is blocked on the lock
+      proceed << :go                             # let first finish minting and cache the token
+
+      expect([first.value, second.value, mints]).to eq(["tok-1", "tok-1", 1])
+    end
+  end
+end

--- a/spec/gcp_database_auth_spec.rb
+++ b/spec/gcp_database_auth_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require_relative "../lib/gcp_database_auth"
+require "googleauth"
+require "google/apis/iamcredentials_v1"
+
+RSpec.describe GcpDatabaseAuth do
+  def stub_iam_credentials(expire_time: (Time.now + 3600).utc.iso8601)
+    adc = Object.new
+    svc = instance_double(Google::Apis::IamcredentialsV1::IAMCredentialsService)
+    allow(svc).to receive(:authorization=).with(adc)
+    allow(svc).to receive(:generate_service_account_access_token) do |resource, _req|
+      Struct.new(:access_token, :expire_time).new(yield(resource), expire_time)
+    end
+    allow(Google::Apis::IamcredentialsV1::IAMCredentialsService).to receive(:new).with(no_args).and_return(svc)
+    allow(Google::Auth).to receive(:get_application_default).with(["https://www.googleapis.com/auth/cloud-platform"]).and_return(adc)
+    svc
+  end
+
+  describe ".url_user" do
+    it "extracts the userinfo from a connection URL" do
+      expect(described_class.url_user("postgres://clover@10.0.0.5/clover?sslmode=require")).to eq("clover")
+    end
+
+    it "percent-decodes the user, matching Sequel" do
+      expect(described_class.url_user("postgres://clover-sa%40p.iam@h/db")).to eq("clover-sa@p.iam")
+    end
+
+    it "reads the role from a ?user= query parameter (Clover's standard URL form)" do
+      expect(described_class.url_user("postgres:///clover_test?user=clover")).to eq("clover")
+    end
+
+    it "lets a ?user= query parameter override userinfo (matches Sequel)" do
+      expect(described_class.url_user("postgres://ignored@h/db?user=clover")).to eq("clover")
+    end
+
+    it "returns nil when the URL carries no user" do
+      expect(described_class.url_user("postgres://h/clover")).to be_nil
+    end
+  end
+
+  describe ".connect_opts_proc" do
+    before { described_class.send(:reset_cache!) }
+
+    let(:sa) { "clover-sa@my-project.iam.gserviceaccount.com" }
+    let(:opts_proc) { described_class.connect_opts_proc({"clover" => sa}) }
+
+    def call_proc(opts_proc, user: "clover")
+      opts = {user:, driver_options: {}}
+      opts_proc.call(opts)
+      opts
+    end
+
+    it "rewrites opts with the SA login user (email minus its .gserviceaccount.com suffix), minted-token password, and role option" do
+      stub_iam_credentials { |_resource| "minted-token" }
+      opts = call_proc(opts_proc)
+      expect(opts[:user]).to eq("clover-sa@my-project.iam")
+      expect(opts[:password]).to eq("minted-token")
+      expect(opts[:driver_options][:options]).to eq("-c role=clover")
+    end
+
+    it "leaves a bare SA db username (no suffix) unchanged" do
+      stub_iam_credentials { |_resource| "minted-token" }
+      opts_proc = described_class.connect_opts_proc({"clover" => "clover-sa@my-project.iam"})
+      expect(call_proc(opts_proc)[:user]).to eq("clover-sa@my-project.iam")
+    end
+
+    it "raises a GcpDatabaseAuth::Error for a role not in the map" do
+      expect { opts_proc.call({user: "nope", driver_options: {}}) }
+        .to raise_error(GcpDatabaseAuth::Error, /no CloudSQL IAM SA mapped for role "nope"/)
+    end
+
+    it "sets no role option when the mapped role is blank" do
+      stub_iam_credentials { |_resource| "minted-token" }
+      opts_proc = described_class.connect_opts_proc({nil => sa, "" => sa})
+      expect(call_proc(opts_proc, user: nil)[:driver_options][:options]).to be_nil
+      expect(call_proc(opts_proc, user: "")[:driver_options][:options]).to be_nil
+    end
+
+    it "rejects a role that is not a bare identifier (fail-closed)" do
+      stub_iam_credentials { |_resource| "minted-token" }
+      opts_proc = described_class.connect_opts_proc({"a; DROP" => sa})
+      expect { call_proc(opts_proc, user: "a; DROP") }.to raise_error(ArgumentError, /invalid role identifier/)
+    end
+
+    it "does not mutate the caller's existing driver_options hash" do
+      stub_iam_credentials { |_resource| "minted-token" }
+      driver_options = {}
+      opts_proc.call({user: "clover", driver_options:})
+      expect(driver_options).to eq({})
+    end
+
+    it "mints by impersonation, targeting the mapped SA" do
+      svc = stub_iam_credentials { |_resource| "minted-token" }
+      call_proc(opts_proc)
+      expect(svc).to have_received(:generate_service_account_access_token)
+        .with("projects/-/serviceAccounts/clover-sa@my-project.iam.gserviceaccount.com", anything)
+    end
+
+    it "surfaces the SA and body, preserving the original backtrace, when generateAccessToken is rejected" do
+      adc = Object.new
+      svc = instance_double(Google::Apis::IamcredentialsV1::IAMCredentialsService)
+      allow(svc).to receive(:authorization=).with(adc)
+      allow(svc).to receive(:generate_service_account_access_token)
+        .with("projects/-/serviceAccounts/#{sa}", anything)
+        .and_raise(Google::Apis::ClientError.new("Invalid request", body: '{"error":{"status":"INVALID_ARGUMENT"}}'))
+      allow(Google::Apis::IamcredentialsV1::IAMCredentialsService).to receive(:new).with(no_args).and_return(svc)
+      allow(Google::Auth).to receive(:get_application_default).with(["https://www.googleapis.com/auth/cloud-platform"]).and_return(adc)
+
+      expect { call_proc(opts_proc) }
+        .to raise_error(GcpDatabaseAuth::Error, /clover-sa@my-project\.iam\.gserviceaccount\.com.*Google::Apis::ClientError.*INVALID_ARGUMENT/m) do |error|
+          expect(error.backtrace).to eq(error.cause.backtrace) # original backtrace kept, not reset to the rescue line
+        end
+    end
+
+    it "caches a minted token per SA and reuses it until near expiry" do
+      calls = 0
+      stub_iam_credentials { |_resource| "tok-#{calls += 1}" }
+      t1 = call_proc(opts_proc)[:password]
+      t2 = call_proc(opts_proc)[:password]
+      expect([t1, t2, calls]).to eq(["tok-1", "tok-1", 1])
+    end
+
+    it "derives the cache lifetime from the response's expire_time (not a fixed 3600)" do
+      calls = 0
+      # expire_time inside the 5-minute refresh buffer => the second call must
+      # re-mint; a hardcoded 3600 lifetime would wrongly reuse the first token.
+      stub_iam_credentials(expire_time: (Time.now + 30).utc.iso8601) { |_resource| "tok-#{calls += 1}" }
+      call_proc(opts_proc)
+      call_proc(opts_proc)
+      expect(calls).to eq(2)
+    end
+
+    it "keys the cache by SA (each SA gets its own token)" do
+      stub_iam_credentials { |resource| "tok:#{resource}" }
+      opts_proc = described_class.connect_opts_proc({
+        "clover" => sa,
+        "clover_password" => "clover-sa-ph@my-project.iam.gserviceaccount.com",
+      })
+      a = call_proc(opts_proc)[:password]
+      b = call_proc(opts_proc, user: "clover_password")[:password]
+      expect(a).not_to eq(b)
+    end
+
+    it "holds the lock while minting so a concurrent fetch reuses the token instead of minting twice" do
+      minting = Queue.new
+      proceed = Queue.new
+      mints = []
+      adc = Object.new
+      svc = instance_double(Google::Apis::IamcredentialsV1::IAMCredentialsService)
+      allow(svc).to receive(:authorization=).with(adc)
+      allow(svc).to receive(:generate_service_account_access_token) do
+        mints << 1
+        minting << 1
+        proceed.pop(timeout: 2) # hold the lock until the second caller is waiting
+        Struct.new(:access_token, :expire_time).new("tok-#{mints.size}", (Time.now + 3600).utc.iso8601)
+      end
+      allow(Google::Apis::IamcredentialsV1::IAMCredentialsService).to receive(:new).with(no_args).and_return(svc)
+      allow(Google::Auth).to receive(:get_application_default).with(["https://www.googleapis.com/auth/cloud-platform"]).and_return(adc)
+
+      first = Thread.new { call_proc(opts_proc)[:password] }
+      expect(minting.pop(timeout: 2)).to eq(1)     # first holds the lock, inside the blocked mint
+      second = Thread.new { call_proc(opts_proc)[:password] }
+      Thread.pass until second.status == "sleep"   # second is parked, and...
+      expect(minting.pop(timeout: 0)).to be_nil    # ...on the lock, not inside a second mint
+      proceed << :go                               # let first finish minting and cache the token
+
+      raise unless first.join(2) && second.join(2)
+      expect([first.value, second.value, mints.size]).to eq(["tok-1", "tok-1", 1])
+    end
+  end
+end


### PR DESCRIPTION
Authenticate to a Google Cloud SQL (PostgreSQL) instance with short-lived impersonated OAuth2 tokens instead of a static password, with no Cloud SQL Auth Proxy. With cloudsql.iam_authentication=on, libpq presents the token as the password over direct TLS and Cloud SQL validates it against Google. Off by default (CLOVER_DATABASE_GCP_IAM_AUTH_ENABLED); when unset the module is not loaded and behavior is unchanged.

The library exposes a Sequel :connect_opts_proc, passed only to the catalog and monitor Database objects, that resolves the connection's role (the URL user) to a service account, impersonates it to mint a sqlservice.login token used as the libpq password, connects as the service account's IAM database username, and switches the active role via the libpq options=-c role=<role> parameter. Because it is scoped to those two Database objects, no other Sequel::Database (such as the customer-DB connections in PostgresServer#check_pulse) is affected. Tokens are minted by impersonation of a dedicated per-role service account and cached per service account until shortly before the response's expireTime.

Configure the per-role service accounts with CLOVER_DATABASE_GCP_CLOVER_LOGIN_SA and CLOVER_DATABASE_GCP_CLOVER_PASSWORD_LOGIN_SA (the latter is used only for the one-time password-hash migration bootstrap and need only be set on the pod that runs migrations).
