### PR TITLE
Start using private_hostname for replication on pg standbys

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -150,7 +150,7 @@ class PostgresResource < Sequel::Model
     }
     query_parameters = query_parameters.map { |k, v| "#{k}=#{v}" }.join("&")
 
-    URI::Generic.build2(scheme: "postgres", userinfo: "ubi_replication", host: hostname, query: query_parameters).to_s
+    URI::Generic.build2(scheme: "postgres", userinfo: "ubi_replication", host: private_hostname, query: query_parameters).to_s
   end
 
   def provision_new_standby

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -149,7 +149,7 @@ class PostgresServer < Sequel::Model
       },
       cert_auth_users: resource.cert_auth_users,
       identity: resource.identity,
-      hosts: "#{resource.representative_server.vm.private_ipv4} #{resource.identity}",
+      hosts: "#{resource.representative_server.vm.private_ipv4} #{resource.private_hostname}",
       pgbouncer_instances: (vm.vcpus / 2.0).ceil.clamp(1, 8),
       metrics_config:,
       disk_throughput_baseline_mbps:,

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -57,36 +57,36 @@ RSpec.describe PostgresResource do
     postgres_resource.update(hostname_version: "v1")
     expect(postgres_resource).to receive(:dns_zone).and_return(instance_double(DnsZone)).at_least(:once)
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
-    expect(s).to include("ubi_replication@pg-name.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
+    expect(s).to include("ubi_replication@private.pg-name.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
     postgres_resource.set(root_cert_1: "rc1", root_cert_2: "rc2")
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
-    expect(s).to include("ubi_replication@pg-name.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000", "sslrootcert=/etc/ssl/certs/server-ca.crt")
+    expect(s).to include("ubi_replication@private.pg-name.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000", "sslrootcert=/etc/ssl/certs/server-ca.crt")
   end
 
   it "returns replication_connection_string for hostname version v2" do
     postgres_resource.update(hostname_version: "v2")
     expect(postgres_resource).to receive(:dns_zone).and_return(instance_double(DnsZone)).at_least(:once)
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
-    expect(s).to include("ubi_replication@pg-name.#{postgres_resource.ubid}.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
+    expect(s).to include("ubi_replication@private.pg-name.#{postgres_resource.ubid}.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
     postgres_resource.set(root_cert_1: "rc1", root_cert_2: "rc2")
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
-    expect(s).to include("ubi_replication@pg-name.#{postgres_resource.ubid}.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000", "sslrootcert=/etc/ssl/certs/server-ca.crt")
+    expect(s).to include("ubi_replication@private.pg-name.#{postgres_resource.ubid}.postgres.ubicloud.com", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000", "sslrootcert=/etc/ssl/certs/server-ca.crt")
   end
 
   it "returns replication_connection_string with ip when no dns_zone exists" do
     vm = create_hosted_vm(project, private_subnet, "pg-vm")
     PostgresServer.create(timeline:, resource_id: postgres_resource.id, vm_id: vm.id, is_representative: true, synchronization_status: "ready", timeline_access: "push", version: "17")
-    AssignedVmAddress.create(dst_vm_id: vm.id, ip: "1.2.3.4/32")
+    vm.nics.first.update(private_ipv4: "172.0.0.9/32")
     expect(postgres_resource.dns_zone).to be_nil
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
-    expect(s).to include("ubi_replication@1.2.3.4", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
+    expect(s).to include("ubi_replication@172.0.0.9", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000")
   end
 
   it "returns replication_connection_string for hostname version v3 without root CAs" do
     expect(postgres_resource).to receive(:dns_zone).and_return(instance_double(DnsZone)).at_least(:once)
     postgres_resource.update(hostname_version: "v3", root_cert_1: nil, root_cert_2: nil)
     s = postgres_resource.replication_connection_string(application_name: "pgubidstandby")
-    expect(s).to include("ubi_replication@pg-name.#{postgres_resource.ubid}.pg.ubicloud.app", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000", "sslrootcert=system")
+    expect(s).to include("ubi_replication@pg-name.#{postgres_resource.ubid}.private.pg.ubicloud.app", "application_name=pgubidstandby", "sslcert=/etc/ssl/certs/client.crt", "tcp_user_timeout=30000", "sslrootcert=system")
   end
 
   it "returns internal_firewall_rules with SSH from control plane, subnet ports 5432/6432, and configured external CIDRs" do


### PR DESCRIPTION
We realized the primary_conninfo was using the identity and we were setting the private ip in the /etc/hosts, while this has worked before, we recently switched primary_conninfo to use hostname in 61d409fa51be2a5db0a7ad4622da67f2d96b2734. With that, our /etc/hosts modification become void and the replication connection in between primary and standby essentially stalled. Here, we are switching both to use private_hostname. While we do not need the change in `/etc/hosts` anymore, keeping it for the time being since it's better than to go out to an upstream dns server.