### PR TITLE
Reconcile detailed response schemas with serializers

### DIFF
--- a/helpers/general.rb
+++ b/helpers/general.rb
@@ -31,7 +31,7 @@ class Clover < Roda
       end
     end
 
-    def rename(object, perm:, serializer:, template_prefix:)
+    def rename(object, perm:, serializer:, template_prefix:, detailed: false)
       post "rename" do
         scope.instance_exec do
           authorize(perm, object)
@@ -55,7 +55,7 @@ class Clover < Roda
           end
 
           if api?
-            serializer.serialize(object)
+            serializer.serialize(object, detailed ? {detailed: true} : {})
           else
             flash["notice"] = "Name updated"
             request.redirect object, "/settings"

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -3323,6 +3323,9 @@ components:
         name:
           description: Name of the firewall
           type: string
+        path:
+          description: Path of the firewall, present when nested in a VM response
+          type: string
       additionalProperties: false
       required:
         - description
@@ -4784,7 +4787,8 @@ components:
             additionalProperties: false
             allOf:
               - $ref: '#/components/schemas/Vm'
-              - additionalProperties: false
+              - type: object
+                additionalProperties: false
                 properties:
                   firewalls:
                     description: List of firewalls
@@ -4802,18 +4806,16 @@ components:
                   subnet:
                     description: Subnet of the VM
                     type: string
-                  unix_user:
-                    description: Unix user of the VM
-                    type: string
                   gpu:
-                    description: GPU configuration
+                    description: GPU configuration, or null if the VM has no GPU
                     type: string
+                    nullable: true
                 required:
                   - firewalls
                   - private_ipv4
                   - private_ipv6
                   - subnet
-                  - unix_user
+                  - gpu
     Vms:
       description: A list of VMs
       content:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -4295,13 +4295,14 @@ components:
             additionalProperties: false
             allOf:
               - $ref: '#/components/schemas/Firewall'
-              - properties:
+              - type: object
+                additionalProperties: false
+                properties:
                   private_subnets:
                     description: List of private subnets
                     type: array
                     items:
                       $ref: '#/components/schemas/PrivateSubnet'
-                additionalProperties: false
                 required:
                   - private_subnets
     Firewalls:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -4470,15 +4470,17 @@ components:
             additionalProperties: false
             allOf:
               - $ref: '#/components/schemas/LoadBalancer'
-              - properties:
+              - type: object
+                additionalProperties: false
+                properties:
                   subnet:
                     description: Subnet of the Load Balancer
                     type: string
                   vms:
+                    description: List of VM IDs attached to the Load Balancer
                     type: array
                     items:
-                      $ref: '#/components/schemas/Vm'
-                additionalProperties: false
+                      type: string
                 required:
                   - location
                   - subnet

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -3907,6 +3907,23 @@ components:
         - name
         - type
         - url
+    PostgresMetricDestination:
+      type: object
+      properties:
+        id:
+          description: ID of the metric destination
+          type: string
+        username:
+          description: Username for the metric destination
+          type: string
+        url:
+          description: Destination URL
+          type: string
+      additionalProperties: false
+      required:
+        - id
+        - username
+        - url
     PrivateSubnet:
       type: object
       properties:
@@ -4509,7 +4526,8 @@ components:
             additionalProperties: false
             allOf:
               - $ref: '#/components/schemas/PostgresDatabase'
-              - additionalProperties: false
+              - type: object
+                additionalProperties: false
                 properties:
                   connection_string:
                     description: Connection string to the Postgres database
@@ -4532,7 +4550,7 @@ components:
                     type: string
                     nullable: true
                   earliest_restore_time:
-                    description: Earliest restore time (if primary)
+                    description: Earliest restore time, only present for a primary with an established backup
                     type: string
                     nullable: true
                   firewall_rules:
@@ -4541,32 +4559,37 @@ components:
                     items:
                       $ref: '#/components/schemas/PostgresFirewallRule'
                   latest_restore_time:
-                    description: Latest restore time (if primary)"
+                    description: Latest restore time, only present for a primary
                     type: string
                   primary:
                     description: Is the database primary
                     type: boolean
-                  maintenance_window_start_at:
-                    description: Maintenance window start time
-                    type: integer
-                    nullable: true
-                  tags:
-                    description: Tags of the Postgres database
+                  metric_destinations:
+                    description: List of Postgres metric destinations
                     type: array
                     items:
-                      $ref: '#/components/schemas/PostgresTag'
+                      $ref: '#/components/schemas/PostgresMetricDestination'
+                  log_destinations:
+                    description: List of Postgres log destinations
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PostgresLogDestination'
+                  read_replicas:
+                    description: List of read replica databases of this database
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PostgresDatabase'
                 required:
                   - connection_string
                   - private_connection_string
                   - username
                   - password
                   - hostname
-                  - earliest_restore_time
                   - firewall_rules
-                  - latest_restore_time
                   - primary
-                  - maintenance_window_start_at
-                  - tags
+                  - metric_destinations
+                  - log_destinations
+                  - read_replicas
     PostgresDatabases:
       description: A list of Postgres Databases
       content:

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -128,7 +128,7 @@ class Clover
         Serializers::LoadBalancer.serialize(lb.reload, {detailed: true})
       end
 
-      r.rename lb, perm: "LoadBalancer:edit", serializer: Serializers::LoadBalancer, template_prefix: "networking/load_balancer" do
+      r.rename lb, perm: "LoadBalancer:edit", serializer: Serializers::LoadBalancer, template_prefix: "networking/load_balancer", detailed: true do
         lb.incr_rewrite_dns_records
         lb.incr_refresh_cert if lb.hostname_version == 1 && lb.cert_enabled
       end

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -130,7 +130,7 @@ class Clover
         end
       end
 
-      r.rename pg, perm: "Postgres:edit", serializer: Serializers::Postgres, template_prefix: "postgres" do
+      r.rename pg, perm: "Postgres:edit", serializer: Serializers::Postgres, template_prefix: "postgres", detailed: true do
         pg.incr_refresh_dns_record
         pg.incr_refresh_certificates unless pg.hostname_version == "v3"
       end
@@ -432,7 +432,7 @@ class Clover
         end
 
         if api?
-          Serializers::Postgres.serialize(pg)
+          Serializers::Postgres.serialize(pg, {detailed: true})
         else
           flash["notice"] = "'#{pg.name}' will be promoted in a few minutes, please refresh the page"
           r.redirect pg, "/settings"

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -55,7 +55,7 @@ class Clover
         end
       end
 
-      r.rename vm, perm: "Vm:edit", serializer: Serializers::Vm, template_prefix: "vm"
+      r.rename vm, perm: "Vm:edit", serializer: Serializers::Vm, template_prefix: "vm", detailed: true
 
       r.show_object(vm, actions: %w[overview networking settings], perm: "Vm:view", template: "vm/show")
 

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -61,11 +61,13 @@ RSpec.describe Clover, "firewall" do
       expect(last_response.status).to eq(200)
 
       get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}"
+      # With type:object on the FirewallDetailed inline allOf member, committee
+      # validates private_subnets (and each nested PrivateSubnet) against the
+      # schema and hard-raises on any drift in TEST mode (clover.rb:298), so a
+      # 200 here means the detailed body conformed. The assertions below pin the
+      # concrete shape the ubi CLI (fw show) and Ruby SDK consume.
       expect(last_response.status).to eq(200)
 
-      # Committee does not validate properties nested in inline (non-$ref) allOf members,
-      # and FirewallDetailed.private_subnets lives in such a member, so the shape that the
-      # ubi CLI and Ruby SDK depend on is asserted explicitly here.
       private_subnets = JSON.parse(last_response.body)["private_subnets"]
       expect(private_subnets.size).to eq(1)
       expect(private_subnets.first.keys.sort).to eq(%w[firewalls id location name net4 net6 nics state])

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -55,6 +55,23 @@ RSpec.describe Clover, "firewall" do
       expect(last_response.status).to eq(200)
     end
 
+    it "embeds private_subnets as PrivateSubnet objects in detailed response" do
+      ps = Prog::Vnet::SubnetNexus.assemble(project.id, name: "test-ps", location_id: Location::HETZNER_FSN1_ID).subject
+      post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/attach-subnet", {private_subnet_id: ps.ubid}.to_json
+      expect(last_response.status).to eq(200)
+
+      get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}"
+      expect(last_response.status).to eq(200)
+
+      # Committee does not validate properties nested in inline (non-$ref) allOf members,
+      # and FirewallDetailed.private_subnets lives in such a member, so the shape that the
+      # ubi CLI and Ruby SDK depend on is asserted explicitly here.
+      private_subnets = JSON.parse(last_response.body)["private_subnets"]
+      expect(private_subnets.size).to eq(1)
+      expect(private_subnets.first.keys.sort).to eq(%w[firewalls id location name net4 net6 nics state])
+      expect(private_subnets.first["id"]).to eq(ps.ubid)
+    end
+
     it "get does not exist for valid name" do
       get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/fooname"
 

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -152,6 +152,59 @@ RSpec.describe Clover, "load-balancer" do
       end
     end
 
+    describe "detailed response openapi conformance" do
+      # In TEST mode committee validates every response against openapi.yml and
+      # hard-raises on any violation (clover.rb:298). With type:object on the
+      # detailed LoadBalancer inline allOf member these requests exercise the
+      # reconciled vms field, whose items were corrected from $ref Vm to a plain
+      # string because the serializer emits VM ubids (lb.vms.map { it.ubid }),
+      # not full Vm objects, plus the subnet string and additionalProperties on
+      # the merged schema. A non-conforming body raises a Committee::Error out of
+      # the request, so a 200 means the body conformed. The assertions pin the
+      # concrete shape the ubi CLI (lb show) and Ruby SDK consume.
+      let(:vm) {
+        nic = Nic.create(name: "nic-1", private_subnet_id: lb.private_subnet.id, mac: "00:00:00:00:00:01", private_ipv4: "1.1.1.1", private_ipv6: "2001:db8::1", state: "active")
+        vm = create_vm
+        nic.update(vm_id: vm.id)
+        vm.update(project_id: project.id)
+        vm
+      }
+
+      it "conforms for a load balancer with an attached VM, serializing vms as ubid strings" do
+        lb.add_vm(vm)
+
+        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}"
+
+        expect(last_response.status).to eq(200)
+        body = JSON.parse(last_response.body)
+        expect(body.fetch("subnet")).to eq(lb.private_subnet.name)
+        expect(body.fetch("location")).to eq(lb.display_location)
+        expect(body.fetch("vms")).to eq([vm.ubid])
+        expect(body["vms"].first).to be_a(String)
+      end
+
+      it "conforms for a load balancer with no attached VMs" do
+        get "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}"
+
+        expect(last_response.status).to eq(200)
+        body = JSON.parse(last_response.body)
+        expect(body.fetch("vms")).to eq([])
+        expect(body.fetch("subnet")).to be_a(String)
+      end
+
+      it "conforms when renaming a load balancer, which now returns the detailed response" do
+        lb.add_vm(vm)
+
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/#{lb.name}/rename", {name: "renamed-lb"}.to_json
+
+        expect(last_response.status).to eq(200)
+        body = JSON.parse(last_response.body)
+        expect(body["name"]).to eq("renamed-lb")
+        expect(body.fetch("subnet")).to be_a(String)
+        expect(body.fetch("vms")).to eq([vm.ubid])
+      end
+    end
+
     describe "update" do
       let(:vm) {
         nic = Nic.create(name: "nic-1", private_subnet_id: lb.private_subnet.id, mac: "00:00:00:00:00:01", private_ipv4: "1.1.1.1", private_ipv6: "2001:db8::1", state: "active")

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -983,6 +983,76 @@ RSpec.describe Clover, "postgres" do
       end
     end
 
+    describe "detailed response openapi conformance" do
+      # In TEST mode committee validates every response against openapi.yml and
+      # hard-raises on any violation (clover.rb:298). With type:object on the
+      # detailed PostgresDatabase inline allOf member these GETs exercise the
+      # reconciled metric_destinations/log_destinations/read_replicas schemas and
+      # the now-optional restore-time fields. A non-conforming body raises a
+      # Committee::Error out of the get, so a 200 means the body conformed.
+      def assemble_read_replica(name)
+        Prog::Postgres::PostgresResourceNexus.assemble(
+          project_id: project.id,
+          location_id: Location::HETZNER_FSN1_ID,
+          name:,
+          target_vm_size: "standard-2",
+          target_storage_size_gib: 128,
+          target_version: pg.version,
+          parent_id: pg.id,
+        ).subject
+      end
+
+      it "conforms for a primary with metric/log destinations and a read replica" do
+        PostgresMetricDestination.create(postgres_resource_id: pg.id, url: "https://metrics.example.com", username: "mduser", password: "mdpass")
+        PostgresLogDestination.create(postgres_resource_id: pg.id, name: "graylog", type: "syslog", url: "tcp://logs.example.com:6514")
+        assemble_read_replica("pg-read-replica")
+
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"
+
+        expect(last_response.status).to eq(200)
+        body = JSON.parse(last_response.body)
+        expect(body["primary"]).to be(true)
+        expect(body.fetch("metric_destinations").length).to eq(1)
+        expect(body["metric_destinations"][0]["username"]).to eq("mduser")
+        expect(body["metric_destinations"][0]["url"]).to eq("https://metrics.example.com")
+        expect(body["metric_destinations"][0]["id"]).to be_a(String)
+        expect(body.fetch("log_destinations").length).to eq(1)
+        expect(body["log_destinations"][0]).to include("name" => "graylog", "type" => "syslog", "url" => "tcp://logs.example.com:6514")
+        expect(body["log_destinations"][0]["id"]).to be_a(String)
+        expect(body.fetch("read_replicas").length).to eq(1)
+        expect(body["read_replicas"][0]["name"]).to eq("pg-read-replica")
+        expect(body["read_replicas"][0]["read_replica"]).to be(true)
+        expect(body).to have_key("earliest_restore_time")
+        expect(body["earliest_restore_time"]).to be_nil
+        expect(body["latest_restore_time"]).to be_a(String)
+      end
+
+      it "conforms for a read replica with restore times absent (the no-timeline shape)" do
+        replica = assemble_read_replica("pg-read-replica")
+
+        get "/project/#{project.ubid}/location/#{replica.display_location}/postgres/#{replica.name}"
+
+        expect(last_response.status).to eq(200)
+        body = JSON.parse(last_response.body)
+        expect(body["read_replica"]).to be(true)
+        expect(body["parent"]).to eq(pg.path)
+        expect(body["read_replicas"]).to eq([])
+        expect(body).not_to have_key("earliest_restore_time")
+        expect(body).not_to have_key("latest_restore_time")
+      end
+
+      it "conforms for a primary whose timeline has an established backup" do
+        pg.timeline.update(cached_earliest_backup_at: Time.now - 3600)
+
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}"
+
+        expect(last_response.status).to eq(200)
+        body = JSON.parse(last_response.body)
+        expect(body["earliest_restore_time"]).to be_a(String)
+        expect(body["latest_restore_time"]).to be_a(String)
+      end
+    end
+
     describe "ca-certificates" do
       it "cannot download ca-certificates if not ready" do
         get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/ca-certificates"

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -374,6 +374,53 @@ RSpec.describe Clover, "vm" do
       end
     end
 
+    describe "detailed response openapi conformance" do
+      # In TEST mode committee validates every response against openapi.yml and
+      # hard-raises on any violation (clover.rb:298). With type:object on the
+      # detailed Vm inline allOf member these requests exercise the reconciled
+      # firewalls (nested Firewall now carries an optional path), the nullable
+      # gpu field, and the redundant unix_user dropped in favor of the base
+      # schema. A non-conforming body raises a Committee::Error out of the
+      # request, so a 200 means the body conformed.
+      it "conforms for a VM with firewalls, private IPs, a subnet, and no GPU" do
+        get "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"
+
+        expect(last_response.status).to eq(200)
+        body = JSON.parse(last_response.body)
+        expect(body.fetch("firewalls")).not_to be_empty
+        expect(body["firewalls"].first).to include("path")
+        expect(body["firewalls"].first["path"]).to start_with("/location/")
+        expect(body.fetch("private_ipv4")).to be_a(String)
+        expect(body.fetch("private_ipv6")).to be_a(String)
+        expect(body.fetch("subnet")).to be_a(String)
+        expect(body).to have_key("gpu")
+        expect(body["gpu"]).to be_nil
+        expect(body.fetch("unix_user")).to be_a(String)
+      end
+
+      it "conforms for a VM exposing a GPU, serializing gpu as a non-null string" do
+        vmh = create_vm_host
+        PciDevice.create(vm_host_id: vmh.id, vm_id: vm.id, slot: "00:00.0", device_class: "0300", vendor: "10de", device: "20b5", numa_node: 0, iommu_group: 0)
+
+        get "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"
+
+        expect(last_response.status).to eq(200)
+        body = JSON.parse(last_response.body)
+        expect(body["gpu"]).to be_a(String)
+      end
+
+      it "conforms when renaming a VM, which now returns the detailed response" do
+        post "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}/rename", {name: "renamed-vm"}.to_json
+
+        expect(last_response.status).to eq(200)
+        body = JSON.parse(last_response.body)
+        expect(body["name"]).to eq("renamed-vm")
+        expect(body.fetch("firewalls")).not_to be_empty
+        expect(body.fetch("subnet")).to be_a(String)
+        expect(body).to have_key("gpu")
+      end
+    end
+
     describe "delete" do
       it "success" do
         delete "/project/#{project.ubid}/location/#{vm.display_location}/vm/#{vm.name}"


### PR DESCRIPTION
The detailed API responses for Postgres, VM, Firewall, and LoadBalancer
had drifted from what the serializers actually emit, and the inline
`allOf` members lacked `type: object`, so committee never enforced
`additionalProperties` on the merged schemas. This reconciles both
directions:

- Add `type: object` to the detailed inline members so committee
  validates the full merged shape in test mode.
- Document fields the server already emits but the spec omitted:
  `metric_destinations`, `log_destinations`, and `read_replicas` on the
  detailed Postgres response (new `PostgresMetricDestination`
  component), and nest `PrivateSubnet` properly in `FirewallDetailed`.
- Drop the detailed member's inline `maintenance_window_start_at` and
  `tags` redefinitions in favor of the base schema. The base already
  carries the nullable window, so this supersedes the inline
  `nullable: true` from #5806 with the same effective schema and one
  less duplicated definition to drift.
- Mark `earliest_restore_time`/`latest_restore_time` optional to match
  their conditional emission.
- Serialize the detailed response where the route declares it: rename
  (via a `detailed:` kwarg on the shared rename helper) for Postgres,
  VM, and LoadBalancer, and the Postgres promote-read-replica route.

These are cherry-picks from the June conformance sweep (`-x` noted per
commit). Validation on this branch: the location route specs pass (229
examples), rubocop clean, and a live end-to-end run of the terraform
provider (PR ubicloud/terraform-provider-ubicloud#29 tip) against a
clover running this branch: full lifecycle including rename (the
endpoint whose response shape changes here), a 16 to 17 major upgrade,
point-in-time restore, and teardown. The provider does not depend on
this PR; it hardens the contract the provider is generated from, so
future drift in the detailed responses fails clover CI instead of
surfacing as provider bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
