### PR TITLE
Optimize metrics-collector

### DIFF
--- a/rhizome/common/bin/metrics-collector
+++ b/rhizome/common/bin/metrics-collector
@@ -51,14 +51,24 @@ File.open(pending_file_path, "w") do |file|
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE # Equivalent to --insecure
 
     request = Net::HTTP::Get.new(uri.request_uri)
+    request["Accept-Encoding"] = "identity" # don't compress over localhost
     request.basic_auth(endpoint["username"], endpoint["password"]) if endpoint["username"]
 
-    response = http.request(request)
-    fail "HTTP request failed with status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+    http.request(request) do |response|
+      fail "HTTP request failed with status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
-    body = response.body
-    body = body.each_line.reject { exclude_regex.match?(_1) }.join if exclude_regex
-    file.write(body)
+      if exclude_regex
+        carry = +""
+        response.read_body do |chunk|
+          carry << chunk
+          next unless (last_nl = carry.rindex("\n"))
+          carry.slice!(0, last_nl + 1).each_line { file.write(_1) unless exclude_regex.match?(_1) }
+        end
+        file.write(carry) unless carry.empty? || exclude_regex.match?(carry)
+      else
+        response.read_body { file.write(_1) }
+      end
+    end
   end
   file.flush
   file.fsync


### PR DESCRIPTION
On small instance gzip encode/decode over localhost wastes CPU,
also body can be streamed, after OOMing there can be large backlog

On instance this was using 100% CPU for a long duration & replacing script resolved situation