### PR TITLE
Make Prog::Github::DeleteCacheEntries handle deleted repository

### DIFF
--- a/prog/github/delete_cache_entries.rb
+++ b/prog/github/delete_cache_entries.rb
@@ -25,6 +25,8 @@ class Prog::Github::DeleteCacheEntries < Prog::Base
   end
 
   def next_entry
+    return unless github_repository
+
     github_repository
       .cache_entries_dataset
       .order(:created_at)

--- a/spec/prog/github/delete_cache_entries_spec.rb
+++ b/spec/prog/github/delete_cache_entries_spec.rb
@@ -67,5 +67,10 @@ RSpec.describe Prog::Github::DeleteCacheEntries do
       entries[1].this.update(created_at: Time.now + 10)
       expect(dce.next_entry).to be_nil
     end
+
+    it "returns nil if no github repository" do
+      repository.destroy
+      expect(dce.next_entry).to be_nil
+    end
   end
 end


### PR DESCRIPTION
If the repository has been deleted, we cannot get the cache entries for it, so the only thing we can do is exit (which returning nil will do).