### PR TITLE
Install Hetzner host OS from rescue mode

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -85,6 +85,8 @@ module Prog::DnsZone; end
 
 module Prog::Github; end
 
+module Prog::Hetzner; end
+
 module Prog::Kubernetes; end
 
 module Prog::MachineImage; end
@@ -253,6 +255,7 @@ def clover_freeze
     Prog::Base::Nap,
     Prog::DnsZone,
     Prog::Github,
+    Prog::Hetzner,
     Prog::Kubernetes,
     Prog::MachineImage,
     Prog::Minio,

--- a/prog/hetzner/install_os.rb
+++ b/prog/hetzner/install_os.rb
@@ -33,6 +33,8 @@ class Prog::Hetzner::InstallOs < Prog::Base
       image_name="$1"
       rm -f /root/ubicloud-install.exit
       trap 'echo $? > /root/ubicloud-install.exit' EXIT
+      mdadm --stop /dev/md/* 2>/dev/null || true
+      wipefs -fa /dev/nvme*n1
       :installimage -a -r no -d nvme0n1 -p /boot/efi:esp:256M,swap:swap:32G,/boot:ext3:1024M,/:ext4:all -i "images/${image_name}"
     SCRIPT
     setup_root_cmd("nohup bash /root/ubicloud-install.sh :image_name > /root/ubicloud-install.log 2>&1 < /dev/null & echo started", image_name:)
@@ -55,6 +57,9 @@ class Prog::Hetzner::InstallOs < Prog::Base
 
   label def wait_reboot
     nap 30 if setup_root_cmd("hostname").strip == "rescue"
+
+    mdstat = setup_root_cmd("cat /proc/mdstat")
+    fail "Unexpected RAID array found after OS install: #{mdstat}" if mdstat.match?(/^md\d+\s*:/)
 
     pop "operating system installed"
   end

--- a/prog/hetzner/install_os.rb
+++ b/prog/hetzner/install_os.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class Prog::Hetzner::InstallOs < Prog::Base
+  subject_is :sshable
+
+  # installimage is a shell alias in the rescue system, so we use its real path
+  # to run it over a non-interactive SSH command.
+  INSTALLIMAGE = "/root/.oldroot/nfs/install/installimage"
+
+  label def start
+    hostname = setup_root_cmd("hostname").strip
+    fail "Host is not in rescue mode: hostname is #{hostname.inspect} instead of \"rescue\"" unless hostname == "rescue"
+    fail "Host is not in rescue mode: installimage is not available" if setup_root_cmd("test -x :path && echo y || true", path: INSTALLIMAGE).strip.empty?
+
+    hop_install
+  end
+
+  label def install
+    image_name = case (machine = setup_root_cmd("uname -m").strip)
+    when "x86_64" then "Ubuntu-2404-noble-amd64-base.tar.zst"
+    when "aarch64" then "Ubuntu-2404-noble-arm64-base.tar.zst"
+    else fail "Unexpected machine architecture #{machine.inspect} reported by the rescue system"
+    end
+
+    # Installs the OS to the first disk.
+    # https://docs.hetzner.com/robot/dedicated-server/operating-systems/installimage/
+    setup_root_cmd("echo :script > /root/ubicloud-install.sh", script: NetSsh.command(<<~SCRIPT, installimage: INSTALLIMAGE))
+      set -ue
+      if [ "$(hostname)" != "rescue" ]; then
+        echo "refusing to install the OS: host is not in rescue mode"
+        exit 1
+      fi
+      image_name="$1"
+      rm -f /root/ubicloud-install.exit
+      trap 'echo $? > /root/ubicloud-install.exit' EXIT
+      :installimage -a -r no -d nvme0n1 -p /boot/efi:esp:256M,swap:swap:32G,/boot:ext3:1024M,/:ext4:all -i "images/${image_name}"
+    SCRIPT
+    setup_root_cmd("nohup bash /root/ubicloud-install.sh :image_name > /root/ubicloud-install.log 2>&1 < /dev/null & echo started", image_name:)
+
+    hop_wait_install
+  end
+
+  label def wait_install
+    exit_status = setup_root_cmd("cat /root/ubicloud-install.exit 2> /dev/null || true").strip
+    nap 30 if exit_status.empty?
+
+    unless exit_status == "0"
+      install_log = setup_root_cmd("tail -n 40 /root/ubicloud-install.log 2> /dev/null || true")
+      fail "installimage failed with exit status #{exit_status}: #{install_log}"
+    end
+
+    setup_root_cmd("reboot")
+    hop_wait_reboot
+  end
+
+  label def wait_reboot
+    nap 30 if setup_root_cmd("hostname").strip == "rescue"
+
+    pop "operating system installed"
+  end
+
+  def setup_root_cmd(cmd, **kwargs)
+    fail "BUG: hetzner_ssh_private_key is not set" unless Config.hetzner_ssh_private_key
+
+    root_key = Net::SSH::Authentication::ED25519::PrivKey.read(Config.hetzner_ssh_private_key, Config.hetzner_ssh_private_key_passphrase).sign_key
+    Util.rootish_ssh(sshable.host, "root", [SshKey.from_binary(root_key.keypair).private_key], cmd, **kwargs)
+  rescue *Sshable::SSH_CONNECTION_ERRORS
+    nap 30
+  end
+end

--- a/prog/hetzner/install_os.rb
+++ b/prog/hetzner/install_os.rb
@@ -3,8 +3,6 @@
 class Prog::Hetzner::InstallOs < Prog::Base
   subject_is :sshable
 
-  # installimage is a shell alias in the rescue system, so we use its real path
-  # to run it over a non-interactive SSH command.
   INSTALLIMAGE = "/root/.oldroot/nfs/install/installimage"
 
   label def start

--- a/prog/learn_storage.rb
+++ b/prog/learn_storage.rb
@@ -4,6 +4,7 @@ require_relative "../lib/system_parser"
 
 class Prog::LearnStorage < Prog::Base
   subject_is :sshable, :vm_host
+  frame_reader :format_storage
 
   def make_model_instances
     devices = SystemParser.extract_disk_info_from_df(sshable.cmd("df -B1 --output=source,target,size,avail"))
@@ -42,6 +43,8 @@ class Prog::LearnStorage < Prog::Base
   end
 
   label def start
+    sshable.cmd("sudo host/bin/format-storage-disks") if format_storage
+
     make_model_instances.each do |sd|
       sd.skip_auto_validations(:unique) do
         sd.insert_conflict(target: [:vm_host_id, :name],

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -5,7 +5,7 @@ class Prog::Vm::HostNexus < Prog::Base
   frame_reader :vhost_block_backend_version, :default_boot_images
   frame_accessor :accepting_before_patch
 
-  def self.assemble(sshable_hostname, location_id: Location::HETZNER_FSN1_ID, family: "standard", net6: nil, ndp_needed: false, provider_name: nil, server_identifier: nil, vhost_block_backend_version: Config.vhost_block_backend_version, default_boot_images: [])
+  def self.assemble(sshable_hostname, location_id: Location::HETZNER_FSN1_ID, family: "standard", net6: nil, ndp_needed: false, provider_name: nil, server_identifier: nil, vhost_block_backend_version: Config.vhost_block_backend_version, default_boot_images: [], install_os: false)
     DB.transaction do
       unless Location[location_id]
         raise "No existing Location"
@@ -36,12 +36,23 @@ class Prog::Vm::HostNexus < Prog::Base
       Strand.create_with_id(id,
         prog: "Vm::HostNexus",
         label: "start",
-        stack: [{"vhost_block_backend_version" => vhost_block_backend_version, "default_boot_images" => default_boot_images}])
+        stack: [{"vhost_block_backend_version" => vhost_block_backend_version, "default_boot_images" => default_boot_images, "install_os" => install_os}])
     end
   end
 
   label def start
+    hop_install_os if frame["install_os"]
+
     hop_setup_ssh_keys
+  end
+
+  label def install_os
+    hop_setup_ssh_keys unless vm_host.provider_name == HostProvider::HETZNER_PROVIDER_NAME
+
+    register_deadline("setup_ssh_keys", 2 * 60 * 60)
+    hop_setup_ssh_keys if retval&.dig("msg") == "operating system installed"
+
+    push Prog::Hetzner::InstallOs
   end
 
   label def setup_ssh_keys
@@ -74,7 +85,7 @@ class Prog::Vm::HostNexus < Prog::Base
     bud Prog::LearnMemory
     bud Prog::LearnOs
     bud Prog::LearnCpu
-    bud Prog::LearnStorage
+    bud Prog::LearnStorage, {"format_storage" => frame["install_os"] && vm_host.provider_name == HostProvider::HETZNER_PROVIDER_NAME}
     bud Prog::LearnPci
     bud Prog::InstallDnsmasq
     bud Prog::SetupSysstat

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -2,7 +2,7 @@
 
 class Prog::Vm::HostNexus < Prog::Base
   subject_is :sshable, :vm_host
-  frame_reader :vhost_block_backend_version, :default_boot_images
+  frame_reader :vhost_block_backend_version, :default_boot_images, :install_os
   frame_accessor :accepting_before_patch
 
   def self.assemble(sshable_hostname, location_id: Location::HETZNER_FSN1_ID, family: "standard", net6: nil, ndp_needed: false, provider_name: nil, server_identifier: nil, vhost_block_backend_version: Config.vhost_block_backend_version, default_boot_images: [], install_os: false)
@@ -41,12 +41,12 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def start
-    hop_install_os if frame["install_os"]
+    hop_install_host_os if install_os
 
     hop_setup_ssh_keys
   end
 
-  label def install_os
+  label def install_host_os
     hop_setup_ssh_keys unless vm_host.provider_name == HostProvider::HETZNER_PROVIDER_NAME
 
     register_deadline("setup_ssh_keys", 2 * 60 * 60)
@@ -85,7 +85,7 @@ class Prog::Vm::HostNexus < Prog::Base
     bud Prog::LearnMemory
     bud Prog::LearnOs
     bud Prog::LearnCpu
-    bud Prog::LearnStorage, {"format_storage" => frame["install_os"] && vm_host.provider_name == HostProvider::HETZNER_PROVIDER_NAME}
+    bud Prog::LearnStorage, {"format_storage" => install_os && vm_host.provider_name == HostProvider::HETZNER_PROVIDER_NAME}
     bud Prog::LearnPci
     bud Prog::InstallDnsmasq
     bud Prog::SetupSysstat

--- a/rhizome/host/bin/format-storage-disks
+++ b/rhizome/host/bin/format-storage-disks
@@ -1,0 +1,6 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/storage_disk_formatter"
+
+StorageDiskFormatter.new.format

--- a/rhizome/host/lib/storage_disk_formatter.rb
+++ b/rhizome/host/lib/storage_disk_formatter.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "fileutils"
+
+# Formats every disk except the boot disk and mounts it persistently
+# under /var/storage/devices, to be used for VM storage. It is idempotent:
+# disks already recorded in /etc/fstab or already mounted are left untouched,
+# so it is safe to re-run on a live host.
+class StorageDiskFormatter
+  FSTAB = "/etc/fstab"
+
+  def format
+    data_disks.each_with_index do |disk, index|
+      format_disk(disk, mount_dir(index))
+    end
+    r "mount", "-a"
+  end
+
+  def mount_dir(index)
+    "/var/storage/devices/disk#{index + 1}"
+  end
+
+  def boot_disk
+    @boot_disk ||= begin
+      boot_partition = r("findmnt", "-n", "-o", "SOURCE", "/boot").strip
+      boot_disk = r("lsblk", "-no", "PKNAME", boot_partition).strip
+      fail "could not determine the boot disk" if boot_disk.empty?
+      boot_disk
+    end
+  end
+
+  def data_disks
+    disk_names = r("lsblk", "-ndo", "NAME,TYPE").lines.filter_map { |line|
+      name, type = line.split
+      name if type == "disk"
+    }.sort
+    (disk_names - [boot_disk]).map { "/dev/#{_1}" }
+  end
+
+  def format_disk(disk, mount_dir)
+    return if File.read(FSTAB).lines.any? { _1.split[1] == mount_dir }
+    return unless r("lsblk", "-no", "MOUNTPOINTS", disk).strip.empty?
+
+    r "wipefs", "-fa", disk
+    r "mkfs.ext4", disk
+    FileUtils.mkdir_p(mount_dir)
+    r "mount", disk, mount_dir
+
+    uuid = r("blkid", "-s", "UUID", "-o", "value", disk).strip
+    File.open(FSTAB, File::RDONLY) do |f|
+      f.flock(File::LOCK_EX)
+      safe_write_to_file(FSTAB, f.read + "# #{disk}\nUUID=#{uuid} #{mount_dir} ext4 defaults 0 2\n")
+    end
+  end
+end

--- a/rhizome/host/spec/storage_disk_formatter_spec.rb
+++ b/rhizome/host/spec/storage_disk_formatter_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative "../lib/storage_disk_formatter"
+
+RSpec.describe StorageDiskFormatter do
+  subject(:formatter) { described_class.new }
+
+  describe "#boot_disk" do
+    it "returns the parent disk of the /boot partition" do
+      expect(formatter).to receive(:r).with("findmnt", "-n", "-o", "SOURCE", "/boot").and_return("/dev/nvme0n1p2\n")
+      expect(formatter).to receive(:r).with("lsblk", "-no", "PKNAME", "/dev/nvme0n1p2").and_return("nvme0n1\n")
+      expect(formatter.boot_disk).to eq("nvme0n1")
+    end
+
+    it "fails if the boot disk cannot be determined" do
+      expect(formatter).to receive(:r).with("findmnt", "-n", "-o", "SOURCE", "/boot").and_return("/dev/nvme0n1p2\n")
+      expect(formatter).to receive(:r).with("lsblk", "-no", "PKNAME", "/dev/nvme0n1p2").and_return("\n")
+      expect { formatter.boot_disk }.to raise_error RuntimeError, "could not determine the boot disk"
+    end
+  end
+
+  describe "#data_disks" do
+    it "returns all disks except the boot disk, sorted by name" do
+      expect(formatter).to receive(:boot_disk).and_return("nvme0n1")
+      expect(formatter).to receive(:r).with("lsblk", "-ndo", "NAME,TYPE").and_return(<<~OUTPUT)
+        nvme2n1 disk
+        nvme0n1 disk
+        loop0 loop
+        nvme1n1 disk
+      OUTPUT
+      expect(formatter.data_disks).to eq(["/dev/nvme1n1", "/dev/nvme2n1"])
+    end
+  end
+
+  describe "#format" do
+    it "formats each data disk and mounts all of them" do
+      expect(formatter).to receive(:data_disks).and_return(["/dev/nvme1n1", "/dev/nvme2n1"])
+      expect(formatter).to receive(:format_disk).with("/dev/nvme1n1", "/var/storage/devices/disk1")
+      expect(formatter).to receive(:format_disk).with("/dev/nvme2n1", "/var/storage/devices/disk2")
+      expect(formatter).to receive(:r).with("mount", "-a")
+      formatter.format
+    end
+  end
+
+  describe "#format_disk" do
+    it "skips disks already recorded in fstab" do
+      expect(File).to receive(:read).with("/etc/fstab").and_return("UUID=123-abc /var/storage/devices/disk1 ext4 defaults 0 2\n")
+      expect(formatter).not_to receive(:r)
+      formatter.format_disk("/dev/nvme1n1", "/var/storage/devices/disk1")
+    end
+
+    it "skips a disk that is already mounted" do
+      expect(File).to receive(:read).with("/etc/fstab").and_return("UUID=y / ext4 defaults 0 1\n")
+      expect(formatter).to receive(:r).with("lsblk", "-no", "MOUNTPOINTS", "/dev/nvme1n1").and_return("/var/foo\n")
+      expect(formatter).not_to receive(:r).with("wipefs", "-fa", "/dev/nvme1n1")
+      formatter.format_disk("/dev/nvme1n1", "/var/storage/devices/disk1")
+    end
+
+    it "wipes, formats, mounts the disk and persists it in fstab" do
+      expect(File).to receive(:read).with("/etc/fstab").and_return("UUID=y / ext4 defaults 0 1\n")
+      expect(formatter).to receive(:r).with("lsblk", "-no", "MOUNTPOINTS", "/dev/nvme1n1").and_return("\n")
+      expect(formatter).to receive(:r).with("wipefs", "-fa", "/dev/nvme1n1")
+      expect(formatter).to receive(:r).with("mkfs.ext4", "/dev/nvme1n1")
+      expect(FileUtils).to receive(:mkdir_p).with("/var/storage/devices/disk1")
+      expect(formatter).to receive(:r).with("mount", "/dev/nvme1n1", "/var/storage/devices/disk1")
+      expect(formatter).to receive(:r).with("blkid", "-s", "UUID", "-o", "value", "/dev/nvme1n1").and_return("123-abc\n")
+
+      fstab_file = instance_double(File)
+      expect(fstab_file).to receive(:flock).with(File::LOCK_EX)
+      expect(fstab_file).to receive(:read).and_return("UUID=y / ext4 defaults 0 1\n")
+      expect(File).to receive(:open).with("/etc/fstab", File::RDONLY).and_yield(fstab_file)
+      expect(formatter).to receive(:safe_write_to_file).with("/etc/fstab", "UUID=y / ext4 defaults 0 1\n# /dev/nvme1n1\nUUID=123-abc /var/storage/devices/disk1 ext4 defaults 0 2\n")
+
+      formatter.format_disk("/dev/nvme1n1", "/var/storage/devices/disk1")
+    end
+  end
+end

--- a/spec/prog/hetzner/install_os_spec.rb
+++ b/spec/prog/hetzner/install_os_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Hetzner::InstallOs do
+  subject(:prog) { described_class.new(st) }
+
+  let(:vm_host) { Prog::Vm::HostNexus.assemble("192.168.0.1").subject }
+  let(:st) { Strand.new(prog: "Hetzner::InstallOs", stack: [{"subject_id" => vm_host.id}]) }
+  let(:sshable) { prog.sshable }
+
+  let(:session) { Net::SSH::Connection::Session.allocate }
+
+  before do
+    allow(Config).to receive(:hetzner_ssh_private_key).and_return(SshKey.generate.private_key)
+    allow(Net::SSH).to receive(:start) { |*, **, &blk| blk.call(session) }
+  end
+
+  def ssh_result(stdout, exitstatus = 0)
+    Net::SSH::Connection::Session::StringWithExitstatus.new(stdout, exitstatus)
+  end
+
+  describe "#start" do
+    it "fails if the hostname is not rescue" do
+      expect(session).to receive(:_exec!).with("hostname").and_return(ssh_result("existing-host\n"))
+      expect { prog.start }.to raise_error RuntimeError, "Host is not in rescue mode: hostname is \"existing-host\" instead of \"rescue\""
+    end
+
+    it "fails if installimage is not available" do
+      expect(session).to receive(:_exec!).with("hostname").and_return(ssh_result("rescue\n"))
+      expect(session).to receive(:_exec!).with("test -x #{described_class::INSTALLIMAGE.shellescape} && echo y || true").and_return(ssh_result("\n"))
+      expect { prog.start }.to raise_error RuntimeError, "Host is not in rescue mode: installimage is not available"
+    end
+
+    it "hops to install if the host is in rescue mode" do
+      expect(session).to receive(:_exec!).with("hostname").and_return(ssh_result("rescue\n"))
+      expect(session).to receive(:_exec!).with("test -x #{described_class::INSTALLIMAGE.shellescape} && echo y || true").and_return(ssh_result("y\n"))
+      expect { prog.start }.to hop("install")
+    end
+  end
+
+  describe "#install" do
+    let(:install_script) { <<~SCRIPT }
+      set -ue
+      if [ "$(hostname)" != "rescue" ]; then
+        echo "refusing to install the OS: host is not in rescue mode"
+        exit 1
+      fi
+      image_name="$1"
+      rm -f /root/ubicloud-install.exit
+      trap 'echo $? > /root/ubicloud-install.exit' EXIT
+      /root/.oldroot/nfs/install/installimage -a -r no -d nvme0n1 -p /boot/efi:esp:256M,swap:swap:32G,/boot:ext3:1024M,/:ext4:all -i "images/${image_name}"
+    SCRIPT
+
+    it "starts installimage with the x64 image" do
+      expect(session).to receive(:_exec!).with("uname -m").and_return(ssh_result("x86_64\n"))
+      expect(session).to receive(:_exec!).with("echo #{install_script.shellescape} > /root/ubicloud-install.sh").and_return(ssh_result(""))
+      expect(session).to receive(:_exec!).with("nohup bash /root/ubicloud-install.sh Ubuntu-2404-noble-amd64-base.tar.zst > /root/ubicloud-install.log 2>&1 < /dev/null & echo started").and_return(ssh_result("started\n"))
+      expect { prog.install }.to hop("wait_install")
+    end
+
+    it "starts installimage with the arm64 image" do
+      expect(session).to receive(:_exec!).with("uname -m").and_return(ssh_result("aarch64\n"))
+      expect(session).to receive(:_exec!).with("echo #{install_script.shellescape} > /root/ubicloud-install.sh").and_return(ssh_result(""))
+      expect(session).to receive(:_exec!).with("nohup bash /root/ubicloud-install.sh Ubuntu-2404-noble-arm64-base.tar.zst > /root/ubicloud-install.log 2>&1 < /dev/null & echo started").and_return(ssh_result("started\n"))
+      expect { prog.install }.to hop("wait_install")
+    end
+
+    it "fails for an unexpected architecture" do
+      expect(session).to receive(:_exec!).with("uname -m").and_return(ssh_result("riscv64\n"))
+      expect { prog.install }.to raise_error RuntimeError, "Unexpected machine architecture \"riscv64\" reported by the rescue system"
+    end
+  end
+
+  describe "#wait_install" do
+    it "naps if installimage is still running" do
+      expect(session).to receive(:_exec!).with("cat /root/ubicloud-install.exit 2> /dev/null || true").and_return(ssh_result("\n"))
+      expect { prog.wait_install }.to nap(30)
+    end
+
+    it "fails if installimage failed" do
+      expect(session).to receive(:_exec!).with("cat /root/ubicloud-install.exit 2> /dev/null || true").and_return(ssh_result("1\n"))
+      expect(session).to receive(:_exec!).with("tail -n 40 /root/ubicloud-install.log 2> /dev/null || true").and_return(ssh_result("something went wrong"))
+      expect { prog.wait_install }.to raise_error RuntimeError, "installimage failed with exit status 1: something went wrong"
+    end
+
+    it "reboots and hops to wait_reboot if installimage succeeded" do
+      expect(session).to receive(:_exec!).with("cat /root/ubicloud-install.exit 2> /dev/null || true").and_return(ssh_result("0\n"))
+      expect(session).to receive(:_exec!).with("reboot").and_return(ssh_result(""))
+      expect { prog.wait_install }.to hop("wait_reboot")
+    end
+  end
+
+  describe "#wait_reboot" do
+    it "naps if the host is still in rescue mode" do
+      expect(session).to receive(:_exec!).with("hostname").and_return(ssh_result("rescue\n"))
+      expect { prog.wait_reboot }.to nap(30)
+    end
+
+    it "pops once the host boots into the installed OS" do
+      expect(session).to receive(:_exec!).with("hostname").and_return(ssh_result("Ubuntu-2404-noble-amd64-base\n"))
+      expect { prog.wait_reboot }.to exit({"msg" => "operating system installed"})
+    end
+  end
+
+  describe "#setup_root_cmd" do
+    it "fails if the hetzner ssh private key is not configured" do
+      expect(Config).to receive(:hetzner_ssh_private_key).and_return(nil)
+      expect { prog.setup_root_cmd("hostname") }.to raise_error RuntimeError, "BUG: hetzner_ssh_private_key is not set"
+    end
+
+    it "runs the command on the host as root and returns the output" do
+      expect(Net::SSH).to receive(:start).with("192.168.0.1", "root", anything) { |*, **, &blk| blk.call(session) }
+      expect(session).to receive(:_exec!).with("echo 1").and_return(ssh_result("1\n"))
+      expect(prog.setup_root_cmd("echo :value", value: 1)).to eq("1\n")
+    end
+
+    it "naps if the host is not reachable" do
+      expect(Net::SSH).to receive(:start).and_raise(Errno::ECONNREFUSED)
+      expect { prog.setup_root_cmd("hostname") }.to nap(30)
+    end
+  end
+end

--- a/spec/prog/hetzner/install_os_spec.rb
+++ b/spec/prog/hetzner/install_os_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Prog::Hetzner::InstallOs do
 
   let(:vm_host) { Prog::Vm::HostNexus.assemble("192.168.0.1").subject }
   let(:st) { Strand.new(prog: "Hetzner::InstallOs", stack: [{"subject_id" => vm_host.id}]) }
-  let(:sshable) { prog.sshable }
 
   let(:session) { Net::SSH::Connection::Session.allocate }
 
@@ -49,6 +48,8 @@ RSpec.describe Prog::Hetzner::InstallOs do
       image_name="$1"
       rm -f /root/ubicloud-install.exit
       trap 'echo $? > /root/ubicloud-install.exit' EXIT
+      mdadm --stop /dev/md/* 2>/dev/null || true
+      wipefs -fa /dev/nvme*n1
       /root/.oldroot/nfs/install/installimage -a -r no -d nvme0n1 -p /boot/efi:esp:256M,swap:swap:32G,/boot:ext3:1024M,/:ext4:all -i "images/${image_name}"
     SCRIPT
 
@@ -97,8 +98,15 @@ RSpec.describe Prog::Hetzner::InstallOs do
       expect { prog.wait_reboot }.to nap(30)
     end
 
-    it "pops once the host boots into the installed OS" do
+    it "fails if a RAID array is present after the install" do
       expect(session).to receive(:_exec!).with("hostname").and_return(ssh_result("Ubuntu-2404-noble-amd64-base\n"))
+      expect(session).to receive(:_exec!).with("cat /proc/mdstat").and_return(ssh_result("Personalities : [raid1]\nmd0 : active raid1 nvme0n1p3[0]\nunused devices: <none>\n"))
+      expect { prog.wait_reboot }.to raise_error(RuntimeError, /Unexpected RAID array found after OS install/)
+    end
+
+    it "pops once the host boots into the installed OS with no RAID" do
+      expect(session).to receive(:_exec!).with("hostname").and_return(ssh_result("Ubuntu-2404-noble-amd64-base\n"))
+      expect(session).to receive(:_exec!).with("cat /proc/mdstat").and_return(ssh_result("Personalities : [raid1]\nunused devices: <none>\n"))
       expect { prog.wait_reboot }.to exit({"msg" => "operating system installed"})
     end
   end

--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -69,6 +69,23 @@ EOS
       expect(vmh.reload.available_storage_gib).to eq(3)
       expect(vmh.reload.total_storage_gib).to eq(13)
     end
+
+    it "formats the storage disks before reading them when format_storage is set" do
+      vmh = Prog::Vm::HostNexus.assemble("::1").subject
+      ls = described_class.new(Strand.new(stack: [{"subject_id" => vmh.id, "format_storage" => true}]))
+      expect(ls.sshable).to receive(:_cmd).with("sudo host/bin/format-storage-disks").ordered
+      expect(ls.sshable).to receive(:_cmd).with("df -B1 --output=source,target,size,avail").ordered.and_return(<<~EOS)
+        Filesystem     Mounted on                   1B-blocks        Avail
+        /dev/sda       /                            205520896     99571712
+      EOS
+      expect(ls.sshable).to receive(:_cmd).with("df -B1 --output=source,target,size,avail /var/storage").and_return(<<~EOS)
+        Filesystem     Mounted on   1B-blocks        Avail
+        /dev/sda       /            205520896     99571712
+      EOS
+      expect(ls.sshable).to receive(:_cmd).with("ls -l /dev/disk/by-id/ | grep sda\\$ | grep 'wwn-' | sed -E 's/.*(wwn[^ ]*).*/\\1/'").and_return("wwn-some-random-id1")
+
+      expect { ls.start }.to exit({"msg" => "created StorageDevice records"})
+    end
   end
 
   describe Prog::LearnStorage, "#make_model_instances" do

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -78,11 +78,49 @@ RSpec.describe Prog::Vm::HostNexus do
       st = described_class.assemble("1.2.3.4")
       expect(st.stack.first["vhost_block_backend_version"]).to eq(Config.vhost_block_backend_version)
     end
+
+    it "stores install_os in stack" do
+      st = described_class.assemble("127.0.0.1")
+      expect(st.stack.first["install_os"]).to be false
+
+      st = described_class.assemble("1.2.3.4", install_os: true)
+      expect(st.stack.first["install_os"]).to be true
+    end
+  end
+
+  def assemble_hetzner_host(**)
+    api = instance_double(Hosting::HetznerApis, pull_ips: nil, pull_data_center: "fsn1-dc14", set_server_name: nil)
+    allow(Hosting::ProviderApis).to receive(:for).and_return(api)
+    described_class.assemble("127.0.0.1", provider_name: HostProvider::HETZNER_PROVIDER_NAME, server_identifier: "1", **)
   end
 
   describe "#start" do
-    it "hops to setup_ssh_keys" do
+    it "hops to install_os when assembled with install_os" do
+      st = described_class.assemble("192.168.0.2", install_os: true)
+      expect { described_class.new(st).start }.to hop("install_os")
+    end
+
+    it "hops to setup_ssh_keys when not installing the OS" do
       expect { nx.start }.to hop("setup_ssh_keys")
+    end
+  end
+
+  describe "#install_os" do
+    it "pushes the Hetzner::InstallOs prog and sets a deadline for a Hetzner host" do
+      nx = described_class.new(assemble_hetzner_host(install_os: true))
+      expect { nx.install_os }.to hop("start", "Hetzner::InstallOs")
+      expect(nx.strand.stack.first["deadline_target"]).to eq("setup_ssh_keys")
+    end
+
+    it "hops to setup_ssh_keys without installing when the host is not on Hetzner" do
+      st = described_class.assemble("192.168.0.2", install_os: true)
+      expect { described_class.new(st).install_os }.to hop("setup_ssh_keys")
+    end
+
+    it "hops to setup_ssh_keys once the OS is installed" do
+      nx = described_class.new(assemble_hetzner_host(install_os: true))
+      nx.strand.retval = {"msg" => "operating system installed"}
+      expect { nx.install_os }.to hop("setup_ssh_keys")
     end
   end
 
@@ -150,7 +188,7 @@ RSpec.describe Prog::Vm::HostNexus do
       }
     end
 
-    it "hops once BootstrapRhizome has returned" do
+    it "hops to prep once BootstrapRhizome has returned" do
       nx.strand.retval = {"msg" => "rhizome user bootstrapped and source installed"}
       expect { nx.bootstrap_rhizome }.to hop("prep")
     end
@@ -182,6 +220,19 @@ RSpec.describe Prog::Vm::HostNexus do
 
       child_progs = Strand.where(parent_id: st.id).select_map(:prog)
       expect(child_progs).to include("LearnNetwork")
+    end
+
+    it "passes format_storage to LearnStorage for a Hetzner host with install_os" do
+      st = assemble_hetzner_host(install_os: true)
+      expect { described_class.new(st).prep }.to hop("wait_prep")
+      learn_storage = Strand.where(parent_id: st.id, prog: "LearnStorage").first
+      expect(learn_storage.stack.first["format_storage"]).to be true
+    end
+
+    it "does not format storage for a host that was not assembled with install_os" do
+      expect { nx.prep }.to hop("wait_prep")
+      learn_storage = Strand.where(parent_id: st.id, prog: "LearnStorage").first
+      expect(learn_storage.stack.first["format_storage"]).to be false
     end
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -95,9 +95,9 @@ RSpec.describe Prog::Vm::HostNexus do
   end
 
   describe "#start" do
-    it "hops to install_os when assembled with install_os" do
+    it "hops to install_host_os when assembled with install_os" do
       st = described_class.assemble("192.168.0.2", install_os: true)
-      expect { described_class.new(st).start }.to hop("install_os")
+      expect { described_class.new(st).start }.to hop("install_host_os")
     end
 
     it "hops to setup_ssh_keys when not installing the OS" do
@@ -105,22 +105,22 @@ RSpec.describe Prog::Vm::HostNexus do
     end
   end
 
-  describe "#install_os" do
+  describe "#install_host_os" do
     it "pushes the Hetzner::InstallOs prog and sets a deadline for a Hetzner host" do
       nx = described_class.new(assemble_hetzner_host(install_os: true))
-      expect { nx.install_os }.to hop("start", "Hetzner::InstallOs")
+      expect { nx.install_host_os }.to hop("start", "Hetzner::InstallOs")
       expect(nx.strand.stack.first["deadline_target"]).to eq("setup_ssh_keys")
     end
 
     it "hops to setup_ssh_keys without installing when the host is not on Hetzner" do
       st = described_class.assemble("192.168.0.2", install_os: true)
-      expect { described_class.new(st).install_os }.to hop("setup_ssh_keys")
+      expect { described_class.new(st).install_host_os }.to hop("setup_ssh_keys")
     end
 
     it "hops to setup_ssh_keys once the OS is installed" do
       nx = described_class.new(assemble_hetzner_host(install_os: true))
       nx.strand.retval = {"msg" => "operating system installed"}
-      expect { nx.install_os }.to hop("setup_ssh_keys")
+      expect { nx.install_host_os }.to hop("setup_ssh_keys")
     end
   end
 


### PR DESCRIPTION
We buy servers from Hetzner, boot them into rescue mode, install the OS with installimage, and format the extra storage disks before assembling the Vm host. These steps used to be run manually by an operator.

Add an opt-in install_os option to Prog::Vm::HostNexus.assemble (default false). When it is set on a Hetzner host, start hops to a new install_os label that pushes Prog::Hetzner::InstallOs, which runs installimage in the rescue system and reboots into the installed OS before setup continues. It refuses to run unless the host is really in rescue mode, so it can never reimage a live host.

The extra storage disks are formatted and mounted under /var/storage/devices by a new host/bin/format-storage-disks script run from LearnStorage, which already reboots later in setup. The formatter is idempotent: disks already recorded in fstab or already mounted are left untouched, so it is safe to re-run on a live host. Package upgrades are handled by the existing patch step.