### PR TITLE
Add prepare to move Vm object action to admin site

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -553,6 +553,13 @@ class CloverAdmin < Roda
           obj.incr_stop
         end
       end,
+      "prepare_to_move" => object_action("Prepare to Move", flash: "Prepare to move scheduled for Vm") do |obj|
+        fail CloverError.new(400, "InvalidRequest", "Prepare to move is only supported for metal Vms") unless obj.location.metal?
+        DB.transaction do
+          obj.incr_prepare_to_move
+          obj.incr_stop
+        end
+      end,
     },
     "VmHost" => {
       "accept" => object_action("Move to Accepting", flash: "Host allocation state changed to accepting") do |obj|

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -49,7 +49,7 @@ class Vm < Sequel::Model
   plugin ResourceMethods, redacted_columns: :public_key
   plugin ProviderDispatcher, __FILE__
   plugin SemaphoreMethods, :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules,
-    :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started, :restart, :start, :stop, :migrate_to_separate_progs, :admin_stop, :stopping
+    :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started, :restart, :start, :stop, :migrate_to_separate_progs, :admin_stop, :stopping, :prepare_to_move
   include HealthMonitorMethods
 
   include ObjectTag::Cleanup

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -386,6 +386,10 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       end
     end
 
+    when_prepare_to_move_set? do
+      hop_stopped_by_admin
+    end
+
     when_start_set? do
       register_deadline("wait", 5 * 60)
       hop_start_after_stop
@@ -394,10 +398,6 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     when_restart_set? do
       register_deadline("wait", 5 * 60)
       hop_restart
-    end
-
-    when_prepare_to_move_set? do
-      hop_stopped_by_admin
     end
 
     if available?

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -396,6 +396,10 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       hop_restart
     end
 
+    when_prepare_to_move_set? do
+      hop_stopped_by_admin
+    end
+
     if available?
       hop_wait
     end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -1221,6 +1221,12 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(sshable).to receive(:_cmd).with("systemctl is-active #{vm.inhost_name} #{vm.inhost_name}-dnsmasq").and_return("active\nactive\n")
       expect { nx.stopped }.to hop("wait")
     end
+
+    it "hops to stopped_by_admin without decrementing prepare_to_move once stopped normally" do
+      vm.incr_prepare_to_move
+      expect { nx.stopped }.to hop("stopped_by_admin")
+        .and not_change { vm.reload.prepare_to_move_set? }
+    end
   end
 
   describe "#unavailable" do

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -1222,8 +1222,10 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect { nx.stopped }.to hop("wait")
     end
 
-    it "hops to stopped_by_admin without decrementing prepare_to_move once stopped normally" do
+    it "hops to stopped_by_admin without decrementing prepare_to_move once stopped normally, even if user has requested start or restart" do
       vm.incr_prepare_to_move
+      vm.incr_start
+      vm.incr_restart
       expect { nx.stopped }.to hop("stopped_by_admin")
         .and not_change { vm.reload.prepare_to_move_set? }
     end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -939,24 +939,22 @@ RSpec.describe CloverAdmin do
   end
 
   it "shows 404 page if DONT_RAISE_ADMIN_ERRORS environment variable is set" do
-    ENV["DONT_RAISE_ADMIN_ERRORS"] = "1"
-    visit "/invalid-page"
-    expect(page.title).to eq "Ubicloud Admin - File Not Found"
-  ensure
-    ENV.delete("DONT_RAISE_ADMIN_ERRORS")
+    dont_raise_admin_errors do
+      visit "/invalid-page"
+      expect(page.title).to eq "Ubicloud Admin - File Not Found"
+    end
   end
 
   it "links to archived-record-by-id on 404 when path contains ubid" do
-    ENV["DONT_RAISE_ADMIN_ERRORS"] = "1"
-    vm = create_vm(name: "life-after-death")
-    visit "/model/Vm/#{vm.ubid}"
-    expect(page).to have_content("life-after-death")
-    vm.destroy
-    visit "/model/Vm/#{vm.ubid}"
-    click_link "searching archived records"
-    expect(page).to have_content("life-after-death")
-  ensure
-    ENV.delete("DONT_RAISE_ADMIN_ERRORS")
+    dont_raise_admin_errors do
+      vm = create_vm(name: "life-after-death")
+      visit "/model/Vm/#{vm.ubid}"
+      expect(page).to have_content("life-after-death")
+      vm.destroy
+      visit "/model/Vm/#{vm.ubid}"
+      click_link "searching archived records"
+      expect(page).to have_content("life-after-death")
+    end
   end
 
   it "raises errors by default in tests" do
@@ -964,12 +962,11 @@ RSpec.describe CloverAdmin do
   end
 
   it "shows error page for errors if DONT_RAISE_ADMIN_ERRORS environment variable is set" do
-    ENV["DONT_RAISE_ADMIN_ERRORS"] = "1"
-    expect(Clog).to receive(:emit).with("admin route exception", instance_of(Hash)).and_call_original
-    visit "/error"
-    expect(page.title).to eq "Ubicloud Admin - Internal Server Error"
-  ensure
-    ENV.delete("DONT_RAISE_ADMIN_ERRORS")
+    dont_raise_admin_errors do
+      expect(Clog).to receive(:emit).with("admin route exception", instance_of(Hash)).and_call_original
+      visit "/error"
+      expect(page.title).to eq "Ubicloud Admin - Internal Server Error"
+    end
   end
 
   it "handles incorrect/missing CSRF tokens" do
@@ -1238,15 +1235,14 @@ RSpec.describe CloverAdmin do
   end
 
   it "does not support preparing non-metal Vms to move" do
-    ENV["DONT_RAISE_ADMIN_ERRORS"] = "1"
-    location = Location.create(name: "l1", display_name: "l1", ui_name: "l1", visible: true, provider: "aws")
-    vm = create_vm(location_id: location.id)
-    visit "/model/Vm/#{vm.ubid}/prepare_to_move"
-    click_button "Prepare to Move"
-    expect(page).to have_content "InvalidRequest: Prepare to move is only supported for metal Vms"
-    expect(vm.semaphores_dataset.select_map(:name)).to eq []
-  ensure
-    ENV.delete("DONT_RAISE_ADMIN_ERRORS")
+    dont_raise_admin_errors do
+      location = Location.create(name: "l1", display_name: "l1", ui_name: "l1", visible: true, provider: "aws")
+      vm = create_vm(location_id: location.id)
+      visit "/model/Vm/#{vm.ubid}/prepare_to_move"
+      click_button "Prepare to Move"
+      expect(page).to have_content "InvalidRequest: Prepare to move is only supported for metal Vms"
+      expect(vm.semaphores_dataset.select_map(:name)).to eq []
+    end
   end
 
   it "supports restarting PostgresResource" do
@@ -1640,14 +1636,13 @@ RSpec.describe CloverAdmin do
       expect(page.title).to eq "Ubicloud Admin - Project #{p.ubid}"
     end
 
-    ENV["DONT_RAISE_ADMIN_ERRORS"] = "1"
-    visit path
-    select "free_runner_upgrade_until", from: "name"
-    fill_in "value", with: "invalid_json"
-    click_button "Set Feature Flag"
-    expect(page).to have_content "InvalidRequest: invalid JSON for feature flag value"
-  ensure
-    ENV.delete("DONT_RAISE_ADMIN_ERRORS")
+    dont_raise_admin_errors do
+      visit path
+      select "free_runner_upgrade_until", from: "name"
+      fill_in "value", with: "invalid_json"
+      click_button "Set Feature Flag"
+      expect(page).to have_content "InvalidRequest: invalid JSON for feature flag value"
+    end
   end
 
   it "allows adding and removing allowed domains for OidcProviders" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1223,6 +1223,32 @@ RSpec.describe CloverAdmin do
     expect(vm.semaphores_dataset.select_order_map(:name)).to eq ["admin_stop", "stop"]
   end
 
+  it "supports preparing metal Vms to move" do
+    vm = Prog::Vm::Nexus.assemble("dummy-public key", Project.create(name: "Default").id, name: "dummy-vm-1").subject
+    fill_in "UBID, UUID, or prefix:term", with: vm.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - Vm #{vm.ubid}"
+
+    expect(vm.semaphores_dataset.select_map(:name)).to eq []
+    click_link "Prepare to Move"
+    click_button "Prepare to Move"
+    expect(page).to have_flash_notice("Prepare to move scheduled for Vm")
+    expect(page.title).to eq "Ubicloud Admin - Vm #{vm.ubid}"
+    expect(vm.semaphores_dataset.select_order_map(:name)).to eq ["prepare_to_move", "stop"]
+  end
+
+  it "does not support preparing non-metal Vms to move" do
+    ENV["DONT_RAISE_ADMIN_ERRORS"] = "1"
+    location = Location.create(name: "l1", display_name: "l1", ui_name: "l1", visible: true, provider: "aws")
+    vm = create_vm(location_id: location.id)
+    visit "/model/Vm/#{vm.ubid}/prepare_to_move"
+    click_button "Prepare to Move"
+    expect(page).to have_content "InvalidRequest: Prepare to move is only supported for metal Vms"
+    expect(vm.semaphores_dataset.select_map(:name)).to eq []
+  ensure
+    ENV.delete("DONT_RAISE_ADMIN_ERRORS")
+  end
+
   it "supports restarting PostgresResource" do
     project_id = Project.create(name: "Default").id
     expect(Config).to receive(:postgres_service_project_id).and_return(project_id).at_least(:once)

--- a/spec/routes/web/admin/spec_helper.rb
+++ b/spec/routes/web/admin/spec_helper.rb
@@ -44,5 +44,12 @@ RSpec.configure do |config|
       fill_in "webauthn_auth", with: admin_webauthn_client.get(challenge:).to_json
       click_button "Authenticate Using WebAuthn"
     end
+
+    def dont_raise_admin_errors
+      ENV["DONT_RAISE_ADMIN_ERRORS"] = "1"
+      yield
+    ensure
+      ENV.delete("DONT_RAISE_ADMIN_ERRORS")
+    end
   end)
 end


### PR DESCRIPTION
VMs that are prepared for move are stopped gracefully (if not already stopped), then transition to the `stopped_by_admin` label, so they cannot be started by a user until the move completes. This sets a semaphore on the Vm which remains even in the `stopped_by_admin` label, so admins can tell the difference between a Vm that was prepared for move versus one that was stopped for a different reason.

Only metal VMs are allowed to be prepared for move, since moving doesn't currently make sense for aws/gcp VMs.

While working on this, I saw we had a some duplicate code in the admin specs regarding error handling, so I added a helper method to DRY that up.

This is designed to be preparation for moving a VM's storage from one host to another, which is being worked on in #5909. The idea is we would only allow a VM move if the VM has already been prepared for move, and if it has been prepared, we know the user cannot start the VM during the process.

Best viewed ignoring whitespace differences.