### PR TITLE
Surface command stderr in exception_to_hash

### DIFF
--- a/lib/util.rb
+++ b/lib/util.rb
@@ -71,8 +71,14 @@ module Util
     [cert, key]
   end
 
+  # Retain only the tail of very long stderr when serializing exceptions.
+  STDERR_LOG_TAIL = 2000
+
   def self.exception_to_hash(ex, backtrace: ex.backtrace[0...50], into: {})
-    into[:exception] = {message: ex.message, class: ex.class.to_s, backtrace:}
+    exception = into[:exception] = {message: ex.message, class: ex.class.to_s, backtrace:}
+    if ex.respond_to?(:stderr) && !(stderr = ex.stderr).to_s.empty?
+      exception[:stderr] = (stderr.bytesize > STDERR_LOG_TAIL) ? "...#{stderr.byteslice(-STDERR_LOG_TAIL..)}" : stderr
+    end
     # Don't log causes if we aren't logging backtraces
     if backtrace && (cause = ex.cause)
       array = into[:causes] = []

--- a/spec/lib/util_spec.rb
+++ b/spec/lib/util_spec.rb
@@ -73,4 +73,43 @@ RSpec.describe Util do
       expect { described_class.parse_key("") }.to raise_error OpenSSL::PKey::RSAError
     end
   end
+
+  describe "#exception_to_hash" do
+    it "captures stderr for exceptions that expose it" do
+      ex = Sshable::SshError.new("cmd", "out", "boom", 1, nil)
+      hash = described_class.exception_to_hash(ex, backtrace: [])
+      expect(hash[:exception][:stderr]).to eq "boom"
+    end
+
+    it "keeps only the tail of stderr longer than STDERR_LOG_TAIL" do
+      ex = Sshable::SshError.new("cmd", "", ("x" * 3000) + "TAIL", 1, nil)
+      hash = described_class.exception_to_hash(ex, backtrace: [])
+      expect(hash[:exception][:stderr].bytesize).to eq 2003
+      expect(hash[:exception][:stderr]).to start_with "..."
+      expect(hash[:exception][:stderr]).to end_with "TAIL"
+    end
+
+    it "caps by bytes, not characters, for multibyte stderr" do
+      ex = Sshable::SshError.new("cmd", "", "é" * 1500, 1, nil)
+      hash = described_class.exception_to_hash(ex, backtrace: [])
+      expect(hash[:exception][:stderr].bytesize).to eq 2003
+    end
+
+    it "captures non-UTF-8 stderr without raising an encoding error" do
+      ex = Sshable::SshError.new("cmd", "", "\xff\xfe".b * 1600, 1, nil)
+      hash = described_class.exception_to_hash(ex, backtrace: [])
+      expect(hash[:exception][:stderr].bytesize).to eq 2003
+    end
+
+    it "omits stderr when it is empty" do
+      ex = Sshable::SshError.new("cmd", "", "", 1, nil)
+      hash = described_class.exception_to_hash(ex, backtrace: [])
+      expect(hash[:exception]).not_to have_key(:stderr)
+    end
+
+    it "omits stderr for exceptions without a stderr reader" do
+      hash = described_class.exception_to_hash(RuntimeError.new("boom"), backtrace: [])
+      expect(hash[:exception]).not_to have_key(:stderr)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
`Util.exception_to_hash` feeds Clog when serializing rescued exceptions but dropped the stderr carried by `SshError`. On the default `log: true` path that stderr still reaches Clog via the adjacent ssh-cmd-execution event, but a synchronous `log: false` command that exits non-zero lost its stderr entirely — so its failures were undiagnosable from logs. Capture it, tail-truncated to `STDERR_LOG_TAIL` (2000) chars, whenever the exception exposes a non-empty `#stderr`.

## Risk
A few sites pass `log: false` deliberately to keep secrets out of logs (kubeadm token, kek, cluster-init creds). Their stderr is now logged on failure, but this stays low risk: at those sites the secret travels over stdin or is the command's stdout, whereas `exception_to_hash` records only stderr plus the command already held in `SshError#message` — never stdin or stdout.

## Non-UTF-8 exposure — depends on #5928
`Clog.write` serializes via `JSON.generate`, which raises on strings that are not valid UTF-8. Capturing raw `ex.stderr` here extends that pre-existing latent bug (already present on the `log: true` path in `model/sshable.rb`) to the `log: false` failure path. Real command stderr is text, so it is rare, but a command emitting high bytes to stderr that then fails would crash its own exception log line. #5928 fixes this at the single `Clog.write` chokepoint (covering both paths). **Land #5928 with or before this PR.**

## Test / context
`coverage_pspec` clean (walk-verified); rubocop clean. Surfaced during the Leaseweb work (#5867) but repo-wide and independent, so split out here.