### PR TITLE
Increase kubeadm API call timeout during cluster init

### DIFF
--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -27,6 +27,9 @@ secret_name = service_account_name
 init_config = {
   "apiVersion" => "kubeadm.k8s.io/v1beta4",
   "kind" => "InitConfiguration",
+  "timeouts" => {
+    "kubernetesAPICall" => "5m0s",
+  },
   "nodeRegistration" => {
     "name" => node_name,
     "kubeletExtraArgs" => [


### PR DESCRIPTION
The bootstrap-admin step of kubeadm init talks to the apiserver through the load balancer endpoint, which only starts routing after the LB health checks mark the node up. That transition takes at least 30-60 seconds after the apiserver starts listening, while kubeadm's default kubernetesAPICall timeout is 1 minute, so cluster init loses this race every now and then. Raise the timeout to 5 minutes to absorb the LB propagation latency.