### PR TITLE
Fix Postgres DNS check to work with hostname_version v3

### DIFF
--- a/lib/dns_checker.rb
+++ b/lib/dns_checker.rb
@@ -31,7 +31,13 @@ module DnsChecker
     def check(type, record_name, expected_value)
       typeclass = TYPE_MAP.fetch(type)
       resource = @resolver.getresource(record_name, typeclass)
-      actual_value = ((type == :CNAME) ? resource.name : resource.address).to_s
+      if type == :CNAME
+        name = resource.name
+        actual_value = name.to_s
+        actual_value += "." if name.absolute?
+      else
+        actual_value = resource.address.to_s
+      end
     rescue Resolv::ResolvError => e
       # Deliberately avoid Util.exception_to_hash here, as backtrace is not helpful
       @failures << {type:, record_name:, expected_value:, exception: "#{e.class}: #{e.message}"}

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -220,7 +220,7 @@ class PostgresResource < Sequel::Model
           dns.check(:AAAA, record_name, vm.ip6_string)
         end
 
-        record_name = "private.#{record_name}"
+        record_name = private_hostname
         dns.check(:A, record_name, vm.private_ipv4_string)
         dns.check(:AAAA, record_name, vm.private_ipv6_string)
       end

--- a/spec/lib/dns_checker_spec.rb
+++ b/spec/lib/dns_checker_spec.rb
@@ -6,9 +6,25 @@ RSpec.describe DnsChecker do
   it ".open returns DNS CNAME record lookup failures" do
     expect(described_class.open(["127.0.0.1"]) do
       expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::CNAME)
-        .and_return(Resolv::DNS::Resource::IN::CNAME.new("actual-val"))
-      it.check(:CNAME, "rec", "expect-val")
-    end).to eq [{actual_value: "actual-val", expected_value: "expect-val", record_name: "rec", type: :CNAME}]
+        .and_return(Resolv::DNS::Resource::IN::CNAME.new(Resolv::DNS::Name.new(["actual-val"], true)))
+      it.check(:CNAME, "rec", "expect-val.")
+    end).to eq [{actual_value: "actual-val.", expected_value: "expect-val.", record_name: "rec", type: :CNAME}]
+  end
+
+  it ".open handles absolute CNAMEs" do
+    expect(described_class.open(["127.0.0.1"]) do
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::CNAME)
+        .and_return(Resolv::DNS::Resource::IN::CNAME.new(Resolv::DNS::Name.new(["actual-val"], true)))
+      it.check(:CNAME, "rec", "actual-val.")
+    end).to eq []
+  end
+
+  it ".open handles non-absolute CNAMEs" do
+    expect(described_class.open(["127.0.0.1"]) do
+      expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::CNAME)
+        .and_return(Resolv::DNS::Resource::IN::CNAME.new(Resolv::DNS::Name.new(["actual-val"], false)))
+      it.check(:CNAME, "rec", "actual-val.")
+    end).to eq [{actual_value: "actual-val", expected_value: "actual-val.", record_name: "rec", type: :CNAME}]
   end
 
   it ".open returns DNS A record lookup failures" do
@@ -30,8 +46,8 @@ RSpec.describe DnsChecker do
   it ".open returns empty array if there are no failures" do
     expect(described_class.open(["127.0.0.1"]) do
       expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::CNAME)
-        .and_return(Resolv::DNS::Resource::IN::CNAME.new("expect-val"))
-      it.check(:CNAME, "rec", "expect-val")
+        .and_return(Resolv::DNS::Resource::IN::CNAME.new(Resolv::DNS::Name.new(["expect-val"], true)))
+      it.check(:CNAME, "rec", "expect-val.")
 
       expect(it.instance_variable_get(:@resolver)).to receive(:getresource).with("rec", Resolv::DNS::Resource::IN::A)
         .and_return(Resolv::DNS::Resource::IN::A.new(Resolv::IPv4.new("\x7f\x00\x00\x01")))

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -834,16 +834,16 @@ RSpec.describe PostgresResource do
 
           expect(checker).to receive(:check).with(:A, postgres_resource.hostname, "10.1.2.3")
           expect(checker).to receive(:check).with(:AAAA, postgres_resource.hostname, "fe80::2")
-          expect(checker).to receive(:check).with(:A, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv4_string)
-          expect(checker).to receive(:check).with(:AAAA, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv6_string)
+          expect(checker).to receive(:check).with(:A, postgres_resource.private_hostname, postgres_resource.representative_server.vm.private_ipv4_string)
+          expect(checker).to receive(:check).with(:AAAA, postgres_resource.private_hostname, postgres_resource.representative_server.vm.private_ipv6_string)
           expect(postgres_resource.check_all_dns_records).to eq []
         end
 
         it "does not attempt to resolve AAAA public record for old metal databases lacking one" do
           postgres_resource.update(created_at: Time.utc(2025))
           expect(checker).to receive(:check).with(:A, postgres_resource.hostname, "10.1.2.3")
-          expect(checker).to receive(:check).with(:A, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv4_string)
-          expect(checker).to receive(:check).with(:AAAA, "private." + postgres_resource.hostname, postgres_resource.representative_server.vm.private_ipv6_string)
+          expect(checker).to receive(:check).with(:A, postgres_resource.private_hostname, postgres_resource.representative_server.vm.private_ipv4_string)
+          expect(checker).to receive(:check).with(:AAAA, postgres_resource.private_hostname, postgres_resource.representative_server.vm.private_ipv6_string)
           expect(postgres_resource.check_all_dns_records).to eq []
         end
 


### PR DESCRIPTION
After I merged #5365, I tested it in staging and found that some resources were failing because it wasn't updated to support the new hostname_version v3 format. This should fix the issue.