### PR TITLE
Separate AWS spill vcpu capacity by architecture

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -135,7 +135,8 @@ module Config
   override :github_runner_aws_spot_instance_enabled, false, bool
   optional :github_runner_aws_spot_instance_max_price_per_vcpu, float
   override :github_runner_aws_spill_threshold_seconds, 30, int
-  override :github_runner_aws_spill_vcpu_capacity, 100, int
+  override :github_runner_aws_spill_vcpu_capacity_x64, 100, int
+  override :github_runner_aws_spill_vcpu_capacity_arm64, 100, int
 
   # GitHub Cache
   optional :github_cache_blob_storage_endpoint, string

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -20,6 +20,11 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     Config.github_ubuntu_2604_arm64_aws_ami_version,
   ].freeze
 
+  SPILL_VCPU_CAPACITIES = {
+    "x64" => Config.github_runner_aws_spill_vcpu_capacity_x64,
+    "arm64" => Config.github_runner_aws_spill_vcpu_capacity_arm64,
+  }.freeze
+
   def self.assemble(installation, repository_name:, label:, actual_label: nil, default_branch: nil)
     unless Github.runner_labels[label]
       fail "Invalid GitHub runner label: #{label}"
@@ -364,8 +369,8 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
         Time.now - github_runner.created_at > Config.github_runner_aws_spill_threshold_seconds
 
       if should_spill_over
-        spilled_vcpus = Vm.where(boot_image: AWS_AMI_VERSIONS).sum(:vcpus) || 0
-        if spilled_vcpus >= Config.github_runner_aws_spill_vcpu_capacity
+        spilled_vcpus = Vm.where(arch:, boot_image: AWS_AMI_VERSIONS).sum(:vcpus) || 0
+        if spilled_vcpus >= SPILL_VCPU_CAPACITIES.fetch(arch)
           Clog.emit("not allowed because of high utilization and spill capacity exceeded", {exceeded_spill_capacity: {family_utilization:, spilled_vcpus:, label: github_runner.label, arch:, repository_name: github_runner.repository_name}})
           nap rand(5..15)
         end

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -423,8 +423,27 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
         expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
         project.set_ff_spill_to_alien_runners(true)
         runner.update(created_at: now - 40)
-        expect(Config).to receive(:github_runner_aws_spill_vcpu_capacity).and_return(10)
-        create_vm(vcpus: 16, boot_image: Config.github_ubuntu_2204_x64_aws_ami_version)
+        create_vm(vcpus: Config.github_runner_aws_spill_vcpu_capacity_x64, boot_image: Config.github_ubuntu_2204_x64_aws_ami_version)
+
+        expect { nx.wait_concurrency_limit }.to nap
+        expect(runner.spill_over_set?).to be(false)
+      end
+
+      it "allocates if utilization is high and only the other arch's spill vcpus limit is exceeded" do
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
+        project.set_ff_spill_to_alien_runners(true)
+        runner.update(created_at: now - 40)
+        create_vm(vcpus: Config.github_runner_aws_spill_vcpu_capacity_arm64, arch: "arm64", boot_image: Config.github_ubuntu_2204_arm64_aws_ami_version)
+
+        expect { nx.wait_concurrency_limit }.to hop("allocate_vm")
+        expect(runner.spill_over_set?).to be(true)
+      end
+
+      it "waits if arm64 utilization is high, spill over enabled, and waited enough but arm64 spill vcpus limit exceeded" do
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpuArm", 0).and_return(false)
+        project.set_ff_spill_to_alien_runners(true)
+        runner.update(label: "ubicloud-standard-4-arm", created_at: now - 40)
+        create_vm(vcpus: Config.github_runner_aws_spill_vcpu_capacity_arm64, arch: "arm64", boot_image: Config.github_ubuntu_2204_arm64_aws_ami_version)
 
         expect { nx.wait_concurrency_limit }.to nap
         expect(runner.spill_over_set?).to be(false)


### PR DESCRIPTION
Runners spilled over to AWS shared a single vCPU budget, and the spilled vCPU count did not distinguish architectures. Since we have a lot more x64 runners than arm64 ones, spilled x64 runners consumed the entire shared budget and starved arm64 runners of spill capacity. Replace the single GITHUB_RUNNER_AWS_SPILL_VCPU_CAPACITY setting with per-arch _X64 and _ARM64 variants and count only spilled VMs of the runner's own architecture against its limit.

The old environment variable is silently ignored after this deploys; operators must set the new per-arch variables instead.