### PR TITLE
Update postgres images to 20260721.1.0

### DIFF
--- a/migrate/20260721_update_postgres_images.rb
+++ b/migrate/20260721_update_postgres_images.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  ami_ids = []
+  gce_images = []
+
+  up do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: old_ami)
+        .update(aws_ami_id: new_ami)
+    end
+
+    gce_images.each do |arch, new_name, _old_name|
+      from(:pg_gce_image).where(arch:).update(gce_image_name: new_name)
+    end
+  end
+
+  down do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: new_ami)
+        .update(aws_ami_id: old_ami)
+    end
+
+    gce_images.each do |arch, _new_name, old_name|
+      raise Sequel::Error, "irreversible: previous GCE image name unknown" if old_name.empty?
+      from(:pg_gce_image).where(arch:).update(gce_image_name: old_name)
+    end
+  end
+end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -184,7 +184,7 @@ class Prog::DownloadBootImage < Prog::Base
     },
     "postgres-ubuntu-2204" => {
       "x64" => {
-        "20260709.1.0" => "09f4c8dad8faaa312512b091a979cce223aa2ab667dcb6076b5f32c515e69d2e",
+        "20260721.1.0" => "3cb2e056a3f30169fd14c23e4109c0bbf1efee0a2011e93064642d81896cc4a1",
       },
     },
     "postgres16-lantern-ubuntu-2204" => {


### PR DESCRIPTION
## Summary
- Updates boot image version and SHA256 hashes in `prog/download_boot_image.rb`
- Adds a single migration updating AWS AMI IDs in `pg_aws_ami` and GCE image names in `pg_gce_image`

## Image Version
`20260721.1.0`

## Changes
- x64 SHA256: `3cb2e056a3f30169fd14c23e4109c0bbf1efee0a2011e93064642d81896cc4a1`
- arm64 SHA256: ``
- GCE x64: ``
- GCE arm64: ``

🤖 Generated by [postgres-vm-images](https://github.com/ubicloud/postgres-vm-images) workflow