### PR TITLE
Fix uninitialized constant Prog::LocationNexus::Aws

### DIFF
--- a/prog/location_nexus.rb
+++ b/prog/location_nexus.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "aws-sdk-ec2"
+
 class Prog::LocationNexus < Prog::Base
   subject_is :location
 


### PR DESCRIPTION
`Aws::EC2::Errors::UnauthorizedOperation` was failing to resolve on `nap`