### PR TITLE
Set up e2e DNS zones before the host reboot

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -28,6 +28,15 @@ def test_metal(options, test_cases)
     wait_until(minio_cluster_st, "wait")
   end
 
+  if options[:test_cases].include?("kubernetes")
+    Project[Config.kubernetes_service_project_id] ||
+      Project.create_with_id(Config.kubernetes_service_project_id, name: "Ubicloud-Kubernetes-Resources")
+    Project[Config.load_balancer_service_project_id] ||
+      Project.create_with_id(Config.load_balancer_service_project_id, name: "Load-Balancer-Service-Project")
+    k8s_dns_zone_st = Prog::Test::DnsZone.assemble(Config.kubernetes_service_hostname, Config.kubernetes_service_project_id)
+    lb_dns_zone_st = Prog::Test::DnsZone.assemble(Config.load_balancer_service_hostname, Config.load_balancer_service_project_id)
+  end
+
   tests_to_wait = []
   if options[:test_cases].include?("vm") && (test_case = test_cases["vm"])
     # This tests encrypted VMs with slices, which will create both standard and
@@ -69,13 +78,7 @@ def test_metal(options, test_cases)
   # exercise the assertion against deny-by-default cloud firewalls
   # where it has teeth.
 
-  if options[:test_cases].include?("kubernetes")
-    Project[Config.kubernetes_service_project_id] ||
-      Project.create_with_id(Config.kubernetes_service_project_id, name: "Ubicloud-Kubernetes-Resources")
-    Project[Config.load_balancer_service_project_id] ||
-      Project.create_with_id(Config.load_balancer_service_project_id, name: "Load-Balancer-Service-Project")
-    k8s_dns_zone_st = Prog::Test::DnsZone.assemble(Config.kubernetes_service_hostname, Config.kubernetes_service_project_id)
-    lb_dns_zone_st = Prog::Test::DnsZone.assemble(Config.load_balancer_service_hostname, Config.load_balancer_service_project_id)
+  if k8s_dns_zone_st
     wait_until(k8s_dns_zone_st, "wait")
     wait_until(lb_dns_zone_st, "wait")
     tests_to_wait << Prog::Test::Kubernetes.assemble


### PR DESCRIPTION
The metal e2e suite gated Kubernetes behind two DnsZone setups: the zones were assembled inside the kubernetes block, only after VmGroup's in-test host reboot completed, and Kubernetes could not start until they reached "wait" (~2 min of Cloudflare registration and DNS propagation).

Test::DnsZone only stands up a Knot DNS-server VM plus external Cloudflare records, so it is reboot-safe: the VM just needs to exist and survive the reboot, exactly like the Minio VMs already assembled before VmGroup. Move the DNS zone assembly ahead of the reboot gate so the zones reach "wait" while the host is still being set up. By the time the kubernetes block runs, wait_until returns immediately and Kubernetes starts a wave earlier, pulling in the tail by ~2 min.