### PR TITLE
Fix issues with Prog::Test::UpgradePostgresResource

### DIFF
--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -314,6 +314,10 @@ SQL
   end
 
   def standby_connected?(standby)
-    representative_server.run_query(DB["SELECT 1 FROM pg_stat_replication WHERE application_name = :ubid", ubid: standby.ubid]).strip == "1"
+    # synchronized_standby_slots blocks pg_replication_slot_advance until the physical slot
+    # named after the standby UBID has an active walsender (active_pid IS NOT NULL).
+    # The standby may be streaming (visible in pg_stat_replication) but still using an
+    # unslotted connection while configure sets primary_slot_name and the standby reconnects.
+    representative_server.run_query(DB["SELECT 1 FROM pg_replication_slots WHERE slot_name = :ubid AND slot_type = 'physical' AND active_pid IS NOT NULL", ubid: standby.ubid]).strip == "1"
   end
 end

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -13,7 +13,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   label def start
     # wal_level=logical needed to create the logical replication slot under test
     user_config = {"wal_level" => "logical"}
-    if start_version.to_i >= 17
+    if start_version_at_least_pg_17?
       # sync_replication_slots is PG17+; PG16 would reject config
       # hot_standby_feedback=on required on standby for PG17 logical slot sync
       user_config["sync_replication_slots"] = "on"
@@ -41,8 +41,8 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
 
     existing = representative_server.run_query("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").strip
     if existing.empty?
-      Clog.emit("Creating logical replication slot", {failover: start_version.to_i >= 17})
-      create_sql = if start_version.to_i >= 17
+      Clog.emit("Creating logical replication slot", {failover: start_version_at_least_pg_17?})
+      create_sql = if start_version_at_least_pg_17?
         "SELECT pg_create_logical_replication_slot('upgrade_test_slot', 'pgoutput', false, false, true)"
       else
         "SELECT pg_create_logical_replication_slot('upgrade_test_slot', 'pgoutput', false, false)"
@@ -139,7 +139,7 @@ SQL
     # pg_upgrade rejects logical slots with unconsumed (decodable) WAL after confirmed_flush.
     # Real upgrades rely on the subscriber draining the slot; the test has none, so advance it
     # to the WAL tip. Convergence waits for the candidate's synced copy to catch up before fencing.
-    if start_version.to_i >= 17
+    if start_version_at_least_pg_17?
       # synchronized_standby_slots blocks pg_replication_slot_advance until all standby
       # walsenders are active; check before entering SQL rather than looping inside it.
       standbys = postgres_resource.servers.reject { it.is_representative }
@@ -265,7 +265,7 @@ SQL
     # PG16 pg_upgrade drops logical slots, assert slot is gone
     Clog.emit("Verifying logical slot state after upgrade")
     slot_row = representative_server.run_query("SELECT failover FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").strip
-    expected_row = (start_version.to_i >= 17) ? "t" : ""
+    expected_row = start_version_at_least_pg_17? ? "t" : ""
     unless slot_row == expected_row
       self.fail_message = "Unexpected slot state after upgrade from v#{start_version}: expected #{expected_row.inspect}, got #{slot_row.inspect}"
       hop_destroy
@@ -306,6 +306,11 @@ SQL
 
   def target_version
     (start_version.to_i + 1).to_s
+  end
+
+  def start_version_at_least_pg_17?
+    return @start_version_at_least_pg_17 unless @start_version_at_least_pg_17.nil?
+    @start_version_at_least_pg_17 = start_version.to_i >= 17
   end
 
   def standby_connected?(standby)

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -28,6 +28,21 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
   label def wait_postgres_resource
     servers = postgres_resource.servers
     nap 10 if servers.count != postgres_resource.target_server_count || servers.filter { it.strand.label != "wait" }.any?
+
+    # On PG17+, the standby reaches "wait" before its physical slot cycle completes:
+    # wait_catch_up fires incr_configure on the primary and hops to wait immediately,
+    # but the primary configure (which sets synchronized_standby_slots, creates the
+    # physical slot, and triggers the standby's own configure to set primary_slot_name)
+    # runs asynchronously afterward. Proceeding before the standby connects via the
+    # physical slot causes pg_replication_slot_advance to block on synchronized_standby_slots.
+    if start_version_at_least_pg_17?
+      standbys = servers.reject { it.is_representative }
+      unless standbys.all? { standby_connected?(it) }
+        Clog.emit("Waiting for standbys to connect via physical slot", {resource: postgres_resource.ubid})
+        nap 10
+      end
+    end
+
     hop_setup_failover_slot
   end
 

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -55,7 +55,7 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
 
     # synchronized_standby_slots blocks pg_replication_slot_advance until the standby's
     # walsender is active; wait here rather than blocking inside the SQL call.
-    unless representative_server.run_query(DB["SELECT 1 FROM pg_stat_replication WHERE application_name = :ubid", ubid: standby.ubid]).strip == "1"
+    unless standby_connected?(standby)
       Clog.emit("Waiting for standby streaming connection before advancing slot", {standby: standby.ubid})
       nap 10
     end
@@ -143,7 +143,7 @@ SQL
       # synchronized_standby_slots blocks pg_replication_slot_advance until all standby
       # walsenders are active; check before entering SQL rather than looping inside it.
       standbys = postgres_resource.servers.reject { it.is_representative }
-      unless standbys.all? { |s| representative_server.run_query(DB["SELECT 1 FROM pg_stat_replication WHERE application_name = :ubid", ubid: s.ubid]).strip == "1" }
+      unless standbys.all? { standby_connected?(it) }
         Clog.emit("Waiting for standbys to stream before advancing upgrade_test_slot")
         nap 10
       end
@@ -306,5 +306,9 @@ SQL
 
   def target_version
     (start_version.to_i + 1).to_s
+  end
+
+  def standby_connected?(standby)
+    representative_server.run_query(DB["SELECT 1 FROM pg_stat_replication WHERE application_name = :ubid", ubid: standby.ubid]).strip == "1"
   end
 end

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -53,6 +53,13 @@ class Prog::Test::UpgradePostgresResource < Prog::Test::PostgresBase
     # PG16 does not sync replication slots to standbys; skip the wait.
     hop_test_postgres_before_read_replica if start_version.to_i < 17
 
+    # synchronized_standby_slots blocks pg_replication_slot_advance until the standby's
+    # walsender is active; wait here rather than blocking inside the SQL call.
+    unless representative_server.run_query(DB["SELECT 1 FROM pg_stat_replication WHERE application_name = :ubid", ubid: standby.ubid]).strip == "1"
+      Clog.emit("Waiting for standby streaming connection before advancing slot", {standby: standby.ubid})
+      nap 10
+    end
+
     # Idle slot stays temporary on standby; advance it & emit standby snapshots each pass so
     # restart_lsn passes the standby's reserved point, letting the sync worker persist the slot
     representative_server.run_query(<<SQL)
@@ -133,6 +140,13 @@ SQL
     # Real upgrades rely on the subscriber draining the slot; the test has none, so advance it
     # to the WAL tip. Convergence waits for the candidate's synced copy to catch up before fencing.
     if start_version.to_i >= 17
+      # synchronized_standby_slots blocks pg_replication_slot_advance until all standby
+      # walsenders are active; check before entering SQL rather than looping inside it.
+      standbys = postgres_resource.servers.reject { it.is_representative }
+      unless standbys.all? { |s| representative_server.run_query(DB["SELECT 1 FROM pg_stat_replication WHERE application_name = :ubid", ubid: s.ubid]).strip == "1" }
+        Clog.emit("Waiting for standbys to stream before advancing upgrade_test_slot")
+        nap 10
+      end
       representative_server.run_query("SELECT pg_replication_slot_advance('upgrade_test_slot', pg_current_wal_lsn())")
     end
 

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -173,6 +173,15 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       SQL
       expect { pgr_test.wait_postgres_resource }.to hop("setup_failover_slot")
     end
+
+    it "hops to setup_failover_slot without checking physical slot for PG16" do
+      refresh_frame(pgr_test, new_values: {"start_version" => "16"})
+      pg = pgr_test.postgres_resource
+      Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg.id, timeline_id: pg.timeline.id, timeline_access: "fetch")
+      pg.servers.each { |server| server.strand.update(label: "wait") }
+      expect(pgr_test.representative_server).not_to receive(:_run_query)
+      expect { pgr_test.wait_postgres_resource }.to hop("setup_failover_slot")
+    end
   end
 
   describe "#setup_failover_slot" do

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -167,10 +167,18 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       refresh_frame(pgr_test, new_values: {"postgres_resource_id" => pg_strand.id})
     end
 
+    it "naps while waiting for standby streaming connection" do
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("1")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_stat_replication/).and_return("")
+      expect(pgr_test.representative_server).not_to receive(:_run_query).with(/pg_replication_slot_advance/)
+      expect { pgr_test.setup_failover_slot }.to nap(10)
+    end
+
     it "creates the slot and naps while the standby has not synced yet" do
       standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
       expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("")
       expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot/).and_return("upgrade_test_slot")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_stat_replication/).and_return("1")
       expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
       expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("")
       expect { pgr_test.setup_failover_slot }.to nap(10)
@@ -179,6 +187,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     it "hops to test_postgres_before_read_replica once the slot is synced on the standby" do
       standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
       expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("1")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_stat_replication/).and_return("1")
       expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
       expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("1")
       expect { pgr_test.setup_failover_slot }.to hop("test_postgres_before_read_replica")
@@ -286,11 +295,19 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
   describe "#trigger_upgrade" do
     before do
       pg_strand = Prog::Postgres::PostgresResourceNexus.assemble(project_id: pgr_test.frame["postgres_test_project_id"], location_id: Location::HETZNER_FSN1_ID, name: "test-pg", target_vm_size: "standard-2", target_storage_size_gib: 128, ha_type: "async", target_version: "17")
+      Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg_strand.id, timeline_id: PostgresResource[pg_strand.id].timeline.id, timeline_access: "fetch")
       replica_strand = Prog::Postgres::PostgresResourceNexus.assemble(project_id: pgr_test.frame["postgres_test_project_id"], location_id: Location::HETZNER_FSN1_ID, name: "test-pg-replica", target_vm_size: "standard-2", target_storage_size_gib: 128, parent_id: pg_strand.id)
       refresh_frame(pgr_test, new_values: {"postgres_resource_id" => pg_strand.id, "read_replica_id" => replica_strand.id})
     end
 
+    it "naps while waiting for standbys to stream before advancing slot" do
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_stat_replication/).and_return("")
+      expect(pgr_test.representative_server).not_to receive(:_run_query).with(/pg_replication_slot_advance/)
+      expect { pgr_test.trigger_upgrade }.to nap(10)
+    end
+
     it "updates target_version to 18 and hops to check_upgrade_progress" do
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_stat_replication/).and_return("1")
       expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
       expect { pgr_test.trigger_upgrade }.to hop("check_upgrade_progress")
       pgr_test.postgres_resource.reload

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -152,10 +152,19 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       expect { pgr_test.wait_postgres_resource }.to nap(10)
     end
 
-    it "hops to setup_failover_slot if the postgres resource is ready" do
+    it "naps when standbys are not yet connected via physical slot" do
       pg = pgr_test.postgres_resource
       Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg.id, timeline_id: pg.timeline.id, timeline_access: "fetch")
       pg.servers.each { |server| server.strand.update(label: "wait") }
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("")
+      expect { pgr_test.wait_postgres_resource }.to nap(10)
+    end
+
+    it "hops to setup_failover_slot once all standbys are connected via physical slot" do
+      pg = pgr_test.postgres_resource
+      Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg.id, timeline_id: pg.timeline.id, timeline_access: "fetch")
+      pg.servers.each { |server| server.strand.update(label: "wait") }
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("1")
       expect { pgr_test.wait_postgres_resource }.to hop("setup_failover_slot")
     end
   end

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
 
     it "naps while waiting for standby streaming connection" do
       expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("1")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_stat_replication/).and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("")
       expect(pgr_test.representative_server).not_to receive(:_run_query).with(/pg_replication_slot_advance/)
       expect { pgr_test.setup_failover_slot }.to nap(10)
     end
@@ -178,7 +178,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
       expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("")
       expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot/).and_return("upgrade_test_slot")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_stat_replication/).and_return("1")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("1")
       expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
       expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("")
       expect { pgr_test.setup_failover_slot }.to nap(10)
@@ -187,7 +187,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     it "hops to test_postgres_before_read_replica once the slot is synced on the standby" do
       standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
       expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("1")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_stat_replication/).and_return("1")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("1")
       expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
       expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("1")
       expect { pgr_test.setup_failover_slot }.to hop("test_postgres_before_read_replica")
@@ -301,13 +301,13 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
 
     it "naps while waiting for standbys to stream before advancing slot" do
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_stat_replication/).and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("")
       expect(pgr_test.representative_server).not_to receive(:_run_query).with(/pg_replication_slot_advance/)
       expect { pgr_test.trigger_upgrade }.to nap(10)
     end
 
     it "updates target_version to 18 and hops to check_upgrade_progress" do
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_stat_replication/).and_return("1")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("1")
       expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
       expect { pgr_test.trigger_upgrade }.to hop("check_upgrade_progress")
       pgr_test.postgres_resource.reload

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -156,7 +156,10 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       pg = pgr_test.postgres_resource
       Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg.id, timeline_id: pg.timeline.id, timeline_access: "fetch")
       pg.servers.each { |server| server.strand.update(label: "wait") }
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("")
+      standby = pg.servers.find { !it.is_representative }
+      expect(pgr_test.representative_server).to receive(:_run_query).with(<<~SQL.chomp).and_return("")
+        SELECT 1 FROM pg_replication_slots WHERE slot_name = '#{standby.ubid}' AND slot_type = 'physical' AND active_pid IS NOT NULL
+      SQL
       expect { pgr_test.wait_postgres_resource }.to nap(10)
     end
 
@@ -164,7 +167,10 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
       pg = pgr_test.postgres_resource
       Prog::Postgres::PostgresServerNexus.assemble(resource_id: pg.id, timeline_id: pg.timeline.id, timeline_access: "fetch")
       pg.servers.each { |server| server.strand.update(label: "wait") }
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("1")
+      standby = pg.servers.find { !it.is_representative }
+      expect(pgr_test.representative_server).to receive(:_run_query).with(<<~SQL.chomp).and_return("1")
+        SELECT 1 FROM pg_replication_slots WHERE slot_name = '#{standby.ubid}' AND slot_type = 'physical' AND active_pid IS NOT NULL
+      SQL
       expect { pgr_test.wait_postgres_resource }.to hop("setup_failover_slot")
     end
   end
@@ -177,28 +183,53 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
 
     it "naps while waiting for standby streaming connection" do
+      standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
       expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("1")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("")
-      expect(pgr_test.representative_server).not_to receive(:_run_query).with(/pg_replication_slot_advance/)
+      expect(pgr_test.representative_server).to receive(:_run_query).with(<<~SQL.chomp).and_return("")
+        SELECT 1 FROM pg_replication_slots WHERE slot_name = '#{standby.ubid}' AND slot_type = 'physical' AND active_pid IS NOT NULL
+      SQL
+      expect(pgr_test.representative_server).not_to receive(:_run_query).with(<<~SQL)
+        SELECT pg_log_standby_snapshot();
+        SELECT pg_replication_slot_advance('upgrade_test_slot', pg_current_wal_lsn());
+        SELECT pg_log_standby_snapshot();
+      SQL
       expect { pgr_test.setup_failover_slot }.to nap(10)
     end
 
     it "creates the slot and naps while the standby has not synced yet" do
       standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
       expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot/).and_return("upgrade_test_slot")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("1")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
-      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(<<~SQL.chomp).and_return("upgrade_test_slot")
+        SELECT pg_create_logical_replication_slot('upgrade_test_slot', 'pgoutput', false, false, true)
+      SQL
+      expect(pgr_test.representative_server).to receive(:_run_query).with(<<~SQL.chomp).and_return("1")
+        SELECT 1 FROM pg_replication_slots WHERE slot_name = '#{standby.ubid}' AND slot_type = 'physical' AND active_pid IS NOT NULL
+      SQL
+      expect(pgr_test.representative_server).to receive(:_run_query).with(<<~SQL).and_return("")
+        SELECT pg_log_standby_snapshot();
+        SELECT pg_replication_slot_advance('upgrade_test_slot', pg_current_wal_lsn());
+        SELECT pg_log_standby_snapshot();
+      SQL
+      expect(standby).to receive(:_run_query).with(<<~SQL.chomp).and_return("")
+        SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot' AND synced AND NOT temporary
+      SQL
       expect { pgr_test.setup_failover_slot }.to nap(10)
     end
 
     it "hops to test_postgres_before_read_replica once the slot is synced on the standby" do
       standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
       expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("1")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("1")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
-      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("1")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(<<~SQL.chomp).and_return("1")
+        SELECT 1 FROM pg_replication_slots WHERE slot_name = '#{standby.ubid}' AND slot_type = 'physical' AND active_pid IS NOT NULL
+      SQL
+      expect(pgr_test.representative_server).to receive(:_run_query).with(<<~SQL).and_return("")
+        SELECT pg_log_standby_snapshot();
+        SELECT pg_replication_slot_advance('upgrade_test_slot', pg_current_wal_lsn());
+        SELECT pg_log_standby_snapshot();
+      SQL
+      expect(standby).to receive(:_run_query).with(<<~SQL.chomp).and_return("1")
+        SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot' AND synced AND NOT temporary
+      SQL
       expect { pgr_test.setup_failover_slot }.to hop("test_postgres_before_read_replica")
     end
 
@@ -213,7 +244,9 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     it "creates a non-failover slot and skips sync wait for PG16" do
       refresh_frame(pgr_test, new_values: {"start_version" => "16"})
       expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot\('upgrade_test_slot', 'pgoutput', false, false\)\Z/).and_return("upgrade_test_slot")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(<<~SQL.chomp).and_return("upgrade_test_slot")
+        SELECT pg_create_logical_replication_slot('upgrade_test_slot', 'pgoutput', false, false)
+      SQL
       expect { pgr_test.setup_failover_slot }.to hop("test_postgres_before_read_replica")
     end
   end
@@ -310,14 +343,24 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
 
     it "naps while waiting for standbys to stream before advancing slot" do
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("")
-      expect(pgr_test.representative_server).not_to receive(:_run_query).with(/pg_replication_slot_advance/)
+      standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
+      expect(pgr_test.representative_server).to receive(:_run_query).with(<<~SQL.chomp).and_return("")
+        SELECT 1 FROM pg_replication_slots WHERE slot_name = '#{standby.ubid}' AND slot_type = 'physical' AND active_pid IS NOT NULL
+      SQL
+      expect(pgr_test.representative_server).not_to receive(:_run_query).with(<<~SQL.chomp)
+        SELECT pg_replication_slot_advance('upgrade_test_slot', pg_current_wal_lsn())
+      SQL
       expect { pgr_test.trigger_upgrade }.to nap(10)
     end
 
     it "updates target_version to 18 and hops to check_upgrade_progress" do
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slots.*physical.*active_pid/).and_return("1")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
+      standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
+      expect(pgr_test.representative_server).to receive(:_run_query).with(<<~SQL.chomp).and_return("1")
+        SELECT 1 FROM pg_replication_slots WHERE slot_name = '#{standby.ubid}' AND slot_type = 'physical' AND active_pid IS NOT NULL
+      SQL
+      expect(pgr_test.representative_server).to receive(:_run_query).with(<<~SQL.chomp).and_return("")
+        SELECT pg_replication_slot_advance('upgrade_test_slot', pg_current_wal_lsn())
+      SQL
       expect { pgr_test.trigger_upgrade }.to hop("check_upgrade_progress")
       pgr_test.postgres_resource.reload
       pgr_test.read_replica.reload


### PR DESCRIPTION
Postgres local E2E tests were stuck in staging, and after working with Claude, it suggested these fixes. I'm not sure whether they fix real race conditions or not.

It's possible the issue is instead that the replication connection string may not work when using publicly signed certificates, I previously submitted #5803 for that.