### PR TITLE
Bind VM DHCP addresses to MAC, ignoring client identifier

### DIFF
--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -497,6 +497,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
       vm_net4 = NetAddr::IPv4Net.parse(nic.net4)
       vm_sub_4 = (vm_net4.netmask.prefix_len == 32) ? vm_net4.nth(0) : vm_net4.nth(1)
       <<DHCP
+dhcp-host=#{nic.mac},id:*,#{vm_sub_4}
 dhcp-range=#{nic.tap},#{vm_sub_4},#{vm_sub_4},6h
 dhcp-range=#{nic.tap},#{vm_sub_6.nth(2)},#{vm_sub_6.nth(2)},#{vm_sub_6.netmask.prefix_len}
 DHCP

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -257,6 +257,17 @@ RSpec.describe VmSetup do
       dnsmasq_conf = vps.writes["dnsmasq.conf"]
       expect(dnsmasq_conf).to include("dhcp-range=nctest,192.168.1.1,192.168.1.1,6h")
     end
+
+    it "binds a dhcp-host entry for each NIC, ignoring the client identifier" do
+      multi_nics = [
+        VmSetup::Nic.new("fd48:666c:a296:ce4b:2cc6::/79", "192.168.5.50/32", "nctest1", "3e:bd:a5:96:f7:b9", "10.0.0.254/32"),
+        VmSetup::Nic.new("fddf:53d2:4c89:2305:46a0::/79", "10.10.10.10/32", "nctest2", "fb:55:dd:ba:21:0a", "10.0.0.253/32"),
+      ]
+      vs.cloudinit("user", ["key"], "fddf:53d2:4c89:2305:46a0::/79", multi_nics, nil, "ubuntu-noble", "10.0.0.2", ipv6_disabled: false)
+      dnsmasq_conf = vps.writes["dnsmasq.conf"]
+      expect(dnsmasq_conf).to include("dhcp-host=3e:bd:a5:96:f7:b9,id:*,192.168.5.50")
+      expect(dnsmasq_conf).to include("dhcp-host=fb:55:dd:ba:21:0a,id:*,10.10.10.10")
+    end
   end
 
   describe "#purge" do


### PR DESCRIPTION
Each VM's dnsmasq serves a dhcp-range holding exactly one address -- the address the control plane already assigned to that NIC. dnsmasq still treats it as a pool, so it hands the lease to whichever DHCP client identifier asks first and refuses every other identifier with "no address available" until the lease expires.

This surfaced on an ubuntu-resolute VM stuck in wait_sshable: the guest booted (link up, IPv6 link-local reachable) but never got an IPv4 address, so it never answered ARP and the strand eventually paged. dnsmasq was holding the single address against the guest, and restarting the per-VM dnsmasq cleared it.

The suspected cause is a guest running more than one DHCP client, each presenting a different client identifier for the same MAC (for example systemd-networkd using an IAID/DUID-based identifier alongside a dhcpcd-based client). One client wins the single address and the other is refused; if the loser owns the interface configuration, the guest ends up with no IPv4 at all. This was not confirmed on the wire (DHCP option 61 was not captured), but it fits the observed behavior and the correlation with the newer image.

Bind the address to the NIC's MAC with dhcp-host and set id:* so dnsmasq matches on MAC alone and disregards the client identifier. Both clients then resolve to the same lease and neither can lock the other out. The pool can only ever serve one known NIC, so letting the client identifier gate the assignment served no purpose. This only affects DHCPv4; the single-address DHCPv6 range has the same shape, but guests configure IPv6 via SLAAC from the router advertisement, so it is not fixed here.

Recovering from this in production is expensive: guests run with --console off and serial redirected to a file, so a VM without an address cannot be logged into and must be debugged entirely from the host.