### PR TITLE
Rebind NVSwitch GPUs to nvidia on teardown

### DIFF
--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -520,6 +520,10 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     vm.update(display_state: "deleting")
 
     unless host.nil?
+      if vm.gpu_partition
+        host.sshable.cmd("sudo host/bin/setup-vm :action :vm_name", action: "delete_gpu_partition", vm_name:)
+      end
+
       begin
         host.sshable.cmd("sudo systemctl stop :vm_name", vm_name:, timeout: 10)
       rescue Sshable::SshError => ex

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -48,6 +48,11 @@ if action == "delete_net"
   exit 0
 end
 
+if action == "delete_gpu_partition"
+  vm_setup.deactivate_gpu_partition
+  exit 0
+end
+
 begin
   # "Global Unicast" subnet, i.e. a subnet for exchanging packets with
   # the internet.

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -3,6 +3,7 @@
 require_relative "../../common/lib/util"
 require_relative "../../common/lib/network"
 
+require "etc"
 require "fileutils"
 require "netaddr"
 require "json"
@@ -186,8 +187,10 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
 
     params = JSON.parse(File.read(vp.prep_json))
 
-    if (gpu_partition_id = params["gpu_partition_id"])
-      r("/usr/bin/fmpm -d #{gpu_partition_id}", expect: [0, 238])
+    if params["gpu_partition_id"]
+      pci_devices = params.fetch("pci_devices", [])
+      gpus = pci_devices.select { _1[0].end_with? ".0" }
+      gpus.each { |pci_dev| bind_driver(pci_dev[0], "nvidia") }
     end
 
     params["storage_volumes"].reject { _1["read_only"] }.each { |params|
@@ -207,6 +210,16 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     r "umount #{vp.q_hugepages}"
   rescue CommandFail => ex
     raise unless /(no mount point specified)|(not mounted)|(No such file or directory)/.match?(ex.stderr)
+  end
+
+  def deactivate_gpu_partition
+    return if !File.exist?(vp.prep_json)
+
+    params = JSON.parse(File.read(vp.prep_json))
+
+    if (gpu_partition_id = params["gpu_partition_id"])
+      r("/usr/bin/fmpm", "-d", gpu_partition_id.to_s, expect: [0, 238])
+    end
   end
 
   def hugepages(mem_gib)
@@ -621,11 +634,16 @@ DNSMASQ_CONF
   end
 
   def prepare_gpus(pci_devices, gpu_partition_id)
-    pci_devices.select { _1[0].end_with? ".0" }.each do |pci_dev|
-      r("echo 1 > /sys/bus/pci/devices/0000:#{pci_dev[0]}/reset")
-      r("chown #{@vm_name}:#{@vm_name} /sys/kernel/iommu_groups/#{pci_dev[1]} /dev/vfio/#{pci_dev[1]}")
+    gpus = pci_devices.select { |bdf, _| bdf.end_with?(".0") }
+
+    gpus.each { |bdf, _| File.write("/sys/bus/pci/devices/0000:#{bdf}/reset", "1") }
+
+    if gpu_partition_id
+      r("/usr/bin/fmpm", "-a", gpu_partition_id.to_s, expect: [0, 239])
+      gpus.each { |bdf, _| bind_driver(bdf, "vfio-pci") }
     end
-    r("/usr/bin/fmpm -a #{gpu_partition_id}", expect: [0, 239]) if gpu_partition_id
+
+    gpus.each { |_, iommu_group| chown_vfio(iommu_group) }
   end
 
   def install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices, slice_name, cpu_percent_limit)
@@ -885,5 +903,33 @@ DNSMASQ_SERVICE
 
   def cpu_vendor
     r("/usr/bin/lscpu | grep -m1 \"Vendor ID\" | cut -d: -f2").strip
+  end
+
+  def bind_driver(bdf_short, driver)
+    bdf = "0000:#{bdf_short}"
+    dev = "/sys/bus/pci/devices/#{bdf}"
+
+    return if current_driver(dev) == driver
+
+    File.write("#{dev}/driver_override", driver)
+    File.write("#{dev}/driver/unbind", bdf) if File.symlink?("#{dev}/driver")
+    File.write("/sys/bus/pci/drivers_probe", bdf)
+
+    actual = current_driver(dev)
+    unless actual == driver
+      raise "bind failed: #{bdf} bound to #{actual || "nothing"}, expected #{driver}"
+    end
+  end
+
+  def current_driver(dev)
+    File.basename(File.readlink("#{dev}/driver"))
+  rescue Errno::ENOENT
+    nil
+  end
+
+  def chown_vfio(iommu_group)
+    uid = Etc.getpwnam(@vm_name).uid
+    gid = Etc.getgrnam(@vm_name).gid
+    File.chown(uid, gid, "/sys/kernel/iommu_groups/#{iommu_group}", "/dev/vfio/#{iommu_group}")
   end
 end

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -860,14 +860,41 @@ NFTABLES_CONF
       expect { vs.purge_storage }.not_to raise_error
     end
 
-    it "calls fmpm when gpu_partition_id is present" do
+    it "binds gpus to nvidia when gpu_partition_id is present" do
+      params = JSON.generate({
+        "gpu_partition_id" => "gpu-partition-123",
+        "pci_devices" => [["00:01.0", "1"], ["00:01.1", "2"], ["00:02.0", "3"]],
+        "storage_volumes" => [],
+      })
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
+      expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
+      expect(vs).to receive(:bind_driver).with("00:01.0", "nvidia")
+      expect(vs).to receive(:bind_driver).with("00:02.0", "nvidia")
+
+      vs.purge_storage
+    end
+
+    it "tolerates a missing pci_devices key when gpu_partition_id is present" do
       params = JSON.generate({
         "gpu_partition_id" => "gpu-partition-123",
         "storage_volumes" => [],
       })
       expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
       expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
-      expect(vs).to receive(:r).with("/usr/bin/fmpm -d gpu-partition-123", expect: [0, 238])
+      expect(vs).not_to receive(:bind_driver)
+
+      vs.purge_storage
+    end
+
+    it "does not bind any driver when gpu_partition_id is absent" do
+      params = JSON.generate({
+        "pci_devices" => [["00:01.0", "1"]],
+        "storage_volumes" => [],
+      })
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
+      expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
+      expect(vs).not_to receive(:bind_driver)
+
       vs.purge_storage
     end
   end
@@ -986,19 +1013,141 @@ NFTABLES_CONF
   describe "#prepare_gpus" do
     it "resets PCI devices ending in .0 and chowns vfio groups" do
       pci_devices = [["00:00.0", "1"], ["00:00.1", "2"]]
-      expect(vs).to receive(:r).with("echo 1 > /sys/bus/pci/devices/0000:00:00.0/reset")
-      expect(vs).to receive(:r).with("chown test:test /sys/kernel/iommu_groups/1 /dev/vfio/1")
+      expect(File).to receive(:write).with("/sys/bus/pci/devices/0000:00:00.0/reset", "1")
+      expect(vs).to receive(:chown_vfio).with("1")
+      expect(vs).not_to receive(:bind_driver)
       vs.prepare_gpus(pci_devices, nil)
     end
 
     it "calls fmpm with gpu_partition_id when present" do
-      expect(vs).to receive(:r).with("/usr/bin/fmpm -a gp1", expect: [0, 239])
-      vs.prepare_gpus([], "gp1")
+      expect(vs).to receive(:r).with("/usr/bin/fmpm", "-a", "3", expect: [0, 239])
+      vs.prepare_gpus([], 3)
     end
 
     it "does nothing when pci_devices is empty and no gpu_partition_id" do
       expect(vs).not_to receive(:r)
+      expect(File).not_to receive(:write)
       vs.prepare_gpus([], nil)
+    end
+
+    it "binds gpus to vfio-pci and activates the partition when gpu_partition_id is present" do
+      pci_devices = [["00:01.0", "1"], ["00:01.1", "2"]]
+      expect(File).to receive(:write).with("/sys/bus/pci/devices/0000:00:01.0/reset", "1")
+      expect(vs).to receive(:r).with("/usr/bin/fmpm", "-a", "3", expect: [0, 239])
+      expect(vs).to receive(:bind_driver).with("00:01.0", "vfio-pci")
+      expect(vs).to receive(:chown_vfio).with("1")
+      vs.prepare_gpus(pci_devices, 3)
+    end
+
+    it "resets devices before activating the partition" do
+      expect(File).to receive(:write).with("/sys/bus/pci/devices/0000:00:01.0/reset", "1").ordered
+      expect(vs).to receive(:r).with("/usr/bin/fmpm", "-a", "3", expect: [0, 239]).ordered
+      expect(vs).to receive(:bind_driver).with("00:01.0", "vfio-pci").ordered
+      expect(vs).to receive(:chown_vfio).with("1").ordered
+      vs.prepare_gpus([["00:01.0", "1"]], 3)
+    end
+  end
+
+  describe "#deactivate_gpu_partition" do
+    it "calls fmpm -d when gpu_partition_id is present" do
+      params = JSON.generate({
+        "gpu_partition_id" => 3,
+        "storage_volumes" => [],
+      })
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
+      expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
+      expect(vs).to receive(:r).with("/usr/bin/fmpm", "-d", "3", expect: [0, 238])
+      vs.deactivate_gpu_partition
+    end
+
+    it "does nothing when gpu_partition_id is absent" do
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
+      expect(File).to receive(:read).with("/vm/test/prep.json").and_return(JSON.generate({"storage_volumes" => []}))
+      expect(vs).not_to receive(:r)
+      vs.deactivate_gpu_partition
+    end
+
+    it "exits silently if vm hasn't been created yet" do
+      expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(false)
+      expect(vs).not_to receive(:r)
+      expect { vs.deactivate_gpu_partition }.not_to raise_error
+    end
+  end
+
+  describe "#bind_driver" do
+    let(:dev) { "/sys/bus/pci/devices/0000:00:01.0" }
+
+    it "returns early when the device is already bound to the driver" do
+      expect(File).to receive(:readlink).with("#{dev}/driver").and_return("../../../../bus/pci/drivers/nvidia")
+      expect(File).not_to receive(:write)
+      vs.bind_driver("00:01.0", "nvidia")
+    end
+
+    it "overrides, unbinds and reprobes when bound to another driver" do
+      expect(File).to receive(:readlink).with("#{dev}/driver")
+        .and_return("../../drivers/nvidia", "../../drivers/vfio-pci")
+      expect(File).to receive(:write).with("#{dev}/driver_override", "vfio-pci")
+      expect(File).to receive(:symlink?).with("#{dev}/driver").and_return(true)
+      expect(File).to receive(:write).with("#{dev}/driver/unbind", "0000:00:01.0")
+      expect(File).to receive(:write).with("/sys/bus/pci/drivers_probe", "0000:00:01.0")
+      vs.bind_driver("00:01.0", "vfio-pci")
+    end
+
+    it "binds a device that has no driver at all" do
+      expect(File).to receive(:readlink).with("#{dev}/driver")
+        .and_raise(Errno::ENOENT).ordered
+      expect(File).to receive(:write).with("#{dev}/driver_override", "vfio-pci")
+      expect(File).to receive(:symlink?).with("#{dev}/driver").and_return(false)
+      expect(File).not_to receive(:write).with("#{dev}/driver/unbind", anything)
+      expect(File).to receive(:write).with("/sys/bus/pci/drivers_probe", "0000:00:01.0")
+      expect(File).to receive(:readlink).with("#{dev}/driver")
+        .and_return("../../drivers/vfio-pci").ordered
+      vs.bind_driver("00:01.0", "vfio-pci")
+    end
+
+    it "raises when the device ends up on the wrong driver" do
+      expect(File).to receive(:readlink).with("#{dev}/driver")
+        .and_raise(Errno::ENOENT).ordered
+      expect(File).to receive(:write).with("#{dev}/driver_override", "vfio-pci")
+      expect(File).to receive(:symlink?).with("#{dev}/driver").and_return(false)
+      expect(File).to receive(:write).with("/sys/bus/pci/drivers_probe", "0000:00:01.0")
+      expect(File).to receive(:readlink).with("#{dev}/driver")
+        .and_return("../../drivers/nvidia").ordered
+      expect { vs.bind_driver("00:01.0", "vfio-pci") }
+        .to raise_error("bind failed: 0000:00:01.0 bound to nvidia, expected vfio-pci")
+    end
+
+    it "raises when no driver claims the device after probing" do
+      expect(File).to receive(:readlink).with("#{dev}/driver").and_raise(Errno::ENOENT).twice
+      expect(File).to receive(:write).with("#{dev}/driver_override", "vfio-pci")
+      expect(File).to receive(:symlink?).with("#{dev}/driver").and_return(false)
+      expect(File).to receive(:write).with("/sys/bus/pci/drivers_probe", "0000:00:01.0")
+      expect { vs.bind_driver("00:01.0", "vfio-pci") }
+        .to raise_error("bind failed: 0000:00:01.0 bound to nothing, expected vfio-pci")
+    end
+  end
+
+  describe "#current_driver" do
+    let(:dev) { "/sys/bus/pci/devices/0000:00:01.0" }
+
+    it "returns the basename of the driver symlink" do
+      expect(File).to receive(:readlink).with("#{dev}/driver")
+        .and_return("../../../../bus/pci/drivers/vfio-pci")
+      expect(vs.current_driver(dev)).to eq("vfio-pci")
+    end
+
+    it "returns nil when the device has no driver" do
+      expect(File).to receive(:readlink).with("#{dev}/driver").and_raise(Errno::ENOENT)
+      expect(vs.current_driver(dev)).to be_nil
+    end
+  end
+
+  describe "#chown_vfio" do
+    it "chowns the iommu group and vfio device to the vm user" do
+      expect(Etc).to receive(:getpwnam).with("test").and_return(instance_double(Etc::Passwd, uid: 1001))
+      expect(Etc).to receive(:getgrnam).with("test").and_return(instance_double(Etc::Group, gid: 1002))
+      expect(File).to receive(:chown).with(1001, 1002, "/sys/kernel/iommu_groups/7", "/dev/vfio/7")
+      vs.chown_vfio("7")
     end
   end
 

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -1421,6 +1421,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     end
 
     it "detaches from gpu partition" do
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete_gpu_partition #{nx.vm_name}")
       expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10)
       expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq")
       expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}")


### PR DESCRIPTION
NVSwitch GPUs should sit on the nvidia driver between tenants to
avoid issues with Fabric Manager. Previously they were left on vfio-pci
after a VM was purged.

prepare_gpus now binds partitioned GPUs to vfio-pci before fmpm -a, and
purge_storage rebinds them to nvidia. Standalone GPUs keep the old
reset + chown path. The fmpm -d call moves out of purge_storage into
deactivate_gpu_partition, which Nexus#destroy invokes over ssh before
stopping the VM.
