### PR TITLE
Skip failover check in unavailable for non representative

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -754,7 +754,7 @@ SQL
       hop_lockout
     end
 
-    nap 0 if resource.ongoing_failover? || postgres_server.trigger_failover(mode: "unplanned")
+    nap 0 if postgres_server.is_representative && (resource.ongoing_failover? || postgres_server.trigger_failover(mode: "unplanned"))
 
     when_configure_set? do
       decr_configure


### PR DESCRIPTION
We recently had an issue where both primary and standby servers were stuck in unavailable. It was because we had just started failover to the standby but the standby had also been unavailable. Since now the failover started and all of the servers are in unavailable state, they cannot even switch back to available. This commit makes that nap 0 dismissed for standby servers so that we can at least go through with the failover.