### PR TITLE
Add Ruby LSP addon that links hop_ methods

### DIFF
--- a/ruby_lsp/ubicloud/addon.rb
+++ b/ruby_lsp/ubicloud/addon.rb
@@ -1,0 +1,34 @@
+# typed: false
+# frozen_string_literal: true
+
+require "ruby_lsp/addon"
+
+module RubyLsp
+  module Ubicloud
+    # Minimal ruby-lsp add-on whose only job is to load the indexing enhancement below.
+    class Addon < ::RubyLsp::Addon
+      def activate(global_state, outgoing_queue) = nil
+
+      def deactivate = nil
+
+      def name = "Ubicloud"
+
+      def version = "0.1.0"
+    end
+
+    # `label def <name>` (prog/base.rb) generates a hop_<name> method with a dynamic name
+    # that ruby-lsp can't see. Register it so go-to-definition jumps to the labelled method.
+    class ProgLabelEnhancement < RubyIndexer::Enhancement
+      #: (Prism::CallNode node) -> void
+      def on_call_node_enter(node)
+        return unless node.name == :label && node.receiver.nil?
+
+        definition = node.arguments&.arguments&.first
+        return unless definition.is_a?(Prism::DefNode)
+
+        name = definition.name
+        @listener.add_method("hop_#{name}", definition.name_loc, [], comments: "Transitions the strand to the `#{name}` label.")
+      end
+    end
+  end
+end

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -22,7 +22,7 @@ elsif (suite = ENV.delete("COVERAGE"))
     else
       add_filter do |file|
         path = file.filename.delete_prefix(File.dirname(__dir__))
-        path.match?(/\A\/(coverage|rhizome|kubernetes|migrate|spec|var|(db|model|loader|\.env)\.rb)/)
+        path.match?(/\A\/(coverage|rhizome|kubernetes|migrate|ruby_lsp|spec|var|(db|model|loader|\.env)\.rb)/)
       end
     end
 


### PR DESCRIPTION
This Ruby LSP addon simplifies code navigation for developers by registering the dynamically defined methods in the SemaphoreMethods module. This allows developers to ctrl/cmd+click the methods in their editor to jump to the SemaphoreMethods plugin line.