### PR TITLE
Exclude reserved-address sub-blocks from private IPv4 allocation

### DIFF
--- a/model/private_subnet.rb
+++ b/model/private_subnet.rb
@@ -114,11 +114,10 @@ class PrivateSubnet < Sequel::Model
     cidr_size = [32, (net4.netmask.prefix_len + 8)].min
     total_hosts = 2**(cidr_size - net4.netmask.prefix_len)
 
-    # For leaf /32 picks (parent /24 or smaller), skip the addresses the
-    # provider reserves at the edges of the subnet. For bigger parent
-    # subnets like /16 we are allocating secondary subnets, not host IPs,
-    # so the full range is used without any reservation.
-    leading, trailing = (cidr_size == 32) ? ipv4_reservation : [0, 0]
+    # Skip the sub-blocks overlapping the addresses the provider reserves at
+    # the edges of the subnet, e.g. the first /24 of a /16 parent contains
+    # the reserved gateway/DNS addresses and must not be leased to a VM.
+    leading, trailing = (cidr_size > 30) ? ipv4_reservation : [1, 1].freeze
     random_offset = SecureRandom.random_number(total_hosts - leading - trailing) + leading
 
     addr = net4.nth_subnet(cidr_size, random_offset)

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -59,13 +59,20 @@ RSpec.describe PrivateSubnet do
       expect(ps.random_private_ipv4.to_s).to eq "10.9.39.9/32"
     end
 
-    it "does not subtract any reservation for bigger parent subnets" do
+    it "skips the sub-blocks containing the reserved edge addresses for bigger parent subnets" do
       prj = Project.create(name: "big-net-prj")
       ps = described_class.create(name: "big-ps", location_id: Location::HETZNER_FSN1_ID,
         net6: "fd1b:9793:dcef:cd0a::/64", net4: "10.9.0.0/16",
         state: "waiting", project_id: prj.id)
-      expect(SecureRandom).to receive(:random_number).with(256).and_return(5)
-      expect(ps.random_private_ipv4.to_s).to eq "10.9.5.0/24"
+      (1..254).each do |i|
+        Nic.create(private_subnet_id: ps.id, private_ipv4: "10.9.#{i}.0/24",
+          private_ipv6: "fd1b:9793:dcef:cd0a:#{(i * 2).to_s(16)}::/79",
+          mac: format("00:00:00:00:%02x:%02x", i / 256, i % 256),
+          name: "nic-#{i}", state: "active")
+      end
+      # Only the reserved first and last /24 remain free; the allocator
+      # must exhaust its draws rather than ever select one of them.
+      expect { ps.random_private_ipv4 }.to raise_error(RuntimeError, "Could not find random IPv4 after 1000 iterations")
     end
 
     it "returns random private ipv6" do


### PR DESCRIPTION

_random_private_ipv4 skips the addresses the provider reserves at the edges of a subnet (on metal: first four for network/gateway/DNS/future use, last one for broadcast), but only applied that reservation to leaf
/32 picks. For parent subnets larger than /24 it allocates sub-blocks
(e.g. a /24 per NIC in a /16) and used [0, 0] as the reservation, so the first and last sub-blocks, which contain the reserved addresses, were legal draws.

This bit Kubernetes VMs, since their clusters are the only users of
/16 subnets (ipv4_range_size: 16). With a 1-in-256 chance a node NIC drew the offset-0 block, and the collision then unfolded like this for a cluster subnet 10.224.0.0/16:

  - nic.private_ipv4 = 10.224.0.0/24 (the offset-0 sub-block)
 - vm_setup places private_ipv4_gateway = subnet.nth(1) = 10.224.0.1
   and dns_ipv4 = subnet.nth(2) = 10.224.0.2 on the tap device
 - cloudinit derives the guest lease as nth(1) of the NIC block,
   which is also 10.224.0.1, and writes
   dhcp-range=<tap>,10.224.0.1,10.224.0.1,6h
 - dnsmasq is asked to lease out its own interface address, so the
   guest's DHCPDISCOVER never gets a usable offer

The guest then boots with IPv6 only (DHCPv6 leases ::2 while the tap holds ::1, so v6 has no overlap), and SSH over the VM's public IPv4, which the host DNATs to the never-configured private IPv4, fails.

Fix by always excluding the edges: for /32 picks (cidr_size > 30) the provider's address-level reservation applies unchanged, and for sub-block picks the first and last blocks are skipped ([1, 1]). One block at each edge is sufficient because sub-blocks are at least four addresses and no provider reserves more than four at either edge. For a /16 parent this bans the first and last /24, which contain the gateway/DNS and broadcast addresses.

The spec proves the exclusion without stubbing the RNG: it fills all 254 allowed /24 blocks of a /16 subnet with real Nic records, leaving only the two reserved blocks free, and asserts the allocator exhausts its 1000 genuine random draws and raises instead of ever selecting one of them. With the fix in place the spec is deterministic. Against a regression it is probabilistic: since the RNG runs for real, there is a very low chance ((254/256)^1000, about 0.04%) that none of the 1000 draws lands on a reserved block and the spec passes although it should fail. Verified two-sided: the spec fails against the old [0, 0] logic and passes with the fix.