### PR TITLE
Skip non-accepting hosts when picking a VhostBlockBackend for URL-based MI capture

### DIFF
--- a/prog/machine_image/version_metal_nexus.rb
+++ b/prog/machine_image/version_metal_nexus.rb
@@ -41,7 +41,7 @@ class Prog::MachineImage::VersionMetalNexus < Prog::Base
   def self.assemble_from_url(machine_image, version, url, sha256sum, store, set_as_latest: true)
     DB.transaction do
       vbb = VhostBlockBackend
-        .where(vm_host_id: VmHost.where(location_id: machine_image.location_id).select(:id))
+        .where(vm_host_id: VmHost.where(location_id: machine_image.location_id, allocation_state: "accepting").select(:id))
         .where { version_code >= VhostBlockBackend::MIN_ARCHIVE_SUPPORT_VERSION }
         .order { random.function }
         .first

--- a/spec/prog/machine_image/version_metal_nexus_spec.rb
+++ b/spec/prog/machine_image/version_metal_nexus_spec.rb
@@ -97,6 +97,13 @@ RSpec.describe Prog::MachineImage::VersionMetalNexus do
       expect { described_class.assemble_from_url(machine_image, "2.0", "https://x/img", "abc", store) }
         .to raise_error("no vm host with archive support found in location")
     end
+
+    it "skips vm hosts that are not accepting allocations" do
+      vbb
+      vm_host.update(allocation_state: "draining")
+      expect { described_class.assemble_from_url(machine_image, "2.0", "https://x/img", "abc", store) }
+        .to raise_error("no vm host with archive support found in location")
+    end
   end
 
   describe "#archive" do


### PR DESCRIPTION
VhostBlockBackend selection in VersionMetalNexus.assemble_from_url matched VBBs on any host in the location, including hosts in `draining` state. Capture would then run against a host that shouldn't be receiving new work. Constrain the host lookup to allocation_state="accepting" to match how scheduling/allocator.rb picks hosts for VM allocation.