### PR TITLE
Handle postgres E2E failures where start never completes

### DIFF
--- a/prog/test/ha_postgres_resource.rb
+++ b/prog/test/ha_postgres_resource.rb
@@ -98,12 +98,6 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
     hop_destroy
   end
 
-  label def destroy_postgres
-    self.timeline_ids = postgres_resource.servers_dataset.distinct.select_map(:timeline_id)
-    postgres_resource.incr_destroy
-    hop_wait_resources_destroyed
-  end
-
   label def wait_resources_destroyed
     nap 5 if postgres_resource
     nap_if_private_subnet
@@ -115,4 +109,5 @@ class Prog::Test::HaPostgresResource < Prog::Test::PostgresBase
   label :finish
   label :failed
   label :destroy
+  label :destroy_postgres
 end

--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -149,6 +149,14 @@ class Prog::Test::PostgresBase < Prog::Test::Base
     hop_destroy_postgres
   end
 
+  def destroy_postgres
+    if postgres_resource
+      self.timeline_ids ||= postgres_resource.servers_dataset.distinct.select_map(:timeline_id)
+      postgres_resource.incr_destroy
+    end
+    hop_wait_resources_destroyed
+  end
+
   # Rule edits fan out differently per provider. On GCP, Firewall bumps
   # update_firewall_rules on the subnet; SubnetNexus#wait then forwards
   # to the GcpVpc, whose VpcNexus runs the shared policy sync. On

--- a/prog/test/postgres_firewall.rb
+++ b/prog/test/postgres_firewall.rb
@@ -113,12 +113,6 @@ class Prog::Test::PostgresFirewall < Prog::Test::PostgresBase
     hop_destroy_postgres
   end
 
-  label def destroy_postgres
-    self.timeline_ids = postgres_resource.servers_dataset.distinct.select_map(:timeline_id)
-    postgres_resource.incr_destroy
-    hop_wait_resources_destroyed
-  end
-
   label def wait_resources_destroyed
     nap 5 if postgres_resource
     nap_if_private_subnet
@@ -174,4 +168,6 @@ class Prog::Test::PostgresFirewall < Prog::Test::PostgresBase
       self.pg_retries = nil
     end
   end
+
+  label :destroy_postgres
 end

--- a/prog/test/postgres_resource.rb
+++ b/prog/test/postgres_resource.rb
@@ -28,12 +28,6 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
     hop_destroy
   end
 
-  label def destroy_postgres
-    self.timeline_ids = postgres_resource.servers_dataset.distinct.select_map(:timeline_id)
-    postgres_resource.incr_destroy
-    hop_wait_resources_destroyed
-  end
-
   label def wait_resources_destroyed
     nap 5 if postgres_resource
     nap_if_private_subnet
@@ -46,4 +40,5 @@ class Prog::Test::PostgresResource < Prog::Test::PostgresBase
   label :finish
   label :failed
   label :destroy
+  label :destroy_postgres
 end

--- a/prog/test/upgrade_postgres_resource.rb
+++ b/prog/test/upgrade_postgres_resource.rb
@@ -266,8 +266,7 @@ SQL
     replica_timeline_ids = read_replica ? read_replica.servers.map(&:timeline_id) : []
     self.timeline_ids = (primary_timeline_ids + replica_timeline_ids).uniq
     read_replica&.incr_destroy
-    postgres_resource.incr_destroy
-    hop_wait_resources_destroyed
+    super
   end
 
   label def wait_resources_destroyed

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -259,12 +259,16 @@ RSpec.describe Prog::Test::PostgresResource do
   end
 
   describe "#destroy_postgres" do
-    before { setup_postgres_resource(with_server: true) }
-
     it "increments the destroy count and hops to wait_resources_destroyed" do
+      setup_postgres_resource(with_server: true)
       expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
       expect(Semaphore.where(strand_id: postgres_resource.id, name: "destroy").count).to eq(1)
       expect(pgr_test.strand.stack[0]["timeline_ids"]).not_to be_empty
+    end
+
+    it "works without postgres resource (jump from start to destroy before creating resource)" do
+      expect { pgr_test.destroy_postgres }.to hop("wait_resources_destroyed")
+      expect(pgr_test.strand.stack[0]).not_to have_key("timeline_ids")
     end
   end
 


### PR DESCRIPTION
Previously, if start didn't complete, the postgres resource wouldn't be created, and destroy_postgres would continually fail. If the postgres resource was never created, there is nothing to destroy, so just hop in that case.

While here, add PostgresBase#destroy_postgres to consolidate the logic.