### PR TITLE
Subnet rekey 2 phase step 2

### DIFF
--- a/model/metal/private_subnet.rb
+++ b/model/metal/private_subnet.rb
@@ -22,6 +22,23 @@ class PrivateSubnet < Sequel::Model
           cycle: {columns: :id})
     end
 
+    # In a mesh of transitively connected subnets, the subnet with the
+    # smallest ID is the "connected leader": the single subnet
+    # responsible for coordinating rekeying for the entire mesh. A
+    # standalone subnet is its own leader.
+    def connected_leader_id
+      DB[:subnet]
+        .with_recursive(:subnet,
+          this.select(:id),
+          DB[:connected_subnet]
+            .join(:subnet, {id: [:subnet_id_1, :subnet_id_2]})
+            .select(Sequel.case({subnet_id_1: :subnet_id_2}, :subnet_id_1, Sequel[:subnet][:id])),
+          cycle: {columns: :id})
+        .exclude(:is_cycle)
+        .order(:id)
+        .get(:id)
+    end
+
     private
 
     def metal_connect_subnet(subnet)

--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -42,6 +42,9 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
   label def refresh_keys
     nics = nics_to_rekey
     nap 10 if nics.any?(&:lock_set?)
+    # A v2 coordinator elsewhere in the mesh holds claims the lock_set?
+    # check cannot see. Wait it out, exactly as for locks.
+    nap 10 if nics.any?(&:rekey_coordinator_id)
     locked_nics = []
     nics.each do |nic|
       nic.update(encryption_key: gen_encryption_key, rekey_payload: {spi4: gen_spi, spi6: gen_spi, reqid: gen_reqid})
@@ -79,7 +82,11 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     nics = get_locked_nics
     if nics.all? { |nic| nic.strand.label == "wait" }
       private_subnet.update(state: "waiting", last_rekey_at: Time.now)
-      get_locked_nics_dataset.update(encryption_key: nil, rekey_payload: nil)
+      # Also clear v2 claim columns: a pass over NICs carrying residue
+      # of an interrupted v2 pass (protocol rollback, incident surgery)
+      # heals them here, making any rollback to v1 self-cleaning.
+      get_locked_nics_dataset.update(encryption_key: nil, rekey_payload: nil,
+        rekey_coordinator_id: nil, rekey_phase: "idle")
       Semaphore.where(strand_id: nics.map(&:id), name: "lock").delete(force: true)
       self.locked_nics = nil
       hop_wait

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -448,6 +448,223 @@ RSpec.describe PrivateSubnet do
     end
   end
 
+  describe "#connected_leader_id" do
+    # The method returns the smallest id among all subnets transitively
+    # connected to the receiver (itself included), via the connected_subnet
+    # edge table, using a recursive CTE. The v2 rekey coordinator relies on
+    # this to pick a single coordinating subnet per mesh: correctness means
+    # every member of a connected component must independently agree on the
+    # same leader, and that leader must be the true minimum id.
+    #
+    # Ordering is by raw uuid bytes, which is not controllable through the
+    # random ubids assemble generates. So these tests inject explicit,
+    # hand-ordered uuids and assert against them, rather than asserting on
+    # whatever random ids happened to be produced. That keeps them
+    # deterministic and makes them a real guard: a refactor that dropped the
+    # ORDER BY or the cycle exclusion would fail here instead of passing by
+    # luck on a particular id draw. Edges are created only through the
+    # `edge` helper, which sorts the pair so subnet_id_1 < subnet_id_2 holds
+    # by construction (the connected_subnet unique_subnet_pair check forbids
+    # self-edges and reversed pairs, and the unique index forbids dupes, so
+    # those states are intentionally not exercised: they cannot occur).
+    let(:leader_project) { Project.create(name: "test-leader") }
+
+    # Deterministic, strictly increasing uuids: u(1) < u(2) < ... by the
+    # byte ordering Postgres uses, so the expected leader of any subset is
+    # the one built with the smallest argument.
+    def u(n)
+      format("00000000-0000-0000-0000-%012d", n)
+    end
+
+    # Metal subnet with an injected id, built through create_with_id (not
+    # assemble) to skip firewall/tunnel machinery irrelevant to leader
+    # selection, while landing in a metal location so Metal dispatch is live.
+    def subnet(n, name: "psleader#{n}")
+      PrivateSubnet.create_with_id(
+        u(n),
+        name:,
+        location_id: Location::HETZNER_FSN1_ID,
+        net6: NetAddr.parse_net("fd1b:9793:dcef:#{format("%04x", n)}::/64"),
+        net4: NetAddr.parse_net("10.#{n}.0.0/16"),
+        state: "waiting",
+        project_id: leader_project.id,
+      )
+    end
+
+    # Wire a connected_subnet edge, pair sorted to satisfy the
+    # subnet_id_1 < subnet_id_2 check.
+    def edge(a, b)
+      lo, hi = [a.id, b.id].sort
+      ConnectedSubnet.create(subnet_id_1: lo, subnet_id_2: hi)
+    end
+
+    # Every member of a component must agree, and the answer must be the
+    # expected subnet. This is the invariant the coordinator depends on, so
+    # it is checked for every topology, not spot-checked on one node.
+    def expect_unanimous_leader(members, expected)
+      leaders = members.map { |ps| ps.reload.connected_leader_id }
+      expect(leaders.uniq).to eq([expected.id]),
+        "expected all of #{members.map(&:name)} to agree on leader " \
+        "#{expected.name} (#{expected.id}), got #{leaders.uniq}"
+    end
+
+    it "returns own id for a standalone subnet (no edges)" do
+      ps = subnet(1)
+      expect(ps.connected_leader_id).to eq(ps.id)
+    end
+
+    it "returns the smaller id for a simple pair, both agreeing" do
+      lo = subnet(1)
+      hi = subnet(2)
+      edge(lo, hi)
+      expect_unanimous_leader([lo, hi], lo)
+    end
+
+    it "ignores subnets in other, unconnected components" do
+      # Two separate pairs; each must see only its own minimum, never the
+      # global minimum across components.
+      a_lo = subnet(1)
+      a_hi = subnet(4)
+      edge(a_lo, a_hi)
+
+      b_lo = subnet(2)
+      b_hi = subnet(3)
+      edge(b_lo, b_hi)
+
+      expect_unanimous_leader([a_lo, a_hi], a_lo)
+      expect_unanimous_leader([b_lo, b_hi], b_lo)
+    end
+
+    context "with stress topologies" do
+      it "chain: leader propagates across many hops" do
+        # 1 - 2 - ... - 8, a path graph. The min-id node sits at one end;
+        # the far end is 7 hops away. All must still resolve to it,
+        # exercising CTE traversal depth.
+        nodes = (1..8).map { subnet(it) }
+        nodes.each_cons(2) { |a, b| edge(a, b) }
+        expect_unanimous_leader(nodes, nodes.first)
+      end
+
+      it "chain with the minimum id in the middle" do
+        # Path 5 - 3 - 1 - 2 - 4 by id, so the global minimum (1) is
+        # interior, not an endpoint. Guards against dependence on traversal
+        # start position.
+        order = [5, 3, 1, 2, 4].map { subnet(it) }
+        order.each_cons(2) { |a, b| edge(a, b) }
+        expect_unanimous_leader(order, order.min_by(&:id))
+      end
+
+      it "star: hub plus many leaves" do
+        hub = subnet(1)
+        leaves = (2..7).map { subnet(it) }
+        leaves.each { edge(hub, it) }
+        expect_unanimous_leader([hub] + leaves, hub)
+      end
+
+      it "star with the minimum on a leaf, not the hub" do
+        hub = subnet(5)
+        leaves = (1..4).map { subnet(it) } + (6..8).map { subnet(it) }
+        leaves.each { edge(hub, it) }
+        expect_unanimous_leader([hub] + leaves, ([hub] + leaves).min_by(&:id))
+      end
+
+      it "clique: every subnet connected to every other" do
+        # K6. Redundant edges and the resulting multiple CTE paths to each
+        # node must not confuse the result or duplicate-explode.
+        nodes = (1..6).map { subnet(it) }
+        nodes.combination(2).each { |a, b| edge(a, b) }
+        expect_unanimous_leader(nodes, nodes.first)
+      end
+
+      it "cycle: ring topology terminates and agrees" do
+        # 1 - 2 - 3 - 4 - 5 - 1. The cycle is the specific reason the CTE
+        # carries cycle: {columns: :id} and excludes is_cycle; without that
+        # the recursion would not terminate. Fails loudly (timeout/dupe) if
+        # that handling regresses.
+        nodes = (1..5).map { subnet(it) }
+        nodes.each_cons(2) { |a, b| edge(a, b) }
+        edge(nodes.last, nodes.first)
+        expect_unanimous_leader(nodes, nodes.first)
+      end
+
+      it "cycle with a tail (lollipop)" do
+        # Ring 2-3-4-2 with pendant minimum 1 off node 2. Cycle handling
+        # plus a one-hop extension to the true min.
+        ring = [2, 3, 4].map { subnet(it) }
+        ring.each_cons(2) { |a, b| edge(a, b) }
+        edge(ring.last, ring.first)
+        tail = subnet(1)
+        edge(tail, ring.first)
+        expect_unanimous_leader(ring + [tail], tail)
+      end
+
+      it "two cliques joined by a single bridge edge" do
+        # K4 {1,3,5,7} and K4 {2,4,6,8}, joined by one edge 7-8. One
+        # component, so the global min (1) wins everywhere, across the bridge.
+        a = [1, 3, 5, 7].map { subnet(it) }
+        b = [2, 4, 6, 8].map { subnet(it) }
+        a.combination(2).each { |x, y| edge(x, y) }
+        b.combination(2).each { |x, y| edge(x, y) }
+        edge(a.last, b.last)
+        expect_unanimous_leader(a + b, a.min_by(&:id))
+      end
+
+      it "barbell: two stars joined at their hubs" do
+        hub_a = subnet(3)
+        hub_b = subnet(6)
+        leaves_a = [1, 4, 5].map { subnet(it) }
+        leaves_b = [2, 7, 8].map { subnet(it) }
+        leaves_a.each { edge(hub_a, it) }
+        leaves_b.each { edge(hub_b, it) }
+        edge(hub_a, hub_b)
+        all = [hub_a, hub_b] + leaves_a + leaves_b
+        expect_unanimous_leader(all, all.min_by(&:id))
+      end
+    end
+
+    context "with edge cases that have bitten similar CTEs" do
+      it "diamond: two distinct paths to the same node are not over-excluded" do
+        # 1-2, 1-3, 2-4, 3-4: node 4 is reachable from 1 by two paths (via
+        # 2 and via 3). Smallest genuine multi-path topology the schema
+        # permits. A cycle guard that excised too aggressively could drop
+        # node 4 on the second path; all four must still agree on the min.
+        nodes = (1..4).map { subnet(it) }
+        n1, n2, n3, n4 = nodes
+        edge(n1, n2)
+        edge(n1, n3)
+        edge(n2, n4)
+        edge(n3, n4)
+        expect_unanimous_leader(nodes, n1)
+      end
+
+      it "agrees with find_all_connected_nics on component membership" do
+        # connected_leader_id and find_all_connected_nics share a CTE shape;
+        # their notions of "the component" must not drift. Build a mesh,
+        # attach a nic per subnet, assert the leader is in the component
+        # every subnet sees, for every subnet.
+        nodes = [4, 1, 3, 2].map { subnet(it) }
+        nodes.each_cons(2) { |a, b| edge(a, b) }
+        nics = nodes.map do |ps|
+          Nic.create_with_id(
+            Nic.generate_uuid,
+            private_subnet_id: ps.id,
+            private_ipv6: ps.net6.nth(2).to_s,
+            private_ipv4: ps.net4.nth(2).to_s,
+            state: "active",
+            name: "nic-#{ps.name}",
+          )
+        end
+        leader_id = nodes.first.connected_leader_id
+        nodes.each do |ps|
+          component_subnet_ids = ps.find_all_connected_nics.map(&:private_subnet_id).uniq
+          expect(component_subnet_ids).to include(leader_id),
+            "leader #{leader_id} not in component seen by #{ps.name}"
+        end
+        expect(leader_id).to eq(nics.map(&:private_subnet_id).min)
+      end
+    end
+  end
+
   describe "AWS connect/disconnect subnet" do
     let(:prj) { Project.create(name: "test-aws-prj") }
 

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -123,6 +123,11 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       nic.update(state: "active")
       expect { nx.refresh_keys }.to nap(10)
     end
+
+    it "naps if a v2 coordinator holds a claim on a nic" do
+      nic.update(state: "active", rekey_coordinator_id: ps2.id)
+      expect { nx.refresh_keys }.to nap(10)
+    end
   end
 
   describe "#wait_inbound_setup" do
@@ -184,6 +189,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
 
     it "hops to wait if all is done" do
       nic.strand.update(label: "wait")
+      nic.update(rekey_coordinator_id: ps.id, rekey_phase: "old_drop")
       ps.update(last_rekey_at: Time.now - 100)
       expect { nx.wait_old_state_drop }.to hop("wait")
       ps.refresh
@@ -192,6 +198,8 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       nic.refresh
       expect(nic.encryption_key).to be_nil
       expect(nic.rekey_payload).to be_nil
+      expect(nic.rekey_coordinator_id).to be_nil
+      expect(nic.rekey_phase).to eq "idle"
       expect(nic.lock_set?).to be false
     end
   end


### PR DESCRIPTION
**Add PrivateSubnet#connected_leader_id**
The min-ID member of a connected mesh, selected via the same recursive CTE find_all_connected_nics uses to walk connected_subnet edges. Under rekey v2 this is the single subnet that coordinates a mesh's rekeying; non-leaders forward their refresh_keys to it.

Read-only over pre-existing schema (connected_subnet and subnet ids only), so it has no dependency on the rekey columns and no consumer until the v2 coordinator lands. Kept separate from the migration so neither has to be read as explaining the other.

The accompanying spec is deliberately heavy. The coordinator's single-writer guarantee rests entirely on this method returning the same leader for every member of a component and never reaching across component boundaries: if two subnets in one mesh disagreed on the leader, two coordinators would rotate the shared NICs at once, which is the exact double-claim that wedged production on 2026-06-10; if the CTE leaked across unconnected components, a rekey of one customer's subnet would lock another customer's NICs. So the tests inject strictly ordered ids (the result is ordered by raw uuid, which random ubids cannot pin) and assert, for a battery of topologies -- chains, stars, cliques, cycles, lollipops, bridged cliques, barbells, diamonds -- both that the leader is the true minimum and that every member agrees. The cycle case specifically guards the cycle: {columns: :id} handling, which if dropped would hang or duplicate-explode rather than fail cleanly; the diamond guards against a cycle exclusion that over-excises a node reachable by two legal paths. A final case asserts connected_leader_id and find_all_connected_nics never drift in their notion of the component, since they share the CTE. The tests live alongside find_all_connected_nics's own tests in private_subnet_spec.rb, following the file-per-model convention; edges are created only through a helper that sorts the pair, since the connected_subnet schema forbids self-edges, reversed pairs, and duplicates.

Extracted from https://github.com/ubicloud/ubicloud/pull/5091
(1ef69fddc).

Verify: every member of a mesh returns the same id; a standalone subnet returns its own.

    PrivateSubnet[mesh_member].connected_leader_id

Deploy: inert until the v2 coordinator reads it. Rollback: revert; nothing to clean.

**Make the v1 rekey protocol aware of v2 claims**
Two hardenings of the live protocol, ahead of introducing v2 itself: refresh_keys waits on a foreign rekey_coordinator_id exactly as it waits on lock semaphores, and the completion cleanup clears the v2 claim columns alongside the key material it already clears.

Ordering is the point. Because this precedes the v2 code in the fleet, every later rollback target is a binary that respects and self-heals v2 claims: reverting the v2 commit cannot strand a claim that blocks a future flip, and no rollback procedure ever needs a manual claim-clearing step. Shipping these same lines together with v2 would leave the v2 commit's own revert target blind to them.

Both branches are dead code today - no claims can exist before v2 deploys - so the change is behaviorally inert now and load-bearing only in rollback scenarios, which is exactly when untested code is least welcome; review accordingly. This is the first commit in the series containing logic not reviewed in https://github.com/ubicloud/ubicloud/pull/5091.

Deploy: roll normally, alone or with the schema deploy (which must precede it: the code references the new columns).

Soak: v1 passes complete exactly as before; the new guard never fires (no claims exist) and the widened cleanup UPDATE writes values the rows already hold. One timer cycle of normal last_rekey_at advancement fleet-wide is sufficient.

Rollback: git revert, roll. Nothing to clean.