### PR TITLE
Stamp the coordinator's last_rekey_at at rekey pass end

### DIFF
--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -276,7 +276,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     abort_rekey_if_no_nics(nics)
     check_nic_phases(nics, %w[outbound old_drop], "phase monotonicity at phase_old_drop")
     if nics.all? { |nic| nic.rekey_phase == "old_drop" }
-      PrivateSubnet.where(id: nics.map(&:private_subnet_id).uniq).update(last_rekey_at: Time.now)
+      PrivateSubnet.where(id: (nics.map(&:private_subnet_id) << private_subnet.id).uniq).update(last_rekey_at: Sequel::CURRENT_TIMESTAMP)
       private_subnet.update(state: "waiting")
       # Must stay one atomic UPDATE: clearing the claim and resetting the
       # phase together is what releases the NICs consistently.

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -422,6 +422,21 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
         end
       end
 
+      it "stamps the coordinator's last_rekey_at when it owns no nics" do
+        psa = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-psa", location_id: Location::HETZNER_FSN1_ID).subject.update(rekey_protocol: 2)
+        psb = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "test-psb", location_id: Location::HETZNER_FSN1_ID).subject.update(rekey_protocol: 2)
+        leader, follower = [psa, psb].sort_by(&:id)
+        leader.connect_subnet(follower)
+        nic = Prog::Vnet::NicNexus.assemble(follower.id, name: "b").subject.update(state: "active")
+        leader.update(last_rekey_at: Time.now - 60 * 60 * 24 - 1)
+        nx = described_class.new(leader.strand)
+        expect { nx.refresh_keys }.to hop("wait_inbound_setup")
+        expect(nic.reload.rekey_coordinator_id).to eq leader.id
+        nic.update(rekey_phase: "old_drop")
+        expect { nx.wait_old_state_drop }.to hop("wait")
+        expect(leader.reload.last_rekey_at).to be_within(5).of(Time.now)
+      end
+
       it "consumes nic_phase_done and naps while nics are still outbound" do
         nic.update(rekey_phase: "outbound")
         nx.incr_nic_phase_done


### PR DESCRIPTION
Pass completion stamped only the subnets owning claimed NICs, but wait's daily timer fires on the leader's own timestamp. A leader owning no active NICs in a mesh that has them ran a full real pass, stamped only the members, saw its own timestamp still stale, and immediately started the next pass: continuous tunnel rotation on the members' VMs. Include the coordinator in the stamped set.