### PR TITLE
Detect out-of-band host reboots and restart their VMs

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -380,14 +380,6 @@ class VmHost < Sequel::Model
     clock_status
   end
 
-  def check_last_boot_id(ssh_session)
-    boot_id = ssh_session.exec!("cat /proc/sys/kernel/random/boot_id")
-    fail "Failed to exec on session: #{boot_id}" unless boot_id.exitstatus.zero?
-    if boot_id.strip != last_boot_id
-      Prog::PageNexus.assemble("Recorded last_boot_id of #{ubid} in database differs from the actual boot_id", ["LastBootIDDiscrepancy", ubid], ubid, severity: "info")
-    end
-  end
-
   def init_health_monitor_session
     {
       ssh_session: sshable.start_fresh_session,

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -359,6 +359,7 @@ TIMER
 
     when_checkup_set? do
       hop_unavailable if !available?
+      check_boot_id
       decr_checkup
     end
 
@@ -395,6 +396,7 @@ TIMER
 
     if available?
       decr_checkup
+      check_boot_id
       hop_wait
     end
 
@@ -439,9 +441,20 @@ TIMER
     end
   end
 
+  # Detect an out-of-band reboot: if the host's live boot_id differs from the one we
+  # recorded, it rebooted without us, so page, adopt the new id, and restart its VMs.
+  # The host was already up, so we skip the fresh-reboot verify checks and start directly.
+  def check_boot_id
+    boot_id = get_boot_id
+    return if boot_id == vm_host.last_boot_id || vm_host.last_boot_id.nil?
+
+    Prog::PageNexus.assemble("Recorded last_boot_id of #{vm_host.ubid} differs from the actual boot_id; treating as an out-of-band reboot and restarting its VMs", ["LastBootIDDiscrepancy", vm_host.ubid], vm_host.ubid, severity: "info")
+    vm_host.update(last_boot_id: boot_id)
+    hop_start_slices
+  end
+
   def available?
     session = sshable.connect
-    vm_host.check_last_boot_id(session)
     vm_host.perform_health_checks(session, test_file_suffix: "respirate")
   rescue
     false

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -540,26 +540,6 @@ RSpec.describe VmHost do
     end
   end
 
-  describe "#check_last_boot_id" do
-    it "raises if command execution exits with non-zero status code" do
-      expect(ssh_session).to receive(:_exec!).with("cat /proc/sys/kernel/random/boot_id").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("it didn't work", 1))
-      expect { vm_host.check_last_boot_id(ssh_session) }.to raise_error(RuntimeError, "Failed to exec on session: it didn't work")
-    end
-
-    it "does nothing if boot_id matches" do
-      vm_host.last_boot_id = "boot-id"
-      expect(ssh_session).to receive(:_exec!).with("cat /proc/sys/kernel/random/boot_id").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("boot-id", 0))
-      expect { vm_host.check_last_boot_id(ssh_session) }.not_to raise_error
-    end
-
-    it "assembles a page for it" do
-      vm_host.last_boot_id = "boot-id"
-      expect(ssh_session).to receive(:_exec!).with("cat /proc/sys/kernel/random/boot_id").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("another-boot-id", 0))
-      vm_host.check_last_boot_id(ssh_session)
-      expect(Page.first.summary).to eq("Recorded last_boot_id of #{vm_host.ubid} in database differs from the actual boot_id")
-    end
-  end
-
   describe "#spdk_cpu_count" do
     it "uses 2 cpus for AX161" do
       vm_host.total_cpus = 64

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -334,7 +334,17 @@ RSpec.describe Prog::Vm::HostNexus do
 
       nx.incr_checkup
       expect(nx).to receive(:available?).and_return(true)
+      expect(nx).to receive(:get_boot_id).and_return("someboot")
       expect { nx.wait }.to nap(6 * 60 * 60)
+    end
+
+    it "restarts the VMs when a checkup finds a reachable host had an out-of-band reboot" do
+      nx.incr_checkup
+      vm_host.update(last_boot_id: "oldboot")
+      expect(nx).to receive(:available?).and_return(true)
+      expect(nx).to receive(:get_boot_id).and_return("newboot")
+      expect { nx.wait }.to hop("start_slices")
+      expect(vm_host.reload.last_boot_id).to eq("newboot")
     end
 
     context "when patch set" do
@@ -399,9 +409,24 @@ RSpec.describe Prog::Vm::HostNexus do
       expect { nx.unavailable }.to nap(30)
     end
 
-    it "hops to wait if host is available" do
+    it "checks the boot_id and hops to wait if an available host did not reboot" do
+      nx.incr_checkup
       expect(nx).to receive(:available?).and_return(true)
+      vm_host.update(last_boot_id: "boot-id")
+      expect(nx).to receive(:get_boot_id).and_return("boot-id")
       expect { nx.unavailable }.to hop("wait")
+      expect(nx.checkup_set?).to be false
+    end
+
+    it "restarts the VMs when an available host had an out-of-band reboot" do
+      nx.incr_checkup
+      expect(nx).to receive(:available?).and_return(true)
+      vm_host.update(last_boot_id: "oldboot")
+      expect(nx).to receive(:get_boot_id).and_return("newboot")
+      expect { nx.unavailable }.to hop("start_slices")
+      expect(vm_host.reload.last_boot_id).to eq("newboot")
+      expect(nx.checkup_set?).to be false
+      expect(Page.first.summary).to eq("Recorded last_boot_id of #{vm_host.ubid} differs from the actual boot_id; treating as an out-of-band reboot and restarting its VMs")
     end
   end
 
@@ -521,6 +546,25 @@ RSpec.describe Prog::Vm::HostNexus do
 
       expect { nx.reboot }.to hop("verify_hugepages")
       expect(vm_host.reload.last_boot_id).to eq("pqr")
+    end
+
+    it "brings VMs back up end-to-end after an out-of-band reboot" do
+      vm = create_vm(vm_host_id: vm_host.id, memory_gib: 1)
+      Strand.create(id: vm.id, prog: "Vm::Nexus", label: "wait")
+      vm_host.update(last_boot_id: "oldboot", allocation_state: "accepting")
+
+      # A healthy host in unavailable whose boot_id changed rebooted out-of-band;
+      # we jump straight to restarting the VMs, skipping the fresh-reboot verify checks.
+      expect(nx).to receive(:available?).and_return(true)
+      expect(nx).to receive(:get_boot_id).and_return("newboot")
+      expect { nx.unavailable }.to hop("start_slices")
+      expect(vm_host.reload.last_boot_id).to eq("newboot")
+
+      expect { nx.start_slices }.to hop("start_vms")
+      expect { nx.start_vms }.to hop("configure_metrics")
+
+      # The VM was signaled to restart, exactly as on a requested reboot.
+      expect(vm.reload.start_after_host_reboot_set?).to be true
     end
 
     it "verify_spdk hops to verify_hugepages if spdk started" do
@@ -686,14 +730,12 @@ RSpec.describe Prog::Vm::HostNexus do
   describe "#available?" do
     it "returns the available status when disks are healthy" do
       expect(sshable).to receive(:connect).and_return(nil)
-      expect(vm_host).to receive(:check_last_boot_id)
       expect(vm_host).to receive(:perform_health_checks).and_return(true)
       expect(nx.available?).to be true
     end
 
     it "returns the available status when disks are not healthy" do
       expect(sshable).to receive(:connect).and_return(nil)
-      expect(vm_host).to receive(:check_last_boot_id)
       allow(vm_host).to receive(:perform_health_checks).and_return(false)
       expect(nx.available?).to be false
     end
@@ -701,6 +743,28 @@ RSpec.describe Prog::Vm::HostNexus do
     it "returns an error trying to connect to VmHost" do
       expect(sshable).to receive(:connect).and_raise Sshable::SshError.new("ssh failed", "", "", nil, nil)
       expect(nx.available?).to be false
+    end
+  end
+
+  describe "#check_boot_id" do
+    it "does nothing when the boot_id still matches" do
+      vm_host.update(last_boot_id: "boot-id")
+      expect(nx).to receive(:get_boot_id).and_return("boot-id")
+      expect { nx.check_boot_id }.not_to hop
+    end
+
+    it "does nothing when last_boot_id is unset" do
+      vm_host.update(last_boot_id: nil)
+      expect(nx).to receive(:get_boot_id).and_return("boot-id")
+      expect { nx.check_boot_id }.not_to hop
+    end
+
+    it "pages, adopts the new boot_id, and hops to start_slices on a mismatch" do
+      vm_host.update(last_boot_id: "oldboot")
+      expect(nx).to receive(:get_boot_id).and_return("newboot")
+      expect { nx.check_boot_id }.to hop("start_slices")
+      expect(vm_host.reload.last_boot_id).to eq("newboot")
+      expect(Page.first.summary).to eq("Recorded last_boot_id of #{vm_host.ubid} differs from the actual boot_id; treating as an out-of-band reboot and restarting its VMs")
     end
   end
 end


### PR DESCRIPTION
When a VM host was rebooted outside of Clover (e.g. `reboot now` on the host), Clover never brought its VMs back up: they stayed down while the web UI kept reporting "running". The only workaround was `incr_reboot`, which rebooted the host a second time just to trigger the bring-up.

Clover now detects these reboots and runs the normal post-reboot bring-up.

- Split the host `reboot` state into `reboot` (issue the reboot) and `finalize_reboot` (post-reboot bring-up: verify SPDK/hugepages, restart slices and VMs). `reboot` hops into `finalize_reboot`, same flow as before.
- `VmHost#check_last_boot_id` now sets an `unexpected_reboot` semaphore when the host's live boot_id differs from the recorded `last_boot_id`, on top of the existing page. The host strand's `finalize_reboot_check` (in `wait`) consumes it, adopts the new boot_id, and hops to `finalize_reboot`.
- Detection runs from the monitor's `check_pulse` on each healthy pulse, so a clean reboot is caught promptly instead of waiting for a checkup escalation.
- Read `last_boot_id` from the database inside `check_last_boot_id`: the monitor caches the VmHost across pulses, so a stale in-memory value kept re-signaling after the strand adopted the new boot_id, re-entering `finalize_reboot` and failing `verify_hugepages` once the VMs were back up.
- Only page/signal once until `finalize_reboot` clears the flag.
- Drop the redundant `check_last_boot_id` call from `available?`; its return value was already discarded, so the monitor pulse is now the single detection path.