### PR TITLE
Destroy GitHub Action runners, and do not hang, upon suspension

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -239,6 +239,17 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       nap 0
     end
 
+    if e.is_a?(Octokit::InstallationSuspended)
+      # The customer suspended the Ubicloud GitHub App installation, so no
+      # installation access token can be created and every API call will fail
+      # until they unsuspend it. Deregistration is impossible; clean up our
+      # side without talking to the GitHub API.
+      Clog.emit("GitHub installation is suspended", {github_installation_suspended: {installation_ubid:, label: github_runner.label, repository_name: github_runner.repository_name}})
+      github_runner.incr_skip_deregistration
+      github_runner.incr_destroy unless destroying_set?
+      nap 0
+    end
+
     if e.message.include?("API rate limit exceeded")
       rate_limit = client.rate_limit
       Prog::PageNexus.assemble(

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -180,6 +180,16 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
 
   def rescue_common_github_api_errors
     yield
+  rescue Octokit::InstallationSuspended
+    # The customer suspended the Ubicloud GitHub App installation, so no
+    # installation access token can be created and every API call will fail
+    # until they unsuspend it. Deregistration is impossible; clean up our
+    # side without talking to the GitHub API.
+    installation_ubid = github_runner.installation.ubid
+    Clog.emit("GitHub installation is suspended", {github_installation_suspended: {installation_ubid:, label: github_runner.label, repository_name: github_runner.repository_name}})
+    github_runner.incr_skip_deregistration
+    github_runner.incr_destroy unless destroying_set?
+    nap 0
   rescue Octokit::Error => e
     installation_ubid = github_runner.installation.ubid
     page_args, email_body = case e.message
@@ -236,17 +246,6 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
         )
       end
       github_runner.incr_destroy
-      nap 0
-    end
-
-    if e.is_a?(Octokit::InstallationSuspended)
-      # The customer suspended the Ubicloud GitHub App installation, so no
-      # installation access token can be created and every API call will fail
-      # until they unsuspend it. Deregistration is impossible; clean up our
-      # side without talking to the GitHub API.
-      Clog.emit("GitHub installation is suspended", {github_installation_suspended: {installation_ubid:, label: github_runner.label, repository_name: github_runner.repository_name}})
-      github_runner.incr_skip_deregistration
-      github_runner.incr_destroy unless destroying_set?
       nap 0
     end
 

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -810,6 +810,19 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(runner.skip_deregistration_set?).to be(true)
     end
 
+    it "skips the deregistration if the installation is suspended while destroying" do
+      nx.incr_destroying
+      expect { nx.rescue_common_github_api_errors { raise Octokit::InstallationSuspended.new({body: "This installation has been suspended"}) } }.to nap(0)
+      expect(runner.skip_deregistration_set?).to be(true)
+      expect(runner.destroy_set?).to be(false)
+    end
+
+    it "destroys the runner without deregistration if the installation is suspended while provisioning" do
+      expect { nx.rescue_common_github_api_errors { raise Octokit::InstallationSuspended.new({body: "This installation has been suspended"}) } }.to nap(0)
+      expect(runner.skip_deregistration_set?).to be(true)
+      expect(runner.destroy_set?).to be(true)
+    end
+
     def add_github_user(email)
       Account.create(email:).tap do |account|
         account.add_project(project)


### PR DESCRIPTION
Without this, GitHub Runners will not make progress, piling up and paging without freeing resources.  They will all error with traces like this:

    Octokit::InstallationSuspended: POST https://api.github.com/app/installations/$INSTALLATIONINTEGERID/access_tokens: 403 - This installation has been suspended // See: https://docs.github.com/rest/reference/apps#create-an-installation-access-token-for-an-app (Octokit::InstallationSuspended)
    from /app/vendor/bundle/ruby/4.0.0/gems/octokit-10.0.0/lib/octokit/response/raise_error.rb:14:in 'Octokit::Response::RaiseError#on_complete'
    [3] ⚠️ clover-production(main)> _ex_.backtrace
    => ["/app/vendor/bundle/ruby/4.0.0/gems/octokit-10.0.0/lib/octokit/response/raise_error.rb:14:in 'Octokit::Response::RaiseError#on_complete'",
     "/app/vendor/bundle/ruby/4.0.0/gems/faraday-2.14.3/lib/faraday/middleware.rb:57:in 'block in Faraday::Middleware#call'",
     "/app/vendor/bundle/ruby/4.0.0/gems/faraday-2.14.3/lib/faraday/response.rb:46:in 'Faraday::Response#on_complete'",
     "/app/vendor/bundle/ruby/4.0.0/gems/faraday-2.14.3/lib/faraday/middleware.rb:56:in 'Faraday::Middleware#call'",
     "/app/vendor/bundle/ruby/4.0.0/gems/octokit-10.0.0/lib/octokit/middleware/follow_redirects.rb:73:in 'Octokit::Middleware::FollowRedirects#perform_with_redirection'",
     "/app/vendor/bundle/ruby/4.0.0/gems/octokit-10.0.0/lib/octokit/middleware/follow_redirects.rb:61:in 'Octokit::Middleware::FollowRedirects#call'",
     "/app/vendor/bundle/ruby/4.0.0/gems/faraday-retry-2.4.0/lib/faraday/retry/middleware.rb:171:in 'block in Faraday::Retry::Middleware#call'",
     "/app/vendor/bundle/ruby/4.0.0/gems/faraday-retry-2.4.0/lib/faraday/retry/retryable.rb:7:in 'Faraday::Retryable#with_retries'",
     "/app/vendor/bundle/ruby/4.0.0/gems/faraday-retry-2.4.0/lib/faraday/retry/middleware.rb:167:in 'Faraday::Retry::Middleware#call'",
     "/app/vendor/bundle/ruby/4.0.0/gems/faraday-2.14.3/lib/faraday/rack_builder.rb:158:in 'Faraday::RackBuilder#build_response'",
     "/app/vendor/bundle/ruby/4.0.0/gems/faraday-2.14.3/lib/faraday/connection.rb:452:in 'Faraday::Connection#run_request'",
     "/app/vendor/bundle/ruby/4.0.0/gems/faraday-2.14.3/lib/faraday/connection.rb:280:in 'Faraday::Connection#post'",
     "/app/vendor/bundle/ruby/4.0.0/gems/sawyer-0.9.3/lib/sawyer/agent.rb:99:in 'Sawyer::Agent#call'",
     "/app/vendor/bundle/ruby/4.0.0/gems/octokit-10.0.0/lib/octokit/connection.rb:158:in 'Octokit::Connection#request'",
     "/app/vendor/bundle/ruby/4.0.0/gems/octokit-10.0.0/lib/octokit/connection.rb:28:in 'Octokit::Connection#post'",
     "/app/vendor/bundle/ruby/4.0.0/gems/octokit-10.0.0/lib/octokit/client/apps.rb:65:in 'Octokit::Client::Apps#create_app_installation_access_token'",
     "/app/lib/github.rb:37:in 'Github.installation_client'",
     "/app/model/github/github_installation.rb:44:in 'GithubInstallation#client'",
     "/app/prog/github/github_runner_nexus.rb:169:in 'Prog::Github::GithubRunnerNexus#client'",
     "/app/prog/github/github_runner_nexus.rb:175:in 'block in Prog::Github::GithubRunnerNexus#busy?'",
     "/app/prog/github/github_runner_nexus.rb:182:in 'Prog::Github::GithubRunnerNexus#rescue_common_github_api_errors'",
     "/app/prog/github/github_runner_nexus.rb:174:in 'Prog::Github::GithubRunnerNexus#busy?'",
     "/app/prog/github/github_runner_nexus.rb:650:in 'Prog::Github::GithubRunnerNexus#destroy'",