### PR TITLE
Simplify MI specs by using the set_latest_version arg 

### DIFF
--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -65,9 +65,7 @@ RSpec.describe Prog::Test::VmGroup do
     it "does not leak machine_image_version_id from a sibling VM sharing a storage_options slot" do
       store = MachineImageStore.create(project_id: mi_project.id, location_id: Location::HETZNER_FSN1_ID, provider: "r2", region: "auto", endpoint: "https://r2.cloudflare.com/", bucket: "test-bucket", access_key: "ak", secret_key: "sk")
       ["ubuntu-noble", "ubuntu-resolute"].each do |name|
-        metal = create_machine_image_version_metal(project_id: mi_project.id, machine_image_store_id: store.id, name:)
-        miv = metal.machine_image_version
-        miv.machine_image.update(latest_version_id: miv.id)
+        create_machine_image_version_metal(project_id: mi_project.id, machine_image_store_id: store.id, name:, set_latest_version: true)
       end
 
       # 4 boot images cycle through 3 storage_options slots; almalinux-9 at

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -197,8 +197,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     it "uses a machine image if a base boot image is requested and boot_image@latest exists in the machine images service project" do
       mi_project = Project.create(name: "machine-images-service-project")
       expect(Config).to receive(:machine_images_service_project_id).at_least(:once).and_return(mi_project.id)
-      miv = create_machine_image_version_metal(project_id: mi_project.id, location_id: Location::HETZNER_FSN1_ID, name: "ubuntu-jammy").machine_image_version
-      miv.machine_image.update(latest_version_id: miv.id)
+      miv = create_machine_image_version_metal(project_id: mi_project.id, location_id: Location::HETZNER_FSN1_ID, name: "ubuntu-jammy", set_latest_version: true).machine_image_version
       vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "ubuntu-jammy", location_id: Location::HETZNER_FSN1_ID).subject
       expect(vm.vm_storage_volumes.first.machine_image_version_id).to eq(miv.id)
     end
@@ -322,11 +321,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
 
   describe ".lookup_machine_image_version" do
     let(:project_id) { Project.create(name: "test").id }
-    let(:miv) {
-      miv = create_machine_image_version_metal(project_id:, location_id: Location::HETZNER_FSN1_ID, name: "ubuntu-jammy").machine_image_version
-      miv.machine_image.update(latest_version_id: miv.id)
-      miv
-    }
+    let(:miv) { create_machine_image_version_metal(project_id:, location_id: Location::HETZNER_FSN1_ID, name: "ubuntu-jammy", set_latest_version: true).machine_image_version }
 
     it "looks up the machine image version for the VM's location and image" do
       miv

--- a/spec/routes/api/cli/mi/destroy_version_spec.rb
+++ b/spec/routes/api/cli/mi/destroy_version_spec.rb
@@ -7,13 +7,12 @@ RSpec.describe Clover, "cli mi destroy-version" do
   let(:extra_metal) { MachineImageVersionMetal[@mi.versions_dataset.first(version: "v2").id] }
 
   before do
-    @mi_metal = create_machine_image_version_metal(project_id: @project.id, location_id:)
+    @mi_metal = create_machine_image_version_metal(project_id: @project.id, location_id:, set_latest_version: true)
     @mi = @mi_metal.machine_image_version.machine_image
     extra = MachineImageVersion.create(machine_image_id: @mi.id, version: "v2")
     MachineImageVersionMetal.create_with_id(extra, archive_kek_id: @mi_metal.archive_kek_id,
       store_id: @mi_metal.store_id, store_prefix: "p2", status: "ready", archive_size_mib: 10)
     Strand.create_with_id(extra, prog: "MachineImage::VersionMetalNexus", label: "wait", stack: [{}])
-    @mi.update(latest_version_id: @mi_metal.machine_image_version.id)
   end
 
   it "schedules version destruction with -f" do

--- a/spec/routes/api/cli/mi/show_spec.rb
+++ b/spec/routes/api/cli/mi/show_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe Clover, "cli mi show" do
   let(:location_id) { Location[display_name: TEST_LOCATION].id }
 
   before do
-    @mi_metal = create_machine_image_version_metal(project_id: @project.id, location_id:)
+    @mi_metal = create_machine_image_version_metal(project_id: @project.id, location_id:, set_latest_version: true)
     @mi = @mi_metal.machine_image_version.machine_image
-    @mi.update(latest_version_id: @mi_metal.machine_image_version.id)
   end
 
   it "shows machine image details" do

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -96,8 +96,7 @@ RSpec.describe Clover, "vm" do
       end
 
       it "rejects boot_image referencing an MI the user cannot view" do
-        miv = create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "my-image", version: "v1").machine_image_version
-        miv.machine_image.update(latest_version_id: miv.id)
+        create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "my-image", version: "v1", set_latest_version: true)
 
         other_user = create_account("other_user@example.com")
         other_user.add_project(project)

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -224,11 +224,7 @@ RSpec.describe Clover, "vm" do
       end
 
       describe "with a published machine image" do
-        let(:miv) do
-          v = create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "my-image", version: "v1").machine_image_version
-          v.machine_image.update(latest_version_id: v.id)
-          v
-        end
+        let(:miv) { create_machine_image_version_metal(project_id: project.id, location_id: Location::HETZNER_FSN1_ID, name: "my-image", version: "v1", set_latest_version: true).machine_image_version }
 
         before do
           miv


### PR DESCRIPTION
Replaces the two-line pattern of calling the create helper and then updating the machine image's latest_version_id with a single call passing `set_latest_version: true`. Applies to specs where the update was immediately adjacent to the helper call.