### PR TITLE
Make Firewall#replace_firewall_rules atomic

### DIFF
--- a/model/firewall.rb
+++ b/model/firewall.rb
@@ -35,14 +35,16 @@ class Firewall < Sequel::Model
   end
 
   def replace_firewall_rules(new_firewall_rules)
-    firewall_rules.each(&:destroy)
-    FirewallRule.import(
-      [:id, :firewall_id, :cidr, :port_range, :protocol],
-      new_firewall_rules.map { [FirewallRule.generate_uuid, id, DB.typecast_value(:cidr, it[:cidr]), it[:port_range], it[:protocol] || "tcp"] },
-    )
-    associations.delete(:firewall_rules)
+    DB.transaction do
+      firewall_rules.each(&:destroy)
+      FirewallRule.import(
+        [:id, :firewall_id, :cidr, :port_range, :protocol],
+        new_firewall_rules.map { [FirewallRule.generate_uuid, id, DB.typecast_value(:cidr, it[:cidr]), it[:port_range], it[:protocol] || "tcp"] },
+      )
+      associations.delete(:firewall_rules)
 
-    update_private_subnet_firewall_rules
+      update_private_subnet_firewall_rules
+    end
   end
 
   def before_destroy

--- a/spec/model/firewall_spec.rb
+++ b/spec/model/firewall_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe Firewall do
     expect(fw.reload.firewall_rules.first.cidr.to_s).to eq("0.0.0.0/32")
   end
 
+  it "keeps existing rules when replacing firewall rules fails partway" do
+    fw.insert_firewall_rule("10.0.0.16/28", Sequel.pg_range(80..5432))
+    expect {
+      fw.replace_firewall_rules([{cidr: "not-a-cidr", port_range: Sequel.pg_range(5432..5432)}])
+    }.to raise_error(Sequel::InvalidValue)
+    expect(fw.reload.firewall_rules.map { it.cidr.to_s }).to eq(["10.0.0.16/28"])
+  end
+
   it "associates with a private subnet" do
     expect {
       fw.associate_with_private_subnet(ps)


### PR DESCRIPTION
replace_firewall_rules destroyed the old rules and imported the new ones without a transaction, so a concurrent reader could observe the empty state between the two and briefly act on a rule set that never existed.

Wrap the destroy, import, and subnet notification in one transaction so readers see either the old rule set or the new one.