### PR TITLE
Subnet rekey 2 phase step 4

### DIFF
--- a/model/metal/private_subnet.rb
+++ b/model/metal/private_subnet.rb
@@ -27,6 +27,27 @@ class PrivateSubnet < Sequel::Model
     # responsible for coordinating rekeying for the entire mesh. A
     # standalone subnet is its own leader.
     def connected_leader_id
+      mesh_dataset.order(:id).get(:id)
+    end
+
+    # All subnets transitively connected to this one, itself included.
+    def mesh_member_ids
+      mesh_dataset.select_map(:id)
+    end
+
+    # Operator cutover tool: flip a whole mesh's rekey protocol in one
+    # transaction, derived from any member, so partial-mesh flips are
+    # impossible. A concurrent connect_subnet can still leave a mixed
+    # mesh; re-running repairs it. Removed with v1.
+    def flip_mesh_rekey_protocol!(to)
+      PrivateSubnet.where(id: mesh_member_ids).update(rekey_protocol: to)
+    end
+
+    private
+
+    # The mesh as a dataset: this subnet plus everything transitively
+    # reachable over connected_subnet edges.
+    def mesh_dataset
       DB[:subnet]
         .with_recursive(:subnet,
           this.select(:id),
@@ -35,11 +56,7 @@ class PrivateSubnet < Sequel::Model
             .select(Sequel.case({subnet_id_1: :subnet_id_2}, :subnet_id_1, Sequel[:subnet][:id])),
           cycle: {columns: :id})
         .exclude(:is_cycle)
-        .order(:id)
-        .get(:id)
     end
-
-    private
 
     def metal_connect_subnet(subnet)
       ConnectedSubnet.create(subnet_hash(subnet))

--- a/model/metal/private_subnet.rb
+++ b/model/metal/private_subnet.rb
@@ -63,8 +63,19 @@ class PrivateSubnet < Sequel::Model
       nics.each do |nic|
         create_tunnels(subnet.nics, nic)
       end
+      normalize_mesh_rekey_protocol
       subnet.incr_refresh_keys
-      incr_refresh_keys if rekey_protocol == 2
+      incr_refresh_keys if reload.rekey_protocol == 2
+    end
+
+    # Transitional: the rekey protocol must be uniform across a
+    # connected mesh because the coordinator and the claimed NICs span
+    # the whole mesh. When meshes with differing protocols are joined,
+    # v1 wins: a customer-initiated connect can shrink the v2 canary
+    # but never silently expand it. Removed with v1.
+    def normalize_mesh_rekey_protocol
+      ds = PrivateSubnet.where(id: mesh_member_ids)
+      ds.update(rekey_protocol: 1) unless ds.where(rekey_protocol: 1).empty?
     end
 
     def metal_disconnect_subnet(subnet)

--- a/prog/vnet/metal/nic_nexus.rb
+++ b/prog/vnet/metal/nic_nexus.rb
@@ -3,6 +3,15 @@
 class Prog::Vnet::Metal::NicNexus < Prog::Base
   subject_is :nic
 
+  # Transitional dispatch: a NIC follows the protocol of the
+  # coordinator that engaged it, identified by the claim it left.
+  # A v2 coordinator sets rekey_coordinator_id before signaling; a v1
+  # coordinator sets the lock semaphore and never the claim column.
+  # Self-synchronizing: immune to a mesh protocol flip mid-pass.
+  def claimed_v2?
+    !nic.rekey_coordinator_id.nil?
+  end
+
   label def start
     when_vm_allocated_set? do
       hop_wait_setup
@@ -38,7 +47,10 @@ class Prog::Vnet::Metal::NicNexus < Prog::Base
 
   label def start_rekey
     decr_start_rekey
+    claimed_v2? ? v2_start_rekey : v1_start_rekey
+  end
 
+  def v1_start_rekey
     if retval&.dig("msg") == "inbound_setup is complete"
       hop_wait_rekey_outbound_trigger
     end
@@ -46,7 +58,24 @@ class Prog::Vnet::Metal::NicNexus < Prog::Base
     push Prog::Vnet::RekeyNicTunnel, {}, :setup_inbound
   end
 
+  def v2_start_rekey
+    fail "BUG: unexpected start_rekey signal (retval=#{retval&.dig("msg").inspect}, phase=#{nic.rekey_phase}, locked=#{!nic.rekey_coordinator_id.nil?})" unless nic.rekey_coordinator_id && nic.rekey_phase == "idle"
+
+    if retval&.dig("msg") == "inbound_setup is complete"
+      nic.update(rekey_phase: "inbound")
+      PrivateSubnet.incr_nic_phase_done(nic.rekey_coordinator_id)
+      hop_wait_rekey_outbound_trigger
+    end
+
+    # RekeyNicTunnel must not modify rekey_phase or rekey_coordinator_id.
+    push Prog::Vnet::RekeyNicTunnel, {}, :setup_inbound
+  end
+
   label def wait_rekey_outbound_trigger
+    claimed_v2? ? v2_wait_rekey_outbound_trigger : v1_wait_rekey_outbound_trigger
+  end
+
+  def v1_wait_rekey_outbound_trigger
     if retval&.dig("msg") == "outbound_setup is complete"
       hop_wait_rekey_old_state_drop_trigger
     end
@@ -59,7 +88,32 @@ class Prog::Vnet::Metal::NicNexus < Prog::Base
     nap 5
   end
 
+  def v2_wait_rekey_outbound_trigger
+    fail "BUG: NIC not locked in wait_rekey_outbound_trigger" unless nic.rekey_coordinator_id
+
+    if retval&.dig("msg") == "outbound_setup is complete"
+      fail "BUG: NIC phase should be inbound before advancing to outbound, got #{nic.rekey_phase}" unless nic.rekey_phase == "inbound"
+      nic.update(rekey_phase: "outbound")
+      PrivateSubnet.incr_nic_phase_done(nic.rekey_coordinator_id)
+      hop_wait_rekey_old_state_drop_trigger
+    end
+
+    when_trigger_outbound_update_set? do
+      decr_trigger_outbound_update
+      # Looks redundant, but semaphore ordering is the only guarantee that
+      # this trigger arrives while claimed and inbound; keep the guard.
+      fail "BUG: unexpected trigger_outbound_update (phase=#{nic.rekey_phase}, locked=#{!nic.rekey_coordinator_id.nil?})" unless nic.rekey_phase == "inbound"
+      push Prog::Vnet::RekeyNicTunnel, {}, :setup_outbound
+    end
+
+    nap 5
+  end
+
   label def wait_rekey_old_state_drop_trigger
+    claimed_v2? ? v2_wait_rekey_old_state_drop_trigger : v1_wait_rekey_old_state_drop_trigger
+  end
+
+  def v1_wait_rekey_old_state_drop_trigger
     if retval&.dig("msg")&.include?("drop_old_state is complete")
       unless nic.state == "active"
         nic.update(state: "active")
@@ -75,6 +129,27 @@ class Prog::Vnet::Metal::NicNexus < Prog::Base
     nap 5
   end
 
+  def v2_wait_rekey_old_state_drop_trigger
+    fail "BUG: NIC not locked in wait_rekey_old_state_drop_trigger" unless nic.rekey_coordinator_id
+
+    if retval&.dig("msg")&.start_with?("drop_old_state is complete")
+      fail "BUG: NIC phase should be outbound before advancing to old_drop, got #{nic.rekey_phase}" unless nic.rekey_phase == "outbound"
+      nic.update(state: "active", rekey_phase: "old_drop")
+      PrivateSubnet.incr_nic_phase_done(nic.rekey_coordinator_id)
+      hop_wait
+    end
+
+    when_old_state_drop_trigger_set? do
+      decr_old_state_drop_trigger
+      # Looks redundant, but semaphore ordering is the only guarantee that
+      # this trigger arrives while claimed and outbound; keep the guard.
+      fail "BUG: unexpected old_state_drop_trigger (phase=#{nic.rekey_phase}, locked=#{!nic.rekey_coordinator_id.nil?})" unless nic.rekey_phase == "outbound"
+      push Prog::Vnet::RekeyNicTunnel, {}, :drop_old_state
+    end
+
+    nap 5
+  end
+
   label def destroy
     if nic.vm
       Clog.emit("Cannot destroy nic with active vm, first clean up the attached resources", nic)
@@ -84,6 +159,8 @@ class Prog::Vnet::Metal::NicNexus < Prog::Base
     decr_destroy
 
     nic.private_subnet.incr_refresh_keys
+    # Hard-delete is load-bearing: the row vanishing from the claimed
+    # set is what releases a mid-rekey NIC's coordinator claim.
     nic.destroy
 
     pop "nic deleted"

--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -2,13 +2,44 @@
 
 class Prog::Vnet::Metal::SubnetNexus < Prog::Base
   subject_is :private_subnet
+  # v1 keeps the claimed NIC set in the strand frame; v2 keeps it in
+  # nic.rekey_coordinator_id. Removed with v1.
   frame_accessor :locked_nics
+
+  # Transitional dispatch: which rekey protocol governs this subnet's
+  # mesh. Uniform per mesh by construction (metal_connect_subnet
+  # normalizes on edge creation, v1 wins). Consulted only at pass
+  # boundaries (wait, refresh_keys); a pass in flight is identified by
+  # its residue, so a mid-pass flip cannot change protocol mid-pass.
+  def rekey_v2?
+    private_subnet.rekey_protocol == 2
+  end
+
+  # A v1 pass in flight leaves its claimed NIC ids in the strand frame;
+  # v2 never touches the frame.
+  def legacy_pass?
+    !locked_nics.nil?
+  end
+
+  # Destroy guard: subnet cannot be destroyed while it holds v2 claims.
+  # Inert for v1, which never creates claims.
+  def before_run
+    super unless destroy_set? && !claimed_nics_dataset.empty?
+  end
+
+  def connected_leader?
+    private_subnet.connected_leader_id == private_subnet.id
+  end
 
   label def start
     hop_wait
   end
 
   label def wait
+    rekey_v2? ? v2_wait : v1_wait
+  end
+
+  def v1_wait
     when_refresh_keys_set? do
       private_subnet.update(state: "refreshing_keys")
       decr_refresh_keys
@@ -16,11 +47,46 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     end
 
     when_update_firewall_rules_set? do
-      private_subnet.vms.each(&:incr_update_firewall_rules)
+      Vm.incr_update_firewall_rules(private_subnet.vms_dataset.select(Sequel[:vm][:id]))
       decr_update_firewall_rules
     end
 
     if private_subnet.last_rekey_at < Time.now - 60 * 60 * 24
+      private_subnet.incr_refresh_keys
+    end
+
+    nap 10 * 60
+  end
+
+  def v2_wait
+    fail "BUG: locks held while in wait (NoOrphanedLocks)" unless claimed_nics_dataset.empty?
+
+    if refresh_keys_set? && !connected_leader?
+      Clog.emit("SubnetNexus forwarding refresh_keys to leader",
+        {subnet_rekey_forward: {subnet_id: private_subnet.id,
+                                connected_leader_id: private_subnet.connected_leader_id}})
+      decr_refresh_keys
+      PrivateSubnet.incr_refresh_keys(private_subnet.connected_leader_id)
+      nap 0
+    end
+
+    when_refresh_keys_set? do
+      Clog.emit("SubnetNexus consuming refresh_keys as leader",
+        {subnet_rekey_entry: {
+          subnet_id: private_subnet.id,
+          last_rekey_at: private_subnet.last_rekey_at.iso8601,
+          connected_leader: connected_leader?.to_s,
+        }})
+      decr_refresh_keys
+      hop_refresh_keys
+    end
+
+    when_update_firewall_rules_set? do
+      Vm.incr_update_firewall_rules(private_subnet.vms_dataset.select(Sequel[:vm][:id]))
+      decr_update_firewall_rules
+    end
+
+    if connected_leader? && private_subnet.last_rekey_at < Time.now - 60 * 60 * 24
       private_subnet.incr_refresh_keys
     end
 
@@ -39,11 +105,29 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     SecureRandom.random_number(1...100000)
   end
 
+  # All locked NICs were destroyed mid-rekey: abort the pass back to idle.
+  def abort_rekey_if_no_nics(nics)
+    return unless nics.empty?
+    Clog.emit("All locked NICs destroyed during rekey, aborting")
+    private_subnet.update(state: "waiting")
+    hop_wait
+  end
+
+  def check_nic_phases(nics, expected_phases, message)
+    bad = nics.reject { |n| expected_phases.include?(n.rekey_phase) }
+    fail "BUG: #{message}: #{bad.map { "#{it.id}=#{it.rekey_phase}" }}" if bad.any?
+  end
+
   label def refresh_keys
-    nics = nics_to_rekey
+    rekey_v2? ? v2_refresh_keys : v1_refresh_keys
+  end
+
+  def v1_refresh_keys
+    nics = v1_nics_to_rekey
     nap 10 if nics.any?(&:lock_set?)
-    # A v2 coordinator elsewhere in the mesh holds claims the lock_set?
-    # check cannot see. Wait it out, exactly as for locks.
+    # Transitional cross-guard: a v2 coordinator elsewhere in the mesh
+    # (possible only transiently, around a protocol flip) holds claims
+    # the lock_set? check cannot see. Wait it out.
     nap 10 if nics.any?(&:rekey_coordinator_id)
     locked_nics = []
     nics.each do |nic|
@@ -58,33 +142,129 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     hop_wait_inbound_setup
   end
 
+  def v2_refresh_keys
+    fail "BUG: locks held at idle" unless claimed_nics_dataset.empty?
+    nics = nics_to_rekey.order(:id).for_update.all
+
+    # Topology changed since the signal was consumed and this subnet is
+    # no longer the leader. Re-enqueue so wait forwards to the leader.
+    unless connected_leader?
+      private_subnet.incr_refresh_keys
+      hop_wait
+    end
+
+    # Leader, but no NICs in the component: nothing to rekey, no
+    # re-enqueue. NIC creation signals refresh_keys when one appears.
+    if nics.empty?
+      hop_wait
+    end
+
+    # Another coordinator holds claims on these NICs. Re-enqueue: the
+    # signal is already consumed, so back out and retry from wait.
+    if nics.any?(&:rekey_coordinator_id)
+      private_subnet.incr_refresh_keys
+      hop_wait
+    end
+
+    # Transitional bail: residue of a v1 pass (this mesh was flipped to
+    # v2 while a v1 pass was in flight, or stale lock semaphores
+    # survived an incident). Same back-out-and-retry treatment as the
+    # claim bail above. Removed with v1.
+    if Semaphore.where(strand_id: nics.map(&:id), name: "lock").count > 0
+      private_subnet.incr_refresh_keys
+      hop_wait
+    end
+
+    claimed = Nic.where(id: nics.map(&:id), rekey_coordinator_id: nil)
+      .update(rekey_coordinator_id: private_subnet.id)
+    # :nocov:
+    # Structurally unreachable: the lock check above verifies rekey_coordinator_id is nil
+    # on the same set, within the same transaction, under FOR UPDATE row locks.
+    fail "BUG: locked #{claimed}/#{nics.count} NICs" unless claimed == nics.count
+    # :nocov:
+
+    check_nic_phases(nics, %w[idle], "freshly locked NICs should all be idle")
+
+    nics.each do |nic|
+      nic.update(encryption_key: gen_encryption_key,
+        rekey_payload: {spi4: gen_spi, spi6: gen_spi, reqid: gen_reqid})
+      private_subnet.create_tunnels(nics, nic)
+    end
+    Nic.incr_start_rekey(nics.map(&:id))
+
+    private_subnet.update(state: "refreshing_keys")
+    hop_wait_inbound_setup
+  end
+
   label def wait_inbound_setup
+    legacy_pass? ? v1_wait_inbound_setup : v2_wait_inbound_setup
+  end
+
+  def v1_wait_inbound_setup
     nics = get_locked_nics
     if nics.all? { |nic| nic.strand.label == "wait_rekey_outbound_trigger" }
-      nics.each(&:incr_trigger_outbound_update)
+      Nic.incr_trigger_outbound_update(nics.map(&:id))
       hop_wait_outbound_setup
     end
 
     nap 5
   end
 
+  def v2_wait_inbound_setup
+    nics = claimed_nics
+    abort_rekey_if_no_nics(nics)
+    check_nic_phases(nics, %w[idle inbound], "phase monotonicity at phase_inbound")
+    if nics.all? { |nic| nic.rekey_phase == "inbound" }
+      Nic.incr_trigger_outbound_update(nics.map(&:id))
+      hop_wait_outbound_setup
+    end
+
+    when_nic_phase_done_set? do
+      decr_nic_phase_done
+    end
+    nap 5
+  end
+
   label def wait_outbound_setup
+    legacy_pass? ? v1_wait_outbound_setup : v2_wait_outbound_setup
+  end
+
+  def v1_wait_outbound_setup
     nics = get_locked_nics
     if nics.all? { |nic| nic.strand.label == "wait_rekey_old_state_drop_trigger" }
-      nics.each(&:incr_old_state_drop_trigger)
+      Nic.incr_old_state_drop_trigger(nics.map(&:id))
       hop_wait_old_state_drop
     end
 
     nap 5
   end
 
+  def v2_wait_outbound_setup
+    nics = claimed_nics
+    abort_rekey_if_no_nics(nics)
+    check_nic_phases(nics, %w[inbound outbound], "phase monotonicity at phase_outbound")
+    if nics.all? { |nic| nic.rekey_phase == "outbound" }
+      Nic.incr_old_state_drop_trigger(nics.map(&:id))
+      hop_wait_old_state_drop
+    end
+
+    when_nic_phase_done_set? do
+      decr_nic_phase_done
+    end
+    nap 5
+  end
+
   label def wait_old_state_drop
+    legacy_pass? ? v1_wait_old_state_drop : v2_wait_old_state_drop
+  end
+
+  def v1_wait_old_state_drop
     nics = get_locked_nics
     if nics.all? { |nic| nic.strand.label == "wait" }
       private_subnet.update(state: "waiting", last_rekey_at: Time.now)
-      # Also clear v2 claim columns: a pass over NICs carrying residue
+      # Also clear v2 claim columns: a v1 pass over NICs carrying residue
       # of an interrupted v2 pass (protocol rollback, incident surgery)
-      # heals them here, making any rollback to v1 self-cleaning.
+      # heals them here, making rollback to v1 self-cleaning.
       get_locked_nics_dataset.update(encryption_key: nil, rekey_payload: nil,
         rekey_coordinator_id: nil, rekey_phase: "idle")
       Semaphore.where(strand_id: nics.map(&:id), name: "lock").delete(force: true)
@@ -95,7 +275,29 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     nap 5
   end
 
+  def v2_wait_old_state_drop
+    nics = claimed_nics
+    abort_rekey_if_no_nics(nics)
+    check_nic_phases(nics, %w[outbound old_drop], "phase monotonicity at phase_old_drop")
+    if nics.all? { |nic| nic.rekey_phase == "old_drop" }
+      PrivateSubnet.where(id: nics.map(&:private_subnet_id).uniq).update(last_rekey_at: Time.now)
+      private_subnet.update(state: "waiting")
+      # Must stay one atomic UPDATE: clearing the claim and resetting the
+      # phase together is what releases the NICs consistently.
+      claimed_nics_dataset.update(encryption_key: nil, rekey_payload: nil,
+        rekey_coordinator_id: nil, rekey_phase: "idle")
+      hop_wait
+    end
+
+    when_nic_phase_done_set? do
+      decr_nic_phase_done
+    end
+    nap 5
+  end
+
   label def destroy
+    fail "BUG: locks held at destroy" unless claimed_nics_dataset.empty?
+
     if private_subnet.nics.any?(&:vm_id)
       unless Semaphore.where(strand_id: private_subnet.nics.filter_map(&:vm_id), name: "prevent_destroy").empty?
         register_deadline(nil, 10 * 60, allow_extension: true)
@@ -123,8 +325,22 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     end
   end
 
+  REKEY_ACTIVE_STATES = %w[active creating].freeze
+
   def nics_to_rekey
-    nics_with_state(%w[active creating]).all
+    nics_with_state(REKEY_ACTIVE_STATES)
+  end
+
+  def v1_nics_to_rekey
+    nics_with_state(REKEY_ACTIVE_STATES).all
+  end
+
+  def claimed_nics
+    claimed_nics_dataset.all
+  end
+
+  def claimed_nics_dataset
+    Nic.where(rekey_coordinator_id: private_subnet.id)
   end
 
   def get_locked_nics

--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -159,21 +159,16 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
       hop_wait
     end
 
-    # Another coordinator holds claims on these NICs. Re-enqueue: the
-    # signal is already consumed, so back out and retry from wait.
-    if nics.any?(&:rekey_coordinator_id)
-      private_subnet.incr_refresh_keys
-      hop_wait
-    end
+    # Another coordinator holds claims on these NICs. Park here and
+    # retry: the claims clear when that coordinator's pass completes.
+    # Re-enqueueing would spin through wait until then.
+    nap 10 if nics.any?(&:rekey_coordinator_id)
 
     # Transitional bail: residue of a v1 pass (this mesh was flipped to
     # v2 while a v1 pass was in flight, or stale lock semaphores
-    # survived an incident). Same back-out-and-retry treatment as the
-    # claim bail above. Removed with v1.
-    if Semaphore.where(strand_id: nics.map(&:id), name: "lock").count > 0
-      private_subnet.incr_refresh_keys
-      hop_wait
-    end
+    # survived an incident). Same parking as the claim bail above.
+    # Removed with v1.
+    nap 10 if Semaphore.where(strand_id: nics.map(&:id), name: "lock").count > 0
 
     claimed = Nic.where(id: nics.map(&:id), rekey_coordinator_id: nil)
       .update(rekey_coordinator_id: private_subnet.id)

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -688,6 +688,35 @@ RSpec.describe PrivateSubnet do
     end
   end
 
+  describe "#flip_mesh_rekey_protocol!" do
+    let(:flip_project) { Project.create(name: "test-flip") }
+
+    def create_subnet(n)
+      ps = PrivateSubnet.create_with_id(format("00000000-0000-0000-0000-%012d", n), name: "psflip#{n}",
+        location_id: Location::HETZNER_FSN1_ID, net6: "fd1b:9793:dcef:#{format("%04x", n)}::/64",
+        net4: "10.#{n}.0.0/16", state: "waiting", project_id: flip_project.id)
+      Strand.create_with_id(ps, prog: "Vnet::Metal::SubnetNexus", label: "wait")
+      ps
+    end
+
+    it "flips every mesh member from any member, including subnets without nics" do
+      s1, s2, s3, bystander = [1, 2, 3, 4].map { create_subnet(it) }
+      Nic.create(private_subnet_id: s1.id, private_ipv6: "fd1b:9793:dcef:1:abc::", private_ipv4: "10.1.0.5", mac: "00:00:00:00:00:00", name: "flip-nic", state: "active")
+      s1.connect_subnet(s2)
+      s2.connect_subnet(s3)
+      s3.flip_mesh_rekey_protocol!(2)
+      expect([s1, s2, s3].map { it.reload.rekey_protocol }).to eq [2, 2, 2]
+      expect(bystander.reload.rekey_protocol).to eq 1
+    end
+
+    it "flips a standalone subnet alone" do
+      s1, other = [1, 2].map { create_subnet(it) }
+      s1.flip_mesh_rekey_protocol!(2)
+      expect(s1.reload.rekey_protocol).to eq 2
+      expect(other.reload.rekey_protocol).to eq 1
+    end
+  end
+
   describe "AWS connect/disconnect subnet" do
     let(:prj) { Project.create(name: "test-aws-prj") }
 

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -451,6 +451,25 @@ RSpec.describe PrivateSubnet do
       expect(ps2.refresh_keys_set?).to be true
     end
 
+    it "connect_subnet downgrades the mesh protocol to v1 only when the joined meshes differ" do
+      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
+      ps3 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps3", location_id: Location::HETZNER_FSN1_ID).subject
+      ps1.update(rekey_protocol: 2)
+      ps2.update(rekey_protocol: 2)
+      ps1.connect_subnet(ps2)
+      expect([ps1, ps2].map { it.reload.rekey_protocol }).to eq [2, 2]
+      ps2.connect_subnet(ps3)
+      expect([ps1, ps2, ps3].map { it.reload.rekey_protocol }).to eq [1, 1, 1]
+    end
+
+    it "connect_subnet signals only the peer when the merge downgrades the mesh to v1" do
+      ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
+      ps1.update(rekey_protocol: 2)
+      ps1.connect_subnet(ps2)
+      expect(ps1.refresh_keys_set?).to be false
+      expect(ps2.refresh_keys_set?).to be true
+    end
+
     it "disconnect_subnet does not destroy in subnet tunnels" do
       ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
       ps1_nic = Prog::Vnet::NicNexus.assemble(ps1.id, name: "test-ps1-nic1").subject

--- a/spec/prog/vnet/metal/nic_nexus_spec.rb
+++ b/spec/prog/vnet/metal/nic_nexus_spec.rb
@@ -147,6 +147,122 @@ RSpec.describe Prog::Vnet::Metal::NicNexus do
     end
   end
 
+  describe "#rekey with a v2 claim" do
+    let(:nic) {
+      n = Nic.create(private_subnet_id: ps.id, private_ipv6: "fd10:9b0b:6b4b:8fbb:3::",
+        private_ipv4: "10.0.0.5", mac: "00:00:00:00:00:05",
+        encryption_key: "0x736f6d655f656e6372797074696f6e5f6b6579", name: "test-nic-v2", state: "active",
+        rekey_coordinator_id: ps.id)
+      Strand.create_with_id(n, prog: "Vnet::NicNexus", label: "start_rekey")
+      n
+    }
+    let(:nx) { described_class.new(nic.strand) }
+
+    before do
+      ps_strand
+    end
+
+    it "pushes setup_inbound when the phase is idle" do
+      expect { nx.start_rekey }.to hop(:setup_inbound, "Vnet::RekeyNicTunnel")
+    end
+
+    it "advances the phase and signals the coordinator when inbound_setup completes" do
+      nic.strand.update(retval: {"msg" => "inbound_setup is complete"})
+      expect { nx.start_rekey }.to hop("wait_rekey_outbound_trigger")
+      expect(nic.reload.rekey_phase).to eq "inbound"
+      expect(Semaphore.where(strand_id: ps.id, name: "nic_phase_done").count).to eq 1
+    end
+
+    it "fails if inbound_setup completes when the phase is not idle" do
+      nic.update(rekey_phase: "inbound")
+      nic.strand.update(retval: {"msg" => "inbound_setup is complete"})
+      expect { nx.start_rekey }.to raise_error(RuntimeError, "BUG: unexpected start_rekey signal (retval=\"inbound_setup is complete\", phase=inbound, locked=true)")
+    end
+
+    it "fails on an unexpected start_rekey signal" do
+      nic.update(rekey_phase: "outbound")
+      expect { nx.start_rekey }.to raise_error(RuntimeError, "BUG: unexpected start_rekey signal (retval=nil, phase=outbound, locked=true)")
+    end
+
+    it "fails if the nic is not locked when inbound_setup completes" do
+      nic.update(rekey_coordinator_id: nil)
+      nic.strand.update(retval: {"msg" => "inbound_setup is complete"})
+      expect { nx.v2_start_rekey }.to raise_error(RuntimeError, "BUG: unexpected start_rekey signal (retval=\"inbound_setup is complete\", phase=idle, locked=false)")
+    end
+
+    it "naps if outbound is not triggered" do
+      nic.update(rekey_phase: "inbound")
+      expect { nx.wait_rekey_outbound_trigger }.to nap(5)
+    end
+
+    it "advances the phase and signals the coordinator when outbound_setup completes" do
+      nic.update(rekey_phase: "inbound")
+      nic.strand.update(retval: {"msg" => "outbound_setup is complete"})
+      expect { nx.wait_rekey_outbound_trigger }.to hop("wait_rekey_old_state_drop_trigger")
+      expect(nic.reload.rekey_phase).to eq "outbound"
+      expect(Semaphore.where(strand_id: ps.id, name: "nic_phase_done").count).to eq 1
+    end
+
+    it "fails if outbound_setup completes when the phase is not inbound" do
+      nic.strand.update(retval: {"msg" => "outbound_setup is complete"})
+      expect { nx.wait_rekey_outbound_trigger }.to raise_error(RuntimeError, "BUG: NIC phase should be inbound before advancing to outbound, got idle")
+    end
+
+    it "pushes setup_outbound when outbound update is triggered" do
+      nic.update(rekey_phase: "inbound")
+      nic.incr_trigger_outbound_update
+      expect { nx.wait_rekey_outbound_trigger }.to hop(:setup_outbound, "Vnet::RekeyNicTunnel")
+      expect(nic.trigger_outbound_update_set?).to be false
+    end
+
+    it "fails on an unexpected trigger_outbound_update" do
+      nic.incr_trigger_outbound_update
+      expect { nx.wait_rekey_outbound_trigger }.to raise_error(RuntimeError, "BUG: unexpected trigger_outbound_update (phase=idle, locked=true)")
+    end
+
+    it "fails if the nic is not locked in wait_rekey_outbound_trigger" do
+      nic.update(rekey_coordinator_id: nil)
+      expect { nx.v2_wait_rekey_outbound_trigger }.to raise_error(RuntimeError, "BUG: NIC not locked in wait_rekey_outbound_trigger")
+    end
+
+    it "naps if old state drop is not triggered" do
+      nic.update(rekey_phase: "outbound")
+      expect { nx.wait_rekey_old_state_drop_trigger }.to nap(5)
+    end
+
+    it "activates the nic, advances the phase and hops to wait when drop_old_state completes" do
+      nic.update(state: "creating", rekey_phase: "outbound")
+      nic.strand.update(retval: {"msg" => "drop_old_state is complete"})
+      expect { nx.wait_rekey_old_state_drop_trigger }.to hop("wait")
+      nic.reload
+      expect(nic.state).to eq "active"
+      expect(nic.rekey_phase).to eq "old_drop"
+      expect(Semaphore.where(strand_id: ps.id, name: "nic_phase_done").count).to eq 1
+    end
+
+    it "fails if drop_old_state completes when the phase is not outbound" do
+      nic.strand.update(retval: {"msg" => "drop_old_state is complete"})
+      expect { nx.wait_rekey_old_state_drop_trigger }.to raise_error(RuntimeError, "BUG: NIC phase should be outbound before advancing to old_drop, got idle")
+    end
+
+    it "pushes drop_old_state when old state drop is triggered" do
+      nic.update(rekey_phase: "outbound")
+      nic.incr_old_state_drop_trigger
+      expect { nx.wait_rekey_old_state_drop_trigger }.to hop(:drop_old_state, "Vnet::RekeyNicTunnel")
+      expect(nic.old_state_drop_trigger_set?).to be false
+    end
+
+    it "fails on an unexpected old_state_drop_trigger" do
+      nic.incr_old_state_drop_trigger
+      expect { nx.wait_rekey_old_state_drop_trigger }.to raise_error(RuntimeError, "BUG: unexpected old_state_drop_trigger (phase=idle, locked=true)")
+    end
+
+    it "fails if the nic is not locked in wait_rekey_old_state_drop_trigger" do
+      nic.update(rekey_coordinator_id: nil)
+      expect { nx.v2_wait_rekey_old_state_drop_trigger }.to raise_error(RuntimeError, "BUG: NIC not locked in wait_rekey_old_state_drop_trigger")
+    end
+  end
+
   describe "#destroy" do
     let(:destroy_project) { Project.create(name: "destroy-test") }
     let(:destroy_ps) {

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       net4: "1.1.1.128/26", state: "waiting", project_id: prj.id)
   }
 
+  let(:leader_ps) {
+    PrivateSubnet.create_with_id("00000000-0000-0000-0000-000000000001", name: "ps-leader",
+      location_id: Location::HETZNER_FSN1_ID, net6: "fd10:9b0b:6b4b:8fdd::/64",
+      net4: "1.1.2.0/26", state: "waiting", project_id: prj.id, rekey_protocol: 2)
+  }
+
   describe ".gen_spi" do
     let(:nx) { described_class.new(Strand.new) }
 
@@ -48,7 +54,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
     it "returns nics that need rekeying" do
       nic1 = Prog::Vnet::NicNexus.assemble(ps.id, name: "a").subject
       nic2 = Prog::Vnet::NicNexus.assemble(ps.id, name: "b").subject
-      expect(nx.nics_to_rekey).to eq([])
+      expect(nx.nics_to_rekey.all).to eq([])
       nic1.update(state: "creating")
       expect(nx.nics_to_rekey.map(&:name)).to eq(["a"])
       nic2.update(state: "active")
@@ -59,6 +65,19 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
   describe "#start" do
     it "hops to wait if location is not aws" do
       expect { nx.start }.to hop("wait")
+    end
+  end
+
+  describe "#before_run" do
+    it "hops to destroy when destroy is set" do
+      nx.incr_destroy
+      expect { nx.before_run }.to hop("destroy")
+    end
+
+    it "does not hop to destroy while v2 claims are held" do
+      nx.incr_destroy
+      Prog::Vnet::NicNexus.assemble(ps.id, name: "a").subject.update(rekey_coordinator_id: ps.id)
+      expect { nx.before_run }.not_to hop("destroy")
     end
   end
 
@@ -91,6 +110,60 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
 
     it "naps if nothing to do" do
       expect { nx.wait }.to nap(10 * 60)
+    end
+
+    context "when rekey_protocol is v2" do
+      before { ps.update(rekey_protocol: 2) }
+
+      it "fails if v2 claims are held" do
+        Prog::Vnet::NicNexus.assemble(ps.id, name: "a").subject.update(rekey_coordinator_id: ps.id)
+        expect { nx.wait }.to raise_error(RuntimeError, "BUG: locks held while in wait (NoOrphanedLocks)")
+      end
+
+      it "forwards refresh_keys to the connected leader when not the leader" do
+        Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait", id: leader_ps.id)
+        nx
+        ps.connect_subnet(leader_ps)
+        Semaphore.where(strand_id: [ps.id, leader_ps.id], name: "refresh_keys").destroy
+        nx.incr_refresh_keys
+        expect { nx.wait }.to nap(0)
+        expect(ps.refresh_keys_set?).to be false
+        expect(leader_ps.refresh_keys_set?).to be true
+      end
+
+      it "consumes refresh_keys and hops to refresh_keys as the leader" do
+        nx.incr_refresh_keys
+        expect { nx.wait }.to hop("refresh_keys")
+        expect(ps.refresh_keys_set?).to be false
+      end
+
+      it "triggers update_firewall_rules if when_update_firewall_rules_set?" do
+        nic = Prog::Vnet::NicNexus.assemble(ps.id, name: "test-nic").subject
+        vm = Prog::Vm::Nexus.assemble("pub key", prj.id, name: "test-vm", private_subnet_id: ps.id, nic_id: nic.id).subject
+        nx.incr_update_firewall_rules
+        expect { nx.wait }.to nap(10 * 60)
+        expect(vm.reload.update_firewall_rules_set?).to be true
+      end
+
+      it "increments refresh_keys as the leader if it passed more than a day" do
+        ps.update(last_rekey_at: Time.now - 60 * 60 * 24 - 1)
+        expect { nx.wait }.to nap(10 * 60)
+        expect(ps.refresh_keys_set?).to be true
+      end
+
+      it "does not enqueue refresh_keys for itself when not the leader" do
+        Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait", id: leader_ps.id)
+        nx
+        ps.connect_subnet(leader_ps)
+        Semaphore.where(strand_id: [ps.id, leader_ps.id], name: "refresh_keys").destroy
+        ps.update(last_rekey_at: Time.now - 60 * 60 * 24 - 1)
+        expect { nx.wait }.to nap(10 * 60)
+        expect(ps.refresh_keys_set?).to be false
+      end
+
+      it "naps if nothing to do" do
+        expect { nx.wait }.to nap(10 * 60)
+      end
     end
   end
 
@@ -128,6 +201,58 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       nic.update(state: "active", rekey_coordinator_id: ps2.id)
       expect { nx.refresh_keys }.to nap(10)
     end
+
+    context "when rekey_protocol is v2" do
+      before { ps.update(rekey_protocol: 2) }
+
+      it "fails if claims are held at idle" do
+        nic.update(rekey_coordinator_id: ps.id)
+        expect { nx.refresh_keys }.to raise_error(RuntimeError, "BUG: locks held at idle")
+      end
+
+      it "re-enqueues and hops to wait if no longer the leader" do
+        Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait", id: leader_ps.id)
+        nx
+        ps.connect_subnet(leader_ps)
+        Semaphore.where(strand_id: [ps.id, leader_ps.id], name: "refresh_keys").destroy
+        expect { nx.refresh_keys }.to hop("wait")
+        expect(ps.refresh_keys_set?).to be true
+      end
+
+      it "hops to wait without re-enqueueing if there are no nics to rekey" do
+        expect { nx.refresh_keys }.to hop("wait")
+        expect(ps.refresh_keys_set?).to be false
+      end
+
+      it "re-enqueues and hops to wait if another coordinator holds a claim" do
+        nic.update(state: "active", rekey_coordinator_id: ps2.id)
+        expect { nx.refresh_keys }.to hop("wait")
+        expect(ps.refresh_keys_set?).to be true
+      end
+
+      it "re-enqueues and hops to wait on v1 lock residue" do
+        nic.incr_lock
+        nic.update(state: "active")
+        expect { nx.refresh_keys }.to hop("wait")
+        expect(ps.refresh_keys_set?).to be true
+      end
+
+      it "fails if a nic to claim is not idle" do
+        nic.update(state: "active", rekey_phase: "inbound")
+        expect { nx.refresh_keys }.to raise_error(RuntimeError, "BUG: freshly locked NICs should all be idle: [\"#{nic.id}=inbound\"]")
+      end
+
+      it "claims the nics, refreshes keys and hops to wait_inbound_setup" do
+        nic.update(state: "active")
+        expect { nx.refresh_keys }.to hop("wait_inbound_setup")
+        nic.reload
+        expect(nic.rekey_coordinator_id).to eq ps.id
+        expect(nic.encryption_key).to be_a String
+        expect(nic.rekey_payload.keys).to eq ["spi4", "spi6", "reqid"]
+        expect(nic.start_rekey_set?).to be true
+        expect(ps.reload.state).to eq "refreshing_keys"
+      end
+    end
   end
 
   describe "#wait_inbound_setup" do
@@ -150,6 +275,39 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       nic.refresh
       expect(nic.trigger_outbound_update_set?).to be true
     end
+
+    context "when the pass is v2" do
+      let(:nic) {
+        Prog::Vnet::NicNexus.assemble(ps.id, name: "a").subject.update(rekey_payload: {}, rekey_coordinator_id: ps.id)
+      }
+      let(:nx) {
+        described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait_inbound_setup", id: ps.id))
+      }
+
+      it "aborts to wait if all claimed nics are gone" do
+        ps.update(state: "refreshing_keys")
+        expect { nx.wait_inbound_setup }.to hop("wait")
+        expect(ps.reload.state).to eq "waiting"
+      end
+
+      it "fails if a nic is beyond the inbound phase" do
+        nic.update(rekey_phase: "outbound")
+        expect { nx.wait_inbound_setup }.to raise_error(RuntimeError, "BUG: phase monotonicity at phase_inbound: [\"#{nic.id}=outbound\"]")
+      end
+
+      it "triggers outbound setup once all nics are inbound" do
+        nic.update(rekey_phase: "inbound")
+        expect { nx.wait_inbound_setup }.to hop("wait_outbound_setup")
+        expect(nic.reload.trigger_outbound_update_set?).to be true
+      end
+
+      it "consumes nic_phase_done and naps while nics are still idle" do
+        nic
+        nx.incr_nic_phase_done
+        expect { nx.wait_inbound_setup }.to nap(5)
+          .and change { Semaphore.where(strand_id: ps.id, name: "nic_phase_done").count }.from(1).to(0)
+      end
+    end
   end
 
   describe "#wait_outbound_setup" do
@@ -171,6 +329,33 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       expect { nx.wait_outbound_setup }.to hop("wait_old_state_drop")
       nic.refresh
       expect(nic.old_state_drop_trigger_set?).to be true
+    end
+
+    context "when the pass is v2" do
+      let(:nic) {
+        Prog::Vnet::NicNexus.assemble(ps.id, name: "a").subject.update(rekey_payload: {}, rekey_coordinator_id: ps.id)
+      }
+      let(:nx) {
+        described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait_outbound_setup", id: ps.id))
+      }
+
+      it "fails if a nic is outside the outbound transition" do
+        nic.update(rekey_phase: "idle")
+        expect { nx.wait_outbound_setup }.to raise_error(RuntimeError, "BUG: phase monotonicity at phase_outbound: [\"#{nic.id}=idle\"]")
+      end
+
+      it "triggers old state drop once all nics are outbound" do
+        nic.update(rekey_phase: "outbound")
+        expect { nx.wait_outbound_setup }.to hop("wait_old_state_drop")
+        expect(nic.reload.old_state_drop_trigger_set?).to be true
+      end
+
+      it "consumes nic_phase_done and naps while nics are still inbound" do
+        nic.update(rekey_phase: "inbound")
+        nx.incr_nic_phase_done
+        expect { nx.wait_outbound_setup }.to nap(5)
+          .and change { Semaphore.where(strand_id: ps.id, name: "nic_phase_done").count }.from(1).to(0)
+      end
     end
   end
 
@@ -202,6 +387,46 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       expect(nic.rekey_phase).to eq "idle"
       expect(nic.lock_set?).to be false
     end
+
+    context "when the pass is v2" do
+      let(:nic) {
+        Prog::Vnet::NicNexus.assemble(ps.id, name: "a").subject.update(rekey_payload: {}, rekey_coordinator_id: ps.id)
+      }
+      let(:nx) {
+        described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait_old_state_drop", id: ps.id))
+      }
+
+      it "fails if a nic is outside the old_drop transition" do
+        nic.update(rekey_phase: "inbound")
+        expect { nx.wait_old_state_drop }.to raise_error(RuntimeError, "BUG: phase monotonicity at phase_old_drop: [\"#{nic.id}=inbound\"]")
+      end
+
+      it "stamps last_rekey_at on every member subnet, releases claims and hops to wait" do
+        nic.update(rekey_phase: "old_drop")
+        nic2 = Prog::Vnet::NicNexus.assemble(ps2.id, name: "b").subject.update(rekey_payload: {}, rekey_coordinator_id: ps.id, rekey_phase: "old_drop")
+        ps.update(state: "refreshing_keys", last_rekey_at: Time.now - 100)
+        ps2.update(last_rekey_at: Time.now - 100)
+        expect { nx.wait_old_state_drop }.to hop("wait")
+        ps.refresh
+        expect(ps.state).to eq "waiting"
+        expect(ps.last_rekey_at > Time.now - 10).to be true
+        expect(ps2.reload.last_rekey_at > Time.now - 10).to be true
+        [nic, nic2].each do |n|
+          n.reload
+          expect(n.encryption_key).to be_nil
+          expect(n.rekey_payload).to be_nil
+          expect(n.rekey_coordinator_id).to be_nil
+          expect(n.rekey_phase).to eq "idle"
+        end
+      end
+
+      it "consumes nic_phase_done and naps while nics are still outbound" do
+        nic.update(rekey_phase: "outbound")
+        nx.incr_nic_phase_done
+        expect { nx.wait_old_state_drop }.to nap(5)
+          .and change { Semaphore.where(strand_id: ps.id, name: "nic_phase_done").count }.from(1).to(0)
+      end
+    end
   end
 
   describe "#destroy" do
@@ -222,6 +447,11 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       Strand.create_with_id(n, prog: "Vnet::NicNexus", label: "wait")
       n
     }
+
+    it "fails if v2 claims are held" do
+      nic.update(rekey_coordinator_id: ps.id)
+      expect { nx.destroy }.to raise_error(RuntimeError, "BUG: locks held at destroy")
+    end
 
     it "extends deadline if a vm prevents destroy" do
       nic.update(vm_id: vm.id)

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -224,17 +224,17 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
         expect(ps.refresh_keys_set?).to be false
       end
 
-      it "re-enqueues and hops to wait if another coordinator holds a claim" do
+      it "naps if another coordinator holds a claim" do
         nic.update(state: "active", rekey_coordinator_id: ps2.id)
-        expect { nx.refresh_keys }.to hop("wait")
-        expect(ps.refresh_keys_set?).to be true
+        expect { nx.refresh_keys }.to nap(10)
+        expect(ps.refresh_keys_set?).to be false
       end
 
-      it "re-enqueues and hops to wait on v1 lock residue" do
+      it "naps on v1 lock residue" do
         nic.incr_lock
         nic.update(state: "active")
-        expect { nx.refresh_keys }.to hop("wait")
-        expect(ps.refresh_keys_set?).to be true
+        expect { nx.refresh_keys }.to nap(10)
+        expect(ps.refresh_keys_set?).to be false
       end
 
       it "fails if a nic to claim is not idle" do


### PR DESCRIPTION
**Why**

The v1 rekey protocol has two production failure classes, both exercised in the 2026-06-10 incident: the lock check and lock acquisition in refresh_keys are separated by a label transaction boundary, so coordinators in a connected mesh can double-claim the same NICs (the incident mesh ran seven full rekeys where one was needed); and the pass barriers compare strand labels, so a NIC pushed past the expected label by a competing coordinator reads as "not arrived" forever (one coordinator wedged ~50 minutes in wait_inbound_setup, leaving a creating NIC without tunnels).

**What**

This PR ships the v2 protocol (pr/5091) alongside v1 in one binary, dispatched per mesh by private_subnet.rekey_protocol, default v1. Deploying changes no behavior: mixed-version workers all run identical v1 logic, and flips happen only on a homogeneous fleet, decoupling code coexistence from protocol coexistence.

v2 fixes the double-claim by making check and claim atomic (SELECT FOR UPDATE over the mesh's NICs, one UPDATE setting rekey_coordinator_id) and confines coordination to the mesh's connected leader (min-id member), with non-leaders forwarding their refresh_keys signals. It fixes the barrier wedge by replacing label equality with the monotonic rekey_phase column, asserted at runtime. Pass-boundary labels dispatch on the flag; mid-pass labels dispatch on the pass's own residue, so a mid-pass flip cannot change a running pass's protocol.

**Commits**

- Add rekey v2 protocol behind a per-mesh dispatch - both protocol bodies, dispatch, and the cutover/soak/rollback runbook. v2 bodies are verbatim pr/5091 except two named deltas (claim accessor naming, and a bail on v1 lock residue - the v2 half of the cross-protocol mutual exclusion).
- Add specs for the rekey v2 protocol bodies - coverage for the leader forward/consume paths, claim and bail ladder, phase barriers, BUG guards, and the destroy claim guards.
- Park refresh_keys bails instead of re-enqueueing - deviation from pr/5091: the foreign-claim and v1-residue bails napped in place (10s) instead of re-enqueueing through wait, which spun in a tight hop loop for the duration of the other coordinator's pass.
- Add PrivateSubnet#flip_mesh_rekey_protocol! - the cutover tool as code instead of a console snippet. Derives mesh membership from the connected_subnet edge walk (shared with connected_leader_id via mesh_dataset), fixing the runbook snippet's bug of missing NIC-less mesh members and partially flipping a mesh.
- Keep the rekey protocol uniform across a mesh - connect_subnet normalizes a merged mesh's protocol; v1 wins, so customer peering can shrink the v2 canary but never silently expand it.

**Deploy and rollback**

Roll normally; inert until an operator flips a mesh via flip_mesh_rekey_protocol!. Cutover proceeds mesh by mesh (staging, low-churn, high-churn runner meshes, then default-v2) with per-mesh soak signals listed in the dispatch commit. Rollback per mesh is a flip back to v1, safe at any moment: in-flight v2 passes finish under v2 via residue dispatch, and any abandoned claims are healed by the next v1 pass (v2-awareness commit, already on main).