### PR TITLE
Make page trigger suppression severity-aware

### DIFF
--- a/model/page.rb
+++ b/model/page.rb
@@ -167,6 +167,10 @@ class Page < Sequel::Model
 
   SEVERITY_ORDER = {"info" => 0, "warning" => 1, "error" => 2, "critical" => 3}.freeze
 
+  SUPPRESSING_SEVERITIES = SEVERITY_ORDER.to_h do |severity, order|
+    [severity, SEVERITY_ORDER.filter_map { |sev, o| sev if o >= order }.freeze]
+  end.freeze
+
   def self.severity_order(severity)
     SEVERITY_ORDER.fetch(severity)
   end

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -37,10 +37,13 @@ class Prog::PageNexus < Prog::Base
         group_ids = uuid_map.values.compact.flat_map { Page.root_resources(it) }
         frame = {}
 
-        # Check if the new page is related to an existing recent active page that did not suppress triggers.
-        # If so, suppress triggers for the current page.
+        # Check if the new page is related to an existing recent active page that did not suppress
+        # triggers and has equal or higher severity. If so, suppress triggers for the current page,
+        # so that a page escalating the severity still pages the operator.
+        suppressing_severities = Page::SEVERITY_ORDER.filter_map { |sev, order| sev if order >= Page.severity_order(severity) }
         duplicate = !DB[:page_root_resource]
           .where(root_resource_id: group_ids, duplicate: false) { at > Time.now - 15 * 60 }
+          .join(:page, id: :page_id, severity: suppressing_severities)
           .empty?
 
         frame["suppress_triggers"] = true if duplicate

--- a/prog/page_nexus.rb
+++ b/prog/page_nexus.rb
@@ -40,10 +40,9 @@ class Prog::PageNexus < Prog::Base
         # Check if the new page is related to an existing recent active page that did not suppress
         # triggers and has equal or higher severity. If so, suppress triggers for the current page,
         # so that a page escalating the severity still pages the operator.
-        suppressing_severities = Page::SEVERITY_ORDER.filter_map { |sev, order| sev if order >= Page.severity_order(severity) }
         duplicate = !DB[:page_root_resource]
           .where(root_resource_id: group_ids, duplicate: false) { at > Time.now - 15 * 60 }
-          .join(:page, id: :page_id, severity: suppressing_severities)
+          .join(:page, id: :page_id, severity: Page::SUPPRESSING_SEVERITIES.fetch(severity))
           .empty?
 
         frame["suppress_triggers"] = true if duplicate

--- a/spec/prog/page_nexus_spec.rb
+++ b/spec/prog/page_nexus_spec.rb
@@ -130,6 +130,29 @@ RSpec.describe Prog::PageNexus do
       expect(Strand.where(prog: "PageNexus").exclude(id: st.id).first.stack[0]["suppress_triggers"]).to be true
     end
 
+    it "does not suppress triggers for page with higher severity than recent related page" do
+      vmh = create_vm_host
+      expect {
+        described_class.assemble(summary, tag_parts + [vmh.ubid], vmh.ubid, severity: "warning", extra_data:)
+      }.to change(Page, :count).from(0).to(1)
+        .and change(Strand.where(prog: "PageNexus"), :count).from(0).to(1)
+        .and change(DB[:page_root_resource], :count).from(0).to(1)
+        .and change(DB[:page_root_resource].exclude(:duplicate), :count).from(0).to(1)
+      st = Strand.first(prog: "PageNexus")
+      expect(st.stack[0]["suppress_triggers"]).to be_nil
+
+      vmhs = create_vm_host_slice(vm_host_id: vmh.id)
+
+      expect {
+        described_class.assemble(summary, tag_parts, vmhs.ubid, severity: "critical", extra_data:)
+      }.to change(Page, :count).from(1).to(2)
+        .and change(Strand.where(prog: "PageNexus"), :count).from(1).to(2)
+        .and change(DB[:page_root_resource], :count).from(1).to(2)
+        .and change(DB[:page_root_resource].exclude(:duplicate), :count).from(1).to(2)
+
+      expect(Strand.where(prog: "PageNexus").exclude(id: st.id).first.stack[0]["suppress_triggers"]).to be_nil
+    end
+
     it "does not suppress triggers for page that may duplicate older page" do
       vmh = create_vm_host
       expect {


### PR DESCRIPTION
Pages sharing root resources with a recent active page have their triggers suppressed to prevent page storms. However, this also suppressed high-urgency pages when a low-urgency one fired first: a "Recorded last_boot_id" warning page on a host would swallow a subsequent host unavailable page, so the oncall was never notified.

Only suppress a new page when a recent related page has equal or higher severity, so escalations still page the operator while lower-severity noise remains suppressed.