### PR TITLE
Default new private subnets to rekey v2

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -90,7 +90,6 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       allow_only_ssh: true,
       ipv4_range_size: 28,
       preferred_azs:,
-      rekey_protocol: 2,
     ).subject
 
     vm_st = Prog::Vm::Nexus.assemble_with_sshable(

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -23,7 +23,6 @@ class Prog::Vm::VmPool < Prog::Base
       Config.vm_pool_project_id,
       location_id: vm_pool.location_id,
       allow_only_ssh: true,
-      rekey_protocol: 2,
     ).subject
 
     Prog::Vm::Nexus.assemble_with_sshable(

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -3,7 +3,7 @@
 class Prog::Vnet::SubnetNexus < Prog::Base
   subject_is :private_subnet
 
-  def self.assemble(project_id, name: nil, location_id: Location::HETZNER_FSN1_ID, ipv6_range: nil, ipv4_range: nil, allow_only_ssh: false, firewall_id: nil, ipv4_range_size: nil, preferred_azs: [], rekey_protocol: 1)
+  def self.assemble(project_id, name: nil, location_id: Location::HETZNER_FSN1_ID, ipv6_range: nil, ipv4_range: nil, allow_only_ssh: false, firewall_id: nil, ipv4_range_size: nil, preferred_azs: [], rekey_protocol: 2)
     unless (project = Project[project_id])
       fail "No existing project"
     end

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -437,6 +437,8 @@ RSpec.describe PrivateSubnet do
 
     it "connect_subnet signals refresh_keys only on the peer under v1" do
       ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
+      ps1.update(rekey_protocol: 1)
+      ps2.update(rekey_protocol: 1)
       ps1.connect_subnet(ps2)
       expect(ps1.refresh_keys_set?).to be false
       expect(ps2.refresh_keys_set?).to be true
@@ -444,8 +446,6 @@ RSpec.describe PrivateSubnet do
 
     it "connect_subnet signals refresh_keys on both sides under v2" do
       ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
-      ps1.update(rekey_protocol: 2)
-      ps2.update(rekey_protocol: 2)
       ps1.connect_subnet(ps2)
       expect(ps1.refresh_keys_set?).to be true
       expect(ps2.refresh_keys_set?).to be true
@@ -454,8 +454,7 @@ RSpec.describe PrivateSubnet do
     it "connect_subnet downgrades the mesh protocol to v1 only when the joined meshes differ" do
       ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
       ps3 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps3", location_id: Location::HETZNER_FSN1_ID).subject
-      ps1.update(rekey_protocol: 2)
-      ps2.update(rekey_protocol: 2)
+      ps3.update(rekey_protocol: 1)
       ps1.connect_subnet(ps2)
       expect([ps1, ps2].map { it.reload.rekey_protocol }).to eq [2, 2]
       ps2.connect_subnet(ps3)
@@ -464,7 +463,7 @@ RSpec.describe PrivateSubnet do
 
     it "connect_subnet signals only the peer when the merge downgrades the mesh to v1" do
       ps2 = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-ps2", location_id: Location::HETZNER_FSN1_ID).subject
-      ps1.update(rekey_protocol: 2)
+      ps2.update(rekey_protocol: 1)
       ps1.connect_subnet(ps2)
       expect(ps1.refresh_keys_set?).to be false
       expect(ps2.refresh_keys_set?).to be true
@@ -713,7 +712,7 @@ RSpec.describe PrivateSubnet do
     def create_subnet(n)
       ps = PrivateSubnet.create_with_id(format("00000000-0000-0000-0000-%012d", n), name: "psflip#{n}",
         location_id: Location::HETZNER_FSN1_ID, net6: "fd1b:9793:dcef:#{format("%04x", n)}::/64",
-        net4: "10.#{n}.0.0/16", state: "waiting", project_id: flip_project.id)
+        net4: "10.#{n}.0.0/16", state: "waiting", project_id: flip_project.id, rekey_protocol: 1)
       Strand.create_with_id(ps, prog: "Vnet::Metal::SubnetNexus", label: "wait")
       ps
     end

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -86,6 +86,8 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait", id: ps.id))
     }
 
+    before { ps.update(rekey_protocol: 1) }
+
     it "hops to refresh_keys if when_refresh_keys_set?" do
       nx.incr_refresh_keys
       expect { nx.wait }.to hop("refresh_keys")
@@ -174,6 +176,8 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
     let(:nx) {
       described_class.new(Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "refresh_keys", id: ps.id))
     }
+
+    before { ps.update(rekey_protocol: 1) }
 
     it "refreshes keys and hops to wait_refresh_keys" do
       expect(nic.start_rekey_set?).to be false
@@ -423,8 +427,8 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       end
 
       it "stamps the coordinator's last_rekey_at when it owns no nics" do
-        psa = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-psa", location_id: Location::HETZNER_FSN1_ID).subject.update(rekey_protocol: 2)
-        psb = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-psb", location_id: Location::HETZNER_FSN1_ID).subject.update(rekey_protocol: 2)
+        psa = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-psa", location_id: Location::HETZNER_FSN1_ID).subject
+        psb = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-psb", location_id: Location::HETZNER_FSN1_ID).subject
         leader, follower = [psa, psb].sort_by(&:id)
         leader.connect_subnet(follower)
         nic = Prog::Vnet::NicNexus.assemble(follower.id, name: "b").subject.update(state: "active")

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -85,14 +85,14 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(ps.subject.firewalls.first).to eq(fw)
     end
 
-    it "creates the subnet with rekey protocol v1 by default" do
+    it "creates the subnet with rekey protocol v2 by default" do
       ps = described_class.assemble(prj.id)
-      expect(ps.subject.rekey_protocol).to eq 1
+      expect(ps.subject.rekey_protocol).to eq 2
     end
 
     it "creates the subnet with the provided rekey protocol" do
-      ps = described_class.assemble(prj.id, rekey_protocol: 2)
-      expect(ps.subject.rekey_protocol).to eq 2
+      ps = described_class.assemble(prj.id, rekey_protocol: 1)
+      expect(ps.subject.rekey_protocol).to eq 1
     end
 
     it "fails if provided firewall does not exist" do


### PR DESCRIPTION
Default assembled subnets to rekey v2
Flip SubnetNexus.assemble's rekey_protocol default to 2, matching the column default. Specs that exercise v1 behavior set rekey_protocol 1 explicitly, and the default expectations move to 2.