### PR TITLE
Use throw/catch instead of raise/rescue for prog flow control

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -248,7 +248,6 @@ def clover_freeze
     Prog::Ai,
     Prog::Aws,
     Prog::Base::Exit,
-    Prog::Base::FlowControl,
     Prog::Base::Hop,
     Prog::Base::Nap,
     Prog::DnsZone,

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -232,52 +232,60 @@ SQL
     end
 
     DB.transaction do
-      SemSnap.use(id) do |snap|
+      prog_action = SemSnap.use(id) do |snap|
         prg = load(snap)
-        prg.public_send(:before_run)
-        prg.public_send(label)
+        catch(:prog_return) do
+          prg.public_send(:before_run)
+          prg.public_send(label)
+          nil
+        end
       end
-    rescue Prog::Base::Nap => e
-      save_changes
 
-      scheduled = DB[<<SQL, schedule, e.seconds, id].get
+      case prog_action
+      when Prog::Base::Nap
+        e = prog_action
+        save_changes
+
+        scheduled = DB[<<SQL, schedule, e.seconds, id].get
 UPDATE strand
 SET try = 0,
     schedule = CASE WHEN schedule = ? THEN now() + (? * '1 second'::interval)
-                    ELSE schedule END
+                      ELSE schedule END
 WHERE id = ?
 RETURNING schedule
 SQL
-      # For convenience, reflect the updated record's schedule content
-      # in the model object, but since it's fresh, remove it from the
-      # changed columns so save_changes won't update it again.
-      self.schedule = scheduled
-      changed_columns.delete(:schedule)
-      e
-    rescue Prog::Base::Hop => hp
-      last_changed_at = Time.parse(top_frame["last_label_changed_at"])
-      Clog.emit("hopped", {strand_hopped: {strand: ubid, duration: Time.now - last_changed_at, from: prog_label, to: "#{hp.new_prog}.#{hp.new_label}"}})
-      top_frame["last_label_changed_at"] = Time.now.to_s
-      modified!(:stack)
+        # For convenience, reflect the updated record's schedule content
+        # in the model object, but since it's fresh, remove it from the
+        # changed columns so save_changes won't update it again.
+        self.schedule = scheduled
+        changed_columns.delete(:schedule)
+      when Prog::Base::Hop
+        hp = prog_action
+        last_changed_at = Time.parse(top_frame["last_label_changed_at"])
+        Clog.emit("hopped", {strand_hopped: {strand: ubid, duration: Time.now - last_changed_at, from: prog_label, to: "#{hp.new_prog}.#{hp.new_label}"}})
+        top_frame["last_label_changed_at"] = Time.now.to_s
+        modified!(:stack)
 
-      update(**hp.strand_update_args, try: 0)
+        update(**hp.strand_update_args, try: 0)
+      when Prog::Base::Exit
+        ext = prog_action
+        last_changed_at = Time.parse(top_frame["last_label_changed_at"])
+        Clog.emit("exited", {strand_exited: {strand: ubid, duration: Time.now - last_changed_at, from: prog_label}})
 
-      hp
-    rescue Prog::Base::Exit => ext
-      last_changed_at = Time.parse(top_frame["last_label_changed_at"])
-      Clog.emit("exited", {strand_exited: {strand: ubid, duration: Time.now - last_changed_at, from: prog_label}})
-
-      update(exitval: ext.exitval, retval: nil)
-      if parent_id
-        @exited = true
+        update(exitval: ext.exitval, retval: nil)
+        if parent_id
+          @exited = true
+        else
+          # No parent Strand to reap here, so self-reap.
+          semaphores_dataset.destroy
+          destroy
+          @deleted = true
+        end
       else
-        # No parent Strand to reap here, so self-reap.
-        semaphores_dataset.destroy
-        destroy
-        @deleted = true
+        raise InternalError, "BUG: Prog #{prog}##{label} did not provide flow control"
       end
 
-      ext
+      prog_action
     rescue RunError, InternalError, Sequel::DatabaseDisconnectError, Sequel::DatabaseConnectionError
       raise
     rescue => ex
@@ -288,8 +296,6 @@ SQL
       duration = Time.now - start_time
       Clog.emit("exception terminates strand run", Util.exception_to_hash(ex, into: {strand_error: {strand: ubid, try:, duration:, from: prog_label}}))
       raise RunError.new(self)
-    else
-      raise InternalError, "BUG: Prog #{prog}##{label} did not provide flow control"
     end
   ensure
     duration = Time.now - start_time

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -129,8 +129,12 @@ end
     end
   end
 
+  def prog_return(flow_control)
+    throw(:prog_return, flow_control)
+  end
+
   def nap(seconds = 30)
-    fail Nap.new(seconds)
+    prog_return Nap.new(seconds)
   end
 
   def pop(arg)
@@ -156,7 +160,7 @@ end
       old_label = strand.label
       prog, label = link
 
-      fail Hop.new(old_prog, old_label,
+      prog_return Hop.new(old_prog, old_label,
         {retval: outval,
          stack: Sequel.pg_jsonb_wrap(@strand.stack[1..]),
          prog:, label:})
@@ -169,59 +173,31 @@ end
       # Child strand with zero or one stack frames, set exitval. Clear
       # retval to avoid confusion, as it would have been set in a
       # previous intra-strand stack pop.
-      fail Exit.new(strand, outval)
+      prog_return Exit.new(strand, outval)
     end
   end
 
-  class FlowControl < RuntimeError; end
-
-  EMPTY_ARRAY = [].freeze
-
-  class Exit < FlowControl
-    attr_reader :exitval
-
-    def initialize(strand, exitval)
-      @strand = strand
-      @exitval = exitval
-      set_backtrace EMPTY_ARRAY
-    end
-
+  Exit = Data.define(:strand, :exitval) do
     def to_s
-      "Strand exits from #{@strand.prog}##{@strand.label} with #{@exitval}"
+      "Strand exits from #{strand.prog}##{strand.label} with #{exitval}"
     end
   end
 
-  class Hop < FlowControl
-    attr_reader :strand_update_args, :old_prog
-
-    def initialize(old_prog, old_label, strand_update_args)
-      @old_prog = old_prog
-      @old_label = old_label
-      @strand_update_args = strand_update_args
-      set_backtrace EMPTY_ARRAY
-    end
-
+  Hop = Data.define(:old_prog, :old_label, :strand_update_args) do
     def new_label
-      @strand_update_args[:label] || @old_label
+      strand_update_args[:label] || old_label
     end
 
     def new_prog
-      @strand_update_args[:prog] || @old_prog
+      strand_update_args[:prog] || old_prog
     end
 
     def to_s
-      "hop #{@old_prog}##{@old_label} -> #{new_prog}##{new_label}"
+      "hop #{old_prog}##{old_label} -> #{new_prog}##{new_label}"
     end
   end
 
-  class Nap < FlowControl
-    attr_reader :seconds
-
-    def initialize(seconds)
-      @seconds = seconds
-      set_backtrace EMPTY_ARRAY
-    end
-
+  Nap = Data.define(:seconds) do
     def to_s
       "nap for #{seconds} seconds"
     end
@@ -240,7 +216,7 @@ end
     old_label = strand.label
     new_frame = {"subject_id" => @subject_id, "link" => [strand.prog, old_label]}.merge(new_frame)
 
-    fail Hop.new(old_prog, old_label,
+    prog_return Hop.new(old_prog, old_label,
       {prog: Strand.prog_verify(prog), label:,
        stack: [new_frame] + strand.stack, retval: nil})
   end
@@ -377,7 +353,7 @@ end
     raise Strand::InternalError, "BUG: not valid hop target" unless self.class.labels.include? label
 
     label = label.to_s
-    fail Hop.new(@strand.prog, @strand.label, {label:, retval: nil})
+    prog_return Hop.new(@strand.prog, @strand.label, {label:, retval: nil})
   end
 
   private def time_string(time)

--- a/prog/vm/gcp/nexus.rb
+++ b/prog/vm/gcp/nexus.rb
@@ -192,7 +192,7 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
     end
 
     when_update_firewall_rules_set? do
-      push vm.update_firewall_rules_prog, {}, :update_firewall_rules
+      push vm.update_firewall_rules_prog, {}, "update_firewall_rules"
     end
 
     addr = vm.ip4

--- a/spec/lib/gcp_lro_spec.rb
+++ b/spec/lib/gcp_lro_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe GcpLro do
       op = Google::Cloud::Compute::V1::Operation.new(status: :RUNNING)
       expect(global_ops_client).to receive(:get).and_return(op)
       yielded = false
-      expect { nx.poll_and_clear_gcp_op("gcp_op") { yielded = true } }.to raise_error(Prog::Base::Nap)
+      expect { nx.poll_and_clear_gcp_op("gcp_op") { yielded = true } }.to nap(0..)
       expect(yielded).to be(false)
       expect(strand.stack.first["gcp_op"]).to eq({"name" => "op-abc", "scope" => "global", "scope_value" => nil})
     end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Prog::Base do
     prg = parent.load
     expect(parent).to receive(:load).twice.and_return(prg)
 
-    expect(prg).to receive(:nap).and_raise(Prog::Base::Nap.new(1))
+    expect(prg).to receive(:nap).and_throw(:prog_return, Prog::Base::Nap.new(1))
     expect(parent.run(10)).to be_a Prog::Base::Nap
     expect(parent.associations).to be_empty
 
@@ -208,7 +208,7 @@ RSpec.describe Prog::Base do
     prg = instance_double(Prog::Vm::Aws::Nexus)
     expect(st).to receive(:load).and_return(prg)
     expect(prg).to receive(:before_run)
-    expect(prg).to receive(:wait).and_raise(Prog::Base::Nap.new(30))
+    expect(prg).to receive(:wait).and_throw(:prog_return, Prog::Base::Nap.new(30))
     st.unsynchronized_run
   end
 

--- a/spec/prog/vm/gcp/nexus_spec.rb
+++ b/spec/prog/vm/gcp/nexus_spec.rb
@@ -671,8 +671,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
   describe "#wait_sshable" do
     it "pushes update_firewall_rules when semaphore is set" do
       nx.incr_update_firewall_rules
-      expect(nx).to receive(:push).with(Prog::Vnet::Gcp::UpdateFirewallRules, {}, :update_firewall_rules).and_call_original
-      expect { nx.wait_sshable }.to raise_error(Prog::Base::Hop)
+      expect { nx.wait_sshable }.to hop("update_firewall_rules", "Vnet::Gcp::UpdateFirewallRules")
     end
 
     it "decrements semaphore when firewall rules are added" do

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -145,9 +145,7 @@ RSpec.describe Prog::Vm::HostNexus do
 
   describe "#bootstrap_rhizome" do
     it "pushes a bootstrap rhizome process" do
-      expect { nx.bootstrap_rhizome }.to raise_error(Prog::Base::Hop) { |hop|
-        expect(hop.new_label).to eq("start")
-        expect(hop.new_prog).to eq("BootstrapRhizome")
+      expect { nx.bootstrap_rhizome }.to hop("start", "BootstrapRhizome") { |hop|
         expect(hop.strand_update_args[:stack].first).to include("target_folder" => "host")
       }
     end
@@ -244,9 +242,7 @@ RSpec.describe Prog::Vm::HostNexus do
   describe "#setup_storage_backend" do
     it "pushes the vhost_block_backend program by default" do
       vm_host.update(arch: "x64")
-      expect { nx.setup_storage_backend }.to raise_error(Prog::Base::Hop) { |hop|
-        expect(hop.new_label).to eq("start")
-        expect(hop.new_prog).to eq("Storage::SetupVhostBlockBackend")
+      expect { nx.setup_storage_backend }.to hop("start", "Storage::SetupVhostBlockBackend") { |hop|
         expect(hop.strand_update_args[:stack].first).to include("allocation_weight" => 100)
       }
     end

--- a/spec/prog/vnet/gcp/subnet_nexus_concurrency_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_concurrency_spec.rb
@@ -87,15 +87,21 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus, :no_db_transaction do
 
       t2_pid_queue = Queue.new
       t2 = Thread.new do
-        DB.synchronize do
+        prog_action = DB.synchronize do
           t2_pid_queue.push(DB.get(Sequel.function(:pg_backend_pid)))
-          nx.start
+          catch(:prog_return) do
+            nx.start
+            false
+          end
         end
         t2_result = :proceeded
-      rescue Prog::Base::Nap => e
-        t2_result = [:napped, e.seconds]
-      rescue Prog::Base::Hop
-        t2_result = :hopped
+
+        case prog_action
+        when Prog::Base::Nap
+          t2_result = [:napped, prog_action.seconds]
+        when Prog::Base::Hop
+          t2_result = :hopped
+        end
       rescue => e
         t2_result = [:error, e.class.name, e.message]
       end
@@ -137,9 +143,15 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus, :no_db_transaction do
 
     t1_error = nil
     t1 = Thread.new do
-      described_class.new(attacher.strand).start
-    rescue Prog::Base::Hop
-      # expected: attach committed, hop to wait_vpc_ready
+      prog_action = catch(:prog_return) do
+        described_class.new(attacher.strand).start
+        false
+      end
+
+      unless prog_action.is_a?(Prog::Base::Hop)
+        # expected: attach committed, hop to wait_vpc_ready
+        raise "unexpected: #{prog_action.inspect}"
+      end
     rescue => e
       t1_error = e
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -177,12 +177,18 @@ RSpec.configure do |config|
     supports_block_expectations
 
     match do |block|
-      block.call
-      false
-    rescue Prog::Base::Hop => hop
-      @hop = hop
-      (expected_label.nil? || hop.new_label == expected_label) &&
-        ((expected_prog.nil? && hop.old_prog == hop.new_prog) || hop.new_prog == expected_prog)
+      @hop = hop = catch(:prog_return) do
+        block.call
+        false
+      end
+
+      if hop.is_a?(Prog::Base::Hop)
+        (expected_label.nil? || hop.new_label == expected_label) &&
+          ((expected_prog.nil? && hop.old_prog == hop.new_prog) || hop.new_prog == expected_prog) &&
+          (block_arg.nil? || block_arg.call(hop))
+      else
+        false
+      end
     end
 
     failure_message do
@@ -207,11 +213,16 @@ RSpec.configure do |config|
     supports_block_expectations
 
     match do |block|
-      block.call
-      false
-    rescue Prog::Base::Exit => ext
-      @ext = ext
-      expected_exitval.nil? || ext.exitval == expected_exitval
+      @ext = ext = catch(:prog_return) do
+        block.call
+        false
+      end
+
+      if ext.is_a?(Prog::Base::Exit)
+        expected_exitval.nil? || ext.exitval == expected_exitval
+      else
+        false
+      end
     end
 
     failure_message do
@@ -231,11 +242,16 @@ RSpec.configure do |config|
     supports_block_expectations
 
     match do |block|
-      block.call
-      false
-    rescue Prog::Base::Nap => nap
-      @nap = nap
-      expected_seconds.nil? || expected_seconds === nap.seconds
+      @nap = nap = catch(:prog_return) do
+        block.call
+        false
+      end
+
+      if nap.is_a?(Prog::Base::Nap)
+        expected_seconds.nil? || expected_seconds === nap.seconds
+      else
+        false
+      end
     end
 
     failure_message do


### PR DESCRIPTION
Flow control exceptions are bad, mkay. throw/catch is specifically
designed for handling non-local flow control.

Add a Prog::Base#prog_return method that handles the throw, and
change the current fail (raise) calls to use it. The FlowControl
exception class is removed, and Prog/Nap/Exit switch from
FlowControl subclasses to Data subclasses.

A few specs that were manually raising or catching Prog/Nap/Exit
were updated to throw instead of raising, or use the nap/hop/exit
rspec matchers.  Those matchers were updated to support the new
format. The hop matcher gains the ability to pass a block, as a
couple Prog::Vm::HostNexus specs needed that.

Best reviewed ignoring whitespace differences.