### PR TITLE
Increment try correctly when parent runs child via reap

### DIFF
--- a/loader.rb
+++ b/loader.rb
@@ -247,6 +247,7 @@ def clover_freeze
     Prog,
     Prog::Ai,
     Prog::Aws,
+    Prog::Base::ChildRunError,
     Prog::Base::Exit,
     Prog::Base::Hop,
     Prog::Base::Nap,

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -231,7 +231,9 @@ SQL
       modified!(:stack)
     end
 
-    DB.transaction do
+    # Savepoint needed for correct error handling behavior when parent runs
+    # child strands via #reap
+    DB.transaction(savepoint: true) do
       prog_action = SemSnap.use(id) do |snap|
         prg = load(snap)
         catch(:prog_return) do
@@ -309,6 +311,9 @@ SQL
     take_lease_and_reload do
       loop do
         ret = unsynchronized_run
+
+        raise(ret.exception) if ret.is_a?(Prog::Base::ChildRunError)
+
         now = Time.now
         if now > deadline ||
             (ret.is_a?(Prog::Base::Nap) && ret.seconds != 0) ||

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -197,9 +197,31 @@ end
     end
   end
 
-  Nap = Data.define(:seconds) do
+  class Nap
+    attr_reader :seconds
+
+    def initialize(seconds)
+      @seconds = seconds
+      freeze
+    end
+
     def to_s
       "nap for #{seconds} seconds"
+    end
+  end
+
+  # Subclass of Nap used by #reap to pass the exception raised by a child strand
+  # run through as a Nap, and have it later be reraised inside Strand#run.
+  class ChildRunError < Nap
+    attr_reader :exception
+
+    def initialize(seconds, exception)
+      @exception = exception
+      super(seconds)
+    end
+
+    def to_s
+      "error running child strand: #{exception.class}: #{exception.message}, #{super}"
     end
   end
 
@@ -289,33 +311,45 @@ end
         nap(nap)
       else
         active_children.each do |child|
-          if (result = child.run)
-            if result.is_a?(Nap)
-              seconds = if active_children.length == 1
-                # For a single active child napping, parent can nap for as long as the child naps,
-                # since the expectation is there will not be anything to do until then.
-                result.seconds
-              else
-                # For multiple active children, if a single child is napping, it's possible the
-                # other children are immediately runnable. However, you don't want to busy
-                # wait on multiple children. Nap until the time of the earliest scheduled child
-                # that isn't currently running. If all children are running, nap for 120 seconds
-                strand.children_dataset
-                  .where(Sequel[:lease] < Sequel::CURRENT_TIMESTAMP)
-                  .min(Sequel.extract(:epoch, Sequel[:schedule] - Sequel::CURRENT_TIMESTAMP)) || 121
-              end
+          begin
+            result = child.run
+          rescue => ex
+            nil
+          else
+            next unless result
+          end
 
-              # Remove a 10th of a second so it is likely the parent will run the child.
-              seconds -= 0.1
-
-              # Nap for a minimum of 0.1 seconds and a maximum of 120 seconds in any case.
-              # The 0.1 seconds is to avoid busy waiting.
-              nap(seconds.clamp(0.1, 120))
+          if result.is_a?(Nap) || ex
+            seconds = if active_children.length == 1 && ex.nil?
+              # For a single active child napping, parent can nap for as long as the child naps,
+              # since the expectation is there will not be anything to do until then.
+              result.seconds
             else
-              # A non-nap (e.g. Exit or Hop) happened, so the state changed, and
-              # it makes sense to rerun the strand immediately.
-              nap 0
+              # For multiple active children, if a single child is napping, it's possible the
+              # other children are immediately runnable. However, you don't want to busy
+              # wait on multiple children. Nap until the time of the earliest scheduled child
+              # that isn't currently running. If all children are running, nap for 120 seconds
+              strand.children_dataset
+                .where(Sequel[:lease] < Sequel::CURRENT_TIMESTAMP)
+                .min(Sequel.extract(:epoch, Sequel[:schedule] - Sequel::CURRENT_TIMESTAMP)) || 121
             end
+
+            # Remove a 10th of a second so it is likely the parent will run the child.
+            seconds -= 0.1
+
+            # Nap for a minimum of 0.1 seconds and a maximum of 120 seconds in any case.
+            # The 0.1 seconds is to avoid busy waiting.
+            seconds = seconds.clamp(0.1, 120)
+
+            if ex
+              prog_return(ChildRunError.new(seconds, ex))
+            else
+              nap(seconds)
+            end
+          else
+            # A non-nap (e.g. Exit or Hop) happened, so the state changed, and
+            # it makes sense to rerun the strand immediately.
+            nap 0
           end
         end
 

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -77,6 +77,13 @@ class Prog::Test < Prog::Base
     reap { pop({msg: "reap_exit_no_children"}) }
   end
 
+  label def reap_emit_reaped_children
+    reaper = lambda do |child|
+      Clog.emit("child exit", strand_exited: {strand: [child.exitval["msg"], child.ubid]})
+    end
+    reap(reaper:)
+  end
+
   label def failer
     fail "failure"
   end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -4,14 +4,21 @@ require_relative "../model/spec_helper"
 
 RSpec.describe Prog::Base do
   it "does not allow failure of one child strand inside donate to affect other strands" do
-    parent = Strand.create(prog: "Test", label: "reap_exit_no_children")
+    parent = Strand.create(prog: "Test", label: "reap_emit_reaped_children")
     popper = Strand.create(parent_id: parent.id, prog: "Test", label: "popper")
     failer = Strand.create(parent_id: parent.id, prog: "Test", label: "failer", schedule: Time.now + 5)
     Strand.create(parent_id: parent.id, prog: "Test", label: "napper", lease: Time.now + 10)
 
+    messages = []
+    expect(Clog).to receive(:emit).twice.and_wrap_original do |method, message, metadata = {}|
+      messages << [message, metadata.dig(:strand_exited, :strand)]
+      method.call(message, metadata)
+    end
+
     expect(Sshable).to receive(:repl?).and_return(true).at_least(:once)
     expect { parent.run(10) }.to raise_error(RuntimeError)
-    expect(popper.this.get(:exitval)).to eq("msg" => "popped")
+    expect(messages).to eq [["exited", popper.ubid], ["child exit", ["popped", popper.ubid]]]
+    expect(popper).not_to exist
     expect(failer.this.get(:exitval)).to be_nil
   end
 
@@ -91,6 +98,14 @@ RSpec.describe Prog::Base do
     }.from(false).to(true).and change {
       Strand[child_id].nil?
     }.from(false).to(true)
+  end
+
+  it "failures when running child strand in reap affect try in child but not in parent" do
+    parent = Strand.create(prog: "Test", label: "reaper")
+    child = Strand.create(parent_id: parent.id, prog: "Test", label: "failer")
+    expect { parent.run }.to raise_error(Strand::RunError)
+    expect(child.reload.try).to eq 1
+    expect(parent.reload.try).to eq 0
   end
 
   it "keeps children array state in sync even in consecutive-run mode" do
@@ -234,6 +249,11 @@ RSpec.describe Prog::Base do
 
     it "can render nap" do
       expect(described_class::Nap.new("10").to_s).to eq("nap for 10 seconds")
+    end
+
+    it "can render child run error" do
+      error = RuntimeError.new("bad")
+      expect(described_class::ChildRunError.new(10, error).to_s).to eq("error running child strand: RuntimeError: bad, nap for 10 seconds")
     end
 
     it "can render exit" do


### PR DESCRIPTION
If a parent strand runs a child strand via reap, and the child strand run raises an exception, try was previously incremented in the parent and not in the child.

Not incrementing try in the child is because the transaction in Strand#unsynchronized_run did not use a savepoint if there was already a transaction in effect. So this changes it to use a savepoint.

To stop the increment of try in the parent, add a Prog::Base::ChildRunError subclass of Nap, that also keeps the exception raised by the child. Child strand run failures are treated as parent naps, napping until the next scheduled child. After the parent has napped and try has been set back to 0 in the parent, the ChildRunError is unpacked and raised by Strand#run.

Best reviewed ignoring whitespace.