### PR TITLE
Disable request checksums when deleting machine image objects

### DIFF
--- a/prog/machine_image/version_metal_nexus.rb
+++ b/prog/machine_image/version_metal_nexus.rb
@@ -178,6 +178,8 @@ class Prog::MachineImage::VersionMetalNexus < Prog::Base
       endpoint: store.endpoint,
       region: store.region,
       force_path_style: true,
+      request_checksum_calculation: "when_required",
+      response_checksum_validation: "when_required",
       http_open_timeout: 5,
       http_read_timeout: 20,
       retry_limit: 0,


### PR DESCRIPTION
destroy_objects builds an Aws::S3::Client against the machine image store (Cloudflare R2) but omitted request_checksum_calculation and response_checksum_validation. Match the setting already used by the other S3-compatible-store clients (invoice, github_repository, download_boot_image) so aws-sdk-core does not attach default checksums.