### PR TITLE
Have postgres resource without root_cert_{1,2} to use sslrootcert=system

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -140,7 +140,7 @@ class PostgresResource < Sequel::Model
 
   def replication_connection_string(application_name:)
     query_parameters = {
-      sslrootcert: "/etc/ssl/certs/server-ca.crt",
+      sslrootcert: (root_cert_1 && root_cert_2) ? "/etc/ssl/certs/server-ca.crt" : "system",
       sslcert: "/etc/ssl/certs/client.crt",
       sslkey: "/etc/ssl/certs/client.key",
       sslmode: dns_zone ? "verify-full" : "require",
@@ -148,7 +148,6 @@ class PostgresResource < Sequel::Model
       application_name:,
       tcp_user_timeout: 30000,
     }
-    query_parameters.delete(:sslrootcert) unless root_cert_1 && root_cert_2
     query_parameters = query_parameters.map { |k, v| "#{k}=#{v}" }.join("&")
 
     URI::Generic.build2(scheme: "postgres", userinfo: "ubi_replication", host: dns_zone ? identity : representative_server.vm.ip4_string, query: query_parameters).to_s

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -150,7 +150,7 @@ class PostgresResource < Sequel::Model
     }
     query_parameters = query_parameters.map { |k, v| "#{k}=#{v}" }.join("&")
 
-    URI::Generic.build2(scheme: "postgres", userinfo: "ubi_replication", host: dns_zone ? identity : representative_server.vm.ip4_string, query: query_parameters).to_s
+    URI::Generic.build2(scheme: "postgres", userinfo: "ubi_replication", host: hostname, query: query_parameters).to_s
   end
 
   def provision_new_standby

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe PostgresResource do
     expect(postgres_resource.connection_string).to eq("postgres://postgres:dummy-password@1.2.3.4:5432/postgres?channel_binding=require")
   end
 
-  it "returns replication_connection_string" do
+  it "returns replication_connection_string for hostname version v1" do
     expect(postgres_resource).to receive(:dns_zone).and_return(instance_double(DnsZone)).at_least(:once)
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
     expect(s).to include("ubi_replication@#{postgres_resource.ubid}.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
@@ -69,6 +69,13 @@ RSpec.describe PostgresResource do
     expect(postgres_resource.dns_zone).to be_nil
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
     expect(s).to include("ubi_replication@1.2.3.4", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
+  end
+
+  it "returns replication_connection_string for hostname version v3 without root CAs" do
+    expect(postgres_resource).to receive(:dns_zone).and_return(instance_double(DnsZone)).at_least(:once)
+    postgres_resource.update(hostname_version: "v3", root_cert_1: nil, root_cert_2: nil)
+    s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
+    expect(s).to include("ubi_replication@#{postgres_resource.ubid}.pg.ubicloud.app", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000", "sslrootcert=system")
   end
 
   it "returns internal_firewall_rules with SSH from control plane, subnet ports 5432/6432, and configured external CIDRs" do

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -54,12 +54,23 @@ RSpec.describe PostgresResource do
   end
 
   it "returns replication_connection_string for hostname version v1" do
+    postgres_resource.update(hostname_version: "v1")
     expect(postgres_resource).to receive(:dns_zone).and_return(instance_double(DnsZone)).at_least(:once)
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
-    expect(s).to include("ubi_replication@#{postgres_resource.ubid}.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
+    expect(s).to include("ubi_replication@pg-name.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
     postgres_resource.set(root_cert_1: "rc1", root_cert_2: "rc2")
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
-    expect(s).to include("ubi_replication@#{postgres_resource.ubid}.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000", "sslrootcert=/etc/ssl/certs/server-ca.crt")
+    expect(s).to include("ubi_replication@pg-name.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000", "sslrootcert=/etc/ssl/certs/server-ca.crt")
+  end
+
+  it "returns replication_connection_string for hostname version v2" do
+    postgres_resource.update(hostname_version: "v2")
+    expect(postgres_resource).to receive(:dns_zone).and_return(instance_double(DnsZone)).at_least(:once)
+    s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
+    expect(s).to include("ubi_replication@pg-name.#{postgres_resource.ubid}.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
+    postgres_resource.set(root_cert_1: "rc1", root_cert_2: "rc2")
+    s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
+    expect(s).to include("ubi_replication@pg-name.#{postgres_resource.ubid}.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000", "sslrootcert=/etc/ssl/certs/server-ca.crt")
   end
 
   it "returns replication_connection_string with ip when no dns_zone exists" do
@@ -75,7 +86,7 @@ RSpec.describe PostgresResource do
     expect(postgres_resource).to receive(:dns_zone).and_return(instance_double(DnsZone)).at_least(:once)
     postgres_resource.update(hostname_version: "v3", root_cert_1: nil, root_cert_2: nil)
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
-    expect(s).to include("ubi_replication@#{postgres_resource.ubid}.pg.ubicloud.app", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000", "sslrootcert=system")
+    expect(s).to include("ubi_replication@pg-name.#{postgres_resource.ubid}.pg.ubicloud.app", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000", "sslrootcert=system")
   end
 
   it "returns internal_firewall_rules with SSH from control plane, subnet ports 5432/6432, and configured external CIDRs" do


### PR DESCRIPTION
Postgres resources with hostname_version v3 do not have root_cert{1,2} when using publicly-signed certificates. However, for sslmode=verify-full to work, they need sslrootcert=system (postgres does not default to using system certificates).

Note that the replication connection string doesn't use `channel_binding=require`. It seems like it should. I can submit a different PR for that if it should.