### PR TITLE
Strand wakeup nudge

### DIFF
--- a/lib/sem_snap.rb
+++ b/lib/sem_snap.rb
@@ -45,7 +45,8 @@ class SemSnap
   end
 
   def incr(name)
-    if (semaphore = Semaphore.incr(@strand_id, name))
+    # The strand is mid-run; its own signal should not defeat its next nap.
+    if (semaphore = Semaphore.incr(@strand_id, name, wake: false))
       add_semaphore_instance_to_snapshot(Semaphore.with_pk(semaphore))
     end
   end

--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -5,7 +5,7 @@ require_relative "../model"
 class Semaphore < Sequel::Model
   plugin ResourceMethods
 
-  def self.incr(id, name)
+  def self.incr(id, name, wake: true)
     case name
     when Symbol
       name = name.to_s
@@ -15,13 +15,18 @@ class Semaphore < Sequel::Model
       raise "invalid name given to Semaphore.incr: #{name.inspect}"
     end
 
-    with(:updated_strand,
-      Strand
-        .where(id:)
-        .returning(:id)
-        .with_sql(:update_sql, schedule: Strand::SCHEDULE_NO_LATER_THAN_NOW))
-      .insert([:id, :strand_id, :name],
-        DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
+    if wake
+      with(:updated_strand,
+        Strand
+          .where(id:)
+          .returning(:id)
+          .with_sql(:update_sql, schedule: Strand::SCHEDULE_NO_LATER_THAN_NOW))
+        .insert([:id, :strand_id, :name],
+          DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
+    else
+      insert([:id, :strand_id, :name],
+        Strand.where(id:).select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
+    end
   end
 
   def self.set_at(id)

--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -15,18 +15,17 @@ class Semaphore < Sequel::Model
       raise "invalid name given to Semaphore.incr: #{name.inspect}"
     end
 
+    values_ds = Strand.where(id:)
+    insert_ds = self
     if wake
-      with(:updated_strand,
-        Strand
-          .where(id:)
+      insert_ds = with(:updated_strand,
+        values_ds
           .returning(:id)
           .with_sql(:update_sql, schedule: Strand::SCHEDULE_NO_LATER_THAN_NOW))
-        .insert([:id, :strand_id, :name],
-          DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
-    else
-      insert([:id, :strand_id, :name],
-        Strand.where(id:).select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
+      values_ds = DB[:updated_strand]
     end
+    insert_ds.insert([:id, :strand_id, :name],
+      values_ds.select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
   end
 
   def self.set_at(id)

--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -19,7 +19,7 @@ class Semaphore < Sequel::Model
       Strand
         .where(id:)
         .returning(:id)
-        .with_sql(:update_sql, schedule: Sequel::CURRENT_TIMESTAMP))
+        .with_sql(:update_sql, schedule: Strand::SCHEDULE_NO_LATER_THAN_NOW))
       .insert([:id, :strand_id, :name],
         DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
   end

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -94,6 +94,11 @@ class Strand < Sequel::Model
     Sequel.function(:least, Sequel[2]**Sequel.function(:least, :try, 20), 600) * Sequel.function(:random)
   end
 
+  # Pull the schedule to no later than now() without demoting an overdue
+  # strand's queue position. The microsecond step makes every wake write
+  # change the value, so the nap handler's equality check sees mid-run signals.
+  SCHEDULE_NO_LATER_THAN_NOW = Sequel.function(:least, Sequel[:schedule], Sequel::CURRENT_TIMESTAMP) - Sequel.cast("1 microsecond", :interval)
+
   TAKE_LEASE_PS = DB[:strand]
     .returning
     .where(
@@ -159,8 +164,7 @@ SQL
             Strand
               .where(id: parent_id)
               .exclude(unfinished_siblings_ds.exists)
-              .where(Sequel[:schedule] > Sequel::CURRENT_TIMESTAMP)
-              .update(schedule: Sequel::CURRENT_TIMESTAMP)
+              .update(schedule: SCHEDULE_NO_LATER_THAN_NOW)
           end
         end
       end

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -106,6 +106,11 @@ class Prog::Test < Prog::Base
     nap(123)
   end
 
+  label def snap_signal_napper
+    incr_test_semaphore
+    nap(123)
+  end
+
   label def popper
     pop({msg: "popped"})
   end

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -101,6 +101,11 @@ class Prog::Test < Prog::Base
     nap(123)
   end
 
+  label def late_signal_napper
+    Semaphore.incr(strand.id, "late_signal")
+    nap(123)
+  end
+
   label def popper
     pop({msg: "popped"})
   end

--- a/spec/model/semaphore_spec.rb
+++ b/spec/model/semaphore_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe Semaphore do
     expect { described_class.incr(st.id, nil) }.to raise_error(RuntimeError)
   end
 
+  it ".incr wakes the strand without demoting an overdue schedule" do
+    st.update(schedule: overdue = Time.now - 100)
+    described_class.incr(st.id, "foo")
+    expect(st.reload.schedule).to be_within(1).of(overdue)
+  end
+
+  it ".incr pulls a future schedule to now" do
+    st.update(schedule: Time.now + 1000)
+    described_class.incr(st.id, "foo")
+    expect(st.reload.schedule).to be_within(2).of(Time.now)
+  end
+
   it ".set_at returns the Time the given semaphore id was set at" do
     time = described_class.set_at(described_class.generate_uuid)
     expect(time).to be_within(1).of(Time.now)

--- a/spec/model/semaphore_spec.rb
+++ b/spec/model/semaphore_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe Semaphore do
     expect(st.reload.schedule).to be_within(1).of(overdue)
   end
 
+  it ".incr with wake: false does not change the schedule" do
+    st.update(schedule: future = Time.now + 1000)
+    expect(described_class.incr(st.id, "foo", wake: false)).not_to be_nil
+    expect(st.reload.schedule).to be_within(1).of(future)
+  end
+
   it ".incr pulls a future schedule to now" do
     st.update(schedule: Time.now + 1000)
     described_class.incr(st.id, "foo")

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Strand do
 
     st.take_lease_and_reload do
       # Simulate concurrent Signal between TAKE_LEASE_PS and nap handler.
-      # LEAST(schedule, NOW()) = NOW() since TAKE_LEASE_PS set schedule > NOW().
+      # The wake write always changes the schedule value the nap handler compares.
       Semaphore.incr(st.id, "test")
 
       ret = st.unsynchronized_run
@@ -108,6 +108,16 @@ RSpec.describe Strand do
       # signal's value (~NOW), NOT set to 123 seconds in the future.
       expect(st.schedule).to be < Time.now + 60
     end
+  end
+
+  it "stays runnable when a semaphore arrives mid-run on an overdue strand" do
+    st.update(label: "late_signal_napper", schedule: Time.now - 100)
+
+    ret = st.unsynchronized_run
+    expect(ret).to be_a(Prog::Base::Nap)
+
+    expect(st.reload.schedule).to be <= Time.now
+    expect(Semaphore.where(strand_id: st.id, name: "late_signal")).not_to be_empty
   end
 
   it "logs end of strand if it took long" do

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -110,6 +110,16 @@ RSpec.describe Strand do
     end
   end
 
+  it "keeps the nap when the prog increments its own semaphore through the snap" do
+    st.update(label: "snap_signal_napper", schedule: Time.now - 100)
+
+    ret = st.unsynchronized_run
+    expect(ret).to be_a(Prog::Base::Nap)
+
+    expect(st.reload.schedule).to be > Time.now + 100
+    expect(Semaphore.where(strand_id: st.id, name: "test_semaphore")).not_to be_empty
+  end
+
   it "stays runnable when a semaphore arrives mid-run on an overdue strand" do
     st.update(label: "late_signal_napper", schedule: Time.now - 100)
 


### PR DESCRIPTION
## Use LEAST minus a microsecond for wake-up schedule updates
Re-land https://github.com/ubicloud/ubicloud/commit/b45f37c7dc890331f7903c3e6f63e0fcc94d57d9's anti-starvation LEAST, reverted in https://github.com/ubicloud/ubicloud/commit/1aea99a79025bf606be32f903c9c088e6b5e3803
because its no-op write on an overdue strand hid mid-run wake-ups from
the nap handler's schedule-equality check. Subtracting one microsecond
keeps the queue position while every wake write, including the
last-child-exit one, still changes the compared value.

## Insert prog-initiated semaphores without waking the running strand
A prog incrementing a semaphore on its own strand is already running,
and the row is visible to the next run's snapshot, so a wake would only
defeat the nap the prog chooses next. External increments still wake.
Prog instances are only constructed by unsynchronized_run with the
run's snap, so wake: false cannot suppress a wake for a strand that is
not currently running.