### PR TITLE
Include S3 error details when machine image deletion fails

### DIFF
--- a/prog/machine_image/version_metal_nexus.rb
+++ b/prog/machine_image/version_metal_nexus.rb
@@ -219,6 +219,10 @@ class Prog::MachineImage::VersionMetalNexus < Prog::Base
     end
 
     nap 0
+  rescue Aws::S3::Errors::ServiceError => e
+    raise "S3 #{e.context.operation_name} failed for machine image archive " \
+      "(store: #{store.ubid}, bucket: #{store.bucket}, prefix: #{machine_image_version_metal.store_prefix}): " \
+      "#{e.code}: #{e.message} (request_id: #{e.context[:request_id]})"
   end
 
   label def finish_destroy

--- a/spec/prog/machine_image/version_metal_nexus_spec.rb
+++ b/spec/prog/machine_image/version_metal_nexus_spec.rb
@@ -329,6 +329,14 @@ RSpec.describe Prog::MachineImage::VersionMetalNexus do
       )
       expect { prog.destroy_objects }.to nap(30)
     end
+
+    it "raises a detailed error when an S3 request fails" do
+      s3.stub_responses(:list_objects_v2, {contents: [{key: "a"}], is_truncated: false})
+      s3.stub_responses(:delete_objects, "AccessDenied")
+      expect { prog.destroy_objects }.to raise_error(RuntimeError) do |e|
+        expect(e.message).to include("S3 delete_objects failed", store.ubid, metal.store_prefix, "AccessDenied")
+      end
+    end
   end
 
   describe "#finish_destroy" do


### PR DESCRIPTION
destroy_objects surfaced only the raw Aws::S3 error message ("We encountered an internal error. Please try again.") in the strand error log, with no error code, request id, or store context. Rescue Aws::S3::Errors::ServiceError and re-raise with the operation, error code, store/bucket/prefix, and request id, so a recurring failure can be diagnosed and correlated with the object store's logs.