### PR TITLE
Improve maintenance window day selection

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -9,6 +9,12 @@
         @apply ring-1 ring-gray-300 bg-white text-gray-900 hover:bg-gray-50 peer-focus-visible:ring-2 peer-focus-visible:ring-orange-600;
         @apply peer-focus-visible:ring-offset-2 peer-checked:bg-orange-600 peer-checked:text-white peer-checked:hover:bg-orange-700;
     }
+
+    .checkbox-chip {
+        @apply flex cursor-pointer items-center justify-center rounded-md bg-white text-gray-700 ring-1 ring-inset ring-gray-300;
+        @apply hover:bg-gray-50 peer-focus-visible:ring-2 peer-focus-visible:ring-orange-600 peer-focus-visible:ring-offset-2;
+        @apply peer-checked:bg-orange-50 peer-checked:text-orange-700 peer-checked:ring-orange-600 peer-checked:hover:bg-orange-100;
+    }
 }
 
 @layer utilities {

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -1203,8 +1203,8 @@ RSpec.describe Clover, "postgres" do
         visit "#{project.path}#{pg.path}/settings"
 
         select "09:00 - 11:00 (UTC)", from: "maintenance_window_start_at"
-        check "mon"
-        check "wed"
+        check "Monday"
+        check "Wednesday"
         click_button "Set"
 
         pg.reload
@@ -1217,7 +1217,8 @@ RSpec.describe Clover, "postgres" do
         pg.update(maintenance_window_start_at: 9, maintenance_window_days_bitmask: (1 << 0))
         visit "#{project.path}#{pg.path}/settings"
 
-        uncheck "mon"
+        expect(page).to have_checked_field("Monday")
+        uncheck "Monday"
         click_button "Set"
 
         pg.reload

--- a/views/postgres/settings.erb
+++ b/views/postgres/settings.erb
@@ -42,10 +42,7 @@
                         class="peer sr-only"
                         <%= "checked" if checked %>
                       >
-                      <label
-                        for="<%= id %>"
-                        class="checkbox-chip px-3 py-2 text-sm font-medium transition"
-                      ><%= day_names[index] %></label>
+                      <label for="<%= id %>" class="checkbox-chip px-3 py-2 text-sm font-medium transition"><%= day_names[index] %></label>
                     </div>
                   <% end %>
                 </div>

--- a/views/postgres/settings.erb
+++ b/views/postgres/settings.erb
@@ -9,38 +9,50 @@
         </h3>
       </div>
     </div>
-    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+    <div class="overflow-hidden rounded-lg bg-white shadow ring-1 ring-black ring-opacity-5">
       <div class="px-4 py-5 sm:p-6">
         <% form(action: "#{path(@pg)}/set-maintenance-window", method: :post) do %>
-          <div class="space-y-4">
-            <div class="grid grid-cols-12 gap-6">
-              <div class="col-span-12 sm:col-span-7">
+          <div class="max-w-3xl space-y-6">
+            <div>
+              <div class="max-w-xl">
                 <%== part(
                     "components/form/select",
                     name: "maintenance_window_start_at",
                     placeholder: "No Maintenance Window",
                     options: PostgresResource.maintenance_hour_options,
-                    label: "Maintenance Window:",
+                    label: "Start time",
                     selected: @pg.maintenance_window_start_at
                   ) %>
               </div>
             </div>
             <% if @project.get_ff_postgres_enable_maintenance_window_days %>
-              <div class="grid grid-cols-12 gap-6">
-                <div class="col-span-12">
-                  <%== part(
-                      "components/form/checkbox",
-                      name: "maintenance_window_days[]",
-                      label: "Days (leave all unchecked for every day):",
-                      options: @pg.maintenance_window_day_options_state.map { |day, checked| [day, day, "", {checked:}] }
-                    ) %>
+              <% day_names = %w[Monday Tuesday Wednesday Thursday Friday Saturday Sunday] %>
+              <fieldset>
+                <legend class="text-sm font-medium leading-6 text-gray-900">Preferred days</legend>
+                <p class="mt-1 text-sm text-gray-500">Select one or more days, or leave all unselected to allow any day.</p>
+                <div class="mt-3 flex flex-wrap gap-2">
+                  <% @pg.maintenance_window_day_options_state.each_with_index do |(day, checked), index| %>
+                    <% id = "maintenance-window-day-#{day}" %>
+                    <div>
+                      <input
+                        id="<%= id %>"
+                        name="maintenance_window_days[]"
+                        type="checkbox"
+                        value="<%= day %>"
+                        class="peer sr-only"
+                        <%= "checked" if checked %>
+                      >
+                      <label
+                        for="<%= id %>"
+                        class="checkbox-chip px-3 py-2 text-sm font-medium transition"
+                      ><%= day_names[index] %></label>
+                    </div>
+                  <% end %>
                 </div>
-              </div>
+              </fieldset>
             <% end %>
-            <div class="grid grid-cols-12 gap-6">
-              <div class="col-span-12 flex justify-end items-end">
-                <%== part("components/form/submit_button", text: "Set") %>
-              </div>
+            <div class="flex justify-end border-t border-gray-200 pt-5">
+              <%== part("components/form/submit_button", text: "Set") %>
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
The maintenance window form spread seven abbreviated checkboxes down a large card, making a small setting difficult to scan and understand.

Present the days as compact, accessible selection chips with full names and a subdued selected state. Constrain the form layout, clarify that an empty selection permits any day, and verify that saved days render as selected.

From this ->
<img width="2313" height="577" alt="image" src="https://github.com/user-attachments/assets/2a70d82d-518c-4ceb-b121-ed828b410caa" />

To this ->
<img width="1632" height="796" alt="CleanShot 2026-07-14 at 14 10 39@2x" src="https://github.com/user-attachments/assets/3f884e61-577d-4d61-9b5d-9a07cfeb57ae" />
