### PR TITLE
Use monitor-observed disk usage for the Postgres scale-down guard

### DIFF
--- a/migrate/20260723_add_postgres_disk_usage_monitor.rb
+++ b/migrate/20260723_add_postgres_disk_usage_monitor.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:postgres_disk_usage_monitor, unlogged: true) do
+      column :postgres_server_id, :uuid, primary_key: true, null: false
+      column :data_disk_usage_percent, :smallint
+      column :observed_at, :timestamptz
+    end
+  end
+end

--- a/migrate/postgres_monitor_db.sql
+++ b/migrate/postgres_monitor_db.sql
@@ -5,3 +5,12 @@ CREATE UNLOGGED TABLE public.postgres_lsn_monitor (
 
 ALTER TABLE ONLY public.postgres_lsn_monitor
     ADD CONSTRAINT postgres_lsn_monitor_pkey PRIMARY KEY (postgres_server_id);
+
+CREATE UNLOGGED TABLE public.postgres_disk_usage_monitor (
+    postgres_server_id uuid NOT NULL,
+    data_disk_usage_percent smallint,
+    observed_at timestamp with time zone
+);
+
+ALTER TABLE ONLY public.postgres_disk_usage_monitor
+    ADD CONSTRAINT postgres_disk_usage_monitor_pkey PRIMARY KEY (postgres_server_id);

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -29,6 +29,7 @@ class PostgresServer < Sequel::Model
   def before_destroy
     super
     lsn_monitor_ds.delete
+    disk_usage_monitor_ds.delete
   end
 
   def aws?
@@ -332,6 +333,16 @@ class PostgresServer < Sequel::Model
 
   def last_known_lsn
     lsn_monitor_ds.get(:last_known_lsn)
+  end
+
+  DISK_USAGE_MAX_AGE_SECONDS = 15 * 60
+
+  def disk_usage_monitor_ds
+    POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].where(postgres_server_id: id)
+  end
+
+  def observed_disk_usage_percent(max_age: DISK_USAGE_MAX_AGE_SECONDS)
+    disk_usage_monitor_ds.where { observed_at > Time.now - max_age }.get(:data_disk_usage_percent)
   end
 
   def failover_target(mode: "unplanned")
@@ -721,6 +732,9 @@ class PostgresServer < Sequel::Model
   def observe_data_disk_usage(session)
     disk_usage_percent = session[:ssh_session].exec!("df --output=pcent /dat | tail -n 1").strip.delete("%").to_i
     session[:disk_usage_percent] = disk_usage_percent
+    POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor]
+      .insert_conflict(target: :postgres_server_id, update: {data_disk_usage_percent: disk_usage_percent, observed_at: Sequel::CURRENT_TIMESTAMP})
+      .insert(postgres_server_id: id, data_disk_usage_percent: disk_usage_percent, observed_at: Sequel::CURRENT_TIMESTAMP)
     if reload.primary?
       if (disk_usage_percent >= 77 || resource.storage_auto_scale_action_performed_80_set? || resource.storage_auto_scale_canceled_set?) && !resource.check_disk_usage_set?
         resource.incr_check_disk_usage

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -74,18 +74,12 @@ class Clover
 
         validate_postgres_input(pg.name, postgres_params)
 
-        if target_storage_size_gib < pg.representative_server.storage_size_gib && (tsdb_client = PostgresServer.victoria_metrics_client)
-          disk_usage = begin
-            query = Metrics::POSTGRES_METRICS[:disk_usage].series[0].query.gsub("$ubicloud_resource_id", pg.ubid)
-            tsdb_client.query(query:).last
-          rescue
-            nil
-          end
+        if target_storage_size_gib < pg.representative_server.storage_size_gib
+          disk_usage_percent = pg.representative_server.observed_disk_usage_percent
 
-          fail CloverError.new(400, "InvalidRequest", "Metrics unavailable right now to verify scale down safety", {}) unless disk_usage
+          fail CloverError.new(400, "InvalidRequest", "Metrics unavailable right now to verify scale down safety", {}) unless disk_usage_percent
 
-          disk_usage_percentage = disk_usage["value"][1].to_f
-          current_disk_usage = disk_usage_percentage * pg.representative_server.storage_size_gib / 100
+          current_disk_usage = disk_usage_percent * pg.representative_server.storage_size_gib / 100.0
 
           if target_storage_size_gib * 0.8 < current_disk_usage
             fail Validation::ValidationFailed.new({storage_size: "Insufficient storage size is requested. It is only possible to reduce the storage size if the current usage is less than 80% of the requested size."})

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -1482,6 +1482,45 @@ RSpec.describe PostgresServer do
     end
   end
 
+  describe "disk usage monitor persistence" do
+    let(:session) {
+      {ssh_session: Net::SSH::Connection::Session.allocate}
+    }
+
+    after do
+      POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].where(postgres_server_id: postgres_server.id).delete
+    end
+
+    it "observe_data_disk_usage upserts the observed percent with a timestamp" do
+      expect(session[:ssh_session]).to receive(:_exec!).with("df --output=pcent /dat | tail -n 1").and_return("  42%\n")
+      postgres_server.observe_data_disk_usage(session)
+      row = postgres_server.disk_usage_monitor_ds.first
+      expect(row[:data_disk_usage_percent]).to eq(42)
+      expect(row[:observed_at]).not_to be_nil
+
+      expect(session[:ssh_session]).to receive(:_exec!).with("df --output=pcent /dat | tail -n 1").and_return("  43%\n")
+      postgres_server.observe_data_disk_usage(session)
+      expect(postgres_server.disk_usage_monitor_ds.count).to eq(1)
+      expect(postgres_server.disk_usage_monitor_ds.get(:data_disk_usage_percent)).to eq(43)
+    end
+
+    it "observed_disk_usage_percent returns fresh observations and nil for stale or missing ones" do
+      expect(postgres_server.observed_disk_usage_percent).to be_nil
+
+      POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].insert(postgres_server_id: postgres_server.id, data_disk_usage_percent: 42, observed_at: Time.now - PostgresServer::DISK_USAGE_MAX_AGE_SECONDS - 60)
+      expect(postgres_server.observed_disk_usage_percent).to be_nil
+
+      postgres_server.disk_usage_monitor_ds.update(observed_at: Time.now)
+      expect(postgres_server.observed_disk_usage_percent).to eq(42)
+    end
+
+    it "deletes the monitor row on destroy" do
+      POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].insert(postgres_server_id: postgres_server.id, data_disk_usage_percent: 42, observed_at: Time.now)
+      postgres_server.destroy
+      expect(POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].where(postgres_server_id: postgres_server.id).count).to eq(0)
+    end
+  end
+
   describe "#observe_root_disk_usage" do
     let(:session) {
       {ssh_session: Net::SSH::Connection::Session.allocate}

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -301,24 +301,22 @@ RSpec.describe Clover, "postgres" do
       it "can scale down storage if the requested size is enough for existing data" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(PostgresResource.dataset.class, first: pg, association_join: instance_double(Sequel::Dataset, sum: 1))).at_least(:once)
         expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
-        tsdb_client = instance_double(VictoriaMetrics::Client)
-        expect(PostgresServer).to receive(:victoria_metrics_client).and_return(tsdb_client)
-        expect(tsdb_client).to receive(:query).and_return([{"value" => [Time.now.to_i, "5.0"]}])
+        POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].insert(postgres_server_id: pg.representative_server.id, data_disk_usage_percent: 5, observed_at: Time.now)
 
         patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}", {
           storage_size: 64,
         }.to_json
 
         expect(pg.reload.target_storage_size_gib).to eq(64)
+      ensure
+        POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].where(postgres_server_id: pg.representative_server.id).delete
       end
 
       it "does not scale down storage if the requested size is too small for existing data" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(Sequel::Dataset, first: pg))
         expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
         expect(pg.representative_server).to receive(:storage_size_gib).and_return(128).at_least(:once)
-        tsdb_client = instance_double(VictoriaMetrics::Client)
-        expect(PostgresServer).to receive(:victoria_metrics_client).and_return(tsdb_client)
-        expect(tsdb_client).to receive(:query).and_return([{"value" => [Time.now.to_i, "95.0"]}])
+        POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].insert(postgres_server_id: pg.representative_server.id, data_disk_usage_percent: 95, observed_at: Time.now)
 
         patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}", {
           storage_size: 64,
@@ -326,6 +324,8 @@ RSpec.describe Clover, "postgres" do
 
         expect(pg.reload.target_storage_size_gib).to eq(128)
         expect(last_response).to have_api_error(400, "Validation failed for following fields: storage_size", {"storage_size" => "Insufficient storage size is requested. It is only possible to reduce the storage size if the current usage is less than 80% of the requested size."})
+      ensure
+        POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].where(postgres_server_id: pg.representative_server.id).delete
       end
 
       it "returns error message if current usage is unknown" do
@@ -337,12 +337,10 @@ RSpec.describe Clover, "postgres" do
         expect(last_response).to have_api_error(400, "Validation failed for following fields: size")
       end
 
-      it "blocks scale down if metrics query fails" do
+      it "blocks scale down if the disk usage observation is stale" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(PostgresResource.dataset.class, first: pg, association_join: instance_double(Sequel::Dataset, sum: 1))).at_least(:once)
         expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
-        tsdb_client = instance_double(VictoriaMetrics::Client)
-        expect(PostgresServer).to receive(:victoria_metrics_client).and_return(tsdb_client)
-        expect(tsdb_client).to receive(:query).and_raise(StandardError.new("error"))
+        POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].insert(postgres_server_id: pg.representative_server.id, data_disk_usage_percent: 5, observed_at: Time.now - PostgresServer::DISK_USAGE_MAX_AGE_SECONDS - 60)
 
         patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}", {
           storage_size: 64,
@@ -350,26 +348,13 @@ RSpec.describe Clover, "postgres" do
 
         expect(last_response.status).to eq(400)
         expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Metrics unavailable right now to verify scale down safety")
+      ensure
+        POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].where(postgres_server_id: pg.representative_server.id).delete
       end
 
-      it "skips disk usage check if metrics client is unavailable" do
+      it "blocks scale down if there is no disk usage observation" do
         expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(PostgresResource.dataset.class, first: pg, association_join: instance_double(Sequel::Dataset, sum: 1))).at_least(:once)
         expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
-        expect(PostgresServer).to receive(:victoria_metrics_client).and_return(nil)
-
-        patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}", {
-          storage_size: 64,
-        }.to_json
-
-        expect(pg.reload.target_storage_size_gib).to eq(64)
-      end
-
-      it "blocks scale down if no disk usage data available" do
-        expect(project).to receive(:postgres_resources_dataset).and_return(instance_double(PostgresResource.dataset.class, first: pg, association_join: instance_double(Sequel::Dataset, sum: 1))).at_least(:once)
-        expect(described_class).to receive(:authorized_project).with(user, project.id).and_return(project)
-        tsdb_client = instance_double(VictoriaMetrics::Client)
-        expect(PostgresServer).to receive(:victoria_metrics_client).and_return(tsdb_client)
-        expect(tsdb_client).to receive(:query).and_return([])
 
         patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}", {
           storage_size: 64,
@@ -377,6 +362,7 @@ RSpec.describe Clover, "postgres" do
 
         expect(last_response.status).to eq(400)
         expect(JSON.parse(last_response.body)["error"]["message"]).to eq("Metrics unavailable right now to verify scale down safety")
+        expect(pg.reload.target_storage_size_gib).to eq(128)
       end
 
       it "fails to update read replica" do


### PR DESCRIPTION
The storage scale-down guard currently queries the disk_usage metric from VictoriaMetrics in the PATCH request path. This has two problems:

1. When no VictoriaMetrics client is configured (VictoriaMetricsResource.client_for_project returns nil), the guard is silently skipped, so a customer can shrink target_storage_size_gib below their data size. Convergence then provisions a replacement server whose backup fetch does not fit the smaller disk.
2. A safety decision in the web request path depends on tsdb availability, while the control plane already observes the same number directly: the storage auto-scaler trusts monitor-observed SSH df (PostgresServer#disk_usage_percent).

This PR persists the df observation the monitor already makes about once a minute in observe_data_disk_usage into a new UNLOGGED postgres_disk_usage_monitor table (same pattern as postgres_lsn_monitor), and points the guard at it:

- Fresh observation (<= 15 minutes): guard evaluates the existing 80%-of-target rule unchanged.
- Missing or stale observation: fail closed with the existing "Metrics unavailable right now to verify scale down safety" 400.

Both user-facing error messages are unchanged. The only behavior change is that the guard no longer silently no-ops when VictoriaMetrics is not configured or unavailable.