### PR TITLE
Add extension points to override HA behavior

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -213,6 +213,11 @@ class PostgresResource < Sequel::Model
     end
   end
 
+  # Whether the primary must run synchronous replication (ANY-1 quorum commit).
+  def needs_sync_replication?
+    ha_type == HaType::SYNC
+  end
+
   def needs_convergence?
     needs_upgrade = version.to_i < target_version.to_i && !ongoing_failover?
     servers.any? { it.needs_recycling? } || servers.count != target_server_count || needs_upgrade

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -112,7 +112,7 @@ class PostgresServer < Sequel::Model
 
       if primary?
         caught_up_standbys = resource.servers.select { it.standby? && it.synchronization_status == "ready" }
-        if resource.ha_type == PostgresResource::HaType::SYNC
+        if resource.needs_sync_replication?
           configs[:synchronous_standby_names] = "'ANY 1 (#{caught_up_standbys.map(&:ubid).join(",")})'" unless caught_up_standbys.empty?
         end
         if version.to_i >= 17

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -577,7 +577,7 @@ SQL
       postgres_server.update(synchronization_status: "ready")
 
       resource.representative_server.incr_configure
-      hop_wait_synchronization if resource.ha_type == PostgresResource::HaType::SYNC
+      hop_wait_synchronization if resource.needs_sync_replication?
       hop_wait
     end
 
@@ -827,7 +827,7 @@ SQL
   end
 
   label def wait_representative_lockout
-    hop_taking_over if resource.representative_server.strand.label == "wait_locked_out"
+    hop_prepare_taking_over if resource.representative_server.strand.label == "wait_locked_out"
 
     nap 1
   end
@@ -868,7 +868,7 @@ SQL
 
   label def wait_fencing_of_old_primary
     representative_server = resource.representative_server
-    hop_taking_over if representative_server.strand.label == "wait_in_fence"
+    hop_prepare_taking_over if representative_server.strand.label == "wait_in_fence"
 
     if deadline_at && Time.now > Time.parse(deadline_at.to_s)
       representative_server.incr_lockout
@@ -891,6 +891,12 @@ SQL
     nap 5
   end
 
+  # Pre-promote step, run once after the old primary is fenced/locked-out and before
+  # pg_promote. Allows forks to override pre-promote behavior.
+  label def prepare_taking_over
+    hop_taking_over
+  end
+
   label def taking_over
     if postgres_server.read_replica?
       resource.representative_server.update(is_representative: false)
@@ -909,7 +915,7 @@ SQL
       resource.incr_refresh_dns_record
       resource.server_incr("configure", "configure_metrics", "configure_logs")
       resource.servers.reject(&:primary?).each { it.update(synchronization_status: "catching_up") }
-      hop_configure
+      hop_finalize_taking_over
     when "Failed"
       vm.sshable.d_run("promote_postgres", "sudo", "postgres/bin/promote", postgres_server.version)
       nap 0
@@ -919,6 +925,12 @@ SQL
     end
 
     nap 5
+  end
+
+  # Post-promote finalization, run once after a successful promote.
+  # Allows forks to override post-promote behavior.
+  label def finalize_taking_over
+    hop_configure
   end
 
   label def destroy

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -696,6 +696,15 @@ RSpec.describe PostgresResource do
     expect(postgres_resource.needs_convergence?).to be(true)
   end
 
+  it "needs_sync_replication? is true only for sync HA" do
+    postgres_resource.update(ha_type: PostgresResource::HaType::SYNC)
+    expect(postgres_resource.needs_sync_replication?).to be(true)
+    postgres_resource.update(ha_type: PostgresResource::HaType::ASYNC)
+    expect(postgres_resource.needs_sync_replication?).to be(false)
+    postgres_resource.update(ha_type: PostgresResource::HaType::NONE)
+    expect(postgres_resource.needs_sync_replication?).to be(false)
+  end
+
   describe "#latest_backup_too_large_for_target?" do
     before do
       create_postgres_server(resource: postgres_resource, timeline:)

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1592,9 +1592,9 @@ CMD
       @standby_nx = create_standby_nexus
     end
 
-    it "hops to taking_over when representative server is in wait_locked_out state" do
+    it "hops to prepare_taking_over when representative server is in wait_locked_out state" do
       postgres_server.strand.update(label: "wait_locked_out")
-      expect { standby_nx.wait_representative_lockout }.to hop("taking_over")
+      expect { standby_nx.wait_representative_lockout }.to hop("prepare_taking_over")
     end
 
     it "naps when representative server is not in wait_locked_out state" do
@@ -1681,9 +1681,9 @@ CMD
       @standby_nx = create_standby_nexus
     end
 
-    it "hops to taking_over when representative server is in wait_in_fence state" do
+    it "hops to prepare_taking_over when representative server is in wait_in_fence state" do
       postgres_server.strand.update(label: "wait_in_fence")
-      expect { @standby_nx.wait_fencing_of_old_primary }.to hop("taking_over")
+      expect { @standby_nx.wait_fencing_of_old_primary }.to hop("prepare_taking_over")
     end
 
     it "naps when representative server is not in wait_in_fence state" do
@@ -1726,6 +1726,18 @@ CMD
     end
   end
 
+  describe "#prepare_taking_over" do
+    it "hops to taking_over" do
+      expect { nx.prepare_taking_over }.to hop("taking_over")
+    end
+  end
+
+  describe "#finalize_taking_over" do
+    it "hops to configure" do
+      expect { nx.finalize_taking_over }.to hop("configure")
+    end
+  end
+
   describe "#taking_over" do
     it "triggers promote if promote command is not sent yet" do
       expect(sshable).to receive(:d_run).with("promote_postgres", "sudo", "postgres/bin/promote", "17")
@@ -1741,7 +1753,7 @@ CMD
       expect { nx.taking_over }.to nap(0)
     end
 
-    it "updates the metadata and hops to configure if promote command is succeeded" do
+    it "updates the metadata and hops to finalize_taking_over if promote command is succeeded" do
       postgres_server
       standby = create_postgres_server(resource: postgres_resource, timeline: postgres_timeline, is_representative: false)
       standby_nx = described_class.new(standby.strand)
@@ -1749,7 +1761,7 @@ CMD
 
       expect(standby_sshable).to receive(:d_check).with("promote_postgres").and_return("Succeeded")
 
-      expect { standby_nx.taking_over }.to hop("configure")
+      expect { standby_nx.taking_over }.to hop("finalize_taking_over")
 
       postgres_server.reload
       expect(Semaphore.where(strand_id: postgres_server.id, name: "destroy").count).to eq(1)
@@ -1767,7 +1779,7 @@ CMD
       end
     end
 
-    it "resolves existing page, updates the metadata and hops to configure if promote command is succeeded" do
+    it "resolves existing page, updates the metadata and hops to finalize_taking_over if promote command is succeeded" do
       postgres_server
       standby = create_postgres_server(resource: postgres_resource, timeline: postgres_timeline, is_representative: false)
       standby_nx = described_class.new(standby.strand)
@@ -1780,7 +1792,7 @@ CMD
       ).subject
       expect(standby_sshable).to receive(:d_check).with("promote_postgres").and_return("Succeeded")
 
-      expect { standby_nx.taking_over }.to hop("configure")
+      expect { standby_nx.taking_over }.to hop("finalize_taking_over")
 
       postgres_server.reload
       expect(Semaphore.where(strand_id: postgres_server.id, name: "destroy").count).to eq(1)


### PR DESCRIPTION
## What

Adds a few small, overridable extension points on the Postgres HA path so a downstream fork can layer a custom synchronous-replication flavor without patching the base classes:

- **`PostgresResource#needs_sync_replication?`** (base: `SYNC` only) — replaces the inline `ha_type == HaType::SYNC` checks in `postgres_server` and `postgres_server_nexus`.
- **`PostgresServerNexus#prepare_taking_over` / `#finalize_taking_over`** — empty pre/post-promote hooks. The base just hops straight through (`prepare_taking_over` → `taking_over`, `finalize_taking_over` → `configure`); `wait_representative_lockout` and `wait_fencing_of_old_primary` now hop through `prepare_taking_over`.