### PR TITLE
Add Update Billing Info admin action for Project

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -512,6 +512,32 @@ class CloverAdmin < Roda
           obj.add_quota(quota_id:, value:)
         end
       end,
+      "update_billing_info" => object_action("Update Billing Info", flash: "Billing info updated", params: ->(obj) {
+        data = obj.billing_info&.stripe_data || {}
+        {
+          name: {typecast: :nonempty_str!, label: "Billing Name", value: data["name"]},
+          email: {typecast: :nonempty_str!, label: "Billing Email", value: data["email"]},
+          country: {
+            typecast: :nonempty_str!,
+            label: "Country",
+            type: "select",
+            add_blank: true,
+            options: ISO3166::Country.all.reject { Config.sanctioned_countries.include?(it.alpha2) }.sort_by(&:common_name).map { [it.common_name, it.alpha2] },
+            value: data["country"],
+          },
+          state: {typecast: :nonempty_str, label: "State", required: nil, value: data["state"]},
+          city: {typecast: :nonempty_str, label: "City", required: nil, value: data["city"]},
+          postal_code: {typecast: :nonempty_str, label: "Postal Code", required: nil, value: data["postal_code"]},
+          address: {typecast: :nonempty_str!, label: "Address", value: data["address"]},
+          tax_id: {typecast: :str, label: "Tax ID", required: nil, value: data["tax_id"]},
+          company_name: {typecast: :str, label: "Company Name", required: nil, value: data["company_name"]},
+          note: {typecast: :str, label: "Note", required: nil, value: data["note"]},
+        }
+      }) do |obj, name, email, country, state, city, postal_code, address, tax_id, company_name, note|
+        fail CloverError.new(400, "InvalidRequest", "Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing.") unless Config.stripe_secret_key
+
+        BillingInfo.update_or_create_stripe_customer(obj, name:, email:, country:, state:, city:, postal_code:, address:, tax_id:, company_name:, note:)
+      end,
     },
     "Strand" => {
       "subject" => object_action("Subject", type: :direct) do |obj|

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -469,6 +469,8 @@ class CloverAdmin < Roda
 
   MAX_PAGE_SNOOZE_MINUTES = 2 * 24 * 60
 
+  BILLING_COUNTRY_OPTIONS = ISO3166::Country.all.reject { Config.sanctioned_countries.include?(it.alpha2) }.sort_by!(&:common_name).map! { [it.common_name, it.alpha2].freeze }.freeze
+
   Object.new.instance_exec do
     def model(...)
       ObjectModelDSL.new(...)
@@ -717,6 +719,27 @@ class CloverAdmin < Roda
           elsif value
             obj.add_quota(quota_id:, value:)
           end
+        end
+      end
+
+      action "update_billing_info", "Update Billing Info" do
+        flash "Billing info updated"
+        allow_if { Config.stripe_secret_key }
+        stripe_value = lambda do |field|
+          ->(obj) { (obj.billing_info&.stripe_data || {})[field] }
+        end
+        param :name, typecast: :nonempty_str!, label: "Billing Name", value: stripe_value["name"]
+        param :email, typecast: :nonempty_str!, label: "Billing Email", value: stripe_value["email"]
+        param :country, typecast: :nonempty_str!, label: "Country", type: "select", add_blank: true, options: BILLING_COUNTRY_OPTIONS, value: stripe_value["country"]
+        param :state, typecast: :nonempty_str, label: "State", required: nil, value: stripe_value["state"]
+        param :city, typecast: :nonempty_str, label: "City", required: nil, value: stripe_value["city"]
+        param :postal_code, typecast: :nonempty_str, label: "Postal Code", required: nil, value: stripe_value["postal_code"]
+        param :address, typecast: :nonempty_str!, label: "Address", value: stripe_value["address"]
+        param :tax_id, typecast: :str, label: "Tax ID", required: nil, value: stripe_value["tax_id"]
+        param :company_name, typecast: :str, label: "Company Name", required: nil, value: stripe_value["company_name"]
+        param :note, typecast: :str, label: "Note", required: nil, value: stripe_value["note"]
+        run do |obj, name, email, country, state, city, postal_code, address, tax_id, company_name, note|
+          BillingInfo.update_or_create_stripe_customer(obj, name:, email:, country:, state:, city:, postal_code:, address:, tax_id:, company_name:, note:)
         end
       end
     end

--- a/helpers/model_hiding.rb
+++ b/helpers/model_hiding.rb
@@ -17,6 +17,7 @@ class Clover < Roda
         ::Account => [:[], :open_with_email, :generate_uuid],
         ::ActionTag => [:options_for_project],
         ::ApiKey => [:create_inference_api_key, :create_personal_access_token, :project_id_for_personal_access_token],
+        ::BillingInfo => [:update_or_create_stripe_customer],
         ::DiscountCode => [:first],
         ::FirewallRule => [:cidr_for_source_type, :protocol_and_range_for_port_type, :port_options, :source_options],
         ::GithubInstallation => [:with_github_installation_id],
@@ -40,7 +41,6 @@ class Clover < Roda
       ALLOWED_MODELS = [
         ::AccessControlEntry,
         ::ActionType,
-        ::BillingInfo,
         ::Firewall,
         ::GithubCacheEntry,
         ::GithubRunner,

--- a/helpers/model_hiding.rb
+++ b/helpers/model_hiding.rb
@@ -17,6 +17,7 @@ class Clover < Roda
         ::Account => [:[], :open_with_email, :generate_uuid],
         ::ActionTag => [:options_for_project],
         ::ApiKey => [:create_inference_api_key, :create_personal_access_token, :project_id_for_personal_access_token],
+        ::BillingInfo => [:update_or_create_stripe_customer],
         ::DiscountCode => [:first],
         ::FirewallRule => [:cidr_for_source_type, :protocol_and_range_for_port_type, :port_options, :source_options],
         ::GithubInstallation => [:with_github_installation_id],
@@ -41,7 +42,6 @@ class Clover < Roda
       ALLOWED_MODELS = [
         ::AccessControlEntry,
         ::ActionType,
-        ::BillingInfo,
         ::Firewall,
         ::GithubCacheEntry,
         ::GithubRunner,

--- a/model/billing_info.rb
+++ b/model/billing_info.rb
@@ -10,6 +10,39 @@ class BillingInfo < Sequel::Model
 
   plugin ResourceMethods
 
+  def self.update_or_create_stripe_customer(project, name:, email:, country:, state:, city:, postal_code:, address:, tax_id:, company_name:, note:)
+    tax_id = tax_id.to_s.gsub(/[^a-zA-Z0-9]/, "")
+    customer_params = {
+      name:,
+      email: email.strip,
+      address: {country:, state:, city:, postal_code:, line1: address, line2: nil},
+      metadata: {tax_id:, company_name:, note:},
+    }
+
+    if (billing_info = project.billing_info)
+      tax_id_changed = tax_id != billing_info.stripe_data["tax_id"].to_s
+      StripeClient.customers.update(billing_info.stripe_id, customer_params)
+    else
+      tax_id_changed = !tax_id.empty?
+      customer = StripeClient.customers.create(customer_params)
+      DB.transaction do
+        billing_info = create(stripe_id: customer["id"])
+        project.update(billing_info_id: billing_info.id)
+      end
+    end
+
+    if tax_id_changed
+      DB.transaction do
+        billing_info.update(valid_vat: nil)
+        if !tax_id.empty? && ISO3166::Country.new(country)&.in_eu_vat?
+          Strand.create(prog: "ValidateVat", label: "start", stack: [{subject_id: billing_info.id}])
+        end
+      end
+    end
+
+    billing_info
+  end
+
   def stripe_data
     if Config.stripe_secret_key
       @stripe_data ||= begin

--- a/model/billing_info.rb
+++ b/model/billing_info.rb
@@ -10,6 +10,39 @@ class BillingInfo < Sequel::Model
 
   plugin ResourceMethods
 
+  def self.update_or_create_stripe_customer(project, name:, email:, country:, state:, city:, postal_code:, address:, tax_id:, company_name:, note:)
+    tax_id = tax_id.to_s.gsub(/[^a-zA-Z0-9]/, "")
+    customer_params = {
+      name:,
+      email: email.strip,
+      address: {country:, state:, city:, postal_code:, line1: address, line2: nil},
+      metadata: {tax_id:, company_name:, note:},
+    }
+
+    if (billing_info = project.billing_info)
+      tax_id_changed = tax_id != billing_info.stripe_data["tax_id"].to_s
+      StripeClient.customers.update(billing_info.stripe_id, customer_params)
+    else
+      tax_id_changed = !tax_id.empty?
+      customer = StripeClient.customers.create(customer_params)
+      DB.transaction do
+        billing_info = create(stripe_id: customer["id"])
+        project.update(billing_info_id: billing_info.id)
+      end
+    end
+
+    if tax_id_changed
+      DB.transaction do
+        billing_info.update(valid_vat: nil)
+        if !tax_id.empty? && ISO3166::Country.new(country).in_eu_vat?
+          Strand.create(prog: "ValidateVat", label: "start", stack: [{subject_id: billing_info.id}])
+        end
+      end
+    end
+
+    billing_info
+  end
+
   def stripe_data
     if Config.stripe_secret_key
       @stripe_data ||= begin

--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -18,37 +18,21 @@ class Clover
       end
 
       r.post true do
-        if (billing_info = @project.billing_info)
+        if @project.billing_info
           handle_validation_failure("project/billing")
-          current_tax_id = billing_info.stripe_data["tax_id"].to_s
           tp = typecast_params
-          new_tax_id = tp.str("tax_id").gsub(/[^a-zA-Z0-9]/, "")
           begin
-            StripeClient.customers.update(billing_info.stripe_id, {
+            BillingInfo.update_or_create_stripe_customer(@project,
               name: tp.str!("name"),
-              email: tp.str!("email").strip,
-              address: {
-                country: tp.str!("country"),
-                state: tp.nonempty_str("state"),
-                city: tp.nonempty_str("city"),
-                postal_code: tp.nonempty_str("postal_code"),
-                line1: tp.str!("address"),
-                line2: nil,
-              },
-              metadata: {
-                tax_id: new_tax_id,
-                company_name: tp.str("company_name"),
-                note: tp.str("note"),
-              },
-            })
-            if new_tax_id != current_tax_id
-              DB.transaction do
-                billing_info.update(valid_vat: nil)
-                if !new_tax_id.empty? && billing_info.country&.in_eu_vat?
-                  Strand.create(prog: "ValidateVat", label: "start", stack: [{subject_id: billing_info.id}])
-                end
-              end
-            end
+              email: tp.str!("email"),
+              country: tp.str!("country"),
+              state: tp.nonempty_str("state"),
+              city: tp.nonempty_str("city"),
+              postal_code: tp.nonempty_str("postal_code"),
+              address: tp.str!("address"),
+              tax_id: tp.str("tax_id"),
+              company_name: tp.str("company_name"),
+              note: tp.str("note"))
             audit_log(@project, "update_billing")
           rescue Stripe::InvalidRequestError => e
             raise_web_error(e.message)

--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -23,16 +23,12 @@ class Clover
           tp = typecast_params
           begin
             BillingInfo.update_or_create_stripe_customer(@project,
-              name: tp.nonempty_str!("name"),
-              email: tp.nonempty_str!("email"),
-              country: tp.nonempty_str!("country"),
-              state: tp.nonempty_str("state"),
-              city: tp.nonempty_str("city"),
-              postal_code: tp.nonempty_str("postal_code"),
-              address: tp.nonempty_str!("address"),
-              tax_id: tp.str!("tax_id"),
-              company_name: tp.str("company_name"),
-              note: tp.str("note"))
+              **tp.convert!(symbolize: true) do |tp|
+                tp.nonempty_str!(%w[name email country address])
+                tp.nonempty_str(%w[state city postal_code])
+                tp.str!("tax_id")
+                tp.str(%w[company_name note])
+              end)
             audit_log(@project, "update_billing")
           rescue Stripe::InvalidRequestError => e
             raise_web_error(e.message)

--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -18,37 +18,21 @@ class Clover
       end
 
       r.post true do
-        if (billing_info = @project.billing_info)
+        if @project.billing_info
           handle_validation_failure("project/billing")
-          current_tax_id = billing_info.stripe_data["tax_id"].to_s
           tp = typecast_params
-          new_tax_id = tp.str!("tax_id").gsub(/[^a-zA-Z0-9]/, "")
           begin
-            StripeClient.customers.update(billing_info.stripe_id, {
-              name: tp.str!("name"),
-              email: tp.str!("email").strip,
-              address: {
-                country: tp.str!("country"),
-                state: tp.nonempty_str("state"),
-                city: tp.nonempty_str("city"),
-                postal_code: tp.nonempty_str("postal_code"),
-                line1: tp.str!("address"),
-                line2: nil,
-              },
-              metadata: {
-                tax_id: new_tax_id,
-                company_name: tp.str("company_name"),
-                note: tp.str("note"),
-              },
-            })
-            if new_tax_id != current_tax_id
-              DB.transaction do
-                billing_info.update(valid_vat: nil)
-                if !new_tax_id.empty? && billing_info.country&.in_eu_vat?
-                  Strand.create(prog: "ValidateVat", label: "start", stack: [{subject_id: billing_info.id}])
-                end
-              end
-            end
+            BillingInfo.update_or_create_stripe_customer(@project,
+              name: tp.nonempty_str!("name"),
+              email: tp.nonempty_str!("email"),
+              country: tp.nonempty_str!("country"),
+              state: tp.nonempty_str("state"),
+              city: tp.nonempty_str("city"),
+              postal_code: tp.nonempty_str("postal_code"),
+              address: tp.nonempty_str!("address"),
+              tax_id: tp.str!("tax_id"),
+              company_name: tp.str("company_name"),
+              note: tp.str("note"))
             audit_log(@project, "update_billing")
           rescue Stripe::InvalidRequestError => e
             raise_web_error(e.message)

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1709,6 +1709,85 @@ RSpec.describe CloverAdmin do
     end
   end
 
+  it "supports updating billing info of Project" do
+    p = Project.create(name: "Default")
+
+    fill_in "UBID, UUID, or prefix:term", with: p.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - Project #{p.ubid}"
+
+    click_link "Update Billing Info"
+    path = page.current_path
+
+    fill_in "Billing Name", with: "ACME Inc."
+    fill_in "Billing Email", with: "acme@example.com"
+    select "Netherlands", from: "Country"
+    fill_in "Address", with: "Main Street 1"
+
+    ENV["DONT_RAISE_ADMIN_ERRORS"] = "1"
+    click_button "Update Billing Info"
+    expect(page).to have_content "InvalidRequest: Billing is not enabled. Set STRIPE_SECRET_KEY to enable billing."
+    ENV.delete("DONT_RAISE_ADMIN_ERRORS")
+
+    allow(Config).to receive(:stripe_secret_key).and_return("secret_key")
+    customers_service = instance_double(Stripe::CustomerService)
+    allow(StripeClient).to receive(:customers).and_return(customers_service)
+
+    # Creates billing info when the project has none
+    visit path
+    expect(page.find_field("Billing Name").value).to be_nil
+    fill_in "Billing Name", with: "ACME Inc."
+    fill_in "Billing Email", with: "acme@example.com"
+    select "Netherlands", from: "Country"
+    fill_in "City", with: "Amsterdam"
+    fill_in "Postal Code", with: "1234 AB"
+    fill_in "Address", with: "Main Street 1"
+    fill_in "Tax ID", with: "NL-123456789B01"
+    fill_in "Company Name", with: "ACME"
+
+    expect(customers_service).to receive(:create).with({
+      name: "ACME Inc.",
+      email: "acme@example.com",
+      address: {country: "NL", state: nil, city: "Amsterdam", postal_code: "1234 AB", line1: "Main Street 1", line2: nil},
+      metadata: {tax_id: "NL123456789B01", company_name: "ACME", note: ""},
+    }).and_return({"id" => "cus_123"})
+    expect { click_button "Update Billing Info" }.to change { Strand.where(prog: "ValidateVat").count }.by(1)
+    expect(page).to have_flash_notice("Billing info updated")
+    expect(page.title).to eq "Ubicloud Admin - Project #{p.ubid}"
+    billing_info = p.reload.billing_info
+    expect(billing_info.stripe_id).to eq "cus_123"
+    expect(Strand.first(prog: "ValidateVat").stack.first["subject_id"]).to eq billing_info.id
+
+    # Prefills form and updates existing billing info without resetting
+    # VAT validity when the tax id is unchanged
+    billing_info.update(valid_vat: true)
+    allow(customers_service).to receive(:retrieve).with("cus_123").and_return(
+      "name" => "ACME Inc.",
+      "email" => "acme@example.com",
+      "address" => {"line1" => "Main Street 1", "country" => "NL", "city" => "Amsterdam", "postal_code" => "1234 AB"},
+      "metadata" => {"tax_id" => "NL123456789B01", "company_name" => "ACME", "note" => ""},
+    )
+    visit path
+    expect(page).to have_field("Billing Name", with: "ACME Inc.")
+    expect(page).to have_select("Country", selected: "Netherlands")
+    expect(page).to have_field("Tax ID", with: "NL123456789B01")
+
+    fill_in "Billing Name", with: "New Name"
+    expect(customers_service).to receive(:update).with("cus_123", hash_including(name: "New Name"))
+    expect { click_button "Update Billing Info" }.not_to change { Strand.where(prog: "ValidateVat").count }
+    expect(page).to have_flash_notice("Billing info updated")
+    expect(billing_info.reload.valid_vat).to be true
+
+    # Resets VAT validity when the tax id changes, without scheduling
+    # validation for a blank tax id
+    visit path
+    fill_in "Tax ID", with: ""
+    expect(customers_service).to receive(:update).with("cus_123", hash_including(metadata: {tax_id: "", company_name: "ACME", note: ""}))
+    expect { click_button "Update Billing Info" }.not_to change { Strand.where(prog: "ValidateVat").count }
+    expect(page).to have_flash_notice("Billing info updated")
+    expect(billing_info.reload.valid_vat).to be_nil
+  end
+
   it "lists multiple info pages with proper links and content in table format" do
     info_pages = [["first", "tag1", Time.now], ["second", "tag2", Time.now - 1], ["third", "tag3", Time.now - 2]].map do |summary, tag, created_at|
       Page.create(summary:, tag:, severity: "info", created_at:)

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2209,6 +2209,89 @@ RSpec.describe CloverAdmin do
     end
   end
 
+  it "supports updating billing info of Project" do
+    p = Project.create(name: "Default")
+
+    fill_in "UBID, UUID, or prefix:term", with: p.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - Project #{p.ubid}"
+
+    # Action is hidden when Stripe is not enabled
+    path = "/model/Project/#{p.ubid}/update_billing_info"
+    expect(page).to have_no_link("Update Billing Info")
+    expect { visit path }.to raise_error(RuntimeError, "admin route not handled: #{path}")
+
+    expect(Config).to receive(:stripe_secret_key).and_return("secret_key").at_least(:once)
+    customers_service = instance_double(Stripe::CustomerService)
+    expect(StripeClient).to receive(:customers).and_return(customers_service).at_least(:once)
+
+    # Creates billing info when the project has none
+    visit "/model/Project/#{p.ubid}"
+    click_link "Update Billing Info"
+    expect(page).to have_current_path path, ignore_query: true
+    expect(page.find_field("Billing Name").value).to be_nil
+    fill_in "Billing Name", with: "ACME Inc."
+    fill_in "Billing Email", with: "acme@example.com"
+    select "Netherlands", from: "Country"
+    fill_in "City", with: "Amsterdam"
+    fill_in "Postal Code", with: "1234 AB"
+    fill_in "Address", with: "Main Street 1"
+    fill_in "Tax ID", with: "NL-123456789B01"
+    fill_in "Company Name", with: "ACME"
+
+    expect(customers_service).to receive(:create).with({
+      name: "ACME Inc.",
+      email: "acme@example.com",
+      address: {country: "NL", state: nil, city: "Amsterdam", postal_code: "1234 AB", line1: "Main Street 1", line2: nil},
+      metadata: {tax_id: "NL123456789B01", company_name: "ACME", note: ""},
+    }).and_return({"id" => "cus_123"})
+    expect { click_button "Update Billing Info" }.to change { Strand.where(prog: "ValidateVat").count }.from(0).to(1)
+    expect(page).to have_flash_notice("Billing info updated")
+    expect(page.title).to eq "Ubicloud Admin - Project #{p.ubid}"
+    billing_info = p.reload.billing_info
+    expect(billing_info.stripe_id).to eq "cus_123"
+    expect(Strand.first(prog: "ValidateVat").stack.first["subject_id"]).to eq billing_info.id
+
+    # Prefills form and updates existing billing info without resetting
+    # VAT validity when the tax id is unchanged
+    billing_info.update(valid_vat: true)
+    expect(customers_service).to receive(:retrieve).with("cus_123").at_least(:once).and_return(
+      "name" => "ACME Inc.",
+      "email" => "acme@example.com",
+      "address" => {"line1" => "Main Street 1", "country" => "NL", "city" => "Amsterdam", "postal_code" => "1234 AB"},
+      "metadata" => {"tax_id" => "NL123456789B01", "company_name" => "ACME", "note" => ""},
+    )
+    visit path
+    expect(page).to have_field("Billing Name", with: "ACME Inc.")
+    expect(page).to have_select("Country", selected: "Netherlands")
+    expect(page).to have_field("Tax ID", with: "NL123456789B01")
+
+    fill_in "Billing Name", with: "New Name"
+    expect(customers_service).to receive(:update).with("cus_123", {
+      name: "New Name",
+      email: "acme@example.com",
+      address: {country: "NL", state: nil, city: "Amsterdam", postal_code: "1234 AB", line1: "Main Street 1", line2: nil},
+      metadata: {tax_id: "NL123456789B01", company_name: "ACME", note: ""},
+    })
+    expect { click_button "Update Billing Info" }.not_to change { Strand.where(prog: "ValidateVat").count }
+    expect(page).to have_flash_notice("Billing info updated")
+    expect(billing_info.reload.valid_vat).to be true
+
+    # Resets VAT validity when the tax id changes, without scheduling
+    # validation for a blank tax id
+    visit path
+    fill_in "Tax ID", with: ""
+    expect(customers_service).to receive(:update).with("cus_123", {
+      name: "ACME Inc.",
+      email: "acme@example.com",
+      address: {country: "NL", state: nil, city: "Amsterdam", postal_code: "1234 AB", line1: "Main Street 1", line2: nil},
+      metadata: {tax_id: "", company_name: "ACME", note: ""},
+    })
+    expect { click_button "Update Billing Info" }.not_to change { Strand.where(prog: "ValidateVat").count }
+    expect(page).to have_flash_notice("Billing info updated")
+    expect(billing_info.reload.valid_vat).to be_nil
+  end
+
   it "lists multiple info pages with proper links and content in table format" do
     info_pages = [["first", "tag1", Time.now], ["second", "tag2", Time.now - 1], ["third", "tag3", Time.now - 2]].map do |summary, tag, created_at|
       Page.create(summary:, tag:, severity: "info", created_at:)

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -167,21 +167,20 @@ RSpec.describe Clover, "billing" do
       expect(customers_service).to receive(:retrieve).with(billing_info.stripe_id).and_return(
         {"name" => "Old Inc.", "address" => {"country" => "NL"}, "metadata" => {"tax_id" => "123456"}},
         {"name" => "Old Inc.", "address" => {"country" => "NL"}, "metadata" => {"tax_id" => "123456"}},
-        {"name" => "New Inc.", "address" => {"country" => "US"}, "metadata" => {"tax_id" => "DE456789"}},
+        {"name" => "New Inc.", "address" => {"country" => "NL"}, "metadata" => {"tax_id" => "NL456789"}},
       ).at_least(:once)
       expect(customers_service).to receive(:update).with(billing_info.stripe_id, anything).at_least(:once)
       visit "#{project.path}/billing"
 
       expect(page.title).to eq("Ubicloud - Project Billing")
-      select "United States", from: "Country"
-      fill_in "VAT ID", with: "DE 456-789"
+      fill_in "VAT ID", with: "NL 456-789"
 
       click_button "Update"
 
       expect(page.status_code).to eq(200)
       expect(page).to have_field("Billing Name", with: "New Inc.")
-      expect(page).to have_field("Country", with: "US")
-      expect(page).to have_field("Tax ID", with: "DE456789")
+      expect(page).to have_field("Country", with: "NL")
+      expect(page).to have_field("VAT ID", with: "NL456789")
       expect(Strand.where(prog: "ValidateVat").count).to eq(1)
       expect(Strand.where(prog: "ValidateVat").first.stack.first["subject_id"]).to eq(billing_info.id)
     end

--- a/spec/routes/web/project/billing_spec.rb
+++ b/spec/routes/web/project/billing_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Clover, "billing" do
 
     it "can update billing info" do
       expect(customers_service).to receive(:retrieve).with(billing_info.stripe_id).and_return(
-        {"name" => "New Inc.", "address" => {"country" => "DE"}, "metadata" => {"tax_id" => "DE456789"}},
+        {"name" => "New Inc.", "email" => "new@example.com", "address" => {"country" => "DE", "line1" => "Main Street 1"}, "metadata" => {"tax_id" => "DE456789"}},
       ).at_least(:once)
       expect(customers_service).to receive(:update).with(billing_info.stripe_id, anything)
       visit "#{project.path}/billing"
@@ -144,55 +144,77 @@ RSpec.describe Clover, "billing" do
       expect(page).to have_field("Country", with: "DE")
     end
 
-    it "can update billing info without address" do
+    it "shows error when updating billing info without an address" do
       expect(customers_service).to receive(:retrieve).with(billing_info.stripe_id).and_return(
-        {"name" => "Old Inc.", "address" => nil, "metadata" => {}},
-        {"name" => "New Inc.", "address" => nil, "metadata" => {}},
+        {"name" => "Old Inc.", "email" => "old@example.com", "address" => nil, "metadata" => {}},
       ).at_least(:once)
-      expect(customers_service).to receive(:update).with(billing_info.stripe_id, anything)
       visit "#{project.path}/billing"
 
       expect(page.title).to eq("Ubicloud - Project Billing")
       expect(page).to have_field("Billing Name", with: "Old Inc.")
 
       fill_in "Billing Name", with: "New Inc."
+      select "Netherlands", from: "Country"
 
       click_button "Update"
 
-      expect(page.status_code).to eq(200)
-      expect(page).to have_field("Billing Name", with: "New Inc.")
+      expect(page.status_code).to eq(400)
+      expect(page).to have_flash_error("empty string provided for parameter address")
     end
 
     it "can update tax id" do
       expect(customers_service).to receive(:retrieve).with(billing_info.stripe_id).and_return(
-        {"name" => "Old Inc.", "address" => {"country" => "NL"}, "metadata" => {"tax_id" => "123456"}},
-        {"name" => "Old Inc.", "address" => {"country" => "NL"}, "metadata" => {"tax_id" => "123456"}},
-        {"name" => "New Inc.", "address" => {"country" => "US"}, "metadata" => {"tax_id" => "DE456789"}},
+        {"name" => "Old Inc.", "email" => "old@example.com", "address" => {"country" => "NL", "line1" => "Main Street 1"}, "metadata" => {"tax_id" => "123456"}},
+        {"name" => "Old Inc.", "email" => "old@example.com", "address" => {"country" => "NL", "line1" => "Main Street 1"}, "metadata" => {"tax_id" => "123456"}},
+        {"name" => "New Inc.", "email" => "old@example.com", "address" => {"country" => "NL", "line1" => "Main Street 1"}, "metadata" => {"tax_id" => "NL456789"}},
       ).at_least(:once)
       expect(customers_service).to receive(:update).with(billing_info.stripe_id, anything).at_least(:once)
       visit "#{project.path}/billing"
 
       expect(page.title).to eq("Ubicloud - Project Billing")
-      select "United States", from: "Country"
-      fill_in "VAT ID", with: "DE 456-789"
+      fill_in "VAT ID", with: "NL 456-789"
 
       click_button "Update"
 
       expect(page.status_code).to eq(200)
       expect(page).to have_field("Billing Name", with: "New Inc.")
-      expect(page).to have_field("Country", with: "US")
-      expect(page).to have_field("Tax ID", with: "DE456789")
+      expect(page).to have_field("Country", with: "NL")
+      expect(page).to have_field("VAT ID", with: "NL456789")
       expect(Strand.where(prog: "ValidateVat").count).to eq(1)
       expect(Strand.where(prog: "ValidateVat").first.stack.first["subject_id"]).to eq(billing_info.id)
     end
 
-    it "can remove tax id" do
+    it "does not schedule VAT validation when the tax id changes together with a change to a non-EU country" do
+      billing_info.update(valid_vat: true)
       expect(customers_service).to receive(:retrieve).with(billing_info.stripe_id).and_return(
-        {"name" => "Old Inc.", "address" => {"country" => "NL"}, "metadata" => {"tax_id" => "123456"}},
-        {"name" => "Old Inc.", "address" => {"country" => "NL"}, "metadata" => {"tax_id" => "123456"}},
-        {"name" => "Old Inc.", "address" => {"country" => nil}, "metadata" => {"tax_id" => nil}},
+        {"name" => "Old Inc.", "email" => "old@example.com", "address" => {"country" => "NL", "line1" => "Main Street 1"}, "metadata" => {"tax_id" => "123456"}},
+        {"name" => "Old Inc.", "email" => "old@example.com", "address" => {"country" => "NL", "line1" => "Main Street 1"}, "metadata" => {"tax_id" => "123456"}},
+        {"name" => "Old Inc.", "email" => "old@example.com", "address" => {"country" => "US", "line1" => "Main Street 1"}, "metadata" => {"tax_id" => "US456789"}},
       ).at_least(:once)
-      expect(customers_service).to receive(:update).with(billing_info.stripe_id, anything).at_least(:once)
+      expect(customers_service).to receive(:update).with(billing_info.stripe_id, anything)
+      visit "#{project.path}/billing"
+
+      expect(page.title).to eq("Ubicloud - Project Billing")
+      select "United States", from: "Country"
+      fill_in "VAT ID", with: "US 456-789"
+
+      click_button "Update"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_field("Country", with: "US")
+      expect(page).to have_field("Tax ID", with: "US456789")
+      expect(Strand.where(prog: "ValidateVat").all).to be_empty
+      expect(billing_info.reload.valid_vat).to be_nil
+    end
+
+    it "can remove tax id" do
+      billing_info.update(valid_vat: true)
+      expect(customers_service).to receive(:retrieve).with(billing_info.stripe_id).and_return(
+        {"name" => "Old Inc.", "email" => "old@example.com", "address" => {"country" => "NL", "line1" => "Main Street 1"}, "metadata" => {"tax_id" => "123456"}},
+        {"name" => "Old Inc.", "email" => "old@example.com", "address" => {"country" => "NL", "line1" => "Main Street 1"}, "metadata" => {"tax_id" => "123456"}},
+        {"name" => "Old Inc.", "email" => "old@example.com", "address" => {"country" => "NL", "line1" => "Main Street 1"}, "metadata" => {"tax_id" => nil}},
+      ).at_least(:once)
+      expect(customers_service).to receive(:update).with(billing_info.stripe_id, anything)
 
       visit "#{project.path}/billing"
 
@@ -201,14 +223,15 @@ RSpec.describe Clover, "billing" do
 
       click_button "Update"
 
-      fill_in "Tax ID", with: "TR123123"
-
-      click_button "Update"
+      expect(page.status_code).to eq(200)
+      expect(page.find_field("VAT ID").value).to be_nil
+      expect(Strand.where(prog: "ValidateVat").all).to be_empty
+      expect(billing_info.reload.valid_vat).to be_nil
     end
 
     it "shows error if billing info update failed" do
       expect(customers_service).to receive(:retrieve).with(billing_info.stripe_id).and_return(
-        {"name" => "Old Inc.", "address" => {"country" => "NL"}, "metadata" => {"tax_id" => "123456"}},
+        {"name" => "Old Inc.", "email" => "old@example.com", "address" => {"country" => "NL", "line1" => "Main Street 1"}, "metadata" => {"tax_id" => "123456"}},
       ).at_least(:once)
       expect(customers_service).to receive(:update).and_raise(Stripe::InvalidRequestError.new("Invalid email address:    test@test.com", "email"))
 

--- a/views/admin/object_action.erb
+++ b/views/admin/object_action.erb
@@ -2,8 +2,10 @@
 
 <% form(method: :post, id: "action-form", class: "form-vertical") do |f| %>
   <% @params.each do |name, value| %>
-    <% options = {options: value[:options].call(@obj)} if value[:options].is_a?(Proc) %>
-    <%== f.input(value.fetch(:type, "text"), key: name, label: name, required: true, **value, **options) %>
+    <% options = value[:options].is_a?(Proc) ? {options: value[:options].call(@obj)} : nil %>
+    <% prefill = value[:value].is_a?(Proc) ? {value: value[:value].call(@obj)} : nil %>
+
+    <%== f.input(value.fetch(:type, "text"), key: name, label: name, required: true, **value, **options, **prefill) %>
   <% end %>
 
   <%== f.button(@label) %>


### PR DESCRIPTION
- **Move Stripe customer update logic to BillingInfo**

Extract the Stripe customer update-or-create and VAT invalidation
logic from the billing route into
BillingInfo.update_or_create_stripe_customer, so an upcoming admin
panel action can reuse it. The create path (creating the Stripe
customer and linking a BillingInfo to the project) is new; the
customer-facing form only reaches the update path.

As a side effect, the billing update form now decides whether to
schedule VAT validation based on the submitted country instead of the
customer's country before the update, so changing the country and tax
id together schedules validation for the new country.

The route also requires name, email, country, and address now, using
nonempty_str!. The billing form already marks these fields as required
in the browser, but the route accepted empty strings from direct POST
requests, storing Stripe customers with blank required fields. Since a
blank country can no longer reach the helper (the admin form requires
it too, and Stripe rejects unknown country codes before the VAT check
runs), the ISO3166 country lookup does not need safe navigation.

- **Add Update Billing Info admin action for Project**

Support tickets sometimes require fixing a project's billing details
(wrong address, missing VAT ID) or setting up billing info for a
project that has none, which previously required console access.

The action prefills the form from the Stripe customer data when the
project already has billing info and updates the customer in place.
Otherwise it creates a new Stripe customer and links a BillingInfo
record to the project. As in the customer-facing billing page, a tax
id change resets the VAT validity and schedules a ValidateVat strand
when the new tax id belongs to an EU VAT country.

<img width="2654" height="1784" alt="CleanShot 2026-07-11 at 09 03 15@2x" src="https://github.com/user-attachments/assets/cab34058-5621-4734-bb91-4be2d435cd36" />