### PR TITLE
Subnet rekey 2 phase step 3

### DIFF
--- a/model/metal/private_subnet.rb
+++ b/model/metal/private_subnet.rb
@@ -47,6 +47,7 @@ class PrivateSubnet < Sequel::Model
         create_tunnels(subnet.nics, nic)
       end
       subnet.incr_refresh_keys
+      incr_refresh_keys if rekey_protocol == 2
     end
 
     def metal_disconnect_subnet(subnet)

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -428,6 +428,22 @@ RSpec.describe PrivateSubnet do
       expect(ps1.all_nics.map(&:id)).to eq [ps1_nic.id]
     end
 
+    it "connect_subnet signals refresh_keys only on the peer under v1" do
+      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
+      ps1.connect_subnet(ps2)
+      expect(ps1.refresh_keys_set?).to be false
+      expect(ps2.refresh_keys_set?).to be true
+    end
+
+    it "connect_subnet signals refresh_keys on both sides under v2" do
+      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
+      ps1.update(rekey_protocol: 2)
+      ps2.update(rekey_protocol: 2)
+      ps1.connect_subnet(ps2)
+      expect(ps1.refresh_keys_set?).to be true
+      expect(ps2.refresh_keys_set?).to be true
+    end
+
     it "disconnect_subnet does not destroy in subnet tunnels" do
       ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
       ps1_nic = Prog::Vnet::NicNexus.assemble(ps1.id, name: "test-ps1-nic1").subject


### PR DESCRIPTION
Signal refresh_keys on both sides of connect_subnet under v2 metal_disconnect_subnet signals both subnets; metal_connect_subnet signaled only the peer. Under the v2 protocol the connecting side's signal is what reaches the mesh's connected leader when the peer's forwarding would race the topology change, so both sides must signal.

The connecting side's signal is gated on rekey_protocol: unlike disconnect, where the split components rekey disjoint NIC sets, a connect merges the mesh, and under v1 two time-aligned signals stage two coordinators over the same NICs - the double-claim race from the 2026-06-10 incident. v2 absorbs concurrent signals by design (forward to leader, atomic claims). The gate is removed with v1.

Deploy: roll normally; behavior unchanged until a mesh is flipped.
Rollback: git revert, roll. Nothing to clean.