### PR TITLE
Strip the default security group of Ubicloud-created AWS VPCs

### DIFF
--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -55,6 +55,21 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
     end
     allow_ingress(private_subnet_aws_resource.mgmt_security_group_id, 443, 443, private_subnet.net4.to_s) if private_subnet.project.get_ff_aws_cloudwatch_logs
 
+    # The VPC's auto-created default security group can't be deleted, so
+    # strip its rules to make it inert. It may not be visible yet due to
+    # EC2's eventual consistency.
+    default_sg = client.describe_security_groups({filters: [
+      {name: "vpc-id", values: [private_subnet_aws_resource.vpc_id]},
+      {name: "group-name", values: ["default"]},
+    ]}).security_groups.first
+    nap 1 unless default_sg
+    unless default_sg.ip_permissions.empty?
+      client.revoke_security_group_ingress({group_id: default_sg.group_id, ip_permissions: default_sg.ip_permissions.map(&:to_h)})
+    end
+    unless default_sg.ip_permissions_egress.empty?
+      client.revoke_security_group_egress({group_id: default_sg.group_id, ip_permissions: default_sg.ip_permissions_egress.map(&:to_h)})
+    end
+
     hop_create_route_table
   end
 

--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
       client.stub_responses(:modify_vpc_attribute)
       client.stub_responses(:create_security_group, group_id: "sg-single")
       client.stub_responses(:authorize_security_group_ingress)
+      client.stub_responses(:describe_security_groups, security_groups: [{group_id: "sg-default", group_name: "default"}])
       ps.firewalls.each { it.firewall_rules.each(&:destroy) }
       ps.reload
     end
@@ -120,6 +121,26 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
       client.stub_responses(:describe_vpcs, vpcs: [{state: "available", vpc_id: "vpc-0123456789abcdefg"}])
       client.stub_responses(:authorize_security_group_ingress, Aws::EC2::Errors::InvalidPermissionDuplicate.new(nil, nil), Aws::EC2::Errors::InvalidPermissionDuplicate.new(nil, nil))
       FirewallRule.create(firewall_id: ps.firewalls.first.id, cidr: "0.0.0.1/32", port_range: 22..80)
+      expect { nx.wait_vpc_created }.to hop("create_route_table")
+    end
+
+    it "naps until the default security group is visible" do
+      client.stub_responses(:describe_vpcs, vpcs: [{state: "available", vpc_id: "vpc-0123456789abcdefg"}])
+      client.stub_responses(:describe_security_groups, security_groups: [])
+      expect { nx.wait_vpc_created }.to nap(1)
+    end
+
+    it "strips rules from the default security group" do
+      client.stub_responses(:describe_vpcs, vpcs: [{state: "available", vpc_id: "vpc-0123456789abcdefg"}])
+      client.stub_responses(:describe_security_groups, security_groups: [{
+        group_id: "sg-default",
+        group_name: "default",
+        ip_permissions: [{ip_protocol: "-1", user_id_group_pairs: [{group_id: "sg-default"}]}],
+        ip_permissions_egress: [{ip_protocol: "-1", ip_ranges: [{cidr_ip: "0.0.0.0/0"}]}],
+      }])
+      expect(client).to receive(:describe_security_groups).with({filters: [{name: "vpc-id", values: ["vpc-0123456789abcdefg"]}, {name: "group-name", values: ["default"]}]}).and_call_original
+      expect(client).to receive(:revoke_security_group_ingress).with(hash_including(group_id: "sg-default")).and_call_original
+      expect(client).to receive(:revoke_security_group_egress).with(hash_including(group_id: "sg-default")).and_call_original
       expect { nx.wait_vpc_created }.to hop("create_route_table")
     end
 


### PR DESCRIPTION
Every VPC comes with a default security group that cannot be deleted. Nothing lands in it since all network interfaces are created with explicit security groups, but its default rules allow all outbound traffic and it gets flagged in security audits.

Revoke its ingress and egress rules after VPC creation so it allows no traffic. The describe can transiently miss the group due to EC2's eventual consistency, so nap until it is visible.