### PR TITLE
Order PG restarts to preserve standby >= primary params

### DIFF
--- a/helpers/model_hiding.rb
+++ b/helpers/model_hiding.rb
@@ -32,7 +32,7 @@ class Clover < Roda
         ::ParseableResource => [:client_for_project],
         ::PaymentMethod => [:fraud?],
         ::PostgresResource => [:default_flavor, :default_version, :ha_type_none, :generate_postgres_options, :maintenance_hour_options, :maintenance_window_days_mask, :partner_notification_flavors, :postgres_flavors],
-        ::PostgresServer => [:victoria_metrics_client],
+        ::PostgresServer => [:victoria_metrics_client, :restart_sensitive_params],
         ::SubjectTag => [:admin_tag?, :options_for_project, :subject_id_map_for_project_and_accounts],
         ::Vm => [:from_runtime_jwt_payload],
       }.freeze

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -413,4 +413,31 @@ module Validation
   def self.validate_postgres_version(version, flavor)
     fail ValidationFailed.new({version: "Version #{version} is not supported for #{flavor} flavor"}) unless Option::POSTGRES_VERSION_OPTIONS[flavor].include?(version)
   end
+
+  def self.validate_postgres_restart_sensitive_params(version, user_config, parent: nil, children: [])
+    params = PostgresServer.restart_sensitive_params
+    target_values = lambda do |cfg_version, cfg|
+      validator = PostgresConfigValidator.new(cfg_version)
+      params.to_h { |k| [k, Integer(cfg[k] || validator.default(k))] }
+    end
+
+    target = target_values.call(version, user_config)
+    errors = {}
+
+    if parent
+      parent_target = target_values.call(parent.version, parent.user_config)
+      params.each do |k|
+        errors[k] = "must be >= #{parent_target[k]} to match the primary's current value" if target[k] < parent_target[k]
+      end
+    end
+
+    children.each do |child|
+      child_target = target_values.call(child.version, child.user_config)
+      params.each do |k|
+        errors[k] ||= "must be <= #{child_target[k]} to match read replica '#{child.name}''s current value" if target[k] > child_target[k]
+      end
+    end
+
+    fail ValidationFailed.new(errors.transform_keys { |key| "pg_config.#{key}" }) if errors.any?
+  end
 end

--- a/lib/validation/postgres_config_validator.rb
+++ b/lib/validation/postgres_config_validator.rb
@@ -40,6 +40,10 @@ module Validation
       restart_required_params.include?(key)
     end
 
+    def default(key)
+      @config_schema.dig(key, :default)
+    end
+
     def validate(config)
       errors = validation_errors(config)
 

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -171,6 +171,10 @@ class PostgresServer < Sequel::Model
 
   RESTART_SENSITIVE_PARAMS = %w[max_connections max_worker_processes max_wal_senders max_prepared_transactions max_locks_per_transaction].freeze
 
+  def self.restart_sensitive_params
+    RESTART_SENSITIVE_PARAMS
+  end
+
   def replication_parent_server
     if is_representative
       # This server can only have a replication parent if this server is the

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -169,6 +169,62 @@ class PostgresServer < Sequel::Model
     DISK_THROUGHPUT_BASELINE_MBPS.fetch(resource.location.provider, 100)
   end
 
+  RESTART_SENSITIVE_PARAMS = %w[max_connections max_worker_processes max_wal_senders max_prepared_transactions max_locks_per_transaction].freeze
+
+  def replication_parent_server
+    if is_representative
+      # This server can only have a replication parent if this server is the
+      # primary for a read replica.
+      resource.parent&.representative_server
+    else
+      resource.representative_server
+    end
+  end
+
+  # Servers that replay this server's WAL (HA standbys and read replicas).
+  # Only the resource's representative feeds downstream consumers.
+  def replication_child_servers
+    return [] unless is_representative
+    (resource.servers.reject(&:is_representative) + resource.read_replicas.map(&:representative_server)).compact
+  end
+
+  def restart_sensitive_target_values
+    validator = Validation::PostgresConfigValidator.new(version)
+    config = resource.user_config
+    RESTART_SENSITIVE_PARAMS.to_h { |param| [param, Integer(config[param] || validator.default(param))] }
+  end
+
+  def restart_sensitive_running_values
+    rows = begin
+      run_query(DB[:pg_settings].where(name: RESTART_SENSITIVE_PARAMS).select(:name, :setting)).split("\n")
+    rescue Sshable::SshTimeout, *Sshable::SSH_CONNECTION_ERRORS => ex
+      Clog.emit("Failed to fetch restart sensitive running values", Util.exception_to_hash(ex, into: {postgres_server_id: id}))
+      return nil
+    end
+
+    values = rows.to_h do |row|
+      name, setting = row.split(",")
+      [name, setting.to_i]
+    end
+    return nil unless RESTART_SENSITIVE_PARAMS.all? { |param| values.key?(param) }
+    values
+  end
+
+  def restart_sensitive_params_safe?
+    targets = restart_sensitive_target_values
+
+    if (parent = replication_parent_server) && (parent_running = parent.restart_sensitive_running_values)
+      return false unless RESTART_SENSITIVE_PARAMS.all? { |param| targets[param] >= parent_running[param] }
+    end
+
+    replication_child_servers.each do |child|
+      next unless (child_running = child.restart_sensitive_running_values)
+      return false unless RESTART_SENSITIVE_PARAMS.all? { |param| child_running[param] >= targets[param] }
+    end
+
+    true
+  end
+
   def trigger_failover(mode:)
     unless is_representative
       Clog.emit("Cannot trigger failover on a non-representative server", {ubid:})

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -677,6 +677,13 @@ SQL
 
     when_restart_set? do
       register_deadline("complete_restart", 2 * 60)
+      # Hold off restarting until applying the new config keeps every
+      # restart-sensitive parameter (max_connections etc.) >= its upstream and
+      # <= its downstream running values. This orders the restart wave correctly
+      # (primary-first on decreases, standby-first on increases) and avoids
+      # standbys/replicas getting stuck in recovery.
+      nap 5 unless postgres_server.restart_sensitive_params_safe?
+
       if daemonized_restart
         decr_restart
         unregister_deadline("complete_restart")

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -387,6 +387,9 @@ class Clover
 
         replica = nil
         DB.transaction do
+          pg.lock!
+          Validation.validate_postgres_restart_sensitive_params(pg.version, user_config, parent: pg)
+
           replica = Prog::Postgres::PostgresResourceNexus.assemble(
             project_id: @project.id,
             location_id: pg.location_id,
@@ -919,12 +922,22 @@ class Clover
           end
 
           validate_postgres_config(pg.version, pg_config, pgbouncer_config)
-          old_pg_config = pg.user_config
-          pg.update(user_config: pg_config, pgbouncer_user_config: pgbouncer_config)
 
-          pg.server_incr("configure")
+          old_pg_config = DB.transaction do
+            parent = pg.parent
+            parent&.lock!
+            pg.lock!
+            Validation.validate_postgres_restart_sensitive_params(pg.version, pg_config, parent:, children: pg.read_replicas)
 
-          audit_log(pg, "update_config")
+            old_config = pg.user_config
+            pg.update(user_config: pg_config, pgbouncer_user_config: pgbouncer_config)
+
+            pg.server_incr("configure")
+
+            audit_log(pg, "update_config")
+
+            old_config
+          end
 
           validator = Validation::PostgresConfigValidator.new(pg.version)
           restart_requiring_changed_params = (pg_config.keys | old_pg_config.keys).select { |k|

--- a/spec/lib/validation/postgres_config_validator_schema_spec.rb
+++ b/spec/lib/validation/postgres_config_validator_schema_spec.rb
@@ -26,5 +26,18 @@ RSpec.describe Validation::PostgresConfigValidatorSchema do
       expect(Validation::PostgresConfigValidatorSchema::PG_18_CONFIG_SCHEMA.select { |_, v| v[:pattern] && !v[:pattern].is_a?(Regexp) }.keys).to be_empty
       expect(Validation::PostgresConfigValidatorSchema::PGBOUNCER_CONFIG_SCHEMA.select { |_, v| v[:pattern] && !v[:pattern].is_a?(Regexp) }.keys).to be_empty
     end
+
+    it "check if all restart-sensitive params have a default value" do
+      [
+        Validation::PostgresConfigValidatorSchema::PG_16_CONFIG_SCHEMA,
+        Validation::PostgresConfigValidatorSchema::PG_17_CONFIG_SCHEMA,
+        Validation::PostgresConfigValidatorSchema::PG_18_CONFIG_SCHEMA,
+      ].each do |schema|
+        PostgresServer::RESTART_SENSITIVE_PARAMS.each do |param|
+          expect(schema[param]).not_to be_nil
+          expect(schema[param][:default]).not_to be_nil
+        end
+      end
+    end
   end
 end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -178,6 +178,10 @@ RSpec.describe PostgresServer do
       expect(postgres_server.configure_hash[:configs]).to include("recovery_init_sync_method" => "syncfs")
     end
 
+    it "sources the max_connections default from the config validator schema" do
+      expect(postgres_server.configure_hash[:configs]["max_connections"]).to eq(Validation::PostgresConfigValidator.new(postgres_server.version).default("max_connections").to_s)
+    end
+
     it "sets strict_overcommit to true by default" do
       expect(postgres_server.configure_hash[:strict_overcommit]).to be true
     end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -206,6 +206,140 @@ RSpec.describe PostgresServer do
     end
   end
 
+  describe "restart-sensitive parameter handling" do
+    let(:standby) {
+      described_class.create(
+        timeline:, resource_id: resource.id, vm_id: create_hosted_vm(project, private_subnet, "standby").id,
+        synchronization_status: "ready", timeline_access: "fetch", version: "16", is_representative: false,
+      )
+    }
+
+    let(:psql_command) { "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'" }
+    let(:settings_query) { %(SELECT "name", "setting" FROM "pg_settings" WHERE ("name" IN ('max_connections', 'max_worker_processes', 'max_wal_senders', 'max_prepared_transactions', 'max_locks_per_transaction'))) }
+
+    def running(values)
+      PostgresServer::RESTART_SENSITIVE_PARAMS.zip(values).to_h
+    end
+
+    def running_csv(values)
+      running(values).map { |name, value| "#{name},#{value}" }.join("\n")
+    end
+
+    describe "#replication_parent_server" do
+      it "is nil for a standalone primary" do
+        expect(postgres_server.replication_parent_server).to be_nil
+      end
+
+      it "is the resource representative for an HA standby" do
+        postgres_server
+        expect(standby.replication_parent_server).to eq(postgres_server)
+      end
+
+      it "is the parent resource's representative for a read replica representative" do
+        postgres_server
+        replica_resource = create_postgres_resource(project:, location_id: location.id)
+        replica_resource.update(parent_id: resource.id)
+        replica = described_class.create(
+          timeline:, resource_id: replica_resource.id, vm_id: create_hosted_vm(project, private_subnet, "replica").id,
+          synchronization_status: "ready", timeline_access: "fetch", version: "16", is_representative: true,
+        )
+        expect(replica.replication_parent_server).to eq(postgres_server)
+      end
+    end
+
+    describe "#replication_child_servers" do
+      it "is empty for a non-representative server" do
+        expect(standby.replication_child_servers).to eq([])
+      end
+
+      it "includes HA standbys and read replica representatives" do
+        postgres_server
+        standby
+        replica_resource = create_postgres_resource(project:, location_id: location.id)
+        replica_resource.update(parent_id: resource.id)
+        replica = described_class.create(
+          timeline:, resource_id: replica_resource.id, vm_id: create_hosted_vm(project, private_subnet, "replica").id,
+          synchronization_status: "ready", timeline_access: "fetch", version: "16", is_representative: true,
+        )
+        expect(postgres_server.replication_child_servers).to contain_exactly(standby, replica)
+      end
+    end
+
+    describe "#restart_sensitive_target_values" do
+      it "uses schema defaults when not overridden" do
+        expect(postgres_server.restart_sensitive_target_values["max_connections"]).to eq(500)
+      end
+
+      it "uses the user override when present" do
+        resource.update(user_config: {"max_connections" => "200"})
+        expect(postgres_server.restart_sensitive_target_values["max_connections"]).to eq(200)
+      end
+    end
+
+    describe "#restart_sensitive_running_values" do
+      it "parses the queried settings" do
+        expect(postgres_server.vm.sshable).to receive(:_cmd).with(psql_command, stdin: settings_query).and_return(running_csv([500, 8, 10, 0, 64]))
+        expect(postgres_server.restart_sensitive_running_values).to eq(running([500, 8, 10, 0, 64]))
+      end
+
+      it "returns nil when a parameter is missing" do
+        expect(postgres_server.vm.sshable).to receive(:_cmd).with(psql_command, stdin: settings_query).and_return("max_connections,500")
+        expect(postgres_server.restart_sensitive_running_values).to be_nil
+      end
+
+      it "returns nil when the query fails" do
+        expect(postgres_server.vm.sshable).to receive(:_cmd).with(psql_command, stdin: settings_query).and_raise(Sshable::SshTimeout.new("boom", "", "", nil, nil))
+        expect(postgres_server.restart_sensitive_running_values).to be_nil
+      end
+    end
+
+    describe "#restart_sensitive_params_safe?" do
+      it "is safe for a standalone primary with no neighbours" do
+        expect(postgres_server.restart_sensitive_params_safe?).to be true
+      end
+
+      it "blocks a standby decrease until the primary has the lower value" do
+        postgres_server
+        resource.update(user_config: {"max_connections" => "200"})
+        primary_sshable = standby.replication_parent_server.vm.sshable
+        expect(primary_sshable).to receive(:_cmd).with(psql_command, stdin: settings_query).and_return(running_csv([500, 8, 10, 0, 64]))
+        expect(standby.restart_sensitive_params_safe?).to be false
+      end
+
+      it "allows a standby decrease once the primary already has the lower value" do
+        postgres_server
+        resource.update(user_config: {"max_connections" => "200"})
+        primary_sshable = standby.replication_parent_server.vm.sshable
+        expect(primary_sshable).to receive(:_cmd).with(psql_command, stdin: settings_query).and_return(running_csv([200, 8, 10, 0, 64]))
+        expect(standby.restart_sensitive_params_safe?).to be true
+      end
+
+      it "blocks a primary increase until the standby has the higher value" do
+        standby
+        resource.update(user_config: {"max_connections" => "800"})
+        child_sshable = postgres_server.replication_child_servers.first.vm.sshable
+        expect(child_sshable).to receive(:_cmd).with(psql_command, stdin: settings_query).and_return(running_csv([500, 8, 10, 0, 64]))
+        expect(postgres_server.restart_sensitive_params_safe?).to be false
+      end
+
+      it "allows a primary increase once the standby already has the higher value" do
+        standby
+        resource.update(user_config: {"max_connections" => "800"})
+        child_sshable = postgres_server.replication_child_servers.first.vm.sshable
+        expect(child_sshable).to receive(:_cmd).with(psql_command, stdin: settings_query).and_return(running_csv([800, 8, 10, 0, 64]))
+        expect(postgres_server.restart_sensitive_params_safe?).to be true
+      end
+
+      it "skips neighbours whose running values cannot be read" do
+        standby
+        resource.update(user_config: {"max_connections" => "800"})
+        child_sshable = postgres_server.replication_child_servers.first.vm.sshable
+        expect(child_sshable).to receive(:_cmd).with(psql_command, stdin: settings_query).and_raise(Sshable::SshTimeout.new("boom", "", "", nil, nil))
+        expect(postgres_server.restart_sensitive_params_safe?).to be true
+      end
+    end
+  end
+
   describe "#trigger_failover" do
     it "logs error when server is not primary" do
       expect(postgres_server).to receive(:is_representative).and_return(false)

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1429,6 +1429,21 @@ CMD
       expect(Semaphore.where(strand_id: postgres_server.id, name: "restart").count).to eq(1)
     end
 
+    it "naps without restarting when applying restart-sensitive params would break replication" do
+      create_postgres_server(resource: postgres_resource, timeline: postgres_timeline, is_representative: false)
+      psql_command = "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'"
+      settings_query = %(SELECT "name", "setting" FROM "pg_settings" WHERE ("name" IN ('max_connections', 'max_worker_processes', 'max_wal_senders', 'max_prepared_transactions', 'max_locks_per_transaction')))
+      running_csv = PostgresServer::RESTART_SENSITIVE_PARAMS.zip([499, 8, 10, 0, 64]).map { |name, value| "#{name},#{value}" }.join("\n")
+      standby = server.resource.servers.find { !it.is_representative }
+
+      nx.incr_restart
+      expect(nx).to receive(:register_deadline).with("complete_restart", 2 * 60)
+      expect(standby.vm.sshable).to receive(:_cmd).with(psql_command, stdin: settings_query).and_return(running_csv)
+      expect(nx).not_to receive(:daemonized_restart)
+      expect { nx.wait }.to nap(5)
+      expect(Semaphore.where(strand_id: postgres_server.id, name: "restart").count).to eq(1)
+    end
+
     describe "read replica" do
       let(:replica_resource) { create_read_replica_resource(parent: postgres_resource) }
       let(:replica_server_record) {

--- a/spec/routes/api/cli/pg/create-read-replica_spec.rb
+++ b/spec/routes/api/cli/pg/create-read-replica_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Clover, "cli pg create-read-replica" do
     server.vm.update(family: "standard", vcpus: 2, memory_gib: 8, arch: "x64")
     pg.timeline.update(cached_earliest_backup_at: Time.now)
 
-    body = cli(%w[pg eu-central-h1/test-pg create-read-replica -c max_connections=99 -u max_client_conn=99 -t foo=bar,baz=quux test-pg-rr])
+    body = cli(%w[pg eu-central-h1/test-pg create-read-replica -c max_connections=500 -u max_client_conn=99 -t foo=bar,baz=quux test-pg-rr])
     pg = PostgresResource.first(name: "test-pg-rr")
     expect(pg.display_location).to eq "eu-central-h1"
     expect(pg.target_vm_size).to eq "standard-2"
@@ -25,7 +25,7 @@ RSpec.describe Clover, "cli pg create-read-replica" do
     expect(pg.ha_type).to eq "none"
     expect(pg.version).to eq "17"
     expect(pg.flavor).to eq "standard"
-    expect(pg.user_config).to eq({"max_connections" => "99"})
+    expect(pg.user_config).to eq({"max_connections" => "500"})
     expect(pg.pgbouncer_user_config).to eq({"max_client_conn" => "99"})
     expect(pg.tags).to eq([{"key" => "foo", "value" => "bar"}, {"key" => "baz", "value" => "quux"}])
     expect(pg.parent_id).to eq(PostgresResource.first(name: "test-pg").id)

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -460,6 +460,19 @@ RSpec.describe Clover, "postgres" do
         expect(last_response).to have_api_error(400, "Validation failed for following fields: pg_config.wal_level")
       end
 
+      it "read-replica rejects restart-sensitive params set below the primary's value" do
+        pg.update(user_config: {"max_connections" => "500"})
+        expect(PostgresTimeline).to receive(:earliest_restore_time).and_return(true)
+
+        post "/project/#{project.ubid}/location/eu-central-h1/postgres/#{pg.name}/read-replica", {
+          name: "my-read-replica-with-low-config",
+          pg_config: {"max_connections" => "100"},
+        }.to_json
+
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: pg_config.max_connections")
+        expect(PostgresResource.first(name: "my-read-replica-with-low-config")).to be_nil
+      end
+
       it "fails read-replica creation if the parent is not ready" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
         expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
@@ -1278,6 +1291,51 @@ RSpec.describe Clover, "postgres" do
 
         expect(pg.reload.user_config).to eq({"max_connections" => "120", "archive_mode" => "on"})
         expect(pg.reload.pgbouncer_user_config).to eq({"max_client_conn" => "100", "admin_users" => "postgres"})
+      end
+
+      it "rejects increasing a restart-sensitive param beyond a read replica's value" do
+        pg.update(user_config: {"max_connections" => "100"})
+        replica = Prog::Postgres::PostgresResourceNexus.assemble(
+          project_id: project.id,
+          location_id: pg.location_id,
+          name: "my-replica-for-config-test",
+          target_vm_size: pg.target_vm_size,
+          target_storage_size_gib: pg.target_storage_size_gib,
+          target_version: pg.version,
+          parent_id: pg.id,
+          user_config: {"max_connections" => "100"},
+        ).subject
+
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/config", {
+          pg_config: {"max_connections" => "200"},
+          pgbouncer_config: {},
+        }.to_json
+
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: pg_config.max_connections")
+        expect(pg.reload.user_config).to eq({"max_connections" => "100"})
+        expect(replica.reload.user_config).to eq({"max_connections" => "100"})
+      end
+
+      it "rejects decreasing a read replica's restart-sensitive param below the primary's value" do
+        pg.update(user_config: {"max_connections" => "200"})
+        replica = Prog::Postgres::PostgresResourceNexus.assemble(
+          project_id: project.id,
+          location_id: pg.location_id,
+          name: "my-replica-for-config-test-2",
+          target_vm_size: pg.target_vm_size,
+          target_storage_size_gib: pg.target_storage_size_gib,
+          target_version: pg.version,
+          parent_id: pg.id,
+          user_config: {"max_connections" => "200"},
+        ).subject
+
+        post "/project/#{project.ubid}/location/#{replica.display_location}/postgres/#{replica.name}/config", {
+          pg_config: {"max_connections" => "100"},
+          pgbouncer_config: {},
+        }.to_json
+
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: pg_config.max_connections")
+        expect(replica.reload.user_config).to eq({"max_connections" => "200"})
       end
     end
 


### PR DESCRIPTION
Lowering a restart-sensitive parameter (max_connections, max_worker_processes, max_wal_senders, max_prepared_transactions, max_locks_per_transaction) and restarting an HA resource could leave a standby/read-replica stuck in "recovery aborted because of insufficient parameter settings": the restart semaphore fans out to all servers at once, so a standby could boot with the lower value while still replaying WAL that records the primary's higher value. WAL replay is sequential, so the standby can never reach the later parameter-change record and loops on FATAL.

Gate each server's restart in PostgresServerNexus#wait on restart_sensitive_params_safe?, which holds off until applying the new config keeps every sensitive parameter >= its replication upstream and <= its downstream running values. This derives the correct ordering automatically (primary-first on decreases, standby-first on increases) without coupling to the decoupled restart action, and covers HA standbys and read replicas. A persistent imbalance surfaces via the existing complete_restart deadline rather than silently breaking replication.