### PR TITLE
Avoid allocating small storage requests to hosts with large storage

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -238,6 +238,7 @@ module Config
   override :allocator_target_host_utilization, 0.72, float
   override :allocator_target_premium_host_utilization, 0.85, float
   override :allocator_max_random_score, 0.1, float
+  override :allocator_large_storage_device_gib, 4096, int
 
   # e2e
   override :e2e_hetzner_server_id, nil, string

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -107,6 +107,12 @@ module Scheduling::Allocator
       return false unless location_filter.one?
       Location[location_filter.first].provider == "ubicloud"
     end
+
+    # True if the request has a volume large enough to require a large storage
+    # device (>= the reserved-device threshold).
+    def needs_large_storage_device?
+      storage_volumes.any? { |_, v| v["size_gib"] >= Config.allocator_large_storage_device_gib }
+    end
   end
 
   class Allocation
@@ -191,6 +197,9 @@ module Scheduling::Allocator
               .select_append { sum(total_storage_gib).as(total_storage_gib) }
               .select_append { json_agg(json_build_object(Sequel.lit("'id'"), Sequel[:storage_device][:id], Sequel.lit("'total_storage_gib'"), total_storage_gib, Sequel.lit("'available_storage_gib'"), available_storage_gib)).order(available_storage_gib).as(storage_devices) }
               .where(enabled: true)
+              # TEMPORARY: protect scarce 4TB disk resources. A request that doesn't need a large disk
+              # may not use storage devices with >= allocator_large_storage_device_gib available.
+              .where { request.needs_large_storage_device? || (available_storage_gib < Config.allocator_large_storage_device_gib) }
               .having { sum(available_storage_gib) >= request.storage_gib }
               .having { count.function.* >= (request.distinct_storage_devices ? request.storage_volumes.count : 1) })
             .with(:gpus, DB[:pci_device]

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -199,6 +199,49 @@ RSpec.describe Scheduling::Allocator do
                  family: "standard"}])
     end
 
+    it "reserves large-available storage devices: a small request cannot use a device with >= threshold available" do
+      large = Config.allocator_large_storage_device_gib
+      vmh = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      StorageDevice.create(vm_host_id: vmh.id, name: "big", available_storage_gib: large, total_storage_gib: large)
+      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
+
+      expect(Al::Allocation.candidate_hosts(req)).to eq([])
+    end
+
+    it "lets a small request use a device with less than the threshold available" do
+      large = Config.allocator_large_storage_device_gib
+      vmh = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      StorageDevice.create(vm_host_id: vmh.id, name: "medium", available_storage_gib: large - 1, total_storage_gib: large)
+      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
+
+      expect(Al::Allocation.candidate_hosts(req).map { it[:vm_host_id] }).to eq([vmh.id])
+    end
+
+    it "lets a small request use a host with two sub-threshold devices totaling more than the threshold" do
+      large = Config.allocator_large_storage_device_gib
+      vmh = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: large - 1, total_storage_gib: large - 1)
+      StorageDevice.create(vm_host_id: vmh.id, name: "stor2", available_storage_gib: large - 1, total_storage_gib: large - 1)
+      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
+
+      expect(Al::Allocation.candidate_hosts(req).map { it[:vm_host_id] }).to eq([vmh.id])
+    end
+
+    it "lets a request that needs a large device use a device with >= threshold available" do
+      large = Config.allocator_large_storage_device_gib
+      vmh = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
+      StorageDevice.create(vm_host_id: vmh.id, name: "big", available_storage_gib: large, total_storage_gib: large)
+      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
+      req.storage_gib = large
+      req.storage_volumes = [[0, {"use_bdev_ubi" => false, "size_gib" => large, "boot" => true}]]
+
+      expect(Al::Allocation.candidate_hosts(req).map { it[:vm_host_id] }).to eq([vmh.id])
+    end
+
     it "retrieves provisioning count" do
       vmh = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
       Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)


### PR DESCRIPTION
The goal of this change is to try and keep large storage volumes on hosts available for large storage volume requests (e.g., 4TB Postgres), and to avoid these volumes filling up with smaller request.

This change implements this by penalizing allocating small storage volume requests to hosts with large amounts of space available. The treshold is configured to 2TB in `config.rb`.