### PR TITLE
Retry transient S3 errors when deleting machine image objects

### DIFF
--- a/prog/machine_image/version_metal_nexus.rb
+++ b/prog/machine_image/version_metal_nexus.rb
@@ -180,7 +180,7 @@ class Prog::MachineImage::VersionMetalNexus < Prog::Base
       force_path_style: true,
       http_open_timeout: 5,
       http_read_timeout: 20,
-      retry_limit: 0,
+      retry_limit: 2,
     )
 
     # delete one page of objects at a time to avoid a long running label


### PR DESCRIPTION
destroy_objects built its Aws::S3::Client with retry_limit: 0, so a single transient error (such as R2's 500 InternalError) fails the label immediately. Raise retry_limit to 2 so the batch DeleteObjects request is retried in-request before the strand has to retry the whole label.