### PR TITLE
Support multiple job IDs in admin Show Job Log action

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -352,13 +352,24 @@ class CloverAdmin < Roda
     },
     "GithubRepository" => {
       "github_page" => github_page_action,
-      "show_job_log" => object_action("Show Job Log", params: {job_id: {typecast: :pos_int!, type: "number", attr: {min: 1, max: 2**63 - 1}}}, type: :content) do |obj, job_id|
-        url = obj.installation.client.workflow_run_job_logs(obj.name, job_id)
-        "<a href=\"#{Erubi.h(url)}\">Download Job Log</a>"
-      rescue Octokit::NotFound
-        "Job not found"
-      rescue Octokit::Error => e
-        "GitHub error: #{e.message}"
+      "show_job_log" => object_action("Show Job Log", params: {job_ids: {typecast: :nonempty_str!, label: "Job IDs (comma-separated)"}}, type: :content) do |obj, job_ids|
+        client = obj.installation.client
+        items = job_ids.split(",").filter_map do |job_id|
+          job_id.strip!
+          next if job_id.empty?
+
+          unless (id = Integer(job_id, exception: false)) && id.between?(1, 2**63 - 1)
+            next "<li>Job #{Erubi.h(job_id)}: invalid job ID</li>"
+          end
+
+          begin
+            url = client.workflow_run_job_logs(obj.name, id)
+            "<li><a href=\"#{Erubi.h(url)}\" target=\"_blank\">Job #{id}: Show Log</a></li>"
+          rescue Octokit::Error => e
+            "<li>Job #{id}: #{e.class}: #{Erubi.h(e.message)}</li>"
+          end
+        end
+        "<ol>#{items.join}</ol>"
       end,
     },
     "GithubRunner" => {

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1405,20 +1405,20 @@ RSpec.describe CloverAdmin do
     click_link "Show Job Log"
     expect(page.title).to eq "Ubicloud Admin - GithubRepository #{repo.ubid}"
 
+    fill_in "job_ids", with: " "
+    click_button "Show Job Log"
+    expect(page).to have_flash_error("Invalid parameter submitted: job_ids")
+
     client = double
     expect(Github).to receive(:installation_client).and_return(client)
-    expect(client).to receive(:workflow_run_job_logs).with("test-org/test-repo", 12345).and_return("https://example.com/logs/12345.zip")
+    expect(client).to receive(:workflow_run_job_logs).with("test-org/test-repo", 12345).and_return("https://example.com/logs/12345")
 
-    fill_in "job_id", with: "bad"
+    fill_in "job_ids", with: "12345"
     click_button "Show Job Log"
-    expect(page).to have_flash_error("Invalid parameter submitted: job_id")
-
-    fill_in "job_id", with: "12345"
-    click_button "Show Job Log"
-    expect(page).to have_link("Download Job Log", href: "https://example.com/logs/12345.zip")
+    expect(page).to have_link("Job 12345: Show Log", href: "https://example.com/logs/12345")
   end
 
-  it "shows job not found for GithubRepository when job id is invalid" do
+  it "supports showing job logs for multiple job ids for GithubRepository" do
     ins = GithubInstallation.create(installation_id: 123, name: "test-org", type: "Organization")
     repo = GithubRepository.create(name: "test-org/test-repo", installation_id: ins.id)
 
@@ -1427,14 +1427,17 @@ RSpec.describe CloverAdmin do
 
     client = double
     expect(Github).to receive(:installation_client).and_return(client)
+    expect(client).to receive(:workflow_run_job_logs).with("test-org/test-repo", 12345).and_return("https://example.com/logs/12345")
     expect(client).to receive(:workflow_run_job_logs).with("test-org/test-repo", 99999).and_raise(Octokit::NotFound)
 
-    fill_in "job_id", with: "99999"
+    fill_in "job_ids", with: "12345, , 99999, bad,"
     click_button "Show Job Log"
-    expect(page).to have_content("Job not found")
+    expect(page).to have_link("Job 12345: Show Log", href: "https://example.com/logs/12345")
+    expect(page).to have_content("Job 99999: Octokit::NotFound: Octokit::NotFound")
+    expect(page).to have_content("Job bad: invalid job ID")
   end
 
-  it "shows job not found for GithubRepository when job id is deprecated" do
+  it "shows GitHub error for GithubRepository when job id is deprecated" do
     ins = GithubInstallation.create(installation_id: 123, name: "test-org", type: "Organization")
     repo = GithubRepository.create(name: "test-org/test-repo", installation_id: ins.id)
 
@@ -1445,9 +1448,9 @@ RSpec.describe CloverAdmin do
     expect(Github).to receive(:installation_client).and_return(client)
     expect(client).to receive(:workflow_run_job_logs).with("test-org/test-repo", 99999).and_raise(Octokit::Deprecated)
 
-    fill_in "job_id", with: "99999"
+    fill_in "job_ids", with: "99999"
     click_button "Show Job Log"
-    expect(page).to have_content("GitHub error: Octokit::Deprecated")
+    expect(page).to have_content("Job 99999: Octokit::Deprecated: Octokit::Deprecated")
   end
 
   it "supports suspending and unsuspending Accounts" do


### PR DESCRIPTION
The Show Job Log action for GithubRepository only accepted a single job ID and returned one download link. Operators often need logs for several jobs from the same workflow run at once.

Accept a comma-separated list of job IDs and render a list of results, one entry per ID. Each line is prefixed with "Job <id>:" and successful entries link to the log (opened in a new tab). A failure on one ID (invalid number, not found, or other GitHub error) is reported inline for that ID without aborting the rest.

<img width="2800" height="1432" alt="CleanShot 2026-07-01 at 17 28 41@2x" src="https://github.com/user-attachments/assets/1c66b55e-1272-4a26-856e-1c9bec53c100" />