### PR TITLE
Cap wal-g daemon stop timeout to avoid 90s SIGKILL

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -528,7 +528,16 @@ class PostgresServer < Sequel::Model
     walg_config = timeline.generate_walg_config(version)
     vm.sshable.cmd("sudo -u postgres tee /etc/postgresql/wal-g.env > /dev/null", stdin: walg_config)
     refresh_walg_blob_storage_credentials
-    vm.sshable.cmd("sudo systemctl restart wal-g") unless resource.use_old_walg_command_set?
+    unless resource.use_old_walg_command_set?
+      ensure_walg_stop_timeout_override
+      vm.sshable.cmd("sudo systemctl restart wal-g")
+    end
+  end
+
+  def ensure_walg_stop_timeout_override
+    vm.sshable.cmd("sudo mkdir -p /etc/systemd/system/wal-g.service.d")
+    vm.sshable.write_file("/etc/systemd/system/wal-g.service.d/stop-timeout.conf", "[Service]\nTimeoutStopSec=5s\n")
+    vm.sshable.cmd("sudo systemctl daemon-reload")
   end
 
   def walg_credentials_ready?

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -855,6 +855,9 @@ RSpec.describe PostgresServer do
       expect(timeline).to receive(:generate_walg_config).and_return("walg_config")
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo -u postgres tee /etc/postgresql/wal-g.env > /dev/null", stdin: "walg_config")
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo tee /usr/lib/ssl/certs/blob_storage_ca.crt > /dev/null", stdin: "root_certs")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo mkdir -p /etc/systemd/system/wal-g.service.d")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/wal-g.service.d/stop-timeout.conf > /dev/null", stdin: "[Service]\nTimeoutStopSec=5s\n")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo systemctl restart wal-g")
       expect { postgres_server.refresh_walg_credentials }.not_to raise_error
     end
@@ -865,6 +868,9 @@ RSpec.describe PostgresServer do
       expect(timeline).to receive(:generate_walg_config).and_return("walg_config")
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo -u postgres tee /etc/postgresql/wal-g.env > /dev/null", stdin: "walg_config")
       expect(postgres_server.vm.sshable).not_to receive(:_cmd).with("sudo tee /usr/lib/ssl/certs/blob_storage_ca.crt > /dev/null", stdin: "root_certs")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo mkdir -p /etc/systemd/system/wal-g.service.d")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/wal-g.service.d/stop-timeout.conf > /dev/null", stdin: "[Service]\nTimeoutStopSec=5s\n")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo systemctl restart wal-g")
       expect { postgres_server.refresh_walg_credentials }.not_to raise_error
     end


### PR DESCRIPTION
Since the upgrade to wal-g e4843b8, the daemon traps SIGTERM via signal.NotifyContext but never acts on the cancelled context, so it ignores `systemctl stop`/`restart` and only dies at systemd's default 90s stop timeout via SIGKILL. That 90s exceeds the SSH command timeout (MAX_TIMEOUT = LEASE_EXPIRATION - 39 = 81s), so `systemctl restart wal-g` raises SshTimeout and the strand retries it in a loop -- which is the repeating Stop/kill/Start churn seen in the journal during cert refresh.

Proper fix would be in the upstream wal-g code, until then we write a TimeoutStopSec=5s drop-in (+ daemon-reload) in refresh_walg_credentials.

An aborted WAL push is safe: the daemon holds no durable state and Postgres' archive_command retries the segment.