### PR TITLE
Skip VM pool when installation has location preferences

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -40,7 +40,10 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
   end
 
   def pick_vm
-    skip_pool = project.get_ff_skip_runner_pool || github_runner.spill_over_set?
+    # Pool VMs are provisioned without installation context, so they cannot
+    # honor per-installation location preferences; allocate a fresh VM instead.
+    has_location_preferences = installation.allocator_preferences.values_at("location_filter", "location_preference").any?
+    skip_pool = project.get_ff_skip_runner_pool || github_runner.spill_over_set? || has_location_preferences
 
     vm_size = if installation.premium_runner_enabled? || installation.free_runner_upgrade?
       "premium-#{label_data["vcpus"]}"

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -34,7 +34,10 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
   end
 
   def pick_vm
-    skip_pool = project.get_ff_skip_runner_pool || github_runner.spill_over_set?
+    # Pool VMs are provisioned without installation context, so they cannot
+    # honor per-installation location preferences; allocate a fresh VM instead.
+    has_location_preferences = installation.allocator_preferences.values_at("location_filter", "location_preference").any?
+    skip_pool = project.get_ff_skip_runner_pool || github_runner.spill_over_set? || has_location_preferences
 
     vm_size = if installation.premium_runner_enabled? || installation.free_runner_upgrade?
       "premium-#{label_data["vcpus"]}"

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -112,6 +112,16 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(picked_vm.pool_id).to be_nil
     end
 
+    it "skips pool if the installation has location preferences even when the pool has a vm" do
+      installation.update(allocator_preferences: {"family_filter" => ["premium", "standard"], "location_filter" => [Location::LEASEWEB_WDC02_ID], "location_preference" => [Location::LEASEWEB_WDC02_ID]})
+      pool = VmPool.create(size: 2, vm_size: "premium-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64")
+      vm = create_vm(pool_id: pool.id, display_state: "running", family: "premium")
+      expect(Prog::Vm::Nexus).to receive(:assemble_with_sshable).and_call_original
+      picked_vm = nx.pick_vm
+      expect(vm.id).not_to eq(picked_vm.id)
+      expect(picked_vm.pool_id).to be_nil
+    end
+
     it "uses alien vms by given ratio" do
       project.set_ff_aws_alien_runners_ratio(0.5)
       expect(nx).to receive(:rand).and_return(0.4)

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -138,6 +138,16 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(picked_vm.strand.stack.first["waiting_strand_id"]).to eq(runner.id)
     end
 
+    it "skips pool if the installation has location preferences even when the pool has a vm" do
+      installation.update(allocator_preferences: {"family_filter" => ["premium", "standard"], "location_filter" => [Location::LEASEWEB_WDC02_ID], "location_preference" => [Location::LEASEWEB_WDC02_ID]})
+      pool = VmPool.create(size: 2, vm_size: "premium-4", boot_image: "github-ubuntu-2404", location_id: Location::GITHUB_RUNNERS_ID, storage_size_gib: 150, arch: "x64")
+      vm = create_vm(pool_id: pool.id, display_state: "running", family: "premium")
+      expect(Prog::Vm::Nexus).to receive(:assemble_with_sshable).and_call_original
+      picked_vm = nx.pick_vm
+      expect(vm.id).not_to eq(picked_vm.id)
+      expect(picked_vm.pool_id).to be_nil
+    end
+
     it "uses alien vms by given ratio" do
       project.set_ff_aws_alien_runners_ratio(0.5)
       expect(nx).to receive(:rand).and_return(0.4)


### PR DESCRIPTION
Pool VMs are pre-provisioned under the shared VM pool project before any GitHub runner is associated with them. When such a VM goes through Prog::Vm::Metal::Nexus, no installation can be found, so it is allocated with the default runner location filter (github-runners, hetzner-fsn1, hetzner-hel1) instead of the installation's allocator_preferences.

Later, pick_vm hands these VMs to runners of installations that set a location_filter or location_preference, silently violating them. For example, an installation restricted to leaseweb-wdc02 received premium pool VMs allocated on hetzner-fsn1, since premium hosts only exist there.

Skip the pool lookup for installations with location preferences, the same way the skip_runner_pool feature flag does, so their runners always go through the allocator with the installation's preferences applied.