### PR TITLE
Remove unused Hetzner SSH key API methods

### DIFF
--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -29,22 +29,6 @@ class Hosting::HetznerApis < Hosting::ProviderApis
     nil
   end
 
-  def add_key(name, key)
-    create_connection.post(path: "/key",
-      body: URI.encode_www_form(name:, data: key),
-      expects: 201)
-    nil
-  end
-
-  def delete_key(key)
-    key_data = key.split(" ")[1]
-    decoded_data = Base64.decode64(key_data)
-    fingerprint = OpenSSL::Digest::MD5.new(decoded_data).hexdigest
-
-    create_connection.delete(path: "/key/#{fingerprint}", expects: [200, 404])
-    nil
-  end
-
   def get_main_ip4
     response = create_connection.get(path: "/server/#{server_id}", expects: 200)
     response_hash = JSON.parse(response.body)

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -59,35 +59,6 @@ RSpec.describe Hosting::HetznerApis do
     end
   end
 
-  describe "add_key" do
-    it "can add a key" do
-      Excon.stub({path: "/key", method: :post}, {status: 201, body: ""})
-      expect(hetzner_apis.add_key("test_key_1", ssh_key)).to be_nil
-    end
-
-    it "raises an error if adding a key fails" do
-      Excon.stub({path: "/key", method: :post}, {status: 500, body: ""})
-      expect { hetzner_apis.add_key("test_key_1", ssh_key) }.to raise_error Excon::Error::InternalServerError
-    end
-  end
-
-  describe "delete_key" do
-    it "can delete a key" do
-      Excon.stub({path: "/key/8003339382ac5baa3637f813becce5e4", method: :delete}, {status: 200, body: ""})
-      expect(hetzner_apis.delete_key(ssh_key)).to be_nil
-    end
-
-    it "raises an error if deleting a key fails" do
-      Excon.stub({path: "/key/8003339382ac5baa3637f813becce5e4", method: :delete}, {status: 500, body: ""})
-      expect { hetzner_apis.delete_key(ssh_key) }.to raise_error Excon::Error::InternalServerError
-    end
-
-    it "regards a missing key as deleted" do
-      Excon.stub({path: "/key/8003339382ac5baa3637f813becce5e4", method: :delete}, {status: 404, body: ""})
-      expect(hetzner_apis.delete_key(ssh_key)).to be_nil
-    end
-  end
-
   describe "get_main_ip4" do
     it "can get the main ip4" do
       Excon.stub({path: "/server/123", method: :get}, {status: 200, body: "{\"server\": {\"server_ip\": \"1.2.3.4\"}}"})


### PR DESCRIPTION
The add_key and delete_key methods on Hosting::HetznerApis are no longer called anywhere.

They were used by E2E tests previously.