### PR TITLE
Freeze most %w[] arrays

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -319,7 +319,7 @@ end
 desc "Update ubicloud/cli checkout in ../cli"
 task "cli-sync" do
   Dir.chdir("cli") do
-    FileUtils.cp(%w[README.md go.mod ubi.go version.txt], "../../cli/")
+    FileUtils.cp(%w[README.md go.mod ubi.go version.txt].freeze, "../../cli/")
   end
   FileUtils.cp("LICENSE", "../cli/")
   write_cli_makefile.call("../cli/Makefile")
@@ -332,8 +332,8 @@ task "ubi-release" do
   Dir.chdir("cli") do
     FileUtils.rm_f("ubi")
 
-    os_list = %w[linux windows darwin]
-    arch_list = %w[amd64 arm64 386]
+    os_list = %w[linux windows darwin].freeze
+    arch_list = %w[amd64 arm64 386].freeze
     os_list.each do |os|
       arch_list.each do |arch|
         next if os == "darwin" && arch == "386"
@@ -518,7 +518,7 @@ namespace :linter do
       number = 0
       File.foreach(file) do |line|
         number += 1
-        cmds = Regexp.union(%w[cmd exec! kubectl rootish_ssh run_query])
+        cmds = Regexp.union(%w[cmd exec! kubectl rootish_ssh run_query].freeze)
         if /\(:#{cmds}|instance_double\(.*#{cmds}: /.match?(line)
           failure = true
           warn "Potentially insecure method override: #{file}:#{number}: #{line}"

--- a/bin/e2e
+++ b/bin/e2e
@@ -14,7 +14,7 @@ end
 
 def test_metal(options, test_cases)
   base_machine_image_names = if Config.machine_images_service_project_id
-    %w[ubuntu-noble ubuntu-resolute]
+    %w[ubuntu-noble ubuntu-resolute].freeze
   else
     []
   end

--- a/bin/monitor
+++ b/bin/monitor
@@ -61,7 +61,7 @@ else
   ]
   host_attached_types = [
     Vm.exclude(unix_user: "runneradmin").eager(:vm_storage_volumes)
-      .exclude(Strand.where(id: Sequel[:vm][:id], label: %w[stopped stopped_by_admin unavailable]).exists),
+      .exclude(Strand.where(id: Sequel[:vm][:id], label: %w[stopped stopped_by_admin unavailable].freeze).exists),
     VmHostSlice.exclude(id: Vm.where(unix_user: "runneradmin").exclude(vm_host_slice_id: nil).select(:vm_host_slice_id)),
   ]
 

--- a/bin/rake-task-runner
+++ b/bin/rake-task-runner
@@ -87,7 +87,7 @@ SQL
 when "refresh_sequel_caches"
   require_args.call(0..0)
 
-  %w[schema index static_cache pg_auto_constraint_validations].each do |type|
+  %w[schema index static_cache pg_auto_constraint_validations].freeze.each do |type|
     filename = "cache/#{type}.cache"
     File.delete(filename) if File.file?(filename)
   end
@@ -105,7 +105,7 @@ when "dump_sequel_caches"
   text_dir = "cache-text-#{Time.now.to_i}"
   Dir.mkdir(text_dir)
   puts "Writing diffable version of cache files to #{text_dir}"
-  %w[schema index static_cache pg_auto_constraint_validations].each do |type|
+  %w[schema index static_cache pg_auto_constraint_validations].freeze.each do |type|
     File.write(File.join(text_dir, "#{type}.txt"), Marshal.load(File.binread("cache/#{type}.cache")).pretty_inspect)
   end
 when "unused_associations_check"
@@ -114,7 +114,7 @@ when "unused_associations_check"
   Sequel::Model.update_unused_associations_data
 
   # Do not complain about unused project, strand, or semaphore associations or options
-  keep_associations = %w[project strand semaphores]
+  keep_associations = %w[project strand semaphores].freeze
   keep = proc { |_, association| keep_associations.include?(association) }
 
   unused = Sequel::Model.unused_associations
@@ -156,7 +156,7 @@ when "annotate"
   require_relative "../model"
   DB.loggers.clear
   require "sequel/annotate"
-  ignore_dirs = %w[aws gcp metal]
+  ignore_dirs = %w[aws gcp metal].freeze
   files = Dir["model/**/*.rb"].reject do |file|
     ignore_dirs.include?(File.basename(File.dirname(file)))
   end

--- a/cli-commands/fw/list.rb
+++ b/cli-commands/fw/list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class UbiCli
-  list("fw", %w[location name id])
+  list("fw", %w[location name id].freeze)
 end

--- a/cli-commands/kc/list.rb
+++ b/cli-commands/kc/list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class UbiCli
-  list("kc", %w[location name id display_state version cp_node_count])
+  list("kc", %w[location name id display_state version cp_node_count].freeze)
 end

--- a/cli-commands/lb/list.rb
+++ b/cli-commands/lb/list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class UbiCli
-  list("lb", %w[location name id src-port dst-port hostname])
+  list("lb", %w[location name id src-port dst-port hostname].freeze)
 end

--- a/cli-commands/mi/list.rb
+++ b/cli-commands/mi/list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class UbiCli
-  list("mi", %w[location name id arch latest-version created-at])
+  list("mi", %w[location name id arch latest-version created-at].freeze)
 end

--- a/cli-commands/pg/list.rb
+++ b/cli-commands/pg/list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class UbiCli
-  list("pg", %w[location name id version flavor])
+  list("pg", %w[location name id version flavor].freeze)
 end

--- a/cli-commands/ps/list.rb
+++ b/cli-commands/ps/list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class UbiCli
-  list("ps", %w[location name id net4 net6])
+  list("ps", %w[location name id net4 net6].freeze)
 end

--- a/cli-commands/vm/list.rb
+++ b/cli-commands/vm/list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class UbiCli
-  list("vm", %w[location name id ip4 ip6])
+  list("vm", %w[location name id ip4 ip6].freeze)
 end

--- a/clover.rb
+++ b/clover.rb
@@ -144,7 +144,7 @@ class Clover < Roda
     SshPublicKey
     SubjectTag
     Vm
-  ].each { path(it, class_name: true, &under_project_path) }
+  ].freeze.each { path(it, class_name: true, &under_project_path) }
 
   path("Project", class_name: true, &:path)
   path("GithubInstallation", class_name: true) { "#{it.project.path}/github/#{it.ubid}" }
@@ -304,7 +304,7 @@ class Clover < Roda
 
     if runtime?
       error
-    elsif api? || request.accepts_json? || !%w[GET POST].include?(request.request_method)
+    elsif api? || request.accepts_json? || !%w[GET POST].freeze.include?(request.request_method)
       {error:}
     else
       @error = error

--- a/helpers/api.rb
+++ b/helpers/api.rb
@@ -3,7 +3,7 @@
 class Clover < Roda
   def paginated_result(dataset, serializer, **serializer_opts)
     opts = typecast_params.convert!(symbolize: true) do |tp|
-      tp.str(%w[start_after order_column])
+      tp.str(%w[start_after order_column].freeze)
       tp.pos_int("page_size")
     end
     opts[:serializer] = serializer

--- a/helpers/load_balancer.rb
+++ b/helpers/load_balancer.rb
@@ -15,8 +15,8 @@ class Clover
   def load_balancer_post(name)
     authorize("LoadBalancer:create", @project)
 
-    algorithm, health_check_protocol, stack = typecast_params.nonempty_str!(%w[algorithm health_check_protocol stack])
-    src_port, dst_port = typecast_params.pos_int!(%w[src_port dst_port])
+    algorithm, health_check_protocol, stack = typecast_params.nonempty_str!(%w[algorithm health_check_protocol stack].freeze)
+    src_port, dst_port = typecast_params.pos_int!(%w[src_port dst_port].freeze)
     cert_enabled_param = typecast_params.bool("cert_enabled")
     cert_enabled = cert_enabled_param.nil? ? health_check_protocol == "https" : cert_enabled_param
     health_check_endpoint = typecast_params.nonempty_str("health_check_endpoint") || Prog::Vnet::LoadBalancerNexus::DEFAULT_HEALTH_CHECK_ENDPOINT

--- a/helpers/ssh_public_key.rb
+++ b/helpers/ssh_public_key.rb
@@ -7,7 +7,7 @@ class Clover
       flash.now["error"] = "Error #{create ? "registering" : "updating"} SSH public key"
     end
 
-    name, public_key = typecast_params.nonempty_str(%w[name public_key])
+    name, public_key = typecast_params.nonempty_str(%w[name public_key].freeze)
     if create || web?
       @ssh_public_key.name = name
       @ssh_public_key.public_key = public_key

--- a/helpers/web.rb
+++ b/helpers/web.rb
@@ -223,7 +223,7 @@ class Clover < Roda
   def self.humanize_size(bytes)
     return nil if bytes.nil? || bytes.zero?
 
-    units = %w[B KB MB GB]
+    units = %w[B KB MB GB].freeze
     exp = (Math.log(bytes) / Math.log(1024)).to_i
     exp = [exp, units.size - 1].min
 

--- a/loader.rb
+++ b/loader.rb
@@ -125,13 +125,13 @@ module Parseable; end
 
 module VictoriaMetrics; end
 
-provider_dirs = %w[aws metal gcp]
+provider_dirs = %w[aws metal gcp].freeze
 autoload_normal.call("model", flat: true, exclude_dirs: provider_dirs)
-%w[lib clover.rb clover_admin.rb].each { autoload_normal.call(it) }
-%w[scheduling prog serializers].each { autoload_normal.call(it, include_first: true) }
+%w[lib clover.rb clover_admin.rb].freeze.each { autoload_normal.call(it) }
+%w[scheduling prog serializers].freeze.each { autoload_normal.call(it, include_first: true) }
 
 if ENV["LOAD_FILES_SEPARATELY_CHECK"] == "1"
-  files = %w[model lib scheduling prog serializers].flat_map { Dir["#{it}/**/*.rb"] }
+  files = %w[model lib scheduling prog serializers].freeze.flat_map { Dir["#{it}/**/*.rb"] }
   files << "clover.rb"
   files << "clover_admin.rb"
 

--- a/model/api_key.rb
+++ b/model/api_key.rb
@@ -30,7 +30,7 @@ class ApiKey < Sequel::Model
   def before_validation
     if new?
       self.key ||= ApiKey.random_key
-      unless %w[project accounts].include?(owner_table)
+      unless %w[project accounts].freeze.include?(owner_table)
         fail "Invalid owner_table: #{owner_table}"
       end
     end

--- a/model/metal/vm.rb
+++ b/model/metal/vm.rb
@@ -88,7 +88,7 @@ class Vm < Sequel::Model
       project_public_keys = project.get_ff_vm_public_ssh_keys || []
 
       # B200 and B300 GPUs require QEMU
-      hypervisor ||= (pci_devices.any? { |pci| %w[2901 3182].include?(pci.device) }) ? "qemu" : "ch"
+      hypervisor ||= (pci_devices.any? { |pci| %w[2901 3182].freeze.include?(pci.device) }) ? "qemu" : "ch"
 
       # we don't write secrets to params_json, because it
       # shouldn't be stored in the host for security reasons.

--- a/model/page.rb
+++ b/model/page.rb
@@ -82,7 +82,7 @@ class Page < Sequel::Model
     PostgresServer
     InferenceEndpointReplica
     InferenceRouterReplica
-    GithubRunner].each do |name|
+    GithubRunner].freeze.each do |name|
       EAGER_ROOT_RESOURCES[name] = :vm
     end
   EAGER_ROOT_RESOURCES["PostgresTimeline"] = :leader

--- a/model/payment_method.rb
+++ b/model/payment_method.rb
@@ -13,7 +13,7 @@ class PaymentMethod < Sequel::Model
 
   def stripe_data
     if Config.stripe_secret_key
-      @stripe_data ||= StripeClient.payment_methods.retrieve(stripe_id)["card"].to_h.transform_keys!(&:to_s).slice(*%w[last4 brand exp_month exp_year country funding wallet checks])
+      @stripe_data ||= StripeClient.payment_methods.retrieve(stripe_id)["card"].to_h.transform_keys!(&:to_s).slice(*%w[last4 brand exp_month exp_year country funding wallet checks].freeze)
     end
   end
 

--- a/model/postgres/aws/postgres_timeline.rb
+++ b/model/postgres/aws/postgres_timeline.rb
@@ -47,7 +47,7 @@ PGDATA=/dat/#{version}/data
 
       # dense NVMe = storage-optimized "i" families, allows more concurrency.
       {vcpu_count: vm.vcpus, memory_mib: vm.memory_gib * 1024,
-       dense_nvme: %w[i8g i8ge i7i i7ie].include?(family)}
+       dense_nvme: %w[i8g i8ge i7i i7ie].freeze.include?(family)}
     end
 
     def aws_walg_config_region

--- a/model/project.rb
+++ b/model/project.rb
@@ -123,7 +123,7 @@ class Project < Sequel::Model
     DB.transaction do
       DB[:access_tag].where(project_id: id).delete
       access_control_entries_dataset.destroy
-      %w[subject action object].each do |tag_type|
+      %w[subject action object].freeze.each do |tag_type|
         dataset = send(:"#{tag_type}_tags_dataset")
         DB[:"applied_#{tag_type}_tag"].where(tag_id: dataset.select(:id)).delete
         dataset.destroy

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -152,11 +152,11 @@ class Vm < Sequel::Model
   end
 
   def can_stop?
-    %w[running starting restarting unavailable rebooting].include?(display_state)
+    %w[running starting restarting unavailable rebooting].freeze.include?(display_state)
   end
 
   def can_start?
-    %w[unavailable stopped].include?(display_state)
+    %w[unavailable stopped].freeze.include?(display_state)
   end
 
   # Reverse look-up the vm_size instance that was used to create this VM

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -467,8 +467,8 @@ class VmHost < Sequel::Model
     end
     target_location = Location.with_pk!(target_location_id)
 
-    target_image_names = %w[github-ubuntu-2404 github-ubuntu-2204]
-    target_image_names += %w[ubuntu-noble ubuntu-jammy almalinux-9 debian-12 postgres-ubuntu-2204] unless target_location.id == Location::GITHUB_RUNNERS_ID
+    target_image_names = %w[github-ubuntu-2404 github-ubuntu-2204].freeze
+    target_image_names += %w[ubuntu-noble ubuntu-jammy almalinux-9 debian-12 postgres-ubuntu-2204].freeze unless target_location.id == Location::GITHUB_RUNNERS_ID
 
     DB.ignore_duplicate_queries do
       target_image_names.each { |image_name| download_boot_image(image_name) }

--- a/prog/rollout_rhizome.rb
+++ b/prog/rollout_rhizome.rb
@@ -23,7 +23,7 @@ class Prog::RolloutRhizome < Prog::Base
       .limit(2)
 
     initial_github_runner_host_ids = DB.ignore_duplicate_queries do
-      %w[x64 arm64].flat_map do |arch|
+      %w[x64 arm64].freeze.flat_map do |arch|
         initial_github_runner_host_ds
           .where(arch:)
           .select_map(:id)

--- a/prog/storage/migrate_spdk_vm_to_ubiblk.rb
+++ b/prog/storage/migrate_spdk_vm_to_ubiblk.rb
@@ -67,7 +67,7 @@ class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
       # on non-zero exit codes, it wouldn't return the stdout directly.
       ex.stdout.strip
     end
-    nap 5 unless %w[inactive failed].include?(vm_state)
+    nap 5 unless %w[inactive failed].freeze.include?(vm_state)
     hop_remove_spdk_controller
   end
 

--- a/prog/victoria_metrics/victoria_metrics_server_nexus.rb
+++ b/prog/victoria_metrics/victoria_metrics_server_nexus.rb
@@ -45,7 +45,7 @@ class Prog::VictoriaMetrics::VictoriaMetricsServerNexus < Prog::Base
         # child strand budded from parent strand unvailable, exit to
         # avoid two strands in #destroy
         pop "exiting early due to destroy semaphore"
-      elsif !%w[destroy wait_children_destroyed].include?(label)
+      elsif !%w[destroy wait_children_destroyed].freeze.include?(label)
         hop_destroy
       elsif strand.stack.count > 1
         pop "operation is cancelled due to the destruction of the VictoriaMetrics server"

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -460,7 +460,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       begin
         result, invocation_id = host.sshable.cmd("systemctl show -p Result -p InvocationID --value :vm_name", vm_name:).strip.split("\n")
 
-        reason = if %w[signal core-dump oom-kill timeout success].include?(result)
+        reason = if %w[signal core-dump oom-kill timeout success].freeze.include?(result)
           result
         else
           host.sshable.cmd(<<~END, invocation_id:).strip

--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -179,7 +179,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
     fail "BUG: locked #{claimed}/#{nics.count} NICs" unless claimed == nics.count
     # :nocov:
 
-    check_nic_phases(nics, %w[idle], "freshly locked NICs should all be idle")
+    check_nic_phases(nics, %w[idle].freeze, "freshly locked NICs should all be idle")
 
     nics.each do |nic|
       nic.update(encryption_key: gen_encryption_key,
@@ -209,7 +209,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
   def v2_wait_inbound_setup
     nics = claimed_nics
     abort_rekey_if_no_nics(nics)
-    check_nic_phases(nics, %w[idle inbound], "phase monotonicity at phase_inbound")
+    check_nic_phases(nics, %w[idle inbound].freeze, "phase monotonicity at phase_inbound")
     if nics.all? { |nic| nic.rekey_phase == "inbound" }
       Nic.incr_trigger_outbound_update(nics.map(&:id))
       hop_wait_outbound_setup
@@ -238,7 +238,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
   def v2_wait_outbound_setup
     nics = claimed_nics
     abort_rekey_if_no_nics(nics)
-    check_nic_phases(nics, %w[inbound outbound], "phase monotonicity at phase_outbound")
+    check_nic_phases(nics, %w[inbound outbound].freeze, "phase monotonicity at phase_outbound")
     if nics.all? { |nic| nic.rekey_phase == "outbound" }
       Nic.incr_old_state_drop_trigger(nics.map(&:id))
       hop_wait_old_state_drop
@@ -274,7 +274,7 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
   def v2_wait_old_state_drop
     nics = claimed_nics
     abort_rekey_if_no_nics(nics)
-    check_nic_phases(nics, %w[outbound old_drop], "phase monotonicity at phase_old_drop")
+    check_nic_phases(nics, %w[outbound old_drop].freeze, "phase monotonicity at phase_old_drop")
     if nics.all? { |nic| nic.rekey_phase == "old_drop" }
       PrivateSubnet.where(id: (nics.map(&:private_subnet_id) << private_subnet.id).uniq).update(last_rekey_at: Sequel::CURRENT_TIMESTAMP)
       private_subnet.update(state: "waiting")

--- a/rhizome/common/bin/daemonizer2
+++ b/rhizome/common/bin/daemonizer2
@@ -64,7 +64,7 @@ when "stop"
 when "run"
   command_parts = ARGV[2..]
   state = get_state(name)
-  clean(name, stdin_path) if %w[Succeeded Failed].include?(state)
+  clean(name, stdin_path) if %w[Succeeded Failed].freeze.include?(state)
 
   dir = Dir.pwd
   stdin = $stdin.read.strip

--- a/rhizome/host/bin/spdk-migration-helper
+++ b/rhizome/host/bin/spdk-migration-helper
@@ -9,7 +9,7 @@ unless (action = ARGV.shift)
 end
 
 params = JSON.parse($stdin.read)
-%w[vm_name storage_device disk_index vhost_block_backend_version slice max_read_mbytes_per_sec max_write_mbytes_per_sec encrypted spdk_version].each do |key|
+%w[vm_name storage_device disk_index vhost_block_backend_version slice max_read_mbytes_per_sec max_write_mbytes_per_sec encrypted spdk_version].freeze.each do |key|
   unless params.has_key?(key)
     puts "Needed #{key} in parameters"
     exit 1

--- a/rhizome/host/lib/storage_archive.rb
+++ b/rhizome/host/lib/storage_archive.rb
@@ -15,8 +15,8 @@ class StorageArchive
   def initialize(disk_config_path, disk_kek_path, disk_kek, target_conf, vhost_block_backend_version, stats_file)
     validate_keys(
       "target_conf",
-      %w[bucket prefix region endpoint access_key_id secret_access_key archive_kek],
-      %w[session_token],
+      %w[bucket prefix region endpoint access_key_id secret_access_key archive_kek].freeze,
+      %w[session_token].freeze,
       target_conf,
     )
     @backend = VhostBlockBackend.new(vhost_block_backend_version)

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -62,7 +62,7 @@ class VmPath
     nftables_conf
     prep.json
     cert
-  ].each do |file_name|
+  ].freeze.each do |file_name|
     method_name = file_name.tr(".-", "_")
 
     # Method producing a path, e.g. #user_data

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -573,7 +573,7 @@ DNSMASQ_CONF
   end
 
   def write_user_data(unix_user, public_keys, swap_size_bytes, boot_image, init_script: nil)
-    runcmd = [%w[systemctl daemon-reload].shelljoin]
+    runcmd = [%w[systemctl daemon-reload].freeze.shelljoin]
     runcmd.concat(install_commands(boot_image))
     runcmd << init_script if init_script
 
@@ -599,9 +599,9 @@ DNSMASQ_CONF
 
   private def install_commands(boot_image)
     if boot_image.include?("almalinux")
-      [%w[dnf install -y nftables].shelljoin]
+      [%w[dnf install -y nftables].freeze.shelljoin]
     elsif boot_image.include?("debian")
-      [%w[apt-get update].shelljoin, %w[apt-get install -y nftables].shelljoin]
+      [%w[apt-get update].freeze.shelljoin, %w[apt-get install -y nftables].freeze.shelljoin]
     else
       []
     end
@@ -609,9 +609,9 @@ DNSMASQ_CONF
 
   private def nft_bootcmd
     [
-      %w[nft add table ip6 filter],
-      %w[nft add chain ip6 filter output { type filter hook output priority 0 ; }],
-      %w[nft add rule ip6 filter output ip6 daddr fd00:0b1c:100d:5AFE::/64 meta skuid != 0 tcp flags syn reject with tcp reset],
+      %w[nft add table ip6 filter].freeze,
+      %w[nft add chain ip6 filter output { type filter hook output priority 0 ; }].freeze,
+      %w[nft add rule ip6 filter output ip6 daddr fd00:0b1c:100d:5AFE::/64 meta skuid != 0 tcp flags syn reject with tcp reset].freeze,
     ].map(&:shelljoin)
   end
 

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe VmSetup do
       expect(config["users"].first["ssh_authorized_keys"]).to eq([])
     end
 
-    %w[yes no true false null ~].each do |special_name|
+    %w[yes no true false null ~].freeze.each do |special_name|
       it "preserves YAML-special username #{special_name.inspect} as a string" do
         vs.write_user_data(special_name, ["key"], nil, "")
         config = parse_user_data
@@ -393,7 +393,7 @@ RSpec.describe VmSetup do
           --cpus boot=2,topology=1:1:1:2 \
           --memory size=2G,hugepages=on,hugepage_size=1G \
           --net mac=02:aa:bb:cc:dd:01,tap=tap0,ip=,mask=,num_queues=5
-        ].each { |frag| expect(content).to include(frag) }
+        ].freeze.each { |frag| expect(content).to include(frag) }
 
         expect(content).to include("Restart=no")
         expect(content).to include("User=test")
@@ -445,7 +445,7 @@ RSpec.describe VmSetup do
           -serial file:/vm/test/serial.log
           -display none
           -vga none
-        ].each { |frag| expect(content).to include(frag) }
+        ].freeze.each { |frag| expect(content).to include(frag) }
 
         expect(content).to include("KillSignal=SIGTERM")
         expect(content).to include("TimeoutStopSec=30s")
@@ -624,8 +624,8 @@ RSpec.describe VmSetup do
       gua = "fddf:53d2:4c89:2305:46a0::/79"
       ip4 = "123.123.123.123"
       nics = [
-        %w[fd48:666c:a296:ce4b:2cc6::/79 192.168.5.50/32 ncaka58xyg 3e:bd:a5:96:f7:b9],
-        %w[fddf:53d2:4c89:2305:46a0::/79 10.10.10.10/32 ncbbbbbbbb fb:55:dd:ba:21:0a],
+        %w[fd48:666c:a296:ce4b:2cc6::/79 192.168.5.50/32 ncaka58xyg 3e:bd:a5:96:f7:b9].freeze,
+        %w[fddf:53d2:4c89:2305:46a0::/79 10.10.10.10/32 ncbbbbbbbb fb:55:dd:ba:21:0a].freeze,
       ].map { VmSetup::Nic.new(*_1) }
 
       expect(vps).to receive(:write_nftables_conf).with(<<NFTABLES_CONF)

--- a/rhizome/postgres/spec/otel_log_config_spec.rb
+++ b/rhizome/postgres/spec/otel_log_config_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe OtelLogConfig do
 
     it "defaults session attributes to empty strings in the pglog receiver when the regex did not capture them" do
       pglog_ops = parsed["receivers"]["filelog/pglog"]["operators"]
-      %w[dbname user remote_host_port].each do |field|
+      %w[dbname user remote_host_port].freeze.each do |field|
         op = pglog_ops.find { |o| o["type"] == "add" && o["field"] == "attributes.#{field}" }
         expect(op).to include("value" => "", "if" => "attributes.#{field} == nil")
       end

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -78,9 +78,9 @@ class Clover
 
       r.rename firewall, perm: "Firewall:edit", serializer: Serializers::Firewall, template_prefix: "networking/firewall"
 
-      r.show_object(firewall, actions: %w[overview networking settings], perm: "Firewall:view", template: "networking/firewall/show")
+      r.show_object(firewall, actions: %w[overview networking settings].freeze, perm: "Firewall:view", template: "networking/firewall/show")
 
-      r.post %w[attach-subnet detach-subnet] do |action|
+      r.post %w[attach-subnet detach-subnet].freeze do |action|
         authorize("Firewall:view", firewall)
         handle_validation_failure("networking/firewall/show") { @page = "networking" }
 
@@ -165,7 +165,7 @@ class Clover
               cidr = cidrs[0].to_s
               description = nil if description == ""
             else
-              cidr, port_range, protocol, description = typecast_params.str(%w[cidr port_range protocol description])
+              cidr, port_range, protocol, description = typecast_params.str(%w[cidr port_range protocol description].freeze)
               cidr = Validation.validate_cidr(cidr).to_s if cidr
 
               if port_range

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -49,7 +49,7 @@ class Clover
 
       r.rename kc, perm: "KubernetesCluster:edit", serializer: Serializers::KubernetesCluster, template_prefix: "kubernetes-cluster"
 
-      r.show_object(kc, actions: %w[overview nodepools networking settings], perm: "KubernetesCluster:view", template: "kubernetes-cluster/show")
+      r.show_object(kc, actions: %w[overview nodepools networking settings].freeze, perm: "KubernetesCluster:view", template: "kubernetes-cluster/show")
 
       r.post web?, "connect-postgres", :ubid_uuid, :ubid_uuid do |pg_id, fw_id|
         authorize("KubernetesCluster:view", kc)

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -23,7 +23,7 @@ class Clover
 
       check_found_object(lb)
 
-      r.post %w[attach-vm detach-vm] do |action|
+      r.post %w[attach-vm detach-vm].freeze do |action|
         authorize("LoadBalancer:edit", lb)
         handle_validation_failure("networking/load_balancer/show") { @page = "vms" }
 
@@ -87,8 +87,8 @@ class Clover
 
       r.patch api? do
         authorize("LoadBalancer:edit", lb)
-        algorithm, health_check_endpoint = typecast_params.nonempty_str!(%w[algorithm health_check_endpoint])
-        src_port, dst_port = typecast_params.pos_int!(%w[src_port dst_port])
+        algorithm, health_check_endpoint = typecast_params.nonempty_str!(%w[algorithm health_check_endpoint].freeze)
+        src_port, dst_port = typecast_params.pos_int!(%w[src_port dst_port].freeze)
         vm_ids = typecast_params.array(:ubid_uuid, "vms")
         cert_enabled = typecast_params.bool!("cert_enabled")
         cert_enablement_changed = lb.cert_enabled != cert_enabled
@@ -160,7 +160,7 @@ class Clover
         end
       end
 
-      r.show_object(lb, actions: %w[overview vms settings], perm: "LoadBalancer:view", template: "networking/load_balancer/show")
+      r.show_object(lb, actions: %w[overview vms settings].freeze, perm: "LoadBalancer:view", template: "networking/load_balancer/show")
     end
   end
 end

--- a/routes/project/location/machine_image.rb
+++ b/routes/project/location/machine_image.rb
@@ -105,7 +105,7 @@ class Clover
         end
       end
 
-      r.show_object(mi, actions: %w[overview versions settings], perm: "MachineImage:view", template: "machine_image/show")
+      r.show_object(mi, actions: %w[overview versions settings].freeze, perm: "MachineImage:view", template: "machine_image/show")
     end
   end
 end

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -136,9 +136,9 @@ class Clover
       end
 
       show_actions = if pg.read_replica?
-        %w[overview connection charts networking config settings]
+        %w[overview connection charts networking config settings].freeze
       else
-        %w[overview connection charts networking resize high-availability read-replica backup-restore config upgrade settings]
+        %w[overview connection charts networking resize high-availability read-replica backup-restore config upgrade settings].freeze
       end
       r.show_object(pg, actions: show_actions, perm: "Postgres:view", template: "postgres/show")
 
@@ -596,7 +596,7 @@ class Clover
             raise CloverError.new(400, "InvalidRequest", "Certificate expiry should be less than 367 days.")
           elsif !common_name.match?(/\A[a-zA-Z0-9_-]{1,64}\z/)
             raise CloverError.new(400, "InvalidRequest", "Common Name must only contain alphanumeric characters, underscores, and hyphens. It must not exceed 64 characters.")
-          elsif %w[postgres ubi_replication].include?(common_name)
+          elsif %w[postgres ubi_replication].freeze.include?(common_name)
             raise CloverError.new(400, "InvalidRequest", "Common Name must not be postgres or ubi_replication.")
           end
 
@@ -682,7 +682,7 @@ class Clover
       r.get "metrics", r.accepts_json? do
         authorize("Postgres:view", pg)
 
-        start_time, end_time = typecast_params.str(%w[start end])
+        start_time, end_time = typecast_params.str(%w[start end].freeze)
         start_time ||= (Time.now.utc - 60 * 30).xmlschema
         start_time = Validation.validate_rfc3339_datetime_str(start_time, "start")
 
@@ -767,7 +767,7 @@ class Clover
         authorize("Postgres:view", pg)
 
         begin
-          start_time, end_time = typecast_params.nonempty_str(%w[start end])
+          start_time, end_time = typecast_params.nonempty_str(%w[start end].freeze)
           now = Time.now.utc
           start_time ||= (now - 60 * 30).strftime("%FT%T%:z")
           start_time = Validation.validate_rfc3339_datetime_str(start_time, "start")

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -62,7 +62,7 @@ class Clover
 
       r.rename ps, perm: "PrivateSubnet:edit", serializer: Serializers::PrivateSubnet, template_prefix: "networking/private_subnet"
 
-      r.show_object(ps, actions: %w[overview vms networking settings], perm: "PrivateSubnet:view", template: "networking/private_subnet/show")
+      r.show_object(ps, actions: %w[overview vms networking settings].freeze, perm: "PrivateSubnet:view", template: "networking/private_subnet/show")
     end
   end
 end

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -57,9 +57,9 @@ class Clover
 
       r.rename vm, perm: "Vm:edit", serializer: Serializers::Vm, template_prefix: "vm"
 
-      r.show_object(vm, actions: %w[overview networking settings], perm: "Vm:view", template: "vm/show")
+      r.show_object(vm, actions: %w[overview networking settings].freeze, perm: "Vm:view", template: "vm/show")
 
-      r.post %w[restart start stop] do |action|
+      r.post %w[restart start stop].freeze do |action|
         authorize("Vm:edit", vm)
         handle_validation_failure("vm/show") { @page = "settings" }
 

--- a/routes/project/token.rb
+++ b/routes/project/token.rb
@@ -43,7 +43,7 @@ class Clover
           r.redirect @project, "/token"
         end
 
-        r.post %w[unrestrict-access restrict-access] do |action|
+        r.post %w[unrestrict-access restrict-access].freeze do |action|
           DB.transaction do
             if action == "restrict-access"
               token.restrict_token_for_project(@project.id)

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -240,7 +240,7 @@ class Clover
           end
         end
 
-        r.on "tag", %w[subject action object] do |tag_type|
+        r.on "tag", %w[subject action object].freeze do |tag_type|
           @tag_type = tag_type
           @display_tag_type = tag_type.capitalize
           @tag_model = Object.const_get(:"#{@display_tag_type}Tag")

--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -10,7 +10,7 @@ class Clover
     r.get "cache" do
       next 204 unless repository.access_key
 
-      keys, version = typecast_params.nonempty_str!(%w[keys version])
+      keys, version = typecast_params.nonempty_str!(%w[keys version].freeze)
       keys = keys.split(",")
       next 204 if keys.empty?
 
@@ -99,7 +99,7 @@ class Clover
             fail CloverError.new(400, "InvalidRequest", "unable to setup blob storage")
           end
 
-          key, version = typecast_params.nonempty_str!(%w[key version])
+          key, version = typecast_params.nonempty_str!(%w[key version].freeze)
           size = typecast_params.pos_int("cacheSize")
 
           unless (scope = runner.workflow_job&.dig("head_branch") || get_scope_from_github(runner, typecast_params.nonempty_str("runId")))

--- a/sdk/ruby/ubicloud.gemspec
+++ b/sdk/ruby/ubicloud.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/ubicloud/ubicloud/tree/main/sdk/ruby",
   }
 
-  s.files = %w[MIT-LICENSE] + Dir["lib/**/*.rb"]
-  s.extra_rdoc_files = %w[MIT-LICENSE]
+  s.files = %w[MIT-LICENSE].freeze + Dir["lib/**/*.rb"]
+  s.extra_rdoc_files = %w[MIT-LICENSE].freeze
 end

--- a/spec/cli_config.ru
+++ b/spec/cli_config.ru
@@ -66,7 +66,7 @@ c = Class.new(Roda) do
         response.status = 400
         argv.join(" ") << "\n"
       when "headers"
-        env.values_at(*%w[HTTP_CONNECTION CONTENT_TYPE HTTP_ACCEPT HTTP_AUTHORIZATION]).join(" ")
+        env.values_at(*%w[HTTP_CONNECTION CONTENT_TYPE HTTP_ACCEPT HTTP_AUTHORIZATION].freeze).join(" ")
       else
         argv.join(" ")
       end

--- a/spec/lib/authorization_spec.rb
+++ b/spec/lib/authorization_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Authorization do
         [{subjects: users[0].id, actions: "Vm:view", objects: vms[0].id}, users[0].id, "Vm:view", 1],
         [{subjects: users[0].id, actions: "Vm:view", objects: [vms[0].id, vms[1].id]}, users[0].id, "Vm:view", 2],
         [{subjects: users[0].id, actions: "Vm:delete", objects: vms[0].id}, users[0].id, "Vm:view", 0],
-        [{subjects: users[0].id, actions: %w[Vm:view Vm:delete], objects: vms[0].id}, users[0].id, "Vm:view", 1],
+        [{subjects: users[0].id, actions: %w[Vm:view Vm:delete].freeze, objects: vms[0].id}, users[0].id, "Vm:view", 1],
         [{subjects: users[0].id, actions: [nil], objects: vms[0].id}, users[0].id, "Vm:view", 1],
         [{subjects: users[0].id, actions: "Postgres:view", objects: pg.id}, users[0].id, "Postgres:edit", 0],
         [{subjects: users[0].id, actions: "Postgres:edit", objects: pg.id}, users[0].id, "Postgres:view", 0],

--- a/spec/model/address_spec.rb
+++ b/spec/model/address_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Address do
   it "populates ipv4_address table with addresses in cidr" do
     vm_host = Prog::Vm::HostNexus.assemble("1.2.3.4").subject
     address = described_class.create(cidr: "0.0.0.0/30", vm_host:)
-    expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq %w[0.0.0.0 0.0.0.1 0.0.0.2 0.0.0.3]
+    expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq %w[0.0.0.0 0.0.0.1 0.0.0.2 0.0.0.3].freeze
     address.destroy
     expect(DB[:ipv4_address]).to be_empty
   end
@@ -36,6 +36,6 @@ RSpec.describe Address do
   it "populates ipv4_address table with addresses in cidr without first and last, when using leaseweb" do
     vm_host = Prog::Vm::HostNexus.assemble("1.2.3.4", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "1").subject
     described_class.create(cidr: "0.0.0.0/30", vm_host:)
-    expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq %w[0.0.0.1 0.0.0.2]
+    expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq %w[0.0.0.1 0.0.0.2].freeze
   end
 end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -1541,7 +1541,7 @@ RSpec.describe PostgresResource do
 
     it "returns true when 90% action is set, not canceled, and converge strand is in an early label" do
       postgres_resource.incr_storage_auto_scale_action_performed_90
-      %w[start provision_servers wait_servers_to_be_ready wait_for_maintenance_window].each do |label|
+      %w[start provision_servers wait_servers_to_be_ready wait_for_maintenance_window].freeze.each do |label|
         Strand.dataset.where(prog: "Postgres::ConvergePostgresResource").destroy
         Strand.create(
           prog: "Postgres::ConvergePostgresResource",

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe VmHost do
       expect(vm_host.reload.location_id).to eq target_location.id
       download_strands = Strand.where(prog: "DownloadBootImage").all
       downloaded_names = download_strands.map { it.stack.first["image_name"] }.sort
-      expect(downloaded_names).to eq %w[almalinux-9 debian-12 github-ubuntu-2204 github-ubuntu-2404 postgres-ubuntu-2204 ubuntu-jammy ubuntu-noble]
+      expect(downloaded_names).to eq %w[almalinux-9 debian-12 github-ubuntu-2204 github-ubuntu-2404 postgres-ubuntu-2204 ubuntu-jammy ubuntu-noble].freeze
     end
 
     it "downloads github images when moving to github-runners location" do
@@ -111,7 +111,7 @@ RSpec.describe VmHost do
       expect(vm_host.reload.location_id).to eq target_location.id
       download_strands = Strand.where(prog: "DownloadBootImage").all
       downloaded_names = download_strands.map { it.stack.first["image_name"] }.sort
-      expect(downloaded_names).to eq %w[github-ubuntu-2204 github-ubuntu-2404]
+      expect(downloaded_names).to eq %w[github-ubuntu-2204 github-ubuntu-2404].freeze
     end
 
     it "logs and returns early if already in the target location" do

--- a/spec/monitor_smoke_test.rb
+++ b/spec/monitor_smoke_test.rb
@@ -74,7 +74,7 @@ unless (missing_ranges = required_ranges - ranges).empty?
   exit 1
 end
 
-up, down, evloop, mc2 = resources = %w[vp down evloop mc2].map { UBID.generate_vanity("et", "mr", it).to_s }
+up, down, evloop, mc2 = resources = %w[vp down evloop mc2].freeze.map { UBID.generate_vanity("et", "mr", it).to_s }
 
 lines = {}
 output.split("\n").each do |line|

--- a/spec/prog/heartbeat_spec.rb
+++ b/spec/prog/heartbeat_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Prog::Heartbeat do
     end
 
     it "naps if not all expected application types are connected" do
-      expect(hb).to receive(:fetch_connected).and_return(%w[monitor puma])
+      expect(hb).to receive(:fetch_connected).and_return(%w[monitor puma].freeze)
 
       expect(Clog).to receive(:emit).with("some expected connected clover services are missing", {heartbeat_missing: {difference: ["respirate"]}})
 

--- a/spec/prog/learn_storage_spec.rb
+++ b/spec/prog/learn_storage_spec.rb
@@ -114,7 +114,7 @@ EOS
       allow(ls.sshable).to receive(:_cmd).with("ls -l /dev/disk/by-id/ | grep sdb\\$ | grep 'wwn-' | sed -E 's/.*(wwn[^ ]*).*/\\1/'").and_return("wwn-some-random-id1")
       expect(ls.sshable).to receive(:_cmd).with("ls -l /dev/disk/by-id/ | grep sdc\\$ | grep 'wwn-' | sed -E 's/.*(wwn[^ ]*).*/\\1/'").and_return("wwn-some-random-id2")
 
-      expect(ls.make_model_instances.map(&:name)).to eq(%w[DEFAULT stor1 stor2])
+      expect(ls.make_model_instances.map(&:name)).to eq(%w[DEFAULT stor1 stor2].freeze)
     end
 
     it "can use any file system that is present at '/var/storage'" do
@@ -137,7 +137,7 @@ Filesystem     Mounted on                   1B-blocks        Avail
 EOS
       allow(ls.sshable).to receive(:_cmd).with("ls -l /dev/disk/by-id/ | grep sda\\$ | grep 'wwn-' | sed -E 's/.*(wwn[^ ]*).*/\\1/'").and_return("wwn-some-random-id1")
 
-      expect(ls.make_model_instances.map(&:name)).to eq(%w[DEFAULT])
+      expect(ls.make_model_instances.map(&:name)).to eq(%w[DEFAULT].freeze)
     end
 
     it "can find underlying unix devices for raided disks" do

--- a/spec/prog/test/base_machine_images_spec.rb
+++ b/spec/prog/test/base_machine_images_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Prog::Test::BaseMachineImages do
   let(:prog) { described_class.new(described_class.assemble(location_id: Location::HETZNER_FSN1_ID, arch: "x64", base_image_names: ["ubuntu-noble", "ubuntu-resolute"])) }
   let(:strand) { prog.strand }
   let(:metals) {
-    %w[ubuntu-resolute ubuntu-noble].map { |name|
+    %w[ubuntu-resolute ubuntu-noble].freeze.map { |name|
       create_machine_image_version_metal(name:)
     }
   }

--- a/spec/prog/test/local_e2e_loop_spec.rb
+++ b/spec/prog/test/local_e2e_loop_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Prog::Test::LocalE2eLoop do
       expect(lel_strand.prog).to eq "Test::LocalE2eLoop"
       expect(lel_strand.label).to eq "start"
       expect(lel_strand.stack).to eq [{
-        "progs" => %w[PostgresResource HaPostgresResource],
+        "progs" => %w[PostgresResource HaPostgresResource].freeze,
         "prog_args" => {"provider" => "metal"},
         "starts" => 0,
         "successes" => 0,
@@ -50,7 +50,7 @@ RSpec.describe Prog::Test::LocalE2eLoop do
       child = lel_strand.children.first
       expect(
         lel_strand.stack[0].values_at("current_strand", "starts", "progs"),
-      ).to eq [child.id, 1, %w[HaPostgresResource PostgresResource]]
+      ).to eq [child.id, 1, %w[HaPostgresResource PostgresResource].freeze]
       expect(child.prog).to eq "Test::PostgresResource"
       expect(child.stack[0]["provider"]).to eq "metal"
       expect(child.stack[0]["local_e2e"]).to be true

--- a/spec/prog/vm/gcp/nexus_spec.rb
+++ b/spec/prog/vm/gcp/nexus_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       network_firewall_policies_client: nfp_client,
       zone_operations_client: zone_ops_client,
     )
-    %w[a b c].each do |suffix|
+    %w[a b c].freeze.each do |suffix|
       LocationAz.create(location_id: location.id, az: suffix)
     end
   end
@@ -374,8 +374,8 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
         expect(disks.length).to eq(3)
         expect(disks[0].boot).to be true
         expect(disks[1..].map(&:boot)).to eq([false, false])
-        expect(disks[1..].map(&:type)).to eq(%w[SCRATCH SCRATCH])
-        expect(disks[1..].map(&:interface)).to eq(%w[NVME NVME])
+        expect(disks[1..].map(&:type)).to eq(%w[SCRATCH SCRATCH].freeze)
+        expect(disks[1..].map(&:interface)).to eq(%w[NVME NVME].freeze)
         op
       end
 
@@ -487,7 +487,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       expect { nx.wait_create_op }.to raise_error(RuntimeError, /GCE instance creation failed.*operation failed/)
     end
 
-    %w[ZONE_RESOURCE_POOL_EXHAUSTED ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS QUOTA_EXCEEDED INTERNAL_ERROR].each do |code|
+    %w[ZONE_RESOURCE_POOL_EXHAUSTED ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS QUOTA_EXCEEDED INTERNAL_ERROR].freeze.each do |code|
       it "retries in a different zone on #{code} operation error" do
         refresh_frame(nx, new_values: {"create_vm" => {"name" => "op-123", "scope" => "zone", "scope_value" => "us-central1-a"}, "gcp_zone_suffix" => "a"})
         ensure_vm_gcp_resource(vm, "a")

--- a/spec/routes/api/ips-v4_spec.rb
+++ b/spec/routes/api/ips-v4_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Clover, "ips-v4" do
       10.1.2.0/31
       3.1.1.0/30
       5.1.1.0/32
-    ].each do |cidr|
+    ].freeze.each do |cidr|
       Address.create(cidr:, routed_to_host_id: hosts.sample.id)
     end
 

--- a/spec/routes/api/project/inference_endpoint_spec.rb
+++ b/spec/routes/api/project/inference_endpoint_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Clover, "inference endpoint" do
 
       expect(last_response.status).to eq(200)
       body = JSON.parse(last_response.body)
-      allowed_keys = %w[hf_model capability multimodal display_name context_length]
+      allowed_keys = %w[hf_model capability multimodal display_name context_length].freeze
       body["items"].each do |item|
         expect(item["tags"].keys - allowed_keys).to eq([])
       end

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -1084,7 +1084,7 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "rejects reserved names" do
-        %w[postgres ubi_replication].each do
+        %w[postgres ubi_replication].freeze.each do
           post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/cert/create-client-keypair", {
             common_name: "postgres",
             duration: 3600,

--- a/spec/routes/web/access_control_spec.rb
+++ b/spec/routes/web/access_control_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe Clover, "access control" do
       expect(AccessControlEntry.count).to eq 2
     end
 
-    %w[subject action object].each do |type|
+    %w[subject action object].freeze.each do |type|
       cap_type = type.capitalize
       model = Object.const_get(:"#{cap_type}Tag")
       perm_type = "Project:#{cap_type.sub(/(ect|ion)\z/, "").downcase}tag"

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -875,7 +875,7 @@ RSpec.describe CloverAdmin do
   it "shows active pages on index page, grouped by related host" do
     expect(page).to have_no_content "Active Pages"
 
-    page1 = Prog::PageNexus.assemble("some problem", %w[a], nil).subject
+    page1 = Prog::PageNexus.assemble("some problem", %w[a].freeze, nil).subject
     page.refresh
     expect(page).to have_content "1 Active Pages"
     expect(page_data).to eq [
@@ -884,7 +884,7 @@ RSpec.describe CloverAdmin do
     click_link page1.summary
     expect(page.title).to eq "Ubicloud Admin - Page #{page1.ubid}"
 
-    Prog::PageNexus.assemble("another problem", %w[b], vm_pool.ubid).subject
+    Prog::PageNexus.assemble("another problem", %w[b].freeze, vm_pool.ubid).subject
     visit "/"
     expect(page).to have_content "2 Active Pages"
     expect(page_data).to eq [
@@ -898,7 +898,7 @@ RSpec.describe CloverAdmin do
     pj = Project.create(name: "test")
     vm = Prog::Vm::Nexus.assemble("a a", pj.id).subject
     vm.update(vm_host_id: vmh.id)
-    Prog::PageNexus.assemble("third problem", %w[c], vm.ubid).subject
+    Prog::PageNexus.assemble("third problem", %w[c].freeze, vm.ubid).subject
     visit "/"
     expect(page).to have_content "3 Active Pages"
     expect(page_data).to eq [
@@ -929,7 +929,7 @@ RSpec.describe CloverAdmin do
   it "handles request for invalid model or missing object" do
     %w[/model/Foo/ts1cyaqvp5ha6j5jt8ypbyagw9
       /model/ArchivedRecord/ts1cyaqvp5ha6j5jt8ypbyagw9
-      /model/SubjectTag/ts1cyaqvp5ha6j5jt8ypbyagw9].each do |path|
+      /model/SubjectTag/ts1cyaqvp5ha6j5jt8ypbyagw9].freeze.each do |path|
       expect { visit path }.to raise_error(RuntimeError, "admin route not handled: #{path}")
     end
   end
@@ -1330,7 +1330,7 @@ RSpec.describe CloverAdmin do
 
     download_strands = Strand.where(prog: "DownloadBootImage").all
     downloaded_names = download_strands.map { it.stack.first["image_name"] }.sort
-    expect(downloaded_names).to eq %w[almalinux-9 debian-12 github-ubuntu-2204 github-ubuntu-2404 postgres-ubuntu-2204 ubuntu-jammy ubuntu-noble]
+    expect(downloaded_names).to eq %w[almalinux-9 debian-12 github-ubuntu-2204 github-ubuntu-2404 postgres-ubuntu-2204 ubuntu-jammy ubuntu-noble].freeze
   end
 
   it "supports moving VmHost to github-runners location and downloading github images" do
@@ -1348,7 +1348,7 @@ RSpec.describe CloverAdmin do
 
     download_strands = Strand.where(prog: "DownloadBootImage").all
     downloaded_names = download_strands.map { it.stack.first["image_name"] }.sort
-    expect(downloaded_names).to eq %w[github-ubuntu-2204 github-ubuntu-2404]
+    expect(downloaded_names).to eq %w[github-ubuntu-2204 github-ubuntu-2404].freeze
   end
 
   it "supports force creating a VM on a VmHost" do
@@ -1398,7 +1398,7 @@ RSpec.describe CloverAdmin do
     BootImage.create(vm_host_id: vmh.id, name: "ubuntu-jammy", version: "2", size_gib: 14, activated_at: Time.now)
     BootImage.create(vm_host_id: vmh.id, name: "debian-12", version: "1", size_gib: 14, activated_at: Time.now)
     visit "/model/VmHost/#{vmh.ubid}/force_create_vm"
-    expect(page.all("select[name=boot_image] option").map(&:text)).to eq %w[debian-12 ubuntu-jammy]
+    expect(page.all("select[name=boot_image] option").map(&:text)).to eq %w[debian-12 ubuntu-jammy].freeze
   end
 
   it "rejects force-create VM when project UBID is invalid" do
@@ -1829,7 +1829,7 @@ RSpec.describe CloverAdmin do
     end
 
     it "allows creation of semaphore increment rollout strands" do
-      page_st = Prog::PageNexus.assemble("some problem", %w[a], nil)
+      page_st = Prog::PageNexus.assemble("some problem", %w[a].freeze, nil)
 
       select "Page - resolve", from: "Class - Semaphore"
       fill_in "Gap (seconds)", with: "90"
@@ -1879,7 +1879,7 @@ RSpec.describe CloverAdmin do
     end
 
     it "allows creation of semaphore increment without wait rollout strands" do
-      page_st = Prog::PageNexus.assemble("some problem", %w[a], nil)
+      page_st = Prog::PageNexus.assemble("some problem", %w[a].freeze, nil)
 
       select "Page - resolve", from: "Class - Semaphore"
       choose "Increment Without Waiting"
@@ -1901,7 +1901,7 @@ RSpec.describe CloverAdmin do
     end
 
     it "allows creation of semaphore decrement rollout strands" do
-      page_st = Prog::PageNexus.assemble("some problem", %w[a], nil)
+      page_st = Prog::PageNexus.assemble("some problem", %w[a].freeze, nil)
 
       select "Page - resolve", from: "Class - Semaphore"
       fill_in "Gap (seconds)", with: "90"

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -1383,14 +1383,14 @@ RSpec.describe Clover, "auth" do
         omniauth_key = oidc_provider.ubid.to_sym
         AccountIdentity.create(account_id: Account.first.id, provider: oidc_provider.ubid, uid: "789")
         OmniAuth.config.add_mock(omniauth_key, provider: oidc_provider.ubid, uid: "789",
-          info: {email: "user@example.com", groups: %w[group1 group2]})
+          info: {email: "user@example.com", groups: %w[group1 group2].freeze})
         click_button "Log out"
 
         fill_in "Email Address", with: TEST_USER_EMAIL
         click_button "Sign in"
         expect(page).to have_content("Password")
         expect(page).to have_content("Or login with:")
-        expect(Clog).to receive(:emit).with("OIDC groups login", oidc_groups_login: {groups: %w[group1 group2], group_prefix: "foo-"})
+        expect(Clog).to receive(:emit).with("OIDC groups login", oidc_groups_login: {groups: %w[group1 group2].freeze, group_prefix: "foo-"})
         click_button "TestOIDC"
 
         expect(page.title).to eq("Ubicloud - Default Dashboard")

--- a/spec/routes/web/firewall_spec.rb
+++ b/spec/routes/web/firewall_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe Clover, "firewall" do
     end
 
     describe "rules" do
-      %w[TCP UDP].each do |protocol|
+      %w[TCP UDP].freeze.each do |protocol|
         it "can add using custom address and #{protocol} port" do
           visit "#{project.path}#{firewall.path}/networking"
           click_link "Add Firewall Rule"

--- a/spec/routes/web/oidc_auth_spec.rb
+++ b/spec/routes/web/oidc_auth_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Clover, "OIDC auth" do
     before { oidc_provider.update(group_prefix: "org-") }
 
     it "extracts groups from id_token without calling userinfo endpoint" do
-      stub_token_endpoint(id_token: {groups: %w[eng ops]})
+      stub_token_endpoint(id_token: {groups: %w[eng ops].freeze})
       initiate_oidc_login
       expect(page.title).to eq("Ubicloud - Default Dashboard")
       visit "/oidc-groups"
@@ -185,7 +185,7 @@ RSpec.describe Clover, "OIDC auth" do
 
     it "issues userinfo call when groups not in id_token" do
       stub_token_endpoint  # generates id_token with sub+email but no groups
-      stub_userinfo_endpoint(body: {"sub" => "oidc_sub_123", "email" => "user@example.com", "groups" => %w[foo bar]})
+      stub_userinfo_endpoint(body: {"sub" => "oidc_sub_123", "email" => "user@example.com", "groups" => %w[foo bar].freeze})
       initiate_oidc_login
       expect(page.title).to eq("Ubicloud - Default Dashboard")
       visit "/oidc-groups"
@@ -194,7 +194,7 @@ RSpec.describe Clover, "OIDC auth" do
 
     it "handles userinfo call not including information that was in id token" do
       stub_token_endpoint(id_token: {email_verified: true})
-      stub_userinfo_endpoint(body: {"groups" => %w[foo bar]})
+      stub_userinfo_endpoint(body: {"groups" => %w[foo bar].freeze})
       initiate_oidc_login
       expect(page.title).to eq("Ubicloud - Default Dashboard")
       visit "/oidc-groups"

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -1246,7 +1246,7 @@ RSpec.describe Clover, "postgres" do
         expect(page).to have_flash_notice("Name updated")
         expect(pg.reload.name).to eq "new-name"
         expect(page).to have_content("new-name")
-        expect(pg.semaphores_dataset.select_order_map(:name)).to eq %w[refresh_certificates refresh_dns_record]
+        expect(pg.semaphores_dataset.select_order_map(:name)).to eq %w[refresh_certificates refresh_dns_record].freeze
       end
 
       it "does not refresh certificates when renaming PostgreSQL database with hostname version v3" do
@@ -1257,7 +1257,7 @@ RSpec.describe Clover, "postgres" do
         click_button "Rename"
         expect(page).to have_flash_notice("Name updated")
         expect(pg.reload.name).to eq "new-name"
-        expect(pg.semaphores_dataset.select_map(:name)).to eq %w[refresh_dns_record]
+        expect(pg.semaphores_dataset.select_map(:name)).to eq %w[refresh_dns_record].freeze
       end
 
       it "does not show rename option without permissions" do

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe Clover, "project" do
         project = Project[name:]
         expect(project.accounts_dataset.count).to eq 1
         expect(project.access_control_entries.count).to eq 2
-        expect(project.subject_tags.map(&:name).sort).to eq %w[Admin Member]
+        expect(project.subject_tags.map(&:name).sort).to eq %w[Admin Member].freeze
         expect(user.projects).to include project
       end
 
@@ -387,7 +387,7 @@ RSpec.describe Clover, "project" do
         find_by_id("desktop-menu").click_link "Settings"
 
         expect(page.title).to eq("Ubicloud - #{project.name}")
-        %w[VmVCpu PostgresVCpu KubernetesVCpu MachineImageVersion].each do |resource_type|
+        %w[VmVCpu PostgresVCpu KubernetesVCpu MachineImageVersion].freeze.each do |resource_type|
           expect(page).to have_content(resource_type)
         end
       end

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -951,7 +951,7 @@ RSpec.describe Clover, "vm" do
       end
     end
 
-    %w[restart start stop].each do |action|
+    %w[restart start stop].freeze.each do |action|
       describe action do
         it "can #{action} vm" do
           if action == "start"

--- a/spec/scheduling/dispatcher_spec.rb
+++ b/spec/scheduling/dispatcher_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Scheduling::Dispatcher do
   end
 
   describe "#repartition_thread" do
-    %w[foo 257].each do |notification|
+    %w[foo 257].freeze.each do |notification|
       it "emits for respirate NOTIFY #{notification}" do
         t = Thread.new do
           payload = nil

--- a/views/admin/github_runner_usage.erb
+++ b/views/admin/github_runner_usage.erb
@@ -1,7 +1,7 @@
 <% @page_title = "GitHub Runner #{@arch} VM Usage" %>
 
 <% total = Hash.new(0)
-types = %w[runner vm]
+types = %w[runner vm].freeze
 @data.each do |row|
     row[:name] = table_link(value: row[:name], link: "/model/GithubInstallation/#{UBID.to_ubid(row.delete(:id))}")
     row.each { |k, v| total[k] += v if v.is_a?(Numeric) }

--- a/views/admin/rollouts.erb
+++ b/views/admin/rollouts.erb
@@ -51,7 +51,7 @@ end %>
     <% form({action: "/rollouts/start/RolloutBootImage", method: "post", id: "start-rollout", class: "rollout-form"}, button: "Start Boot Image Rollout", wrapper: :div) do |f| %>
       <%== f.input(:select, key: :image_name, label: "Image Name", required: true, add_blank: true, options: Prog::DownloadBootImage::BOOT_IMAGE_SHA256.keys) %>
       <%== f.input(:text, key: :version, label: "Version", required: true) %>
-      <%== f.input(:select, key: :arch, label: "Arch", required: true, options: %w[x64 arm64], value: "x64") %>
+      <%== f.input(:select, key: :arch, label: "Arch", required: true, options: %w[x64 arm64].freeze, value: "x64") %>
       <%== f.input(:number, key: :concurrency, label: "Concurrency", required: true, attr: {min: 1}, value: 10) %>
       <%== f.input(:text, key: :exclude_vm_host_ids, label: "Exclude VM Host IDs (comma separated)") %>
       <%== f.input(:checkbox, key: :exclude_minio_hosts, label: "Exclude Minio Hosts", checked: true) %>

--- a/views/github/tabbar.erb
+++ b/views/github/tabbar.erb
@@ -2,7 +2,7 @@
   "components/page_header",
   title: "GitHub Runners Integration",
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["GitHub Runners", "#{@project.path}/github"],
     [@page_title, "#"]

--- a/views/kubernetes-cluster/create.erb
+++ b/views/kubernetes-cluster/create.erb
@@ -7,10 +7,10 @@
 <%== part(
   "components/page_header",
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["Kubernetes Clusters", "#{@project.path}/kubernetes-cluster"],
-    %w[Create #]
+    %w[Create #].freeze
   ]
 ) %>
 

--- a/views/kubernetes-cluster/overview.erb
+++ b/views/kubernetes-cluster/overview.erb
@@ -11,7 +11,7 @@
   ["Worker Nodes", @kc.nodepools.sum { it.node_count }]
 ]
 
-if %w[running upgrading].include?(@kc.display_state)
+if %w[running upgrading].freeze.include?(@kc.display_state)
   data.push(["Service URL", @kc.services_lb.hostname, { copyable: true }]) # TODO: Assign LB to a column properly
 end
 

--- a/views/machine_image/create.erb
+++ b/views/machine_image/create.erb
@@ -4,10 +4,10 @@ option_tree, option_parents = generate_machine_image_options %>
 <%== part(
   "components/page_header",
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["Machine Images", "#{@project.path}/machine-image"],
-    %w[Create #]
+    %w[Create #].freeze
   ]
 ) %>
 

--- a/views/machine_image/create_version.erb
+++ b/views/machine_image/create_version.erb
@@ -4,11 +4,11 @@ option_tree, option_parents = generate_machine_image_version_options(@machine_im
 <%== part(
   "components/page_header",
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["Machine Images", "#{@project.path}/machine-image"],
     [@machine_image.name, path(@machine_image)],
-    %w[Create\ Version #]
+    %w[Create\ Version #].freeze
   ]
 ) %>
 

--- a/views/machine_image/index.erb
+++ b/views/machine_image/index.erb
@@ -2,7 +2,7 @@
 
 <%== part(
   "components/page_header",
-  breadcrumbs: [%w[Projects /project], [@project.name, @project.path], ["Machine Images", "#"]],
+  breadcrumbs: [%w[Projects /project].freeze, [@project.name, @project.path], ["Machine Images", "#"]],
   right_items: has_project_permission("MachineImage:create") ?
     [part("components/button", text: "Create Machine Image", link: "#{@project.path}/machine-image/create")] : []
 ) %>

--- a/views/machine_image/versions.erb
+++ b/views/machine_image/versions.erb
@@ -3,7 +3,7 @@
   latest_version_id = @machine_image.latest_version_id
   version_headers = ["Version", "State", "Size", "Archive Size", "Created"]
   version_headers << "" if can_edit
-  in_flight_states = %w[creating destroying] %>
+  in_flight_states = %w[creating destroying].freeze %>
 
 <% if @versions.any? { |v| in_flight_states.include?(v.metal&.display_state) } %>
   <div class="auto-refresh hidden" data-interval="60"></div>

--- a/views/networking/firewall/create.erb
+++ b/views/networking/firewall/create.erb
@@ -6,10 +6,10 @@
 <%== part(
   "components/page_header",
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["Firewalls", "#{@project.path}/firewall"],
-    %w[Create #]
+    %w[Create #].freeze
   ]
 ) %>
 

--- a/views/networking/load_balancer/create.erb
+++ b/views/networking/load_balancer/create.erb
@@ -4,10 +4,10 @@
 <%== part(
   "components/page_header",
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["Load Balancers", "#{@project.path}/load-balancer"],
-    %w[Create #]
+    %w[Create #].freeze
   ]
 ) %>
 

--- a/views/networking/private_subnet/create.erb
+++ b/views/networking/private_subnet/create.erb
@@ -4,10 +4,10 @@
 <%== part(
   "components/page_header",
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["Private Subnets", "#{@project.path}/private-subnet"],
-    %w[Create #]
+    %w[Create #].freeze
   ]
 ) %>
 

--- a/views/networking/private_subnet/networking.erb
+++ b/views/networking/private_subnet/networking.erb
@@ -30,7 +30,7 @@ viewable_fws, viewable_subnets, disconnectable_subnets =
   <%== part(
     "components/table_card",
     title: "Attached Firewalls",
-    headers: %w[Name Description],
+    headers: %w[Name Description].freeze,
     empty_state: "No firewall attached",
     rows:
       @ps.firewalls.map do |fw|

--- a/views/object/show.erb
+++ b/views/object/show.erb
@@ -4,7 +4,7 @@
   "components/page_header",
   title: "",
   breadcrumbs: breadcrumbs || [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     [breadcrumb_label, "#{@project.path}/#{type}"],
     [object.name, "#"]

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -18,10 +18,10 @@
 <%== part(
   "components/page_header",
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["PostgreSQL Databases", "#{@project.path}/postgres"],
-    %w[Create #]
+    %w[Create #].freeze
   ],
   right_items: [logo ? "<img src=\"/#{logo}\" class=\"h-6 object-contain\"/>" : nil]
 ) %>

--- a/views/postgres/index.erb
+++ b/views/postgres/index.erb
@@ -3,7 +3,7 @@
 <% if @postgres_databases.count > 0 %>
   <%== part(
     "components/page_header",
-    breadcrumbs: [%w[Projects /project], [@project.name, @project.path], ["PostgreSQL Databases", "#"]],
+    breadcrumbs: [%w[Projects /project].freeze, [@project.name, @project.path], ["PostgreSQL Databases", "#"]],
     right_items: [<<-DROPDOWN]
       <div class="group dropdown relative inline-block text-left">
         <div>#{part("components/button", text: "Create PostgreSQL Database", right_icon: "hero-chevron-down")}
@@ -48,7 +48,7 @@
   <%== part(
     "components/page_header",
     title: "Create PostgreSQL Database",
-    breadcrumbs: [%w[Projects /project], [@project.name, @project.path], ["PostgreSQL Databases", "#"]]
+    breadcrumbs: [%w[Projects /project].freeze, [@project.name, @project.path], ["PostgreSQL Databases", "#"]]
   ) %>
 
   <div class="grid gap-6">

--- a/views/postgres/settings.erb
+++ b/views/postgres/settings.erb
@@ -26,7 +26,7 @@
               </div>
             </div>
             <% if @project.get_ff_postgres_enable_maintenance_window_days %>
-              <% day_names = %w[Monday Tuesday Wednesday Thursday Friday Saturday Sunday] %>
+              <% day_names = %w[Monday Tuesday Wednesday Thursday Friday Saturday Sunday].freeze %>
               <fieldset>
                 <legend class="text-sm font-medium leading-6 text-gray-900">Preferred days</legend>
                 <p class="mt-1 text-sm text-gray-500">Select one or more days, or leave all unselected to allow any day.</p>

--- a/views/private-location/create.erb
+++ b/views/private-location/create.erb
@@ -11,10 +11,10 @@ options.add_option(name: "secret_key")
 <%== part(
   "components/page_header",
   breadcrumbs: [
-    %w[Projects project],
+    %w[Projects project].freeze,
     [@project.name, @project.path],
     ["AWS Regions", "#{@project.path}/private-location"],
-    %w[Create #]
+    %w[Create #].freeze
   ]
 ) %>
 

--- a/views/private-location/show.erb
+++ b/views/private-location/show.erb
@@ -4,7 +4,7 @@
   "components/page_header",
   title: "Region Detail",
   back: "/private-location",
-  breadcrumbs: [%w[AWS\ Regions /private-location], [@location.ui_name, @location.path]]
+  breadcrumbs: [%w[AWS\ Regions /private-location].freeze, [@location.ui_name, @location.path]]
 ) %>
 
 <div class="grid gap-6">

--- a/views/project/access-control.erb
+++ b/views/project/access-control.erb
@@ -5,7 +5,7 @@
     ["aces[][object]", @object_options.to_h { |k, v| [k, k ? v.map { [_1.ubid, _1.name] } : v] }]
   ]
   form_action = path(@token)
-  table_headers = %w[Action Object]
+  table_headers = %w[Action Object].freeze
   edit_perm = true
 
   unrestricted = @token.unrestricted_token_for_project?(@project.id)
@@ -23,7 +23,7 @@ else
     ["aces[][object]", @object_options.to_h { |k, v| [k, k ? v.map { [_1.ubid, _1.name] } : v] }]
   ]
   form_action = "#{user_path}/access-control"
-  table_headers = %w[Subject Action Object]
+  table_headers = %w[Subject Action Object].freeze
   edit_perm = has_project_permission("Project:editaccess")
 end
 @page_title = "#{@project.name} - #{page_header}" %>
@@ -34,7 +34,7 @@ end
   <%== part(
     "components/page_header",
     title: page_header,
-    breadcrumbs: [%w[Projects /project], [@project.name, @project.path], [page_header, "#"]]
+    breadcrumbs: [%w[Projects /project].freeze, [@project.name, @project.path], [page_header, "#"]]
   ) %>
 </div>
 
@@ -97,7 +97,7 @@ end
                   <% end %>
                   <td class="py-4 px-3 text-right">
                     <%== hidden_inputs("aces[][ubid]" => ubid) %>
-                    <%== part("components/form/checkbox", id_prefix: "ace-#{ubid}-", name: "aces[][deleted]", options: [%w[true Delete]]) %>
+                    <%== part("components/form/checkbox", id_prefix: "ace-#{ubid}-", name: "aces[][deleted]", options: [%w[true Delete].freeze]) %>
                   </td>
                 <% else %>
                   <% tags.each do |tag| %>

--- a/views/project/audit_log.erb
+++ b/views/project/audit_log.erb
@@ -3,7 +3,7 @@
 <%== part(
   "components/page_header",
   title: "Audit Log",
-  breadcrumbs: [%w[Projects /project], [@project.name, @project.path], ["Audit Log", "#"]]
+  breadcrumbs: [%w[Projects /project].freeze, [@project.name, @project.path], ["Audit Log", "#"]]
 ) %>
 
 <div class="grid gap-6">

--- a/views/project/authentication_audit_log.erb
+++ b/views/project/authentication_audit_log.erb
@@ -5,7 +5,7 @@
   <%== part(
     "components/page_header",
     title: "Authentication Audit Log",
-    breadcrumbs: [%w[Projects /project], [@project.name, @project.path], ["Authentication Audit Log", "#"]]
+    breadcrumbs: [%w[Projects /project].freeze, [@project.name, @project.path], ["Authentication Audit Log", "#"]]
   ) %>
 <% else %>
   <% @page_title = "Authentication Audit Log" %>

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -9,7 +9,7 @@ end
 <% if billing_info = @project.billing_info %>
   <%== part(
     "components/page_header",
-    breadcrumbs: [%w[Projects /project], [@project.name, @project.path], %w[Billing #]]
+    breadcrumbs: [%w[Projects /project].freeze, [@project.name, @project.path], %w[Billing #].freeze]
   ) %>
 
   <div class="grid grid-cols-1 gap-6">

--- a/views/project/create.erb
+++ b/views/project/create.erb
@@ -1,6 +1,6 @@
 <% @page_title = "Create Project" %>
 
-<%== part("components/page_header", breadcrumbs: [%w[Projects /project], %w[Create #]]) %>
+<%== part("components/page_header", breadcrumbs: [%w[Projects /project].freeze, %w[Create #].freeze]) %>
 
 <div class="grid gap-6">
   <% form(action: "/project", method: :post) do %>

--- a/views/project/index.erb
+++ b/views/project/index.erb
@@ -50,7 +50,7 @@
     <%== part(
         "components/table_card",
         title: "Project Invitations",
-        headers: %w[Name ID Invited\ By Accept Decline],
+        headers: %w[Name ID Invited\ By Accept Decline].freeze,
         rows: @invitations.map do |inv|
            project_ubid = inv.project.ubid
            [

--- a/views/project/invoice.erb
+++ b/views/project/invoice.erb
@@ -3,7 +3,7 @@
 <%== part(
   "components/page_header",
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["Billing", "#{@project.path}/billing"],
     ["Current Usage Summary", "#"]

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -11,7 +11,7 @@
   "components/page_header",
   title: "Project Settings",
   back: "/project",
-  breadcrumbs: [%w[Projects /project], [@project.name, @project.path], %w[Settings #]]
+  breadcrumbs: [%w[Projects /project].freeze, [@project.name, @project.path], %w[Settings #].freeze]
 ) %>
 
 <div class="grid gap-6">

--- a/views/project/tag-list.erb
+++ b/views/project/tag-list.erb
@@ -10,7 +10,7 @@ modification_allowed = has_project_permission("Project:#{@tag_type.sub(/(ect|ion
     "components/page_header",
     title: page_title,
     breadcrumbs: [
-      %w[Projects /project],
+      %w[Projects /project].freeze,
       [@project.name, @project.path],
       ["Access Control", "#{@project.path}/user/access-control"],
       [page_title, "#"]

--- a/views/project/tag.erb
+++ b/views/project/tag.erb
@@ -45,7 +45,7 @@ current_members.sort! %>
     "components/page_header",
     title: "#{@display_tag_type} Tag: #{@tag.name}",
     breadcrumbs: [
-      %w[Projects /project],
+      %w[Projects /project].freeze,
       [@project.name, @project.path],
       ["Access Control", "#{@project.path}/user/access-control"],
       ["#{@display_tag_type} Tags", "#{@project.path}/user/access-control/tag/#{@tag_type}"],

--- a/views/project/token.erb
+++ b/views/project/token.erb
@@ -3,7 +3,7 @@
 <%== part(
   "components/page_header",
   title: "Personal Access Tokens",
-  breadcrumbs: [%w[Projects /project], [@project.name, @project.path], ["Personal Access Tokens", "#"]],
+  breadcrumbs: [%w[Projects /project].freeze, [@project.name, @project.path], ["Personal Access Tokens", "#"]],
   right_items: [form({action: "#{@project.path}/token", method: :post, id: "create-pat"}, emit: false) do |f|
     f << part("components/form/submit_button", text: "Create Token")
   end]

--- a/views/project/user.erb
+++ b/views/project/user.erb
@@ -10,7 +10,7 @@
 <%== part(
   "components/page_header",
   title: "User Management",
-  breadcrumbs: [%w[Projects /project], [@project.name, @project.path], %w[Users #]]
+  breadcrumbs: [%w[Projects /project].freeze, [@project.name, @project.path], %w[Users #].freeze]
 ) %>
 
 <div class="grid gap-6">

--- a/views/ssh-public-key/index.erb
+++ b/views/ssh-public-key/index.erb
@@ -6,7 +6,7 @@
   back: @project.path,
   right_items: [part("components/button", text: "Register SSH Public Key", link: "#{@project.path}/ssh-public-key/register", extra_class: "mr-2")],
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["SSH Public Keys", "#{@project.path}/ssh-public-key"]
   ]

--- a/views/ssh-public-key/register.erb
+++ b/views/ssh-public-key/register.erb
@@ -16,7 +16,7 @@ back = "#{@project.path}/ssh-public-key" %>
   back:,
   right_items:,
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["SSH Public Keys", back],
     %W[#{action_type} #]

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -13,10 +13,10 @@ current_usage = @project.current_resource_usage("VmVCpu")
 <%== part(
   "components/page_header",
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["Virtual Machines", "#{@project.path}/vm"],
-    %w[Create #]
+    %w[Create #].freeze
   ]
 ) %>
 

--- a/views/vm/create_gpu_request_access.erb
+++ b/views/vm/create_gpu_request_access.erb
@@ -4,10 +4,10 @@
 <%== part(
   "components/page_header",
   breadcrumbs: [
-    %w[Projects /project],
+    %w[Projects /project].freeze,
     [@project.name, @project.path],
     ["Virtual Machines", "#{@project.path}/vm"],
-    %w[Create #]
+    %w[Create #].freeze
   ]
 ) %>
 

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -3,7 +3,7 @@
 
 <%== part(
   "components/page_header",
-  breadcrumbs: [%w[Projects /project], [@project.name, @project.path], ["Virtual Machines", "#"]],
+  breadcrumbs: [%w[Projects /project].freeze, [@project.name, @project.path], ["Virtual Machines", "#"]],
   right_items: (!@vms.empty? && has_project_permission("Vm:create")) ?
     ([
         part("components/button", text: "Create Virtual Machine", link: "vm/create?show_gpu=f", extra_class: "mr-2"),


### PR DESCRIPTION
`%w[a b]` will allocate a new array at runtime. `%w[a b].freeze` will not (if the file uses frozen string literals, which is true for our files).

This was a mechanical change using the following script:

```
ruby \
  -e 'ARGV.each{|f| p f; File.write(f, File.read(f).gsub(/(%w\[[^\]]*\])(?!\.freeze)/, "\\1.freeze"))}' \
  `git grep -F '%w[' | fgrep -v '].freeze' | awk '{print $1}' | uniq | sed -e 's/:.*$//'`
```

However, there were some patterns this doesn't work with, such as `%w[].map!` and `%w[] <<`. I reverted those changes manually before committing.