### PR TITLE
Capture machine-image screenshots in regen-screenshots

### DIFF
--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -599,6 +599,53 @@ class RegenScreenshots
     select "Postgres:all", from: "ace-select-3-1"
     screenshot "security/access-control-3-screenshot.png"
 
+    mi_store = MachineImageStore.create(
+      project_id: project.id,
+      location_id: Location::HETZNER_FSN1_ID,
+      provider: "r2",
+      region: "auto",
+      endpoint: "https://r2.cloudflare.com/",
+      bucket: "demo-bucket",
+      access_key: "ak",
+      secret_key: "sk",
+    )
+    machine_image = MachineImage.create(
+      name: "prod-image",
+      project_id: project.id,
+      arch: "x64",
+      location_id: Location::HETZNER_FSN1_ID,
+    )
+    archive_kek = StorageKeyEncryptionKey.create_random(auth_data: "auth_data")
+
+    versions = [
+      [Time.utc(2026, 1, 15, 10, 30), "ready", 10240, 746],
+      [Time.utc(2026, 2, 20, 10, 30), "ready", 10240, 751],
+      [Time.utc(2026, 3, 25, 10, 30), "ready", 10240, 780],
+      [Time.utc(2026, 4, 10, 10, 30), "creating", nil, nil],
+    ].map do |created_at, status, actual_size_mib, archive_size_mib|
+      label = created_at.strftime("%Y%m%d%H%M%S")
+      version = MachineImageVersion.create(machine_image_id: machine_image.id, version: label, actual_size_mib:) { it.created_at = created_at }
+      MachineImageVersionMetal.create_with_id(version,
+        store_id: mi_store.id,
+        store_prefix: "prod-image/#{label}",
+        archive_kek_id: archive_kek.id,
+        status:,
+        archive_size_mib:)
+      Strand.create_with_id(version, prog: "MachineImage::VersionMetalNexus", label: "wait", stack: [{}])
+      version
+    end
+    machine_image.update(latest_version_id: versions[2].id)
+
+    within("#desktop-menu") { click_link "Machine Images" }
+    click_link "prod-image"
+    click_link "Versions"
+    resize(800, width: 1600)
+    screenshot "machine-images/versions-screenshot.png"
+
+    within("#machine-image-submenu") { click_link "Settings" }
+    resize(800, width: 1600)
+    screenshot "machine-images/latest-version-screenshot.png"
+
     resize(1800)
     click_link "Compute"
     click_link "Create Virtual Machine"

--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -437,6 +437,7 @@ class RegenScreenshots
       node_count: 5,
       kubernetes_cluster_id: k8s_cluster.id,
       target_node_size: "standard-8",
+      version: "v1.34",
     ) do |kn|
       kn.id = UBID.parse(kn_ubid).to_uuid
     end


### PR DESCRIPTION
(used in https://github.com/ubicloud/documentation/pull/207)

Add steps to bin/regen-screenshots for the machine images documentation pages:

- machine-images/versions-screenshot.png: a machine image's versions page, listing several ready versions alongside one still being created, with their sizes and the latest version marked.

<img width="1600" height="800" alt="image" src="https://github.com/user-attachments/assets/e133b0a2-67a0-4a1c-908a-6fb07b754d9f" />

- machine-images/latest-version-screenshot.png: a machine image's   settings page, from which one can change the latest version.

<img width="1600" height="800" alt="image" src="https://github.com/user-attachments/assets/130a879e-b80f-4b4e-8af1-2288dbc479a8" />
