### PR TITLE
Support DNS server VMs on GCP

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -57,8 +57,8 @@ module Option
     "#{family}.#{suffix}"
   end
 
-  def self.gcp_instance_type_name(family, vcpu_count)
-    "#{family}-#{vcpu_count}-lssd"
+  def self.gcp_instance_type_name(family, vcpu_count, lssd: true)
+    "#{family}-#{vcpu_count}#{"-lssd" if lssd}"
   end
 
   def self.vring_workers(vcpus)

--- a/lib/option.rb
+++ b/lib/option.rb
@@ -61,8 +61,8 @@ module Option
     "#{family}.#{suffix}"
   end
 
-  def self.gcp_instance_type_name(family, vcpu_count)
-    "#{family}-#{vcpu_count}-lssd"
+  def self.gcp_instance_type_name(family, vcpu_count, lssd: true)
+    "#{family}-#{vcpu_count}#{"-lssd" if lssd}"
   end
 
   def self.vring_workers(vcpus)

--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -5,30 +5,40 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
 
   frame_reader :dns_server_id
 
-  def self.assemble(dns_server, name: nil, vm_size: "standard-2", storage_size_gib: 30, location_id: Location::HETZNER_FSN1_ID, boot_image: "ubuntu-noble")
+  def self.assemble(dns_server, name: nil, vm_size: "standard-2", storage_size_gib: 30, location_id: Location::HETZNER_FSN1_ID, boot_image: "ubuntu-noble", restrict_ssh_to_control_plane: false)
     fail "No existing Dns Server" unless dns_server
-    fail "No existing Project" unless Project[Config.dns_service_project_id]
-    fail "No existing Location" unless Location[location_id]
+    fail "No existing Project" unless (project = Project[Config.dns_service_project_id])
+    fail "No existing Location" unless (location = Location[location_id])
 
     # The .assemble function is meant to be run by an operator manually. If/when we want to make this more programmatic
     # we should move this check to a pre-validation label of the prog.
     fail "Existing DNS Server VMs are not in sync, try again later" unless vms_in_sync?(dns_server.vms)
 
     name ||= "#{dns_server.ubid}-#{SecureRandom.alphanumeric(8).downcase}"
+    arch = Option::VmSizes.find { it.name == vm_size }&.arch
 
     DB.transaction do
+      private_subnet_id = if restrict_ssh_to_control_plane
+        subnet = project.default_private_subnet(location)
+        ssh_rules = Config.control_plane_outbound_cidrs.map { {cidr: it, port_range: Sequel.pg_range(22..22)} }
+        subnet.firewalls.each { it.replace_firewall_rules(ssh_rules) }
+        subnet.id
+      end
+
       vm_st = Prog::Vm::Nexus.assemble_with_sshable(
         Config.dns_service_project_id,
         sshable_unix_user: "ubi",
         location_id:,
         name:,
         size: vm_size,
+        arch:,
         storage_volumes: [
           {encrypted: true, size_gib: storage_size_gib},
         ],
         boot_image:,
         enable_ip4: true,
-        exclude_host_ids: Config.allow_unspread_servers ? [] : dns_server.vms_dataset.where(location_id:).select_map(:vm_host_id),
+        private_subnet_id:,
+        exclude_host_ids: Config.allow_unspread_servers ? [] : dns_server.vms_dataset.where(location_id:).select_map(:vm_host_id).compact,
       )
 
       Strand.create(prog: "DnsZone::SetupDnsServerVm", label: "start", stack: [{subject_id: vm_st.id, dns_server_id: dns_server.id}])
@@ -63,9 +73,9 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
   label def start
     nap 5 unless vm.strand.label == "wait"
     register_deadline(nil, 15 * 60)
-    if vm.location.aws?
-      # Open UDP & TCP port 53 for DNS queries on AWS
-      fw = Firewall[name: "dns", project_id: Config.dns_service_project_id]
+    if vm.location.aws? || vm.location.gcp?
+      # Open UDP & TCP port 53 for DNS queries on AWS & GCP
+      fw = Firewall[name: "dns", project_id: Config.dns_service_project_id, location_id: vm.location_id]
       unless fw
         fw = Firewall.create(name: "dns", location: vm.location, project_id: Config.dns_service_project_id)
         fw.add_firewall_rule(cidr: "0.0.0.0/0", port_range: 53..53, protocol: "udp")

--- a/prog/dns_zone/setup_dns_server_vm.rb
+++ b/prog/dns_zone/setup_dns_server_vm.rb
@@ -5,30 +5,45 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
 
   frame_reader :dns_server_id
 
-  def self.assemble(dns_server, name: nil, vm_size: "standard-2", storage_size_gib: 30, location_id: Location::HETZNER_FSN1_ID, boot_image: "ubuntu-noble")
+  def self.assemble(dns_server, name: nil, vm_size: "standard-2", storage_size_gib: 30, location_id: Location::HETZNER_FSN1_ID, boot_image: "ubuntu-noble", restrict_ssh_to_control_plane: false)
     fail "No existing Dns Server" unless dns_server
-    fail "No existing Project" unless Project[Config.dns_service_project_id]
-    fail "No existing Location" unless Location[location_id]
+    fail "No existing Project" unless (project = Project[Config.dns_service_project_id])
+    fail "No existing Location" unless (location = Location[location_id])
 
     # The .assemble function is meant to be run by an operator manually. If/when we want to make this more programmatic
     # we should move this check to a pre-validation label of the prog.
     fail "Existing DNS Server VMs are not in sync, try again later" unless vms_in_sync?(dns_server.vms)
 
     name ||= "#{dns_server.ubid}-#{SecureRandom.alphanumeric(8).downcase}"
+    arches = Option::VmSizes.select { it.name == vm_size }.map(&:arch)
+    arch = arches.include?("x64") ? "x64" : arches.first
 
     DB.transaction do
+      private_subnet_id = if restrict_ssh_to_control_plane
+        subnet_name = "dns-#{location.display_name}"
+        subnet = project.private_subnets_dataset.first(location_id:, name: subnet_name)
+        unless subnet
+          firewall = Firewall.create(name: subnet_name, location_id:, project_id: project.id)
+          Config.control_plane_outbound_cidrs.each { firewall.add_firewall_rule(cidr: it, port_range: 22..22) }
+          subnet = Prog::Vnet::SubnetNexus.assemble(project.id, name: subnet_name, location_id:, firewall_id: firewall.id).subject
+        end
+        subnet.id
+      end
+
       vm_st = Prog::Vm::Nexus.assemble_with_sshable(
         Config.dns_service_project_id,
         sshable_unix_user: "ubi",
         location_id:,
         name:,
         size: vm_size,
+        arch:,
         storage_volumes: [
           {encrypted: true, size_gib: storage_size_gib},
         ],
         boot_image:,
         enable_ip4: true,
-        exclude_host_ids: Config.allow_unspread_servers ? [] : dns_server.vms_dataset.where(location_id:).select_map(:vm_host_id),
+        private_subnet_id:,
+        exclude_host_ids: Config.allow_unspread_servers ? [] : dns_server.vms_dataset.where(location_id:).exclude(vm_host_id: nil).select_map(:vm_host_id),
       )
 
       Strand.create(prog: "DnsZone::SetupDnsServerVm", label: "start", stack: [{subject_id: vm_st.id, dns_server_id: dns_server.id}])
@@ -63,9 +78,9 @@ class Prog::DnsZone::SetupDnsServerVm < Prog::Base
   label def start
     nap 5 unless vm.strand.label == "wait"
     register_deadline(nil, 15 * 60)
-    if vm.location.aws?
-      # Open UDP & TCP port 53 for DNS queries on AWS
-      fw = Firewall[name: "dns", project_id: Config.dns_service_project_id]
+    if vm.location.aws? || vm.location.gcp?
+      # Open UDP & TCP port 53 for DNS queries on AWS & GCP
+      fw = Firewall[name: "dns", project_id: Config.dns_service_project_id, location_id: vm.location_id]
       unless fw
         fw = Firewall.create(name: "dns", location: vm.location, project_id: Config.dns_service_project_id)
         fw.add_firewall_rule(cidr: "0.0.0.0/0", port_range: 53..53, protocol: "udp")

--- a/prog/vm/gcp/nexus.rb
+++ b/prog/vm/gcp/nexus.rb
@@ -326,7 +326,8 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
   end
 
   def gce_machine_type
-    @gce_machine_type ||= Option.gcp_instance_type_name(vm.family, vm.vcpus)
+    # -lssd is needed only when there are non-boot (data) volumes
+    @gce_machine_type ||= Option.gcp_instance_type_name(vm.family, vm.vcpus, lssd: !vm.vm_storage_volumes_dataset.where(boot: false).empty?)
   end
 
   GCE_BOOT_IMAGE_FAMILIES = {

--- a/spec/lib/option_spec.rb
+++ b/spec/lib/option_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe Option do
     end
   end
 
+  describe ".gcp_instance_type_name" do
+    it "appends -lssd for machine types with local SSDs" do
+      expect(described_class.gcp_instance_type_name("c4a-standard", 8, lssd: true)).to eq("c4a-standard-8-lssd")
+    end
+
+    it "defaults to the -lssd variant" do
+      expect(described_class.gcp_instance_type_name("c4a-standard", 8)).to eq("c4a-standard-8-lssd")
+    end
+
+    it "returns the plain machine type without local SSDs" do
+      expect(described_class.gcp_instance_type_name("c4a-standard", 4, lssd: false)).to eq("c4a-standard-4")
+    end
+  end
+
   describe "GCP Postgres options" do
     it "defines all GCP family options" do
       expect(Option::GCP_FAMILY_OPTIONS).to eq(["c4a-standard", "c4a-highmem"])

--- a/spec/lib/option_spec.rb
+++ b/spec/lib/option_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe Option do
     end
   end
 
+  describe ".gcp_instance_type_name" do
+    it "appends -lssd for machine types with local SSDs" do
+      expect(described_class.gcp_instance_type_name("c4a-standard", 8, lssd: true)).to eq("c4a-standard-8-lssd")
+    end
+
+    it "defaults to the -lssd variant" do
+      expect(described_class.gcp_instance_type_name("c4a-standard", 8)).to eq("c4a-standard-8-lssd")
+    end
+
+    it "returns the plain machine type without local SSDs" do
+      expect(described_class.gcp_instance_type_name("c4a-standard", 4, lssd: false)).to eq("c4a-standard-4")
+    end
+  end
+
   describe "GCP Postgres options" do
     it "defines all GCP family options" do
       expect(Option::GCP_FAMILY_OPTIONS).to eq(["c4a-standard", "c4a-highmem"])

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -56,6 +56,24 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       }.to raise_error RuntimeError, "No existing Project"
     end
 
+    it "rejects a vm size that does not exist" do
+      expect {
+        described_class.assemble(ds, vm_size: "bogus-2")
+      }.to raise_error Validation::ValidationFailed, /size/
+    end
+
+    it "derives the arch from the vm size for arm64-only GCP sizes" do
+      gcp_location = Location.create(name: "gcp-us-central1", provider: "gcp",
+        display_name: "gcp-us-central1", ui_name: "GCP US Central 1", visible: true)
+
+      described_class.assemble(ds, vm_size: "c4a-standard-4", location_id: gcp_location.id)
+
+      vm = Vm.first
+      expect(vm.arch).to eq "arm64"
+      expect(vm.family).to eq "c4a-standard"
+      expect(vm.vcpus).to eq 4
+    end
+
     it "excludes host ids of existing dns server vms" do
       existing_vm = create_vm_with_sshable
       vm_host = create_vm_host
@@ -69,6 +87,34 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
         vm_strand = Strand[st.stack.first["subject_id"]]
         expect(vm_strand.stack.first["exclude_host_ids"]).to eq expected_ids
       end
+    end
+
+    it "locks the shared subnet firewall to control-plane SSH when restrict_ssh_to_control_plane is set" do
+      gcp_location = Location.create(name: "gcp-us-central1", provider: "gcp",
+        display_name: "gcp-us-central1", ui_name: "GCP US Central 1", visible: true)
+
+      described_class.assemble(ds, vm_size: "c4a-standard-4", location_id: gcp_location.id, restrict_ssh_to_control_plane: true)
+
+      rules = Vm.first.user_nic.private_subnet.firewalls.flat_map(&:firewall_rules)
+      expect(rules.map { it.port_range.begin }.uniq).to eq [22]
+      expect(rules.map { it.cidr.to_s }.sort).to eq Config.control_plane_outbound_cidrs.sort
+    end
+
+    it "keeps the metal subnet default firewall untouched" do
+      described_class.assemble(ds)
+
+      rules = Vm.first.user_nic.private_subnet.firewalls.flat_map(&:firewall_rules)
+      expect(rules.map { it.port_range.begin }.uniq).to eq [0]
+    end
+
+    it "does not exclude hosts for existing cloud vms without a vm host" do
+      existing_vm = create_vm_with_sshable
+      ds.add_vm(existing_vm)
+      expect(Config).to receive(:allow_unspread_servers).and_return(false)
+
+      st = described_class.assemble(ds)
+      vm_strand = Strand[st.stack.first["subject_id"]]
+      expect(vm_strand.stack.first["exclude_host_ids"]).to eq []
     end
 
     it "propagates parameters to the created vm" do
@@ -149,6 +195,7 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       expect(prog.strand.stack.first["deadline_at"]).to be_nil
       expect { prog.start }.to hop("prepare")
       expect(prog.vm.firewall_rules.filter { it.protocol == "udp" && it.port_range.begin == 53 }.map { it.cidr.to_s }.sort).to eq(["0.0.0.0/0", "::/0"])
+      expect(prog.vm.firewall_rules.filter { it.protocol == "tcp" && it.port_range.begin == 53 }.map { it.cidr.to_s }.sort).to eq(["0.0.0.0/0", "::/0"])
       expect(prog.strand.stack.first["deadline_at"]).not_to be_nil
     end
 
@@ -167,6 +214,18 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       expect(prog.strand.stack.first["deadline_at"]).not_to be_nil
 
       expect(prog.vm.firewalls.map(&:id)).to include(fw.id)
+    end
+
+    it "does not reuse a dns firewall from another location" do
+      other_location = Location.create(name: "gcp-us-east4", provider: "gcp",
+        display_name: "gcp-us-east4", ui_name: "GCP US East 4", visible: true)
+      other_fw = Firewall.create(name: "dns", location_id: other_location.id, project_id: Config.dns_service_project_id)
+
+      prog.vm.location.update(provider: "gcp")
+      prog.vm.strand.update(label: "wait")
+      expect { prog.start }.to hop("prepare")
+      expect(prog.vm.firewalls.map(&:id)).not_to include(other_fw.id)
+      expect(prog.vm.vm_firewalls.map(&:location_id)).to eq [prog.vm.location_id]
     end
   end
 

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
     (1..2).map { |i| build_zone.call("zone#{i}.domain.io", 3600) } << build_zone.call("k8s.ubicloud.com", 15)
   end
   let(:project) { Project.create(name: "ubicloud-dns") }
+  let(:gcp_location) do
+    Location.create(name: "gcp-us-central1", provider: "gcp",
+      display_name: "gcp-us-central1", ui_name: "GCP US Central 1", visible: true)
+  end
 
   describe ".assemble" do
     it "validates input" do
@@ -56,6 +60,27 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       }.to raise_error RuntimeError, "No existing Project"
     end
 
+    it "rejects a vm size that does not exist" do
+      expect {
+        described_class.assemble(ds, vm_size: "bogus-2")
+      }.to raise_error Validation::ValidationFailed, /size/
+    end
+
+    it "derives the arch from the vm size for arm64-only GCP sizes" do
+      described_class.assemble(ds, vm_size: "c4a-standard-4", location_id: gcp_location.id)
+
+      vm = Vm.first
+      expect(vm.arch).to eq "arm64"
+      expect(vm.family).to eq "c4a-standard"
+      expect(vm.vcpus).to eq 4
+    end
+
+    it "keeps the x64 default for a vm size that exists for both arches" do
+      described_class.assemble(ds, vm_size: "standard-2")
+
+      expect(Vm.first.arch).to eq "x64"
+    end
+
     it "excludes host ids of existing dns server vms" do
       existing_vm = create_vm_with_sshable
       vm_host = create_vm_host
@@ -69,6 +94,47 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
         vm_strand = Strand[st.stack.first["subject_id"]]
         expect(vm_strand.stack.first["exclude_host_ids"]).to eq expected_ids
       end
+    end
+
+    it "creates a dedicated dns subnet with control-plane-only SSH when restrict_ssh_to_control_plane is set" do
+      described_class.assemble(ds, vm_size: "c4a-standard-4", location_id: gcp_location.id, restrict_ssh_to_control_plane: true)
+
+      subnet = Vm.first.user_nic.private_subnet
+      expect(subnet.name).to eq "dns-gcp-us-central1"
+      expect(subnet.firewalls.map(&:name)).to eq ["dns-gcp-us-central1"]
+      rules = subnet.firewalls.flat_map(&:firewall_rules)
+      expect(rules.map { it.port_range.begin }.uniq).to eq [22]
+      expect(rules.map(&:protocol).uniq).to eq ["tcp"]
+      expect(rules.map { it.cidr.to_s }.sort).to eq Config.control_plane_outbound_cidrs.sort
+    end
+
+    it "reuses an existing dns subnet without touching its firewall rules" do
+      subnet = Prog::Vnet::SubnetNexus.assemble(project.id, name: "dns-gcp-us-central1", location_id: gcp_location.id).subject
+
+      described_class.assemble(ds, vm_size: "c4a-standard-4", location_id: gcp_location.id, restrict_ssh_to_control_plane: true)
+
+      expect(Vm.first.user_nic.private_subnet_id).to eq subnet.id
+      rules = subnet.firewalls.flat_map(&:firewall_rules)
+      expect(rules.map { it.port_range.begin }.uniq).to eq [0]
+    end
+
+    it "keeps the metal subnet default firewall untouched" do
+      described_class.assemble(ds)
+
+      subnet = Vm.first.user_nic.private_subnet
+      expect(subnet.name).to eq "default-eu-central-h1"
+      rules = subnet.firewalls.flat_map(&:firewall_rules)
+      expect(rules.map { it.port_range.begin }.uniq).to eq [0]
+    end
+
+    it "does not exclude hosts for existing cloud vms without a vm host" do
+      existing_vm = create_vm_with_sshable
+      ds.add_vm(existing_vm)
+      expect(Config).to receive(:allow_unspread_servers).and_return(false)
+
+      st = described_class.assemble(ds)
+      vm_strand = Strand[st.stack.first["subject_id"]]
+      expect(vm_strand.stack.first["exclude_host_ids"]).to eq []
     end
 
     it "propagates parameters to the created vm" do
@@ -149,6 +215,7 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       expect(prog.strand.stack.first["deadline_at"]).to be_nil
       expect { prog.start }.to hop("prepare")
       expect(prog.vm.firewall_rules.filter { it.protocol == "udp" && it.port_range.begin == 53 }.map { it.cidr.to_s }.sort).to eq(["0.0.0.0/0", "::/0"])
+      expect(prog.vm.firewall_rules.filter { it.protocol == "tcp" && it.port_range.begin == 53 }.map { it.cidr.to_s }.sort).to eq(["0.0.0.0/0", "::/0"])
       expect(prog.strand.stack.first["deadline_at"]).not_to be_nil
     end
 
@@ -167,6 +234,18 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
       expect(prog.strand.stack.first["deadline_at"]).not_to be_nil
 
       expect(prog.vm.firewalls.map(&:id)).to include(fw.id)
+    end
+
+    it "does not reuse a dns firewall from another location" do
+      other_location = Location.create(name: "gcp-us-east4", provider: "gcp",
+        display_name: "gcp-us-east4", ui_name: "GCP US East 4", visible: true)
+      other_fw = Firewall.create(name: "dns", location_id: other_location.id, project_id: Config.dns_service_project_id)
+
+      prog.vm.location.update(provider: "gcp")
+      prog.vm.strand.update(label: "wait")
+      expect { prog.start }.to hop("prepare")
+      expect(prog.vm.vm_firewalls_dataset.select_map(:id)).not_to include(other_fw.id)
+      expect(prog.vm.vm_firewalls_dataset.select_map(:location_id)).to eq [prog.vm.location_id]
     end
   end
 

--- a/spec/prog/vm/gcp/nexus_spec.rb
+++ b/spec/prog/vm/gcp/nexus_spec.rb
@@ -180,7 +180,8 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
         expect(args[:zone]).to eq("us-central1-a")
         expect(args[:instance_resource]).to be_a(Google::Cloud::Compute::V1::Instance)
         expect(args[:instance_resource].name).to eq("testvm")
-        expect(args[:instance_resource].machine_type).to include("c4a-standard-8-lssd")
+        # Boot-disk-only VM: plain machine type, no -lssd variant
+        expect(args[:instance_resource].machine_type).to end_with("machineTypes/c4a-standard-8")
 
         expect(args[:instance_resource].tags).to be_nil
         expect(args[:instance_resource].labels.to_h).to eq("ubicloud" => "555666777")
@@ -346,6 +347,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
 
       op = instance_double(Gapic::GenericLRO::Operation, name: "op-lssd-1")
       expect(compute_client).to receive(:insert) do |args|
+        expect(args[:instance_resource].machine_type).to end_with("machineTypes/c4a-standard-8-lssd")
         disks = args[:instance_resource].disks
         expect(disks.length).to eq(2)
         expect(disks[0].boot).to be true
@@ -848,9 +850,15 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
   end
 
   describe "helper methods" do
-    it "delegates gce_machine_type to Option.gcp_instance_type_name" do
+    it "picks an -lssd machine type when the VM has non-boot volumes" do
       nx.vm.update(family: "c4a-standard", vcpus: 8)
+      VmStorageVolume.create(vm_id: vm.id, size_gib: 375, boot: false, use_bdev_ubi: false, disk_index: 1)
       expect(nx.send(:gce_machine_type)).to eq("c4a-standard-8-lssd")
+    end
+
+    it "picks a plain machine type when the VM only has a boot volume" do
+      nx.vm.update(family: "c4a-standard", vcpus: 8)
+      expect(nx.send(:gce_machine_type)).to eq("c4a-standard-8")
     end
 
     it "reads GCP zone suffix from VM strand frame" do

--- a/spec/prog/vm/gcp/nexus_spec.rb
+++ b/spec/prog/vm/gcp/nexus_spec.rb
@@ -180,7 +180,8 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
         expect(args[:zone]).to eq("us-central1-a")
         expect(args[:instance_resource]).to be_a(Google::Cloud::Compute::V1::Instance)
         expect(args[:instance_resource].name).to eq("testvm")
-        expect(args[:instance_resource].machine_type).to include("c4a-standard-8-lssd")
+        # Boot-disk-only VM: plain machine type, no -lssd variant
+        expect(args[:instance_resource].machine_type).to end_with("machineTypes/c4a-standard-8")
 
         expect(args[:instance_resource].tags).to be_nil
         expect(args[:instance_resource].labels.to_h).to eq("ubicloud" => "555666777")
@@ -346,6 +347,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
 
       op = instance_double(Gapic::GenericLRO::Operation, name: "op-lssd-1")
       expect(compute_client).to receive(:insert) do |args|
+        expect(args[:instance_resource].machine_type).to end_with("machineTypes/c4a-standard-8-lssd")
         disks = args[:instance_resource].disks
         expect(disks.length).to eq(2)
         expect(disks[0].boot).to be true
@@ -849,9 +851,15 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
   end
 
   describe "helper methods" do
-    it "delegates gce_machine_type to Option.gcp_instance_type_name" do
+    it "picks an -lssd machine type when the VM has non-boot volumes" do
       nx.vm.update(family: "c4a-standard", vcpus: 8)
+      VmStorageVolume.create(vm_id: vm.id, size_gib: 375, boot: false, use_bdev_ubi: false, disk_index: 1)
       expect(nx.send(:gce_machine_type)).to eq("c4a-standard-8-lssd")
+    end
+
+    it "picks a plain machine type when the VM only has a boot volume" do
+      nx.vm.update(family: "c4a-standard", vcpus: 8)
+      expect(nx.send(:gce_machine_type)).to eq("c4a-standard-8")
     end
 
     it "reads GCP zone suffix from VM strand frame" do


### PR DESCRIPTION
Option.gcp_instance_type_name gains an lssd: keyword (default true); Vm::Gcp::Nexus appends -lssd only when the VM has non-boot (data) volumes, since -lssd machine types cannot launch without their local SSDs declared and boot-only VMs have none to declare.

SetupDnsServerVm.assemble derives the arch from the vm size (GCP c4a sizes are arm64-only), drops nil vm_host_ids from host exclusion (cloud VMs have no vm_host, which tripped the force/exclude check when re-provisioning next to an existing VM), and gains restrict_ssh_to_control_plane: to rewrite the subnet's default firewall to control-plane-only SSH in the same transaction that creates it. #start opens port 53 on GCP as well as AWS, with the "dns" firewall row scoped per location.