### PR TITLE
Improve k8s management

### DIFF
--- a/model/page.rb
+++ b/model/page.rb
@@ -90,7 +90,7 @@ class Page < Sequel::Model
 
   def self.root_resources(obj)
     ids = case obj
-    when VmHost, GithubInstallation, PostgresResource
+    when VmHost, GithubInstallation, PostgresResource, KubernetesCluster
       [obj.id]
     when Vm, VmHostSlice, VhostBlockBackend, StorageDevice, SpdkInstallation, PciDevice
       [obj.vm_host_id]
@@ -106,6 +106,10 @@ class Page < Sequel::Model
       [obj.installation_id, obj.vm&.vm_host_id]
     when GithubRepository
       [obj.installation_id]
+    when KubernetesNode
+      [obj.vm&.vm_host_id, obj.kubernetes_cluster_id]
+    when KubernetesNodepool, KubernetesEtcdBackup
+      [obj.kubernetes_cluster_id]
     end
 
     ids&.compact!

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -325,11 +325,12 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     end
 
     public_keys = key_pairs.map { |kp| kp[:ssh_key].public_key }
+    public_keys << Config.operator_ssh_public_keys if Config.operator_ssh_public_keys
     key_pairs.each do |kp|
       vm = kp[:vm]
       vm.sshable.cmd("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: kp[:ssh_key].private_key)
       all_keys_str = ([vm.sshable.keys.first.public_key] + public_keys).join("\n") + "\n"
-      vm.sshable.cmd("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: all_keys_str)
+      vm.sshable.write_file("/home/ubi/.ssh/authorized_keys", all_keys_str, user: :current)
     end
 
     hop_wait

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -277,7 +277,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
         Prog::PageNexus.assemble(
           "Invalid version format for #{node.name} of cluster #{kubernetes_cluster.ubid}",
           ["K8sInvalidVersion", kubernetes_cluster.ubid, node.name],
-          [kubernetes_cluster.ubid, node.ubid],
+          node.ubid,
           extra_data: {node_version:, cluster_version: kubernetes_cluster.version},
         )
         next false

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -83,6 +83,10 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
   end
 
   label def unavailable
+    when_retire_set? do
+      hop_retire
+    end
+
     if available?
       decr_checkup
       hop_wait

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -75,7 +75,7 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
         Prog::PageNexus.assemble(
           "Invalid version format for #{node.name} of cluster #{kubernetes_nodepool.cluster.ubid}",
           ["K8sInvalidVersion", kubernetes_nodepool.cluster.ubid, node.name],
-          [kubernetes_nodepool.cluster.ubid, node.ubid],
+          node.ubid,
           extra_data: {node_version:, cluster_version: kubernetes_nodepool.cluster.version},
         )
         next false

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -124,6 +124,11 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     vm.sshable.cmd("sudo systemctl enable --now nftables")
     vm.sshable.cmd "sudo systemctl enable --now kubelet"
 
+    if kubernetes_nodepool.nil? && Config.operator_ssh_public_keys
+      all_keys_str = "#{vm.sshable.keys.first.public_key}\n#{Config.operator_ssh_public_keys}\n"
+      vm.sshable.write_file("/home/ubi/.ssh/authorized_keys", all_keys_str, user: :current)
+    end
+
     bud Prog::BootstrapRhizome, {"target_folder" => "kubernetes", "subject_id" => vm.id, "user" => "ubi"}
 
     hop_wait_bootstrap_rhizome

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -161,7 +161,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
       Prog::PageNexus.assemble(
         "init kubernetes cluster failed on node #{node.ubid}",
         ["KubernetesNodeInitClusterFailed", node.ubid],
-        [node.ubid, kubernetes_cluster.ubid],
+        node.ubid,
       )
       nap 30
     else
@@ -197,7 +197,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
       Prog::PageNexus.assemble(
         "join cp node to cluster failed on node #{node.ubid}",
         ["KubernetesNodeJoinControlPlaneFailed", node.ubid],
-        [node.ubid, kubernetes_cluster.ubid],
+        node.ubid,
       )
       nap 30
     else
@@ -232,7 +232,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
       Prog::PageNexus.assemble(
         "join worker node to cluster failed on node #{node.ubid}",
         ["KubernetesNodeJoinWorkerFailed", node.ubid],
-        [node.ubid, kubernetes_cluster.ubid],
+        node.ubid,
       )
       nap 30
     else

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -44,6 +44,13 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
 
   label def start
     register_deadline(nil, 20 * 60)
+    hop_create_node
+  end
+
+  label def create_node
+    if kubernetes_nodepool && kubernetes_nodepool.kubernetes_cluster_id != kubernetes_cluster.id
+      fail "nodepool #{kubernetes_nodepool.ubid} does not belong to cluster #{kubernetes_cluster.ubid}"
+    end
 
     name, vm_size, storage_size_gib = if kubernetes_nodepool
       ["#{kubernetes_nodepool.ubid}-#{SecureRandom.alphanumeric(5).downcase}",

--- a/spec/model/page_spec.rb
+++ b/spec/model/page_spec.rb
@@ -45,6 +45,15 @@ RSpec.describe Page do
       lb = Prog::Vnet::LoadBalancerNexus.assemble(private_subnet.id, name: "test", src_port: 1234, dst_port: 4321).subject
       lb.add_vm(pv.vm)
       expect(described_class.root_resources(LoadBalancerVmPort.first)).to eq [pv.vm.vm_host_id]
+
+      kn = KubernetesNode.new(kubernetes_cluster_id: KubernetesCluster.generate_uuid)
+      expect(described_class.root_resources(kn)).to eq [kn.kubernetes_cluster_id]
+
+      knp = KubernetesNodepool.new(kubernetes_cluster_id: KubernetesCluster.generate_uuid)
+      expect(described_class.root_resources(knp)).to eq [knp.kubernetes_cluster_id]
+
+      keb = KubernetesEtcdBackup.new(kubernetes_cluster_id: KubernetesCluster.generate_uuid)
+      expect(described_class.root_resources(keb)).to eq [keb.kubernetes_cluster_id]
     end
 
     it "returns empty array for exceptions" do

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -695,11 +695,28 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
       expect(first_sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: first_ssh_key.private_key)
       first_vm_authorized_keys = [first_sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n") + "\n"
-      expect(first_sshable).to receive(:_cmd).with("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: first_vm_authorized_keys)
+      expect(first_sshable).to receive(:_cmd).with("tee /home/ubi/.ssh/authorized_keys > /dev/null", stdin: first_vm_authorized_keys)
 
       expect(second_sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: second_ssh_key.private_key)
       second_vm_authorized_keys = [second_sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n") + "\n"
-      expect(second_sshable).to receive(:_cmd).with("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: second_vm_authorized_keys)
+      expect(second_sshable).to receive(:_cmd).with("tee /home/ubi/.ssh/authorized_keys > /dev/null", stdin: second_vm_authorized_keys)
+
+      expect { nx.sync_worker_mesh }.to hop("wait")
+    end
+
+    it "appends operator keys to the mesh when configured" do
+      operator_key = "ssh-ed25519 AAAAoperator operator@ubicloud"
+      allow(Config).to receive(:operator_ssh_public_keys).and_return(operator_key)
+      first_sshable = worker_mesh_nodes.first.vm.sshable
+      second_sshable = worker_mesh_nodes.last.vm.sshable
+
+      expect(first_sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: first_ssh_key.private_key)
+      first_vm_authorized_keys = [first_sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key, operator_key].join("\n") + "\n"
+      expect(first_sshable).to receive(:_cmd).with("tee /home/ubi/.ssh/authorized_keys > /dev/null", stdin: first_vm_authorized_keys)
+
+      expect(second_sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: second_ssh_key.private_key)
+      second_vm_authorized_keys = [second_sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key, operator_key].join("\n") + "\n"
+      expect(second_sshable).to receive(:_cmd).with("tee /home/ubi/.ssh/authorized_keys > /dev/null", stdin: second_vm_authorized_keys)
 
       expect { nx.sync_worker_mesh }.to hop("wait")
     end
@@ -715,11 +732,11 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
       expect(first_vm.sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: first_ssh_key.private_key)
       first_vm_authorized_keys = [first_vm.sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n") + "\n"
-      expect(first_vm.sshable).to receive(:_cmd).with("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: first_vm_authorized_keys)
+      expect(first_vm.sshable).to receive(:_cmd).with("tee /home/ubi/.ssh/authorized_keys > /dev/null", stdin: first_vm_authorized_keys)
 
       expect(second_vm.sshable).to receive(:_cmd).with("tee ~/.ssh/id_ed25519 > /dev/null && chmod 0600 ~/.ssh/id_ed25519", stdin: second_ssh_key.private_key)
       second_vm_authorized_keys = [second_vm.sshable.keys.first.public_key, first_ssh_key.public_key, second_ssh_key.public_key].join("\n") + "\n"
-      expect(second_vm.sshable).to receive(:_cmd).with("tee ~/.ssh/authorized_keys > /dev/null && chmod 0600 ~/.ssh/authorized_keys", stdin: second_vm_authorized_keys)
+      expect(second_vm.sshable).to receive(:_cmd).with("tee /home/ubi/.ssh/authorized_keys > /dev/null", stdin: second_vm_authorized_keys)
 
       expect { nx.sync_worker_mesh }.to hop("wait")
     end

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -161,6 +161,11 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
   end
 
   describe "#unavailable" do
+    it "hops to retire when retire semaphore is set" do
+      nx.incr_retire
+      expect { nx.unavailable }.to hop("retire")
+    end
+
     it "hops to wait when node becomes available" do
       nx.incr_checkup
       status_json = JSON.generate({"pods" => {"pod-1" => {"reachable" => true}}, "external_endpoints" => {}})

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -91,13 +91,18 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   end
 
   describe "#start" do
+    it "registers the deadline and hops to create_node" do
+      expect { prog.start }.to hop("create_node")
+      expect(Time.parse(prog.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 20 * 60)
+    end
+  end
+
+  describe "#create_node" do
     it "creates a control plane node and hops if a nodepool is not given" do
       expect(prog.kubernetes_nodepool).to be_nil
       expect(kubernetes_cluster.nodes.count).to eq(2)
 
-      expect { prog.start }.to hop("bootstrap_rhizome")
-      expect(prog.strand.stack.first["deadline_target"]).to be_nil
-      expect(Time.parse(prog.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 20 * 60)
+      expect { prog.create_node }.to hop("bootstrap_rhizome")
       kubernetes_cluster.reload
 
       expect(kubernetes_cluster.nodes.count).to eq(3)
@@ -112,7 +117,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     it "creates a worker node and hops if a nodepool is given" do
       refresh_frame(prog, new_values: {"nodepool_id" => kubernetes_nodepool.id})
 
-      expect { prog.start }.to hop("bootstrap_rhizome")
+      expect { prog.create_node }.to hop("bootstrap_rhizome")
         .and change { kubernetes_nodepool.reload.nodes.count }.from(0).to(1)
 
       new_vm = kubernetes_nodepool.nodes.last.vm
@@ -123,12 +128,20 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(new_vm.boot_image).to eq("kubernetes-#{Option.selectable_kubernetes_versions.first.tr(".", "_")}")
     end
 
+    it "fails if the given nodepool does not belong to the cluster" do
+      other_cluster = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "other-cluster", version: Option.selectable_kubernetes_versions.first, cp_node_count: 1, location_id: Location::HETZNER_FSN1_ID, project_id: project.id, target_node_size: "standard-4").subject
+      other_nodepool = KubernetesNodepool.create(name: "other-np", node_count: 1, kubernetes_cluster_id: other_cluster.id, target_node_size: "standard-2")
+      refresh_frame(prog, new_values: {"nodepool_id" => other_nodepool.id})
+
+      expect { prog.create_node }.to raise_error(RuntimeError, "nodepool #{other_nodepool.ubid} does not belong to cluster #{kubernetes_cluster.ubid}")
+    end
+
     it "assigns the default storage size if not specified" do
       kubernetes_cluster.update(target_node_storage_size_gib: nil)
 
       expect(kubernetes_cluster.nodes.count).to eq(2)
 
-      expect { prog.start }.to hop("bootstrap_rhizome")
+      expect { prog.create_node }.to hop("bootstrap_rhizome")
       kubernetes_cluster.reload
 
       expect(kubernetes_cluster.nodes.count).to eq(3)

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -152,15 +152,8 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   end
 
   describe "#bootstrap_rhizome" do
-    it "waits until the node is ready" do
-      prog.node.vm.strand.update(label: "non-wait")
-      expect { prog.bootstrap_rhizome }.to nap(5)
-    end
-
-    it "enables kubelet and buds a bootstrap rhizome process" do
-      prog.node.vm.strand.update(label: "wait")
-      sshable = prog.vm.sshable
-      expected_nft_rules = <<~NFT
+    let(:expected_nft_rules) do
+      <<~NFT
         #!/usr/sbin/nft -f
         flush ruleset
 
@@ -188,12 +181,23 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
           }
         }
       NFT
-      expect(sshable).to receive(:_cmd).with(
-        "sudo tee /etc/nftables.conf > /dev/null",
-        stdin: expected_nft_rules,
-      ).ordered
+    end
+
+    it "waits until the node is ready" do
+      prog.node.vm.strand.update(label: "non-wait")
+      expect { prog.bootstrap_rhizome }.to nap(5)
+    end
+
+    it "enables kubelet, grants control plane operator access, and buds a bootstrap rhizome process" do
+      prog.node.vm.strand.update(label: "wait")
+      operator_key = "ssh-ed25519 AAAAoperator operator@ubicloud"
+      allow(Config).to receive(:operator_ssh_public_keys).and_return(operator_key)
+      sshable = prog.vm.sshable
+      expect(sshable).to receive(:_cmd).with("sudo tee /etc/nftables.conf > /dev/null", stdin: expected_nft_rules).ordered
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now nftables").ordered
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now kubelet").ordered
+      authorized_keys = "#{sshable.keys.first.public_key}\n#{operator_key}\n"
+      expect(sshable).to receive(:_cmd).with("tee /home/ubi/.ssh/authorized_keys > /dev/null", stdin: authorized_keys).ordered
 
       br_strand_ds = Strand.where(prog: "BootstrapRhizome")
       expect { prog.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")
@@ -202,6 +206,28 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(br_frame["target_folder"]).to eq "kubernetes"
       expect(br_frame["subject_id"]).to eq prog.node.vm.id
       expect(br_frame["user"]).to eq "ubi"
+    end
+
+    it "does not grant operator access to control plane nodes when operator keys are not configured" do
+      prog.node.vm.strand.update(label: "wait")
+      sshable = prog.vm.sshable
+      expect(sshable).to receive(:_cmd).with("sudo tee /etc/nftables.conf > /dev/null", stdin: expected_nft_rules).ordered
+      expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now nftables").ordered
+      expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now kubelet").ordered
+
+      expect { prog.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")
+    end
+
+    it "does not grant operator access to worker nodes" do
+      prog.node.vm.strand.update(label: "wait")
+      refresh_frame(prog, new_values: {"nodepool_id" => kubernetes_nodepool.id})
+      allow(Config).to receive(:operator_ssh_public_keys).and_return("ssh-ed25519 AAAAoperator operator@ubicloud")
+      sshable = prog.vm.sshable
+      expect(sshable).to receive(:_cmd).with("sudo tee /etc/nftables.conf > /dev/null", stdin: expected_nft_rules).ordered
+      expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now nftables").ordered
+      expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now kubelet").ordered
+
+      expect { prog.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")
     end
   end
 


### PR DESCRIPTION
**Group KubernetesNode pages under their cluster**

**Allow retiring an unavailable KubernetesNode**
Check retire before availability in the unavailable label so a customer can retire a node that is stuck unavailable.

**Verify nodepool belongs to cluster in ProvisionKubernetesNode**
Fail in start when the nodepool's cluster does not match the subject cluster. This strand won't auto-recover; it's a deliberate guard against mismatched nodes while manually working with a cluster.

**Add operator SSH keys to kubernetes nodes**
Include Config.operator_ssh_public_keys in worker authorized_keys during sync_worker_mesh and in control plane authorized_keys during bootstrap.