### PR TITLE
Hardware-size wal-g backup/restore config for AWS & GCP

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -196,6 +196,8 @@ module Config
   optional :postgres_lantern_notification_email, string
   optional :postgres_notification_email, string
   override :aws_postgres_iam_access, false, bool
+  override :postgres_walg_optimized_config, false, bool
+  override :postgres_walg_direct_io_enabled, false, bool
   override :postgres_internal_firewall_cidrs, "", array(string)
 
   # Logging

--- a/lib/walg_config.rb
+++ b/lib/walg_config.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Computes wal-g backup/restore config from a server's vCPU, RAM and Disk count.
+# The config maximizes Backup/Restore throughput, applying limits on RAM used.
+module WalgConfig
+  UPLOAD_QUEUE = 2
+  UPLOAD_CONCURRENCY = 4
+  S3_MAX_PART_SIZE_UPPER_LIMIT = 64
+  DIRECT_IO_BLOCKS_PER_DRIVE = 256
+
+  def self.config_env_contents(vcpu_count:, memory_mib:, direct_io: false, direct_io_drive_count: 4, dense_nvme: false)
+    budget_memory_mib = memory_mib * 5 / 100
+
+    # WALG_UPLOAD_DISK_CONCURRENCY is CPU or Disk bound, hence different thresholds
+    disk_concurrency =
+      if direct_io
+        (dense_nvme || vcpu_count <= 2) ? vcpu_count : (vcpu_count / 2)
+      else
+        (vcpu_count / 2).clamp(1, 128)
+      end
+
+    # WALG_S3_MAX_PART_SIZE is memory bound. calculate based on memory budget and concurrency
+    peak_parts_in_memory = (disk_concurrency + UPLOAD_QUEUE) * (UPLOAD_CONCURRENCY + 1)
+    max_part_size_mib = (budget_memory_mib / peak_parts_in_memory).clamp(5, S3_MAX_PART_SIZE_UPPER_LIMIT)
+
+    # Maximize restore throughput by setting concurrency to vCpu count, 10 is the wal-g default
+    # kept as lower bound.
+    restore_download_concurrency = vcpu_count.clamp(10, 128)
+
+    lines = [
+      "WALG_COMPRESSION_METHOD=lz4",
+      "WALG_UPLOAD_DISK_CONCURRENCY=#{disk_concurrency}",
+      "WALG_UPLOAD_CONCURRENCY=#{UPLOAD_CONCURRENCY}",
+      "WALG_UPLOAD_QUEUE=#{UPLOAD_QUEUE}",
+      "WALG_S3_MAX_PART_SIZE=#{max_part_size_mib * 1024 * 1024}",
+      "WALG_DOWNLOAD_CONCURRENCY=#{restore_download_concurrency}",
+    ]
+    if direct_io
+      # RAID0 arrays attempt to evenly distribute the data blocks across the block devices.
+      # Therefore, larger block reads get fan out to more devices and produce higher throughput.
+      direct_io_block_count = direct_io_drive_count * DIRECT_IO_BLOCKS_PER_DRIVE
+
+      lines << "WALG_DIRECT_IO=true"
+      lines << "WALG_DIRECT_IO_BLOCK_COUNT=#{direct_io_block_count}"
+    end
+    lines.join("\n") + "\n"
+  end
+end

--- a/model/postgres/aws/postgres_timeline.rb
+++ b/model/postgres/aws/postgres_timeline.rb
@@ -23,7 +23,7 @@ AWS_ACCESS_KEY_ID=#{access_key}
 AWS_SECRET_ACCESS_KEY=#{secret_key}
         WALG_CONF
       end
-      <<-WALG_CONF
+      config = <<-WALG_CONF
 WALG_S3_PREFIX=s3://#{ubid}
 AWS_ENDPOINT=#{blob_storage_endpoint}
 #{walg_credentials}
@@ -32,6 +32,17 @@ AWS_S3_FORCE_PATH_STYLE=true
 PGHOST=/var/run/postgresql
 PGDATA=/dat/#{version}/data
       WALG_CONF
+      # Append the hardware-sized wal-g knobs (empty unless the feature is enabled).
+      config + walg_config_env_contents
+    end
+
+    def aws_walg_config_params
+      return nil unless (vm = leader.vm)
+      family = leader.resource.target_vm_size.split(".").first
+
+      # dense NVMe = storage-optimized "i" families, allows more concurrency.
+      {vcpu_count: vm.vcpus, memory_mib: vm.memory_gib * 1024,
+       dense_nvme: %w[i8g i8ge i7i i7ie].include?(family)}
     end
 
     def aws_walg_config_region

--- a/model/postgres/gcp/postgres_timeline.rb
+++ b/model/postgres/gcp/postgres_timeline.rb
@@ -8,12 +8,19 @@ class PostgresTimeline < Sequel::Model
     private
 
     def gcp_generate_walg_config(version)
-      <<-WALG_CONF
+      config = <<-WALG_CONF
 WALG_GS_PREFIX=gs://#{ubid}
 GOOGLE_APPLICATION_CREDENTIALS=/etc/postgresql/gcs-sa-key.json
 PGHOST=/var/run/postgresql
 PGDATA=/dat/#{version}/data
       WALG_CONF
+      config + walg_config_env_contents
+    end
+
+    def gcp_walg_config_params
+      return nil unless (vm = leader.vm)
+
+      {vcpu_count: vm.vcpus, memory_mib: vm.memory_gib * 1024}
     end
 
     def gcp_walg_config_region

--- a/model/postgres/metal/postgres_timeline.rb
+++ b/model/postgres/metal/postgres_timeline.rb
@@ -11,7 +11,7 @@ AWS_ACCESS_KEY_ID=#{access_key}
 AWS_SECRET_ACCESS_KEY=#{secret_key}
         WALG_CONF
       end
-      <<-WALG_CONF
+      config = <<-WALG_CONF
 WALG_S3_PREFIX=s3://#{ubid}
 AWS_ENDPOINT=#{blob_storage_endpoint}
 #{walg_credentials}
@@ -20,6 +20,11 @@ AWS_S3_FORCE_PATH_STYLE=true
 PGHOST=/var/run/postgresql
 PGDATA=/dat/#{version}/data
       WALG_CONF
+      config + walg_config_env_contents
+    end
+
+    def metal_walg_config_params
+      nil
     end
 
     def metal_walg_config_region

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -19,6 +19,26 @@ class PostgresTimeline < Sequel::Model
     ubid
   end
 
+  def walg_config_env_contents
+    return "" unless walg_optimized_config_enabled?
+    return "" unless (params = walg_config_params)
+
+    direct_io = walg_direct_io_enabled?
+    direct_io_drive_count = leader.storage_device_paths.count if direct_io
+    WalgConfig.config_env_contents(**params, direct_io:, direct_io_drive_count:)
+  end
+
+  def walg_optimized_config_enabled?
+    return false unless Config.postgres_walg_optimized_config
+    return false if leader.nil?
+
+    !!leader.resource.project.get_ff_postgres_walg_optimized_config
+  end
+
+  def walg_direct_io_enabled?
+    Config.postgres_walg_direct_io_enabled && leader.resource.project.get_ff_postgres_walg_direct_io_enabled
+  end
+
   def need_backup?
     return false if blob_storage.nil?
     return false if leader.nil?

--- a/model/project.rb
+++ b/model/project.rb
@@ -260,6 +260,8 @@ class Project < Sequel::Model
     :vm_public_ssh_keys,
     :postgres_aws_use_different_azs_for_standbys,
     :postgres_instance_type_fallback,
+    :postgres_walg_optimized_config,
+    :postgres_walg_direct_io_enabled,
     :cache_proxy_download_url,
   )
 end

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -3,6 +3,8 @@
 class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   subject_is :postgres_timeline
 
+  BACKUP_CPU_WEIGHT = 25
+
   def self.assemble(location_id:, parent_id: nil)
     if parent_id && (parent = PostgresTimeline[parent_id]).nil?
       fail "No existing parent"
@@ -85,7 +87,11 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
       nap 60
     else # "Failed", "NotStarted"
       size_gib = postgres_timeline.leader.data_disk_usage(raise_on_error: true).fdiv(1024 * 1024).ceil
-      sshable.d_run("take_postgres_backup", "sudo", "postgres/bin/take-backup", postgres_timeline.leader.version)
+
+      args = ["sudo", "postgres/bin/take-backup", postgres_timeline.leader.version]
+      args << BACKUP_CPU_WEIGHT.to_s if postgres_timeline.walg_optimized_config_enabled?
+
+      sshable.d_run("take_postgres_backup", *args)
       postgres_timeline.update(latest_backup_started_at: Time.now, latest_backup_size_in_gib: size_gib)
       nap 60
     end

--- a/rhizome/postgres/bin/take-backup
+++ b/rhizome/postgres/bin/take-backup
@@ -3,10 +3,14 @@
 
 require_relative "../../common/lib/util"
 
-if ARGV.count != 1
-  fail "Wrong number of arguments. Expected 1, Given #{ARGV.count}"
+if ARGV.count < 1 || ARGV.count > 2
+  fail "Wrong number of arguments. Expected 1 or 2, Given #{ARGV.count}"
 end
 
 v = ARGV[0]
+cpu_weight = ARGV[1]
 
-r "sudo -u postgres wal-g backup-push /dat/#{v}/data --config /etc/postgresql/wal-g.env --verify"
+# start backup with cpu.weight limiting scope if the corresponding parameter passed
+scope = (cpu_weight.to_s.match?(/\A\d+\z/) && cpu_weight.to_i.positive?) ? "systemd-run --scope --collect -p CPUWeight=#{cpu_weight} " : ""
+
+r "#{scope}sudo -u postgres wal-g backup-push /dat/#{v}/data --config /etc/postgresql/wal-g.env --verify"

--- a/spec/lib/walg_config_spec.rb
+++ b/spec/lib/walg_config_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe WalgConfig do
+  # parse the "KEY=value\n" fragment into a hash for assertions
+  def env(**) = WalgConfig.config_env_contents(**).lines.map { it.strip.split("=", 2) }.to_h
+
+  describe ".config_env_contents" do
+    it "sizes the i8ge.12xlarge (48 vCPU / 384 GiB) row with O_DIRECT (dense NVMe -> vCPU readers)" do
+      h = env(vcpu_count: 48, memory_mib: 384 * 1024, direct_io: true, dense_nvme: true)
+      expect(h["WALG_COMPRESSION_METHOD"]).to eq("lz4")
+      expect(h["WALG_UPLOAD_DISK_CONCURRENCY"]).to eq("48")   # dense NVMe -> full vCPU under O_DIRECT
+      expect(h["WALG_UPLOAD_CONCURRENCY"]).to eq("4")
+      expect(h["WALG_UPLOAD_QUEUE"]).to eq("2")
+      expect(h["WALG_S3_MAX_PART_SIZE"]).to eq((64 * 1024 * 1024).to_s)
+      expect(h["WALG_DOWNLOAD_CONCURRENCY"]).to eq("48")      # vCPU, clamped [10,128]
+      expect(h["WALG_DIRECT_IO"]).to eq("true")
+      expect(h["WALG_DIRECT_IO_BLOCK_COUNT"]).to eq("1024")   # 4 drives * 256
+    end
+
+    it "sizes the m8gd.large (2 vCPU / 8 GiB) row: buffered, 5%-RAM cap binds the part size" do
+      h = env(vcpu_count: 2, memory_mib: 8 * 1024)
+      expect(h["WALG_UPLOAD_DISK_CONCURRENCY"]).to eq("1")    # 1/2 vCPU (buffered) = 2/2 = 1
+      expect(h["WALG_UPLOAD_CONCURRENCY"]).to eq("4")
+      expect(h["WALG_S3_MAX_PART_SIZE"]).to eq((27 * 1024 * 1024).to_s) # floor(5%*8GiB / ((1+2)*(4+1)))
+      expect(h["WALG_DOWNLOAD_CONCURRENCY"]).to eq("10")      # floor
+      expect(h).not_to have_key("WALG_DIRECT_IO")             # off by default
+    end
+
+    it "keeps peak upload RAM <= 5% of RAM across sizes (the memory cap)" do
+      [[2, 8], [16, 128], [48, 384], [192, 1536]].each do |vcpu_count, ram_gib|
+        h = env(vcpu_count:, memory_mib: ram_gib * 1024)
+        disk = h["WALG_UPLOAD_DISK_CONCURRENCY"].to_i
+        upl = h["WALG_UPLOAD_CONCURRENCY"].to_i
+        part = h["WALG_S3_MAX_PART_SIZE"].to_i
+        peak = (disk + 2) * (upl + 1) * part
+        expect(peak).to be <= (ram_gib * 1024**3 / 20)
+      end
+    end
+
+    it "sets DOWNLOAD_CONCURRENCY = clamp(vCPU, 10, 128) (DR restore, one stream/core)" do
+      expect(env(vcpu_count: 2, memory_mib: 16 * 1024)["WALG_DOWNLOAD_CONCURRENCY"]).to eq("10")     # floor
+      expect(env(vcpu_count: 24, memory_mib: 192 * 1024)["WALG_DOWNLOAD_CONCURRENCY"]).to eq("24")
+      expect(env(vcpu_count: 96, memory_mib: 768 * 1024)["WALG_DOWNLOAD_CONCURRENCY"]).to eq("96")
+      expect(env(vcpu_count: 192, memory_mib: 1536 * 1024)["WALG_DOWNLOAD_CONCURRENCY"]).to eq("128") # cap
+    end
+
+    it "scales DISK_CONCURRENCY by disk parallelism: 1/2 vCPU generic, vCPU for dense NVMe or <=2 vCPU" do
+      # O_DIRECT, generic NVMe, >2 vCPU -> 1/2 vCPU (a single stream saturates the faster device)
+      expect(env(vcpu_count: 48, memory_mib: 384 * 1024, direct_io: true)["WALG_UPLOAD_DISK_CONCURRENCY"]).to eq("24")
+      # O_DIRECT, dense NVMe -> full vCPU (dense device only saturates with more parallel readers)
+      expect(env(vcpu_count: 48, memory_mib: 384 * 1024, direct_io: true, dense_nvme: true)["WALG_UPLOAD_DISK_CONCURRENCY"]).to eq("48")
+      # O_DIRECT, generic but <=2 vCPU -> full vCPU (1/2 vCPU would round to 1 and starve reads under load)
+      expect(env(vcpu_count: 2, memory_mib: 16 * 1024, direct_io: true)["WALG_UPLOAD_DISK_CONCURRENCY"]).to eq("2")
+      # buffered -> 1/2 vCPU regardless of dense flag (cpu.weight, not this count, governs impact)
+      buffered = env(vcpu_count: 48, memory_mib: 384 * 1024, direct_io: false, dense_nvme: true)
+      expect(buffered["WALG_UPLOAD_DISK_CONCURRENCY"]).to eq("24")
+      expect(buffered).not_to have_key("WALG_DIRECT_IO")
+      # buffered on 1 vCPU -> clamp floor keeps concurrency >= 1
+      expect(env(vcpu_count: 1, memory_mib: 8 * 1024, direct_io: false)["WALG_UPLOAD_DISK_CONCURRENCY"]).to eq("1")
+    end
+
+    it "sizes DIRECT_IO_BLOCK_COUNT to the RAID0 drive count (O_DIRECT read spans the stripe)" do
+      bc = ->(d) { env(vcpu_count: 48, memory_mib: 384 * 1024, direct_io: true, direct_io_drive_count: d)["WALG_DIRECT_IO_BLOCK_COUNT"] }
+      expect(bc.call(1)).to eq("256")    # 1 MiB, single drive
+      expect(bc.call(4)).to eq("1024")   # 4 MiB
+      expect(bc.call(8)).to eq("2048")   # 8 MiB (caller clamps drive count to 1..8)
+    end
+
+    it "emits no rate-limit or bandwidth knobs" do
+      h = env(vcpu_count: 48, memory_mib: 384 * 1024, direct_io: true)
+      expect(h).not_to have_key("WALG_NETWORK_RATE_LIMIT")
+      expect(h).not_to have_key("WALG_DISK_RATE_LIMIT")
+    end
+  end
+end

--- a/spec/model/postgres/gcp/postgres_timeline_spec.rb
+++ b/spec/model/postgres/gcp/postgres_timeline_spec.rb
@@ -44,6 +44,29 @@ PGDATA=/dat/17/data
 
         expect(postgres_timeline.generate_walg_config(17)).to eq(walg_config)
       end
+
+      it "appends the hardware-sized config on local-SSD instances when enabled" do
+        allow(Config).to receive_messages(postgres_walg_optimized_config: true, postgres_walg_direct_io_enabled: true)
+        leader = instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 8, memory_gib: 32),
+          storage_device_paths: ["/dev/nvme0n1", "/dev/nvme1n1"],
+          resource: instance_double(PostgresResource, target_vm_size: "c4a-standard-8",
+            project: instance_double(Project, get_ff_postgres_walg_optimized_config: true, get_ff_postgres_walg_direct_io_enabled: true)))
+        allow(postgres_timeline).to receive(:leader).and_return(leader)
+
+        config = postgres_timeline.generate_walg_config(17)
+        expect(config).to include("WALG_UPLOAD_DISK_CONCURRENCY=4")   # floor(0.50*8)
+        expect(config).to include("WALG_DIRECT_IO=true")
+        expect(config).to include("WALG_DIRECT_IO_BLOCK_COUNT=512")   # 2 local SSDs * 256
+      end
+
+      it "leaves stock config (no hardware knobs) when the leader has no vm yet" do
+        allow(Config).to receive(:postgres_walg_optimized_config).and_return(true)
+        leader = instance_double(PostgresServer, vm: nil,
+          resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config: true)))
+        allow(postgres_timeline).to receive(:leader).and_return(leader)
+
+        expect(postgres_timeline.generate_walg_config(17)).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
+      end
     end
 
     describe "#walg_config_region" do

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -92,6 +92,68 @@ PGDATA=/dat/17/data
     expect(postgres_timeline.generate_walg_config(17)).to eq(walg_config)
   end
 
+  it "appends hardware-sized wal-g config for aws when the feature is enabled (O_DIRECT on)" do
+    postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
+    allow(Config).to receive_messages(postgres_walg_optimized_config: true, postgres_walg_direct_io_enabled: true)
+    leader = instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 48, memory_gib: 384),
+      storage_device_paths: ["/dev/nvme1n1", "/dev/nvme2n1", "/dev/nvme3n1"],
+      resource: instance_double(PostgresResource, target_vm_size: "i8ge.12xlarge",
+        project: instance_double(Project, get_ff_postgres_walg_optimized_config: true, get_ff_postgres_walg_direct_io_enabled: true)))
+    allow(postgres_timeline).to receive(:leader).and_return(leader)
+
+    config = postgres_timeline.generate_walg_config(17)
+    expect(config).to include("WALG_UPLOAD_DISK_CONCURRENCY=48")   # i8ge dense NVMe -> vCPU under O_DIRECT
+    expect(config).to include("WALG_S3_MAX_PART_SIZE=#{64 * 1024 * 1024}")
+    expect(config).to include("WALG_DOWNLOAD_CONCURRENCY=48")
+    expect(config).to include("WALG_DIRECT_IO=true")
+    expect(config).to include("WALG_DIRECT_IO_BLOCK_COUNT=#{3 * 256}")   # drive count = RAID0 members (storage_device_paths)
+  end
+
+  it "uses buffered config (no O_DIRECT) when walg_config is on but direct_io is off" do
+    postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
+    allow(Config).to receive_messages(postgres_walg_optimized_config: true, postgres_walg_direct_io_enabled: false)
+    leader = instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 48, memory_gib: 384),
+      resource: instance_double(PostgresResource, target_vm_size: "i8ge.12xlarge",
+        project: instance_double(Project, get_ff_postgres_walg_optimized_config: true)))
+    allow(postgres_timeline).to receive(:leader).and_return(leader)
+
+    config = postgres_timeline.generate_walg_config(17)
+    expect(config).to include("WALG_UPLOAD_DISK_CONCURRENCY=24")   # 1/2 vCPU (buffered; cpu.weight governs impact)
+    expect(config).not_to include("WALG_DIRECT_IO")
+  end
+
+  it "omits wal-g config for aws when the feature is disabled (default no-op)" do
+    postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
+    allow(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 48, memory_gib: 384)))
+
+    expect(postgres_timeline.generate_walg_config(17)).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
+  end
+
+  it "leaves stock config for aws when enabled but the leader has no vm yet" do
+    postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
+    allow(Config).to receive(:postgres_walg_optimized_config).and_return(true)
+    leader = instance_double(PostgresServer, vm: nil,
+      resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config: true)))
+    allow(postgres_timeline).to receive(:leader).and_return(leader)
+
+    expect(postgres_timeline.generate_walg_config(17)).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
+  end
+
+  it "leaves stock config when enabled but the timeline has no push-leader yet" do
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
+    allow(Config).to receive(:postgres_walg_optimized_config).and_return(true)
+
+    expect(postgres_timeline.generate_walg_config(17)).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
+  end
+
+  it "returns nil walg_config_params for metal (stock config, no hardware sizing)" do
+    expect(postgres_timeline.walg_config_params).to be_nil
+  end
+
   it "returns walg_config_region for metal" do
     expect(postgres_timeline.walg_config_region).to eq("us-east-1")
   end

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -485,6 +485,16 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       expect(postgres_timeline.latest_backup_size_in_gib).to eq(200)
     end
 
+    it "passes cpu.weight to take-backup when the optimized backup config is enabled" do
+      sshable = nx.postgres_timeline.leader.vm.sshable
+      allow(nx.postgres_timeline).to receive(:walg_optimized_config_enabled?).and_return(true)
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("NotStarted").ordered
+      expect(sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return((200 * 1024 * 1024).to_s).ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17 25", {log: true, stdin: nil}).ordered
+
+      expect { nx.take_backup }.to nap(60)
+    end
+
     it "retries when the previous backup failed" do
       sshable = nx.postgres_timeline.leader.vm.sshable
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("Failed").ordered


### PR DESCRIPTION
Why: Before this change backup on large VMs doesn't complete in
24 hours, backup and restore use default wal-g params which
don't scale with VM size.

What: Optimize wal-g params based on CPU, Memory and RAID0 array size
Optionally enable Direct IO, usable with wal-g build post the commit:
https://github.com/wal-g/wal-g/commit/e334dc4a91715eda65e1f33863fe1468e61156bc

Workload impact prevention:
- 5% memory cap to reduce worst-case workload impact.
- Default 25% cpu.weight. can be bumped when backup script called for faster backup when needed.

Gated by
- postgres_walg_optimized_config
- postgres_walg_direct_io_enabled

Results: With Direct_io and assuming 80% data disk fill, this change gives:
- Without load: 30m backup on VM sizes except i8**ge**, 60m on i8**ge**,
- With load: 60m backup on VM sizes except i8**ge**, 120m on i8**ge**,
- Impact on pgbench tcp-b and hammerdb tcp-c limited to 25% regression during backup. 

Without Direct_io, the impact on workload can be closer to 33% due to page cache CPU usage and churn.

plus ability to trigger backup script with 100%+ cpu.weight to get faster backup regardless of customer load. planning to use it fo
