### PR TITLE
Make machine image screenshots stable

### DIFF
--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -610,7 +610,8 @@ class RegenScreenshots
       access_key: "ak",
       secret_key: "sk",
     )
-    machine_image = MachineImage.create(
+    machine_image = MachineImage.create_with_id(
+      UBID.parse("m11846np50b60k7va7d70y5qg6").to_uuid,
       name: "prod-image",
       project_id: project.id,
       arch: "x64",


### PR DESCRIPTION
machine-images/latest-version-screenshot.png and
machine-images/versions-screenshot.png varied from run to run because of new ubid generation. Make them stable by assigning an explicit ubid.