### PR TITLE
Serialize kubernetes node retirement with a nodepool lock

### DIFF
--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -174,17 +174,23 @@ class Clover
 
         authorize("KubernetesCluster:edit", kc.id)
 
-        np = @kn = node.kubernetes_nodepool
         handle_validation_failure("kubernetes-cluster/nodepool/show") { @page = "nodes" }
 
-        if np.node_count <= 1
-          fail_kubernetes_unprocessable("You cannot retire the last node of a nodepool")
-        end
-
+        np = nil
         DB.transaction do
+          np = @kn = node.kubernetes_nodepool(&:for_update)
+
+          if node.retire_set?
+            fail_kubernetes_unprocessable("Node #{node.name} is already being retired")
+          end
+
+          if np.node_count <= 1
+            fail_kubernetes_unprocessable("You cannot retire the last node of a nodepool")
+          end
+
           node.incr_retire
           np.this.update(node_count: Sequel[:node_count] - 1)
-          audit_log(node, "retire", [kc])
+          audit_log(node, "retire", [kc, np])
         end
 
         if api?

--- a/spec/routes/api/project/location/kubernetes_cluster_spec.rb
+++ b/spec/routes/api/project/location/kubernetes_cluster_spec.rb
@@ -419,6 +419,16 @@ RSpec.describe Clover, "kubernetes-cluster" do
         expect(node.retire_set?).to be false
         expect(kn.reload.node_count).to eq(1)
       end
+
+      it "does not allow retiring a node that is already being retired" do
+        node = assemble_worker_node("retiring-node")
+        node.incr_retire
+
+        post "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.name}/node/#{node.name}/retire"
+
+        expect(last_response).to have_api_error(422, "Node retiring-node is already being retired")
+        expect(kn.reload.node_count).to eq(2)
+      end
     end
 
     describe "upgrade" do


### PR DESCRIPTION
Two concurrent retire requests could both read node_count before either decrement committed, allowing every node of a nodepool to be retired. Take a FOR UPDATE lock on the nodepool and re-check node_count inside the transaction, mirroring the nodepool delete endpoint. Also reject retiring a node whose retire semaphore is already set, since a repeated retire would decrement node_count twice for a single node.