### PR TITLE
Return 204 for runtime github cache request with no keys

### DIFF
--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -12,6 +12,7 @@ class Clover
 
       keys, version = typecast_params.nonempty_str!(%w[keys version])
       keys = keys.split(",")
+      next 204 if keys.empty?
 
       dataset = repository.cache_entries_dataset.exclude(committed_at: nil).where(version:)
 

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -282,6 +282,12 @@ RSpec.describe Clover, "github" do
         expect(last_response.status).to eq(204)
       end
 
+      it "fails if no keys given" do
+        get "/runtime/github/cache", {keys: ",", version: "v1"}
+
+        expect(last_response.status).to eq(204)
+      end
+
       it "fails if one of the parameters are missing" do
         [
           ["k1,k2", nil],


### PR DESCRIPTION
This prevents a later exception due to invalid SQL.