### PR TITLE
Add basic security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Report vulnerabilities to `security@ubicloud.com`. Do not open a public issue. We will acknowledge your report within 3 business day and aim to give you an initial assessment within 14 days.
+
+## Supported Versions
+
+Only the main branch receives security fixes. If you are on an older commit, upgrade before reporting. We do not backport patches.
+
+## Disclosure Timeline
+
+We merge a commit fixing the issue as soon as it is fully tested and working. Publication of the issue details is handled on a case-by-case basis.
+
+## Scope
+
+In scope: flaws exploitable by an attacker in our production environment or in the default configuration. Out of scope: hardening suggestions, missing defense-in-depth, and issues requiring an already-compromised host or a hostile application developer. Hardening ideas are welcome, as regular issues, not security reports.
+
+## Triage & Severity
+
+We triage each report on its own terms: how exploitable it is, how many users are realistically affected, and how disruptive the fix is. Each advisory explains our reasoning in plain language instead of assigning a score.
+
+## Credit
+
+We are grateful for reports and will happily credit reporters in advisories on request, but we make no standing commitments. Compensation for significant findings is done on a case-by-case basis using GitHub sponsorships.


### PR DESCRIPTION
This will show up on GitHub if a user attempts to report a security vulnerability. It's deliberately left quite simple, we can expand it later as needed.