### PR TITLE
Retry and disable checksums when deleting machine image objects

### DIFF
--- a/prog/machine_image/version_metal_nexus.rb
+++ b/prog/machine_image/version_metal_nexus.rb
@@ -178,9 +178,11 @@ class Prog::MachineImage::VersionMetalNexus < Prog::Base
       endpoint: store.endpoint,
       region: store.region,
       force_path_style: true,
+      request_checksum_calculation: "when_required",
+      response_checksum_validation: "when_required",
       http_open_timeout: 5,
       http_read_timeout: 20,
-      retry_limit: 0,
+      retry_limit: 2,
     )
 
     # delete one page of objects at a time to avoid a long running label


### PR DESCRIPTION
destroy_objects builds an Aws::S3::Client against the machine image store (Cloudflare R2) with retry_limit: 0 and default request checksums. Raise retry_limit to 2 so a transient error retries in-request, and set request_checksum_calculation/response_checksum_validation to "when_required" to match the other S3-compatible-store clients.