### PR TITLE
Replace Semaphore.incr with Model.incr_destroy

### DIFF
--- a/prog/test/postgres_base.rb
+++ b/prog/test/postgres_base.rb
@@ -121,7 +121,7 @@ class Prog::Test::PostgresBase < Prog::Test::Base
   def verify_timelines_destroyed(timeline_ids)
     remaining = PostgresTimeline.where(id: timeline_ids).select_map(:id)
     return if remaining.empty?
-    Semaphore.incr(remaining, "destroy")
+    PostgresTimeline.incr_destroy(remaining)
     Clog.emit("Verifying timelines are retained after resource destroy (found #{remaining.count})")
     nap 5
   end

--- a/prog/vnet/maintain_presigned_certs.rb
+++ b/prog/vnet/maintain_presigned_certs.rb
@@ -23,7 +23,7 @@ class Prog::Vnet::MaintainPresignedCerts < Prog::Base
         .returning(:cert_id)
         .with_sql(:delete_sql))
       .select_map(:cert_id)
-    Semaphore.incr(old_cert_ids, "destroy")
+    Cert.incr_destroy(old_cert_ids)
 
     hop_request_cert if ds.count < MIN_CERTS
 


### PR DESCRIPTION
### Replace Semaphore.incr with Cert.incr_destroy for old certs 

The class helper validates the semaphore name against Cert's SemaphoreMethods declaration at load time, so a typo or renamed semaphore fails fast instead of silently inserting a row nobody reads.

### Replace Semaphore.incr with PostgresTimeline.incr_destroy for timelines 

The class helper validates the semaphore name against PostgresTimeline's SemaphoreMethods declaration.
