### PR TITLE
Aggregate GitHub usage by repository behind a feature flag

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -245,6 +245,7 @@ class Project < Sequel::Model
     :enable_r8gd,
     :enable_r8id,
     :free_runner_upgrade_until,
+    :github_billing_by_repository,
     :gpu_vm,
     :ipv6_disabled,
     :postgres_enable_maintenance_window_days,

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -131,6 +131,12 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     github_runner.update(billed_vm_size:)
     rate_id = BillingRate.from_resource_properties("GitHubRunnerMinutes", billed_vm_size, "global")["id"]
 
+    resource_id, resource_label = if project.get_ff_github_billing_by_repository
+      [github_runner.repository_id, github_runner.repository_name]
+    else
+      [installation.id, installation.name]
+    end
+
     retries = 0
     begin
       begin_time = Time.now.to_date.to_time
@@ -139,7 +145,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       used_amount = (duration / 60).ceil
       github_runner.log_duration("runner_completed", duration)
       today_record = BillingRecord
-        .where(project_id: project.id, resource_id: installation.id, billing_rate_id: rate_id)
+        .where(project_id: project.id, resource_id:, billing_rate_id: rate_id)
         .where { Sequel.pg_range(it.span).overlaps(Sequel.pg_range(begin_time...end_time)) }
         .first
 
@@ -149,8 +155,8 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       else
         BillingRecord.create(
           project_id: project.id,
-          resource_id: installation.id,
-          resource_name: "Daily Usage #{begin_time.strftime("%Y-%m-%d")} (#{installation.name})",
+          resource_id:,
+          resource_name: "Daily Usage #{begin_time.strftime("%Y-%m-%d")} (#{resource_label})",
           billing_rate_id: rate_id,
           span: Sequel.pg_range(begin_time...end_time),
           amount: used_amount,

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -279,6 +279,21 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
         .to change { BillingRecord[resource_id: installation.id].amount }.from(5).to(10)
     end
 
+    it "aggregates billing records by repository when the feature flag is enabled" do
+      project.set_ff_github_billing_by_repository(true)
+      repository = GithubRepository.create(name: "ubicloud/test-repo", installation_id: installation.id)
+      runner.update(repository_id: repository.id, ready_at: now - 5 * 60)
+
+      expect { nx.update_billing_record }
+        .to change { BillingRecord.where(resource_id: repository.id).count }.from(0).to(1)
+
+      expect { nx.update_billing_record }
+        .to change { BillingRecord[resource_id: repository.id].amount }.from(5).to(10)
+
+      expect(BillingRecord.where(resource_id: installation.id).count).to eq(0)
+      expect(BillingRecord[resource_id: repository.id].resource_name).to eq("Daily Usage 2026-02-05 (test-repo)")
+    end
+
     it "create a new record for a new day" do
       today = Time.now
       tomorrow = today + 24 * 60 * 60


### PR DESCRIPTION
Daily GitHub billing records are aggregated per installation, which is the right default granularity. However, some customers want to see their runner usage broken down by repository on the invoice. Doing this for everyone would bloat invoices of projects with hundreds of active repositories, so it is opt-in.

When the github_billing_by_repository feature flag is enabled for a project, daily usage records are keyed by the repository instead of the installation and named after the repository. Toggling the flag mid-day is safe: lookups include the resource id, so a new record simply starts at the new granularity and both are invoiced.