### PR TITLE
VictoriaMetrics dual write

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -160,7 +160,7 @@ module Config
   # VictoriaMetrics
   optional :victoria_metrics_service_project_id, uuid
   override :victoria_metrics_host_name, "metrics.ubicloud.com", string
-  override :victoria_metrics_version, "v1.113.0", string
+  override :victoria_metrics_version, "v1.148.0", string
   optional :victoria_metrics_endpoint_override, string
 
   # Spdk

--- a/lib/victoria_metrics/client.rb
+++ b/lib/victoria_metrics/client.rb
@@ -7,7 +7,7 @@ require "openssl"
 require "zlib"
 
 class VictoriaMetrics::Client
-  def initialize(endpoint:, ssl_ca_data: nil, socket: nil, username: nil, password: nil)
+  def initialize(endpoint:, ssl_ca_data: nil, socket: nil, username: nil, password: nil, verify_host: nil)
     @endpoint = endpoint
     @username = username
     @password = password
@@ -18,7 +18,7 @@ class VictoriaMetrics::Client
         cert = OpenSSL::X509::Certificate.new(cert_pem)
         cert_store.add_cert(cert)
       end
-      Excon.new(endpoint, socket:, ssl_cert_store: cert_store)
+      Excon.new(endpoint, socket:, ssl_cert_store: cert_store, ssl_verify_peer_host: verify_host)
     else
       Excon.new(endpoint, socket:)
     end

--- a/lib/victoria_metrics/tee_client.rb
+++ b/lib/victoria_metrics/tee_client.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "delegate"
+
+class VictoriaMetrics::TeeClient < SimpleDelegator
+  def initialize(primary:, secondaries:)
+    super(primary)
+    @secondaries = secondaries
+  end
+
+  def import_prometheus(scrape, extra_labels = {})
+    result = super
+
+    @secondaries.each do |secondary|
+      secondary.import_prometheus(scrape, extra_labels)
+    rescue => ex
+      Clog.emit("VictoriaMetrics secondary write failed", Util.exception_to_hash(ex))
+    end
+
+    result
+  end
+end

--- a/mise.toml
+++ b/mise.toml
@@ -2,4 +2,4 @@
 node = "24.12.0"
 ruby = "4.0.5"
 go = "1.24.0"
-victoria-metrics = "v1.113.0"
+victoria-metrics = "v1.148.0"

--- a/model/victoria_metrics_resource.rb
+++ b/model/victoria_metrics_resource.rb
@@ -24,7 +24,19 @@ class VictoriaMetricsResource < Sequel::Model
       break if (vmr = VictoriaMetricsResource.first(project_id:))
     end
 
-    vmr&.servers&.first&.client || (VictoriaMetrics::Client.new(endpoint: "http://localhost:8428") if Config.development?)
+    dev_client = VictoriaMetrics::Client.new(endpoint: "http://localhost:8428") if Config.development?
+    return dev_client unless vmr
+
+    client = vmr.representative_server&.client || dev_client
+
+    secondary = vmr.servers_dataset.where(is_representative: false).first
+    return client if secondary.nil?
+
+    secondary_client = secondary.client(
+      endpoint: "https://#{secondary.vm.ip4_string}:8427",
+      verify_host: vmr.hostname,
+    )
+    VictoriaMetrics::TeeClient.new(primary: client, secondaries: [secondary_client])
   end
 
   def hostname

--- a/model/victoria_metrics_server.rb
+++ b/model/victoria_metrics_server.rb
@@ -59,11 +59,12 @@ class VictoriaMetricsServer < Sequel::Model
     true
   end
 
-  def client(socket: nil)
+  def client(socket: nil, endpoint: self.endpoint, verify_host: nil)
     VictoriaMetrics::Client.new(
       endpoint:,
       ssl_ca_data: resource.root_certs,
       socket:,
+      verify_host:,
       username: resource.admin_user,
       password: resource.admin_password,
     )

--- a/spec/lib/metrics_target_resource_spec.rb
+++ b/spec/lib/metrics_target_resource_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe MetricsTargetResource do
     vmr = VictoriaMetricsResource.create(project:, location_id: Location::HETZNER_FSN1_ID,
       name: "test-vmr", admin_user: "admin", admin_password: "pass", target_vm_size: "standard-2",
       target_storage_size_gib: 100, root_cert_1: "cert")
-    VictoriaMetricsServer.create(resource: vmr, vm:, cert: "cert", cert_key: "key")
+    VictoriaMetricsServer.create(resource: vmr, vm:, cert: "cert", cert_key: "key", is_representative: true)
     vmr
   end
 

--- a/spec/lib/victoria_metrics/tee_client_spec.rb
+++ b/spec/lib/victoria_metrics/tee_client_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe VictoriaMetrics::TeeClient do
+  subject(:tee_client) { described_class.new(primary:, secondaries:) }
+
+  let(:primary) { instance_double(VictoriaMetrics::Client) }
+  let(:secondary) { instance_double(VictoriaMetrics::Client) }
+  let(:secondaries) { [secondary] }
+  let(:scrape) { VictoriaMetrics::Client::Scrape.new(time: Time.now, samples: "metric 1") }
+
+  it "delegates read methods to the primary client only" do
+    expect(primary).to receive(:query).with(query: "up").and_return("query result")
+    expect(secondary).not_to receive(:query)
+    expect(tee_client.query(query: "up")).to eq("query result")
+  end
+
+  describe "#import_prometheus" do
+    it "forwards to all secondaries and returns the primary's result" do
+      expect(primary).to receive(:import_prometheus).with(scrape, {label: "value"}).and_return("primary result")
+      expect(secondary).to receive(:import_prometheus).with(scrape, {label: "value"})
+      expect(tee_client.import_prometheus(scrape, {label: "value"})).to eq("primary result")
+    end
+
+    it "raises if the primary write fails, without attempting the secondaries" do
+      expect(primary).to receive(:import_prometheus).and_raise(VictoriaMetrics::ClientError.new("boom"))
+      expect(secondary).not_to receive(:import_prometheus)
+      expect { tee_client.import_prometheus(scrape) }.to raise_error(VictoriaMetrics::ClientError, "boom")
+    end
+
+    it "logs and swallows secondary write failures" do
+      expect(primary).to receive(:import_prometheus).and_return("primary result")
+      expect(secondary).to receive(:import_prometheus).and_raise(VictoriaMetrics::ClientError.new("boom"))
+      expect(Clog).to receive(:emit).with("VictoriaMetrics secondary write failed", instance_of(Hash)).and_call_original
+      expect(tee_client.import_prometheus(scrape)).to eq("primary result")
+    end
+
+    it "still writes to remaining secondaries when one fails" do
+      other_secondary = instance_double(VictoriaMetrics::Client)
+      tee_client = described_class.new(primary:, secondaries: [secondary, other_secondary])
+      expect(primary).to receive(:import_prometheus).and_return("primary result")
+      expect(secondary).to receive(:import_prometheus).and_raise(VictoriaMetrics::ClientError.new("boom"))
+      expect(other_secondary).to receive(:import_prometheus)
+      expect(Clog).to receive(:emit).and_call_original
+      expect(tee_client.import_prometheus(scrape)).to eq("primary result")
+    end
+  end
+end

--- a/spec/model/victoria_metrics/victoria_metrics_resource_spec.rb
+++ b/spec/model/victoria_metrics/victoria_metrics_resource_spec.rb
@@ -42,6 +42,44 @@ RSpec.describe VictoriaMetricsResource do
     expect(vmr.hostname).to eq("victoria-metrics-name.victoria.ubicloud.com")
   end
 
+  describe "#client_for_project" do
+    it "returns nil when the resource has no representative server outside development" do
+      vmr # ensure the resource exists for the lookup
+      expect(described_class.client_for_project(project.id)).to be_nil
+    end
+
+    it "returns the representative server's client unwrapped when there is only one server" do
+      vm = create_vm
+      VictoriaMetricsServer.create(victoria_metrics_resource_id: vmr.id, vm_id: vm.id, is_representative: true)
+      client = instance_double(VictoriaMetrics::Client)
+      expect(VictoriaMetrics::Client).to receive(:new).and_return(client)
+      expect(described_class.client_for_project(project.id)).to be(client)
+    end
+
+    it "wraps the client in a TeeClient pointed at every non-representative server's IPv4 when there are multiple servers" do
+      representative_vm = create_vm
+      VictoriaMetricsServer.create(victoria_metrics_resource_id: vmr.id, vm_id: representative_vm.id, is_representative: true)
+      secondary_vm = create_vm
+      VictoriaMetricsServer.create(victoria_metrics_resource_id: vmr.id, vm_id: secondary_vm.id, is_representative: false)
+
+      primary_client = instance_double(VictoriaMetrics::Client)
+      secondary_client = instance_double(VictoriaMetrics::Client)
+      expect(VictoriaMetrics::Client).to receive(:new).with(hash_including(verify_host: nil)).and_return(primary_client)
+      expect(VictoriaMetrics::Client).to receive(:new).with(hash_including(
+        endpoint: a_string_matching(%r{\Ahttps://[^\[\]]*:8427\z}),
+        ssl_ca_data: vmr.root_certs,
+        verify_host: vmr.hostname,
+        username: vmr.admin_user,
+        password: vmr.admin_password,
+      )).and_return(secondary_client)
+
+      tee_client = described_class.client_for_project(project.id)
+      expect(tee_client).to be_a(VictoriaMetrics::TeeClient)
+      expect(tee_client.__getobj__).to be(primary_client)
+      expect(tee_client.instance_variable_get(:@secondaries)).to eq([secondary_client])
+    end
+  end
+
   describe "#dns_zone" do
     it "returns the DnsZone matching victoria_metrics_service_project_id and victoria_metrics_host_name" do
       dns_zone = DnsZone.create(project_id: vmr.project_id, name: "victoria.example.com")

--- a/spec/model/victoria_metrics/victoria_metrics_server_spec.rb
+++ b/spec/model/victoria_metrics/victoria_metrics_server_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe VictoriaMetricsServer do
         endpoint: vms.endpoint,
         ssl_ca_data: vms.resource.root_certs,
         socket: File.join("unix://", socket_path, "health_monitor_socket"),
+        verify_host: nil,
         username: vms.resource.admin_user,
         password: vms.resource.admin_password,
       ).and_return(client)
@@ -159,6 +160,7 @@ RSpec.describe VictoriaMetricsServer do
         endpoint: vms.endpoint,
         ssl_ca_data: vms.resource.root_certs,
         socket: nil,
+        verify_host: nil,
         username: vms.resource.admin_user,
         password: vms.resource.admin_password,
       )
@@ -172,6 +174,7 @@ RSpec.describe VictoriaMetricsServer do
         endpoint: vms.endpoint,
         ssl_ca_data: vms.resource.root_certs,
         socket:,
+        verify_host: nil,
         username: vms.resource.admin_user,
         password: vms.resource.admin_password,
       )


### PR DESCRIPTION
Add a dual-write setup to write to both representative and secondary server to migrate with (near)-zero downtime.

Migration steps:

1. Provision the replacement server, on a different host, as a normal tracked server:
Prog::VictoriaMetrics::VictoriaMetricsServerNexus.assemble(resource.id, is_representative: false, exclude_host_ids: [old_host.id]).

2. Dual-write is already active from the moment that second server starts + a monitor restart.

3. Backfill history: from the new VM, run vmctl (already installed alongside victoria-metrics) in vm-native mode, pulling from the old server's /api/v1/export/native into the new one's /api/v1/import/native for the full retention window. Overlap is harmless due to dedup.

4. Cutover (zero downtime):

    old_server.update(is_representative: false) then new_server.update(is_representative: true)
victoria_metrics_resource.incr_refresh_dns_record
Re-verify via the public hostname.
Dual-write keeps running post-cutover (old server is now the non-representative one) — useful insurance if cutover needs rolling back.
Decommission the old server: old_server.incr_destroy.