### PR TITLE
Log GC and process memory stats from web workers

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -13,8 +13,10 @@ require_relative "loader"
 if ENV["WEB_CONCURRENCY"]
   CONNECTION_CHECKOUT_TELEMETRY = ConnectionCheckoutTelemetry.new
   CONNECTION_CHECKOUT_TELEMETRY.setup
+  GC_STATS_REPORTER = GcStatsReporter.new
 else
   CONNECTION_CHECKOUT_TELEMETRY = nil
+  GC_STATS_REPORTER = nil
 end
 
 clover_freeze

--- a/lib/gc_stats_reporter.rb
+++ b/lib/gc_stats_reporter.rb
@@ -16,12 +16,11 @@ class GcStatsReporter
     oldmalloc_increase_bytes
   ].freeze
 
-  # key :: Clog.emit key to use
+  KEY = "web_gc_stats"
+
   # report_every :: the number of seconds between reports
   # status_file :: file to read process RSS and swap usage from
-  def initialize(key: "#{ENV["PROCESS_TYPE"]}_gc_stats", report_every: 60, status_file: "/proc/self/status")
-    @key = key
-    @message = key.tr("_", " ").freeze
+  def initialize(report_every: 60, status_file: "/proc/self/status")
     @report_every = report_every
     @status_file = status_file
     @queue = Queue.new
@@ -50,7 +49,7 @@ class GcStatsReporter
       run
       true
     rescue => e
-      Clog.emit("#{@key} failure", Util.exception_to_hash(e))
+      Clog.emit("#{KEY} failure", Util.exception_to_hash(e))
       false
     end
   end
@@ -59,7 +58,7 @@ class GcStatsReporter
   # shutdown! is called.
   def run
     until @shutdown
-      Clog.emit(@message, {@key => stats})
+      Clog.emit("web gc stats", {KEY => stats})
       @queue.pop(timeout: @report_every)
     end
   end

--- a/lib/gc_stats_reporter.rb
+++ b/lib/gc_stats_reporter.rb
@@ -1,0 +1,83 @@
+# frozen-string-literal: true
+
+class GcStatsReporter
+  # GC.stat entries that separate Ruby heap growth (heap_live_slots,
+  # old_objects) from allocation pressure and native memory growth
+  # (malloc_increase_bytes, oldmalloc_increase_bytes).
+  GC_STAT_KEYS = %i[
+    count
+    minor_gc_count
+    major_gc_count
+    heap_live_slots
+    heap_free_slots
+    old_objects
+    total_allocated_objects
+    malloc_increase_bytes
+    oldmalloc_increase_bytes
+  ].freeze
+
+  # key :: Clog.emit key to use
+  # report_every :: the number of seconds between reports
+  # status_file :: file to read process RSS and swap usage from
+  def initialize(key: "#{ENV["PROCESS_TYPE"]}_gc_stats", report_every: 60, status_file: "/proc/self/status")
+    @key = key
+    @message = key.tr("_", " ").freeze
+    @report_every = report_every
+    @status_file = status_file
+    @queue = Queue.new
+    @thread = nil
+    @shutdown = false
+  end
+
+  # Stop reporting and shutdown the reporting thread, if it is running.
+  def shutdown!
+    # Make method idempotent
+    return if @shutdown
+
+    @shutdown = true
+
+    @queue.push(nil)
+
+    @thread&.join
+
+    nil
+  end
+
+  # Start a thread that runs the run method. This thread will generally run
+  # until shutdown! is called.
+  def run_thread
+    @thread = Thread.new do
+      run
+      true
+    rescue => e
+      Clog.emit("#{@key} failure", Util.exception_to_hash(e))
+      false
+    end
+  end
+
+  # Emit GC and process memory statistics every report_every seconds until
+  # shutdown! is called.
+  def run
+    until @shutdown
+      Clog.emit(@message, {@key => stats})
+      @queue.pop(timeout: @report_every)
+    end
+  end
+
+  # A hash of the current GC statistics and process memory usage.
+  def stats
+    stat = GC.stat
+    data = GC_STAT_KEYS.to_h { [it.to_s, stat[it]] }
+    data["pid"] = Process.pid
+
+    if File.file?(@status_file)
+      File.foreach(@status_file) do |line|
+        if (md = /\AVm(RSS|Swap):\s+(\d+) kB/.match(line))
+          data["#{md[1].downcase}_kb"] = md[2].to_i
+        end
+      end
+    end
+
+    data
+  end
+end

--- a/puma_config.rb
+++ b/puma_config.rb
@@ -14,8 +14,10 @@ before_fork do
 end
 before_worker_boot do
   CONNECTION_CHECKOUT_TELEMETRY&.run_thread
+  GC_STATS_REPORTER&.run_thread
 end
 after_stopped do
   CONNECTION_CHECKOUT_TELEMETRY&.shutdown!
+  GC_STATS_REPORTER&.shutdown!
 end
 # :nocov:

--- a/spec/lib/gc_stats_reporter_spec.rb
+++ b/spec/lib/gc_stats_reporter_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+require "tempfile"
+
+RSpec.describe GcStatsReporter do
+  let(:reporter) { described_class.new(key: "test", report_every: 30, status_file: @status_file || "/proc/self/status") }
+
+  after do
+    expect(reporter.shutdown!).to be_nil
+  end
+
+  it "uses defaults for key, report_every, and status_file" do
+    expect(described_class.new.shutdown!).to be_nil
+  end
+
+  it "#shutdown! works if the thread hasn't been started" do
+    expect(reporter.shutdown!).to be_nil
+  end
+
+  it "#shutdown! works if the thread has been started" do
+    thread = reporter.run_thread
+    expect(reporter.shutdown!).to be_nil
+    expect(thread.alive?).to be false
+    expect(thread.value).to be true
+  end
+
+  it "#run_thread emits if run method fails" do
+    expect(reporter).to receive(:run).and_raise(RuntimeError)
+    expect(Clog).to receive(:emit).with("test failure", Hash)
+    thread = reporter.run_thread
+    expect(thread.join(1).value).to be false
+  end
+
+  it "#run emits GC stats until shutdown" do
+    emitted = Queue.new
+    expect(Clog).to receive(:emit).at_least(:once) do |message, hash|
+      expect(message).to eq "test"
+      emitted.push(hash["test"])
+    end
+    thread = reporter.run_thread
+    data = emitted.pop
+    expect(data["pid"]).to eq Process.pid
+    expect(reporter.shutdown!).to be_nil
+    expect(thread.value).to be true
+  end
+
+  it "#stats returns GC statistics and process memory usage" do
+    data = reporter.stats
+    described_class::GC_STAT_KEYS.each do |key|
+      expect(data[key.to_s]).to be_a Integer
+    end
+    expect(data["pid"]).to eq Process.pid
+    expect(data["rss_kb"]).to be_a Integer
+  end
+
+  it "#stats parses RSS and swap usage from the status file" do
+    Tempfile.create("status") do |file|
+      file.write("Name:\ttest\nVmRSS:\t    123 kB\nVmSwap:\t      4 kB\n")
+      file.flush
+      @status_file = file.path
+      data = reporter.stats
+      expect(data["rss_kb"]).to eq 123
+      expect(data["swap_kb"]).to eq 4
+    end
+  end
+
+  it "#stats omits process memory usage if the status file does not exist" do
+    @status_file = "/nonexistent-status-file"
+    data = reporter.stats
+    expect(data).not_to have_key("rss_kb")
+    expect(data).not_to have_key("swap_kb")
+  end
+end

--- a/spec/lib/gc_stats_reporter_spec.rb
+++ b/spec/lib/gc_stats_reporter_spec.rb
@@ -4,13 +4,13 @@ require_relative "../spec_helper"
 require "tempfile"
 
 RSpec.describe GcStatsReporter do
-  let(:reporter) { described_class.new(key: "test", report_every: 30, status_file: @status_file || "/proc/self/status") }
+  let(:reporter) { described_class.new(report_every: 30, status_file: @status_file || "/proc/self/status") }
 
   after do
     expect(reporter.shutdown!).to be_nil
   end
 
-  it "uses defaults for key, report_every, and status_file" do
+  it "uses defaults for report_every and status_file" do
     expect(described_class.new.shutdown!).to be_nil
   end
 
@@ -27,7 +27,7 @@ RSpec.describe GcStatsReporter do
 
   it "#run_thread emits if run method fails" do
     expect(reporter).to receive(:run).and_raise(RuntimeError)
-    expect(Clog).to receive(:emit).with("test failure", Hash)
+    expect(Clog).to receive(:emit).with("web_gc_stats failure", Hash)
     thread = reporter.run_thread
     expect(thread.join(1).value).to be false
   end
@@ -35,8 +35,8 @@ RSpec.describe GcStatsReporter do
   it "#run emits GC stats until shutdown" do
     emitted = Queue.new
     expect(Clog).to receive(:emit).at_least(:once) do |message, hash|
-      expect(message).to eq "test"
-      emitted.push(hash["test"])
+      expect(message).to eq "web gc stats"
+      emitted.push(hash["web_gc_stats"])
     end
     thread = reporter.run_thread
     data = emitted.pop


### PR DESCRIPTION
The web dynos on Heroku show steady memory growth of roughly 100 MB per hour per dyno that only resets on deploy. The dynos regularly exceed their memory quota (R14), pushing them into swap and causing request timeouts (H12) once paging starts.

To find the cause, we need to know whether the Ruby object heap grows along with RSS (an object-level leak), or RSS grows while the heap stays flat (native memory growth or allocator fragmentation). Emit a subset of GC.stat along with RSS and swap usage from /proc/self/status every minute from each Puma worker, using the same reporting pattern as ConnectionCheckoutTelemetry.