### PR TITLE
Mark detailed maintenance_window_start_at nullable

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -4545,6 +4545,7 @@ components:
                   maintenance_window_start_at:
                     description: Maintenance window start time
                     type: integer
+                    nullable: true
                   tags:
                     description: Tags of the Postgres database
                     type: array


### PR DESCRIPTION
Stacked on #5753 (base is `jeremy-openapi-terraform`); the diff is one line on top of it.

The detailed postgres response lists `maintenance_window_start_at` in its required properties while the serializer returns `null` until a maintenance window is set. The base `PostgresDatabase` component already declares the field `nullable: true`; this marks the inline copy in the detailed response the same way.

Found while regenerating the terraform provider from this spec: oapi-codegen maps a required non-nullable integer to a plain Go `int`, so decoding the detailed response of any database without a maintenance window fails. With this line the field generates as `*int` and the null round-trips (verified end-to-end against a live clover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)