### PR TITLE
Consider /runtime as a runtime path

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -165,7 +165,7 @@ class Clover < Roda
         :api
       elsif host.start_with?("admin.")
         :admin
-      elsif request.path_info.start_with?("/runtime/")
+      elsif request.path_info == "/runtime" || request.path_info.start_with?("/runtime/")
         :runtime
       end
     end


### PR DESCRIPTION
Should avoid a missing_handle_validation_failure emit in production for this path.