### PR TITLE
Add Customer - Resource - Host mapping views to Admin

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1556,16 +1556,16 @@ class CloverAdmin < Roda
     end
 
     r.get "customer-usage" do
-      count_filter = ->(cond) { Sequel.function(:count).*.filter(cond) }
+      count = Sequel.function(:count).*
       vm_agg = customer_vm_dataset
         .group(:project_id)
         .select(
           :project_id,
           Sequel.function(:sum, :vcpus).as(:total_vcpus),
-          count_filter.call(pg_resource_id: nil, kubernetes_cluster_id: nil, github_runner_id: nil).as(:vm_count),
-          count_filter.call(Sequel.~(pg_resource_id: nil)).as(:postgres_count),
-          count_filter.call(Sequel.~(kubernetes_cluster_id: nil)).as(:kubernetes_count),
-          count_filter.call(Sequel.~(github_runner_id: nil)).as(:runner_count),
+          count.filter(pg_resource_id: nil, kubernetes_cluster_id: nil, github_runner_id: nil).as(:vm_count),
+          count.filter(Sequel.~(pg_resource_id: nil)).as(:postgres_count),
+          count.filter(Sequel.~(kubernetes_cluster_id: nil)).as(:kubernetes_count),
+          count.filter(Sequel.~(github_runner_id: nil)).as(:runner_count),
         )
 
       spend_agg = DB[:invoice]

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1495,6 +1495,96 @@ class CloverAdmin < Roda
       view("vm_host_usage")
     end
 
+    r.get "customer-usage" do
+      vm = Sequel[:vm]
+      # Managed services (PostgreSQL, Kubernetes, GitHub runners) run on VMs
+      # owned by internal service projects, so each VM is attributed to the
+      # actual customer project through its managing resource, falling back to
+      # the VM's own project for plain customer VMs.
+      customer_project_id = Sequel.function(
+        :coalesce,
+        Sequel[:pr][:project_id],
+        Sequel[:kc][:project_id],
+        Sequel[:gi][:project_id],
+        vm[:project_id],
+      )
+
+      count_filter = ->(cond) { Sequel.function(:count).*.filter(cond) }
+      vm_agg = DB[:vm]
+        .left_join(Sequel[:postgres_server].as(:ps), vm_id: vm[:id])
+        .left_join(Sequel[:postgres_resource].as(:pr), id: Sequel[:ps][:resource_id])
+        .left_join(Sequel[:kubernetes_node].as(:kn), vm_id: vm[:id])
+        .left_join(Sequel[:kubernetes_cluster].as(:kc), id: Sequel[:kn][:kubernetes_cluster_id])
+        .left_join(Sequel[:github_runner].as(:gr), vm_id: vm[:id])
+        .left_join(Sequel[:github_installation].as(:gi), id: Sequel[:gr][:installation_id])
+        .group(customer_project_id)
+        .select(
+          customer_project_id.as(:project_id),
+          Sequel.function(:sum, vm[:vcpus]).as(:total_vcpus),
+          count_filter.call(Sequel[:pr][:id] => nil, Sequel[:kc][:id] => nil, Sequel[:gr][:id] => nil).as(:vm_count),
+          count_filter.call(Sequel.~(Sequel[:pr][:id] => nil)).as(:postgres_count),
+          count_filter.call(Sequel.~(Sequel[:kc][:id] => nil)).as(:kubernetes_count),
+          count_filter.call(Sequel.~(Sequel[:gr][:id] => nil)).as(:runner_count),
+        )
+
+      spend_agg = DB[:invoice]
+        .group(:project_id)
+        .select(
+          :project_id,
+          Sequel.function(:sum, Sequel.cast(Sequel.pg_jsonb_op(:content).get_text("cost"), :numeric)).as(:total_spend),
+        )
+
+      # Account email(s) make the customer identifiable, since project names are
+      # frequently just "Default". Accounts are linked through access_tag.
+      emails_agg = DB[:access_tag]
+        .join(:accounts, id: Sequel[:access_tag][:hyper_tag_id])
+        .group(Sequel[:access_tag][:project_id])
+        .select(
+          Sequel[:access_tag][:project_id],
+          Sequel.function(:string_agg, Sequel[:accounts][:email], ", ").distinct.order(Sequel[:accounts][:email]).as(:emails),
+        )
+
+      proj = Sequel[:project]
+      total_vcpus = Sequel.function(:coalesce, Sequel[:va][:total_vcpus], 0)
+      total_spend = Sequel.function(:coalesce, Sequel[:sa][:total_spend], 0)
+
+      @data = DB[:project]
+        .left_join(vm_agg.as(:va), project_id: proj[:id])
+        .left_join(spend_agg.as(:sa), project_id: proj[:id])
+        .left_join(emails_agg.as(:ea), project_id: proj[:id])
+        # Only projects with attributed resources or invoices are customers.
+        .exclude(Sequel[:va][:project_id] => nil, Sequel[:sa][:project_id] => nil)
+        .select(
+          proj[:id],
+          proj[:name],
+          Sequel[:ea][:emails],
+          proj[:reputation],
+          Sequel.function(:coalesce, Sequel[:va][:vm_count], 0).as(:vm_count),
+          Sequel.function(:coalesce, Sequel[:va][:postgres_count], 0).as(:postgres_count),
+          Sequel.function(:coalesce, Sequel[:va][:kubernetes_count], 0).as(:kubernetes_count),
+          Sequel.function(:coalesce, Sequel[:va][:runner_count], 0).as(:runner_count),
+          total_vcpus.as(:total_vcpus),
+          total_spend.as(:total_spend),
+        )
+        .order(Sequel.desc(total_vcpus), Sequel.desc(total_spend), Sequel.function(:lower, proj[:name]))
+        .map do |row|
+          ubid = UBID.to_ubid(row[:id])
+          name = row[:emails] ? "#{row[:name]} (#{row[:emails]})" : row[:name]
+          {
+            "Project" => table_link(name, "/model/Project/#{ubid}"),
+            "Reputation" => row[:reputation],
+            "VMs" => row[:vm_count],
+            "PostgreSQL" => row[:postgres_count],
+            "Kubernetes" => row[:kubernetes_count],
+            "Runners" => row[:runner_count],
+            "Total vCPUs" => row[:total_vcpus],
+            "Total Spend" => "$%.2f" % row[:total_spend],
+          }
+        end
+
+      view("customer_usage")
+    end
+
     r.post "close-admin-account" do
       login = typecast_params.nonempty_str!("login")
 

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -201,6 +201,66 @@ class CloverAdmin < Roda
     _classes { it < ResourceMethods::InstanceMethods }
   end
 
+  def customer_vm_dataset
+    vm = Sequel[:vm]
+    customer_project_id = Sequel.function(:coalesce, Sequel[:pg][:project_id], Sequel[:kc][:project_id], Sequel[:gi][:project_id], vm[:project_id])
+    DB[:vm]
+      .left_join(Sequel[:postgres_server].as(:ps), vm_id: vm[:id])
+      .left_join(Sequel[:postgres_resource].as(:pg), id: Sequel[:ps][:resource_id])
+      .left_join(Sequel[:kubernetes_node].as(:kn), vm_id: vm[:id])
+      .left_join(Sequel[:kubernetes_cluster].as(:kc), id: Sequel[:kn][:kubernetes_cluster_id])
+      .left_join(Sequel[:github_runner].as(:gr), vm_id: vm[:id])
+      .left_join(Sequel[:github_installation].as(:gi), id: Sequel[:gr][:installation_id])
+      .select(
+        vm[:id].as(:vm_id),
+        vm[:name].as(:vm_name),
+        vm[:vcpus],
+        vm[:created_at],
+        vm[:vm_host_id],
+        customer_project_id.as(:project_id),
+        Sequel[:pg][:id].as(:pg_resource_id),
+        Sequel[:pg][:name].as(:pg_resource_name),
+        Sequel[:kc][:id].as(:kubernetes_cluster_id),
+        Sequel[:kc][:name].as(:kubernetes_cluster_name),
+        Sequel[:gr][:id].as(:github_runner_id),
+        Sequel[:gi][:name].as(:github_installation_name),
+      )
+      .from_self(alias: :cvm)
+  end
+
+  # Classify a customer_vm_dataset row into a [type, resource_link] pair.
+  def customer_resource_type(row)
+    if row[:pg_resource_id]
+      ["PostgreSQL", table_link(row[:pg_resource_name], "/model/PostgresResource/#{UBID.to_ubid(row[:pg_resource_id])}")]
+    elsif row[:kubernetes_cluster_id]
+      ["Kubernetes", table_link(row[:kubernetes_cluster_name], "/model/KubernetesCluster/#{UBID.to_ubid(row[:kubernetes_cluster_id])}")]
+    elsif row[:github_runner_id]
+      ["GitHub Runner", table_link(row[:github_installation_name], "/model/GithubRunner/#{UBID.to_ubid(row[:github_runner_id])}")]
+    else
+      ["VM", nil]
+    end
+  end
+
+  # Email of the earliest-created account per project (one row per project via
+  # DISTINCT ON), used to make customers identifiable since project names are
+  # frequently just "Default".
+  def customer_email_dataset
+    DB[:access_tag]
+      .join(:accounts, id: Sequel[:access_tag][:hyper_tag_id])
+      .distinct(Sequel[:access_tag][:project_id])
+      .order(Sequel[:access_tag][:project_id], Sequel[:accounts][:created_at], Sequel[:accounts][:email])
+      .select(
+        Sequel[:access_tag][:project_id],
+        Sequel[:accounts][:email],
+      )
+  end
+
+  # Human-readable project label combining the project name with its account
+  # email, when present.
+  def project_label(name, email)
+    email ? "#{name} (#{email})" : name
+  end
+
   ROLLOUT_SEMAPHORE_OPTIONS = Prog::RolloutSemaphore::ALLOWED_SEMAPHORES_PER_RESOURCE_TYPE.flat_map do |klass, semaphores|
     semaphores.map { "#{klass.name} - #{it}" }
   end.freeze
@@ -1496,35 +1556,16 @@ class CloverAdmin < Roda
     end
 
     r.get "customer-usage" do
-      vm = Sequel[:vm]
-      # Managed services (PostgreSQL, Kubernetes, GitHub runners) run on VMs
-      # owned by internal service projects, so each VM is attributed to the
-      # actual customer project through its managing resource, falling back to
-      # the VM's own project for plain customer VMs.
-      customer_project_id = Sequel.function(
-        :coalesce,
-        Sequel[:pr][:project_id],
-        Sequel[:kc][:project_id],
-        Sequel[:gi][:project_id],
-        vm[:project_id],
-      )
-
       count_filter = ->(cond) { Sequel.function(:count).*.filter(cond) }
-      vm_agg = DB[:vm]
-        .left_join(Sequel[:postgres_server].as(:ps), vm_id: vm[:id])
-        .left_join(Sequel[:postgres_resource].as(:pr), id: Sequel[:ps][:resource_id])
-        .left_join(Sequel[:kubernetes_node].as(:kn), vm_id: vm[:id])
-        .left_join(Sequel[:kubernetes_cluster].as(:kc), id: Sequel[:kn][:kubernetes_cluster_id])
-        .left_join(Sequel[:github_runner].as(:gr), vm_id: vm[:id])
-        .left_join(Sequel[:github_installation].as(:gi), id: Sequel[:gr][:installation_id])
-        .group(customer_project_id)
+      vm_agg = customer_vm_dataset
+        .group(:project_id)
         .select(
-          customer_project_id.as(:project_id),
-          Sequel.function(:sum, vm[:vcpus]).as(:total_vcpus),
-          count_filter.call(Sequel[:pr][:id] => nil, Sequel[:kc][:id] => nil, Sequel[:gr][:id] => nil).as(:vm_count),
-          count_filter.call(Sequel.~(Sequel[:pr][:id] => nil)).as(:postgres_count),
-          count_filter.call(Sequel.~(Sequel[:kc][:id] => nil)).as(:kubernetes_count),
-          count_filter.call(Sequel.~(Sequel[:gr][:id] => nil)).as(:runner_count),
+          :project_id,
+          Sequel.function(:sum, :vcpus).as(:total_vcpus),
+          count_filter.call(pg_resource_id: nil, kubernetes_cluster_id: nil, github_runner_id: nil).as(:vm_count),
+          count_filter.call(Sequel.~(pg_resource_id: nil)).as(:postgres_count),
+          count_filter.call(Sequel.~(kubernetes_cluster_id: nil)).as(:kubernetes_count),
+          count_filter.call(Sequel.~(github_runner_id: nil)).as(:runner_count),
         )
 
       spend_agg = DB[:invoice]
@@ -1534,15 +1575,7 @@ class CloverAdmin < Roda
           Sequel.function(:sum, Sequel.cast(Sequel.pg_jsonb_op(:content).get_text("cost"), :numeric)).as(:total_spend),
         )
 
-      # Account email(s) make the customer identifiable, since project names are
-      # frequently just "Default". Accounts are linked through access_tag.
-      emails_agg = DB[:access_tag]
-        .join(:accounts, id: Sequel[:access_tag][:hyper_tag_id])
-        .group(Sequel[:access_tag][:project_id])
-        .select(
-          Sequel[:access_tag][:project_id],
-          Sequel.function(:string_agg, Sequel[:accounts][:email], ", ").distinct.order(Sequel[:accounts][:email]).as(:emails),
-        )
+      email_agg = customer_email_dataset
 
       proj = Sequel[:project]
       total_vcpus = Sequel.function(:coalesce, Sequel[:va][:total_vcpus], 0)
@@ -1551,13 +1584,13 @@ class CloverAdmin < Roda
       @data = DB[:project]
         .left_join(vm_agg.as(:va), project_id: proj[:id])
         .left_join(spend_agg.as(:sa), project_id: proj[:id])
-        .left_join(emails_agg.as(:ea), project_id: proj[:id])
+        .left_join(email_agg.as(:ea), project_id: proj[:id])
         # Only projects with attributed resources or invoices are customers.
         .exclude(Sequel[:va][:project_id] => nil, Sequel[:sa][:project_id] => nil)
         .select(
           proj[:id],
           proj[:name],
-          Sequel[:ea][:emails],
+          Sequel[:ea][:email],
           proj[:reputation],
           Sequel.function(:coalesce, Sequel[:va][:vm_count], 0).as(:vm_count),
           Sequel.function(:coalesce, Sequel[:va][:postgres_count], 0).as(:postgres_count),
@@ -1569,7 +1602,7 @@ class CloverAdmin < Roda
         .order(Sequel.desc(total_vcpus), Sequel.desc(total_spend), Sequel.function(:lower, proj[:name]))
         .map do |row|
           ubid = UBID.to_ubid(row[:id])
-          name = row[:emails] ? "#{row[:name]} (#{row[:emails]})" : row[:name]
+          name = project_label(row[:name], row[:email])
           {
             "Project" => table_link(name, "/model/Project/#{ubid}"),
             "Reputation" => row[:reputation],

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -778,6 +778,56 @@ RSpec.describe CloverAdmin do
     expect(page.all(".project-usage-table tbody tr").first.all("td").map(&:text)).to eq ["test-vm", "VmVCpu", "standard", "61 minutes", "$0.047"]
   end
 
+  it "shows hosted resources and utilized VM hosts for project as extra" do
+    project = Project.create(name: "some-customer")
+    other_project = Project.create(name: "some-other-customer")
+    service_project = Project.create(name: "internal-service")
+    vm_host = create_vm_host
+    other_vm_host = create_vm_host
+
+    # Plain customer VM, owned directly by the project.
+    create_vm(vm_host_id: vm_host.id, project_id: project.id, name: "customer-vm")
+    create_vm(vm_host_id: other_vm_host.id, project_id: project.id, name: "different-host")
+    create_vm(vm_host_id: vm_host.id, project_id: other_project.id, name: "other-project-vm")
+
+    # Managed PostgreSQL, Kubernetes, and GitHub runner all run on VMs owned by
+    # an internal service project but are attributed back to this project through
+    # their managing resource.
+    pg = create_postgres_resource(project:, location_id: vm_host.location_id)
+    pg_server = create_postgres_server(resource: pg)
+    pg_server.vm.update(vm_host_id: vm_host.id, project_id: service_project.id)
+
+    k8s_ps = PrivateSubnet.create(name: "k8s-ps", project_id: project.id, location_id: vm_host.location_id, net4: "10.1.0.0/26", net6: "fdfb::/64")
+    cluster = KubernetesCluster.create(project_id: project.id, name: "k8s-cluster", private_subnet_id: k8s_ps.id, location_id: vm_host.location_id, cp_node_count: 1, version: Option.selectable_kubernetes_versions.first, target_node_size: "standard-2")
+    k8s_vm = create_vm(vm_host_id: vm_host.id, project_id: service_project.id, name: "k8s-vm")
+    KubernetesNode.create(kubernetes_cluster_id: cluster.id, vm_id: k8s_vm.id)
+
+    installation = GithubInstallation.create(installation_id: 99, name: "gh-org", type: "Organization", project_id: project.id)
+    gh_vm = create_vm(vm_host_id: other_vm_host.id, project_id: service_project.id, name: "gh-runner-vm")
+    GithubRunner.create(vm_id: gh_vm.id, repository_name: "repo", label: "ubicloud", installation_id: installation.id)
+
+    visit "/model/Project/#{project.ubid}"
+
+    hosts = page.all(".project-vm-hosts-table tbody tr").map { it.all("td").map(&:text) }
+    expect(hosts).to eq([
+      [vm_host.ubid, "1", "1", "1", "0", "3"],
+      [other_vm_host.ubid, "1", "0", "0", "1", "2"],
+    ].sort_by(&:first))
+
+    rows = page.all(".project-resources-table tbody tr").map { it.all("td").map(&:text) }
+    expect(rows.map { it[0] }.sort).to eq(["GitHub Runner", "Kubernetes", "PostgreSQL", "VM", "VM"])
+    expect(rows.map { it[3] }.uniq.sort).to eq([vm_host.ubid, other_vm_host.ubid].sort)
+
+    expect(page).to have_no_content("other-project-vm")
+  end
+
+  it "shows no resource tables when project has no hosted resources" do
+    project = Project.create(name: "empty-customer")
+    visit "/model/Project/#{project.ubid}"
+    expect(page).to have_no_css(".project-resources-table")
+    expect(page).to have_no_css(".project-vm-hosts-table")
+  end
+
   it "converts ubids to link" do
     p = Page.create(summary: "test", tag: "a", details: {"related_resources" => [vm_pool.ubid, "cc489f465gqa5pzq04gch3162h"]})
     fill_in "UBID, UUID, or prefix:term", with: p.ubid

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -778,54 +778,71 @@ RSpec.describe CloverAdmin do
     expect(page.all(".project-usage-table tbody tr").first.all("td").map(&:text)).to eq ["test-vm", "VmVCpu", "standard", "61 minutes", "$0.047"]
   end
 
-  it "shows hosted resources and utilized VM hosts for project as extra" do
+  it "shows hosted resources and utilized VM hosts for a Project as extra" do
     project = Project.create(name: "some-customer")
     other_project = Project.create(name: "some-other-customer")
     service_project = Project.create(name: "internal-service")
     vm_host = create_vm_host
     other_vm_host = create_vm_host(location_id: Location::HETZNER_HEL1_ID, allocation_state: "draining")
 
-    # Plain customer VM, owned directly by the project.
-    create_vm(vm_host_id: vm_host.id, project_id: project.id, name: "customer-vm")
-    create_vm(vm_host_id: other_vm_host.id, project_id: project.id, name: "different-host")
+    # A VM owned by another project on the same host must never appear here.
     create_vm(vm_host_id: vm_host.id, project_id: other_project.id, name: "other-project-vm")
 
-    # Managed PostgreSQL, Kubernetes, and GitHub runner all run on VMs owned by
-    # an internal service project but are attributed back to this project through
-    # their managing resource.
+    reload = -> { visit "/model/Project/#{project.ubid}" }
+    hosts_rows = -> { page.all(".project-vm-hosts-table tbody tr").map { it.all("td").map(&:text) } }
+    resource_rows = -> { page.all(".project-resources-table tbody tr").map { it.all("td").map(&:text).first(4) }.sort_by { it[2] } }
+
+    # Before any resource is hosted for this project: no resource/host tables.
+    reload.call
+    expect(page).to have_no_css(".project-resources-table")
+    expect(page).to have_no_css(".project-vm-hosts-table")
+
+    # Plain customer VM, owned directly by the project.
+    create_vm(vm_host_id: vm_host.id, project_id: project.id, name: "customer-vm")
+    reload.call
+    expect(page.all(".project-resources-table thead th").map(&:text)).to eq(["Type", "Resource", "VM", "VM Host", "vCPUs", "Created At"])
+    expect(page.all(".project-vm-hosts-table thead th").map(&:text)).to eq(["VM Host", "Location", "State", "VMs", "PostgreSQL", "Kubernetes", "GitHub Runners", "Total"])
+    expect(resource_rows.call).to eq([["VM", "", "customer-vm", vm_host.ubid]])
+    expect(hosts_rows.call).to eq([[vm_host.ubid, "hetzner-fsn1", "accepting", "1", "0", "0", "0", "1"]])
+
     pg = create_postgres_resource(project:, location_id: vm_host.location_id)
-    pg_server = create_postgres_server(resource: pg)
-    pg_server.vm.update(vm_host_id: vm_host.id, project_id: service_project.id)
+    pg_vm = create_postgres_server(resource: pg).vm
+    pg_vm.update(vm_host_id: vm_host.id, project_id: service_project.id)
+    reload.call
+    expect(resource_rows.call).to eq([
+      ["VM", "", "customer-vm", vm_host.ubid],
+      ["PostgreSQL", pg.name, pg_vm.name, vm_host.ubid],
+    ].sort_by { it[2] })
+    expect(hosts_rows.call).to eq([[vm_host.ubid, "hetzner-fsn1", "accepting", "1", "1", "0", "0", "2"]])
 
     k8s_ps = PrivateSubnet.create(name: "k8s-ps", project_id: project.id, location_id: vm_host.location_id, net4: "10.1.0.0/26", net6: "fdfb::/64")
     cluster = KubernetesCluster.create(project_id: project.id, name: "k8s-cluster", private_subnet_id: k8s_ps.id, location_id: vm_host.location_id, cp_node_count: 1, version: Option.selectable_kubernetes_versions.first, target_node_size: "standard-2")
-    k8s_vm = create_vm(vm_host_id: vm_host.id, project_id: service_project.id, name: "k8s-vm")
-    KubernetesNode.create(kubernetes_cluster_id: cluster.id, vm_id: k8s_vm.id)
+    KubernetesNode.create(kubernetes_cluster_id: cluster.id, vm_id: create_vm(vm_host_id: vm_host.id, project_id: service_project.id, name: "k8s-vm").id)
+    reload.call
+    expect(resource_rows.call).to eq([
+      ["VM", "", "customer-vm", vm_host.ubid],
+      ["PostgreSQL", pg.name, pg_vm.name, vm_host.ubid],
+      ["Kubernetes", "k8s-cluster", "k8s-vm", vm_host.ubid],
+    ].sort_by { it[2] })
+    expect(hosts_rows.call).to eq([[vm_host.ubid, "hetzner-fsn1", "accepting", "1", "1", "1", "0", "3"]])
 
+    # The GitHub runner runs on the other host, so a second host row appears.
     installation = GithubInstallation.create(installation_id: 99, name: "gh-org", type: "Organization", project_id: project.id)
     gh_vm = create_vm(vm_host_id: other_vm_host.id, project_id: service_project.id, name: "gh-runner-vm")
     GithubRunner.create(vm_id: gh_vm.id, repository_name: "repo", label: "ubicloud", installation_id: installation.id)
-
-    visit "/model/Project/#{project.ubid}"
-
-    hosts = page.all(".project-vm-hosts-table tbody tr").map { it.all("td").map(&:text) }
-    expect(hosts).to eq([
+    reload.call
+    expect(resource_rows.call).to eq([
+      ["VM", "", "customer-vm", vm_host.ubid],
+      ["PostgreSQL", pg.name, pg_vm.name, vm_host.ubid],
+      ["Kubernetes", "k8s-cluster", "k8s-vm", vm_host.ubid],
+      ["GitHub Runner", "gh-org", "gh-runner-vm", other_vm_host.ubid],
+    ].sort_by { it[2] })
+    expect(hosts_rows.call).to eq([
       [vm_host.ubid, "hetzner-fsn1", "accepting", "1", "1", "1", "0", "3"],
-      [other_vm_host.ubid, "hetzner-hel1", "draining", "1", "0", "0", "1", "2"],
+      [other_vm_host.ubid, "hetzner-hel1", "draining", "0", "0", "0", "1", "1"],
     ].sort_by(&:first))
 
-    rows = page.all(".project-resources-table tbody tr").map { it.all("td").map(&:text) }
-    expect(rows.map { it[0] }.sort).to eq(["GitHub Runner", "Kubernetes", "PostgreSQL", "VM", "VM"])
-    expect(rows.map { it[3] }.uniq.sort).to eq([vm_host.ubid, other_vm_host.ubid].sort)
-
     expect(page).to have_no_content("other-project-vm")
-  end
-
-  it "shows no resource tables when project has no hosted resources" do
-    project = Project.create(name: "empty-customer")
-    visit "/model/Project/#{project.ubid}"
-    expect(page).to have_no_css(".project-resources-table")
-    expect(page).to have_no_css(".project-vm-hosts-table")
   end
 
   it "converts ubids to link" do
@@ -2994,113 +3011,184 @@ RSpec.describe CloverAdmin do
     expect(ubids.call).to eq([x64_48.ubid])
   end
 
-  it "shows Customer Usage with resources, vcpu usage, and spend, ordered by spend" do
+  it "shows Customer Usage with resources, vcpu usage, and spend, ordered by vcpus" do
     big = Project.create(name: "big-customer")
     small = Project.create(name: "small-customer")
     service_project = Project.create(name: "internal-service")
-    Project.create(name: "empty-customer")
+    Project.create(name: "empty-customer") # no resources or invoices; never appears
 
-    account = create_account("a@b.com", with_project: false)
-    DB[:access_tag].insert(project_id: big.id, hyper_tag_id: account.id)
+    ac1 = create_account("a@ibi.com", with_project: false)
+    ac2 = create_account("b@ibi.com", with_project: false)
+    ac3 = create_account("c@ibi.com", with_project: false)
+    DB[:access_tag].insert(project_id: big.id, hyper_tag_id: ac1.id)
+    DB[:access_tag].insert(project_id: big.id, hyper_tag_id: ac2.id)
+    DB[:access_tag].insert(project_id: big.id, hyper_tag_id: ac3.id)
+    ac2.update(created_at: Time.now - 100)
 
-    # An account created earlier but with an alphabetically-later email; its
-    # email is the one shown, since the earliest-created account wins.
-    earlier_account = create_account("z@b.com", with_project: false)
-    DB[:accounts].where(id: earlier_account.id).update(created_at: Time.now - 3600)
-    DB[:access_tag].insert(project_id: big.id, hyper_tag_id: earlier_account.id)
+    big_label = "big-customer (b@ibi.com)"
 
-    # big-customer owns a plain VM plus managed PostgreSQL, Kubernetes, and
-    # GitHub runner resources whose VMs are owned by an internal service project
-    # but attributed back to the customer through their managing resource.
+    reload = -> { visit "/customer-usage" }
+    rows = -> { page.all(".customer-usage-table tbody tr").map { it.all("td").map(&:text) } }
+
+    # Before any project has resources or invoices, there are no customers.
+    click_link "Customer Usage"
+    expect(page.title).to eq "Ubicloud Admin - Customer Usage"
+    expect(page).to have_no_css(".customer-usage-table")
+    expect(page).to have_content("No data available")
+
     create_vm(project_id: big.id, vcpus: 8)
+    reload.call
+    expect(page.all(".customer-usage-table thead th").map(&:text)).to eq(["Project", "Reputation", "VMs", "PostgreSQL", "Kubernetes", "Runners", "Total vCPUs", "Total Spend"])
+    expect(rows.call).to eq([[big_label, "new", "1", "0", "0", "0", "8", "$0.00"]])
+
     pg = create_postgres_resource(project: big, location_id: Location::HETZNER_FSN1_ID)
-    pg_server = create_postgres_server(resource: pg)
-    pg_server.vm.update(project_id: service_project.id)
+    create_postgres_server(resource: pg).vm.update(project_id: service_project.id)
+    reload.call
+    expect(rows.call).to eq([[big_label, "new", "1", "1", "0", "0", "10", "$0.00"]])
 
     k8s_ps = PrivateSubnet.create(name: "k8s-ps", project_id: big.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.1.0.0/26", net6: "fdfb::/64")
     kc = KubernetesCluster.create(project_id: big.id, name: "k8s-cluster", private_subnet_id: k8s_ps.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 1, version: Option.selectable_kubernetes_versions.first, target_node_size: "standard-2")
-    k8s_vm = create_vm(project_id: service_project.id, vcpus: 4, name: "k8s-node-vm")
-    KubernetesNode.create(kubernetes_cluster_id: kc.id, vm_id: k8s_vm.id)
+    KubernetesNode.create(kubernetes_cluster_id: kc.id, vm_id: create_vm(project_id: service_project.id, vcpus: 4, name: "k8s-node-vm").id)
+    reload.call
+    expect(rows.call).to eq([[big_label, "new", "1", "1", "1", "0", "14", "$0.00"]])
+
+    installation = GithubInstallation.create(installation_id: 99, name: "gh-org", type: "Organization", project_id: big.id)
+    gh_vm = create_vm(project_id: service_project.id, vcpus: 2, name: "gh-runner-vm")
+    GithubRunner.create(vm_id: gh_vm.id, repository_name: "repo", label: "ubicloud", installation_id: installation.id)
+    reload.call
+    expect(rows.call).to eq([[big_label, "new", "1", "1", "1", "1", "16", "$0.00"]])
 
     Invoice.create(project_id: big.id, invoice_number: "2601-big-01", content: {cost: 10.0}, begin_time: "2025-01-01", end_time: "2025-02-01")
     Invoice.create(project_id: big.id, invoice_number: "2602-big-02", content: {cost: 5.5}, begin_time: "2025-02-01", end_time: "2025-03-01")
+    reload.call
+    expect(rows.call).to eq([[big_label, "new", "1", "1", "1", "1", "16", "$15.50"]])
 
     create_vm(project_id: small.id, vcpus: 2)
-
-    installation = GithubInstallation.create(installation_id: 99, name: "gh-org", type: "Organization", project_id: small.id)
-    gh_vm = create_vm(project_id: service_project.id, vcpus: 2, name: "gh-runner-vm")
-    GithubRunner.create(vm_id: gh_vm.id, repository_name: "repo", label: "ubicloud", installation_id: installation.id)
-
     Invoice.create(project_id: small.id, invoice_number: "2601-small-01", content: {cost: 1.0}, begin_time: "2025-01-01", end_time: "2025-02-01")
+    reload.call
+    expect(rows.call).to eq([
+      [big_label, "new", "1", "1", "1", "1", "16", "$15.50"],
+      ["small-customer", "new", "1", "0", "0", "0", "2", "$1.00"],
+    ])
 
-    click_link "Customer Usage"
-    expect(page.title).to eq "Ubicloud Admin - Customer Usage"
+    DB[:access_tag].insert(project_id: small.id, hyper_tag_id: create_account("x@small.com", with_project: false).id)
+    reload.call
+    expect(rows.call).to eq([
+      [big_label, "new", "1", "1", "1", "1", "16", "$15.50"],
+      ["small-customer (x@small.com)", "new", "1", "0", "0", "0", "2", "$1.00"],
+    ])
 
-    headers = page.all(".customer-usage-table thead th").map(&:text)
-    expect(headers).to eq(["Project", "Reputation", "VMs", "PostgreSQL", "Kubernetes", "Runners", "Total vCPUs", "Total Spend"])
+    minio_service = Project.create(name: "minio-service")
+    minio_host = create_vm_host(location_id: Location::HETZNER_FSN1_ID)
+    minio_cluster = MinioCluster.create(name: "minio-cluster", project_id: minio_service.id, location_id: minio_host.location_id, admin_user: "admin", admin_password: "dummy-password")
+    minio_pool = MinioPool.create(cluster_id: minio_cluster.id, server_count: 1, drive_count: 1, storage_size_gib: 100, vm_size: "standard-2", start_index: 0)
+    MinioServer.create(minio_pool_id: minio_pool.id, vm_id: create_vm(vm_host_id: minio_host.id, project_id: minio_service.id, name: "minio-vm").id, index: 0)
 
-    rows = page.all(".customer-usage-table tbody tr").map { it.all("td").map(&:text) }
-    expect(rows.map(&:first)).to eq(["big-customer (z@b.com)", "small-customer"])
-    expect(rows.first).to eq(["big-customer (z@b.com)", "new", "1", "1", "1", "0", "14", "$15.50"])
-    expect(rows.last).to eq(["small-customer", "new", "1", "0", "0", "1", "4", "$1.00"])
+    reload.call
+    expect(rows.call).to eq([
+      [big_label, "new", "1", "1", "1", "1", "16", "$15.50"],
+      ["small-customer (x@small.com)", "new", "1", "0", "0", "0", "2", "$1.00"],
+      ["minio-service", "new", "1", "0", "0", "0", "2", "$0.00"],
+    ])
 
     expect(page).to have_no_content("empty-customer")
+    expect(page).to have_no_content("internal-service")
   end
 
   it "shows customer resources hosted on a VM host, resolving managed services to the customer" do
     vm_host = create_vm_host
     other_vm_host = create_vm_host
     customer = Project.create(name: "some-customer")
-    other_customer = Project.create(name: "some-other-customer")
     service_project = Project.create(name: "internal-service")
+    minio_service = Project.create(name: "minio-service")
 
-    customer_account = create_account("a@b.com", with_project: true)
-    DB[:access_tag].insert(project_id: customer.id, hyper_tag_id: customer_account.id)
+    ac1 = create_account("a@someuser.com", with_project: false)
+    ac2 = create_account("b@someuser.com", with_project: false)
+    ac2.update(created_at: ac1.created_at + 100)
 
-    other_customer_account = create_account("c@d.com", with_project: true)
-    DB[:access_tag].insert(project_id: other_customer.id, hyper_tag_id: other_customer_account.id)
+    DB[:access_tag].insert(project_id: customer.id, hyper_tag_id: ac1.id)
+    DB[:access_tag].insert(project_id: customer.id, hyper_tag_id: ac2.id)
+    customer_label = "some-customer (a@someuser.com)"
+
+    # A VM on another host must never appear in this host's tables.
+    create_vm(vm_host_id: other_vm_host.id, project_id: customer.id, name: "vm-in-another-host")
+
+    reload = -> { visit "/model/VmHost/#{vm_host.ubid}" }
+    summary_rows = -> { page.all(".vm-host-customers-summary-table tbody tr").map { it.all("td").map(&:text) }.sort_by(&:first) }
+    # Assert the identifying columns (customer, type, resource, vm), ordered by vm name.
+    resource_rows = -> { page.all(".vm-host-resources-table tbody tr").map { it.all("td").map(&:text).first(4) }.sort_by(&:last) }
+
+    # Before any VM is hosted: only the empty-state message, no tables.
+    reload.call
+    expect(page).to have_content("No customer resources are hosted on this host.")
+    expect(page).to have_no_css(".vm-host-customers-summary-table")
+    expect(page).to have_no_css(".vm-host-resources-table")
 
     # Plain customer VM, owned directly by the customer project.
     create_vm(vm_host_id: vm_host.id, project_id: customer.id, name: "customer-vm")
-    create_vm(vm_host_id: vm_host.id, project_id: other_customer.id, name: "another-customer-vm")
-    create_vm(vm_host_id: other_vm_host.id, project_id: customer.id, name: "vm-in-another-host") # must not be included in the results
+    reload.call
+    expect(page.all(".vm-host-customers-summary-table thead th").map(&:text)).to eq(["Customer", "VMs", "PostgreSQL", "Kubernetes", "GitHub Runners", "Total"])
+    expect(page.all(".vm-host-resources-table thead th").map(&:text)).to eq(["Customer", "Type", "Resource", "VM", "vCPUs", "Created At"])
+    expect(summary_rows.call).to eq([[customer_label, "1", "0", "0", "0", "1"]])
+    expect(resource_rows.call).to eq([[customer_label, "VM", "", "customer-vm"]])
 
-    # PostgreSQL: the VM is owned by an internal service project, but the
-    # resource (and thus the customer) is resolved through the postgres resource.
+    # PostgreSQL: the VM is owned by the service project but attributed to the
+    # customer through the postgres resource.
     pg = create_postgres_resource(project: customer, location_id: vm_host.location_id)
-    pg_server = create_postgres_server(resource: pg)
-    pg_server.vm.update(vm_host_id: vm_host.id, project_id: service_project.id)
+    pg_vm = create_postgres_server(resource: pg).vm
+    pg_vm.update(vm_host_id: vm_host.id, project_id: service_project.id)
+    reload.call
+    expect(summary_rows.call).to eq([[customer_label, "1", "1", "0", "0", "2"]])
+    expect(resource_rows.call).to eq([
+      [customer_label, "VM", "", "customer-vm"],
+      [customer_label, "PostgreSQL", pg.name, pg_vm.name],
+    ].sort_by(&:last))
 
-    # K8s node, resolved to the customer via the cluster.
-    k8s_ps = PrivateSubnet.create(name: "k8s-ps", project_id: other_customer.id, location_id: vm_host.location_id, net4: "10.1.0.0/26", net6: "fdfb::/64")
-    cluster = KubernetesCluster.create(project_id: other_customer.id, name: "k8s-cluster", private_subnet_id: k8s_ps.id, location_id: vm_host.location_id, cp_node_count: 1, version: Option.selectable_kubernetes_versions.first, target_node_size: "standard-2")
-    k8s_vm = create_vm(vm_host_id: vm_host.id, project_id: service_project.id, name: "k8s-node-vm")
-    KubernetesNode.create(kubernetes_cluster_id: cluster.id, vm_id: k8s_vm.id)
+    # Kubernetes: attributed to the customer through the cluster.
+    k8s_ps = PrivateSubnet.create(name: "k8s-ps", project_id: customer.id, location_id: vm_host.location_id, net4: "10.1.0.0/26", net6: "fdfb::/64")
+    cluster = KubernetesCluster.create(project_id: customer.id, name: "k8s-cluster", private_subnet_id: k8s_ps.id, location_id: vm_host.location_id, cp_node_count: 1, version: Option.selectable_kubernetes_versions.first, target_node_size: "standard-2")
+    KubernetesNode.create(kubernetes_cluster_id: cluster.id, vm_id: create_vm(vm_host_id: vm_host.id, project_id: service_project.id, name: "k8s-node-vm").id)
+    reload.call
+    expect(summary_rows.call).to eq([[customer_label, "1", "1", "1", "0", "3"]])
+    expect(resource_rows.call).to eq([
+      [customer_label, "VM", "", "customer-vm"],
+      [customer_label, "PostgreSQL", pg.name, pg_vm.name],
+      [customer_label, "Kubernetes", "k8s-cluster", "k8s-node-vm"],
+    ].sort_by(&:last))
 
-    # GitHub runner, resolved to the customer via the installation.
-    installation = GithubInstallation.create(installation_id: 99, name: "gh-org", type: "Organization", project_id: other_customer.id)
+    # GitHub runner: attributed to the customer through the installation.
+    installation = GithubInstallation.create(installation_id: 99, name: "gh-org", type: "Organization", project_id: customer.id)
     gh_vm = create_vm(vm_host_id: vm_host.id, project_id: service_project.id, name: "gh-runner-vm")
     GithubRunner.create(vm_id: gh_vm.id, repository_name: "repo", label: "ubicloud", installation_id: installation.id)
+    reload.call
+    expect(summary_rows.call).to eq([[customer_label, "1", "1", "1", "1", "4"]])
+    expect(resource_rows.call).to eq([
+      [customer_label, "VM", "", "customer-vm"],
+      [customer_label, "PostgreSQL", pg.name, pg_vm.name],
+      [customer_label, "Kubernetes", "k8s-cluster", "k8s-node-vm"],
+      [customer_label, "GitHub Runner", "gh-org", "gh-runner-vm"],
+    ].sort_by(&:last))
 
-    visit "/model/VmHost/#{vm_host.ubid}"
-
-    summary = page.all(".vm-host-customers-summary-table tbody tr").map { it.all("td").map(&:text) }
-    expect(summary).to eq([
-      ["some-customer (a@b.com)", "1", "1", "0", "0", "2"],
-      ["some-other-customer (c@d.com)", "1", "0", "1", "1", "3"],
+    # Minio server: the VM is owned by the internal Minio service project and is
+    # not mapped to a customer, so it appears under the service project with no
+    # email.
+    minio_cluster = MinioCluster.create(name: "minio-cluster", project_id: minio_service.id, location_id: vm_host.location_id, admin_user: "admin", admin_password: "dummy-password")
+    minio_pool = MinioPool.create(cluster_id: minio_cluster.id, server_count: 1, drive_count: 1, storage_size_gib: 100, vm_size: "standard-2", start_index: 0)
+    MinioServer.create(minio_pool_id: minio_pool.id, vm_id: create_vm(vm_host_id: vm_host.id, project_id: minio_service.id, name: "minio-vm").id, index: 0)
+    reload.call
+    expect(summary_rows.call).to eq([
+      ["minio-service", "1", "0", "0", "0", "1"],
+      [customer_label, "1", "1", "1", "1", "4"],
     ])
+    expect(resource_rows.call).to eq([
+      [customer_label, "VM", "", "customer-vm"],
+      ["minio-service", "VM", "", "minio-vm"],
+      [customer_label, "PostgreSQL", pg.name, pg_vm.name],
+      [customer_label, "Kubernetes", "k8s-cluster", "k8s-node-vm"],
+      [customer_label, "GitHub Runner", "gh-org", "gh-runner-vm"],
+    ].sort_by(&:last))
 
-    rows = page.all(".vm-host-resources-table tbody tr").map { it.all("td").map(&:text) }
-    expect(rows.map { it[1] }.sort).to eq(["GitHub Runner", "Kubernetes", "PostgreSQL", "VM", "VM"])
-    # Managed-service rows are attributed to the customer, not the service project.
-    expect(rows.map { it.first }.uniq.sort).to eq(["some-customer (a@b.com)", "some-other-customer (c@d.com)"])
     expect(page).to have_no_content("internal-service")
     expect(page).to have_no_content("vm-in-another-host")
-  end
-
-  it "shows a message when no customer resources are hosted on a VM host" do
-    vm_host = create_vm_host
-    visit "/model/VmHost/#{vm_host.ubid}"
-    expect(page).to have_content("No customer resources are hosted on this host.")
   end
 end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -783,7 +783,7 @@ RSpec.describe CloverAdmin do
     other_project = Project.create(name: "some-other-customer")
     service_project = Project.create(name: "internal-service")
     vm_host = create_vm_host
-    other_vm_host = create_vm_host
+    other_vm_host = create_vm_host(location_id: Location::HETZNER_HEL1_ID, allocation_state: "draining")
 
     # Plain customer VM, owned directly by the project.
     create_vm(vm_host_id: vm_host.id, project_id: project.id, name: "customer-vm")
@@ -810,8 +810,8 @@ RSpec.describe CloverAdmin do
 
     hosts = page.all(".project-vm-hosts-table tbody tr").map { it.all("td").map(&:text) }
     expect(hosts).to eq([
-      [vm_host.ubid, "1", "1", "1", "0", "3"],
-      [other_vm_host.ubid, "1", "0", "0", "1", "2"],
+      [vm_host.ubid, "hetzner-fsn1", "accepting", "1", "1", "1", "0", "3"],
+      [other_vm_host.ubid, "hetzner-hel1", "draining", "1", "0", "0", "1", "2"],
     ].sort_by(&:first))
 
     rows = page.all(".project-resources-table tbody tr").map { it.all("td").map(&:text) }

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -788,7 +788,10 @@ RSpec.describe CloverAdmin do
     # A VM owned by another project on the same host must never appear here.
     create_vm(vm_host_id: vm_host.id, project_id: other_project.id, name: "other-project-vm")
 
-    reload = -> { visit "/model/Project/#{project.ubid}" }
+    reload = -> {
+      visit "/model/Project/#{project.ubid}"
+      page.all("summary").each(&:click)
+    }
     hosts_rows = -> { page.all(".project-vm-hosts-table tbody tr").map { it.all("td").map(&:text) } }
     resource_rows = -> { page.all(".project-resources-table tbody tr").map { it.all("td").map(&:text).first(4) }.sort_by { it[2] } }
 
@@ -3113,7 +3116,10 @@ RSpec.describe CloverAdmin do
     # A VM on another host must never appear in this host's tables.
     create_vm(vm_host_id: other_vm_host.id, project_id: customer.id, name: "vm-in-another-host")
 
-    reload = -> { visit "/model/VmHost/#{vm_host.ubid}" }
+    reload = -> {
+      visit "/model/VmHost/#{vm_host.ubid}"
+      page.all("summary").each(&:click)
+    }
     summary_rows = -> { page.all(".vm-host-customers-summary-table tbody tr").map { it.all("td").map(&:text) }.sort_by(&:first) }
     # Assert the identifying columns (customer, type, resource, vm), ordered by vm name.
     resource_rows = -> { page.all(".vm-host-resources-table tbody tr").map { it.all("td").map(&:text).first(4) }.sort_by(&:last) }

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -3003,6 +3003,12 @@ RSpec.describe CloverAdmin do
     account = create_account("a@b.com", with_project: false)
     DB[:access_tag].insert(project_id: big.id, hyper_tag_id: account.id)
 
+    # An account created earlier but with an alphabetically-later email; its
+    # email is the one shown, since the earliest-created account wins.
+    earlier_account = create_account("z@b.com", with_project: false)
+    DB[:accounts].where(id: earlier_account.id).update(created_at: Time.now - 3600)
+    DB[:access_tag].insert(project_id: big.id, hyper_tag_id: earlier_account.id)
+
     # big-customer owns a plain VM plus managed PostgreSQL, Kubernetes, and
     # GitHub runner resources whose VMs are owned by an internal service project
     # but attributed back to the customer through their managing resource.
@@ -3034,11 +3040,11 @@ RSpec.describe CloverAdmin do
     expect(headers).to eq(["Project", "Reputation", "VMs", "PostgreSQL", "Kubernetes", "Runners", "Total vCPUs", "Total Spend"])
 
     rows = page.all(".customer-usage-table tbody tr").map { it.all("td").map(&:text) }
-    expect(rows.map(&:first)).to eq(["big-customer (a@b.com)", "small-customer"])
-    expect(rows.first).to eq(["big-customer (a@b.com)", "new", "1", "1", "1", "0", "14", "$15.50"])
+    expect(rows.map(&:first)).to eq(["big-customer (z@b.com)", "small-customer"])
+    expect(rows.first).to eq(["big-customer (z@b.com)", "new", "1", "1", "1", "0", "14", "$15.50"])
     expect(rows.last).to eq(["small-customer", "new", "1", "0", "0", "1", "4", "$1.00"])
 
-    expect(page).not_to have_content("empty-customer")
+    expect(page).to have_no_content("empty-customer")
   end
 
   it "shows customer resources hosted on a VM host, resolving managed services to the customer" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2943,4 +2943,61 @@ RSpec.describe CloverAdmin do
     click_button "Search"
     expect(ubids.call).to eq([x64_48.ubid])
   end
+
+  it "shows customer resources hosted on a VM host, resolving managed services to the customer" do
+    vm_host = create_vm_host
+    other_vm_host = create_vm_host
+    customer = Project.create(name: "some-customer")
+    other_customer = Project.create(name: "some-other-customer")
+    service_project = Project.create(name: "internal-service")
+
+    customer_account = create_account("a@b.com", with_project: true)
+    DB[:access_tag].insert(project_id: customer.id, hyper_tag_id: customer_account.id)
+
+    other_customer_account = create_account("c@d.com", with_project: true)
+    DB[:access_tag].insert(project_id: other_customer.id, hyper_tag_id: other_customer_account.id)
+
+    # Plain customer VM, owned directly by the customer project.
+    create_vm(vm_host_id: vm_host.id, project_id: customer.id, name: "customer-vm")
+    create_vm(vm_host_id: vm_host.id, project_id: other_customer.id, name: "another-customer-vm")
+    create_vm(vm_host_id: other_vm_host.id, project_id: customer.id, name: "vm-in-another-host") # must not be included in the results
+
+    # PostgreSQL: the VM is owned by an internal service project, but the
+    # resource (and thus the customer) is resolved through the postgres resource.
+    pg = create_postgres_resource(project: customer, location_id: vm_host.location_id)
+    pg_server = create_postgres_server(resource: pg)
+    pg_server.vm.update(vm_host_id: vm_host.id, project_id: service_project.id)
+
+    # K8s node, resolved to the customer via the cluster.
+    k8s_ps = PrivateSubnet.create(name: "k8s-ps", project_id: other_customer.id, location_id: vm_host.location_id, net4: "10.1.0.0/26", net6: "fdfb::/64")
+    cluster = KubernetesCluster.create(project_id: other_customer.id, name: "k8s-cluster", private_subnet_id: k8s_ps.id, location_id: vm_host.location_id, cp_node_count: 1, version: Option.selectable_kubernetes_versions.first, target_node_size: "standard-2")
+    k8s_vm = create_vm(vm_host_id: vm_host.id, project_id: service_project.id, name: "k8s-node-vm")
+    KubernetesNode.create(kubernetes_cluster_id: cluster.id, vm_id: k8s_vm.id)
+
+    # GitHub runner, resolved to the customer via the installation.
+    installation = GithubInstallation.create(installation_id: 99, name: "gh-org", type: "Organization", project_id: other_customer.id)
+    gh_vm = create_vm(vm_host_id: vm_host.id, project_id: service_project.id, name: "gh-runner-vm")
+    GithubRunner.create(vm_id: gh_vm.id, repository_name: "repo", label: "ubicloud", installation_id: installation.id)
+
+    visit "/model/VmHost/#{vm_host.ubid}"
+
+    summary = page.all(".vm-host-customers-summary-table tbody tr").map { it.all("td").map(&:text) }
+    expect(summary).to eq([
+      ["some-customer (a@b.com)", "1", "1", "0", "0", "2"],
+      ["some-other-customer (c@d.com)", "1", "0", "1", "1", "3"],
+    ])
+
+    rows = page.all(".vm-host-resources-table tbody tr").map { it.all("td").map(&:text) }
+    expect(rows.map { it[1] }.sort).to eq(["GitHub Runner", "Kubernetes", "PostgreSQL", "VM", "VM"])
+    # Managed-service rows are attributed to the customer, not the service project.
+    expect(rows.map { it.first }.uniq.sort).to eq(["some-customer (a@b.com)", "some-other-customer (c@d.com)"])
+    expect(page).to have_no_content("internal-service")
+    expect(page).to have_no_content("vm-in-another-host")
+  end
+
+  it "shows a message when no customer resources are hosted on a VM host" do
+    vm_host = create_vm_host
+    visit "/model/VmHost/#{vm_host.ubid}"
+    expect(page).to have_content("No customer resources are hosted on this host.")
+  end
 end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2994,6 +2994,53 @@ RSpec.describe CloverAdmin do
     expect(ubids.call).to eq([x64_48.ubid])
   end
 
+  it "shows Customer Usage with resources, vcpu usage, and spend, ordered by spend" do
+    big = Project.create(name: "big-customer")
+    small = Project.create(name: "small-customer")
+    service_project = Project.create(name: "internal-service")
+    Project.create(name: "empty-customer")
+
+    account = create_account("a@b.com", with_project: false)
+    DB[:access_tag].insert(project_id: big.id, hyper_tag_id: account.id)
+
+    # big-customer owns a plain VM plus managed PostgreSQL, Kubernetes, and
+    # GitHub runner resources whose VMs are owned by an internal service project
+    # but attributed back to the customer through their managing resource.
+    create_vm(project_id: big.id, vcpus: 8)
+    pg = create_postgres_resource(project: big, location_id: Location::HETZNER_FSN1_ID)
+    pg_server = create_postgres_server(resource: pg)
+    pg_server.vm.update(project_id: service_project.id)
+
+    k8s_ps = PrivateSubnet.create(name: "k8s-ps", project_id: big.id, location_id: Location::HETZNER_FSN1_ID, net4: "10.1.0.0/26", net6: "fdfb::/64")
+    kc = KubernetesCluster.create(project_id: big.id, name: "k8s-cluster", private_subnet_id: k8s_ps.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 1, version: Option.selectable_kubernetes_versions.first, target_node_size: "standard-2")
+    k8s_vm = create_vm(project_id: service_project.id, vcpus: 4, name: "k8s-node-vm")
+    KubernetesNode.create(kubernetes_cluster_id: kc.id, vm_id: k8s_vm.id)
+
+    Invoice.create(project_id: big.id, invoice_number: "2601-big-01", content: {cost: 10.0}, begin_time: "2025-01-01", end_time: "2025-02-01")
+    Invoice.create(project_id: big.id, invoice_number: "2602-big-02", content: {cost: 5.5}, begin_time: "2025-02-01", end_time: "2025-03-01")
+
+    create_vm(project_id: small.id, vcpus: 2)
+
+    installation = GithubInstallation.create(installation_id: 99, name: "gh-org", type: "Organization", project_id: small.id)
+    gh_vm = create_vm(project_id: service_project.id, vcpus: 2, name: "gh-runner-vm")
+    GithubRunner.create(vm_id: gh_vm.id, repository_name: "repo", label: "ubicloud", installation_id: installation.id)
+
+    Invoice.create(project_id: small.id, invoice_number: "2601-small-01", content: {cost: 1.0}, begin_time: "2025-01-01", end_time: "2025-02-01")
+
+    click_link "Customer Usage"
+    expect(page.title).to eq "Ubicloud Admin - Customer Usage"
+
+    headers = page.all(".customer-usage-table thead th").map(&:text)
+    expect(headers).to eq(["Project", "Reputation", "VMs", "PostgreSQL", "Kubernetes", "Runners", "Total vCPUs", "Total Spend"])
+
+    rows = page.all(".customer-usage-table tbody tr").map { it.all("td").map(&:text) }
+    expect(rows.map(&:first)).to eq(["big-customer (a@b.com)", "small-customer"])
+    expect(rows.first).to eq(["big-customer (a@b.com)", "new", "1", "1", "1", "0", "14", "$15.50"])
+    expect(rows.last).to eq(["small-customer", "new", "1", "0", "0", "1", "4", "$1.00"])
+
+    expect(page).not_to have_content("empty-customer")
+  end
+
   it "shows customer resources hosted on a VM host, resolving managed services to the customer" do
     vm_host = create_vm_host
     other_vm_host = create_vm_host

--- a/views/admin/customer_usage.erb
+++ b/views/admin/customer_usage.erb
@@ -1,0 +1,9 @@
+<% @page_title = "Customer Usage" %>
+
+<p>
+  Customer projects with attributed resources (VMs, PostgreSQL, Kubernetes,
+  GitHub runners) or invoices, ordered by lifetime spend. Managed-service VMs
+  are attributed to the customer that owns the managing resource.
+</p>
+
+<%== part("components/table", title: nil, table_class: "customer-usage-table", data: @data, use_admin_label: false) %>

--- a/views/admin/extras/Project.erb
+++ b/views/admin/extras/Project.erb
@@ -27,53 +27,14 @@
   }
 ) %>
 
-<% vm = Sequel[:vm]
-# The project's managed resources (PostgreSQL, Kubernetes, GitHub runners) run
-# on VMs owned by internal service projects, so a VM belongs to this project if
-# it is owned directly or through one of those managing resources.
-customer_project_id = Sequel.function(
-  :coalesce,
-  Sequel[:pg][:project_id],
-  Sequel[:kc][:project_id],
-  Sequel[:gi][:project_id],
-  vm[:project_id],
-)
-
-rows = DB[:vm]
-  .left_join(Sequel[:postgres_server].as(:ps), vm_id: vm[:id])
-  .left_join(Sequel[:postgres_resource].as(:pg), id: Sequel[:ps][:resource_id])
-  .left_join(Sequel[:kubernetes_node].as(:kd), vm_id: vm[:id])
-  .left_join(Sequel[:kubernetes_cluster].as(:kc), id: Sequel[:kd][:kubernetes_cluster_id])
-  .left_join(Sequel[:github_runner].as(:gr), vm_id: vm[:id])
-  .left_join(Sequel[:github_installation].as(:gi), id: Sequel[:gr][:installation_id])
-  .where(customer_project_id => obj.id)
-  .select(
-    vm[:id].as(:vm_id),
-    vm[:name].as(:vm_name),
-    vm[:vcpus],
-    vm[:created_at],
-    vm[:vm_host_id],
-    Sequel[:pg][:id].as(:pg_resource_id),
-    Sequel[:pg][:name].as(:pg_resource_name),
-    Sequel[:kc][:id].as(:kubernetes_cluster_id),
-    Sequel[:kc][:name].as(:kubernetes_cluster_name),
-    Sequel[:gr][:id].as(:github_runner_id),
-    Sequel[:gi][:name].as(:github_installation_name),
-  )
-  .order(vm[:vm_host_id], vm[:created_at])
+<% rows = customer_vm_dataset
+  .where(project_id: obj.id)
+  .order(:vm_host_id, :created_at)
   .all
 
 host_summary = Hash.new { |h, k| h[k] = Hash.new(0) }
 resources = rows.map do |row|
-  type, resource = if row[:pg_resource_id]
-    ["PostgreSQL", table_link(row[:pg_resource_name], "/model/PostgresResource/#{UBID.to_ubid(row[:pg_resource_id])}")]
-  elsif row[:kubernetes_cluster_id]
-    ["Kubernetes", table_link(row[:kubernetes_cluster_name], "/model/KubernetesCluster/#{UBID.to_ubid(row[:kubernetes_cluster_id])}")]
-  elsif row[:github_runner_id]
-    ["GitHub Runner", table_link(row[:github_installation_name], "/model/GithubRunner/#{UBID.to_ubid(row[:github_runner_id])}")]
-  else
-    ["VM", nil]
-  end
+  type, resource = customer_resource_type(row)
 
   host = if row[:vm_host_id]
     host_ubid = UBID.to_ubid(row[:vm_host_id])

--- a/views/admin/extras/Project.erb
+++ b/views/admin/extras/Project.erb
@@ -36,9 +36,9 @@ host_summary = Hash.new { |h, k| h[k] = Hash.new(0) }
 resources = rows.map do |row|
   type, resource = customer_resource_type(row)
 
-  host = if row[:vm_host_id]
-    host_ubid = UBID.to_ubid(row[:vm_host_id])
-    host_summary[host_ubid][type] += 1
+  host = if (host_id = row[:vm_host_id])
+    host_summary[host_id][type] += 1
+    host_ubid = UBID.to_ubid(host_id)
     table_link(host_ubid, "/model/VmHost/#{host_ubid}")
   end
 
@@ -52,11 +52,26 @@ resources = rows.map do |row|
   }
 end
 
+# Location and allocation state for each utilized host.
+host_details = DB[:vm_host]
+  .join(:location, id: Sequel[:vm_host][:location_id])
+  .where(Sequel[:vm_host][:id] => host_summary.keys)
+  .select(
+    Sequel[:vm_host][:id],
+    Sequel[:location][:name].as(:location),
+    Sequel[:vm_host][:allocation_state],
+  )
+  .to_hash(:id)
+
 host_summary_data = host_summary
-  .sort_by { |ubid, _counts| ubid }
-  .map do |ubid, counts|
+  .sort_by { |host_id, _counts| UBID.to_ubid(host_id) }
+  .map do |host_id, counts|
+    ubid = UBID.to_ubid(host_id)
+    detail = host_details[host_id]
     {
       "VM Host" => table_link(ubid, "/model/VmHost/#{ubid}"),
+      "Location" => detail[:location],
+      "State" => detail[:allocation_state],
       "VMs" => counts["VM"],
       "PostgreSQL" => counts["PostgreSQL"],
       "Kubernetes" => counts["Kubernetes"],

--- a/views/admin/extras/Project.erb
+++ b/views/admin/extras/Project.erb
@@ -26,3 +26,86 @@
     }
   }
 ) %>
+
+<% vm = Sequel[:vm]
+# The project's managed resources (PostgreSQL, Kubernetes, GitHub runners) run
+# on VMs owned by internal service projects, so a VM belongs to this project if
+# it is owned directly or through one of those managing resources.
+customer_project_id = Sequel.function(
+  :coalesce,
+  Sequel[:pg][:project_id],
+  Sequel[:kc][:project_id],
+  Sequel[:gi][:project_id],
+  vm[:project_id],
+)
+
+rows = DB[:vm]
+  .left_join(Sequel[:postgres_server].as(:ps), vm_id: vm[:id])
+  .left_join(Sequel[:postgres_resource].as(:pg), id: Sequel[:ps][:resource_id])
+  .left_join(Sequel[:kubernetes_node].as(:kd), vm_id: vm[:id])
+  .left_join(Sequel[:kubernetes_cluster].as(:kc), id: Sequel[:kd][:kubernetes_cluster_id])
+  .left_join(Sequel[:github_runner].as(:gr), vm_id: vm[:id])
+  .left_join(Sequel[:github_installation].as(:gi), id: Sequel[:gr][:installation_id])
+  .where(customer_project_id => obj.id)
+  .select(
+    vm[:id].as(:vm_id),
+    vm[:name].as(:vm_name),
+    vm[:vcpus],
+    vm[:created_at],
+    vm[:vm_host_id],
+    Sequel[:pg][:id].as(:pg_resource_id),
+    Sequel[:pg][:name].as(:pg_resource_name),
+    Sequel[:kc][:id].as(:kubernetes_cluster_id),
+    Sequel[:kc][:name].as(:kubernetes_cluster_name),
+    Sequel[:gr][:id].as(:github_runner_id),
+    Sequel[:gi][:name].as(:github_installation_name),
+  )
+  .order(vm[:vm_host_id], vm[:created_at])
+  .all
+
+host_summary = Hash.new { |h, k| h[k] = Hash.new(0) }
+resources = rows.map do |row|
+  type, resource = if row[:pg_resource_id]
+    ["PostgreSQL", table_link(row[:pg_resource_name], "/model/PostgresResource/#{UBID.to_ubid(row[:pg_resource_id])}")]
+  elsif row[:kubernetes_cluster_id]
+    ["Kubernetes", table_link(row[:kubernetes_cluster_name], "/model/KubernetesCluster/#{UBID.to_ubid(row[:kubernetes_cluster_id])}")]
+  elsif row[:github_runner_id]
+    ["GitHub Runner", table_link(row[:github_installation_name], "/model/GithubRunner/#{UBID.to_ubid(row[:github_runner_id])}")]
+  else
+    ["VM", nil]
+  end
+
+  host = if row[:vm_host_id]
+    host_ubid = UBID.to_ubid(row[:vm_host_id])
+    host_summary[host_ubid][type] += 1
+    table_link(host_ubid, "/model/VmHost/#{host_ubid}")
+  end
+
+  {
+    "Type" => type,
+    "Resource" => resource,
+    "VM" => table_link(row[:vm_name], "/model/Vm/#{UBID.to_ubid(row[:vm_id])}"),
+    "VM Host" => host,
+    "vCPUs" => row[:vcpus],
+    "Created At" => row[:created_at].strftime("%F %T"),
+  }
+end
+
+host_summary_data = host_summary
+  .sort_by { |ubid, _counts| ubid }
+  .map do |ubid, counts|
+    {
+      "VM Host" => table_link(ubid, "/model/VmHost/#{ubid}"),
+      "VMs" => counts["VM"],
+      "PostgreSQL" => counts["PostgreSQL"],
+      "Kubernetes" => counts["Kubernetes"],
+      "GitHub Runners" => counts["GitHub Runner"],
+      "Total" => counts.values.sum,
+    }
+  end %>
+
+<% unless resources.empty? %>
+  <%== part("components/table", title: "Resources", table_class: "project-resources-table", data: resources, use_admin_label: false) %>
+
+  <%== part("components/table", title: "VM Hosts Utilized", table_class: "project-vm-hosts-table", data: host_summary_data, use_admin_label: false) %>
+<% end %>

--- a/views/admin/extras/Project.erb
+++ b/views/admin/extras/Project.erb
@@ -56,22 +56,20 @@ end
 host_details = DB[:vm_host]
   .join(:location, id: Sequel[:vm_host][:location_id])
   .where(Sequel[:vm_host][:id] => host_summary.keys)
-  .select(
+  .select_hash(
     Sequel[:vm_host][:id],
-    Sequel[:location][:name].as(:location),
-    Sequel[:vm_host][:allocation_state],
+    [Sequel[:location][:name].as(:location), Sequel[:vm_host][:allocation_state]],
   )
-  .to_hash(:id)
 
 host_summary_data = host_summary
   .sort_by { |host_id, _counts| UBID.to_ubid(host_id) }
   .map do |host_id, counts|
     ubid = UBID.to_ubid(host_id)
-    detail = host_details[host_id]
+    location, state = host_details[host_id]
     {
       "VM Host" => table_link(ubid, "/model/VmHost/#{ubid}"),
-      "Location" => detail[:location],
-      "State" => detail[:allocation_state],
+      "Location" => location,
+      "State" => state,
       "VMs" => counts["VM"],
       "PostgreSQL" => counts["PostgreSQL"],
       "Kubernetes" => counts["Kubernetes"],

--- a/views/admin/extras/Project.erb
+++ b/views/admin/extras/Project.erb
@@ -79,7 +79,7 @@ host_summary_data = host_summary
   end %>
 
 <% unless resources.empty? %>
-  <%== part("components/table", title: "Resources", table_class: "project-resources-table", data: resources, use_admin_label: false) %>
+  <%== part("components/collapsible_table", title: "Resources", table_class: "project-resources-table", data: resources, use_admin_label: false) %>
 
-  <%== part("components/table", title: "VM Hosts Utilized", table_class: "project-vm-hosts-table", data: host_summary_data, use_admin_label: false) %>
+  <%== part("components/collapsible_table", title: "VM Hosts Utilized", table_class: "project-vm-hosts-table", data: host_summary_data, use_admin_label: false) %>
 <% end %>

--- a/views/admin/extras/VmHost.erb
+++ b/views/admin/extras/VmHost.erb
@@ -1,73 +1,25 @@
 <%# locals: (obj:) %>
 
-<% vm = Sequel[:vm]
-
-# Managed services (PostgreSQL, Kubernetes, GitHub runners) run on VMs owned by
-# internal service projects, so the actual customer project is resolved through
-# the managing resource, falling back to the VM's own project for plain VMs.
-
-customer_project_id = Sequel.function(
-  :coalesce,
-  Sequel[:pg][:project_id],
-  Sequel[:kc][:project_id],
-  Sequel[:gi][:project_id],
-  vm[:project_id],
-)
-
-# Project names are frequently just "Default", so the account email(s)
-# associated with the project are aggregated to make the customer more identifiable.
-customer_emails = DB[:access_tag]
-  .join(:accounts, id: Sequel[:access_tag][:hyper_tag_id])
-  .group(Sequel[:access_tag][:project_id])
+<% rows = customer_vm_dataset
+  .where(Sequel[:cvm][:vm_host_id] => obj.id)
+  .left_join(Sequel[:project].as(:proj), id: Sequel[:cvm][:project_id])
+  .left_join(customer_email_dataset.as(:ce), project_id: Sequel[:proj][:id])
   .select(
-    Sequel[:access_tag][:project_id],
-    Sequel.function(:string_agg, Sequel[:accounts][:email], ", ").distinct.order(Sequel[:accounts][:email]).as(:emails),
-  )
-
-rows = DB[:vm]
-  .where(vm[:vm_host_id] => obj.id)
-  .left_join(Sequel[:postgres_server].as(:ps), vm_id: vm[:id])
-  .left_join(Sequel[:postgres_resource].as(:pg), id: Sequel[:ps][:resource_id])
-  .left_join(Sequel[:kubernetes_node].as(:kn), vm_id: vm[:id])
-  .left_join(Sequel[:kubernetes_cluster].as(:kc), id: Sequel[:kn][:kubernetes_cluster_id])
-  .left_join(Sequel[:github_runner].as(:gr), vm_id: vm[:id])
-  .left_join(Sequel[:github_installation].as(:gi), id: Sequel[:gr][:installation_id])
-  .left_join(Sequel[:project].as(:proj), id: customer_project_id)
-  .left_join(customer_emails.as(:ce), project_id: customer_project_id)
-  .select(
-    vm[:id].as(:vm_id),
-    vm[:name].as(:vm_name),
-    vm[:vcpus],
-    vm[:created_at],
-    Sequel[:proj][:id].as(:project_id),
+    Sequel[:cvm].*,
     Sequel[:proj][:name].as(:project_name),
-    Sequel[:ce][:emails].as(:emails),
-    Sequel[:pg][:id].as(:pg_resource_id),
-    Sequel[:pg][:name].as(:pg_resource_name),
-    Sequel[:kc][:id].as(:kubernetes_cluster_id),
-    Sequel[:kc][:name].as(:kubernetes_cluster_name),
-    Sequel[:gr][:id].as(:github_runner_id),
-    Sequel[:gi][:name].as(:github_installation_name),
+    Sequel[:ce][:email].as(:email),
   )
-  .order(Sequel.function(:lower, Sequel[:proj][:name]), Sequel[:proj][:id], vm[:created_at])
+  .order(Sequel.function(:lower, Sequel[:proj][:name]), Sequel[:proj][:id], Sequel[:cvm][:created_at])
   .all
 
 summary = Hash.new { |h, k| h[k] = Hash.new(0) }
 resource_data = rows.map do |row|
-  type, resource = if row[:pg_resource_id]
-    ["PostgreSQL", table_link(row[:pg_resource_name], "/model/PostgresResource/#{UBID.to_ubid(row[:pg_resource_id])}")]
-  elsif row[:kubernetes_cluster_id]
-    ["Kubernetes", table_link(row[:kubernetes_cluster_name], "/model/KubernetesCluster/#{UBID.to_ubid(row[:kubernetes_cluster_id])}")]
-  elsif row[:github_runner_id]
-    ["GitHub Runner", table_link(row[:github_installation_name], "/model/GithubRunner/#{UBID.to_ubid(row[:github_runner_id])}")]
-  else
-    ["VM", nil]
-  end
+  type, resource = customer_resource_type(row)
 
   # A VM's project_id is NOT NULL and references an existing project, so the
   # customer is always resolvable.
   customer_ubid = UBID.to_ubid(row[:project_id])
-  label = row[:emails] ? "#{row[:project_name]} (#{row[:emails]})" : row[:project_name]
+  label = project_label(row[:project_name], row[:email])
   summary[[customer_ubid, label]][type] += 1
 
   {

--- a/views/admin/extras/VmHost.erb
+++ b/views/admin/extras/VmHost.erb
@@ -1,0 +1,102 @@
+<%# locals: (obj:) %>
+
+<% vm = Sequel[:vm]
+
+# Managed services (PostgreSQL, Kubernetes, GitHub runners) run on VMs owned by
+# internal service projects, so the actual customer project is resolved through
+# the managing resource, falling back to the VM's own project for plain VMs.
+
+customer_project_id = Sequel.function(
+  :coalesce,
+  Sequel[:pg][:project_id],
+  Sequel[:kc][:project_id],
+  Sequel[:gi][:project_id],
+  vm[:project_id],
+)
+
+# Project names are frequently just "Default", so the account email(s)
+# associated with the project are aggregated to make the customer more identifiable.
+customer_emails = DB[:access_tag]
+  .join(:accounts, id: Sequel[:access_tag][:hyper_tag_id])
+  .group(Sequel[:access_tag][:project_id])
+  .select(
+    Sequel[:access_tag][:project_id],
+    Sequel.function(:string_agg, Sequel[:accounts][:email], ", ").distinct.order(Sequel[:accounts][:email]).as(:emails),
+  )
+
+rows = DB[:vm]
+  .where(vm[:vm_host_id] => obj.id)
+  .left_join(Sequel[:postgres_server].as(:ps), vm_id: vm[:id])
+  .left_join(Sequel[:postgres_resource].as(:pg), id: Sequel[:ps][:resource_id])
+  .left_join(Sequel[:kubernetes_node].as(:kn), vm_id: vm[:id])
+  .left_join(Sequel[:kubernetes_cluster].as(:kc), id: Sequel[:kn][:kubernetes_cluster_id])
+  .left_join(Sequel[:github_runner].as(:gr), vm_id: vm[:id])
+  .left_join(Sequel[:github_installation].as(:gi), id: Sequel[:gr][:installation_id])
+  .left_join(Sequel[:project].as(:proj), id: customer_project_id)
+  .left_join(customer_emails.as(:ce), project_id: customer_project_id)
+  .select(
+    vm[:id].as(:vm_id),
+    vm[:name].as(:vm_name),
+    vm[:vcpus],
+    vm[:created_at],
+    Sequel[:proj][:id].as(:project_id),
+    Sequel[:proj][:name].as(:project_name),
+    Sequel[:ce][:emails].as(:emails),
+    Sequel[:pg][:id].as(:pg_resource_id),
+    Sequel[:pg][:name].as(:pg_resource_name),
+    Sequel[:kc][:id].as(:kubernetes_cluster_id),
+    Sequel[:kc][:name].as(:kubernetes_cluster_name),
+    Sequel[:gr][:id].as(:github_runner_id),
+    Sequel[:gi][:name].as(:github_installation_name),
+  )
+  .order(Sequel.function(:lower, Sequel[:proj][:name]), Sequel[:proj][:id], vm[:created_at])
+  .all
+
+summary = Hash.new { |h, k| h[k] = Hash.new(0) }
+resource_data = rows.map do |row|
+  type, resource = if row[:pg_resource_id]
+    ["PostgreSQL", table_link(row[:pg_resource_name], "/model/PostgresResource/#{UBID.to_ubid(row[:pg_resource_id])}")]
+  elsif row[:kubernetes_cluster_id]
+    ["Kubernetes", table_link(row[:kubernetes_cluster_name], "/model/KubernetesCluster/#{UBID.to_ubid(row[:kubernetes_cluster_id])}")]
+  elsif row[:github_runner_id]
+    ["GitHub Runner", table_link(row[:github_installation_name], "/model/GithubRunner/#{UBID.to_ubid(row[:github_runner_id])}")]
+  else
+    ["VM", nil]
+  end
+
+  # A VM's project_id is NOT NULL and references an existing project, so the
+  # customer is always resolvable.
+  customer_ubid = UBID.to_ubid(row[:project_id])
+  label = row[:emails] ? "#{row[:project_name]} (#{row[:emails]})" : row[:project_name]
+  summary[[customer_ubid, label]][type] += 1
+
+  {
+    "Customer" => table_link(label, "/model/Project/#{customer_ubid}"),
+    "Type" => type,
+    "Resource" => resource,
+    "VM" => table_link(row[:vm_name], "/model/Vm/#{UBID.to_ubid(row[:vm_id])}"),
+    "vCPUs" => row[:vcpus],
+    "Created At" => row[:created_at].strftime("%F %T"),
+  }
+end
+
+summary_data = summary
+  .map do |(ubid, name), counts|
+    {
+      "Customer" => table_link(name, "/model/Project/#{ubid}"),
+      "VMs" => counts["VM"],
+      "PostgreSQL" => counts["PostgreSQL"],
+      "Kubernetes" => counts["Kubernetes"],
+      "GitHub Runners" => counts["GitHub Runner"],
+      "Total" => counts.values.sum,
+    }
+  end
+  .sort_by { [it["Total"], it["Customer"]] } %>
+
+<% if resource_data.empty? %>
+  <p>No customer resources are hosted on this host.</p>
+<% else %>
+  <%== part("components/table", title: "Customers", table_class: "vm-host-customers-summary-table", data: summary_data, use_admin_label: false) %>
+
+  <%== part("components/table", title: "Resources", table_class: "vm-host-resources-table", data: resource_data, use_admin_label: false) %>
+<% end %>

--- a/views/admin/extras/VmHost.erb
+++ b/views/admin/extras/VmHost.erb
@@ -48,7 +48,7 @@ summary_data = summary
 <% if resource_data.empty? %>
   <p>No customer resources are hosted on this host.</p>
 <% else %>
-  <%== part("components/table", title: "Customers", table_class: "vm-host-customers-summary-table", data: summary_data, use_admin_label: false) %>
+  <%== part("components/collapsible_table", title: "Customers", table_class: "vm-host-customers-summary-table", data: summary_data, use_admin_label: false) %>
 
-  <%== part("components/table", title: "Resources", table_class: "vm-host-resources-table", data: resource_data, use_admin_label: false) %>
+  <%== part("components/collapsible_table", title: "Resources", table_class: "vm-host-resources-table", data: resource_data, use_admin_label: false) %>
 <% end %>

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -51,6 +51,7 @@
     <li><a href="/vm-by-ipv4">Find VM by IPv4 Address</a></li>
     <li><a href="/github-runner-usage">GitHub Runner VM Usage</a></li>
     <li><a href="/vm-host-usage">VM Host Usage</a></li>
+    <li><a href="/customer-usage">Customer Usage</a></li>
     <li>
       <a href="/audit-log">View Audit Logs</a> |
       <a href="/authentication-audit-log">View Authentication Audit Logs</a> |


### PR DESCRIPTION
This PR contains changes for adding different views to 

VmHost admin page now shows which customers benefit from the host and which resources are hosted.
<img width="1384" height="448" alt="image" src="https://github.com/user-attachments/assets/3ae06fa9-7178-4580-afd5-73ea22c48794" />

Project admin page now shows which vm hosts are used to host the resources of a project.
<img width="1629" height="549" alt="image" src="https://github.com/user-attachments/assets/d6c842cb-9393-4405-9f40-17332bbcf68f" />


A separate Customer Usage page displays the vcpus and total spent for each project.
<img width="1682" height="349" alt="image" src="https://github.com/user-attachments/assets/806e5ebb-0be3-4141-add7-f188ca915618" />
