### PR TITLE
Take the visible flag into account for AWS postgres locations

### DIFF
--- a/model/location.rb
+++ b/model/location.rb
@@ -35,10 +35,10 @@ class Location < Sequel::Model
     end
   end
 
-  def self.postgres_locations(visible_gcp_names = nil)
+  def self.postgres_locations(visible_location_names = nil)
     where(project_id: nil, name: ["hetzner-fsn1", "leaseweb-wdc02"])
-      .or(provider: "aws", project_id: nil)
-      .or(provider: "gcp", project_id: nil, name: visible_gcp_names || [])
+      .or(provider: "aws", project_id: nil, visible: true)
+      .or(provider: ["aws", "gcp"], project_id: nil, name: visible_location_names || [])
       .order(:display_name)
       .all
   end

--- a/spec/model/location_spec.rb
+++ b/spec/model/location_spec.rb
@@ -46,13 +46,20 @@ RSpec.describe Location do
   end
 
   describe ".postgres_locations" do
-    it "without arg returns metal and AWS public locations but no GCP" do
+    it "without arg returns metal and visible AWS public locations but no GCP" do
       names = described_class.postgres_locations.map(&:name)
 
       expect(names).to include("hetzner-fsn1", "leaseweb-wdc02")
-      expect(names).to include("us-east-1", "us-west-2")
+      expect(names).not_to include("us-east-1", "us-west-2")
       expect(names).not_to include("gcp-us-central1")
       expect(names).not_to include("github-runners")
+    end
+
+    it "includes an AWS public location once it is marked visible" do
+      described_class[name: "us-east-1"].update(visible: true)
+      names = described_class.postgres_locations.map(&:name)
+      expect(names).to include("us-east-1")
+      expect(names).not_to include("us-west-2")
     end
 
     it "excludes a visible: true GCP public location when arg is nil (no visible bypass for GCP)" do
@@ -61,16 +68,23 @@ RSpec.describe Location do
       expect(names).not_to include("gcp-us-central1")
     end
 
-    it "with empty array arg behaves like nil (still no GCP)" do
+    it "with empty array arg behaves like nil (still no GCP or hidden AWS)" do
       names = described_class.postgres_locations([]).map(&:name)
-      expect(names).to include("hetzner-fsn1", "leaseweb-wdc02", "us-east-1", "us-west-2")
-      expect(names).not_to include("gcp-us-central1")
+      expect(names).to include("hetzner-fsn1", "leaseweb-wdc02")
+      expect(names).not_to include("gcp-us-central1", "us-east-1", "us-west-2")
     end
 
     it "with array containing a GCP region name includes that GCP region" do
       names = described_class.postgres_locations(["gcp-us-central1"]).map(&:name)
       expect(names).to include("gcp-us-central1")
-      expect(names).to include("hetzner-fsn1", "leaseweb-wdc02", "us-east-1", "us-west-2")
+      expect(names).to include("hetzner-fsn1", "leaseweb-wdc02")
+    end
+
+    it "with array containing a hidden AWS region name includes that AWS region" do
+      expect(described_class[name: "us-east-1"].visible).to be(false)
+      names = described_class.postgres_locations(["us-east-1"]).map(&:name)
+      expect(names).to include("us-east-1")
+      expect(names).not_to include("us-west-2")
     end
 
     it "excludes BYOC GCP locations even when their name is in the array" do
@@ -79,10 +93,10 @@ RSpec.describe Location do
       expect(names).not_to include("my-gcp")
     end
 
-    it "excludes BYOC AWS locations" do
+    it "excludes BYOC AWS locations even when visible or named in the array" do
       described_class.create(name: "my-aws", display_name: "my-aws", ui_name: "my-aws", visible: true, provider: "aws", project_id: p1_id)
-      names = described_class.postgres_locations.map(&:name)
-      expect(names).not_to include("my-aws")
+      expect(described_class.postgres_locations.map(&:name)).not_to include("my-aws")
+      expect(described_class.postgres_locations(["my-aws"]).map(&:name)).not_to include("my-aws")
     end
 
     it "excludes a project-owned location even if its name matches a public metal location" do
@@ -92,12 +106,14 @@ RSpec.describe Location do
       expect(locations.find { it.name == "hetzner-fsn1" }.project_id).to be_nil
     end
 
-    it "includes AWS public locations regardless of array (bypass preserved)" do
+    it "excludes hidden AWS public locations regardless of array (no visible bypass for AWS)" do
       expect(described_class[name: "us-east-1"].visible).to be(false)
       names_nil = described_class.postgres_locations.map(&:name)
       names_empty = described_class.postgres_locations([]).map(&:name)
       names_with_gcp = described_class.postgres_locations(["gcp-us-central1"]).map(&:name)
-      expect([names_nil, names_empty, names_with_gcp]).to all(include("us-east-1", "us-west-2"))
+      [names_nil, names_empty, names_with_gcp].each do |names|
+        expect(names).not_to include("us-east-1", "us-west-2")
+      end
     end
   end
 

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -1482,9 +1482,23 @@ RSpec.describe PostgresResource do
       expect(names).not_to include("gcp-us-central1")
     end
 
-    it "includes AWS public regions regardless of visible_postgres_locations" do
+    it "excludes hidden AWS public regions by default" do
       names = described_class.postgres_locations(project).map(&:name)
-      expect(names).to include("us-east-1", "us-west-2")
+      expect(names).not_to include("us-east-1", "us-west-2")
+    end
+
+    it "includes a hidden AWS public region when project has it in visible_postgres_locations" do
+      project.set_ff_visible_postgres_locations(["us-east-1"])
+      names = described_class.postgres_locations(project).map(&:name)
+      expect(names).to include("us-east-1")
+      expect(names).not_to include("us-west-2")
+    end
+
+    it "includes AWS public regions marked visible" do
+      Location[name: "us-west-2"].update(visible: true)
+      names = described_class.postgres_locations(project).map(&:name)
+      expect(names).to include("us-west-2")
+      expect(names).not_to include("us-east-1")
     end
 
     it "still appends project's own BYOC locations" do

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Clover, "postgres" do
           ha_type: "sync",
         }.to_json
 
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: location", {"location" => "Invalid location. Available options: eu-central-h1, us-east-1, us-east-a2, us-west-2"})
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: location", {"location" => "Invalid location. Available options: eu-central-h1, us-east-a2"})
       end
 
       it "location not exist" do

--- a/spec/routes/api/project/postgres_capabilities_spec.rb
+++ b/spec/routes/api/project/postgres_capabilities_spec.rb
@@ -84,7 +84,42 @@ RSpec.describe Clover, "postgres/capabilities" do
       expect(metadata.dig("ha_type", "none", "standby_count")).to eq(0)
     end
 
+    it "excludes hidden aws locations by default" do
+      expect(Location[name: "us-east-1"].visible).to be(false)
+
+      get "/project/#{project.ubid}/postgres/capabilities"
+      body = JSON.parse(last_response.body)
+
+      locations = body.dig("option_tree", "flavor", "standard", "location").keys
+      expect(locations).not_to include("us-east-1", "us-west-2")
+      expect(body.dig("metadata", "location").keys).not_to include("us-east-1", "us-west-2")
+    end
+
+    it "includes an aws location marked visible" do
+      Location[name: "us-east-1"].update(visible: true)
+
+      get "/project/#{project.ubid}/postgres/capabilities"
+      body = JSON.parse(last_response.body)
+
+      locations = body.dig("option_tree", "flavor", "standard", "location").keys
+      expect(locations).to include("us-east-1")
+      expect(locations).not_to include("us-west-2")
+    end
+
+    it "includes a hidden aws location when named in visible_postgres_locations" do
+      project.set_ff_visible_postgres_locations(["us-east-1"])
+
+      get "/project/#{project.ubid}/postgres/capabilities"
+      body = JSON.parse(last_response.body)
+
+      locations = body.dig("option_tree", "flavor", "standard", "location").keys
+      expect(locations).to include("us-east-1")
+      expect(locations).not_to include("us-west-2")
+    end
+
     it "filters aws sizes by instance availability" do
+      Location[name: "us-east-1"].update(visible: true)
+
       get "/project/#{project.ubid}/postgres/capabilities"
       body = JSON.parse(last_response.body)
       tree = body["option_tree"]
@@ -110,6 +145,8 @@ RSpec.describe Clover, "postgres/capabilities" do
     end
 
     it "excludes feature-flagged aws families by default" do
+      Location[name: "us-east-1"].update(visible: true)
+
       get "/project/#{project.ubid}/postgres/capabilities"
       body = JSON.parse(last_response.body)
       tree = body["option_tree"]
@@ -125,6 +162,7 @@ RSpec.describe Clover, "postgres/capabilities" do
     end
 
     it "includes feature-flagged aws family when enabled" do
+      Location[name: "us-east-1"].update(visible: true)
       project.set_ff_enable_i8ge(true)
 
       get "/project/#{project.ubid}/postgres/capabilities"


### PR DESCRIPTION
Public AWS locations are seeded with visible: false and enabled per project, but Location.postgres_locations included every public AWS location regardless of the visible flag. As a result, the /project/{project_id}/postgres/capabilities endpoint advertised locations that check_visible_location then rejects at creation time for API requests, and the location validation error message listed locations the project cannot use.

Only include AWS public locations that are visible: true, and allow hidden AWS locations to be enabled per project via the visible_postgres_locations feature flag, matching the existing GCP handling.