### PR TITLE
Fix paradedb PG provisioning by installing binaries before configure

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -446,6 +446,16 @@ CONFIG
     case vm.sshable.d_check("setup_hugepages")
     when "Succeeded"
       vm.sshable.d_clean("setup_hugepages")
+
+      when_initial_provisioning_set? do
+        if resource.flavor == PostgresResource::Flavor::PARADEDB
+          postgres_server.vm.sshable.cmd(<<CMD, version: postgres_server.version)
+set -ueo pipefail
+sudo apt-get install -y /var/cache/paradedb/postgresql-:version-pg-analytics.deb /var/cache/paradedb/postgresql-:version-pg-search.deb
+CMD
+        end
+      end
+
       hop_configure
     when "Failed", "NotStarted"
       vm.sshable.d_run("setup_hugepages", "sudo", "postgres/bin/setup-hugepages")
@@ -505,14 +515,6 @@ SQL
     postgres_server.run_query(commands)
 
     when_initial_provisioning_set? do
-      if postgres_server.paradedb_and_primary?
-        postgres_server.vm.sshable.cmd(<<CMD, version: postgres_server.version)
-set -ueo pipefail
-sudo apt-get install /var/cache/paradedb/postgresql-:version-pg-analytics.deb
-sudo apt-get install /var/cache/paradedb/postgresql-:version-pg-search.deb
-CMD
-      end
-
       hop_run_post_installation_script
     end
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -956,6 +956,45 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.setup_hugepages }.to hop("configure")
     end
 
+    it "installs paradedb packages during initial provisioning before hopping to configure" do
+      nx.incr_initial_provisioning
+      postgres_server.resource.update(flavor: PostgresResource::Flavor::PARADEDB)
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check setup_hugepages").and_return("Succeeded")
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 clean setup_hugepages")
+      expect(sshable).to receive(:_cmd).with(<<CMD).and_return("")
+set -ueo pipefail
+sudo apt-get install -y /var/cache/paradedb/postgresql-17-pg-analytics.deb /var/cache/paradedb/postgresql-17-pg-search.deb
+CMD
+      expect { nx.setup_hugepages }.to hop("configure")
+    end
+
+    it "installs paradedb packages on standbys as well, since the extension libraries are preloaded regardless of role" do
+      server
+      standby = create_postgres_server(resource: postgres_resource, timeline: postgres_timeline, is_representative: false)
+      postgres_resource.update(flavor: PostgresResource::Flavor::PARADEDB)
+      standby_nx = described_class.new(standby.strand)
+      standby_sshable = standby_nx.postgres_server.vm.sshable
+      standby_nx.incr_initial_provisioning
+      expect(standby_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check setup_hugepages").and_return("Succeeded")
+      expect(standby_sshable).to receive(:_cmd).with("common/bin/daemonizer2 clean setup_hugepages")
+      expect(standby_sshable).to receive(:_cmd).with(<<CMD).and_return("")
+set -ueo pipefail
+sudo apt-get install -y /var/cache/paradedb/postgresql-17-pg-analytics.deb /var/cache/paradedb/postgresql-17-pg-search.deb
+CMD
+      expect { standby_nx.setup_hugepages }.to hop("configure")
+    end
+
+    it "does not install paradedb packages for standard flavor during initial provisioning" do
+      nx.incr_initial_provisioning
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check setup_hugepages").and_return("Succeeded")
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 clean setup_hugepages")
+      expect(sshable).not_to receive(:_cmd).with(<<CMD)
+set -ueo pipefail
+sudo apt-get install -y /var/cache/paradedb/postgresql-17-pg-analytics.deb /var/cache/paradedb/postgresql-17-pg-search.deb
+CMD
+      expect { nx.setup_hugepages }.to hop("configure")
+    end
+
     it "retries the setup if it fails" do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check setup_hugepages").and_return("Failed")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run setup_hugepages sudo postgres/bin/setup-hugepages", {log: true, stdin: nil})
@@ -1102,19 +1141,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
         "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'",
         hash_including(stdin: password_update_sql_matcher),
       ).and_return("")
-      expect { nx.update_superuser_password }.to hop("run_post_installation_script")
-    end
-
-    it "updates password, installs paradedb packages, and hops to run_post_installation_script during initial provisioning for non-standard flavors" do
-      nx.incr_initial_provisioning
-      expect(sshable).to receive(:_cmd).with(
-        /sudo apt-get install.*pg-analytics.*pg-search/m,
-      ).and_return("")
-      expect(sshable).to receive(:_cmd).with(
-        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'",
-        hash_including(stdin: password_update_sql_matcher),
-      ).and_return("")
-      postgres_server.resource.update(flavor: PostgresResource::Flavor::PARADEDB)
       expect { nx.update_superuser_password }.to hop("run_post_installation_script")
     end
 


### PR DESCRIPTION
Without this change, provisioning a ParadeDB instance would get stuck at the `configure` step. The configure step requires postgres to be able to start, which cannot happen without the extension binaries being installed.