### PR TITLE
Add ipv6 unistack aws mgmt support

### DIFF
--- a/prog/postgres/postgres_server_aws_nic_migration.rb
+++ b/prog/postgres/postgres_server_aws_nic_migration.rb
@@ -49,7 +49,6 @@ class Prog::Postgres::PostgresServerAwsNicMigration < Prog::Base
       end
 
       Config.control_plane_outbound_cidrs.each do |cidr|
-        next if cidr.include?(":")
         authorize_mgmt_ssh_ingress(sg_id, cidr)
       end
 

--- a/prog/postgres/postgres_server_aws_nic_migration.rb
+++ b/prog/postgres/postgres_server_aws_nic_migration.rb
@@ -50,10 +50,7 @@ class Prog::Postgres::PostgresServerAwsNicMigration < Prog::Base
 
       Config.control_plane_outbound_cidrs.each do |cidr|
         next if cidr.include?(":")
-        begin
-          client.authorize_security_group_ingress(group_id: sg_id, ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: cidr}]}])
-        rescue Aws::EC2::Errors::InvalidPermissionDuplicate
-        end
+        authorize_mgmt_ssh_ingress(sg_id, cidr)
       end
 
       ps_aws.update(mgmt_security_group_id: sg_id)
@@ -332,6 +329,18 @@ class Prog::Postgres::PostgresServerAwsNicMigration < Prog::Base
 
   def client
     @client ||= vm.location.location_credential_aws.client
+  end
+
+  def authorize_mgmt_ssh_ingress(sg_id, cidr)
+    # IPv4 sources go in ip_ranges, IPv6 sources in ipv_6_ranges
+    ranges = if cidr.include?(":")
+      {ipv_6_ranges: [{cidr_ipv_6: cidr}]}
+    else
+      {ip_ranges: [{cidr_ip: cidr}]}
+    end
+    client.authorize_security_group_ingress(group_id: sg_id, ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, **ranges}])
+  rescue Aws::EC2::Errors::InvalidPermissionDuplicate
+    nil
   end
 
   def get_network_interface(nic)

--- a/prog/postgres/postgres_server_aws_nic_migration.rb
+++ b/prog/postgres/postgres_server_aws_nic_migration.rb
@@ -48,9 +48,12 @@ class Prog::Postgres::PostgresServerAwsNicMigration < Prog::Base
         client.describe_security_groups(filters: [{name: "group-name", values: [group_name]}]).security_groups[0].group_id
       end
 
-      begin
-        client.authorize_security_group_ingress(group_id: sg_id, ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "0.0.0.0/0"}]}])
-      rescue Aws::EC2::Errors::InvalidPermissionDuplicate
+      Config.control_plane_outbound_cidrs.each do |cidr|
+        next if cidr.include?(":")
+        begin
+          client.authorize_security_group_ingress(group_id: sg_id, ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: cidr}]}])
+        rescue Aws::EC2::Errors::InvalidPermissionDuplicate
+        end
       end
 
       ps_aws.update(mgmt_security_group_id: sg_id)

--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -279,13 +279,18 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
   end
 
   def allow_ingress(group_id, from_port, to_port, cidr)
+    ranges = if cidr.include?(":")
+      {ipv_6_ranges: [{cidr_ipv_6: cidr}]}
+    else
+      {ip_ranges: [{cidr_ip: cidr}]}
+    end
     client.authorize_security_group_ingress({
       group_id:,
       ip_permissions: [{
         ip_protocol: "tcp",
         from_port:,
         to_port:,
-        ip_ranges: [{cidr_ip: cidr}],
+        **ranges,
       }],
     })
   rescue Aws::EC2::Errors::InvalidPermissionDuplicate

--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -51,7 +51,6 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
     end
 
     Config.control_plane_outbound_cidrs.each do |cidr|
-      next if cidr.include?(":")
       allow_ingress(private_subnet_aws_resource.mgmt_security_group_id, 22, 22, cidr)
     end
     allow_ingress(private_subnet_aws_resource.mgmt_security_group_id, 443, 443, private_subnet.net4.to_s) if private_subnet.project.get_ff_aws_cloudwatch_logs

--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -50,7 +50,10 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
       allow_ingress(private_subnet_aws_resource.user_security_group_id, firewall_rule.port_range.first, firewall_rule.port_range.last - 1, firewall_rule.cidr.to_s)
     end
 
-    allow_ingress(private_subnet_aws_resource.mgmt_security_group_id, 22, 22, "0.0.0.0/0")
+    Config.control_plane_outbound_cidrs.each do |cidr|
+      next if cidr.include?(":")
+      allow_ingress(private_subnet_aws_resource.mgmt_security_group_id, 22, 22, cidr)
+    end
     allow_ingress(private_subnet_aws_resource.mgmt_security_group_id, 443, 443, private_subnet.net4.to_s) if private_subnet.project.get_ff_aws_cloudwatch_logs
 
     hop_create_route_table

--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
 
   describe "#wait_vpc_created" do
     before do
+      allow(Config).to receive(:control_plane_outbound_cidrs).and_return(["0.0.0.0/0", "::/0"])
       client.stub_responses(:modify_vpc_attribute)
       client.stub_responses(:create_security_group, group_id: "sg-single")
       client.stub_responses(:authorize_security_group_ingress)
@@ -99,6 +100,17 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
       expect { nx.wait_vpc_created }.to hop("create_route_table")
       expect(aws_resource.reload.user_security_group_id).to eq("sg-user")
       expect(aws_resource.mgmt_security_group_id).to eq("sg-mgmt")
+    end
+
+    it "authorizes mgmt SSH ingress from each control_plane_outbound_cidrs entry, skipping IPv6 cidrs" do
+      Prog::Vnet::NicNexus.assemble(ps.id, name: "test-mgmt-nic", is_management: true)
+      allow(Config).to receive(:control_plane_outbound_cidrs).and_return(["100.64.0.0/10", "192.0.2.0/24", "fd00::/8"])
+      client.stub_responses(:describe_vpcs, vpcs: [{state: "available", vpc_id: "vpc-0123456789abcdefg"}])
+      client.stub_responses(:create_security_group, [{group_id: "sg-user"}, {group_id: "sg-mgmt"}])
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-mgmt", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "100.64.0.0/10"}]}]}).and_call_original
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-mgmt", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "192.0.2.0/24"}]}]}).and_call_original
+      expect { nx.wait_vpc_created }.to hop("create_route_table")
+      expect(aws_resource.reload.mgmt_security_group_id).to eq("sg-mgmt")
     end
 
     it "skips security group ingress rule if it already exists" do

--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
       expect(client).to receive(:create_security_group).with({group_name: "aws-us-west-2-#{ps.ubid}-user", description: "User security group for aws-us-west-2-#{ps.ubid}", vpc_id: "vpc-0123456789abcdefg", tag_specifications: Util.aws_tag_specifications("security-group", ps.name)}).and_call_original
       expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-single", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 80, ip_ranges: [{cidr_ip: "0.0.0.1/32"}]}]}).and_call_original
       expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-single", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "0.0.0.0/0"}]}]}).and_call_original
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-single", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ipv_6_ranges: [{cidr_ipv_6: "::/0"}]}]}).and_call_original
       FirewallRule.create(firewall_id: ps.firewalls.first.id, cidr: "0.0.0.1/32", port_range: 22..80)
       expect { nx.wait_vpc_created }.to hop("create_route_table")
       expect(aws_resource.reload.user_security_group_id).to eq("sg-single")
@@ -97,18 +98,20 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
       expect(client).to receive(:create_security_group).with(hash_including(group_name: "aws-us-west-2-#{ps.ubid}-user")).and_call_original
       expect(client).to receive(:create_security_group).with(hash_including(group_name: "aws-us-west-2-#{ps.ubid}-mgmt")).and_call_original
       expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-mgmt", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "0.0.0.0/0"}]}]}).and_call_original
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-mgmt", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ipv_6_ranges: [{cidr_ipv_6: "::/0"}]}]}).and_call_original
       expect { nx.wait_vpc_created }.to hop("create_route_table")
       expect(aws_resource.reload.user_security_group_id).to eq("sg-user")
       expect(aws_resource.mgmt_security_group_id).to eq("sg-mgmt")
     end
 
-    it "authorizes mgmt SSH ingress from each control_plane_outbound_cidrs entry, skipping IPv6 cidrs" do
+    it "authorizes mgmt SSH ingress from each control_plane_outbound_cidrs entry, routing IPv6 cidrs to ipv_6_ranges" do
       Prog::Vnet::NicNexus.assemble(ps.id, name: "test-mgmt-nic", is_management: true)
       allow(Config).to receive(:control_plane_outbound_cidrs).and_return(["100.64.0.0/10", "192.0.2.0/24", "fd00::/8"])
       client.stub_responses(:describe_vpcs, vpcs: [{state: "available", vpc_id: "vpc-0123456789abcdefg"}])
       client.stub_responses(:create_security_group, [{group_id: "sg-user"}, {group_id: "sg-mgmt"}])
       expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-mgmt", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "100.64.0.0/10"}]}]}).and_call_original
       expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-mgmt", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "192.0.2.0/24"}]}]}).and_call_original
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-mgmt", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ipv_6_ranges: [{cidr_ipv_6: "fd00::/8"}]}]}).and_call_original
       expect { nx.wait_vpc_created }.to hop("create_route_table")
       expect(aws_resource.reload.mgmt_security_group_id).to eq("sg-mgmt")
     end
@@ -124,6 +127,7 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
       nx.private_subnet.project.set_ff_aws_cloudwatch_logs(true)
       client.stub_responses(:describe_vpcs, vpcs: [{state: "available", vpc_id: "vpc-0123456789abcdefg"}])
       expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-single", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "0.0.0.0/0"}]}]}).and_call_original
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-single", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ipv_6_ranges: [{cidr_ipv_6: "::/0"}]}]}).and_call_original
       expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-single", ip_permissions: [{ip_protocol: "tcp", from_port: 443, to_port: 443, ip_ranges: [{cidr_ip: ps.net4.to_s}]}]}).and_call_original
       expect { nx.wait_vpc_created }.to hop("create_route_table")
     end

--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -129,6 +129,25 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
     end
   end
 
+  describe "#allow_ingress" do
+    it "authorizes an IPv4 cidr via ip_ranges" do
+      client.stub_responses(:authorize_security_group_ingress)
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-test", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "203.0.113.0/24"}]}]}).and_call_original
+      nx.allow_ingress("sg-test", 22, 22, "203.0.113.0/24")
+    end
+
+    it "authorizes an IPv6 cidr via ipv_6_ranges" do
+      client.stub_responses(:authorize_security_group_ingress)
+      expect(client).to receive(:authorize_security_group_ingress).with({group_id: "sg-test", ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ipv_6_ranges: [{cidr_ipv_6: "2001:db8::/32"}]}]}).and_call_original
+      nx.allow_ingress("sg-test", 22, 22, "2001:db8::/32")
+    end
+
+    it "swallows a duplicate permission for either family" do
+      client.stub_responses(:authorize_security_group_ingress, Aws::EC2::Errors::InvalidPermissionDuplicate.new(nil, nil))
+      expect { nx.allow_ingress("sg-test", 22, 22, "2001:db8::/32") }.not_to raise_error
+    end
+  end
+
   describe "#create_route_table" do
     before { aws_resource.update(internet_gateway_id: nil, route_table_id: nil) }
 


### PR DESCRIPTION
As clickhouse doesn't wish to pass a extraneous IP cost to their customers, and the exposure is a loss anyway, since they avail themselves of contiguous IPv6 blocks to get a simple firewall rule between the control plane and any number of VPCs. 