### PR TITLE
Enable the hardware size configs for walg by default

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -196,8 +196,6 @@ module Config
   optional :postgres_lantern_notification_email, string
   optional :postgres_notification_email, string
   override :aws_postgres_iam_access, false, bool
-  override :postgres_walg_optimized_config, false, bool
-  override :postgres_walg_direct_io_enabled, false, bool
   override :postgres_internal_firewall_cidrs, "", array(string)
 
   # Logging

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -29,14 +29,11 @@ class PostgresTimeline < Sequel::Model
   end
 
   def walg_optimized_config_enabled?
-    return false unless Config.postgres_walg_optimized_config
-    return false if leader.nil?
-
-    !!leader.resource.project.get_ff_postgres_walg_optimized_config
+    !leader.nil? && !leader.resource.project.get_ff_postgres_walg_optimized_config_disabled
   end
 
   def walg_direct_io_enabled?
-    Config.postgres_walg_direct_io_enabled && leader.resource.project.get_ff_postgres_walg_direct_io_enabled
+    !leader.resource.project.get_ff_postgres_walg_direct_io_disabled
   end
 
   def need_backup?

--- a/model/project.rb
+++ b/model/project.rb
@@ -262,8 +262,8 @@ class Project < Sequel::Model
     :vm_public_ssh_keys,
     :postgres_aws_use_different_azs_for_standbys,
     :postgres_instance_type_fallback,
-    :postgres_walg_optimized_config,
-    :postgres_walg_direct_io_enabled,
+    :postgres_walg_optimized_config_disabled,
+    :postgres_walg_direct_io_disabled,
     :cache_proxy_download_url,
   )
 end

--- a/spec/model/postgres/gcp/postgres_timeline_spec.rb
+++ b/spec/model/postgres/gcp/postgres_timeline_spec.rb
@@ -46,11 +46,10 @@ PGDATA=/dat/17/data
       end
 
       it "appends the hardware-sized config on local-SSD instances when enabled" do
-        allow(Config).to receive_messages(postgres_walg_optimized_config: true, postgres_walg_direct_io_enabled: true)
         leader = instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 8, memory_gib: 32),
           storage_device_paths: ["/dev/nvme0n1", "/dev/nvme1n1"],
           resource: instance_double(PostgresResource, target_vm_size: "c4a-standard-8",
-            project: instance_double(Project, get_ff_postgres_walg_optimized_config: true, get_ff_postgres_walg_direct_io_enabled: true)))
+            project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: false, get_ff_postgres_walg_direct_io_disabled: false)))
         allow(postgres_timeline).to receive(:leader).and_return(leader)
 
         config = postgres_timeline.generate_walg_config(17)
@@ -60,9 +59,8 @@ PGDATA=/dat/17/data
       end
 
       it "leaves stock config (no hardware knobs) when the leader has no vm yet" do
-        allow(Config).to receive(:postgres_walg_optimized_config).and_return(true)
         leader = instance_double(PostgresServer, vm: nil,
-          resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config: true)))
+          resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: nil)))
         allow(postgres_timeline).to receive(:leader).and_return(leader)
 
         expect(postgres_timeline.generate_walg_config(17)).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -95,11 +95,10 @@ PGDATA=/dat/17/data
   it "appends hardware-sized wal-g config for aws when the feature is enabled (O_DIRECT on)" do
     postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
-    allow(Config).to receive_messages(postgres_walg_optimized_config: true, postgres_walg_direct_io_enabled: true)
     leader = instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 48, memory_gib: 384),
       storage_device_paths: ["/dev/nvme1n1", "/dev/nvme2n1", "/dev/nvme3n1"],
       resource: instance_double(PostgresResource, target_vm_size: "i8ge.12xlarge",
-        project: instance_double(Project, get_ff_postgres_walg_optimized_config: true, get_ff_postgres_walg_direct_io_enabled: true)))
+        project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: false, get_ff_postgres_walg_direct_io_disabled: false)))
     allow(postgres_timeline).to receive(:leader).and_return(leader)
 
     config = postgres_timeline.generate_walg_config(17)
@@ -113,10 +112,9 @@ PGDATA=/dat/17/data
   it "uses buffered config (no O_DIRECT) when walg_config is on but direct_io is off" do
     postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
-    allow(Config).to receive_messages(postgres_walg_optimized_config: true, postgres_walg_direct_io_enabled: false)
     leader = instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 48, memory_gib: 384),
       resource: instance_double(PostgresResource, target_vm_size: "i8ge.12xlarge",
-        project: instance_double(Project, get_ff_postgres_walg_optimized_config: true)))
+        project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: nil, get_ff_postgres_walg_direct_io_disabled: true)))
     allow(postgres_timeline).to receive(:leader).and_return(leader)
 
     config = postgres_timeline.generate_walg_config(17)
@@ -128,6 +126,9 @@ PGDATA=/dat/17/data
     postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
     allow(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 48, memory_gib: 384)))
+    leader = instance_double(PostgresServer, vm: nil,
+      resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: true)))
+    allow(postgres_timeline).to receive(:leader).and_return(leader)
 
     expect(postgres_timeline.generate_walg_config(17)).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
   end
@@ -135,9 +136,8 @@ PGDATA=/dat/17/data
   it "leaves stock config for aws when enabled but the leader has no vm yet" do
     postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
-    allow(Config).to receive(:postgres_walg_optimized_config).and_return(true)
     leader = instance_double(PostgresServer, vm: nil,
-      resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config: true)))
+      resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: false)))
     allow(postgres_timeline).to receive(:leader).and_return(leader)
 
     expect(postgres_timeline.generate_walg_config(17)).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
@@ -145,7 +145,6 @@ PGDATA=/dat/17/data
 
   it "leaves stock config when enabled but the timeline has no push-leader yet" do
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
-    allow(Config).to receive(:postgres_walg_optimized_config).and_return(true)
 
     expect(postgres_timeline.generate_walg_config(17)).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
   end

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -478,19 +478,19 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       sshable = nx.postgres_timeline.leader.vm.sshable
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("NotStarted").ordered
       expect(sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return((200 * 1024 * 1024).to_s).ordered
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17", {log: true, stdin: nil}).ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17 25", {log: true, stdin: nil}).ordered
 
       expect { nx.take_backup }.to nap(60)
       expect(postgres_timeline.reload.latest_backup_started_at).not_to be_nil
       expect(postgres_timeline.latest_backup_size_in_gib).to eq(200)
     end
 
-    it "passes cpu.weight to take-backup when the optimized backup config is enabled" do
+    it "passes cpu.weight to take-backup when the optimized backup config is disabled" do
       sshable = nx.postgres_timeline.leader.vm.sshable
-      allow(nx.postgres_timeline).to receive(:walg_optimized_config_enabled?).and_return(true)
+      allow(nx.postgres_timeline).to receive(:walg_optimized_config_enabled?).and_return(false)
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("NotStarted").ordered
       expect(sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return((200 * 1024 * 1024).to_s).ordered
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17 25", {log: true, stdin: nil}).ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17", {log: true, stdin: nil}).ordered
 
       expect { nx.take_backup }.to nap(60)
     end
@@ -499,7 +499,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       sshable = nx.postgres_timeline.leader.vm.sshable
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("Failed").ordered
       expect(sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return("0").ordered
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17", {log: true, stdin: nil}).ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17 25", {log: true, stdin: nil}).ordered
 
       expect { nx.take_backup }.to nap(60)
     end


### PR DESCRIPTION
The previous commit added 2 layered gateway for enabling walg configuration changes depending on hardware size. That doesn't really make sense, we are enabling it by default for the deployment and every new instance while keeping the project level flags to disable in case we need.