### PR TITLE
Clear a stale temp before every safe_write_to_file

### DIFF
--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -70,7 +70,7 @@ def safe_write_to_file(filename, content = nil)
   File.open(lock_filename, File::RDWR | File::CREAT) do |lock_file|
     lock_file.flock(File::LOCK_EX)
     if block_given?
-      File.open(temp_filename, File::RDWR | File::CREAT) do |f|
+      File.open(temp_filename, "w") do |f|
         yield f
       end
     else

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe "util" do
         expect(File.read(path)).to eq("block content")
       end
     end
+
+    it "drops a stale temp so the block path never publishes an old tail" do
+      Dir.mktmpdir do |dir|
+        path = "#{dir}/test.txt"
+        File.write("#{path}.tmp", "stale-and-longer-than-the-new-content")
+        safe_write_to_file(path) do |f|
+          f.write("fresh")
+        end
+        expect(File.read(path)).to eq("fresh")
+      end
+    end
   end
 
   describe "validate_keys" do


### PR DESCRIPTION
## Summary
`safe_write_to_file`'s block form opens the temp with `RDWR|CREAT` **without truncating**, so a temp left behind by a crashed run keeps its tail under shorter new content, and the atomic rename then publishes the mixture. The string form is unaffected (`File.write` truncates); the block form is not.

Callers on the block path that write state files this way:
- `kubernetes/csi` `ubi_cni` IPAM store
- `cloud_hypervisor`
- `storage_volume`

A short write over a longer stale temp could publish a corrupt file at any of these. The fix unlinks any stale temp before writing so every write starts from empty.

## Test
Added a rhizome spec that seeds a stale `.tmp` longer than the new content and asserts only the fresh bytes are published; it fails without the fix and passes with it. `rake rhizome_spec` 100% line + branch, rubocop clean.

## Context
Surfaced while auditing this helper during the Leaseweb networking work (#5867), but the bug and its impact are entirely outside Leaseweb — hence a standalone PR so the kubernetes/storage owners can review it directly. Independent of #5867 except that both touch `rhizome/common/lib/util.rb`; **merging this first** keeps #5867's rebase trivial.