### PR TITLE
Scrub non-UTF-8 strings before Clog JSON serialization

### DIFF
--- a/lib/clog.rb
+++ b/lib/clog.rb
@@ -45,7 +45,7 @@ class Clog
   end
 
   private_class_method def self.write(out)
-    raw = (JSON.generate(out) << "\n").freeze
+    raw = generate_line(out) << "\n"
 
     return if Config.test?
 
@@ -54,6 +54,28 @@ class Clog
     end
 
     nil
+  end
+
+  # Command stderr/stdout can carry bytes that are not valid UTF-8, which
+  # JSON.generate rejects. Output is text in the normal case, so scrub only on
+  # the rare failure rather than walking every payload on every emit.
+  private_class_method def self.generate_line(out)
+    JSON.generate(out)
+  rescue JSON::GeneratorError
+    JSON.generate(scrub(out))
+  end
+
+  private_class_method def self.scrub(value)
+    case value
+    when String
+      (value.encoding == Encoding::UTF_8 && value.valid_encoding?) ? value : value.b.force_encoding(Encoding::UTF_8).scrub
+    when Hash
+      value.transform_values { scrub(it) }
+    when Array
+      value.map { scrub(it) }
+    else
+      value
+    end
   end
 
   # Only works for models using the ResourceMethods plugin.

--- a/spec/lib/clog_spec.rb
+++ b/spec/lib/clog_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe Clog do
     described_class.emit "hello"
   end
 
+  it "scrubs non-UTF-8 string values anywhere in the payload instead of raising" do
+    allow(Config).to receive(:test?).and_return(false)
+    captured = nil
+    expect($stdout).to receive(:write) { |line| captured = line }
+    described_class.emit("boom", {stderr: "bad\xff", list: ["ok", "\xfe".b]})
+    expect(captured).to include('"stderr":"bad').and include('"list":["ok",')
+  end
+
   it "adds the thread name to the structured data" do
     Thread.new do
       Thread.current.name = "test thread name"


### PR DESCRIPTION
## Summary
`Clog.write` serializes every log line with `JSON.generate` (lib/clog.rb), which raises `JSON::GeneratorError` on strings that are not valid UTF-8. Command stderr/stdout is accumulated as raw bytes (`model/sshable.rb`), so a command that emits high/non-UTF-8 bytes produces a UTF-8-tagged-but-invalid string that crashes the log line instead of being logged.

Two paths hit this identically:
- `model/sshable.rb` `log: true` -- `Clog.emit("ssh cmd execution")` on every logged command.
- `Util.exception_to_hash` now also captures `ex.stderr` (#5925).

Real command output is text, so it has gone unnoticed. Fix at the **single `Clog.write` chokepoint** so all callers are covered uniformly (scrubbing only in `exception_to_hash` would be inconsistent with the sshable path). Scrub runs only on the rare `JSON::GeneratorError`, keeping the common valid-UTF-8 path free of a per-emit walk.

## Test
Added a `clog_spec` case that emits a payload with an invalid UTF-8 value nested in a hash and an array, and asserts the line is written (scrubbed) rather than raising. It fails with `JSON::GeneratorError` without the fix. Full `coverage_pspec` 100% line + branch, rubocop clean.

## Relationship to other PRs
Pre-existing bug, independent. It retroactively protects the existing sshable `log: true` path and should ideally land **with or before #5925**, which widens exposure by capturing stderr on the failure path.