### PR TITLE
Subnet rekey 2 phase step 6

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -133,6 +133,10 @@ end
     throw(:prog_return, flow_control)
   end
 
+  def hibernate
+    nap(60 * 60 * 24 * 365 * 1000)
+  end
+
   def nap(seconds = 30)
     prog_return Nap.new(seconds)
   end

--- a/prog/vnet/metal/nic_nexus.rb
+++ b/prog/vnet/metal/nic_nexus.rb
@@ -7,7 +7,7 @@ class Prog::Vnet::Metal::NicNexus < Prog::Base
     when_vm_allocated_set? do
       hop_wait_setup
     end
-    nap 5
+    hibernate
   end
 
   label def wait_setup
@@ -20,7 +20,7 @@ class Prog::Vnet::Metal::NicNexus < Prog::Base
     when_start_rekey_set? do
       hop_start_rekey
     end
-    nap 5
+    hibernate
   end
 
   label def wait
@@ -33,7 +33,7 @@ class Prog::Vnet::Metal::NicNexus < Prog::Base
       hop_start_rekey
     end
 
-    nap 6 * 60 * 60
+    hibernate
   end
 
   label def start_rekey
@@ -68,7 +68,7 @@ class Prog::Vnet::Metal::NicNexus < Prog::Base
       push Prog::Vnet::RekeyNicTunnel, {}, :setup_outbound
     end
 
-    nap 5
+    hibernate
   end
 
   label def wait_rekey_old_state_drop_trigger
@@ -89,7 +89,7 @@ class Prog::Vnet::Metal::NicNexus < Prog::Base
       push Prog::Vnet::RekeyNicTunnel, {}, :drop_old_state
     end
 
-    nap 5
+    hibernate
   end
 
   label def destroy

--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -131,7 +131,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     when_nic_phase_done_set? do
       decr_nic_phase_done
     end
-    nap 5
+    hibernate
   end
 
   label def wait_outbound_setup
@@ -146,7 +146,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     when_nic_phase_done_set? do
       decr_nic_phase_done
     end
-    nap 5
+    hibernate
   end
 
   label def wait_old_state_drop
@@ -166,7 +166,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     when_nic_phase_done_set? do
       decr_nic_phase_done
     end
-    nap 5
+    hibernate
   end
 
   label def destroy

--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -35,6 +35,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
           connected_leader: connected_leader?.to_s,
         }})
       decr_refresh_keys
+      register_deadline("wait", 30 * 60)
       hop_refresh_keys
     end
 

--- a/spec/prog/vnet/metal/nic_nexus_spec.rb
+++ b/spec/prog/vnet/metal/nic_nexus_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Prog::Vnet::Metal::NicNexus do
   let(:ps_strand) { Strand.create_with_id(ps, prog: "Vnet::SubnetNexus", label: "wait") }
 
   describe "#start" do
-    it "naps if nothing to do" do
-      expect { nx.start }.to nap(5)
+    it "hibernates if nothing to do" do
+      expect { nx.start }.to hibernate
     end
 
     it "hops to wait_setup if allocated" do
@@ -27,9 +27,9 @@ RSpec.describe Prog::Vnet::Metal::NicNexus do
   end
 
   describe "#wait_setup" do
-    it "naps if nothing to do" do
+    it "hibernates if nothing to do" do
       expect(nx).to receive(:decr_vm_allocated)
-      expect { nx.wait_setup }.to nap(5)
+      expect { nx.wait_setup }.to hibernate
     end
 
     it "incrs refresh_keys when setup_nic is set" do
@@ -42,7 +42,7 @@ RSpec.describe Prog::Vnet::Metal::NicNexus do
       expect(nx).to receive(:decr_vm_allocated)
       expect(nx).to receive(:when_setup_nic_set?).and_yield
       expect(nx).to receive(:decr_setup_nic)
-      expect { nx.wait_setup }.to nap(5)
+      expect { nx.wait_setup }.to hibernate
       expect(nic.reload.state).to eq("creating")
       expect(Semaphore.where(strand_id: ps.id, name: "refresh_keys").count).to eq(1)
     end
@@ -65,8 +65,8 @@ RSpec.describe Prog::Vnet::Metal::NicNexus do
       allow(nx).to receive(:nic).and_return(nic)
     end
 
-    it "naps if nothing to do" do
-      expect { nx.wait }.to nap(6 * 60 * 60)
+    it "hibernates if nothing to do" do
+      expect { nx.wait }.to hibernate
     end
 
     it "hops to start rekey if needed" do
@@ -76,7 +76,7 @@ RSpec.describe Prog::Vnet::Metal::NicNexus do
 
     it "naps if repopulate is set" do
       expect(nx).to receive(:when_repopulate_set?).and_yield
-      expect { nx.wait }.to nap(6 * 60 * 60)
+      expect { nx.wait }.to hibernate
     end
   end
 
@@ -123,9 +123,9 @@ RSpec.describe Prog::Vnet::Metal::NicNexus do
       expect { nx.start_rekey }.to raise_error(RuntimeError, "BUG: unexpected start_rekey signal (retval=\"inbound_setup is complete\", phase=idle, locked=false)")
     end
 
-    it "naps if outbound is not triggered" do
+    it "hibernates if outbound is not triggered" do
       nic.update(rekey_phase: "inbound")
-      expect { nx.wait_rekey_outbound_trigger }.to nap(5)
+      expect { nx.wait_rekey_outbound_trigger }.to hibernate
     end
 
     it "advances the phase and signals the coordinator when outbound_setup completes" do
@@ -158,9 +158,9 @@ RSpec.describe Prog::Vnet::Metal::NicNexus do
       expect { nx.wait_rekey_outbound_trigger }.to raise_error(RuntimeError, "BUG: NIC not locked in wait_rekey_outbound_trigger")
     end
 
-    it "naps if old state drop is not triggered" do
+    it "hibernates if old state drop is not triggered" do
       nic.update(rekey_phase: "outbound")
-      expect { nx.wait_rekey_old_state_drop_trigger }.to nap(5)
+      expect { nx.wait_rekey_old_state_drop_trigger }.to hibernate
     end
 
     it "activates the nic, advances the phase and hops to wait when drop_old_state completes" do

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -214,10 +214,10 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       expect(nic.trigger_outbound_update_set?(cached: false)).to be true
     end
 
-    it "consumes nic_phase_done and naps while nics are still idle" do
+    it "consumes nic_phase_done and hibernates while nics are still idle" do
       nic
       nx.incr_nic_phase_done
-      expect { nx.wait_inbound_setup }.to nap(5)
+      expect { nx.wait_inbound_setup }.to hibernate
         .and change { Semaphore.where(strand_id: ps.id, name: "nic_phase_done").count }.from(1).to(0)
     end
   end
@@ -241,10 +241,10 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       expect(nic.old_state_drop_trigger_set?(cached: false)).to be true
     end
 
-    it "consumes nic_phase_done and naps while nics are still inbound" do
+    it "consumes nic_phase_done and hibernates while nics are still inbound" do
       nic.update(rekey_phase: "inbound")
       nx.incr_nic_phase_done
-      expect { nx.wait_outbound_setup }.to nap(5)
+      expect { nx.wait_outbound_setup }.to hibernate
         .and change { Semaphore.where(strand_id: ps.id, name: "nic_phase_done").count }.from(1).to(0)
     end
   end
@@ -296,10 +296,10 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       expect(leader.reload.last_rekey_at).to be_within(5).of(Time.now)
     end
 
-    it "consumes nic_phase_done and naps while nics are still outbound" do
+    it "consumes nic_phase_done and hibernates while nics are still outbound" do
       nic.update(rekey_phase: "outbound")
       nx.incr_nic_phase_done
-      expect { nx.wait_old_state_drop }.to nap(5)
+      expect { nx.wait_old_state_drop }.to hibernate
         .and change { Semaphore.where(strand_id: ps.id, name: "nic_phase_done").count }.from(1).to(0)
     end
   end

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -102,10 +102,12 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       expect(leader_ps.refresh_keys_set?).to be true
     end
 
-    it "consumes refresh_keys and hops to refresh_keys as the leader" do
+    it "consumes refresh_keys, registers a deadline and hops to refresh_keys as the leader" do
       nx.incr_refresh_keys
       expect { nx.wait }.to hop("refresh_keys")
       expect(ps.refresh_keys_set?).to be false
+      expect(nx.strand.stack.first["deadline_target"]).to eq "wait"
+      expect(Time.parse(nx.strand.stack.first["deadline_at"])).to be_within(5).of(Time.now + 30 * 60)
     end
 
     it "triggers update_firewall_rules if when_update_firewall_rules_set?" do

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -214,10 +214,10 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       expect(nic.reload.trigger_outbound_update_set?).to be true
     end
 
-    it "consumes nic_phase_done and naps while nics are still idle" do
+    it "consumes nic_phase_done and hibernates while nics are still idle" do
       nic
       nx.incr_nic_phase_done
-      expect { nx.wait_inbound_setup }.to nap(5)
+      expect { nx.wait_inbound_setup }.to hibernate
         .and change { Semaphore.where(strand_id: ps.id, name: "nic_phase_done").count }.from(1).to(0)
     end
   end
@@ -241,10 +241,10 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       expect(nic.reload.old_state_drop_trigger_set?).to be true
     end
 
-    it "consumes nic_phase_done and naps while nics are still inbound" do
+    it "consumes nic_phase_done and hibernates while nics are still inbound" do
       nic.update(rekey_phase: "inbound")
       nx.incr_nic_phase_done
-      expect { nx.wait_outbound_setup }.to nap(5)
+      expect { nx.wait_outbound_setup }.to hibernate
         .and change { Semaphore.where(strand_id: ps.id, name: "nic_phase_done").count }.from(1).to(0)
     end
   end
@@ -296,10 +296,10 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       expect(leader.reload.last_rekey_at).to be_within(5).of(Time.now)
     end
 
-    it "consumes nic_phase_done and naps while nics are still outbound" do
+    it "consumes nic_phase_done and hibernates while nics are still outbound" do
       nic.update(rekey_phase: "outbound")
       nx.incr_nic_phase_done
-      expect { nx.wait_old_state_drop }.to nap(5)
+      expect { nx.wait_old_state_drop }.to hibernate
         .and change { Semaphore.where(strand_id: ps.id, name: "nic_phase_done").count }.from(1).to(0)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -454,6 +454,10 @@ RSpec.configure do |config|
     def frame_value(prog, key)
       prog.strand.stack.first[key]
     end
+
+    def hibernate
+      nap(60 * 60 * 24 * 365 * 1000)
+    end
   end)
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -424,6 +424,10 @@ RSpec.configure do |config|
     def frame_value(prog, key)
       prog.strand.stack.first[key]
     end
+
+    def hibernate
+      nap(60 * 60 * 24 * 365 * 1000)
+    end
   end)
 end
 


### PR DESCRIPTION
The coordinator's three barrier waits and the NIC's trigger waits are woken by semaphores (nic_phase_done, trigger_outbound_update, old_state_drop_trigger, start_rekey), and a NIC's steady-state wait needs no timer at all, so retire the polling naps in favor of indefinite hibernation. Correctness rests on the earlier LEAST scheduling change: a signal arriving concurrently with any schedule write can only move the wake earlier, so a hibernating strand cannot sleep through it. The destroy retry naps remain: they wait on external resource cleanup, not on a semaphore.

Extracted from https://github.com/ubicloud/ubicloud/pull/5091 (a5fae79ae); the rekey tree now matches that PR exactly, minus TLA pragma comments.

Deploy: roll normally. Mixed versions differ only in nap duration; a long-napping strand is woken by any semaphore, so coexistence is safe in both directions.

Soak: 1-2 weeks of polling already validated the wake path - every pass that advanced faster than its 5s poll did so via a signal. Here watch that pass latency does not regress (a stage stuck near a 5s multiple would have been a masked lost wake; a stage stuck indefinitely now is one) and that respirate load from NicNexus strands drops to ~zero between passes, the point of the change.

Rollback: git revert, roll, then force-wake anything already hibernating so nothing waits on a signal that came and went during the roll:

    Strand.where(prog: ["Vnet::Metal::SubnetNexus",
                        "Vnet::Metal::NicNexus"])
      .update(schedule: Sequel::CURRENT_TIMESTAMP)