### PR TITLE
Include instance family in client_token when creating AWS instances

### DIFF
--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -246,7 +246,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
       max_count: 1,
       user_data: Base64.encode64(user_data.gsub(/^(\s*# .*)?\n/, "")),
       tag_specifications: Util.aws_tag_specifications("instance", vm.name) + Util.aws_tag_specifications("volume", vm.name),
-      client_token: vm.id,
+      client_token: "#{vm.id}-#{vm.family}",
       instance_market_options:,
     }
     params[:iam_instance_profile] = {name: instance_profile_name} unless is_runner?

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -348,7 +348,7 @@ usermod -L ubuntu
         max_count: 1,
         tag_specifications: Util.aws_tag_specifications("instance", vm.name) + Util.aws_tag_specifications("volume", vm.name),
         iam_instance_profile: {name: "#{vm.name}-instance-profile"},
-        client_token: vm.id,
+        client_token: "#{vm.id}-#{vm.family}",
         instance_market_options: nil,
         user_data: Base64.encode64(user_data),
       }).and_call_original


### PR DESCRIPTION
When creating an instance if we hit capacity issues (`InsufficientInstanceCapacity`), then it is possible that we retry creating the instance using an alternative family. If we reuse the same token for the retry with different family, we will get the following error:

> Aws::EC2::Errors::IdempotentParameterMismatch: Arguments on this
> idempotent request are inconsistent with arguments used in previous
> request(s).

This change adds the family name to the token to avoid this exception.