### PR TITLE
Fix typos in code comments

### DIFF
--- a/prog/kubernetes/upgrade_kubernetes_node.rb
+++ b/prog/kubernetes/upgrade_kubernetes_node.rb
@@ -45,7 +45,7 @@ class Prog::Kubernetes::UpgradeKubernetesNode < Prog::Base
 
     reap(reaper:) do
       # This will not work correctly if the strand has multiple children.
-      # However, the strand has only has a single child created in start.
+      # However, the strand has only a single child created in start.
       self.new_node_id = node_id
 
       hop_wait_node_ready

--- a/prog/victoria_metrics/victoria_metrics_server_nexus.rb
+++ b/prog/victoria_metrics/victoria_metrics_server_nexus.rb
@@ -42,7 +42,7 @@ class Prog::VictoriaMetrics::VictoriaMetricsServerNexus < Prog::Base
     when_destroy_set? do
       label = strand.label
       if label == "restart" && strand.parent_id
-        # child strand budded from parent strand unvailable, exit to
+        # child strand budded from parent strand unavailable, exit to
         # avoid two strands in #destroy
         pop "exiting early due to destroy semaphore"
       elsif !%w[destroy wait_children_destroyed].include?(label)

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -306,7 +306,7 @@ module Scheduling::Allocator
           end
         end
 
-        # If we dont want to use slices, place those only on hosts that do not accept them
+        # If we don't want to use slices, place those only on hosts that do not accept them
         # If we require a shared slice (for burstable vm), allocate those only on hosts that accept slices
         # In all other cases, the host's acceptance of slices will determine if the VM is created in a slice or not
         if !request.use_slices


### PR DESCRIPTION
Fix three small typos in code comments:

- `scheduling/allocator.rb`: `dont` -> `don't`
- `prog/victoria_metrics/victoria_metrics_server_nexus.rb`: `unvailable` -> `unavailable`
- `prog/kubernetes/upgrade_kubernetes_node.rb`: `has only has` -> `has only`

All changes are in comment text only. No logic, behavior, or API surface is affected.