### PR TITLE
Tighten e2e CI timeouts to match current run times

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -111,7 +111,7 @@ jobs:
     name: E2E - ${{ matrix.provider }}
     runs-on: ubicloud-standard-4
     environment: E2E-${{ matrix.provider }}
-    timeout-minutes: 110
+    timeout-minutes: 75
     concurrency: ${{ (matrix.provider == 'metal' && 'E2E-metal') || (matrix.provider == 'gcp' && format('E2E-gcp-{0}', github.run_id)) || (needs.setup.outputs.has_github_runner == 'true' && 'E2E-aws') || format('E2E-aws-{0}', github.run_id) }}
     env:
       # Set repo variable E2E_PAUSE_METAL=true to halt metal e2e runs while
@@ -249,7 +249,7 @@ jobs:
         OPERATOR_SSH_PUBLIC_KEYS: ${{ secrets.OPERATOR_SSH_PUBLIC_KEYS }}
       run: |
         set -o pipefail
-        timeout 100m foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"
+        timeout 60m foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"
 
     - name: Print logs
       if: always() && env.METAL_PAUSED != 'true'


### PR DESCRIPTION
The e2e suite has gotten much faster: metal now finishes in ~38m, gcp ~31m, aws ~23m, well under the old 100m/110m limits. Drop the foreman run timeout to 60m and the job timeout to 75m so a hung run is caught far sooner while still leaving generous headroom over the slowest provider (metal) and room for the on-failure debug sleep.