### PR TITLE
Fence AWS PG databases by detaching the user NIC

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -194,6 +194,7 @@ module Config
   optional :postgres_lantern_notification_email, string
   optional :postgres_notification_email, string
   override :aws_postgres_iam_access, false, bool
+  override :aws_postgres_detach_nic_fencing, true, bool
   override :postgres_internal_firewall_cidrs, "", array(string)
 
   # Logging

--- a/model/postgres/aws/postgres_resource.rb
+++ b/model/postgres/aws/postgres_resource.rb
@@ -35,7 +35,7 @@ class PostgresResource < Sequel::Model
     end
 
     def aws_lockout_mechanisms
-      ["pg_stop", "hba"].freeze
+      ["pg_stop", "hba", "detach_nic"].freeze
     end
 
     def aws_new_server_exclusion_filters

--- a/model/postgres/aws/postgres_resource.rb
+++ b/model/postgres/aws/postgres_resource.rb
@@ -35,7 +35,9 @@ class PostgresResource < Sequel::Model
     end
 
     def aws_lockout_mechanisms
-      ["pg_stop", "hba", "detach_nic"].freeze
+      mechanisms = ["pg_stop", "hba"]
+      mechanisms << "detach_nic" if Config.aws_postgres_detach_nic_fencing
+      mechanisms.freeze
     end
 
     def aws_new_server_exclusion_filters

--- a/prog/postgres/postgres_lockout.rb
+++ b/prog/postgres/postgres_lockout.rb
@@ -8,7 +8,7 @@ class Prog::Postgres::PostgresLockout < Prog::Base
     send("lockout_with_#{mechanism}")
     Clog.emit("Fenced unresponsive primary", {fenced_unresponsive_primary: {server_ubid: postgres_server.ubid, mechanism:}})
     pop "lockout_succeeded"
-  rescue *Sshable::SSH_CONNECTION_ERRORS, Sshable::SshError
+  rescue *Sshable::SSH_CONNECTION_ERRORS, Sshable::SshError, Aws::EC2::Errors::ServiceError
     pop "lockout_failed"
   end
 
@@ -32,6 +32,17 @@ class Prog::Postgres::PostgresLockout < Prog::Base
     postgres_server.vm.vm_host.sshable.cmd(
       "timeout 10 sudo ip link set :interface down", interface: "vetho#{postgres_server.vm.inhost_name}",
       timeout: 15,
+    )
+  end
+
+  def lockout_with_detach_nic
+    client = postgres_server.vm.location.location_credential_aws.client
+    network_interface = client.describe_network_interfaces(
+      network_interface_ids: [postgres_server.vm.user_nic.nic_aws_resource.network_interface_id],
+    ).network_interfaces.first
+    client.detach_network_interface(
+      attachment_id: network_interface.attachment.attachment_id,
+      force: true,
     )
   end
 end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -471,6 +471,21 @@ RSpec.describe PostgresResource do
       )
       expect(aws_resource.lockout_mechanisms).to eq(["pg_stop", "hba", "detach_nic"])
     end
+
+    it "omits detach_nic for AWS resources when detach_nic fencing is disabled" do
+      allow(Config).to receive(:aws_postgres_detach_nic_fencing).and_return(false)
+      aws_location = Location.create(
+        name: "us-east-1-lockout", provider: "aws", display_name: "aws",
+        ui_name: "aws", visible: true,
+      )
+      aws_resource = described_class.create(
+        name: "pg-aws-lockout", superuser_password: "dummy-password", ha_type: "none",
+        target_version: "17", location_id: aws_location.id, project_id: project.id,
+        user_config: {}, pgbouncer_user_config: {}, target_vm_size: "standard-2",
+        target_storage_size_gib: 64,
+      )
+      expect(aws_resource.lockout_mechanisms).to eq(["pg_stop", "hba"])
+    end
   end
 
   describe "#boot_image" do

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -458,7 +458,7 @@ RSpec.describe PostgresResource do
       expect(postgres_resource.lockout_mechanisms).to eq(["pg_stop", "hba", "host_routing"])
     end
 
-    it "returns pg_stop and hba for AWS resources" do
+    it "returns pg_stop, hba, and detach_nic for AWS resources" do
       aws_location = Location.create(
         name: "us-east-1-lockout", provider: "aws", display_name: "aws",
         ui_name: "aws", visible: true,
@@ -469,7 +469,7 @@ RSpec.describe PostgresResource do
         user_config: {}, pgbouncer_user_config: {}, target_vm_size: "standard-2",
         target_storage_size_gib: 64,
       )
-      expect(aws_resource.lockout_mechanisms).to eq(["pg_stop", "hba"])
+      expect(aws_resource.lockout_mechanisms).to eq(["pg_stop", "hba", "detach_nic"])
     end
   end
 

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -532,7 +532,7 @@ RSpec.describe PostgresResource do
       expect(postgres_resource.lockout_mechanisms).to eq(["pg_stop", "hba", "host_routing"])
     end
 
-    it "returns pg_stop and hba for AWS resources" do
+    it "returns pg_stop, hba, and detach_nic for AWS resources" do
       aws_location = Location.create(
         name: "us-east-1-lockout", provider: "aws", display_name: "aws",
         ui_name: "aws", visible: true,
@@ -543,7 +543,7 @@ RSpec.describe PostgresResource do
         user_config: {}, pgbouncer_user_config: {}, target_vm_size: "standard-2",
         target_storage_size_gib: 64,
       )
-      expect(aws_resource.lockout_mechanisms).to eq(["pg_stop", "hba"])
+      expect(aws_resource.lockout_mechanisms).to eq(["pg_stop", "hba", "detach_nic"])
     end
   end
 

--- a/spec/prog/postgres/postgres_lockout_spec.rb
+++ b/spec/prog/postgres/postgres_lockout_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Prog::Postgres::PostgresLockout do
 
   describe "#start" do
     it "uses the appropriate lockout mechanism" do
-      ["pg_stop", "hba", "host_routing"].each do |mechanism|
+      ["pg_stop", "hba", "host_routing", "detach_nic"].each do |mechanism|
         refresh_frame(nx, new_frame: {"mechanism" => mechanism})
         expect(nx).to receive("lockout_with_#{mechanism}").and_return(true)
         expect(Clog).to receive(:emit).with("Fenced unresponsive primary", {fenced_unresponsive_primary: {server_ubid: server.ubid, mechanism:}})
@@ -39,6 +39,12 @@ RSpec.describe Prog::Postgres::PostgresLockout do
         "timeout 10 sudo pg_ctlcluster 17 main stop -m immediate",
         timeout: 15,
       ).and_raise(Sshable::SshError.new("", "", "", "", ""))
+      expect { nx.start }.to exit({"msg" => "lockout_failed"})
+    end
+
+    it "returns false for AWS API failures" do
+      refresh_frame(nx, new_frame: {"mechanism" => "detach_nic"})
+      expect(nx).to receive(:lockout_with_detach_nic).and_raise(Aws::EC2::Errors::ServiceError.new(nil, "boom"))
       expect { nx.start }.to exit({"msg" => "lockout_failed"})
     end
   end
@@ -78,6 +84,30 @@ RSpec.describe Prog::Postgres::PostgresLockout do
         timeout: 15,
       ).and_return(true)
       expect { nx.lockout_with_host_routing }.not_to raise_error
+    end
+  end
+
+  describe "#lockout_with_detach_nic" do
+    let(:aws_location) {
+      loc = Location.create(name: "us-west-2", display_name: "aws-us-west-2", ui_name: "aws-us-west-2", visible: true, provider: "aws", project_id: project.id)
+      LocationCredentialAws.create_with_id(loc, access_key: "k", secret_key: "s")
+      LocationAz.create(location_id: loc.id, az: "a", zone_id: "usw2-az1")
+      loc
+    }
+    let(:aws_resource) { create_postgres_resource(project:, location_id: aws_location.id) }
+    let(:aws_server) { create_postgres_server(resource: aws_resource, timeline: postgres_timeline) }
+    let(:aws_nx) { described_class.new(aws_server.strand) }
+    let(:ec2_client) { Aws::EC2::Client.new(stub_responses: true) }
+
+    before do
+      NicAwsResource.create_with_id(aws_server.vm.nics.first, network_interface_id: "eni-abc")
+      allow(Aws::EC2::Client).to receive(:new).with(credentials: anything, region: "us-west-2").and_return(ec2_client)
+    end
+
+    it "looks up the attachment id and detaches the tracked ENI" do
+      ec2_client.stub_responses(:describe_network_interfaces, network_interfaces: [{network_interface_id: "eni-abc", attachment: {attachment_id: "eni-attach-123"}}])
+      expect(ec2_client).to receive(:detach_network_interface).with(attachment_id: "eni-attach-123", force: true).and_call_original
+      expect { aws_nx.lockout_with_detach_nic }.not_to raise_error
     end
   end
 end

--- a/spec/prog/postgres/postgres_lockout_spec.rb
+++ b/spec/prog/postgres/postgres_lockout_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Prog::Postgres::PostgresLockout do
 
   describe "#start" do
     it "uses the appropriate lockout mechanism" do
-      ["pg_stop", "hba", "host_routing"].each do |mechanism|
+      ["pg_stop", "hba", "host_routing", "detach_nic"].each do |mechanism|
         refresh_frame(nx, new_frame: {"mechanism" => mechanism})
         expect(nx).to receive("lockout_with_#{mechanism}").and_return(true)
         expect(Clog).to receive(:emit).with("Fenced unresponsive primary", {fenced_unresponsive_primary: {server_ubid: server.ubid, mechanism:}})
@@ -39,6 +39,12 @@ RSpec.describe Prog::Postgres::PostgresLockout do
         "timeout 10 sudo pg_ctlcluster 18 main stop -m immediate",
         timeout: 15,
       ).and_raise(Sshable::SshError.new("", "", "", "", ""))
+      expect { nx.start }.to exit({"msg" => "lockout_failed"})
+    end
+
+    it "returns false for AWS API failures" do
+      refresh_frame(nx, new_frame: {"mechanism" => "detach_nic"})
+      expect(nx).to receive(:lockout_with_detach_nic).and_raise(Aws::EC2::Errors::ServiceError.new(nil, "boom"))
       expect { nx.start }.to exit({"msg" => "lockout_failed"})
     end
   end
@@ -78,6 +84,30 @@ RSpec.describe Prog::Postgres::PostgresLockout do
         timeout: 15,
       ).and_return(true)
       expect { nx.lockout_with_host_routing }.not_to raise_error
+    end
+  end
+
+  describe "#lockout_with_detach_nic" do
+    let(:aws_location) {
+      loc = Location.create(name: "us-west-2", display_name: "aws-us-west-2", ui_name: "aws-us-west-2", visible: true, provider: "aws", project_id: project.id)
+      LocationCredentialAws.create_with_id(loc, access_key: "k", secret_key: "s")
+      LocationAz.create(location_id: loc.id, az: "a", zone_id: "usw2-az1")
+      loc
+    }
+    let(:aws_resource) { create_postgres_resource(project:, location_id: aws_location.id) }
+    let(:aws_server) { create_postgres_server(resource: aws_resource, timeline: postgres_timeline) }
+    let(:aws_nx) { described_class.new(aws_server.strand) }
+    let(:ec2_client) { Aws::EC2::Client.new(stub_responses: true) }
+
+    before do
+      NicAwsResource.create_with_id(aws_server.vm.nics.first, network_interface_id: "eni-abc")
+      allow(Aws::EC2::Client).to receive(:new).with(credentials: anything, region: "us-west-2").and_return(ec2_client)
+    end
+
+    it "looks up the attachment id and detaches the tracked ENI" do
+      ec2_client.stub_responses(:describe_network_interfaces, network_interfaces: [{network_interface_id: "eni-abc", attachment: {attachment_id: "eni-attach-123"}}])
+      expect(ec2_client).to receive(:detach_network_interface).with(attachment_id: "eni-attach-123", force: true).and_call_original
+      expect { aws_nx.lockout_with_detach_nic }.not_to raise_error
     end
   end
 end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1600,6 +1600,19 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       child_mechanisms = Strand.where(parent_id: st.id, prog: "Postgres::PostgresLockout").map { it.stack.first["mechanism"] }
       expect(child_mechanisms).to contain_exactly("pg_stop", "hba")
     end
+
+    it "dispatches detach_nic on AWS" do
+      aws_location = Location.create(
+        name: "us-west-2", display_name: "aws-us-west-2", ui_name: "aws-us-west-2",
+        visible: true, provider: "aws", project:,
+      )
+      LocationCredentialAws.create_with_id(aws_location, access_key: "k", secret_key: "s")
+      server.resource.update(location_id: aws_location.id)
+
+      expect { nx.lockout }.to hop("wait_lockout_attempt")
+      child_mechanisms = Strand.where(parent_id: st.id, prog: "Postgres::PostgresLockout").map { it.stack.first["mechanism"] }
+      expect(child_mechanisms).to contain_exactly("pg_stop", "hba", "detach_nic")
+    end
   end
 
   describe "#wait_lockout_attempt" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1649,6 +1649,19 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       child_mechanisms = Strand.where(parent_id: st.id, prog: "Postgres::PostgresLockout").map { it.stack.first["mechanism"] }
       expect(child_mechanisms).to contain_exactly("pg_stop", "hba")
     end
+
+    it "dispatches detach_nic on AWS" do
+      aws_location = Location.create(
+        name: "us-west-2", display_name: "aws-us-west-2", ui_name: "aws-us-west-2",
+        visible: true, provider: "aws", project:,
+      )
+      LocationCredentialAws.create_with_id(aws_location, access_key: "k", secret_key: "s")
+      server.resource.update(location_id: aws_location.id)
+
+      expect { nx.lockout }.to hop("wait_lockout_attempt")
+      child_mechanisms = Strand.where(parent_id: st.id, prog: "Postgres::PostgresLockout").map { it.stack.first["mechanism"] }
+      expect(child_mechanisms).to contain_exactly("pg_stop", "hba", "detach_nic")
+    end
   end
 
   describe "#wait_lockout_attempt" do


### PR DESCRIPTION
When a primary becomes unresponsive it must be fenced before a standby
takes over, so it cannot keep serving clients or replicating and cause a
split brain. The existing AWS lockout mechanisms, pg_stop and hba, both
act over SSH into the guest, so neither can fence a primary whose OS or
sshd is wedged.

Add a detach_nic mechanism that force-detaches the VM's user NIC through
the EC2 API, cutting all client and replication traffic from the control
plane without touching the guest. This works because of the dual-NIC
layout: customer traffic rides the detachable data NIC at device_index
1, while the management NIC stays at device_index 0 (which AWS will not
let us detach), so SSH and later cleanup keep working.

Lockout mechanisms run in parallel and the fence succeeds as soon as any
one does, so detach_nic just joins pg_stop and hba in
aws_lockout_mechanisms as the control-plane-only option. An
Aws::EC2::Errors::ServiceError now counts as a lockout failure too, so
an API error pops "lockout_failed" instead of crashing the strand, like
the SSH errors already do.