### PR TITLE
Run VmGroup's heavy VM checks only on the post-reboot pass

### DIFF
--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -35,6 +35,8 @@ class Prog::Test::Vm < Prog::Test::Base
         sha256 = sshable.cmd("head -c 1M /dev/urandom | tee /tmp/persistence-test | sha256sum | awk '{print $1}'").strip
         sshable.cmd("mv /tmp/persistence-test :file", file: File.join("/home/ubi/persistence_test", sha256))
       end
+      # The pre-reboot pass is on the critical path, so it keeps only the disk and network checks plus seeding the persistence data.
+      hop_ping_google
     else
       files = sshable.cmd("ls ~/persistence_test").split
       fail_test "persistence test: unexpected number of files" if files.size != num_files
@@ -43,9 +45,8 @@ class Prog::Test::Vm < Prog::Test::Base
         sha256 = sshable.cmd("sha256sum :file | awk '{print $1}'", file: File.join("/home/ubi/persistence_test", file)).strip
         fail_test "persistence test: file content mismatch" unless sha256 == file
       end
+      hop_install_packages
     end
-
-    hop_install_packages
   end
 
   label def install_packages
@@ -192,6 +193,8 @@ class Prog::Test::Vm < Prog::Test::Base
 
   label def ping_google
     sshable.cmd("ping -c 2 google.com")
+    # The pre-reboot pass skips the fio throughput check.
+    hop_ping_vms_in_subnet if first_boot
     hop_verify_io_rates
   end
 

--- a/spec/prog/test/vm_spec.rb
+++ b/spec/prog/test/vm_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Prog::Test::Vm do
   end
 
   describe "#storage_persistence" do
-    it "creates files on first boot" do
+    it "creates files on first boot and skips the heavy checks to ping_google" do
       refresh_frame(vm_test, new_values: {"first_boot" => true})
       expect(sshable).to receive(:_cmd).with("mkdir ~/persistence_test")
       (1..5).each do |i|
@@ -72,10 +72,10 @@ RSpec.describe Prog::Test::Vm do
         expect(sshable).to receive(:_cmd).with("head -c 1M /dev/urandom | tee /tmp/persistence-test | sha256sum | awk '{print $1}'").and_return(some_sha256)
         expect(sshable).to receive(:_cmd).with("mv /tmp/persistence-test /home/ubi/persistence_test/#{some_sha256}")
       end
-      expect { vm_test.storage_persistence }.to hop("install_packages")
+      expect { vm_test.storage_persistence }.to hop("ping_google")
     end
 
-    it "verifies files on subsequent boots" do
+    it "verifies files on subsequent boots and continues to the full suite" do
       refresh_frame(vm_test, new_values: {"first_boot" => false})
       expect(sshable).to receive(:_cmd).with("ls ~/persistence_test").and_return("sha256_1\nsha256_2\nsha256_3\nsha256_4\nsha256_5\n")
       (1..5).each do |i|
@@ -261,9 +261,16 @@ RSpec.describe Prog::Test::Vm do
   end
 
   describe "#ping_google" do
-    it "pings google and hops to next step" do
+    it "pings google and hops to verify_io_rates on the post-reboot pass" do
+      refresh_frame(vm_test, new_values: {"first_boot" => false})
       expect(sshable).to receive(:_cmd).with("ping -c 2 google.com")
       expect { vm_test.ping_google }.to hop("verify_io_rates")
+    end
+
+    it "skips fio and hops to ping_vms_in_subnet on the pre-reboot pass" do
+      refresh_frame(vm_test, new_values: {"first_boot" => true})
+      expect(sshable).to receive(:_cmd).with("ping -c 2 google.com")
+      expect { vm_test.ping_google }.to hop("ping_vms_in_subnet")
     end
   end
 


### PR DESCRIPTION
VmGroup's reboot test runs Prog::Test::Vm twice: once before the host reboot and once after, to confirm the VMs survive. The pre-reboot pass sits on the e2e serial critical path (the parallel block can't start until the host reboot completes), yet it runs the entire suite -- package install, extra-disk format/mount, the stop/start/shutdown lifecycle, and fio throughput -- about five minutes of work that is then simply repeated on the post-reboot pass.

Keep the cheap, reboot-relevant checks on both passes so a bad pre-reboot setup can't hide behind a good post-reboot one: disk health (dd), the storage-persistence seed/verify, and the network checks (ping google, in-subnet connectivity, cross-subnet isolation). Move the heavier checks that are independent of the reboot -- package install, extra disks, vm stats/storage rpc, the vm lifecycle, and fio -- to the post-reboot pass only, which the suite already runs in parallel with the other tests (see the verify_vms_after_reboot handoff).

This shrinks VmGroup's serial pre-reboot portion by several minutes, so the parallel block -- and therefore the run's long pole -- starts earlier.