### PR TITLE
Return 204 from getCacheEntry when cache scope cannot be determined

### DIFF
--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -24,6 +24,8 @@ class Clover
         scopes.compact!
         scopes.uniq!
 
+        next 204 if scopes.empty?
+
         dataset = dataset.where(scope: scopes)
           .order(Sequel.case(scopes.map.with_index { |scope, idx| [{scope:}, idx] }.to_h, scopes.length))
       end

--- a/spec/routes/runtime/github_spec.rb
+++ b/spec/routes/runtime/github_spec.rb
@@ -347,6 +347,15 @@ RSpec.describe Clover, "github" do
         expect(JSON.parse(last_response.body).slice("cacheKey", "cacheVersion", "scope").values).to eq(["k1", "v1", "main"])
       end
 
+      it "returns no cache when scope cannot be determined and check is enabled" do
+        runner.update(workflow_job: nil)
+        repository.update(default_branch: nil)
+        GithubCacheEntry.create(key: "k1", version: "v1", scope: "dev", repository_id: repository.id, created_by: runner.id, committed_at: Time.now)
+        get "/runtime/github/cache", {keys: "k1", version: "v1"}
+
+        expect(last_response.status).to eq(204)
+      end
+
       it "returns the first matched cache with key for runner's branch" do
         [
           ["k1", "v1", "dev"],


### PR DESCRIPTION
When cache_scope_protected is on but neither the runner's head branch nor the repository's default_branch is known, scopes ended up empty, producing an invalid ORDER BY (CASE ELSE ... END) and a PG::SyntaxError. Return 204 instead, rather than falling through to an unscoped query that would leak caches across scopes.