### PR TITLE
Subnet rekey 2 phase step 7

### DIFF
--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -111,7 +111,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
 
     nics.each do |nic|
       nic.update(encryption_key: gen_encryption_key,
-        rekey_payload: {spi4: gen_spi, spi6: gen_spi, reqid: gen_reqid})
+        rekey_payload: {spi4: gen_spi, spi6: gen_spi, reqid: gen_reqid, esn: true})
       private_subnet.create_tunnels(nics, nic)
     end
     Nic.incr_start_rekey(nics.map(&:id))

--- a/prog/vnet/rekey_nic_tunnel.rb
+++ b/prog/vnet/rekey_nic_tunnel.rb
@@ -109,6 +109,15 @@ class Prog::Vnet::RekeyNicTunnel < Prog::Base
       begin
         cmd = "sudo -- xargs -I {} -- ip -n :namespace xfrm state add src :src dst :dst proto esp spi :spi reqid :reqid mode tunnel aead 'rfc4106(gcm(aes))' {} 128"
 
+        # Extended Sequence Numbers: 64-bit replay counter, so a
+        # long-lived SA's sequence space cannot wrap before the next
+        # rekey. Gated on rekey_payload["esn"] so it takes effect only
+        # on a coordinated rotation -- the new SA is created under a
+        # fresh SPI alongside the old non-ESN SA under the old SPI, and
+        # the outbound barrier flips senders over only once every new
+        # inbound SA exists, so no tunnel ever carries mismatched SAs.
+        cmd = NetSsh.combine(cmd, "flag esn") if @args["esn"]
+
         cmd = NetSsh.combine(cmd, "sel src 0.0.0.0/0 dst 0.0.0.0/0") if is_ipv4
 
         @nic.vm.vm_host.sshable.cmd(cmd, namespace: @namespace, src:, dst:, spi:, reqid: @reqid, stdin: key)

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -185,7 +185,8 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       nic.reload
       expect(nic.rekey_coordinator_id).to eq ps.id
       expect(nic.encryption_key).to be_a String
-      expect(nic.rekey_payload.keys).to eq ["spi4", "spi6", "reqid"]
+      expect(nic.rekey_payload.keys).to eq ["esn", "spi4", "spi6", "reqid"]
+      expect(nic.rekey_payload["esn"]).to be true
       expect(nic.start_rekey_set?).to be true
       expect(ps.reload.state).to eq "refreshing_keys"
     end

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -84,6 +84,15 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
       expect { nx.setup_inbound }.to exit({"msg" => "inbound_setup is complete"})
     end
 
+    it "creates states with the esn flag if the rekey payload has esn" do
+      tunnel.src_nic.update(rekey_payload: {"reqid" => 86879, "spi4" => "0xe2222222", "spi6" => "0xe3333333", "esn" => true})
+      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo -- xargs -I {} -- ip -n hellovm xfrm state add src 2a01:4f8:10a:128b:4919:8000:: dst 2a01:4f8:10a:128b:4919:8000:: proto esp spi 0xe2222222 reqid 86879 mode tunnel aead 'rfc4106(gcm(aes))' {} 128 flag esn sel src 0.0.0.0/0 dst 0.0.0.0/0", stdin: "0x736f6d655f656e6372797074696f6e5f6b6579").and_return(true)
+      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo -- xargs -I {} -- ip -n hellovm xfrm state add src 2a01:4f8:10a:128b:4919:8000:: dst 2a01:4f8:10a:128b:4919:8000:: proto esp spi 0xe3333333 reqid 86879 mode tunnel aead 'rfc4106(gcm(aes))' {} 128 flag esn", stdin: "0x736f6d655f656e6372797074696f6e5f6b6579").and_return(true)
+      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo ip -n hellovm xfrm policy show src 10.0.0.1/32 dst 10.0.0.2/32 dir fwd").and_return("not_empty")
+      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo ip -n hellovm xfrm policy show src fd10:9b0b:6b4b:8fbb:abc::/128 dst fd10:9b0b:6b4b:8fbb:def::/128 dir fwd").and_return("not_empty")
+      expect { nx.setup_inbound }.to exit({"msg" => "inbound_setup is complete"})
+    end
+
     it "skips tunnel if its src_nic doesn't have rekey_payload" do
       expect(tunnel.src_nic).to receive(:rekey_payload).and_return(nil)
       expect { nx.setup_inbound }.to exit({"msg" => "inbound_setup is complete"})


### PR DESCRIPTION
IPsec ESP sequence numbers are 32-bit by default; an SA carrying enough packets wraps the counter, at which point the SA must be torn down and rekeyed or it stops being safe to use. Enable Extended Sequence Numbers (flag esn) on the SAs created during rekey, giving a 64-bit counter whose space cannot realistically wrap within an SA's lifetime. (replay-window is deliberately left at the kernel default: this is wraparound headroom, not anti-replay tightening.)

The flag is gated on a new rekey_payload field, esn: true, set by the coordinator when it generates SPIs, rather than applied unconditionally in the tunnel prog. Two reasons:

- Gradual rollout: because rekey_protocol is now per-mesh and the payload is regenerated each pass, ESN reaches a mesh only when that mesh next rotates under v2. Flipping the field for a subset of meshes (or staging it behind the same canary used for the v2 cutover) meters the blast radius; an unconditional flag would enable it fleet-wide on the next pass of every NIC at once.
- Atomic per rotation: create_xfrm_state runs for new SAs under freshly generated SPIs. The ESN SA therefore coexists with the prior non-ESN SA (different SPI) until the outbound barrier flips senders over, which the rekey state machine only does once every new inbound SA is in place. No tunnel ever holds one ESN and one non-ESN SA under the same SPI, so there is no wire-format mismatch window -- the same additivity that makes key rotation safe makes the ESN transition safe, for free.

No capability gate: ESN is supported on all current host kernels (22.04 and 24.04), and there will be no host that does not qualify, so a per-host check would be dead code.

Sequenced after v1 retirement so only the single surviving payload generator (v2_refresh_keys) needs the field; v1 is gone and never emits it.

Deploy: with or after the v2 series; the field is inert until a v2 rotation reads it, and a NIC rekeyed by pre-ESN code simply omits the flag (its next rotation adds it). Rollback: drop esn from the payload generator (or set it false); the next rotation per mesh recreates SAs without the flag, no manual host cleanup. Verify on a canary after one rotation:

    ip -n <inhost_name> xfrm state get src <s> dst <d> proto esp spi <spi>
    # shows "flag esn" and "replay-window 0"

Soak: per flipped mesh, confirm tunnels stay up across a full rotation (the SA swap is the risk point) and no esn-related errors appear in the host's kernel log; widen as the v2 canary widens.