### PR TITLE
Render bracketed ubid links after raw uuids in the admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -159,11 +159,14 @@ class CloverAdmin < Roda
   end
 
   def linkify_ubids(body)
-    h(body).gsub(/\b[a-tv-z0-9]{26}\b/) do
-      if (klass = UBID.class_for_ubid(it))
-        "<a href=\"/model/#{klass}/#{it}\">#{it}</a>"
+    h(body).gsub(/\b(?:[a-tv-z0-9]{26}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/) do |id|
+      uuid = id if id.include?("-")
+      ubid = uuid ? UBID.to_ubid(uuid) : id
+      if (klass = UBID.class_for_ubid(ubid))
+        link = "<a href=\"/model/#{klass}/#{ubid}\">#{ubid}</a>"
+        uuid ? "#{uuid} [#{link}]" : link
       else
-        it
+        id
       end
     end
   end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2396,6 +2396,7 @@ RSpec.describe CloverAdmin do
       end
       expect(page).to have_content("archived-vm")
       expect(page).to have_content(vm.id)
+      expect(page).to have_link(vm.ubid, href: "/model/Vm/#{vm.ubid}")
 
       within("#archived_record_form") do
         fill_in "id", with: vm.id
@@ -2403,6 +2404,7 @@ RSpec.describe CloverAdmin do
       end
       expect(page).to have_content("archived-vm")
       expect(page).to have_content(vm.id)
+      expect(page).to have_link(vm.ubid, href: "/model/Vm/#{vm.ubid}")
     end
 
     it "uses model_name from select when provided" do

--- a/spec/routes/web/admin/model/strand_spec.rb
+++ b/spec/routes/web/admin/model/strand_spec.rb
@@ -19,4 +19,15 @@ RSpec.describe CloverAdmin, "Strand" do
     expect(page.status_code).to eq 200
     expect(page.title).to eq "Ubicloud Admin - Strand #{@instance.ubid}"
   end
+
+  it "links raw uuids in the stack as ubids" do
+    vm = create_vm
+    @instance.update(stack: [{"remaining" => [vm.id], "current" => "00000000-0000-0000-0000-000000000000"}])
+
+    visit "/model/Strand/#{@instance.ubid}"
+    expect(page).to have_link(vm.ubid, href: "/model/Vm/#{vm.ubid}")
+    expect(page.find("pre").text).to include "#{vm.id} [#{vm.ubid}]"
+    expect(page).to have_content "00000000-0000-0000-0000-000000000000"
+    expect(page).to have_no_link "00000000-0000-0000-0000-000000000000"
+  end
 end


### PR DESCRIPTION
uuid-typed columns already display as ubids via `INSPECT_CONVERTERS`, but uuids embedded in jsonb — strand stacks and archived record values — render as plain text. Tracking a `RolloutSemaphore`'s progress means converting ids by hand to tell whether a given resource is in `remaining` or `completed`.

Extend `linkify_ubids` to also match uuids and append a bracketed ubid link after each one — `uuid [ubid]` — keeping the stored value visible verbatim (per review discussion, a pure rewrite would be misleading about what the column actually contains). The link resolves the type through the same static prefix mapping the existing ubid pass uses, so there are no per-id existence queries; unknown-prefix uuids render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)