### PR TITLE
Hard wrap object-list li tags on admin site

### DIFF
--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -227,6 +227,9 @@ code {
 
 #object-list {
   columns: 200px 4;
+  li {
+    word-break: break-all;
+  }
 }
 
 #strand-info form {


### PR DESCRIPTION
DnsRecord browsing is almost impossible to use without this change.