### PR TITLE
Run read-only control-plane queries as ubi_monitoring

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -252,7 +252,7 @@ class PostgresServer < Sequel::Model
   end
 
   def current_lsn
-    run_query(DB.select(last_lsn_expression))
+    run_query(DB.select(last_lsn_expression), user: "ubi_monitoring")
   end
 
   def data_disk_usage(raise_on_error: false)
@@ -324,10 +324,10 @@ class PostgresServer < Sequel::Model
     return [] if read_replica? || version.to_i < 17
     return [] if strand.label == "wait_in_fence"
 
-    primary_slots = run_query("SELECT slot_name, confirmed_flush_lsn FROM pg_replication_slots WHERE slot_type = 'logical' AND failover").split("\n").map { it.split(",") }
+    primary_slots = run_query("SELECT slot_name, confirmed_flush_lsn FROM pg_replication_slots WHERE slot_type = 'logical' AND failover", user: "ubi_monitoring").split("\n").map { it.split(",") }
     return [] if primary_slots.empty?
 
-    synced = standby.run_query("SELECT slot_name, confirmed_flush_lsn FROM pg_replication_slots WHERE slot_type = 'logical' AND synced AND NOT temporary").split("\n").to_h { it.split(",") }
+    synced = standby.run_query("SELECT slot_name, confirmed_flush_lsn FROM pg_replication_slots WHERE slot_type = 'logical' AND synced AND NOT temporary", user: "ubi_monitoring").split("\n").to_h { it.split(",") }
     primary_slots.reject { |name, lsn| synced[name] && lsn_diff(synced[name], lsn) >= 0 }.map(&:first)
   end
 
@@ -407,18 +407,18 @@ class PostgresServer < Sequel::Model
     lsn2int(lsn1) - lsn2int(lsn2)
   end
 
-  def run_query(query)
+  def run_query(query, user: "postgres")
     if query.is_a?(Sequel::Dataset)
       query = query.no_auto_parameterize.sql
     elsif !query.frozen?
       raise NetSsh::PotentialInsecurity, "Interpolated string passed to PostgresServer#run_query at #{caller(1, 1).first}\nReplace string interpolation with a Sequel dataset."
     end
 
-    _run_query(query)
+    _run_query(query, user:)
   end
 
-  private def _run_query(query)
-    vm.sshable.cmd("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: query).chomp
+  private def _run_query(query, user:)
+    vm.sshable.cmd("PGOPTIONS='-c statement_timeout=60s' psql -U :user -t --csv -v 'ON_ERROR_STOP=1'", user:, stdin: query).chomp
   end
 
   def export_metrics(session:, tsdb_client:)

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -338,7 +338,7 @@ class PostgresServer < Sequel::Model
   end
 
   def current_lsn
-    run_query(DB.select(last_lsn_expression))
+    run_query(DB.select(last_lsn_expression), user: "ubi_monitoring", dbname: "ubi_admin")
   end
 
   def data_disk_usage(raise_on_error: false)
@@ -423,10 +423,10 @@ class PostgresServer < Sequel::Model
     return [] if read_replica? || version.to_i < 17
     return [] if strand.label == "wait_in_fence"
 
-    primary_slots = run_query("SELECT slot_name, confirmed_flush_lsn FROM pg_replication_slots WHERE slot_type = 'logical' AND failover").split("\n").map { it.split(",") }
+    primary_slots = run_query("SELECT slot_name, confirmed_flush_lsn FROM pg_replication_slots WHERE slot_type = 'logical' AND failover", user: "ubi_monitoring", dbname: "ubi_admin").split("\n").map { it.split(",") }
     return [] if primary_slots.empty?
 
-    synced = standby.run_query("SELECT slot_name, confirmed_flush_lsn FROM pg_replication_slots WHERE slot_type = 'logical' AND synced AND NOT temporary").split("\n").to_h { it.split(",") }
+    synced = standby.run_query("SELECT slot_name, confirmed_flush_lsn FROM pg_replication_slots WHERE slot_type = 'logical' AND synced AND NOT temporary", user: "ubi_monitoring", dbname: "ubi_admin").split("\n").to_h { it.split(",") }
     primary_slots.reject { |name, lsn| synced[name] && lsn_diff(synced[name], lsn) >= 0 }.map(&:first)
   end
 
@@ -521,18 +521,18 @@ class PostgresServer < Sequel::Model
     lsn2int(lsn1) - lsn2int(lsn2)
   end
 
-  def run_query(query)
+  def run_query(query, user: "postgres", dbname: "postgres")
     if query.is_a?(Sequel::Dataset)
       query = query.no_auto_parameterize.sql
     elsif !query.frozen?
       raise NetSsh::PotentialInsecurity, "Interpolated string passed to PostgresServer#run_query at #{caller(1, 1).first}\nReplace string interpolation with a Sequel dataset."
     end
 
-    _run_query(query)
+    _run_query(query, user:, dbname:)
   end
 
-  private def _run_query(query)
-    vm.sshable.cmd("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: query).chomp
+  private def _run_query(query, user:, dbname:)
+    vm.sshable.cmd("PGOPTIONS='-c statement_timeout=60s' psql -U :user -d :dbname -t --csv -v 'ON_ERROR_STOP=1'", user:, dbname:, stdin: query).chomp
   end
 
   def export_metrics(session:, tsdb_client:)
@@ -809,7 +809,7 @@ class PostgresServer < Sequel::Model
     parent_server = read_replica? ? resource.parent.representative_server : resource.representative_server
     return unless (primary_lsn = parent_server.last_known_lsn)
 
-    in_recovery, replay_lsn, replay_age = run_query("SELECT pg_is_in_recovery(), pg_last_wal_replay_lsn(), EXTRACT(EPOCH FROM (NOW() - pg_last_xact_replay_timestamp()))::int").split(",")
+    in_recovery, replay_lsn, replay_age = run_query("SELECT pg_is_in_recovery(), pg_last_wal_replay_lsn(), EXTRACT(EPOCH FROM (NOW() - pg_last_xact_replay_timestamp()))::int", user: "ubi_monitoring", dbname: "ubi_admin").split(",")
 
     if in_recovery == "f"
       resolve_replica_lag(session)

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -600,7 +600,7 @@ SQL
     register_deadline("wait", 5 * 60)
 
     query = DB["SELECT sync_state FROM pg_stat_replication WHERE application_name = :ubid", ubid: postgres_server.ubid]
-    sync_state = resource.representative_server.run_query(query).chomp
+    sync_state = resource.representative_server.run_query(query, user: "ubi_monitoring").chomp
     hop_wait if ["quorum", "sync"].include?(sync_state)
 
     nap 30

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe PostgresServer do
       )
     }
 
-    let(:psql_command) { "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'" }
+    let(:psql_command) { "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d postgres -t --csv -v 'ON_ERROR_STOP=1'" }
     let(:settings_query) { %(SELECT "name", "setting" FROM "pg_settings" WHERE ("name" IN ('max_connections', 'max_worker_processes', 'max_wal_senders', 'max_prepared_transactions', 'max_locks_per_transaction'))) }
 
     def running(values)
@@ -701,6 +701,7 @@ RSpec.describe PostgresServer do
         synchronization_status: "ready", timeline_access: "fetch", version: "16",
       )
     }
+    let(:monitoring_psql_command) { "PGOPTIONS='-c statement_timeout=60s' psql -U ubi_monitoring -d ubi_admin -t --csv -v 'ON_ERROR_STOP=1'" }
 
     it "returns empty for read replicas" do
       expect(postgres_server).to receive(:read_replica?).and_return(true)
@@ -724,7 +725,7 @@ RSpec.describe PostgresServer do
       expect(postgres_server).to receive(:read_replica?).and_return(false)
       postgres_server.update(version: "17")
       Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
-      expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with(monitoring_psql_command, stdin: a_string_including("AND failover")).and_return("")
       expect(postgres_server.unsynced_logical_failover_slots(standby)).to be_empty
     end
 
@@ -732,8 +733,8 @@ RSpec.describe PostgresServer do
       expect(postgres_server).to receive(:read_replica?).and_return(false)
       postgres_server.update(version: "17")
       Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
-      expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("slot1,0/100\nslot2,0/200")
-      expect(standby.vm.sshable).to receive(:_cmd).and_return("slot1,0/100\nslot2,0/200")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with(monitoring_psql_command, stdin: a_string_including("AND failover")).and_return("slot1,0/100\nslot2,0/200")
+      expect(standby.vm.sshable).to receive(:_cmd).with(monitoring_psql_command, stdin: a_string_including("synced AND NOT temporary")).and_return("slot1,0/100\nslot2,0/200")
       expect(postgres_server.unsynced_logical_failover_slots(standby)).to be_empty
     end
 
@@ -741,8 +742,8 @@ RSpec.describe PostgresServer do
       expect(postgres_server).to receive(:read_replica?).and_return(false)
       postgres_server.update(version: "17")
       Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
-      expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("slot1,0/100\nslot2,0/200")
-      expect(standby.vm.sshable).to receive(:_cmd).and_return("slot1,0/100")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with(monitoring_psql_command, stdin: a_string_including("AND failover")).and_return("slot1,0/100\nslot2,0/200")
+      expect(standby.vm.sshable).to receive(:_cmd).with(monitoring_psql_command, stdin: a_string_including("synced AND NOT temporary")).and_return("slot1,0/100")
       expect(postgres_server.unsynced_logical_failover_slots(standby)).to eq(["slot2"])
     end
 
@@ -750,8 +751,8 @@ RSpec.describe PostgresServer do
       expect(postgres_server).to receive(:read_replica?).and_return(false)
       postgres_server.update(version: "17")
       Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
-      expect(postgres_server.vm.sshable).to receive(:_cmd).and_return("slot1,0/200")
-      expect(standby.vm.sshable).to receive(:_cmd).and_return("slot1,0/100")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with(monitoring_psql_command, stdin: a_string_including("AND failover")).and_return("slot1,0/200")
+      expect(standby.vm.sshable).to receive(:_cmd).with(monitoring_psql_command, stdin: a_string_including("synced AND NOT temporary")).and_return("slot1,0/100")
       expect(postgres_server.unsynced_logical_failover_slots(standby)).to eq(["slot1"])
     end
   end
@@ -888,7 +889,7 @@ RSpec.describe PostgresServer do
     # Stub the ssh layer rather than run_query, which the cmd_exec linter forbids
     # stubbing; last_lsn_expression's branches are covered by their own examples.
     it "runs the recovery-aware lsn query on the server" do
-      expect(postgres_server.vm.sshable).to receive(:_cmd).with(anything, stdin: a_string_including("pg_is_in_recovery")).and_return("1/5\n")
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U ubi_monitoring -d ubi_admin -t --csv -v 'ON_ERROR_STOP=1'", stdin: a_string_including("pg_is_in_recovery")).and_return("1/5\n")
       expect(postgres_server.current_lsn).to eq("1/5")
     end
   end
@@ -1066,7 +1067,7 @@ RSpec.describe PostgresServer do
   end
 
   it "runs query on vm" do
-    expect(postgres_server.vm.sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: "SELECT 1").and_return("1\n")
+    expect(postgres_server.vm.sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: "SELECT 1").and_return("1\n")
     expect(postgres_server.run_query("SELECT 1")).to eq("1")
   end
 
@@ -1646,7 +1647,7 @@ RSpec.describe PostgresServer do
       session[:replica_lag_previous_replay_lsn] = "C/00000000"
       # 12 GiB behind, which would page, but the frozen replay lsn means nothing
       # on a server that has been promoted.
-      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("f,D/00000000,5")
+      expect(standby).to receive(:_run_query).with(replica_lag_query, user: "ubi_monitoring", dbname: "ubi_admin").and_return("f,D/00000000,5")
       standby.observe_replica_lag(session)
       expect(existing_page.reload.semaphores.map(&:name)).to include("resolve")
       expect(session[:replica_lag_breach_count]).to eq(0)
@@ -1661,7 +1662,7 @@ RSpec.describe PostgresServer do
 
     it "does nothing when the replica replay lsn is empty" do
       set_primary_lsn("10/00000000")
-      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("t,,100")
+      expect(standby).to receive(:_run_query).with(replica_lag_query, user: "ubi_monitoring", dbname: "ubi_admin").and_return("t,,100")
       standby.observe_replica_lag(session)
       expect(Page.from_tag_parts("PGReplicaLagHigh", standby.id)).to be_nil
     end
@@ -1669,7 +1670,7 @@ RSpec.describe PostgresServer do
     it "treats a caught-up replica as zero lag even when the replay timestamp is old" do
       set_primary_lsn("10/00000000")
       # Replay caught up to the primary, but replay_age is huge (idle primary).
-      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("t,10/00000000,100000")
+      expect(standby).to receive(:_run_query).with(replica_lag_query, user: "ubi_monitoring", dbname: "ubi_admin").and_return("t,10/00000000,100000")
       session[:replica_lag_breach_count] = 4
       standby.observe_replica_lag(session)
       expect(Page.from_tag_parts("PGReplicaLagHigh", standby.id)).to be_nil
@@ -1678,7 +1679,7 @@ RSpec.describe PostgresServer do
 
     it "does not page while the replica is past the soft limit but still making progress" do
       set_primary_lsn("10/00000000")
-      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return(
+      expect(standby).to receive(:_run_query).with(replica_lag_query, user: "ubi_monitoring", dbname: "ubi_admin").and_return(
         "t,F/80000000,5", "t,F/88000000,5", "t,F/90000000,5", "t,F/98000000,5", "t,F/A0000000,5",
       )
       5.times { standby.observe_replica_lag(session) }
@@ -1690,7 +1691,7 @@ RSpec.describe PostgresServer do
       set_primary_lsn("10/00000000")
       session[:replica_lag_breach_count] = 3
       session[:replica_lag_previous_replay_lsn] = "F/80000000"
-      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("t,F/80000000,5", "t,F/80000000,5") # same lsn as previous => no progress
+      expect(standby).to receive(:_run_query).with(replica_lag_query, user: "ubi_monitoring", dbname: "ubi_admin").and_return("t,F/80000000,5", "t,F/80000000,5") # same lsn as previous => no progress
       2.times { standby.observe_replica_lag(session) }
       expect(Page.from_tag_parts("PGReplicaLagHigh", standby.id)).not_to be_nil
     end
@@ -1699,7 +1700,7 @@ RSpec.describe PostgresServer do
       set_primary_lsn("10/00000000")
       session[:replica_lag_breach_count] = 4
       session[:replica_lag_previous_replay_lsn] = "C/00000000"
-      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("t,D/00000000,5") # 12 GiB behind, but progressed from C/0
+      expect(standby).to receive(:_run_query).with(replica_lag_query, user: "ubi_monitoring", dbname: "ubi_admin").and_return("t,D/00000000,5") # 12 GiB behind, but progressed from C/0
       standby.observe_replica_lag(session)
       expect(Page.from_tag_parts("PGReplicaLagHigh", standby.id)).not_to be_nil
     end
@@ -1708,7 +1709,7 @@ RSpec.describe PostgresServer do
       set_primary_lsn("10/00000000")
       session[:replica_lag_breach_count] = 4
       session[:replica_lag_previous_replay_lsn] = "F/E0000000"
-      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("t,F/E0000000,1000") # 512 MiB behind, replay 1000s old
+      expect(standby).to receive(:_run_query).with(replica_lag_query, user: "ubi_monitoring", dbname: "ubi_admin").and_return("t,F/E0000000,1000") # 512 MiB behind, replay 1000s old
       standby.observe_replica_lag(session)
       expect(Page.from_tag_parts("PGReplicaLagHigh", standby.id)).not_to be_nil
     end
@@ -1716,14 +1717,14 @@ RSpec.describe PostgresServer do
     it "resolves an existing page once lag recovers" do
       set_primary_lsn("10/00000000")
       existing_page = Prog::PageNexus.assemble("#{standby.ubid} replica lag high", ["PGReplicaLagHigh", standby.id], standby.ubid, severity: "warning", extra_data: {byte_lag: 0, time_lag: 0, read_replica: false}).subject
-      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("t,10/00000000,5") # caught up
+      expect(standby).to receive(:_run_query).with(replica_lag_query, user: "ubi_monitoring", dbname: "ubi_admin").and_return("t,10/00000000,5") # caught up
       standby.observe_replica_lag(session)
       expect(existing_page.reload.semaphores.map(&:name)).to include("resolve")
     end
 
     it "logs and does not raise when the replica query fails" do
       set_primary_lsn("10/00000000")
-      expect(standby).to receive(:_run_query).with(replica_lag_query).and_raise("boom")
+      expect(standby).to receive(:_run_query).with(replica_lag_query, user: "ubi_monitoring", dbname: "ubi_admin").and_raise("boom")
       expect(Clog).to receive(:emit).with("Failed to observe replica lag", instance_of(Hash)).and_call_original
       expect { standby.observe_replica_lag(session) }.not_to raise_error
     end
@@ -1742,7 +1743,7 @@ RSpec.describe PostgresServer do
       expect(postgres_server.read_replica?).to be(true)
       session[:replica_lag_breach_count] = 4
       session[:replica_lag_previous_replay_lsn] = "C/00000000"
-      expect(postgres_server).to receive(:_run_query).with(replica_lag_query).and_return("t,D/00000000,5") # 12 GiB behind > hard
+      expect(postgres_server).to receive(:_run_query).with(replica_lag_query, user: "ubi_monitoring", dbname: "ubi_admin").and_return("t,D/00000000,5") # 12 GiB behind > hard
       postgres_server.observe_replica_lag(session)
       page = Page.from_tag_parts("PGReplicaLagHigh", postgres_server.id)
       expect(page).not_to be_nil
@@ -1764,7 +1765,7 @@ RSpec.describe PostgresServer do
       standby.update(timeline_access: "fetch")
       session[:replica_lag_breach_count] = 4
       session[:replica_lag_previous_replay_lsn] = "C/00000000"
-      expect(standby).to receive(:_run_query).with(replica_lag_query).and_return("t,D/00000000,5")
+      expect(standby).to receive(:_run_query).with(replica_lag_query, user: "ubi_monitoring", dbname: "ubi_admin").and_return("t,D/00000000,5")
       standby.observe_replica_lag(session)
       page = Page.from_tag_parts("PGReplicaLagHigh", standby.id)
       expect(page).not_to be_nil

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -452,7 +452,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
       fresh_nx = described_class.new(st)
       parent_sshable = fresh_nx.postgres_resource.parent.representative_server.vm.sshable
-      expect(parent_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", hash_including(:stdin)).and_return("1234")
+      expect(parent_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d postgres -t --csv -v 'ON_ERROR_STOP=1'", hash_including(:stdin)).and_return("1234")
 
       expect { fresh_nx.trigger_pg_current_xact_id_on_parent }.to exit({"msg" => "triggered pg_current_xact_id"})
     end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1261,14 +1261,14 @@ CMD
 
     it "hops to wait if sync replication is established" do
       expect(standby_nx).to receive(:register_deadline).with("wait", 5 * 60).twice
-      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("quorum", "sync")
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U ubi_monitoring -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("quorum", "sync")
       expect { standby_nx.wait_synchronization }.to hop("wait")
       expect { standby_nx.wait_synchronization }.to hop("wait")
     end
 
     it "naps and registers a deadline while sync replication is not established" do
       expect(standby_nx).to receive(:register_deadline).with("wait", 5 * 60).twice
-      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("", "async")
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U ubi_monitoring -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("", "async")
       expect { standby_nx.wait_synchronization }.to nap(30)
       expect { standby_nx.wait_synchronization }.to nap(30)
     end
@@ -1276,32 +1276,32 @@ CMD
 
   describe "#wait_recovery_completion" do
     it "naps if it is still in recovery and wal replay is not paused" do
-      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_return("t")
-      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state()").and_return("not paused")
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres").and_return("t")
+      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state()", user: "postgres").and_return("not paused")
       expect { nx.wait_recovery_completion }.to nap(5)
     end
 
     it "naps if it cannot connect to database due to recovery" do
-      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_raise(Sshable::SshError.new("", nil, "Consistent recovery state has not been yet reached.", nil, nil))
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres").and_raise(Sshable::SshError.new("", nil, "Consistent recovery state has not been yet reached.", nil, nil))
       expect { nx.wait_recovery_completion }.to nap(5)
     end
 
     it "raises error if it cannot connect to database due a problem other than to continueing recovery" do
-      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_raise(Sshable::SshError.new("", nil, "Bogus", nil, nil))
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres").and_raise(Sshable::SshError.new("", nil, "Bogus", nil, nil))
       expect { nx.wait_recovery_completion }.to raise_error(Sshable::SshError)
     end
 
     it "stops wal replay and switches to new timeline if it is still in recovery but wal replay is paused" do
-      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_return("t")
-      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state()").and_return("paused")
-      expect(server).to receive(:_run_query).with("SELECT pg_wal_replay_resume()")
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres").and_return("t")
+      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state()", user: "postgres").and_return("paused")
+      expect(server).to receive(:_run_query).with("SELECT pg_wal_replay_resume()", user: "postgres")
       expect(server).to receive(:switch_to_new_timeline)
 
       expect { nx.wait_recovery_completion }.to hop("configure")
     end
 
     it "switches to new timeline if the recovery is completed" do
-      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_return("f")
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres").and_return("f")
       expect(server).to receive(:switch_to_new_timeline)
       expect { nx.wait_recovery_completion }.to hop("configure")
     end
@@ -1541,7 +1541,7 @@ CMD
   describe "#fence" do
     it "runs checkpoints and perform lockout" do
       expect(nx).to receive(:decr_fence)
-      expect(server).to receive(:_run_query).with("CHECKPOINT; CHECKPOINT; CHECKPOINT;")
+      expect(server).to receive(:_run_query).with("CHECKPOINT; CHECKPOINT; CHECKPOINT;", user: "postgres")
       expect(sshable).to receive(:_cmd).with("sudo postgres/bin/lockout 17")
       expect(sshable).to receive(:_cmd).with("sudo systemctl stop postgres-metrics.timer")
       expect(sshable).to receive(:_cmd).with("sudo pg_ctlcluster 17 main stop -m fast")
@@ -1897,24 +1897,24 @@ CMD
     end
 
     it "returns true if health check is successful" do
-      expect(server).to receive(:_run_query).with("SELECT 1").and_return("1")
+      expect(server).to receive(:_run_query).with("SELECT 1", user: "postgres").and_return("1")
       expect(nx.available?).to be(true)
     end
 
     it "returns true if the database is in crash recovery" do
-      expect(server).to receive(:_run_query).with("SELECT 1").and_raise(Sshable::SshError)
+      expect(server).to receive(:_run_query).with("SELECT 1", user: "postgres").and_raise(Sshable::SshError)
       expect(sshable).to receive(:_cmd).with(a_string_matching(/find.*-mmin -5.*tail -n 50.*grep.*redo in progress/)).and_return("redo in progress")
       expect(nx.available?).to be(true)
     end
 
     it "returns false otherwise" do
-      expect(server).to receive(:_run_query).with("SELECT 1").and_raise(Sshable::SshError)
+      expect(server).to receive(:_run_query).with("SELECT 1", user: "postgres").and_raise(Sshable::SshError)
       expect(sshable).to receive(:_cmd).with(a_string_matching(/find.*-mmin -5.*tail -n 50.*grep.*redo in progress/)).and_return("")
       expect(nx.available?).to be(false)
     end
 
     it "returns false if both health check and log check raise" do
-      expect(server).to receive(:_run_query).with("SELECT 1").and_raise(Sshable::SshError)
+      expect(server).to receive(:_run_query).with("SELECT 1", user: "postgres").and_raise(Sshable::SshError)
       expect(sshable).to receive(:_cmd).with(a_string_matching(/find.*-mmin -5.*tail -n 50.*grep.*redo in progress/)).and_raise(Sshable::SshError)
       expect(nx.available?).to be(false)
     end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1139,7 +1139,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "updates password and hops to run_post_installation_script during initial provisioning" do
       nx.incr_initial_provisioning
       expect(sshable).to receive(:_cmd).with(
-        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'",
+        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d postgres -t --csv -v 'ON_ERROR_STOP=1'",
         hash_including(stdin: password_update_sql_matcher),
       ).and_return("")
       expect { nx.update_superuser_password }.to hop("run_post_installation_script")
@@ -1147,7 +1147,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "updates password and hops to wait at times other than the initial provisioning" do
       expect(sshable).to receive(:_cmd).with(
-        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'",
+        "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d postgres -t --csv -v 'ON_ERROR_STOP=1'",
         hash_including(stdin: password_update_sql_matcher),
       ).and_return("")
       expect { nx.update_superuser_password }.to hop("wait")
@@ -1251,56 +1251,56 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "hops to wait if sync replication is established" do
       expect(standby_nx).to receive(:register_deadline).with("wait", 5 * 60).twice
-      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("quorum", "sync")
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("quorum", "sync")
       expect { standby_nx.wait_synchronization }.to hop("wait")
       expect { standby_nx.wait_synchronization }.to hop("wait")
     end
 
     it "naps and registers a deadline while sync replication is not established" do
       expect(standby_nx).to receive(:register_deadline).with("wait", 5 * 60)
-      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("")
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("")
       expect { standby_nx.wait_synchronization }.to nap(30)
     end
 
     it "hops to wait_catch_up if replication is async" do
-      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("async")
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("async")
       expect { standby_nx.wait_synchronization }.to hop("wait_catch_up")
     end
 
     it "naps if sync replication is not established" do
-      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("")
+      expect(representative_sshable).to receive(:_cmd).with("PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d postgres -t --csv -v 'ON_ERROR_STOP=1'", stdin: anything).and_return("")
       expect { standby_nx.wait_synchronization }.to nap(30)
     end
   end
 
   describe "#wait_recovery_completion" do
     it "naps if it is still in recovery and wal replay is not paused" do
-      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_return("t")
-      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state()").and_return("not paused")
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres", dbname: "postgres").and_return("t")
+      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state()", user: "postgres", dbname: "postgres").and_return("not paused")
       expect { nx.wait_recovery_completion }.to nap(5)
     end
 
     it "naps if it cannot connect to database due to recovery" do
-      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_raise(Sshable::SshError.new("", nil, "Consistent recovery state has not been yet reached.", nil, nil))
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres", dbname: "postgres").and_raise(Sshable::SshError.new("", nil, "Consistent recovery state has not been yet reached.", nil, nil))
       expect { nx.wait_recovery_completion }.to nap(5)
     end
 
     it "raises error if it cannot connect to database due a problem other than to continueing recovery" do
-      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_raise(Sshable::SshError.new("", nil, "Bogus", nil, nil))
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres", dbname: "postgres").and_raise(Sshable::SshError.new("", nil, "Bogus", nil, nil))
       expect { nx.wait_recovery_completion }.to raise_error(Sshable::SshError)
     end
 
     it "stops wal replay and switches to new timeline if it is still in recovery but wal replay is paused" do
-      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_return("t")
-      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state()").and_return("paused")
-      expect(server).to receive(:_run_query).with("SELECT pg_wal_replay_resume()")
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres", dbname: "postgres").and_return("t")
+      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state()", user: "postgres", dbname: "postgres").and_return("paused")
+      expect(server).to receive(:_run_query).with("SELECT pg_wal_replay_resume()", user: "postgres", dbname: "postgres")
       expect(server).to receive(:switch_to_new_timeline)
 
       expect { nx.wait_recovery_completion }.to hop("configure")
     end
 
     it "switches to new timeline if the recovery is completed" do
-      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_return("f")
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres", dbname: "postgres").and_return("f")
       expect(server).to receive(:switch_to_new_timeline)
       expect { nx.wait_recovery_completion }.to hop("configure")
       expect(Semaphore.where(strand_id: server.id, name: "update_superuser_password").count).to eq(1)
@@ -1440,7 +1440,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "naps without restarting when applying restart-sensitive params would break replication" do
       create_postgres_server(resource: postgres_resource, timeline: postgres_timeline, is_representative: false)
-      psql_command = "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -t --csv -v 'ON_ERROR_STOP=1'"
+      psql_command = "PGOPTIONS='-c statement_timeout=60s' psql -U postgres -d postgres -t --csv -v 'ON_ERROR_STOP=1'"
       settings_query = %(SELECT "name", "setting" FROM "pg_settings" WHERE ("name" IN ('max_connections', 'max_worker_processes', 'max_wal_senders', 'max_prepared_transactions', 'max_locks_per_transaction')))
       running_csv = PostgresServer::RESTART_SENSITIVE_PARAMS.zip([499, 8, 10, 0, 64]).map { |name, value| "#{name},#{value}" }.join("\n")
       standby = server.resource.servers.find { !it.is_representative }
@@ -1567,7 +1567,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   describe "#fence" do
     it "runs checkpoints and perform lockout" do
       expect(nx).to receive(:decr_fence)
-      expect(server).to receive(:_run_query).with("CHECKPOINT; CHECKPOINT; CHECKPOINT;")
+      expect(server).to receive(:_run_query).with("CHECKPOINT; CHECKPOINT; CHECKPOINT;", user: "postgres", dbname: "postgres")
       expect(sshable).to receive(:_cmd).with("sudo postgres/bin/lockout 18")
       expect(sshable).to receive(:_cmd).with("sudo systemctl stop postgres-metrics.timer")
       expect(sshable).to receive(:_cmd).with("sudo pg_ctlcluster 18 main stop -m fast")
@@ -1977,24 +1977,24 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "returns true if health check is successful" do
-      expect(server).to receive(:_run_query).with("SELECT 1").and_return("1")
+      expect(server).to receive(:_run_query).with("SELECT 1", user: "postgres", dbname: "postgres").and_return("1")
       expect(nx.available?).to be(true)
     end
 
     it "returns true if the database is in crash recovery" do
-      expect(server).to receive(:_run_query).with("SELECT 1").and_raise(Sshable::SshError)
+      expect(server).to receive(:_run_query).with("SELECT 1", user: "postgres", dbname: "postgres").and_raise(Sshable::SshError)
       expect(sshable).to receive(:_cmd).with(a_string_matching(/find.*-mmin -5.*tail -n 50.*grep.*redo in progress/)).and_return("redo in progress")
       expect(nx.available?).to be(true)
     end
 
     it "returns false otherwise" do
-      expect(server).to receive(:_run_query).with("SELECT 1").and_raise(Sshable::SshError)
+      expect(server).to receive(:_run_query).with("SELECT 1", user: "postgres", dbname: "postgres").and_raise(Sshable::SshError)
       expect(sshable).to receive(:_cmd).with(a_string_matching(/find.*-mmin -5.*tail -n 50.*grep.*redo in progress/)).and_return("")
       expect(nx.available?).to be(false)
     end
 
     it "returns false if both health check and log check raise" do
-      expect(server).to receive(:_run_query).with("SELECT 1").and_raise(Sshable::SshError)
+      expect(server).to receive(:_run_query).with("SELECT 1", user: "postgres", dbname: "postgres").and_raise(Sshable::SshError)
       expect(sshable).to receive(:_cmd).with(a_string_matching(/find.*-mmin -5.*tail -n 50.*grep.*redo in progress/)).and_raise(Sshable::SshError)
       expect(nx.available?).to be(false)
     end

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -170,18 +170,18 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
 
     it "creates the slot and naps while the standby has not synced yet" do
       standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
-      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot/).and_return("upgrade_test_slot")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
-      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'", user: "postgres").and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot/, user: "postgres").and_return("upgrade_test_slot")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/, user: "postgres").and_return("")
+      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/, user: "postgres").and_return("")
       expect { pgr_test.setup_failover_slot }.to nap(10)
     end
 
     it "hops to test_postgres_before_read_replica once the slot is synced on the standby" do
       standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
-      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("1")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
-      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("1")
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'", user: "postgres").and_return("1")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/, user: "postgres").and_return("")
+      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/, user: "postgres").and_return("1")
       expect { pgr_test.setup_failover_slot }.to hop("test_postgres_before_read_replica")
     end
 
@@ -195,8 +195,8 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
 
     it "creates a non-failover slot and skips sync wait for PG16" do
       refresh_frame(pgr_test, new_values: {"start_version" => "16"})
-      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot\('upgrade_test_slot', 'pgoutput', false, false\)\Z/).and_return("upgrade_test_slot")
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'", user: "postgres").and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot\('upgrade_test_slot', 'pgoutput', false, false\)\Z/, user: "postgres").and_return("upgrade_test_slot")
       expect { pgr_test.setup_failover_slot }.to hop("test_postgres_before_read_replica")
     end
   end
@@ -292,7 +292,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
 
     it "updates target_version to 18 and hops to check_upgrade_progress" do
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/, user: "postgres").and_return("")
       expect { pgr_test.trigger_upgrade }.to hop("check_upgrade_progress")
       pgr_test.postgres_resource.reload
       pgr_test.read_replica.reload

--- a/spec/prog/test/upgrade_postgres_resource_spec.rb
+++ b/spec/prog/test/upgrade_postgres_resource_spec.rb
@@ -170,18 +170,18 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
 
     it "creates the slot and naps while the standby has not synced yet" do
       standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
-      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot/).and_return("upgrade_test_slot")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
-      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'", user: "postgres", dbname: "postgres").and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot/, user: "postgres", dbname: "postgres").and_return("upgrade_test_slot")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/, user: "postgres", dbname: "postgres").and_return("")
+      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/, user: "postgres", dbname: "postgres").and_return("")
       expect { pgr_test.setup_failover_slot }.to nap(10)
     end
 
     it "hops to test_postgres_before_read_replica once the slot is synced on the standby" do
       standby = pgr_test.postgres_resource.servers.find { !it.is_representative }
-      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("1")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
-      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/).and_return("1")
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'", user: "postgres", dbname: "postgres").and_return("1")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/, user: "postgres", dbname: "postgres").and_return("")
+      expect(standby).to receive(:_run_query).with(/synced AND NOT temporary/, user: "postgres", dbname: "postgres").and_return("1")
       expect { pgr_test.setup_failover_slot }.to hop("test_postgres_before_read_replica")
     end
 
@@ -195,8 +195,8 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
 
     it "creates a non-failover slot and skips sync wait for PG16" do
       refresh_frame(pgr_test, new_values: {"start_version" => "16"})
-      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'").and_return("")
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot\('upgrade_test_slot', 'pgoutput', false, false\)\Z/).and_return("upgrade_test_slot")
+      expect(pgr_test.representative_server).to receive(:_run_query).with("SELECT 1 FROM pg_replication_slots WHERE slot_name = 'upgrade_test_slot'", user: "postgres", dbname: "postgres").and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_create_logical_replication_slot\('upgrade_test_slot', 'pgoutput', false, false\)\Z/, user: "postgres", dbname: "postgres").and_return("upgrade_test_slot")
       expect { pgr_test.setup_failover_slot }.to hop("test_postgres_before_read_replica")
     end
   end
@@ -292,7 +292,7 @@ RSpec.describe Prog::Test::UpgradePostgresResource do
     end
 
     it "updates target_version to 18 and hops to check_upgrade_progress" do
-      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/).and_return("")
+      expect(pgr_test.representative_server).to receive(:_run_query).with(/pg_replication_slot_advance/, user: "postgres", dbname: "postgres").and_return("")
       expect { pgr_test.trigger_upgrade }.to hop("check_upgrade_progress")
       pgr_test.postgres_resource.reload
       pgr_test.read_replica.reload


### PR DESCRIPTION
`PostgresServer#run_query` gains `user:` and `dbname:` keywords (default `postgres`/`postgres`, the previous implicit behavior; psql otherwise defaults the database to the user name) and the monitoring reads switch to `ubi_monitoring` against `ubi_admin`: `failover_target` LSN scoring (`current_lsn`), the failover slot sync check, and the replica lag reads.

The `wait_synchronization` sync_state read stays on superuser: unlike the switched reads, which are PUBLIC-readable, `pg_stat_replication.sync_state` needs `pg_read_all_stats`, and a revoked `pg_monitor` membership nulls the columns so the query returns empty with exit 0 instead of raising. `available?` also stays on superuser as an independent check of the monitoring auth path, and privileged actions keep superuser. Requires the fleet-wide `system2monitoring` pg_ident map, the same precondition as the health-pulse user change (#5423/#5424, both merged).

Verified live on an AWS sync-HA trio: a planned failover scored its target through `current_lsn` as `ubi_monitoring`, and the slot-sync and replica-lag reads ran as `ubi_monitoring` against `ubi_admin` on both the primary and an in-recovery standby, with superuser denied to the monitoring role and failures surfacing loudly.
