### PR TITLE
Stop parseable restart storm while server boots

### DIFF
--- a/prog/parseable/parseable_server_nexus.rb
+++ b/prog/parseable/parseable_server_nexus.rb
@@ -217,6 +217,13 @@ TIMER
       hop_wait
     end
 
+    # An operator can incr_restart to force another restart when the first
+    # one didn't bring the server back.
+    when_restart_set? do
+      decr_restart
+      clear_restart_state
+    end
+
     daemonized_restart
     nap 5
   end
@@ -252,7 +259,8 @@ TIMER
   def daemonized_restart
     case vm.sshable.d_check("restart_parseable")
     when "Succeeded"
-      vm.sshable.d_clean("restart_parseable")
+      # Restart already issued; parseable needs a few minutes to come up.
+      # Keep the marker and wait instead of restarting every checkup cycle.
       return true
     when "Failed", "NotStarted"
       vm.sshable.d_run("restart_parseable", "/home/ubi/parseable/bin/restart")

--- a/spec/prog/parseable/parseable_server_nexus_spec.rb
+++ b/spec/prog/parseable/parseable_server_nexus_spec.rb
@@ -318,6 +318,28 @@ RSpec.describe Prog::Parseable::ParseableServerNexus do
       expect(sshable).to receive(:d_run).with("restart_parseable", "/home/ubi/parseable/bin/restart")
       expect { nx.unavailable }.to nap(5)
     end
+
+    it "does not re-restart while a previous restart is still coming up" do
+      client = instance_double(Parseable::Client)
+      expect(nx.parseable_server).to receive(:client).and_return(client)
+      expect(client).to receive(:healthy?).and_return(false)
+      expect(sshable).to receive(:d_check).with("restart_parseable").and_return("Succeeded")
+      expect(sshable).not_to receive(:d_run)
+      expect(sshable).not_to receive(:d_clean)
+      expect { nx.unavailable }.to nap(5)
+    end
+
+    it "forces a fresh restart when the restart semaphore is set" do
+      nx.incr_restart
+      client = instance_double(Parseable::Client)
+      expect(nx.parseable_server).to receive(:client).and_return(client)
+      expect(client).to receive(:healthy?).and_return(false)
+      expect(sshable).to receive(:d_check).with("restart_parseable").and_return("Succeeded", "NotStarted")
+      expect(sshable).to receive(:d_clean).with("restart_parseable")
+      expect(sshable).to receive(:d_run).with("restart_parseable", "/home/ubi/parseable/bin/restart")
+      expect { nx.unavailable }.to nap(5)
+      expect(Semaphore.where(strand_id: nx.strand.id, name: "restart").count).to eq(0)
+    end
   end
 
   describe "#clear_restart_state" do
@@ -346,9 +368,10 @@ RSpec.describe Prog::Parseable::ParseableServerNexus do
       expect(nx.daemonized_restart).to be false
     end
 
-    it "returns true and cleans up when restart succeeds" do
+    it "returns true without re-restarting or cleaning while a restart is already in flight" do
       expect(sshable).to receive(:d_check).with("restart_parseable").and_return("Succeeded")
-      expect(sshable).to receive(:d_clean).with("restart_parseable")
+      expect(sshable).not_to receive(:d_clean)
+      expect(sshable).not_to receive(:d_run)
       expect(nx.daemonized_restart).to be true
     end
   end


### PR DESCRIPTION
A production parseable server got stuck in a restart storm and never became available. The restart script runs `systemctl restart parseable`, which returns as soon as the process starts, but parseable needs a few minutes before its HTTP endpoints answer. We use those endpoints for the health check, so the server reads as down for the entire startup window.

daemonized_restart turned that window into a loop. On the cycle after issuing a restart it saw the daemonizer marker in the Succeeded state, cleaned it, and the next cycle re-issued a fresh restart. The server was killed and restarted roughly every ten seconds and could never finish booting:

    parseable.service: Deactivated successfully.
    Stopped parseable.service - Parseable Log Analytics Server.
    Started parseable.service - Parseable Log Analytics Server.
    Stopping parseable.service - Parseable Log Analytics Server...
    parseable.service: Deactivated successfully.
    Stopped parseable.service - Parseable Log Analytics Server.
    Started parseable.service - Parseable Log Analytics Server.

Leave the Succeeded marker in place instead of cleaning it, so once a restart has been issued we keep polling health rather than restarting on every checkup cycle. clear_restart_state still clears the marker once the server recovers. If it never recovers, the existing wait deadline pages an operator, which is the right escalation instead of an endless restart loop.