### PR TITLE
Poll VmGroup's pre-reboot VM checks instead of napping 120s

### DIFF
--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -64,7 +64,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   label def wait_verify_vms
-    reap(:verify_host_capacity)
+    reap(:verify_host_capacity, nap: 10)
   end
 
   label def verify_host_capacity

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -75,19 +75,9 @@ RSpec.describe Prog::Test::VmGroup do
       expect { vg_test.wait_verify_vms }.to hop("verify_host_capacity")
     end
 
-    it "stays in wait_verify_vms" do
+    it "polls on a short interval while a child is still running" do
       Strand.create(parent_id: st.id, prog: "Test::Vm", label: "start", stack: [{}], lease: Time.now + 10)
-      expect { vg_test.wait_verify_vms }.to nap(120)
-
-      expect(st).to receive(:lock!).and_wrap_original do |m|
-        # Pretend child strand updated schedule before lock.
-        # After the lock, shouldn't be possible as the child
-        # strand's update of the parent will block until
-        # parent strand commits.
-        st.this.update(schedule: Time.now - 1)
-        m.call
-      end
-      expect { vg_test.wait_verify_vms }.to nap(0)
+      expect { vg_test.wait_verify_vms }.to nap(10)
     end
   end
 
@@ -215,6 +205,21 @@ RSpec.describe Prog::Test::VmGroup do
   describe "#verify_vms_after_reboot" do
     it "reaps and hops to verify_host_capacity" do
       expect { vg_test.verify_vms_after_reboot }.to hop("verify_host_capacity")
+    end
+
+    it "stays in verify_vms_after_reboot while a child is still running" do
+      Strand.create(parent_id: st.id, prog: "Test::Vm", label: "start", stack: [{}], lease: Time.now + 10)
+      expect { vg_test.verify_vms_after_reboot }.to nap(120)
+
+      expect(st).to receive(:lock!).and_wrap_original do |m|
+        # Pretend child strand updated schedule before lock.
+        # After the lock, shouldn't be possible as the child
+        # strand's update of the parent will block until
+        # parent strand commits.
+        st.this.update(schedule: Time.now - 1)
+        m.call
+      end
+      expect { vg_test.verify_vms_after_reboot }.to nap(0)
     end
   end
 


### PR DESCRIPTION
VmGroup's wait_verify_vms reaps the per-VM check children on the e2e critical path: it gates the parallel block. With the default reap, when the children are all running on their own respirate threads the parent falls back to a 120s nap and relies on the last exiting child to wake it sooner. That wake is unreliable when several children finish close together, so the parent can sit idle ~2 minutes after the checks actually complete.

This was masked while the pre-reboot pass ran the full ~6 minute VM suite, but now that it does only the quick disk/network/persistence checks, the ~120s reap nap dominates that phase.

Pass a short nap to reap so the parent polls every 10s instead, capping the post-completion lag at ~10s. The post-reboot reap runs in parallel and is left on the default.