### PR TITLE
Restrict journald receiver to postgres units

### DIFF
--- a/rhizome/postgres/lib/otel_log_config.rb
+++ b/rhizome/postgres/lib/otel_log_config.rb
@@ -164,6 +164,11 @@ class OtelLogConfig
   def journald_receiver_hash
     {
       "storage" => "file_storage/state",
+      "units" => [
+        "system-postgresql.slice",
+        "system-pgbouncer.slice",
+        "upgrade_postgres.service",
+      ],
       "operators" => [
         {
           "id" => "parse_journal_timestamp",

--- a/rhizome/postgres/spec/otel_log_config_spec.rb
+++ b/rhizome/postgres/spec/otel_log_config_spec.rb
@@ -87,6 +87,14 @@ RSpec.describe OtelLogConfig do
       expect(parsed["receivers"]).to have_key("journald")
     end
 
+    it "filters journald at the receiver to postgres-related units" do
+      expect(parsed["receivers"]["journald"]["units"]).to contain_exactly(
+        "system-postgresql.slice",
+        "system-pgbouncer.slice",
+        "upgrade_postgres.service",
+      )
+    end
+
     it "parses journald realtime timestamp into the log timestamp" do
       time_parser = parsed["receivers"]["journald"]["operators"].find { |op| op["id"] == "parse_journal_timestamp" }
       expect(time_parser).to include(
@@ -101,7 +109,7 @@ RSpec.describe OtelLogConfig do
       expect(time_parser_idx).to be < filter_idx
     end
 
-    it "filters journal to postgres-related units" do
+    it "routes journal records to postgres-related streams" do
       routes = parsed["receivers"]["journald"]["operators"].find { |op| op["id"] == "filter_units" }["routes"]
       exprs = routes.map { |r| r["expr"] }
       expect(exprs).to include(a_string_including('startsWith "postgresql@"'))


### PR DESCRIPTION
Collector read whole journal, dropping logs with filter_units router. This meant everything was serialized to JSON by journalctl, decoded by receiver, & pushed through operator pipeline to discard

Units list becomes journalctl --unit matches, so journald filters in-process using its field indexes, never emitting unrelated entries

filter_units isn't removed since it performs stream classification, & some unit matches from PID 1 which would have nil stream attribute