### PR TITLE
Opt github runner subnets into rekey v2

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -90,6 +90,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       allow_only_ssh: true,
       ipv4_range_size: 28,
       preferred_azs:,
+      rekey_protocol: 2,
     ).subject
 
     vm_st = Prog::Vm::Nexus.assemble_with_sshable(

--- a/prog/vm/vm_pool.rb
+++ b/prog/vm/vm_pool.rb
@@ -23,6 +23,7 @@ class Prog::Vm::VmPool < Prog::Base
       Config.vm_pool_project_id,
       location_id: vm_pool.location_id,
       allow_only_ssh: true,
+      rekey_protocol: 2,
     ).subject
 
     Prog::Vm::Nexus.assemble_with_sshable(

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -3,7 +3,7 @@
 class Prog::Vnet::SubnetNexus < Prog::Base
   subject_is :private_subnet
 
-  def self.assemble(project_id, name: nil, location_id: Location::HETZNER_FSN1_ID, ipv6_range: nil, ipv4_range: nil, allow_only_ssh: false, firewall_id: nil, ipv4_range_size: nil, preferred_azs: [])
+  def self.assemble(project_id, name: nil, location_id: Location::HETZNER_FSN1_ID, ipv6_range: nil, ipv4_range: nil, allow_only_ssh: false, firewall_id: nil, ipv4_range_size: nil, preferred_azs: [], rekey_protocol: 1)
     unless (project = Project[project_id])
       fail "No existing project"
     end
@@ -24,7 +24,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
     ipv6_range ||= random_private_ipv6(location, project).to_s
     ipv4_range ||= random_private_ipv4(location, project, ipv4_range_size).to_s
     DB.transaction do
-      ps = PrivateSubnet.create_with_id(id, name:, location_id: location.id, net6: ipv6_range, net4: ipv4_range, state: "waiting", project_id:)
+      ps = PrivateSubnet.create_with_id(id, name:, location_id: location.id, net6: ipv6_range, net4: ipv4_range, state: "waiting", project_id:, rekey_protocol:)
       firewall_dataset = project.firewalls_dataset.where(location_id:)
 
       if firewall_id

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(vm.family).to eq("standard")
       expect(vm.vcpus).to eq(4)
       expect(vm.project_id).to eq(Config.github_runner_service_project_id)
+      expect(vm.nics.first.private_subnet.rekey_protocol).to eq 2
     end
 
     it "provisions a new vm if pool is valid but there is no vm" do

--- a/spec/prog/vm/vm_pool_spec.rb
+++ b/spec/prog/vm/vm_pool_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Prog::Vm::VmPool do
       expect(vm.unix_user).to eq("runneradmin")
       expect(vm.sshable.unix_user).to eq("runneradmin")
       expect(vm.vm_storage_volumes.first.track_written).to be(false)
+      expect(vm.nics.first.private_subnet.rekey_protocol).to eq 2
     end
   end
 

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -85,6 +85,16 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(ps.subject.firewalls.first).to eq(fw)
     end
 
+    it "creates the subnet with rekey protocol v1 by default" do
+      ps = described_class.assemble(prj.id)
+      expect(ps.subject.rekey_protocol).to eq 1
+    end
+
+    it "creates the subnet with the provided rekey protocol" do
+      ps = described_class.assemble(prj.id, rekey_protocol: 2)
+      expect(ps.subject.rekey_protocol).to eq 2
+    end
+
     it "fails if provided firewall does not exist" do
       expect {
         described_class.assemble(prj.id, firewall_id: "550e8400-e29b-41d4-a716-446655440000")


### PR DESCRIPTION
SubnetNexus.assemble gains a rekey_protocol keyword (default v1, matching the column default, so existing call sites are unchanged), and the two runner subnet creation paths — on-demand in GithubRunnerNexus and the warm pool in VmPool#create_new_vm — pass rekey_protocol: 2.

Runner subnets serve as the v2 canary population: they are standalone (never peered, so connect-time normalization cannot downgrade them) and high-churn, the profile of the 2026-06-10 incident. Because the fleet recreates itself within minutes, the off-switch is reverting the second commit rather than flipping existing subnets.