### PR TITLE
Restrict AWS mgmt SSH ingress to control_plane_outbound_cidrs

### DIFF
--- a/prog/postgres/postgres_server_aws_nic_migration.rb
+++ b/prog/postgres/postgres_server_aws_nic_migration.rb
@@ -48,9 +48,12 @@ class Prog::Postgres::PostgresServerAwsNicMigration < Prog::Base
         client.describe_security_groups(filters: [{name: "group-name", values: [group_name]}]).security_groups[0].group_id
       end
 
-      begin
-        client.authorize_security_group_ingress(group_id: sg_id, ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "0.0.0.0/0"}]}])
-      rescue Aws::EC2::Errors::InvalidPermissionDuplicate
+      Config.control_plane_outbound_cidrs.each do |cidr|
+        next if cidr.include?(":")
+        begin
+          client.authorize_security_group_ingress(group_id: sg_id, ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: cidr}]}])
+        rescue Aws::EC2::Errors::InvalidPermissionDuplicate
+        end
       end
 
       ps_aws.update(mgmt_security_group_id: sg_id)

--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -50,7 +50,10 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
       allow_ingress(private_subnet_aws_resource.user_security_group_id, firewall_rule.port_range.first, firewall_rule.port_range.last - 1, firewall_rule.cidr.to_s)
     end
 
-    allow_ingress(private_subnet_aws_resource.mgmt_security_group_id, 22, 22, "0.0.0.0/0")
+    Config.control_plane_outbound_cidrs.each do |cidr|
+      next if cidr.include?(":")
+      allow_ingress(private_subnet_aws_resource.mgmt_security_group_id, 22, 22, cidr)
+    end
     allow_ingress(private_subnet_aws_resource.mgmt_security_group_id, 443, 443, private_subnet.net4.to_s) if private_subnet.project.get_ff_aws_cloudwatch_logs
 
     hop_create_route_table

--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
 
   describe "#wait_vpc_created" do
     before do
+      allow(Config).to receive(:control_plane_outbound_cidrs).and_return(["0.0.0.0/0", "::/0"])
       client.stub_responses(:modify_vpc_attribute)
       client.stub_responses(:create_security_group, group_id: "sg-single")
       client.stub_responses(:authorize_security_group_ingress)
@@ -99,6 +100,17 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
       expect { nx.wait_vpc_created }.to hop("create_route_table")
       expect(aws_resource.reload.user_security_group_id).to eq("sg-user")
       expect(aws_resource.mgmt_security_group_id).to eq("sg-mgmt")
+    end
+
+    it "authorizes mgmt SSH ingress from each control_plane_outbound_cidrs entry, skipping IPv6 cidrs" do
+      Prog::Vnet::NicNexus.assemble(ps.id, name: "test-mgmt-nic", is_management: true)
+      allow(Config).to receive(:control_plane_outbound_cidrs).and_return(["100.64.0.0/10", "192.0.2.0/24", "fd00::/8"])
+      client.stub_responses(:describe_vpcs, vpcs: [{state: "available", vpc_id: "vpc-0123456789abcdefg"}])
+      client.stub_responses(:create_security_group, [{group_id: "sg-user"}, {group_id: "sg-mgmt"}])
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-mgmt", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "100.64.0.0/10"}]}]}).and_call_original
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-mgmt", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "192.0.2.0/24"}]}]}).and_call_original
+      expect { nx.wait_vpc_created }.to hop("create_route_table")
+      expect(aws_resource.reload.mgmt_security_group_id).to eq("sg-mgmt")
     end
 
     it "skips security group ingress rule if it already exists" do


### PR DESCRIPTION
The management security group allowed SSH from 0.0.0.0/0, ignoring the Config.control_plane_outbound_cidrs that all other control plane SSH ingress respects. IPv6 entries are skipped since the control plane reaches AWS VMs over the management NIC's public IPv4 address. With the default value of 0.0.0.0/0,::/0 the resulting rules are unchanged.