### PR TITLE
Do not show CA certificates download for databases without root certs

### DIFF
--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -558,8 +558,16 @@ class Clover
 
       r.get "ca-certificates" do
         authorize("Postgres:view", pg)
+        handle_validation_failure("postgres/show") { @page = "connection" }
 
-        next unless (certs = pg.ca_certificates)
+        unless (certs = pg.ca_certificates)
+          message = if pg.uses_publicly_signed_certificates?
+            "This database uses certificates from a public signed certificate authority"
+          else
+            "Certificate authority certificates for this database have not yet been generated"
+          end
+          raise CloverError.new(404, "NotFound", message)
+        end
 
         response.attachment "#{pg.name}.pem"
         response.content_type = :pem

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -1153,7 +1153,21 @@ RSpec.describe Clover, "postgres" do
     end
 
     describe "ca-certificates" do
-      it "sets maintenance window to nil when empty string is passed" do
+      it "does not show link if certificates are not available, and shows error if they are requested" do
+        visit "#{project.path}#{pg.path}/connection"
+        expect(page).to have_no_content "CA Certificates"
+
+        visit "#{project.path}#{pg.path}/ca-certificates"
+        expect(page).to have_flash_error "Certificate authority certificates for this database have not yet been generated"
+
+        pg.update(hostname_version: "v3")
+        expect(Config).to receive(:acme_email).and_return("acme@example.com").at_least(:once)
+        DnsZone.create(project_id: postgres_project.id, name: "pg.ubicloud.app")
+        visit "#{project.path}#{pg.path}/ca-certificates"
+        expect(page).to have_flash_error "This database uses certificates from a public signed certificate authority"
+      end
+
+      it "downloads certificates if available" do
         pg.update(root_cert_1: "a", root_cert_2: "b")
         pg.strand.update(label: "wait")
         visit "#{project.path}#{pg.path}/connection"

--- a/views/postgres/connection.erb
+++ b/views/postgres/connection.erb
@@ -62,9 +62,11 @@
       </div>
     <% end %>
 
-    <div class="mt-5 flex items-center gap-2">
-      CA Certificates: <%== part("components/download_button", link: "#{path(@pg)}/ca-certificates")%>
-    </div>
+    <% if @pg.ca_certificates %>
+      <div class="mt-5 flex items-center gap-2">
+        CA Certificates: <%== part("components/download_button", link: "#{path(@pg)}/ca-certificates")%>
+      </div>
+    <% end %>
   <% else %>
     <div class="flex flex-col items-center justify-center h-full">
       <h2 class="text-2xl font-semibold text-gray-900">No connection information available</h2>


### PR DESCRIPTION
Databases could be lacking root certs for 2 reasons:

* Databases using publicly signed certificates never have root certs
* Other databases should have them, but they may not be generated yet

In either case, show an appropriate error message if the route is requested.