### PR TITLE
Skip unreadable servers when postgres is down in restart gate

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -201,7 +201,7 @@ class PostgresServer < Sequel::Model
   def restart_sensitive_running_values
     rows = begin
       run_query(DB[:pg_settings].where(name: RESTART_SENSITIVE_PARAMS).select(:name, :setting)).split("\n")
-    rescue Sshable::SshTimeout, *Sshable::SSH_CONNECTION_ERRORS => ex
+    rescue Sshable::SshError, *Sshable::SSH_CONNECTION_ERRORS => ex
       Clog.emit("Failed to fetch restart sensitive running values", Util.exception_to_hash(ex, into: {postgres_server_id: id}))
       return nil
     end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -291,8 +291,13 @@ RSpec.describe PostgresServer do
         expect(postgres_server.restart_sensitive_running_values).to be_nil
       end
 
-      it "returns nil when the query fails" do
+      it "returns nil when the query times out" do
         expect(postgres_server.vm.sshable).to receive(:_cmd).with(psql_command, stdin: settings_query).and_raise(Sshable::SshTimeout.new("boom", "", "", nil, nil))
+        expect(postgres_server.restart_sensitive_running_values).to be_nil
+      end
+
+      it "returns nil when postgres is not accepting connections" do
+        expect(postgres_server.vm.sshable).to receive(:_cmd).with(psql_command, stdin: settings_query).and_raise(Sshable::SshError.new(psql_command, "", "connection refused", 2, nil))
         expect(postgres_server.restart_sensitive_running_values).to be_nil
       end
     end


### PR DESCRIPTION
restart_sensitive_running_values is meant to return nil when a replication neighbour's running parameter values can't be read, so restart_sensitive_params_safe? skips that server. Its rescue only caught SSH transport failures (SshTimeout and SSH_CONNECTION_ERRORS), not the case where SSH succeeds but postgres itself is not accepting connections: psql exits non-zero and cmd raises a plain SshError.

During an upgrade the candidate is not yet serving, so querying its running values raised SshError out of the wait label, terminating the strand and blocking the restart indefinitely. Broaden the rescue to Sshable::SshError (which subsumes SshTimeout) so a down neighbour is skipped by the gate rather than crashing the strand.