### PR TITLE
Add dark mode to the admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1244,6 +1244,15 @@ class CloverAdmin < Roda
       view("authentication_audit_log")
     end
 
+    r.post "theme", %w[light dark system] do |theme|
+      if theme == "system"
+        session.delete("theme")
+      else
+        session["theme"] = theme
+      end
+      r.redirect env["HTTP_REFERER"] || "/"
+    end
+
     r.on "rollouts" do
       strand_ds = Strand.where(prog: ROLLOUT_PROGS)
 

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -570,7 +570,7 @@ class CloverAdmin < Roda
           add_blank: true,
           required: true,
           options: Location
-            .where(project_id: nil, provider: %w[hetzner leaseweb])
+            .where(project_id: nil, provider: %w[hetzner leaseweb].freeze)
             .or(id: Location::GITHUB_RUNNERS_ID)
             .select_order_map([:display_name, :id])
             .each { it[1] = UBID.to_ubid(it[1]) },
@@ -844,7 +844,7 @@ class CloverAdmin < Roda
           [:invoice_number, :project, :status, :subtotal, :cost]
         end
       end
-      column_options status: {type: "select", options: %w[unpaid paid fraud waiting_transfer below_minimum_threshold], add_blank: true},
+      column_options status: {type: "select", options: %w[unpaid paid fraud waiting_transfer below_minimum_threshold].freeze, add_blank: true},
         project: ubid_input.call("Project")
 
       column_search_filter do |ds, column, value|
@@ -884,8 +884,8 @@ class CloverAdmin < Roda
         [:location, :parent, :project] unless type == :association
       end
       columns [:name, :project, :location, :flavor, :target_vm_size, :target_storage_size_gib, :ha_type, :target_version, :parent, :created_at]
-      column_options flavor: {type: "select", options: %w[standard paradedb lantern], add_blank: true},
-        ha_type: {type: "select", options: %w[none async sync], add_blank: true},
+      column_options flavor: {type: "select", options: %w[standard paradedb lantern].freeze, add_blank: true},
+        ha_type: {type: "select", options: %w[none async sync].freeze, add_blank: true},
         target_version: {type: "select", options: Option::POSTGRES_VERSION_OPTIONS[PostgresResource::Flavor::STANDARD], add_blank: true},
         target_storage_size_gib: {type: "number"},
         project: ubid_input.call("Project"),
@@ -914,8 +914,8 @@ class CloverAdmin < Roda
         cs
       end
       column_options resource: ubid_input.call("Resource"),
-        timeline_access: {type: "select", options: %w[push fetch], add_blank: true},
-        synchronization_status: {type: "select", options: %w[ready catching_up], add_blank: true},
+        timeline_access: {type: "select", options: %w[push fetch].freeze, add_blank: true},
+        synchronization_status: {type: "select", options: %w[ready catching_up].freeze, add_blank: true},
         version: {type: "select", options: Option::POSTGRES_VERSION_OPTIONS[PostgresResource::Flavor::STANDARD], add_blank: true},
         created_at: {type: "text"}
 
@@ -932,7 +932,7 @@ class CloverAdmin < Roda
     model Project do
       order Sequel.desc(:created_at)
       columns [:name, :reputation, :billing_info_id, :credit, :created_at]
-      column_options reputation: {type: "select", options: %w[new verified limited], add_blank: true},
+      column_options reputation: {type: "select", options: %w[new verified limited].freeze, add_blank: true},
         created_at: {type: "text"}
     end
 
@@ -1244,7 +1244,7 @@ class CloverAdmin < Roda
       view("authentication_audit_log")
     end
 
-    r.post "theme", %w[light dark system] do |theme|
+    r.post "theme", %w[light dark system].freeze do |theme|
       if theme == "system"
         session.delete("theme")
       else
@@ -1263,7 +1263,7 @@ class CloverAdmin < Roda
 
       r.post "start", ROLLOUT_PROGS do |prog|
         st = if prog == "RolloutSemaphore"
-          class_semaphore, increment = typecast_params.nonempty_str!(%w[class_semaphore increment])
+          class_semaphore, increment = typecast_params.nonempty_str!(%w[class_semaphore increment].freeze)
           gap = typecast_params.pos_int!("gap")
           wait = typecast_params.nonempty_str("wait_label")
           location_id = typecast_params.ubid_uuid("location_id")
@@ -1292,7 +1292,7 @@ class CloverAdmin < Roda
 
           Prog.const_get(prog).assemble(semaphore:, ids:, gap:, increment:, wait:)
         elsif prog == "RolloutBootImage"
-          image_name, version, arch = typecast_params.nonempty_str!(%w[image_name version arch])
+          image_name, version, arch = typecast_params.nonempty_str!(%w[image_name version arch].freeze)
           concurrency = typecast_params.pos_int!("concurrency")
           exclude_minio_hosts = typecast_params.bool("exclude_minio_hosts")
           pause_stages = typecast_params.bool("pause_stages")
@@ -1324,7 +1324,7 @@ class CloverAdmin < Roda
       end
 
       strand_semaphore_action(strand_ds, ROLLOUT_PROGS,
-        additional_semaphores: {"RolloutRhizome" => %w[github_runners_work], "RolloutBootImage" => %w[rollback]})
+        additional_semaphores: {"RolloutRhizome" => %w[github_runners_work].freeze, "RolloutBootImage" => %w[rollback].freeze})
     end
 
     r.on "remove-boot-images" do
@@ -1343,7 +1343,7 @@ class CloverAdmin < Roda
       end
 
       r.is "confirm" do
-        @name, @version = typecast_params.nonempty_str!(%w[name version])
+        @name, @version = typecast_params.nonempty_str!(%w[name version].freeze)
 
         images_ds = BootImage.where(name: @name, version: @version)
         # Only images with no active storage volumes (i.e. no active VM) can be removed.
@@ -1475,9 +1475,9 @@ class CloverAdmin < Roda
 
     r.get "vm-host-usage" do
       @locations = Location.where(id: VmHost.select(:location_id)).select_order_map([:name, :id]).map { |name, id| [name, UBID.to_ubid(id)] }
-      @archs = %w[x64 arm64]
+      @archs = %w[x64 arm64].freeze
       @core_counts = VmHost.exclude(total_cores: nil).distinct.select_order_map(:total_cores)
-      @states = %w[unprepared accepting draining]
+      @states = %w[unprepared accepting draining].freeze
 
       @location_id = typecast_params.ubid("location_id")
       @arch = typecast_params.nonempty_str("arch")

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -1,3 +1,68 @@
+:root {
+  color-scheme: light dark;
+  --bg: #fff;
+  --fg: #000;
+  --muted: #666;
+  --link: #b04209;
+  --accent: #ea580c;
+  --border: #000;
+  --border-soft: #ddd;
+  --surface: #fafafa;
+  --shade: #eee;
+  --alert-success-bg: #dff0d8;
+  --alert-success-border: #d6e9c6;
+  --alert-danger-bg: #f2dede;
+  --alert-danger-border: #ebccd1;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #16181a;
+    --fg: #dfe2e4;
+    --muted: #9aa1a7;
+    --link: #f08b4b;
+    --border: #6b7177;
+    --border-soft: #34393e;
+    --surface: #1e2124;
+    --shade: #26292c;
+    --alert-success-bg: #1c3a23;
+    --alert-success-border: #2c5836;
+    --alert-danger-bg: #43201f;
+    --alert-danger-border: #663130;
+  }
+}
+/* explicit override set by the footer theme switcher (session-backed) */
+html.theme-light {
+  color-scheme: light;
+  --bg: #fff;
+  --fg: #000;
+  --muted: #666;
+  --link: #b04209;
+  --accent: #ea580c;
+  --border: #000;
+  --border-soft: #ddd;
+  --surface: #fafafa;
+  --shade: #eee;
+  --alert-success-bg: #dff0d8;
+  --alert-success-border: #d6e9c6;
+  --alert-danger-bg: #f2dede;
+  --alert-danger-border: #ebccd1;
+}
+html.theme-dark {
+  color-scheme: dark;
+  --bg: #16181a;
+  --fg: #dfe2e4;
+  --muted: #9aa1a7;
+  --link: #f08b4b;
+  --border: #6b7177;
+  --border-soft: #34393e;
+  --surface: #1e2124;
+  --shade: #26292c;
+  --alert-success-bg: #1c3a23;
+  --alert-success-border: #2c5836;
+  --alert-danger-bg: #43201f;
+  --alert-danger-border: #663130;
+}
+
 html, body {
   height: 100%;
   margin: 0;
@@ -8,13 +73,15 @@ body {
   font-size: 1em;
   font-family: sans-serif;
   padding-bottom: 40px;
+  background-color: var(--bg);
+  color: var(--fg);
 }
 .container {
   max-width: 1200px;
   margin: auto;
 }
 
-a, .navbar-brand { color: #b04209; }
+a, .navbar-brand { color: var(--link); }
 
 a {
   text-decoration: none;
@@ -27,8 +94,8 @@ input, select, textarea {
 }
 input[type=submit] {
   color: white;
-  border: 2px solid black;
-  background-color: #ea580c;
+  border: 2px solid var(--border);
+  background-color: var(--accent);
   font-weight: bold;
 
   #ubid_form & { font-size: 0.9em; }
@@ -42,17 +109,17 @@ input[type=submit] {
   margin-top: 8px;
 }
 .rollout-card {
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-soft);
   border-radius: 6px;
   padding: 16px 20px 20px;
-  background-color: #fafafa;
+  background-color: var(--surface);
 }
 .rollout-card h3 {
   margin: 0;
 }
 .rollout-card .rollout-desc {
   margin: 4px 0 0;
-  color: #666;
+  color: var(--muted);
   font-size: 0.9em;
 }
 .rollout-form > div {
@@ -111,8 +178,8 @@ nav div.container, .associations {
 footer {
   flex-shrink: 0;
   margin-top: 10px;
-  background-color: white;
-  border-top: 1px solid #ddd;
+  background-color: var(--bg);
+  border-top: 1px solid var(--border-soft);
   padding: 5px 0;
   font-size: 85%;
   & div {
@@ -132,12 +199,12 @@ footer {
   margin-bottom: 10px;
 }
 .alert-success {
-  background-color: #dff0d8;
-  border-color: #d6e9c6;
+  background-color: var(--alert-success-bg);
+  border-color: var(--alert-success-border);
 }
 .alert-danger {
-  background-color: #f2dede;
-  border-color: #ebccd1;
+  background-color: var(--alert-danger-bg);
+  border-color: var(--alert-danger-border);
 }
 
 h1 { font-size: 1.5em; }
@@ -152,7 +219,7 @@ label:after { content: ": "; }
 
 table, thead, tbody, tr, th, td {
   border-collapse: collapse;
-  border: 1px solid black;
+  border: 1px solid var(--border);
   padding: 2px;
 }
 table { margin-top: 1em; }
@@ -162,9 +229,9 @@ th {
 }
 tbody tr {
   &:nth-child(6n+1), &:nth-child(6n+2), &:nth-child(6n+3) {
-    background-color: #eee;
+    background-color: var(--shade);
   }
-  td[rowspan] { background-color: white; }
+  td[rowspan] { background-color: var(--bg); }
 }
 caption, .collapsible-table summary {
   font-size: 1.3em;
@@ -181,7 +248,7 @@ caption, .collapsible-table summary {
 code {
   display: inline-block;
   padding: 5px;
-  background-color: #eee;
+  background-color: var(--shade);
 }
 
 #associations-header {
@@ -195,7 +262,7 @@ code {
   gap: 10px;
 }
 .association {
-  border: 1px solid black;
+  border: 1px solid var(--border);
   padding: 5px;
 
   & h3 {
@@ -239,13 +306,13 @@ code {
   gap: 10px;
   align-items: center;
 
-  & > :not(:first-child) { border-left: 1px solid black; padding-left: 10px; }
+  & > :not(:first-child) { border-left: 1px solid var(--border); padding-left: 10px; }
 
   input[type=submit] {
     background: none;
     border: none;
     padding: 0;
-    color: #b04209;
+    color: var(--link);
     cursor: pointer;
     font-size: inherit;
     font-family: inherit;
@@ -278,7 +345,7 @@ code {
     padding: 10px;
   }
 }
-.nav-tabs > :first-child { border-right: 1px solid black; }
+.nav-tabs > :first-child { border-right: 1px solid var(--border); }
 
 #autoforme_content form div {
   margin: 10px;
@@ -313,6 +380,9 @@ code {
 
 .svg-chart {
   font: 11px monospace;
+
+  & line { stroke: var(--shade); }
+  & text { fill: var(--muted); }
 }
 
 .chart-grid {
@@ -340,4 +410,27 @@ code {
   flex-wrap: wrap;
   gap: 1em;
   align-items: flex-end;
+}
+
+#theme-switcher {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+
+  form { display: inline; }
+  input[type=submit] {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--link);
+    cursor: pointer;
+    font-size: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    &:hover { text-decoration: underline; }
+  }
+}
+
+#theme-switcher form.current input[type=submit] {
+  font-weight: bold;
 }

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -1,37 +1,13 @@
 :root {
+  --theme: light;
   color-scheme: light dark;
-  --bg: #fff;
-  --fg: #000;
-  --muted: #666;
-  --link: #b04209;
-  --accent: #ea580c;
-  --border: #000;
-  --border-soft: #ddd;
-  --surface: #fafafa;
-  --shade: #eee;
-  --alert-success-bg: #dff0d8;
-  --alert-success-border: #d6e9c6;
-  --alert-danger-bg: #f2dede;
-  --alert-danger-border: #ebccd1;
 }
 @media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #16181a;
-    --fg: #dfe2e4;
-    --muted: #9aa1a7;
-    --link: #f08b4b;
-    --border: #6b7177;
-    --border-soft: #34393e;
-    --surface: #1e2124;
-    --shade: #26292c;
-    --alert-success-bg: #1c3a23;
-    --alert-success-border: #2c5836;
-    --alert-danger-bg: #43201f;
-    --alert-danger-border: #663130;
-  }
+  :root { --theme: dark; }
 }
-/* explicit override set by the footer theme switcher (session-backed) */
-html.theme-light {
+html.theme-light {--theme: light; }
+html.theme-dark { --theme: dark; }
+body {
   color-scheme: light;
   --bg: #fff;
   --fg: #000;
@@ -47,20 +23,22 @@ html.theme-light {
   --alert-danger-bg: #f2dede;
   --alert-danger-border: #ebccd1;
 }
-html.theme-dark {
-  color-scheme: dark;
-  --bg: #16181a;
-  --fg: #dfe2e4;
-  --muted: #9aa1a7;
-  --link: #f08b4b;
-  --border: #6b7177;
-  --border-soft: #34393e;
-  --surface: #1e2124;
-  --shade: #26292c;
-  --alert-success-bg: #1c3a23;
-  --alert-success-border: #2c5836;
-  --alert-danger-bg: #43201f;
-  --alert-danger-border: #663130;
+@container style(--theme: dark) {
+  body {
+    color-scheme: dark;
+    --bg: #16181a;
+    --fg: #dfe2e4;
+    --muted: #9aa1a7;
+    --link: #f08b4b;
+    --border: #6b7177;
+    --border-soft: #34393e;
+    --surface: #1e2124;
+    --shade: #26292c;
+    --alert-success-bg: #1c3a23;
+    --alert-success-border: #2c5836;
+    --alert-danger-bg: #43201f;
+    --alert-danger-border: #663130;
+  }
 }
 
 html, body {

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2384,6 +2384,27 @@ RSpec.describe CloverAdmin do
     expect(page.find_field("days").value).to eq "5"
   end
 
+  describe "theme" do
+    it "switches theme via the footer forms" do
+      current = -> { page.find("#theme-switcher form.current input")[:value] }
+      visit "/"
+      expect(page.find("html")[:class]).to eq "theme-system"
+      expect(current.call).to eq "System"
+
+      within("#theme-switcher") { click_button "Dark" }
+      expect(page.find("html")[:class]).to eq "theme-dark"
+      expect(current.call).to eq "Dark"
+
+      within("#theme-switcher") { click_button "Light" }
+      expect(page.find("html")[:class]).to eq "theme-light"
+      expect(current.call).to eq "Light"
+
+      within("#theme-switcher") { click_button "System" }
+      expect(page.find("html")[:class]).to eq "theme-system"
+      expect(current.call).to eq "System"
+    end
+  end
+
   describe "archived-record-by-id" do
     it "finds archived records" do
       (vm = create_vm(name: "archived-vm")).destroy

--- a/views/admin/layout.erb
+++ b/views/admin/layout.erb
@@ -39,29 +39,29 @@
       <%== yield %>
     </div>
 
-    <footer>
-      <div class="container">
-        <span><%= Time.now.utc %></span>
-        <% if Config.staging %>
-          <span>clover-staging</span>
-        <% elsif Config.production? %>
-          <span class="env-production">clover-<%= Config.rack_env %></span>
-        <% else %>
-          <span>clover-<%= Config.rack_env %></span>
-        <% end %>
-        <% if commit = Config.git_commit_hash %>
-          <span>commit:
-            <a href="https://github.com/ubicloud/ubicloud/commit/<%= commit %>" target="_blank"><%= commit %></a></span>
-        <% end %>
-        <% if rodauth.logged_in? %>
+    <% if rodauth.logged_in? %>
+      <footer>
+        <div class="container">
+          <span><%= Time.now.utc %></span>
+          <% if Config.staging %>
+            <span>clover-staging</span>
+          <% elsif Config.production? %>
+            <span class="env-production">clover-<%= Config.rack_env %></span>
+          <% else %>
+            <span>clover-<%= Config.rack_env %></span>
+          <% end %>
           <span id="theme-switcher">Theme:
             <% current_theme = session["theme"] || "system" %>
             <% %w[light dark system].each do |theme| %>
               <%== form({action: "/theme/#{theme}", method: :post, class: ("current" if theme == current_theme)}, button: theme.capitalize) %>
             <% end %>
           </span>
-        <% end %>
-      </div>
-    </footer>
+          <% if commit = Config.git_commit_hash %>
+            <span>commit:
+              <a href="https://github.com/ubicloud/ubicloud/commit/<%= commit %>" target="_blank"><%= commit %></a></span>
+          <% end %>
+        </div>
+      </footer>
+    <% end %>
   </body>
 </html>

--- a/views/admin/layout.erb
+++ b/views/admin/layout.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="theme-<%= session["theme"] || "system" %>">
   <head>
     <meta charset="UTF-8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
@@ -52,6 +52,14 @@
         <% if commit = Config.git_commit_hash %>
           <span>commit:
             <a href="https://github.com/ubicloud/ubicloud/commit/<%= commit %>" target="_blank"><%= commit %></a></span>
+        <% end %>
+        <% if rodauth.logged_in? %>
+          <span id="theme-switcher">Theme:
+            <% current_theme = session["theme"] || "system" %>
+            <% %w[light dark system].each do |theme| %>
+              <%== form({action: "/theme/#{theme}", method: :post, class: ("current" if theme == current_theme)}, button: theme.capitalize) %>
+            <% end %>
+          </span>
         <% end %>
       </div>
     </footer>


### PR DESCRIPTION
The admin panel's stylesheet hard-codes its palette, so it renders light regardless of the operator's preference. Move the colors to custom properties on `:root` and override them under `prefers-color-scheme: dark`; light mode keeps the exact existing hex values.

- `color-scheme: light dark` lets native form controls, scrollbars, and selects follow the theme, since the panel uses unstyled native inputs throughout.
- The svg charts hard-code grid/label colors as presentation attributes; two rules under `.svg-chart` re-point them at the tokens (stylesheet rules win over presentation attributes), so `lib/svg_chart.rb` is untouched.
- A footer switcher (Light / Dark / System) stores an explicit override in the session — plain form POST to `/theme/:name`, rendered as a `theme-*` class on `<html>`. System means follow the OS. No JS, no CSP change — the panel stays script-free.
- Theme-invariant on purpose: the orange submit buttons and the red `production` footer badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)