### PR TITLE
PG log aggregation schema fixes

### DIFF
--- a/lib/validation/postgres_config_validator_schema.rb
+++ b/lib/validation/postgres_config_validator_schema.rb
@@ -935,11 +935,13 @@ module Validation
         description: "Sets the destination for server log output.",
         type: :string,
         default: "stderr",
+        deny: true,
       },
       "log_directory" => {
         description: "Sets the destination directory for log files.",
         type: :string,
         default: "pg_log",
+        deny: true,
       },
       "log_disconnections" => {
         description: "Logs end of a session, including duration.",
@@ -973,6 +975,7 @@ module Validation
         description: "Sets the file name pattern for log files.",
         type: :string,
         default: "postgresql.log",
+        deny: true,
       },
       "log_hostname" => {
         description: "Logs the host name in the connection logs.",
@@ -1097,6 +1100,7 @@ module Validation
         description: "Sets the time zone to use in log messages.",
         type: :string,
         default: "UTC",
+        deny: true,
       },
       "log_transaction_sample_rate" => {
         description: "Sets the fraction of transactions from which to log all statements.",
@@ -1115,6 +1119,7 @@ module Validation
         type: :bool,
         default: "on",
         requires_restart: true,
+        deny: true,
       },
       "logical_decoding_work_mem" => {
         description: "Sets the maximum memory to be used for logical decoding.",

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -44,6 +44,15 @@ FileUtils.rm_f(upgrade_override)
 user_configs = PostgresConfig.format(configure_hash["user_config"])
 safe_write_to_file("/etc/postgresql/#{v}/main/conf.d/099-user.conf", user_configs)
 
+# Append include_dir = 'conf.d' to postgresql.conf to ensure that the custom
+# settings override the default pg_createcluster stub.
+base_conf = "/etc/postgresql/#{v}/main/postgresql.conf"
+base_lines = File.readlines(base_conf).reject { _1.match?(/\Ainclude_dir\s*=\s*'conf\.d'\s*\z/) }
+base_lines << "\n" unless base_lines.last&.end_with?("\n")
+base_lines << "include_dir = 'conf.d'\n"
+safe_write_to_file(base_conf, base_lines.join)
+r "chown postgres:postgres #{base_conf}"
+
 # Update pg_hba.conf
 private_subnets = configure_hash["private_subnets"].flat_map {
   [

--- a/rhizome/postgres/lib/otel_log_config.rb
+++ b/rhizome/postgres/lib/otel_log_config.rb
@@ -135,6 +135,9 @@ class OtelLogConfig
         {"type" => "add", "field" => "attributes.resource_name", "value" => @resource_name},
         {"type" => "add", "field" => "attributes.resource_id", "value" => @resource_id},
         {"type" => "remove", "field" => "attributes.timestamp", "if" => "attributes.timestamp != nil"},
+        {"type" => "add", "field" => "attributes.dbname", "value" => "", "if" => "attributes.dbname == nil"},
+        {"type" => "add", "field" => "attributes.user", "value" => "", "if" => "attributes.user == nil"},
+        {"type" => "add", "field" => "attributes.remote_host_port", "value" => "", "if" => "attributes.remote_host_port == nil"},
         {
           "type" => "retain",
           "fields" => [

--- a/rhizome/postgres/spec/otel_log_config_spec.rb
+++ b/rhizome/postgres/spec/otel_log_config_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe OtelLogConfig do
       )
     end
 
+    it "defaults session attributes to empty strings in the pglog receiver when the regex did not capture them" do
+      pglog_ops = parsed["receivers"]["filelog/pglog"]["operators"]
+      %w[dbname user remote_host_port].each do |field|
+        op = pglog_ops.find { |o| o["type"] == "add" && o["field"] == "attributes.#{field}" }
+        expect(op).to include("value" => "", "if" => "attributes.#{field} == nil")
+      end
+    end
+
     it "maps pglog severity levels without using non-standard info3" do
       severity_op = parsed["receivers"]["filelog/pglog"]["operators"].find { |op| op["type"] == "regex_parser" }
       mapping = severity_op["severity"]["mapping"]


### PR DESCRIPTION
* Ensure all log fields are present when exporting postgres logs

Default the session attributes to an empty string when the regex did not
capture them (e.g. custom log-prefix, non-matching/continuation lines).
Parseable infers the stream schema from ingested attributes, so a
never-present attribute means no column and queries selecting it fail
with a Datafusion schema error.

* Restrict PG logging configurations

Deny changing certain PG logging related configs that the log export
pipeline depends on.

* Fix base postgresql.conf log_line_prefix override

Ensure our conf.d overrides always take precedence over settings baked into
the base postgresql.conf. pg_createcluster can emit the base conf with
`include_dir = 'conf.d'` *before* directives such as log_line_prefix (this
happens on the restore-from-backup path, where the base conf is generated
from an empty file rather than the package template). Since Postgres applies
settings in file order, those later directives would otherwise clobber the
conf.d values. This breaks log parsing as the log_line_prefix is
overriden by a default.

Move the conf.d include to the end of the file so it is always
processed last.