### PR TITLE
Automate Leaseweb host networking

### DIFF
--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -78,7 +78,11 @@ class Hosting::HetznerApis < Hosting::ProviderApis
     end
   end
 
-  IpInfo = Data.define(:ip_address, :source_host_ip, :is_failover)
+  IpInfo = Data.define(:ip_address, :source_host_ip) do
+    # Hetzner routes every extra address to the host's main IP, so the host
+    # claims only the main IP itself and every extra stays VM-allocatable.
+    def host_only? = ip_address == "#{source_host_ip}/32"
+  end
 
   # Finds IP addresses that match with the host's IP address. An important
   # detail about this function is that; Hetzner API returns the failover IPv6
@@ -97,7 +101,6 @@ class Hosting::HetznerApis < Hosting::ProviderApis
         IpInfo.new(
           ip_address: "#{ip["ip"]}/32",
           source_host_ip: ip["server_ip"],
-          is_failover: ip["failover_ip"],
         )
       end +
 
@@ -111,7 +114,6 @@ class Hosting::HetznerApis < Hosting::ProviderApis
         IpInfo.new(
           ip_address: "#{subnet["ip"]}/#{mask}",
           source_host_ip: subnet["server_ip"],
-          is_failover: subnet["failover_ip"],
         )
       end
     )

--- a/lib/hosting/leaseweb_apis.rb
+++ b/lib/hosting/leaseweb_apis.rb
@@ -2,6 +2,16 @@
 
 require "excon"
 class Hosting::LeasewebApis < Hosting::ProviderApis
+  IpInfo = Data.define(:ip_address, :source_host_ip, :gateway) do
+    # A gatewayed IPv4 sits on a switched segment the host must claim (no VM may
+    # take it); a gateway-less IPv4 is a block routed here that VMs draw from.
+    def host_only? = !gateway.nil? && !ip_address.include?(":")
+  end
+
+  NetworkInterfaces = Data.define(:public_mac, :internal_mac, :internal_ip)
+
+  IPS_PAGE_SIZE = 50
+
   def hardware_reset
     create_connection.post(path: "/bareMetals/v2/servers/#{@provider.server_identifier}/powerCycle", expects: 204)
     nil
@@ -15,12 +25,113 @@ class Hosting::LeasewebApis < Hosting::ProviderApis
   end
 
   def pull_data_center
-    response = create_connection.get(path: "/bareMetals/v2/servers/#{@provider.server_identifier}", expects: 200)
-    location = JSON.parse(response.body).fetch("location")
+    location = pull_server.fetch("location")
     [location["site"], location["suite"], location["rack"]].compact.join("-")
   end
 
+  # Leaseweb reports MACs upper-cased; `ip -j link` lower-cases them. The
+  # privateNetworks record, not the internal MAC (present even without one),
+  # decides whether there is an internal interface, and carries the host's
+  # statically-configured VLAN address on internal.ip.
+  def pull_network_interfaces
+    server = pull_server
+    nics = server.fetch("networkInterfaces")
+    private_networks = server["privateNetworks"].to_a
+    if server["isPrivateNetworkEnabled"] && private_networks.empty?
+      fail "leaseweb server #{@provider.server_identifier} enables private networking but reports no private network"
+    end
+
+    if private_networks.any?
+      internal_mac = nics.dig("internal", "mac")
+      fail "leaseweb server #{@provider.server_identifier} has a private network but no internal interface" unless internal_mac
+      internal_ip = presence(nics.dig("internal", "ip"))
+      fail "leaseweb server #{@provider.server_identifier} has a private network but no internal address" unless internal_ip
+    end
+    NetworkInterfaces.new(
+      public_mac: nics.fetch("public").fetch("mac").downcase,
+      internal_mac: internal_mac&.downcase,
+      internal_ip:,
+    )
+  end
+
+  # NORMAL_IP excludes the segment's NETWORK/GATEWAY/BROADCAST/ROUTER rows;
+  # PUBLIC excludes the REMOTE_MANAGEMENT (IPMI) address.
+  def pull_ips
+    rows = fetch_ips.select { it["networkType"] == "PUBLIC" && it["type"] == "NORMAL_IP" }
+    main_row = rows.find { it["mainIp"] }
+    fail "leaseweb server #{@provider.server_identifier} has no main IP" unless main_row
+    fail "leaseweb server #{@provider.server_identifier} has a main ip without a gateway" unless presence(main_row["gateway"])
+    main_ip4 = parse_ip(main_row).first
+
+    # Gateway-less IPv4s collapse into one Address per routed block; the rest
+    # stand alone as /32s.
+    blocks = []
+    singles = rows.filter_map do |row|
+      address, prefix = parse_ip(row)
+      gateway = presence(row["gateway"])
+
+      if address.include?(":")
+        net = NetAddr::IPv6Net.new(NetAddr.parse_ip(address), NetAddr::Mask128.new(prefix))
+        IpInfo.new(net.to_s, main_ip4, gateway)
+      elsif row["mainIp"] || gateway
+        IpInfo.new("#{address}/32", main_ip4, gateway)
+      else
+        net = NetAddr::IPv4Net.new(NetAddr.parse_ip(address), NetAddr::Mask32.new(prefix))
+        blocks << net.to_s
+        nil
+      end
+    end
+
+    singles + blocks.uniq.map { IpInfo.new(it, main_ip4, nil) }
+  end
+
   private
+
+  def presence(value)
+    value if value.is_a?(String) && !value.empty?
+  end
+
+  # Leaseweb's "ip" field carries a trailing block suffix ("216.22.15.64/26"),
+  # and for IPv6 an "_<prefixlen>" marker naming the delegated prefix within it
+  # ("2604:9a00:2100:a020:4::_112/64"). The marker wins over prefixLength.
+  def parse_ip(row)
+    address = row.fetch("ip").split("/").first
+    base, marker, suffix = address.rpartition("_")
+    marker.empty? ? [address, row.fetch("prefixLength")] : [base, Integer(suffix, 10)]
+  end
+
+  def pull_server
+    response = create_connection.get(path: "/bareMetals/v2/servers/#{@provider.server_identifier}", expects: 200)
+    JSON.parse(response.body)
+  end
+
+  def fetch_ips
+    connection = create_connection
+    ips = []
+    seen = Set.new
+    total = nil
+
+    loop do
+      response = connection.get(path: "/bareMetals/v2/servers/#{@provider.server_identifier}/ips",
+        query: {limit: IPS_PAGE_SIZE, offset: ips.length},
+        expects: 200)
+      body = JSON.parse(response.body)
+      page = body.fetch("ips")
+      # This list is the host's whole routed set, so fail on a repeat: it masks a
+      # dropped row behind the count and can loop an offset-ignoring server.
+      page.each do |row|
+        fail "leaseweb server #{@provider.server_identifier} repeated an ip in its ip list" unless seen.add?(row.fetch("ip"))
+      end
+      ips.concat(page)
+      total = body.dig("_metadata", "totalCount")
+      # Page until a short page ends the list; totalCount can lag the rows served.
+      break if page.length < IPS_PAGE_SIZE
+    end
+
+    fail "leaseweb server #{@provider.server_identifier} returned #{ips.length} of #{total} ips" unless ips.length == total
+
+    ips
+  end
 
   def create_connection
     Excon.new(Config.leaseweb_connection_string,

--- a/lib/hosting/leaseweb_netplan.rb
+++ b/lib/hosting/leaseweb_netplan.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+# Builds the desired-state /etc/netplan/01-netcfg.yaml for a Leaseweb host
+# from its ip records, NIC names, and the resolvers its environment provided.
+class Hosting::LeasewebNetplan
+  ROUTE_METRIC = 100
+  INTERNAL_MTU = 9000
+
+  # The host claims ::2 out of a connectivity prefix, whose gateway lives
+  # outside it in the parent block, and ::1 out of a prefix routed to it.
+  CONNECTIVITY_HOST_OFFSET = 2
+  ROUTED_HOST_OFFSET = 1
+
+  def initialize(public_interface:, internal_interface:, internal_ip:, ip_infos:, nameservers:, search_domains:)
+    @public_interface = public_interface
+    @internal_interface = internal_interface
+    @internal_ip = internal_ip
+    @ip_infos = ip_infos
+    @nameservers = nameservers
+    @search_domains = search_domains
+    @main = ip_infos.find { it.ip_address == "#{it.source_host_ip}/32" }
+    fail "no main IPv4 address among leaseweb ip infos" unless @main
+  end
+
+  def to_yaml
+    YAML.dump(to_h)
+  end
+
+  def to_h
+    ethernets = {@public_interface => public_ethernet}
+    ethernets[@internal_interface] = internal_ethernet if @internal_interface
+
+    {"network" => {"version" => 2, "renderer" => "networkd", "ethernets" => ethernets}}
+  end
+
+  # Desired addresses keyed by the interface each belongs to, so verify can check
+  # placement, not mere presence.
+  def interface_addresses
+    interfaces = {@public_interface => public_addresses}
+    interfaces[@internal_interface] = internal_addresses if @internal_interface
+    interfaces
+  end
+
+  # One default route per family; a segment gateway resolves to the same router.
+  def gateways
+    [@main.gateway] + ipv6.filter_map(&:gateway)
+  end
+
+  private
+
+  # Main IP, switched-segment IPs, IPv4 blocks, then the host address per IPv6 prefix.
+  def public_addresses
+    [@main.ip_address] + (ipv4_segment + ipv4_blocks).map(&:ip_address) + ipv6.map { host_address(it) }
+  end
+
+  def internal_addresses
+    [@internal_ip]
+  end
+
+  # Declare the reserved VLAN address (a DHCP-disabled VLAN still gets addressed).
+  # optional keeps a dead private port from stalling network-online.target.
+  def internal_ethernet
+    {"addresses" => internal_addresses, "mtu" => INTERNAL_MTU, "optional" => true}
+  end
+
+  # accept-ra false: dhcp6 off still accepts router advertisements, which would
+  # add a competing default route / SLAAC address; this file is the whole state.
+  def public_ethernet
+    {
+      "dhcp4" => false,
+      "dhcp6" => false,
+      "accept-ra" => false,
+      "addresses" => public_addresses,
+      "routes" => routes,
+      "nameservers" => {"search" => @search_domains, "addresses" => @nameservers},
+    }
+  end
+
+  def routes
+    gateways.map do |gateway|
+      {"to" => "default", "via" => gateway, "metric" => ROUTE_METRIC, "on-link" => true}
+    end
+  end
+
+  def ipv4
+    @ip_infos.reject { it.ip_address.include?(":") || it == @main }
+  end
+
+  # Switched-segment members (gatewayed); pull_ips yields /32s so the host holds
+  # only these, not the whole segment.
+  def ipv4_segment
+    sorted_ipv4(ipv4.select(&:gateway))
+  end
+
+  # A block of one or two addresses is a standalone VM address Leaseweb
+  # routes here, not a block the host anchors. Claiming it on the NIC would
+  # pull the VM's inbound into the host's local table.
+  def ipv4_blocks
+    sorted_ipv4(ipv4.reject(&:gateway).select { NetAddr::IPv4Net.parse(it.ip_address).len > 2 })
+  end
+
+  def sorted_ipv4(ip_infos)
+    ip_infos.sort_by { NetAddr::IPv4Net.parse(it.ip_address).network.addr }
+  end
+
+  def ipv6
+    @ip_infos.select { it.ip_address.include?(":") }
+      .sort_by { NetAddr::IPv6Net.parse(it.ip_address).network.addr }
+  end
+
+  def host_address(ip_info)
+    net = NetAddr::IPv6Net.parse(ip_info.ip_address)
+    offset = ip_info.gateway ? CONNECTIVITY_HOST_OFFSET : ROUTED_HOST_OFFSET
+    "#{net.nth(offset)}/#{net.netmask.prefix_len}"
+  end
+end

--- a/loader.rb
+++ b/loader.rb
@@ -89,6 +89,8 @@ module Prog::Hetzner; end
 
 module Prog::Kubernetes; end
 
+module Prog::Leaseweb; end
+
 module Prog::MachineImage; end
 
 module Prog::Minio; end
@@ -257,6 +259,7 @@ def clover_freeze
     Prog::Github,
     Prog::Hetzner,
     Prog::Kubernetes,
+    Prog::Leaseweb,
     Prog::MachineImage,
     Prog::Minio,
     Prog::Postgres,

--- a/migrate/20260731_delete_stale_assigned_host_addresses.rb
+++ b/migrate/20260731_delete_stale_assigned_host_addresses.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# create_addresses inserted an assigned_host_address row for every
+# non-failover record it pulled, including routed blocks and IPv6 prefixes
+# that belong to VMs rather than to the host. An assigned_host_address
+# row must mean the host claims the address, so drop every row that is
+# not the host's own sshable address. Nothing read the extra rows.
+Sequel.migration do
+  up do
+    run <<~SQL
+      DELETE FROM assigned_host_address AS aha
+      USING sshable AS s
+      WHERE s.id = aha.host_id AND host(aha.ip) != s.host
+    SQL
+  end
+end

--- a/model/address.rb
+++ b/model/address.rb
@@ -24,20 +24,19 @@ class Address < Sequel::Model
     super
   end
 
-  def after_create
-    super
-    populate_ipv4_addresses
-  end
-
+  # The caller decides which addresses open a VM pool; host-claimed ones,
+  # recorded in assigned_host_address instead, never do.
   def populate_ipv4_addresses
-    # Do nothing for ipv6 addresses, since VM addresses are chosen randomly from the /64.
-    # Ignore the host's sshable IP address.
-    return unless cidr.is_a?(NetAddr::IPv4Net) && vm_host.sshable.host != cidr.network.to_s
+    # ipv6 has no pool table; VM addresses are chosen randomly from the /64.
+    return unless cidr.is_a?(NetAddr::IPv4Net)
 
     addresses = Array.new(cidr.len) { [cidr.nth(it), cidr.to_s] }
 
-    if vm_host.provider_name == "leaseweb"
-      # Do not use first or last addresses for leaseweb
+    # Leaseweb routes whole blocks to the host, network and broadcast address
+    # included; neither is usable by a VM. A block of one or two addresses is
+    # not a block but a standalone address Leaseweb routes here, so it has no
+    # network or broadcast address to drop.
+    if vm_host.provider_name == "leaseweb" && addresses.length > 2
       addresses.shift
       addresses.pop
     end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -184,31 +184,19 @@ class VmHost < Sequel::Model
     DB.transaction do
       ip_records.each do |ip_record|
         ip_addr = ip_record.ip_address
-        source_host_ip = ip_record.source_host_ip
-        is_failover_ip = ip_record.is_failover
 
         next if assigned_subnets.any? { |a| a.cidr.to_s == ip_addr }
 
-        # we need to find if it was previously created
-        # if it was, we need to update the routed_to_host_id but only if there is no VM that's using it
-        # if it wasn't, we need to create it
-        adr = Address.first(cidr: ip_addr)
-        if adr && is_failover_ip
-          unless adr.assigned_vm_addresses_dataset.empty?
-            fail "BUG: failover ip #{ip_addr} is already assigned to a vm"
-          end
-
-          adr.update(routed_to_host_id: id)
-        else
-          if Sshable.where(host: source_host_ip).empty?
-            fail "BUG: source host #{source_host_ip} isn't added to the database"
-          end
-
-          adr = Address.create(cidr: ip_addr, routed_to_host_id: id, is_failover_ip:)
+        if Sshable.where(host: ip_record.source_host_ip).empty?
+          fail "BUG: source host #{ip_record.source_host_ip} isn't added to the database"
         end
 
-        unless is_failover_ip
+        adr = Address.create(cidr: ip_addr, routed_to_host_id: id)
+        # A claimed address joins the host's set; a routed one opens its VM pool.
+        if ip_record.host_only?
           AssignedHostAddress.create(host_id: id, ip: ip_addr, address_id: adr.id)
+        else
+          adr.populate_ipv4_addresses
         end
       end
     end

--- a/prog/learn_network.rb
+++ b/prog/learn_network.rb
@@ -6,6 +6,16 @@ class Prog::LearnNetwork < Prog::Base
   subject_is :sshable, :vm_host
 
   label def start
+    if vm_host.provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
+      hop_learn_ip6 if retval&.dig("msg") == "leaseweb networking configured"
+      register_deadline("learn_ip6", 5 * 60)
+      push Prog::Leaseweb::SetupNetworking
+    end
+
+    hop_learn_ip6
+  end
+
+  label def learn_ip6
     ip6 = parse_ip_addr_j(sshable.cmd_json("/usr/sbin/ip -j -6 addr show scope global"))
 
     # While it would be ideal for NetAddr's IPv6 support to convey

--- a/prog/leaseweb/setup_networking.rb
+++ b/prog/leaseweb/setup_networking.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class Prog::Leaseweb::SetupNetworking < Prog::Base
+  subject_is :sshable, :vm_host
+
+  # start passes verify the desired addresses, gateways, and internal ifname
+  # through the frame, so verify needs no second API pull.
+  frame_accessor :expected_addresses, :expected_gateways, :expected_internal_interface
+
+  # Leaseweb hands a fresh server only its main IP over DHCP, so we configure
+  # every other routed address as the whole desired-state netplan.
+  label def start
+    api = vm_host.provider.api
+    nics = api.pull_network_interfaces
+    links = sshable.cmd_json("/usr/sbin/ip -j link")
+
+    public_interface = interface_for(links, nics.public_mac)
+    fail "no interface with leaseweb public mac #{nics.public_mac}" unless public_interface
+
+    internal_interface = nil
+    if nics.internal_mac
+      internal_interface = interface_for(links, nics.internal_mac)
+      fail "no interface with leaseweb internal mac #{nics.internal_mac}" unless internal_interface
+    end
+
+    # /etc/resolv.conf names only the local stub; this file holds the real
+    # upstreams the environment handed the host, frozen in since dhcp4 goes off.
+    resolv_conf = sshable.cmd("cat /run/systemd/resolve/resolv.conf")
+    nameservers = resolv_conf.scan(/^nameserver (\S+)/).flatten.uniq
+    fail "no upstream resolvers on the host" if nameservers.empty?
+    search_domains = resolv_conf.scan(/^search (.+)/).flatten.flat_map(&:split).uniq
+
+    # The same snapshot records the Address rows and builds the netplan, so a
+    # block added since assemble reaches both.
+    ip_infos = api.pull_ips
+    vm_host.create_addresses(ip_records: ip_infos)
+
+    netplan = Hosting::LeasewebNetplan.new(public_interface:, internal_interface:, internal_ip: nics.internal_ip, ip_infos:, nameservers:, search_domains:)
+    sshable.cmd("sudo host/bin/setup-leaseweb-networking :netplan", netplan: netplan.to_yaml)
+
+    self.expected_addresses = netplan.interface_addresses
+    self.expected_gateways = netplan.gateways
+    self.expected_internal_interface = internal_interface
+    hop_verify
+  end
+
+  def interface_for(links, mac)
+    links.find { it["address"] == mac }&.fetch("ifname")
+  end
+
+  # netplan apply returns before the kernel holds the addresses, so a separate
+  # label naps for them without rerunning the apply or the API pulls.
+  label def verify
+    links = sshable.cmd_json("/usr/sbin/ip -j addr")
+
+    # Check per interface, not the union: an address on the wrong NIC would pass a
+    # global check. Exclude the optional internal NIC so a dead port never pages.
+    configured = configured_addresses(links)
+    nap 1 unless expected_addresses.except(expected_internal_interface).all? { |ifname, addresses| (addresses - configured.fetch(ifname, [])).empty? }
+
+    # netplan apply exits zero even if a gateway is unreachable, so ping each.
+    expected_gateways.each do |gateway|
+      if gateway.include?(":")
+        sshable.cmd("sudo ping6 -c 2 -W 5 :gateway", gateway:)
+      else
+        sshable.cmd("sudo ping -c 2 -W 5 :gateway", gateway:)
+      end
+    end
+
+    # A green public path says nothing about the private port; record its state
+    # for diagnostics, never page.
+    emit_internal_port_state(links) if expected_internal_interface
+
+    hop_refresh_nftables
+  end
+
+  # The SetupNftables strand prep buds is not ordered against this one, so a
+  # block this snapshot added may have missed it. Rerun against the final
+  # address set; the run is a full-state rewrite, safe to repeat.
+  label def refresh_nftables
+    pop "leaseweb networking configured" if retval&.dig("msg") == "nftables was setup"
+    push Prog::SetupNftables
+  end
+
+  # Addresses each interface holds, keyed by ifname, so verify checks placement.
+  def configured_addresses(links)
+    links.to_h do |link|
+      [link["ifname"], link.fetch("addr_info", []).map { "#{it["local"]}/#{it["prefixlen"]}" }]
+    end
+  end
+
+  # Internal port operstate + carrier for diagnostics; absent when it never got
+  # carrier to install a link.
+  def emit_internal_port_state(links)
+    link = links.find { it["ifname"] == expected_internal_interface } || {}
+    Clog.emit("leaseweb internal port state", {leaseweb_internal_port: {ifname: expected_internal_interface, operstate: link["operstate"], carrier: link.fetch("flags", []).include?("LOWER_UP")}})
+  end
+end

--- a/prog/setup_nftables.rb
+++ b/prog/setup_nftables.rb
@@ -3,8 +3,14 @@
 class Prog::SetupNftables < Prog::Base
   subject_is :sshable, :vm_host
 
+  # The blocked set holds the IPv4s a VM may take, dropping traffic to each
+  # until one does. An address the host configures on its own NIC never enters
+  # the allowed set, so blocking it would blackhole it for good.
   label def start
-    additional_subnets = vm_host.assigned_subnets.select { |a| a.cidr.version == 4 && a.cidr.network.to_s != vm_host.sshable.host }
+    additional_subnets = vm_host.assigned_subnets_dataset
+      .where { {family(cidr) => 4} }
+      .exclude(id: AssignedHostAddress.select(:address_id))
+      .all
     sshable.cmd("sudo host/bin/setup-nftables.rb :json", json: additional_subnets.map { it.cidr.to_s }.to_json)
 
     pop "nftables was setup"

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -23,7 +23,7 @@ class Prog::Vm::HostNexus < Prog::Base
         end
       end
 
-      if provider_name == HostProvider::HETZNER_PROVIDER_NAME
+      if provider_name == HostProvider::HETZNER_PROVIDER_NAME || provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
         vmh.create_addresses
         vmh.set_data_center
         # Avoid overriding custom server names for development hosts.

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -62,20 +62,28 @@ def sync_parent_dir(f)
   }
 end
 
-def safe_write_to_file(filename, content = nil)
+def safe_write_to_file(filename, content = nil, perm: nil)
   raise ArgumentError, "must provide either content or block" if content.nil? ^ block_given?
 
   temp_filename = filename + ".tmp"
   lock_filename = "/tmp/#{OpenSSL::Digest::SHA256.hexdigest(temp_filename)}.lock"
   File.open(lock_filename, File::RDWR | File::CREAT) do |lock_file|
     lock_file.flock(File::LOCK_EX)
+    # Create the temp at its final mode so content is never written through the
+    # default 0644 nor left there on a mid-write crash. A mode only lands on a
+    # freshly created file, so unlink a temp a crashed run left behind first;
+    # else our content inherits its stale mode. nil perm keeps prior behavior.
+    File.unlink(temp_filename) if perm && File.exist?(temp_filename)
     if block_given?
-      File.open(temp_filename, "w") do |f|
+      open_args = perm ? [File::RDWR | File::CREAT, perm] : ["w"]
+      File.open(temp_filename, *open_args) do |f|
         yield f
       end
     else
-      File.write(temp_filename, content)
+      File.write(temp_filename, content, perm: perm)
     end
+    # Creation masks the mode by umask; force the exact perm before publishing.
+    File.chmod(perm, temp_filename) if perm
     File.rename(temp_filename, filename)
   end
 end

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -69,6 +69,60 @@ RSpec.describe "util" do
         expect(File.read(path)).to eq("fresh")
       end
     end
+
+    it "creates string content at the requested perm" do
+      Dir.mktmpdir do |dir|
+        path = "#{dir}/test.txt"
+        safe_write_to_file(path, "string content", perm: 0o600)
+        expect(File.read(path)).to eq("string content")
+        expect(File.stat(path).mode & 0o777).to eq(0o600)
+      end
+    end
+
+    it "creates the block's file at the requested perm" do
+      Dir.mktmpdir do |dir|
+        path = "#{dir}/test.txt"
+        safe_write_to_file(path, perm: 0o600) do |f|
+          f.write("block content")
+        end
+        expect(File.read(path)).to eq("block content")
+        expect(File.stat(path).mode & 0o777).to eq(0o600)
+      end
+    end
+
+    it "writes string content into a fresh perm-mode temp when a crashed run left a stale one" do
+      Dir.mktmpdir do |dir|
+        path = "#{dir}/test.txt"
+        File.write("#{path}.tmp", "stale")
+        File.chmod(0o644, "#{path}.tmp")
+        mode_at_finalize = nil
+        expect(File).to receive(:chmod).and_wrap_original do |orig, mode, file|
+          mode_at_finalize = File.stat(file).mode & 0o777
+          orig.call(mode, file)
+        end
+        safe_write_to_file(path, "string content", perm: 0o600)
+        # Content was written into a fresh 0600 temp, never the stale 0644 one.
+        expect(mode_at_finalize).to eq(0o600)
+        expect(File.read(path)).to eq("string content")
+        expect(File.stat(path).mode & 0o777).to eq(0o600)
+      end
+    end
+
+    it "writes block content into a fresh perm-mode temp when a crashed run left a stale one" do
+      Dir.mktmpdir do |dir|
+        path = "#{dir}/test.txt"
+        File.write("#{path}.tmp", "stale-and-longer-than-the-new-content")
+        File.chmod(0o644, "#{path}.tmp")
+        safe_write_to_file(path, perm: 0o600) do |f|
+          # The block writes into a temp that is already at perm, not the stale one.
+          expect(File.stat("#{path}.tmp").mode & 0o777).to eq(0o600)
+          f.write("fresh")
+        end
+        # The stale temp was dropped, so none of its content survives.
+        expect(File.read(path)).to eq("fresh")
+        expect(File.stat(path).mode & 0o777).to eq(0o600)
+      end
+    end
   end
 
   describe "validate_keys" do

--- a/rhizome/host/bin/setup-leaseweb-networking
+++ b/rhizome/host/bin/setup-leaseweb-networking
@@ -1,0 +1,10 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/leaseweb_networking_setup"
+
+unless (netplan = ARGV.shift)
+  fail "netplan config didn't get passed"
+end
+
+LeasewebNetworkingSetup.new(netplan).run

--- a/rhizome/host/lib/leaseweb_networking_setup.rb
+++ b/rhizome/host/lib/leaseweb_networking_setup.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "fileutils"
+
+class LeasewebNetworkingSetup
+  NETPLAN_DIR = "/etc/netplan"
+  NETPLAN_PATH = File.join(NETPLAN_DIR, "01-netcfg.yaml")
+  STAGING_DIR = "/var/tmp/leaseweb-netplan"
+
+  def initialize(netplan)
+    @netplan = netplan
+  end
+
+  def run
+    generate
+    install
+    archive
+    apply
+  end
+
+  private
+
+  # Validate in a scratch root so a rejected config never reaches /etc/netplan.
+  def generate
+    staged = File.join(STAGING_DIR, "etc/netplan")
+    staged_path = File.join(staged, "01-netcfg.yaml")
+    FileUtils.rm_rf(STAGING_DIR)
+    FileUtils.mkdir_p(staged, mode: 0o700)
+    File.write(staged_path, @netplan)
+    FileUtils.chmod(0o600, staged_path)
+    r "netplan generate --root-dir #{STAGING_DIR}"
+    FileUtils.rm_rf(STAGING_DIR)
+  end
+
+  # Copy the current config aside, then replace it atomically, so 01-netcfg.yaml
+  # is never absent for a crash to find.
+  def install
+    if File.exist?(NETPLAN_PATH)
+      target = archive_target(NETPLAN_PATH)
+      tmp = "#{target}.tmp"
+      FileUtils.cp(NETPLAN_PATH, tmp, preserve: true)
+      File.rename(tmp, target)
+    end
+    safe_write_to_file(NETPLAN_PATH, @netplan, perm: 0o600)
+  end
+
+  # Runs after #install lands ours: netplan merges every *.yaml, so displacing
+  # the stock configs sooner could leave it with none.
+  def archive
+    Dir.glob(File.join(NETPLAN_DIR, "*.yaml")).each do |path|
+      next if path == NETPLAN_PATH
+
+      File.rename(path, archive_target(path))
+    end
+  end
+
+  def apply
+    r "netplan generate"
+    r "netplan apply"
+  end
+
+  # First config displaced at a name stays under .ubicloud-orig; later ones
+  # rotate through .ubicloud-disabled.
+  def archive_target(path)
+    orig = path + ".ubicloud-orig"
+    File.exist?(orig) ? path + ".ubicloud-disabled" : orig
+  end
+end

--- a/rhizome/host/spec/leaseweb_networking_setup_spec.rb
+++ b/rhizome/host/spec/leaseweb_networking_setup_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require_relative "../lib/leaseweb_networking_setup"
+require "tmpdir"
+
+RSpec.describe LeasewebNetworkingSetup do
+  subject(:setup) { described_class.new("netplan-yaml") }
+
+  describe "#run" do
+    it "generates, installs, archives, then applies" do
+      expect(setup).to receive(:generate).ordered
+      expect(setup).to receive(:install).ordered
+      expect(setup).to receive(:archive).ordered
+      expect(setup).to receive(:apply).ordered
+
+      setup.run
+    end
+  end
+
+  describe "#generate" do
+    it "generates the config under a staging root and clears it" do
+      expect(FileUtils).to receive(:rm_rf).with("/var/tmp/leaseweb-netplan").twice
+      expect(FileUtils).to receive(:mkdir_p).with("/var/tmp/leaseweb-netplan/etc/netplan", mode: 0o700)
+      expect(File).to receive(:write).with("/var/tmp/leaseweb-netplan/etc/netplan/01-netcfg.yaml", "netplan-yaml")
+      expect(FileUtils).to receive(:chmod).with(0o600, "/var/tmp/leaseweb-netplan/etc/netplan/01-netcfg.yaml")
+      expect(setup).to receive(:r).with("netplan generate --root-dir /var/tmp/leaseweb-netplan")
+
+      setup.send(:generate)
+    end
+  end
+
+  describe "#install" do
+    it "copies the config it displaces to a temp, renames it onto the archive suffix, then writes the new one in place" do
+      expect(File).to receive(:exist?).with("/etc/netplan/01-netcfg.yaml").and_return(true)
+      expect(File).to receive(:exist?).with("/etc/netplan/01-netcfg.yaml.ubicloud-orig").and_return(false)
+      expect(FileUtils).to receive(:cp)
+        .with("/etc/netplan/01-netcfg.yaml", "/etc/netplan/01-netcfg.yaml.ubicloud-orig.tmp", preserve: true).ordered
+      expect(File).to receive(:rename)
+        .with("/etc/netplan/01-netcfg.yaml.ubicloud-orig.tmp", "/etc/netplan/01-netcfg.yaml.ubicloud-orig").ordered
+      expect(setup).to receive(:safe_write_to_file).with("/etc/netplan/01-netcfg.yaml", "netplan-yaml", perm: 0o600).ordered
+
+      setup.send(:install)
+    end
+
+    it "writes the new config without a copy when there is nothing to displace" do
+      expect(File).to receive(:exist?).with("/etc/netplan/01-netcfg.yaml").and_return(false)
+      expect(FileUtils).not_to receive(:cp)
+      expect(File).not_to receive(:rename)
+      expect(setup).to receive(:safe_write_to_file).with("/etc/netplan/01-netcfg.yaml", "netplan-yaml", perm: 0o600)
+
+      setup.send(:install)
+    end
+  end
+
+  describe "#archive" do
+    it "displaces the other configs but leaves 01-netcfg.yaml in place" do
+      expect(Dir).to receive(:glob).with("/etc/netplan/*.yaml")
+        .and_return(["/etc/netplan/01-netcfg.yaml", "/etc/netplan/50-cloud-init.yaml"])
+      expect(File).to receive(:exist?).with("/etc/netplan/50-cloud-init.yaml.ubicloud-orig").and_return(false)
+      expect(File).to receive(:rename)
+        .with("/etc/netplan/50-cloud-init.yaml", "/etc/netplan/50-cloud-init.yaml.ubicloud-orig")
+
+      setup.send(:archive)
+    end
+  end
+
+  # The mock examples above pin the call sequence; these run install then
+  # archive against a real directory to pin the on-disk invariant: /etc/netplan
+  # never goes empty and the displaced configs survive.
+  describe "install then archive against a real /etc/netplan" do
+    before do
+      @dir = Dir.mktmpdir
+      @netplan_path = File.join(@dir, "01-netcfg.yaml")
+      stub_const("LeasewebNetworkingSetup::NETPLAN_DIR", @dir)
+      stub_const("LeasewebNetworkingSetup::NETPLAN_PATH", @netplan_path)
+    end
+
+    after do
+      FileUtils.rm_rf(@dir)
+    end
+
+    it "keeps a config live through install and archive, and keeps the stock one" do
+      stock = File.join(@dir, "50-cloud-init.yaml")
+      File.write(stock, "stock")
+
+      setup.send(:install)
+      expect(File.read(@netplan_path)).to eq("netplan-yaml")
+      expect(File.stat(@netplan_path).mode & 0o777).to eq(0o600)
+      expect(Dir.glob(File.join(@dir, "*.yaml")).sort).to eq([@netplan_path, stock].sort)
+
+      setup.send(:archive)
+      expect(Dir.glob(File.join(@dir, "*.yaml"))).to eq([@netplan_path])
+      expect(File.read("#{stock}.ubicloud-orig")).to eq("stock")
+    end
+
+    it "preserves the config it displaces and rotates the next run behind it" do
+      File.write(@netplan_path, "old-ours")
+
+      setup.send(:install)
+      expect(File.read(@netplan_path)).to eq("netplan-yaml")
+      expect(File.read("#{@netplan_path}.ubicloud-orig")).to eq("old-ours")
+
+      described_class.new("newer-yaml").send(:install)
+      expect(File.read(@netplan_path)).to eq("newer-yaml")
+      expect(File.read("#{@netplan_path}.ubicloud-orig")).to eq("old-ours")
+      expect(File.read("#{@netplan_path}.ubicloud-disabled")).to eq("netplan-yaml")
+    end
+  end
+
+  describe "#apply" do
+    it "generates and applies the live config" do
+      expect(setup).to receive(:r).with("netplan generate").ordered
+      expect(setup).to receive(:r).with("netplan apply").ordered
+
+      setup.send(:apply)
+    end
+  end
+
+  describe "#archive_target" do
+    it "settles the first config displaced at a name in .ubicloud-orig" do
+      expect(File).to receive(:exist?).with("/etc/netplan/50-cloud-init.yaml.ubicloud-orig").and_return(false)
+
+      expect(setup.send(:archive_target, "/etc/netplan/50-cloud-init.yaml"))
+        .to eq("/etc/netplan/50-cloud-init.yaml.ubicloud-orig")
+    end
+
+    it "rotates through .ubicloud-disabled once .ubicloud-orig is taken" do
+      expect(File).to receive(:exist?).with("/etc/netplan/01-netcfg.yaml.ubicloud-orig").and_return(true)
+
+      expect(setup.send(:archive_target, "/etc/netplan/01-netcfg.yaml"))
+        .to eq("/etc/netplan/01-netcfg.yaml.ubicloud-disabled")
+    end
+  end
+end

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -216,13 +216,13 @@ RSpec.describe Hosting::HetznerApis do
       ]))
 
       expected = [
-        ["1.1.1.1/32", "1.1.1.1", false],
-        ["1.1.2.0/32", "1.1.1.1", false],
-        ["2.2.2.0/29", "1.1.1.1", false],
-        ["30.30.30.30/29", "1.1.1.1", true],
-        ["2a01:4f8:10a:128b::/64", "1.1.1.1", false],
+        ["1.1.1.1/32", "1.1.1.1"],
+        ["1.1.2.0/32", "1.1.1.1"],
+        ["2.2.2.0/29", "1.1.1.1"],
+        ["30.30.30.30/29", "1.1.1.1"],
+        ["2a01:4f8:10a:128b::/64", "1.1.1.1"],
       ].map {
-        Hosting::HetznerApis::IpInfo.new(ip_address: _1, source_host_ip: _2, is_failover: _3)
+        Hosting::HetznerApis::IpInfo.new(ip_address: _1, source_host_ip: _2)
       }
 
       expect(hetzner_apis.pull_ips).to eq expected
@@ -277,13 +277,13 @@ RSpec.describe Hosting::HetznerApis do
       stub_request(:get, "https://robot-ws.your-server.de/failover").to_return(status: 404)
 
       expected = [
-        ["1.1.1.1/32", "1.1.1.1", false],
-        ["1.1.2.0/32", "1.1.1.1", false],
-        ["2.2.2.0/29", "1.1.1.1", false],
-        ["15.15.15.15/29", "1.1.1.1", false],
-        ["30.30.30.30/29", "1.1.1.1", false],
+        ["1.1.1.1/32", "1.1.1.1"],
+        ["1.1.2.0/32", "1.1.1.1"],
+        ["2.2.2.0/29", "1.1.1.1"],
+        ["15.15.15.15/29", "1.1.1.1"],
+        ["30.30.30.30/29", "1.1.1.1"],
       ].map {
-        Hosting::HetznerApis::IpInfo.new(ip_address: _1, source_host_ip: _2, is_failover: _3)
+        Hosting::HetznerApis::IpInfo.new(ip_address: _1, source_host_ip: _2)
       }
 
       expect(hetzner_apis.pull_ips).to eq expected

--- a/spec/lib/hosting/leaseweb_apis_spec.rb
+++ b/spec/lib/hosting/leaseweb_apis_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe Hosting::LeasewebApis do
   let(:leaseweb_apis) do
     vmh = create_vm_host
+    vmh.sshable.update(host: "216.22.50.197")
     provider = HostProvider.create do
       it.id = vmh.id
       it.server_identifier = "123"
@@ -16,6 +17,58 @@ RSpec.describe Hosting::LeasewebApis do
       leaseweb_connection_string: "https://api.leaseweb.com",
       leaseweb_api_key: "key123",
     )
+  end
+
+  def ip_row(ip, prefix_length:, type: "NORMAL_IP", network_type: "PUBLIC", main_ip: false, gateway: "")
+    {"ip" => ip, "prefixLength" => prefix_length, "type" => type, "networkType" => network_type,
+     "mainIp" => main_ip, "gateway" => gateway}
+  end
+
+  def stub_ips(pages)
+    total = pages.sum(&:length)
+    offset = 0
+    pages.each do |page|
+      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset:}},
+        {status: 200, body: JSON.generate(ips: page, _metadata: {totalCount: total})})
+      offset += page.length
+    end
+  end
+
+  # Real /ips output for server 12493302: the whole /26 is routed to the host
+  # (every address NORMAL_IP, no gateway), the main IP stands alone behind a
+  # gateway, and two IPv6 prefixes arrive with an "_<prefixlen>" marker.
+  def reference_ip_rows
+    block = (64..127).map { ip_row("216.22.15.#{it}/26", prefix_length: 26) }
+    [
+      ip_row("10.59.61.133/26", prefix_length: 26, type: "IPMI", network_type: "REMOTE_MANAGEMENT", gateway: "10.59.61.190"),
+      *block,
+      ip_row("216.22.50.197/26", prefix_length: 26, main_ip: true, gateway: "216.22.50.254"),
+      ip_row("2604:9a00:2100:a020:4::_112/64", prefix_length: 64, gateway: "2604:9a00:2100:a020::1"),
+      ip_row("2607:f5b7:3:104::_64/64", prefix_length: 64),
+    ]
+  end
+
+  # Real /ips output for server 91478: its extra IPv4s arrive as a switched /29
+  # whose infra addresses are typed, and every row of which carries the segment
+  # gateway. It has no routed IPv4 block and a single IPv6 prefix.
+  def segment_ip_rows
+    [
+      ip_row("10.59.22.90/26", prefix_length: 26, type: "IPMI", network_type: "REMOTE_MANAGEMENT", gateway: "10.59.22.126"),
+      ip_row("23.105.171.112/26", prefix_length: 26, main_ip: true, gateway: "23.105.171.126"),
+      ip_row("23.105.176.0/29", prefix_length: 29, type: "NETWORK", gateway: "23.105.176.6"),
+      ip_row("23.105.176.1/29", prefix_length: 29, gateway: "23.105.176.6"),
+      ip_row("23.105.176.2/29", prefix_length: 29, gateway: "23.105.176.6"),
+      ip_row("23.105.176.3/29", prefix_length: 29, gateway: "23.105.176.6"),
+      ip_row("23.105.176.4/29", prefix_length: 29, type: "ROUTER1", gateway: "23.105.176.6"),
+      ip_row("23.105.176.5/29", prefix_length: 29, type: "ROUTER2", gateway: "23.105.176.6"),
+      ip_row("23.105.176.6/29", prefix_length: 29, type: "GATEWAY", gateway: "23.105.176.6"),
+      ip_row("23.105.176.7/29", prefix_length: 29, type: "BROADCAST", gateway: "23.105.176.6"),
+      ip_row("2607:f5b7:1:30:9::_112/64", prefix_length: 64, gateway: "2607:f5b7:1:30::1"),
+    ]
+  end
+
+  def ip_info(ip_address, gateway)
+    described_class::IpInfo.new(ip_address:, source_host_ip: "216.22.50.197", gateway:)
   end
 
   describe "hardware_reset" do
@@ -39,9 +92,188 @@ RSpec.describe Hosting::LeasewebApis do
     end
   end
 
+  describe "pull_network_interfaces" do
+    def stub_server(**body)
+      Excon.stub({path: "/bareMetals/v2/servers/123", method: :get}, {status: 200, body: JSON.generate(body)})
+    end
+
+    # Server 91478's private network, as the API reports it.
+    def private_network
+      {id: "24197", linkSpeed: 1000, status: "CONFIGURED", dhcp: "ENABLED", subnet: "10.31.2.0/27", vlanId: "2033"}
+    end
+
+    def both_macs
+      {public: {mac: "8C:84:74:54:EA:D0"}, internal: {mac: "8C:84:74:54:EA:D1"}}
+    end
+
+    # Server 91478's shape: a private network carries the host's reserved VLAN
+    # address on internal.ip.
+    it "downcases the macs and keeps the internal interface's reserved address" do
+      stub_server(networkInterfaces: {public: {mac: "28:92:4A:34:29:FA"}, internal: {mac: "28:92:4A:34:29:FB", ip: "10.31.2.19/27"}},
+        isPrivateNetworkEnabled: true, privateNetworks: [private_network])
+      expect(leaseweb_apis.pull_network_interfaces).to eq described_class::NetworkInterfaces.new(
+        public_mac: "28:92:4a:34:29:fa", internal_mac: "28:92:4a:34:29:fb", internal_ip: "10.31.2.19/27",
+      )
+    end
+
+    # Server 12493302 reports an internal MAC although it has no private network;
+    # its internal port has no VLAN and nothing answering DHCP behind it, and its
+    # internal.ip is null.
+    it "reports no internal mac or address when the server has no private network" do
+      stub_server(networkInterfaces: both_macs, isPrivateNetworkEnabled: false, privateNetworks: [])
+      expect(leaseweb_apis.pull_network_interfaces).to eq described_class::NetworkInterfaces.new(
+        public_mac: "8c:84:74:54:ea:d0", internal_mac: nil, internal_ip: nil,
+      )
+    end
+
+    it "reports no internal mac when the api omits the private networks" do
+      stub_server(networkInterfaces: both_macs)
+      expect(leaseweb_apis.pull_network_interfaces.internal_mac).to be_nil
+    end
+
+    it "reports no internal mac when the api nulls the private networks" do
+      stub_server(networkInterfaces: both_macs, privateNetworks: nil)
+      expect(leaseweb_apis.pull_network_interfaces.internal_mac).to be_nil
+    end
+
+    # Silently dropping the internal interface in either case would leave a host
+    # that wants private networking without it; a missing record is only safe to
+    # ignore when the server does not claim the feature at all.
+    it "fails when the server enables private networking but reports no private network" do
+      stub_server(networkInterfaces: both_macs, isPrivateNetworkEnabled: true, privateNetworks: [])
+      expect { leaseweb_apis.pull_network_interfaces }.to raise_error RuntimeError,
+        "leaseweb server 123 enables private networking but reports no private network"
+    end
+
+    it "fails when the api nulls the private networks of a server that enables them" do
+      stub_server(networkInterfaces: both_macs, isPrivateNetworkEnabled: true, privateNetworks: nil)
+      expect { leaseweb_apis.pull_network_interfaces }.to raise_error RuntimeError,
+        "leaseweb server 123 enables private networking but reports no private network"
+    end
+
+    it "fails when the server has a private network but no internal interface" do
+      stub_server(networkInterfaces: {public: {mac: "28:92:4A:34:29:FA"}},
+        isPrivateNetworkEnabled: true, privateNetworks: [private_network])
+      expect { leaseweb_apis.pull_network_interfaces }.to raise_error RuntimeError,
+        "leaseweb server 123 has a private network but no internal interface"
+    end
+
+    # A private network we cannot address is as much a contradiction as one with
+    # no internal port: fail rather than emit an addressless internal ethernet.
+    it "fails when the server has a private network but no internal address" do
+      stub_server(networkInterfaces: {public: {mac: "28:92:4A:34:29:FA"}, internal: {mac: "28:92:4A:34:29:FB", ip: nil}},
+        isPrivateNetworkEnabled: true, privateNetworks: [private_network])
+      expect { leaseweb_apis.pull_network_interfaces }.to raise_error RuntimeError,
+        "leaseweb server 123 has a private network but no internal address"
+    end
+  end
+
+  describe "pull_ips" do
+    it "collapses a routed block, keeps the main ip and both ipv6 prefixes, and pages" do
+      rows = reference_ip_rows
+      stub_ips([rows.take(50), rows.drop(50)])
+
+      expect(leaseweb_apis.pull_ips).to eq [
+        ip_info("216.22.50.197/32", "216.22.50.254"),
+        ip_info("2604:9a00:2100:a020:4::/112", "2604:9a00:2100:a020::1"),
+        ip_info("2607:f5b7:3:104::/64", nil),
+        ip_info("216.22.15.64/26", nil),
+      ]
+    end
+
+    # Server 91478 delivers its extra IPv4s as a switched /29: the infra rows are
+    # typed, and every row carries the segment's gateway.
+    it "keeps gatewayed non-main ipv4s as single addresses and drops typed infra rows" do
+      stub_ips([segment_ip_rows])
+
+      expect(leaseweb_apis.pull_ips.map { [it.ip_address, it.gateway] }).to eq [
+        ["23.105.171.112/32", "23.105.171.126"],
+        ["23.105.176.1/32", "23.105.176.6"],
+        ["23.105.176.2/32", "23.105.176.6"],
+        ["23.105.176.3/32", "23.105.176.6"],
+        ["2607:f5b7:1:30:9::/112", "2607:f5b7:1:30::1"],
+      ]
+    end
+
+    # The host claims every gatewayed IPv4 in netplan, so none of them may reach
+    # the VM pool. A routed block is what VMs draw from, and IPv6 never populates
+    # that pool.
+    it "marks gatewayed ipv4s host only and leaves routed blocks allocatable" do
+      stub_ips([segment_ip_rows + [ip_row("216.22.15.64/26", prefix_length: 26)]])
+
+      expect(leaseweb_apis.pull_ips.map { [it.ip_address, it.host_only?] }).to eq [
+        ["23.105.171.112/32", true],
+        ["23.105.176.1/32", true],
+        ["23.105.176.2/32", true],
+        ["23.105.176.3/32", true],
+        ["2607:f5b7:1:30:9::/112", false],
+        ["216.22.15.64/26", false],
+      ]
+    end
+
+    # A short page that falls short of the promised total is a truncated snapshot.
+    # Reconciling it would prune Address rows and stop routing blocks Leaseweb
+    # still carries, so the pull fails instead of handing prune_addresses less.
+    it "fails on a truncated page rather than returning a partial ip list" do
+      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
+        {status: 200, body: JSON.generate(ips: [ip_row("216.22.50.197/26", prefix_length: 26, main_ip: true, gateway: "216.22.50.254")], _metadata: {totalCount: 9})})
+
+      expect { leaseweb_apis.pull_ips }.to raise_error RuntimeError, "leaseweb server 123 returned 1 of 9 ips"
+    end
+
+    # A response that repeats a row holds fewer distinct ips than it promises, so
+    # it is still partial. A repeat also hides a missing row behind a low count
+    # that matches after dedup, so any duplicate fails outright rather than let
+    # prune_addresses delete the ips it silently dropped.
+    it "fails when a page repeats a row even where dedup would match the count" do
+      main = ip_row("216.22.50.197/26", prefix_length: 26, main_ip: true, gateway: "216.22.50.254")
+      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
+        {status: 200, body: JSON.generate(ips: [main, main], _metadata: {totalCount: 1})})
+
+      expect { leaseweb_apis.pull_ips }.to raise_error RuntimeError, "leaseweb server 123 repeated an ip in its ip list"
+    end
+
+    # A server that ignores offset re-serves the same full page, which never ends
+    # the pager on its own. The first ip repeated across pages stops it before it
+    # loops forever concatenating the same rows.
+    it "fails when a later page repeats an ip from an earlier full page" do
+      page = (1..50).map { ip_row("23.0.0.#{it}/32", prefix_length: 32, gateway: "23.0.0.254") }
+      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
+        {status: 200, body: JSON.generate(ips: page, _metadata: {totalCount: 100})})
+      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 50}},
+        {status: 200, body: JSON.generate(ips: page, _metadata: {totalCount: 100})})
+
+      expect { leaseweb_apis.pull_ips }.to raise_error RuntimeError, "leaseweb server 123 repeated an ip in its ip list"
+    end
+
+    # totalCount can lag the rows a full page already serves. Stopping at it would
+    # drop the routed ips still waiting at the next offset, so the pager reads on
+    # until a short page and only then trusts the (now consistent) count.
+    it "pages past a full page whose totalCount already matches it" do
+      main = ip_row("216.22.50.197/26", prefix_length: 26, main_ip: true, gateway: "216.22.50.254")
+      filler = (1..49).map { ip_row("23.0.0.#{it}/32", prefix_length: 32, gateway: "23.0.0.254") }
+      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
+        {status: 200, body: JSON.generate(ips: [main] + filler, _metadata: {totalCount: 50})})
+      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 50}},
+        {status: 200, body: JSON.generate(ips: [ip_row("216.22.15.64/26", prefix_length: 26)], _metadata: {totalCount: 51})})
+
+      expect(leaseweb_apis.pull_ips.map(&:ip_address)).to include("216.22.15.64/26")
+    end
+
+    it "fails when the server has no main ip" do
+      stub_ips([[ip_row("216.22.15.65/26", prefix_length: 26)]])
+      expect { leaseweb_apis.pull_ips }.to raise_error RuntimeError, "leaseweb server 123 has no main IP"
+    end
+
+    it "fails when the main ip has no gateway" do
+      stub_ips([[ip_row("216.22.50.197/26", prefix_length: 26, main_ip: true)]])
+      expect { leaseweb_apis.pull_ips }.to raise_error RuntimeError, "leaseweb server 123 has a main ip without a gateway"
+    end
+  end
+
   describe "unimplemented operations" do
     it "does not respond to operations leaseweb does not implement" do
-      [:pull_ips, :reimage, :get_main_ip4].each do |operation|
+      [:reimage, :get_main_ip4].each do |operation|
         expect(leaseweb_apis).not_to respond_to(operation)
       end
     end

--- a/spec/lib/hosting/leaseweb_netplan_spec.rb
+++ b/spec/lib/hosting/leaseweb_netplan_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+RSpec.describe Hosting::LeasewebNetplan do
+  def ip_info(ip_address, gateway = nil, source_host_ip: "216.22.50.197")
+    Hosting::LeasewebApis::IpInfo.new(ip_address:, source_host_ip:, gateway:)
+  end
+
+  # The prog learns these from the host's resolved state and passes them in.
+  def netplan_for(**kwargs)
+    described_class.new(nameservers: ["23.19.53.53", "23.19.52.52"], search_domains: ["dedi.leaseweb.net"], **kwargs)
+  end
+
+  # What pull_ips returns for server 12493302, the hand-configured reference.
+  let(:reference_ip_infos) do
+    [
+      ip_info("216.22.50.197/32", "216.22.50.254"),
+      ip_info("2604:9a00:2100:a020:4::/112", "2604:9a00:2100:a020::1"),
+      ip_info("2607:f5b7:3:104::/64"),
+      ip_info("216.22.15.64/26"),
+    ]
+  end
+
+  # /etc/netplan/01-netcfg.yaml as hand-written on 12493302, less its second
+  # default route via the host's own address, and less its ens3f1np1 stanza: the
+  # hand-written file configures dhcp4 on an internal port with no private
+  # network behind it, which puts the port in netplan's -i <iface>:degraded
+  # wait-online list and delays every boot. It also gains accept-ra, which the
+  # hand-written file leaves at networkd's default of on. Compared parsed rather
+  # than byte for byte: the hand-written file mixes indent widths and quoting
+  # styles, neither of which YAML gives meaning to.
+  let(:reference_netplan) do
+    <<~YAML
+      network:
+          version: 2
+          renderer: networkd
+          ethernets:
+              ens3f0np0:
+                  dhcp4: no
+                  dhcp6: no
+                  accept-ra: no
+                  addresses:
+                    - '216.22.50.197/32'
+                    - '216.22.15.64/26'
+                    - '2604:9a00:2100:a020:4::2/112'
+                    - '2607:f5b7:3:104::1/64'
+                  routes:
+                      - to: default
+                        via: 216.22.50.254
+                        metric: 100
+                        on-link: true
+                      - to: default
+                        via: 2604:9a00:2100:a020::1
+                        metric: 100
+                        on-link: true
+                  nameservers:
+                      search: ['dedi.leaseweb.net']
+                      addresses: ['23.19.53.53', '23.19.52.52']
+    YAML
+  end
+  # 12493302 reports no private network, so pull_network_interfaces gives it no
+  # internal interface even though it reports an internal MAC.
+  let(:netplan) do
+    netplan_for(public_interface: "ens3f0np0", internal_interface: nil, internal_ip: nil, ip_infos: reference_ip_infos)
+  end
+
+  it "keeps standalone routed addresses off the NIC" do
+    netplan = netplan_for(public_interface: "eno1", internal_interface: nil, internal_ip: nil,
+      ip_infos: [
+        ip_info("216.22.50.197/32", "216.22.50.254"),
+        ip_info("5.6.7.8/32"),
+        ip_info("5.6.7.10/31"),
+      ])
+    # The /32 and /31 belong to VMs whole; only claimed and anchored
+    # addresses appear on the interface.
+    expect(netplan.interface_addresses).to eq("eno1" => ["216.22.50.197/32"])
+  end
+
+  it "reproduces the hand-written netplan of server 12493302, less its internal stanza" do
+    expect(YAML.safe_load(netplan.to_yaml)).to eq YAML.safe_load(reference_netplan)
+  end
+
+  it "claims ::2 out of a connectivity prefix and ::1 out of a routed prefix" do
+    expect(netplan.interface_addresses).to eq(
+      "ens3f0np0" => [
+        "216.22.50.197/32",
+        "216.22.15.64/26",
+        "2604:9a00:2100:a020:4::2/112",
+        "2607:f5b7:3:104::1/64",
+      ],
+    )
+  end
+
+  it "routes by default through the main ipv4 gateway and the ipv6 gateway only" do
+    expect(netplan.gateways).to eq ["216.22.50.254", "2604:9a00:2100:a020::1"]
+  end
+
+  it "omits the internal ethernet when the server has no private network" do
+    expect(netplan.to_h.dig("network", "ethernets").keys).to eq ["ens3f0np0"]
+  end
+
+  # Server 91478's shape. The internal NIC takes its reserved VLAN address
+  # statically, not over DHCP, so a VLAN whose DHCP is disabled still gets
+  # addressed. `optional: true` keeps the port out of the `-i <iface>:degraded`
+  # list netplan generates for systemd-networkd-wait-online, so a private port
+  # whose link never comes up cannot stall boot.
+  it "addresses the internal ethernet statically when the server has a private network" do
+    netplan = netplan_for(public_interface: "eno0", internal_interface: "eno1", internal_ip: "10.31.2.19/27", ip_infos: reference_ip_infos)
+    expect(netplan.to_h.dig("network", "ethernets", "eno1")).to eq(
+      "addresses" => ["10.31.2.19/27"], "mtu" => 9000, "optional" => true,
+    )
+  end
+
+  it "never marks the public ethernet optional" do
+    netplan = netplan_for(public_interface: "eno0", internal_interface: "eno1", internal_ip: "10.31.2.19/27", ip_infos: reference_ip_infos)
+    expect(netplan.to_h.dig("network", "ethernets", "eno0")).not_to include "optional"
+  end
+
+  # The internal VLAN address joins the desired state the prog verifies the host
+  # converged on, keyed to the internal NIC, never the public one.
+  it "keys the internal address to the internal interface, never the public one" do
+    netplan = netplan_for(public_interface: "eno0", internal_interface: "eno1", internal_ip: "10.31.2.19/27", ip_infos: reference_ip_infos)
+    expect(netplan.interface_addresses).to eq(
+      "eno0" => [
+        "216.22.50.197/32",
+        "216.22.15.64/26",
+        "2604:9a00:2100:a020:4::2/112",
+        "2607:f5b7:3:104::1/64",
+      ],
+      "eno1" => ["10.31.2.19/27"],
+    )
+  end
+
+  # netplan renders this as IPv6AcceptRA=no. Without it networkd accepts router
+  # advertisements even though dhcp6 is off, so the host would take a default
+  # route from the segment's router if ours ever went missing.
+  it "refuses router advertisements on the public ethernet" do
+    expect(netplan.to_h.dig("network", "ethernets", "ens3f0np0", "accept-ra")).to be false
+  end
+
+  # Server 91478's extra IPv4s sit on a switched /29 behind their own gateway.
+  # The host claims each as a /32, so the segment never becomes a connected
+  # route. Its gateway resolves to the same router as the main one, so it must
+  # not add a second default route.
+  it "claims gatewayed non-main ipv4s as /32 without routing through their gateway" do
+    netplan = netplan_for(public_interface: "eno1", internal_interface: nil, internal_ip: nil, ip_infos: [
+      ip_info("23.105.171.112/32", "23.105.171.126", source_host_ip: "23.105.171.112"),
+      ip_info("23.105.176.3/32", "23.105.176.6", source_host_ip: "23.105.171.112"),
+      ip_info("23.105.176.1/32", "23.105.176.6", source_host_ip: "23.105.171.112"),
+      ip_info("23.105.176.2/32", "23.105.176.6", source_host_ip: "23.105.171.112"),
+      ip_info("2607:f5b7:1:30:9::/112", "2607:f5b7:1:30::1", source_host_ip: "23.105.171.112"),
+    ])
+
+    expect(netplan.interface_addresses).to eq(
+      "eno1" => [
+        "23.105.171.112/32",
+        "23.105.176.1/32",
+        "23.105.176.2/32",
+        "23.105.176.3/32",
+        "2607:f5b7:1:30:9::2/112",
+      ],
+    )
+    expect(netplan.gateways).to eq ["23.105.171.126", "2607:f5b7:1:30::1"]
+  end
+
+  it "sorts multiple routed ipv4 blocks by network address" do
+    netplan = netplan_for(public_interface: "eno1", internal_interface: nil, internal_ip: nil, ip_infos: [
+      ip_info("216.22.50.197/32", "216.22.50.254"),
+      ip_info("216.22.60.0/26"),
+      ip_info("216.22.15.64/26"),
+    ])
+
+    expect(netplan.interface_addresses).to eq("eno1" => ["216.22.50.197/32", "216.22.15.64/26", "216.22.60.0/26"])
+  end
+
+  it "fails when no address matches the source host ip" do
+    expect {
+      netplan_for(public_interface: "eno1", internal_interface: nil, internal_ip: nil, ip_infos: [ip_info("216.22.15.64/26")])
+    }.to raise_error RuntimeError, "no main IPv4 address among leaseweb ip infos"
+  end
+end

--- a/spec/model/address_spec.rb
+++ b/spec/model/address_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Address do
   it "populates ipv4_address table with addresses in cidr" do
     vm_host = Prog::Vm::HostNexus.assemble("1.2.3.4").subject
     address = described_class.create(cidr: "0.0.0.0/30", vm_host:)
+    address.populate_ipv4_addresses
     expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq %w[0.0.0.0 0.0.0.1 0.0.0.2 0.0.0.3].freeze
     address.destroy
     expect(DB[:ipv4_address]).to be_empty
@@ -33,9 +34,43 @@ RSpec.describe Address do
     expect(DB[:ipv4_address]).to be_empty
   end
 
-  it "populates ipv4_address table with addresses in cidr without first and last, when using leaseweb" do
-    vm_host = Prog::Vm::HostNexus.assemble("1.2.3.4", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "1").subject
-    described_class.create(cidr: "0.0.0.0/30", vm_host:)
-    expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq %w[0.0.0.1 0.0.0.2].freeze
+  describe "leaseweb" do
+    # Leaseweb routes whole blocks to the host, so assemble pulls them from the
+    # API rather than deriving one address from the sshable host.
+    def assemble_leaseweb_host
+      allow(Config).to receive_messages(
+        leaseweb_connection_string: "https://api.leaseweb.com",
+        leaseweb_api_key: "key123",
+      )
+      Excon.stub({path: "/bareMetals/v2/servers/1/ips", query: {limit: 50, offset: 0}},
+        {status: 200, body: JSON.generate(
+          ips: [{ip: "1.2.3.4/24", prefixLength: 24, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: true, gateway: "1.2.3.254"}],
+          _metadata: {totalCount: 1},
+        )})
+      Excon.stub({path: "/bareMetals/v2/servers/1", method: :get},
+        {status: 200, body: JSON.generate(location: {site: "AMS-01", suite: "8", rack: "9200"})})
+      Excon.stub({path: "/bareMetals/v2/servers/1", method: :put}, {status: 204})
+      Prog::Vm::HostNexus.assemble("1.2.3.4", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "1").subject
+    end
+
+    it "populates ipv4_address table with addresses in cidr without first and last" do
+      vm_host = assemble_leaseweb_host
+      described_class.create(cidr: "0.0.0.0/30", vm_host:).populate_ipv4_addresses
+      expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq %w[0.0.0.1 0.0.0.2]
+    end
+
+    # A /32 Leaseweb routes here is not a block: dropping a network and a
+    # broadcast address would leave nothing behind.
+    it "keeps the only address of a standalone ip" do
+      vm_host = assemble_leaseweb_host
+      described_class.create(cidr: "5.6.7.8/32", vm_host:).populate_ipv4_addresses
+      expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq %w[5.6.7.8]
+    end
+
+    it "keeps both addresses of a two address block" do
+      vm_host = assemble_leaseweb_host
+      described_class.create(cidr: "5.6.7.8/31", vm_host:).populate_ipv4_addresses
+      expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq %w[5.6.7.8 5.6.7.9]
+    end
   end
 end

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe VmHost do
     end
 
     it "returns an unused ip address if there is one" do
-      address_id = Address.create(vm_host:, cidr: "128.0.0.0/30").id
+      address_id = Address.create(vm_host:, cidr: "128.0.0.0/30").tap(&:populate_ipv4_addresses).id
       ips = %w[128.0.0.0 128.0.0.1 128.0.0.2 128.0.0.3]
 
       4.times do
@@ -229,16 +229,38 @@ RSpec.describe VmHost do
   describe "#create_addresses" do
     let(:hetzner_ips) {
       [
-        ["1.1.1.0/30", "1.1.1.1", true],
-        ["1.1.1.12/32", "1.1.0.0", true],
-        ["1.1.1.13/32", "1.1.1.1", false],
-        ["2a01:4f8:10a:128b::/64", "1.1.1.1", true],
+        ["1.1.1.0/30", "1.1.1.1"],
+        ["1.1.1.12/32", "1.1.0.0"],
+        ["1.1.1.13/32", "1.1.1.1"],
+        ["2a01:4f8:10a:128b::/64", "1.1.1.1"],
       ].map {
-        Hosting::HetznerApis::IpInfo.new(ip_address: _1, source_host_ip: _2, is_failover: _3)
+        Hosting::HetznerApis::IpInfo.new(ip_address: _1, source_host_ip: _2)
       }
     }
 
-    it "fails if a failover ip of non existent server is being added" do
+    # Server 91478's real /ips rows, with server 12493302's routed /26 bolted on
+    # so one host exercises both of Leaseweb's shapes.
+    def leaseweb_91478_ip_rows
+      row = ->(ip, prefix_length, type: "NORMAL_IP", main_ip: false, gateway: "") {
+        {"ip" => ip, "prefixLength" => prefix_length, "type" => type, "networkType" => "PUBLIC",
+         "mainIp" => main_ip, "gateway" => gateway}
+      }
+      [
+        row.call("23.105.171.112/26", 26, main_ip: true, gateway: "23.105.171.126"),
+        row.call("23.105.176.0/29", 29, type: "NETWORK", gateway: "23.105.176.6"),
+        row.call("23.105.176.1/29", 29, gateway: "23.105.176.6"),
+        row.call("23.105.176.2/29", 29, gateway: "23.105.176.6"),
+        row.call("23.105.176.3/29", 29, gateway: "23.105.176.6"),
+        row.call("23.105.176.4/29", 29, type: "ROUTER1", gateway: "23.105.176.6"),
+        row.call("23.105.176.5/29", 29, type: "ROUTER2", gateway: "23.105.176.6"),
+        row.call("23.105.176.6/29", 29, type: "GATEWAY", gateway: "23.105.176.6"),
+        row.call("23.105.176.7/29", 29, type: "BROADCAST", gateway: "23.105.176.6"),
+        row.call("2607:f5b7:1:30:9::_112/64", 64, gateway: "2607:f5b7:1:30::1"),
+        *(64..127).map { row.call("216.22.15.#{it}/26", 26) },
+      ]
+    end
+
+    it "fails if the source host isn't in the database" do
       expect(provider_api).to receive(:pull_ips).with(no_args).and_return(hetzner_ips)
       expect { vm_host.create_addresses }.to raise_error(RuntimeError, "BUG: source host 1.1.1.1 isn't added to the database")
     end
@@ -283,31 +305,72 @@ RSpec.describe VmHost do
       expect { vm_host.create_addresses }.to change { vm_host.assigned_subnets_dataset.count }.by(3)
     end
 
-    it "updates the routed_to_host_id if the address is reassigned to another host and there is no vm using the ip range" do
+    it "fails loudly when the provider hands an address another host still holds" do
       vm_host.sshable.update(host: "1.1.0.0")
-      adr = Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vm_host.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vm_host.id)
 
       vm_host2 = create_vm_host
       vm_host2.sshable.update(host: "1.1.1.1")
-      ip_records = [Hosting::HetznerApis::IpInfo.new(ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1", is_failover: true)]
+      ip_records = [Hosting::HetznerApis::IpInfo.new(ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1")]
 
-      expect { vm_host2.create_addresses(ip_records:) }.to change { adr.reload.routed_to_host_id }.from(vm_host.id).to(vm_host2.id)
+      # Addresses never move between hosts, so a cidr collision is a bug to
+      # surface, not a failover to re-point.
+      expect { vm_host2.create_addresses(ip_records:) }.to raise_error Sequel::ValidationFailed, "cidr is already taken"
     end
 
-    it "fails if the ip range is already assigned to a vm" do
-      vm_host.sshable.update(host: "1.1.0.0")
-      adr = Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vm_host.id)
+    # The switched /29 members carry the segment's gateway. Its router is
+    # attached to the segment and ARPs for them, so the host claims each one in
+    # netplan and no VM may take it. The routed block, which Leaseweb sends to
+    # the main IP unasked, is what VMs draw from.
+    it "claims the leaseweb switched segment on the host and keeps it out of the vm pool" do
+      allow(Config).to receive_messages(
+        leaseweb_connection_string: "https://api.leaseweb.com",
+        leaseweb_api_key: "key123",
+      )
+      HostProvider.create do
+        it.id = vm_host.id
+        it.server_identifier = "91478"
+        it.provider_name = HostProvider::LEASEWEB_PROVIDER_NAME
+      end
+      vm_host.sshable.update(host: "23.105.171.112")
+      rows = leaseweb_91478_ip_rows
+      Excon.stub({path: "/bareMetals/v2/servers/91478/ips", query: {limit: 50, offset: 0}},
+        {status: 200, body: JSON.generate(ips: rows.take(50), _metadata: {totalCount: rows.length})})
+      Excon.stub({path: "/bareMetals/v2/servers/91478/ips", query: {limit: 50, offset: 50}},
+        {status: 200, body: JSON.generate(ips: rows.drop(50), _metadata: {totalCount: rows.length})})
 
-      vm_host2 = create_vm_host
-      vm_host2.sshable.update(host: "1.1.1.1")
-      ip_records = [Hosting::HetznerApis::IpInfo.new(ip_address: "1.1.1.0/30", source_host_ip: "1.1.1.1", is_failover: true)]
+      ip_records = vm_host.provider.api.pull_ips
+      vm_host.create_addresses(ip_records:)
+      netplan = Hosting::LeasewebNetplan.new(public_interface: "eno0", internal_interface: nil, internal_ip: nil, ip_infos: ip_records,
+        nameservers: ["23.19.53.53", "23.19.52.52"], search_domains: ["dedi.leaseweb.net"])
 
-      vm = create_vm
-      AssignedVmAddress.create(address_id: adr.id, dst_vm_id: vm.id, ip: "1.1.1.1/32")
+      expect(netplan.interface_addresses).to eq(
+        "eno0" => [
+          "23.105.171.112/32",
+          "23.105.176.1/32",
+          "23.105.176.2/32",
+          "23.105.176.3/32",
+          "216.22.15.64/26",
+          "2607:f5b7:1:30:9::2/112",
+        ],
+      )
+      # The claim set is exactly the main IP and the segment members; the
+      # routed block and the delegated prefix belong to VMs, not the host.
+      expect(vm_host.assigned_host_addresses_dataset.select_order_map(:ip).map(&:to_s)).to eq [
+        "23.105.171.112/32",
+        "23.105.176.1/32",
+        "23.105.176.2/32",
+        "23.105.176.3/32",
+      ]
+      # Every IPv4 netplan configures is held back from the VM pool, and from the
+      # nftables set SetupNftables drops traffic to until a VM claims an address.
+      # Only the routed block reaches either, so the same rows drive all three
+      # consumers coherently.
+      expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq((65..126).map { "216.22.15.#{it}" })
 
-      expect {
-        vm_host2.create_addresses(ip_records:)
-      }.to raise_error RuntimeError, "BUG: failover ip 1.1.1.0/30 is already assigned to a vm"
+      sn = Prog::SetupNftables.new(Strand.new(stack: [{"subject_id" => vm_host.id}], prog: "SetupNftables"))
+      expect(sn.sshable).to receive(:_cmd).with("sudo host/bin/setup-nftables.rb \\[\\\"216.22.15.64/26\\\"\\]")
+      expect { sn.start }.to exit({"msg" => "nftables was setup"})
     end
   end
 

--- a/spec/prog/learn_network_spec.rb
+++ b/spec/prog/learn_network_spec.rb
@@ -40,9 +40,18 @@ JSON
     let(:vm_host) { Prog::Vm::HostNexus.assemble("::1").subject }
     let(:ln) { described_class.new(Strand.new(stack: [{"subject_id" => vm_host.id}])) }
 
+    it "learns the ip6 address directly on a host that configures itself" do
+      expect { ln.start }.to hop("learn_ip6")
+    end
+  end
+
+  describe "#learn_ip6" do
+    let(:vm_host) { Prog::Vm::HostNexus.assemble("::1").subject }
+    let(:ln) { described_class.new(Strand.new(stack: [{"subject_id" => vm_host.id}])) }
+
     it "exits, saving the ip6 address" do
       expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j -6 addr show scope global").and_return(ip6_interface_output)
-      expect { ln.start }.to exit({"msg" => "learned network information"})
+      expect { ln.learn_ip6 }.to exit({"msg" => "learned network information"})
       vm_host.reload
       expect(vm_host.ip6.to_s).to eq("2a01:4f8:173:1ed3::2")
       expect(vm_host.net6.to_s).to eq("2a01:4f8:173:1ed3::/64")
@@ -50,7 +59,34 @@ JSON
 
     it "pops if there is no global unique address prefix provided" do
       expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j -6 addr show scope global").and_return("[]")
-      expect { ln.start }.to exit({"msg" => "learned network information"})
+      expect { ln.learn_ip6 }.to exit({"msg" => "learned network information"})
+    end
+  end
+
+  describe "leaseweb" do
+    let(:vm_host) do
+      vmh = create_vm_host
+      HostProvider.create do
+        it.id = vmh.id
+        it.server_identifier = "123"
+        it.provider_name = HostProvider::LEASEWEB_PROVIDER_NAME
+      end
+      vmh
+    end
+
+    let(:ln) do
+      described_class.new(Strand.create_with_id(Strand.generate_uuid,
+        prog: "LearnNetwork", label: "start", stack: [{"subject_id" => vm_host.id}]))
+    end
+
+    it "configures networking before learning, under a deadline" do
+      expect { ln.start }.to hop("start", "Leaseweb::SetupNetworking")
+      expect(ln.strand.stack.first["deadline_target"]).to eq("learn_ip6")
+    end
+
+    it "learns the ip6 once networking is configured" do
+      ln.strand.retval = {"msg" => "leaseweb networking configured"}
+      expect { ln.start }.to hop("learn_ip6")
     end
   end
 

--- a/spec/prog/leaseweb/setup_networking_spec.rb
+++ b/spec/prog/leaseweb/setup_networking_spec.rb
@@ -1,0 +1,299 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Leaseweb::SetupNetworking do
+  let(:vm_host) do
+    vmh = create_vm_host
+    vmh.sshable.update(host: "216.22.50.197")
+    HostProvider.create do
+      it.id = vmh.id
+      it.server_identifier = "123"
+      it.provider_name = HostProvider::LEASEWEB_PROVIDER_NAME
+    end
+    vmh
+  end
+
+  let(:ln) { described_class.new(Strand.new(stack: [{"subject_id" => vm_host.id}])) }
+
+  let(:resolv_conf_output) { "nameserver 23.19.53.53\nnameserver 23.19.52.52\nsearch dedi.leaseweb.net\n" }
+
+  let(:link_output) do
+    JSON.generate([
+      {ifindex: 2, ifname: "ens3f0np0", address: "8c:84:74:54:ea:d0"},
+      {ifindex: 3, ifname: "ens3f1np1", address: "8c:84:74:54:ea:d1"},
+    ])
+  end
+
+  let(:addr_output) do
+    JSON.generate([{
+      ifname: "ens3f0np0",
+      addr_info: [
+        {local: "216.22.50.197", prefixlen: 32},
+        {local: "216.22.15.64", prefixlen: 26},
+        {local: "2604:9a00:2100:a020:4::2", prefixlen: 112},
+        {local: "2607:f5b7:3:104::1", prefixlen: 64},
+      ],
+    }])
+  end
+
+  # What the kernel holds in the beat between `netplan apply` returning and the
+  # rest of the addresses landing.
+  let(:unsettled_addr_output) do
+    JSON.generate([{ifname: "ens3f0np0", addr_info: [{local: "216.22.50.197", prefixlen: 32}]}])
+  end
+
+  # The addresses and gateways setup hands verify through the frame: netplan
+  # host offsets, not the /112 and /64 prefixes the API and Address rows carry.
+  let(:expected_addresses) do
+    ["216.22.50.197/32", "216.22.15.64/26", "2604:9a00:2100:a020:4::2/112", "2607:f5b7:3:104::1/64"]
+  end
+  let(:expected_gateways) { ["216.22.50.254", "2604:9a00:2100:a020::1"] }
+
+  # Server 12493302 reports an internal MAC but no private network behind it,
+  # and a null internal.ip.
+  let(:private_networks) { [] }
+  let(:internal_nic) { {mac: "8C:84:74:54:EA:D1"} }
+
+  before do
+    allow(Config).to receive_messages(
+      leaseweb_connection_string: "https://api.leaseweb.com",
+      leaseweb_api_key: "key123",
+    )
+
+    Excon.stub({path: "/bareMetals/v2/servers/123", method: :get},
+      {status: 200, body: JSON.generate(networkInterfaces: {public: {mac: "8C:84:74:54:EA:D0"}, internal: internal_nic},
+        isPrivateNetworkEnabled: private_networks.any?, privateNetworks: private_networks)})
+
+    block = (64..127).map do
+      {ip: "216.22.15.#{it}/26", prefixLength: 26, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: false, gateway: ""}
+    end
+    rows = [
+      *block,
+      {ip: "216.22.50.197/26", prefixLength: 26, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: true, gateway: "216.22.50.254"},
+      {ip: "2604:9a00:2100:a020:4::_112/64", prefixLength: 64, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: false, gateway: "2604:9a00:2100:a020::1"},
+      {ip: "2607:f5b7:3:104::_64/64", prefixLength: 64, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: false, gateway: ""},
+    ]
+    Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
+      {status: 200, body: JSON.generate(ips: rows.take(50), _metadata: {totalCount: rows.length})})
+    Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 50}},
+      {status: 200, body: JSON.generate(ips: rows.drop(50), _metadata: {totalCount: rows.length})})
+  end
+
+  describe "#start" do
+    it "records an address for every ip in one snapshot, then hops to verify" do
+      expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j link").and_return(link_output)
+      expect(ln.sshable).to receive(:_cmd).with("cat /run/systemd/resolve/resolv.conf").and_return(resolv_conf_output)
+      expect(ln.sshable).to receive(:_cmd).with(a_string_starting_with("sudo host/bin/setup-leaseweb-networking")).and_return("")
+
+      expect {
+        expect { ln.start }.to hop("verify")
+      }.to change { vm_host.assigned_subnets_dataset.count }.from(0).to(4)
+
+      expect(ln.expected_addresses).to eq("ens3f0np0" => expected_addresses)
+      expect(ln.expected_gateways).to eq expected_gateways
+      expect(ln.expected_internal_interface).to be_nil
+    end
+
+    it "skips the addresses assemble already recorded from the same snapshot" do
+      vm_host.create_addresses
+
+      expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j link").and_return(link_output)
+      expect(ln.sshable).to receive(:_cmd).with("cat /run/systemd/resolve/resolv.conf").and_return(resolv_conf_output)
+      expect(ln.sshable).to receive(:_cmd).with(a_string_starting_with("sudo host/bin/setup-leaseweb-networking")).and_return("")
+
+      expect {
+        expect { ln.start }.to hop("verify")
+      }.not_to change { vm_host.assigned_subnets_dataset.count }.from(4)
+    end
+
+    it "sends the netplan the generator produced" do
+      expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j link").and_return(link_output)
+      expect(ln.sshable).to receive(:_cmd).with("cat /run/systemd/resolve/resolv.conf").and_return(resolv_conf_output)
+      expect(ln.sshable).to receive(:_cmd).with(a_string_starting_with("sudo host/bin/setup-leaseweb-networking")) do |command|
+        netplan = YAML.safe_load(Shellwords.split(command).last)
+        expect(netplan.dig("network", "ethernets", "ens3f0np0", "addresses")).to eq expected_addresses
+        expect(netplan.dig("network", "ethernets", "ens3f0np0", "nameservers")).to eq("search" => ["dedi.leaseweb.net"], "addresses" => ["23.19.53.53", "23.19.52.52"])
+        expect(netplan.dig("network", "ethernets")).not_to include "ens3f1np1"
+        ""
+      end
+
+      expect { ln.start }.to hop("verify")
+    end
+
+    context "when the server has a private network" do
+      # Server 91478's private network and internal NIC, as the API reports them.
+      let(:private_networks) do
+        [{id: "24197", linkSpeed: 1000, status: "CONFIGURED", dhcp: "ENABLED", subnet: "10.31.2.0/27", vlanId: "2033"}]
+      end
+      let(:internal_nic) { {mac: "8C:84:74:54:EA:D1", ip: "10.31.2.19/27"} }
+
+      it "addresses the internal interface statically and adds it to the state it verifies" do
+        expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j link").and_return(link_output)
+        expect(ln.sshable).to receive(:_cmd).with("cat /run/systemd/resolve/resolv.conf").and_return(resolv_conf_output)
+        expect(ln.sshable).to receive(:_cmd).with(a_string_starting_with("sudo host/bin/setup-leaseweb-networking")) do |command|
+          netplan = YAML.safe_load(Shellwords.split(command).last)
+          expect(netplan.dig("network", "ethernets", "ens3f1np1")).to eq(
+            "addresses" => ["10.31.2.19/27"], "mtu" => 9000, "optional" => true,
+          )
+          ""
+        end
+
+        expect { ln.start }.to hop("verify")
+        expect(ln.expected_addresses).to eq("ens3f0np0" => expected_addresses, "ens3f1np1" => ["10.31.2.19/27"])
+        expect(ln.expected_internal_interface).to eq("ens3f1np1")
+      end
+
+      it "fails when no interface carries the internal mac" do
+        expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j link")
+          .and_return(JSON.generate([{ifindex: 2, ifname: "ens3f0np0", address: "8c:84:74:54:ea:d0"}]))
+
+        expect { ln.start }.to raise_error RuntimeError,
+          "no interface with leaseweb internal mac 8c:84:74:54:ea:d1"
+      end
+    end
+
+    it "fails when no interface carries the public mac" do
+      expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j link")
+        .and_return(JSON.generate([{ifindex: 2, ifname: "eno1", address: "aa:bb:cc:dd:ee:ff"}]))
+
+      expect { ln.start }.to raise_error RuntimeError,
+        "no interface with leaseweb public mac 8c:84:74:54:ea:d0"
+    end
+
+    it "fails when the host reports no upstream resolvers" do
+      expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j link").and_return(link_output)
+      expect(ln.sshable).to receive(:_cmd).with("cat /run/systemd/resolve/resolv.conf").and_return("# operation timed out\n")
+      expect { ln.start }.to raise_error RuntimeError, "no upstream resolvers on the host"
+    end
+  end
+
+  describe "#verify" do
+    let(:ln) do
+      described_class.new(Strand.new(stack: [{
+        "subject_id" => vm_host.id,
+        "expected_addresses" => {"ens3f0np0" => expected_addresses},
+        "expected_gateways" => expected_gateways,
+      }]))
+    end
+
+    it "pings each gateway and refreshes nftables once the host holds every address" do
+      expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j addr").and_return(addr_output)
+      expect(ln.sshable).to receive(:_cmd).with("sudo ping -c 2 -W 5 216.22.50.254").and_return("")
+      expect(ln.sshable).to receive(:_cmd).with("sudo ping6 -c 2 -W 5 2604:9a00:2100:a020::1").and_return("")
+
+      expect { ln.verify }.to hop("refresh_nftables")
+    end
+
+    it "naps while the kernel has not taken every address" do
+      expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j addr").and_return(unsettled_addr_output)
+
+      expect { ln.verify }.to nap(1)
+    end
+
+    it "naps when a public address landed on the wrong interface" do
+      # Placement still matters for the public NIC under tolerate: a public block
+      # sitting on the internal NIC satisfies a global membership check but not
+      # the per-interface one, so the host has not converged even though every
+      # address is present somewhere.
+      ln = described_class.new(Strand.new(stack: [{
+        "subject_id" => vm_host.id,
+        "expected_addresses" => {"ens3f0np0" => expected_addresses, "ens3f1np1" => ["10.31.2.19/27"]},
+        "expected_gateways" => expected_gateways,
+        "expected_internal_interface" => "ens3f1np1",
+      }]))
+      misplaced = JSON.generate([{
+        ifname: "ens3f0np0",
+        addr_info: [
+          {local: "216.22.50.197", prefixlen: 32},
+          {local: "2604:9a00:2100:a020:4::2", prefixlen: 112},
+          {local: "2607:f5b7:3:104::1", prefixlen: 64},
+        ],
+      }, {ifname: "ens3f1np1", addr_info: [
+        {local: "216.22.15.64", prefixlen: 26},
+        {local: "10.31.2.19", prefixlen: 27},
+      ]}])
+      expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j addr").and_return(misplaced)
+
+      expect { ln.verify }.to nap(1)
+    end
+
+    context "when the server has a private network" do
+      let(:ln) do
+        described_class.new(Strand.new(stack: [{
+          "subject_id" => vm_host.id,
+          "expected_addresses" => {"ens3f0np0" => expected_addresses, "ens3f1np1" => ["10.31.2.19/27"]},
+          "expected_gateways" => expected_gateways,
+          "expected_internal_interface" => "ens3f1np1",
+        }]))
+      end
+
+      let(:public_link) do
+        {ifname: "ens3f0np0", addr_info: [
+          {local: "216.22.50.197", prefixlen: 32},
+          {local: "216.22.15.64", prefixlen: 26},
+          {local: "2604:9a00:2100:a020:4::2", prefixlen: 112},
+          {local: "2607:f5b7:3:104::1", prefixlen: 64},
+        ]}
+      end
+
+      # The public path is converged in every case below, so verify hops
+      # regardless of the internal port: it is tolerated, only recorded.
+      before do
+        expect(ln.sshable).to receive(:_cmd).with("sudo ping -c 2 -W 5 216.22.50.254").and_return("")
+        expect(ln.sshable).to receive(:_cmd).with("sudo ping6 -c 2 -W 5 2604:9a00:2100:a020::1").and_return("")
+      end
+
+      it "records the internal port up when it has carrier" do
+        addr = JSON.generate([public_link,
+          {ifname: "ens3f1np1", operstate: "UP", flags: ["BROADCAST", "MULTICAST", "UP", "LOWER_UP"],
+           addr_info: [{local: "10.31.2.19", prefixlen: 27}]}])
+        expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j addr").and_return(addr)
+        expect(Clog).to receive(:emit).with("leaseweb internal port state",
+          {leaseweb_internal_port: {ifname: "ens3f1np1", operstate: "UP", carrier: true}}).and_call_original
+
+        expect { ln.verify }.to hop("refresh_nftables")
+      end
+
+      it "tolerates a private port that came up, took its address, then dropped" do
+        # The static /27 survives carrier loss, so presence alone would read a
+        # dead port green. Record the drop, hop anyway; the port is optional.
+        addr = JSON.generate([public_link,
+          {ifname: "ens3f1np1", operstate: "DOWN", flags: ["BROADCAST", "MULTICAST"],
+           addr_info: [{local: "10.31.2.19", prefixlen: 27}]}])
+        expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j addr").and_return(addr)
+        expect(Clog).to receive(:emit).with("leaseweb internal port state",
+          {leaseweb_internal_port: {ifname: "ens3f1np1", operstate: "DOWN", carrier: false}}).and_call_original
+
+        expect { ln.verify }.to hop("refresh_nftables")
+      end
+
+      it "tolerates a private port whose link never came up" do
+        # No carrier means networkd never installed the /27, so the interface is
+        # absent from `ip -j addr`; the tolerate policy hops on the public path.
+        addr = JSON.generate([public_link])
+        expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j addr").and_return(addr)
+        expect(Clog).to receive(:emit).with("leaseweb internal port state",
+          {leaseweb_internal_port: {ifname: "ens3f1np1", operstate: nil, carrier: false}}).and_call_original
+
+        expect { ln.verify }.to hop("refresh_nftables")
+      end
+    end
+  end
+
+  describe "#refresh_nftables" do
+    let(:ln) do
+      described_class.new(Strand.create_with_id(Strand.generate_uuid,
+        prog: "Leaseweb::SetupNetworking", label: "refresh_nftables", stack: [{"subject_id" => vm_host.id}]))
+    end
+
+    it "reruns nftables against the final address set" do
+      expect { ln.refresh_nftables }.to hop("start", "SetupNftables")
+    end
+
+    it "pops once nftables was rewritten" do
+      ln.strand.retval = {"msg" => "nftables was setup"}
+      expect { ln.refresh_nftables }.to exit({"msg" => "leaseweb networking configured"})
+    end
+  end
+end

--- a/spec/prog/setup_nftables_spec.rb
+++ b/spec/prog/setup_nftables_spec.rb
@@ -18,5 +18,18 @@ RSpec.describe Prog::SetupNftables do
 
       expect { sn.start }.to exit({"msg" => "nftables was setup"})
     end
+
+    # A Leaseweb switched segment member is claimed by the host itself and no
+    # VM can take it, so nothing would ever add it to the allowed set and a
+    # block would strand it. The claim is its assigned_host_address row.
+    it "never blocks an address the host claims" do
+      claimed = Address.create(cidr: "23.105.176.1/32", routed_to_host_id: vmh.id)
+      AssignedHostAddress.create(host_id: vmh.id, ip: "23.105.176.1", address_id: claimed.id)
+      Address.create(cidr: "123.123.123.0/24", routed_to_host_id: vmh.id)
+
+      expect(sn.sshable).to receive(:_cmd).with("sudo host/bin/setup-nftables.rb \\[\\\"123.123.123.0/24\\\"\\]")
+
+      expect { sn.start }.to exit({"msg" => "nftables was setup"})
+    end
   end
 end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Prog::Vm::HostNexus do
   let(:st) { described_class.assemble("192.168.0.1") }
   let(:hetzner_ips) {
     [
-      ["127.0.0.1", "127.0.0.1", false],
-      ["30.30.30.32/29", "127.0.0.1", true],
-      ["2a01:4f8:10a:128b::/64", "127.0.0.1", true],
+      ["127.0.0.1/32", "127.0.0.1"],
+      ["30.30.30.32/29", "127.0.0.1"],
+      ["2a01:4f8:10a:128b::/64", "127.0.0.1"],
     ].map {
-      Hosting::HetznerApis::IpInfo.new(ip_address: _1, source_host_ip: _2, is_failover: _3)
+      Hosting::HetznerApis::IpInfo.new(ip_address: _1, source_host_ip: _2)
     }
   }
 
@@ -58,6 +58,33 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(st.subject.assigned_host_addresses.first.ip.to_s).to eq("127.0.0.1/32")
       expect(st.subject.provider_name).to eq(HostProvider::HETZNER_PROVIDER_NAME)
       expect(st.subject.data_center).to eq("fsn1-dc14")
+    end
+
+    it "creates addresses from the leaseweb api" do
+      allow(Config).to receive_messages(
+        leaseweb_connection_string: "https://api.leaseweb.com",
+        leaseweb_api_key: "key123",
+      )
+      rows = [
+        {ip: "216.22.50.197/26", prefixLength: 26, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: true, gateway: "216.22.50.254"},
+        {ip: "216.22.15.64/26", prefixLength: 26, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: false, gateway: ""},
+        {ip: "216.22.15.65/26", prefixLength: 26, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: false, gateway: ""},
+        {ip: "2607:f5b7:3:104::_64/64", prefixLength: 64, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: false, gateway: ""},
+      ]
+      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
+        {status: 200, body: JSON.generate(ips: rows, _metadata: {totalCount: rows.length})})
+      Excon.stub({path: "/bareMetals/v2/servers/123", method: :get},
+        {status: 200, body: JSON.generate(location: {site: "AMS-01", suite: "8", rack: "9200"})})
+      Excon.stub({path: "/bareMetals/v2/servers/123", method: :put}, {status: 204})
+
+      st = described_class.assemble("216.22.50.197", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "123")
+      expect(st.subject.provider_name).to eq(HostProvider::LEASEWEB_PROVIDER_NAME)
+      expect(st.subject.data_center).to eq("AMS-01-8-9200")
+      expect(st.subject.assigned_subnets.map { it.cidr.to_s }.sort).to eq(["216.22.15.64/26", "216.22.50.197/32", "2607:f5b7:3:104::/64"])
+      # Only the gatewayed main IP is claimed; the routed block and prefix are VM space.
+      expect(st.subject.assigned_host_addresses.map { it.ip.to_s }).to eq ["216.22.50.197/32"]
+      # The block's network and broadcast addresses stay out of the VM pool.
+      expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq((65..126).map { "216.22.15.#{it}" })
     end
 
     it "does not set the server name in development" do

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Scheduling::Allocator do
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
       StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       SpdkInstallation.create_with_id(vmh, vm_host_id: vmh.id, version: "v1", allocation_weight: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id).populate_ipv4_addresses
 
       described_class.allocate(vm, storage_volumes)
       expect(vm.reload.vm_host_id).to eq(vmh.id)
@@ -102,7 +102,7 @@ RSpec.describe Scheduling::Allocator do
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
       StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       SpdkInstallation.create_with_id(vmh, vm_host_id: vmh.id, version: "v1", allocation_weight: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id).populate_ipv4_addresses
 
       described_class.allocate(vm, storage_volumes, family_filter: ["premium", "standard"])
       expect(vm.reload.vm_host_id).to eq(vmh.id)
@@ -152,11 +152,11 @@ RSpec.describe Scheduling::Allocator do
       StorageDevice.create(vm_host_id: vmh4.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh5.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100, enabled: false)
 
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
-      Address.create(cidr: "3.1.1.0/30", routed_to_host_id: vmh3.id)
-      Address.create(cidr: "4.1.1.0/30", routed_to_host_id: vmh4.id)
-      Address.create(cidr: "5.1.1.0/30", routed_to_host_id: vmh5.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id).populate_ipv4_addresses
+      Address.create(cidr: "3.1.1.0/30", routed_to_host_id: vmh3.id).populate_ipv4_addresses
+      Address.create(cidr: "4.1.1.0/30", routed_to_host_id: vmh4.id).populate_ipv4_addresses
+      Address.create(cidr: "5.1.1.0/30", routed_to_host_id: vmh5.id).populate_ipv4_addresses
 
       expect(Clog).to receive(:emit).twice.with("Allocator query for vm", instance_of(Hash)) do |_, b|
         expect(b[:allocator_query][:counts]).to eq [[:base, 3], [:space, 1], [:boot_image, 0]]
@@ -171,7 +171,7 @@ RSpec.describe Scheduling::Allocator do
 
     it "retrieves correct values" do
       vmh = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id).populate_ipv4_addresses
       sd1 = StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 123, total_storage_gib: 345)
       sd2 = StorageDevice.create(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 12, total_storage_gib: 99)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
@@ -202,7 +202,7 @@ RSpec.describe Scheduling::Allocator do
     it "does not filter out storage devices with >= threshold available for a small request" do
       large = Config.allocator_large_storage_device_gib
       vmh = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id).populate_ipv4_addresses
       StorageDevice.create(vm_host_id: vmh.id, name: "big", available_storage_gib: large, total_storage_gib: large)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
       req.location_filter = [Location::HETZNER_FSN1_ID]
@@ -212,7 +212,7 @@ RSpec.describe Scheduling::Allocator do
 
     it "retrieves provisioning count" do
       vmh = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id).populate_ipv4_addresses
       sd1 = StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 123, total_storage_gib: 345)
       create_vm(vm_host_id: vmh.id, location_id: vmh.location_id, boot_image: "", display_state: "creating")
       create_vm(vm_host_id: vmh.id, location_id: vmh.location_id, boot_image: "ubuntu-jammy", display_state: "creating")
@@ -249,8 +249,8 @@ RSpec.describe Scheduling::Allocator do
       vmh2 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id).populate_ipv4_addresses
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
@@ -266,8 +266,8 @@ RSpec.describe Scheduling::Allocator do
       vmh2 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id).populate_ipv4_addresses
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
@@ -283,8 +283,8 @@ RSpec.describe Scheduling::Allocator do
       vmh2 = create_vm_host(data_center: "dc2", total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id).populate_ipv4_addresses
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
@@ -300,8 +300,8 @@ RSpec.describe Scheduling::Allocator do
       vmh2 = create_vm_host(location_id: "6b9ef786-b842-8420-8c65-c25e3d4bdf3d", total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id).populate_ipv4_addresses
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
@@ -317,8 +317,8 @@ RSpec.describe Scheduling::Allocator do
       vmh2 = create_vm_host(family: "standard", total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id).populate_ipv4_addresses
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
@@ -334,8 +334,8 @@ RSpec.describe Scheduling::Allocator do
       vmh2 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id).populate_ipv4_addresses
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
       create_vhost_block_backend(version: "v0.4.0", vm_host_id: vmh1.id, allocation_weight: 100)
@@ -352,7 +352,7 @@ RSpec.describe Scheduling::Allocator do
     it "excludes hosts with zero-weight vhost block backend even if version matches" do
       vmh1 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
       create_vhost_block_backend(version: "v0.4.0", vm_host_id: vmh1.id, allocation_weight: 0)
 
@@ -365,7 +365,7 @@ RSpec.describe Scheduling::Allocator do
     it "does not filter by vhost block backend version when not requested" do
       vmh1 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
 
       cand = Al::Allocation.candidate_hosts(req)
@@ -379,8 +379,8 @@ RSpec.describe Scheduling::Allocator do
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor2", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id).populate_ipv4_addresses
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
@@ -395,8 +395,8 @@ RSpec.describe Scheduling::Allocator do
       vmh2 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      address = Address.create(cidr: "2.1.1.0/32", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
+      address = Address.create(cidr: "2.1.1.0/32", routed_to_host_id: vmh2.id).tap(&:populate_ipv4_addresses)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
@@ -416,8 +416,8 @@ RSpec.describe Scheduling::Allocator do
       vmh2 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      Address.create(cidr: "2.1.1.0/32", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
+      Address.create(cidr: "2.1.1.0/32", routed_to_host_id: vmh2.id).populate_ipv4_addresses
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh1.id, activated_at: Time.now, size_gib: 3)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh2.id, activated_at: Time.now, size_gib: 3)
 
@@ -441,8 +441,8 @@ RSpec.describe Scheduling::Allocator do
       vmh2 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id).populate_ipv4_addresses
       PciDevice.create(vm_host_id: vmh2.id, slot: "01:00.0", device_class: "0300", vendor: "vd", device: "dv1", numa_node: 0, iommu_group: 3)
       PciDevice.create(vm_host_id: vmh2.id, slot: "02:00.0", device_class: "0300", vendor: "vd", device: "dv2", numa_node: 0, iommu_group: 9)
       PciDevice.create(vm_host_id: vmh2.id, slot: "03:00.0", device_class: "1234", vendor: "vd", device: "dv3", numa_node: 0, iommu_group: 11)
@@ -464,8 +464,8 @@ RSpec.describe Scheduling::Allocator do
       vmh2 = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh1.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh1.id).populate_ipv4_addresses
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh2.id).populate_ipv4_addresses
       PciDevice.create(vm_host_id: vmh2.id, slot: "01:00.0", device_class: "0300", vendor: "vd", device: "dv1", numa_node: 0, iommu_group: 3)
       PciDevice.create(vm_host_id: vmh2.id, slot: "02:00.0", device_class: "0300", vendor: "vd", device: "dv2", numa_node: 0, iommu_group: 9)
       PciDevice.create(vm_host_id: vmh2.id, slot: "03:00.0", device_class: "1234", vendor: "vd", device: "dv3", numa_node: 0, iommu_group: 11)
@@ -486,7 +486,7 @@ RSpec.describe Scheduling::Allocator do
       loc = Location.first(provider: "ubicloud")
       vmh = create_vm_host(location_id: loc.id, total_cpus: 14, total_cores: 7, used_cores: 4, total_hugepages_1g: 10, used_hugepages_1g: 2)
       StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id).populate_ipv4_addresses
       PciDevice.create(vm_host_id: vmh.id, slot: "01:00.0", device_class: "0300", vendor: "vd", device: "dv1", numa_node: 0, iommu_group: 3)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
       req.location_filter = [loc.id]
@@ -792,7 +792,7 @@ RSpec.describe Scheduling::Allocator do
       StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)
       SpdkInstallation.create_with_id(vmh, vm_host_id: vmh.id, version: "v1", allocation_weight: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id).populate_ipv4_addresses
     end
 
     it "updates resources" do
@@ -1191,7 +1191,7 @@ RSpec.describe Scheduling::Allocator do
       StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)
       SpdkInstallation.create_with_id(vmh, vm_host_id: vmh.id, version: "v1", allocation_weight: 100)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh.id)
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh.id).populate_ipv4_addresses
       (0..8).each do |i|
         VmHostCpu.create(vm_host_id: vmh.id, cpu_number: i, spdk: i < 1)
       end
@@ -1241,7 +1241,7 @@ RSpec.describe Scheduling::Allocator do
       StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)
       SpdkInstallation.create_with_id(vmh, vm_host_id: vmh.id, version: "v1", allocation_weight: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id).populate_ipv4_addresses
       (0..16).each do |i|
         VmHostCpu.create(vm_host_id: vmh.id, cpu_number: i, spdk: i < 2)
       end
@@ -1309,7 +1309,7 @@ RSpec.describe Scheduling::Allocator do
       StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)
       SpdkInstallation.create_with_id(vmh, vm_host_id: vmh.id, version: "v1", allocation_weight: 100)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id).populate_ipv4_addresses
       (0..16).each do |i|
         VmHostCpu.create(vm_host_id: vmh.id, cpu_number: i, spdk: i < 2)
       end
@@ -1479,7 +1479,7 @@ RSpec.describe Scheduling::Allocator do
       StorageDevice.create(vm_host_id: vh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vh2.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)
       SpdkInstallation.create_with_id(vh2, vm_host_id: vh2.id, version: "v1", allocation_weight: 100)
-      Address.create(cidr: "1.1.2.0/30", routed_to_host_id: vh2.id)
+      Address.create(cidr: "1.1.2.0/30", routed_to_host_id: vh2.id).populate_ipv4_addresses
       PciDevice.create(vm_host_id: vh2.id, slot: "01:00.0", device_class: "0300", vendor: "vd", device: "dv1", numa_node: 0, iommu_group: 3)
       PciDevice.create(vm_host_id: vh2.id, slot: "01:00.1", device_class: "0420", vendor: "vd", device: "dv2", numa_node: 0, iommu_group: 3)
       vh2.update(used_cores: 4, used_hugepages_1g: 26)
@@ -1528,7 +1528,7 @@ RSpec.describe Scheduling::Allocator do
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)
       SpdkInstallation.create_with_id(vmh2, vm_host_id: vmh2.id, version: "v1", allocation_weight: 100)
-      Address.create(cidr: "1.2.1.0/30", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.2.1.0/30", routed_to_host_id: vmh2.id).populate_ipv4_addresses
       (0..16).each do |i|
         VmHostCpu.create(vm_host_id: vmh2.id, cpu_number: i, spdk: i < 2)
       end
@@ -1554,7 +1554,7 @@ RSpec.describe Scheduling::Allocator do
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh2.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)
       SpdkInstallation.create_with_id(vmh2, vm_host_id: vmh2.id, version: "v1", allocation_weight: 100)
-      Address.create(cidr: "1.2.1.0/30", routed_to_host_id: vmh2.id)
+      Address.create(cidr: "1.2.1.0/30", routed_to_host_id: vmh2.id).populate_ipv4_addresses
       PciDevice.create(vm_host_id: vmh2.id, slot: "01:00.0", device_class: "0300", vendor: "vd", device: "dv1", numa_node: 0, iommu_group: 3)
       PciDevice.create(vm_host_id: vmh2.id, slot: "01:00.1", device_class: "0420", vendor: "vd", device: "dv2", numa_node: 0, iommu_group: 3)
       (0..16).each do |i|
@@ -1573,7 +1573,7 @@ RSpec.describe Scheduling::Allocator do
       StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
       StorageDevice.create(vm_host_id: vmh.id, name: "stor2", available_storage_gib: 90, total_storage_gib: 90)
       SpdkInstallation.create_with_id(vmh, vm_host_id: vmh.id, version: "v1", allocation_weight: 100)
-      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh.id)
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: vmh.id).populate_ipv4_addresses
       (0..12).each do |i|
         VmHostCpu.create(vm_host_id: vmh.id, cpu_number: i, spdk: i < 1)
       end


### PR DESCRIPTION
## Summary
Automates Leaseweb bare-metal host networking end to end, mirroring the Hetzner integration's shape (API client + control-plane addresses) plus the on-host netplan configuration Leaseweb requires. Five commits:

1. **Pull leaseweb host addresses and NIC macs from the API** — `Hosting::LeasewebApis` gains `pull_ips`/`get_main_ip4`/`pull_network_interfaces` (pagination to a short page, dup/gatewayless guards, IPv6 `_NNN` normalization); carries the `address.host_only` migration + schema cache.
2. **Generate the leaseweb netplan from control plane data** — `Hosting::LeasewebNetplan` renders the full desired-state `01-netcfg.yaml` (interfaces keyed by MAC, internal NIC gated on a real private network and static+optional, RA refused, reference-config quirks deliberately dropped); reproduces server 12493302's hand-written config from its real API data in a spec.
3. **Create leaseweb host addresses from the API on assemble** — `create_addresses` stores `host_only`, prunes deprovisioned blocks, and keeps host-claimed addresses out of the VM pool and out of SetupNftables.
4. **Install the leaseweb netplan on the host** — rhizome `LeasewebNetworkingSetup` validates in a scratch root, lands the config with one atomic rename (never leaving the host without a netplan), and preserves the original under `.ubicloud-orig`.
5. **Configure leaseweb host networking before learning it** — `LearnNetwork` pulls once, reconciles addresses and builds netplan from the same snapshot, then verifies per-interface convergence under a deadline; tolerates a down internal port.

## Validation
- Per-commit `coverage_pspec` exit 0 at 100% line + 100% branch; rhizome suite 100%; rubocop clean.
- Netplan generator reproduces the 12493302 reference; the generated config was live-validated on server 91478 (host restored byte-identically afterward).

## Merge order
Independent of the two split-out fixes, but **please merge `fix-safe-write-to-file-stale-temp` first** — commit 4 here adds a `perm:` keyword to `rhizome/common/lib/util.rb`; that PR fixes an unrelated stale-temp bug in the same file, and rebasing this branch onto it afterward is trivial.