### PR TITLE
Stamp last_rekey_at when a rekey pass finds no NICs

### DIFF
--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -156,6 +156,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     # Leader, but no NICs in the component: nothing to rekey, no
     # re-enqueue. NIC creation signals refresh_keys when one appears.
     if nics.empty?
+      private_subnet.update(last_rekey_at: Time.now)
       hop_wait
     end
 

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -219,9 +219,11 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
         expect(ps.refresh_keys_set?).to be true
       end
 
-      it "hops to wait without re-enqueueing if there are no nics to rekey" do
+      it "stamps last_rekey_at and hops to wait without re-enqueueing if there are no nics to rekey" do
+        ps.update(last_rekey_at: Time.now - 60 * 60 * 24 - 1)
         expect { nx.refresh_keys }.to hop("wait")
         expect(ps.refresh_keys_set?).to be false
+        expect(ps.reload.last_rekey_at).to be_within(5).of(Time.now)
       end
 
       it "naps if another coordinator holds a claim" do


### PR DESCRIPTION
The empty-component bail in refresh_keys hopped back to wait without advancing last_rekey_at, so a NIC-less v2 subnet with a stale timestamp looped: wait's daily timer re-enqueued refresh_keys, refresh_keys bailed empty, and the timer fired again immediately, two label runs per second. Stamping the timestamp makes an empty pass count as complete, as v1's vacuous pass did via wait_old_state_drop.