### PR TITLE
Apply the clover secure SSH command generation approach to rhizome

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -525,6 +525,20 @@ namespace :linter do
         end
       end
     end
+
+    # Rhizome specs must mock the underlying _run_command instead of r,
+    # so that r's command-building/checking logic is actually exercised.
+    Dir.glob("rhizome/*/spec/**/*.rb").each do |file|
+      number = 0
+      File.foreach(file) do |line|
+        number += 1
+        if line.include?("(:r)")
+          failure = true
+          warn "Potentially insecure method override: #{file}:#{number}: #{line}"
+        end
+      end
+    end
+
     exit(failure ? 1 : 0)
   end
 end

--- a/lib/net_ssh.rb
+++ b/lib/net_ssh.rb
@@ -2,13 +2,13 @@
 
 require "net/ssh"
 require "shellwords"
+require_relative "../rhizome/common/lib/command"
 
 module NetSsh
   class MissingMock < StandardError
   end
 
-  class PotentialInsecurity < StandardError
-  end
+  PotentialInsecurity = Command::PotentialInsecurity
 
   # Allow SSH calls from web process if specific ENV variable is set.
   WEB_SSH_DISABLED = ENV["PROCESS_TYPE"] == "web" && ENV["ALLOW_WEB_SSH"] != "true"
@@ -32,89 +32,7 @@ module NetSsh
 
   module WarnUnsafe
     def self.convert(command, klass, method, **kw)
-      raise TypeError, "invalid type passed to #{klass}##{method}: #{command.inspect}" unless command.is_a?(String)
-
-      if command.frozen?
-        unless kw.empty?
-          if Config.unfrozen_test? && method
-            result = +""
-            mode = :unquoted
-            base_re = Regexp.union(kw.keys.map(&:to_s))
-            unquoted_re, single_re, double_re = nil
-            until command.empty?
-              re = case mode
-              when :unquoted
-                unquoted_re ||= /(\\.|['"]|#.*$)|:(#{base_re})\b/
-              when :single
-                single_re ||= /(')|:(#{base_re})\b/
-              else # :double
-                double_re ||= /(\\.|")|:(#{base_re})\b/
-              end
-
-              pre, _, command = command.partition(re)
-              ch = $1
-              q = $2
-
-              if ch
-                case mode
-                when :unquoted
-                  case ch
-                  when "'"
-                    mode = :single
-                  when '"'
-                    mode = :double
-                  end
-                when :single
-                  mode = :unquoted
-                else # :double
-                  mode = :unquoted if ch == '"'
-                end
-                result << pre << ch
-              elsif mode != :unquoted
-                if q && !q.empty?
-                  raise PotentialInsecurity, "Placeholder '#{q}' inside #{mode} quote in command at #{caller(2, 1).first}\nFix command to move the placeholder outside quotes, because shell escaping does not work correctly inside quotes."
-                end
-              else
-                result << pre
-                if q && !q.empty?
-                  v = kw[q.to_sym]
-                  result << if q.start_with?("shelljoin_")
-                    v.shelljoin
-                  else
-                    v.to_s.shellescape
-                  end
-                end
-              end
-            end
-
-            unless mode == :unquoted
-              raise PotentialInsecurity, "Unterminated #{mode} quote in command at #{caller(2, 1).first}\nFix command syntax."
-            end
-          else
-            re = /:(#{Regexp.union(kw.keys.map(&:to_s))})\b/
-            result = +""
-            until command.empty?
-              pre, _, command = command.partition(re)
-              q = $1
-              result << pre
-              if q && !q.empty?
-                v = kw[q.to_sym]
-                result << if q.start_with?("shelljoin_")
-                  v.shelljoin
-                else
-                  v.to_s.shellescape
-                end
-              end
-            end
-          end
-
-          command = result.freeze
-        end
-      else
-        raise PotentialInsecurity, "Interpolated string passed to #{klass}##{method} at #{caller(2, 1).first}\nReplace interpolation with :placeholders and provide values for placeholders in keyword arguments."
-      end
-
-      command
+      Command.build(command, "#{klass}##{method}", __FILE__, Config.unfrozen_test? && method, **kw)
     end
 
     def self.extract_keywords(kw, syms)

--- a/rhizome/common/bin/daemonizer
+++ b/rhizome/common/bin/daemonizer
@@ -17,7 +17,7 @@ STATE_MAP = {
 }
 
 def get_state(name)
-  state = r("systemctl show -p SubState --value #{name}.service").chomp
+  state = r("systemctl", "show", "-p", "SubState", "--value", "#{name}.service").chomp
 
   STATE_MAP[state] || "Unknown"
 end
@@ -31,9 +31,9 @@ def clean(name)
     # no-op, can occur if a previous clean was run but transition
     # recording that it ran could not commit.
   when "Succeeded"
-    r "sudo systemctl stop #{name}.service"
+    r "sudo", "systemctl", "stop", "#{name}.service"
   when "Failed"
-    r "sudo systemctl reset-failed #{name}.service"
+    r "sudo", "systemctl", "reset-failed", "#{name}.service"
   end
 end
 
@@ -68,7 +68,7 @@ else
       command = "#{command} < #{dir}/var/proc/#{name}.stdin"
     end
 
-    command = "/bin/bash -c '#{command} > #{dir}/var/log/#{name}.stdout 2> #{dir}/var/log/#{name}.stderr'"
-    r "sudo systemd-run --working-directory #{dir} --unit #{name} --remain-after-exit #{command}"
+    inner = "#{command} > #{dir}/var/log/#{name}.stdout 2> #{dir}/var/log/#{name}.stderr"
+    r "sudo systemd-run --working-directory :dir --unit :name --remain-after-exit /bin/bash -c :inner", dir: dir, name: name, inner: inner
   end
 end

--- a/rhizome/common/bin/daemonizer2
+++ b/rhizome/common/bin/daemonizer2
@@ -17,7 +17,7 @@ STATE_MAP = {
 }
 
 def get_state(name)
-  state = r("systemctl show -p SubState --value #{name}.service").chomp
+  state = r("systemctl", "show", "-p", "SubState", "--value", "#{name}.service").chomp
   STATE_MAP[state] || "Unknown"
 end
 
@@ -28,9 +28,9 @@ def clean(name, stdin_path)
     when "InProgress", "Unknown"
       fail "Cleanup is only allowed when the service is in a Succeeded, Failed, or NotStarted state"
     when "Succeeded"
-      r "sudo systemctl stop #{name}.service"
+      r "sudo", "systemctl", "stop", "#{name}.service"
     when "Failed"
-      r "sudo systemctl reset-failed #{name}.service"
+      r "sudo", "systemctl", "reset-failed", "#{name}.service"
     end
   ensure
     begin
@@ -41,11 +41,11 @@ def clean(name, stdin_path)
 end
 
 def restart(name)
-  r "sudo systemctl restart #{name}"
+  r "sudo", "systemctl", "restart", name
 end
 
 def stop(name)
-  r "sudo systemctl stop #{name}"
+  r "sudo", "systemctl", "stop", name
 end
 
 command = ARGV[0]
@@ -75,7 +75,7 @@ when "run"
     command = "cat #{stdin_path} | " + Shellwords.shelljoin(command_parts)
   end
 
-  r "sudo systemd-run --working-directory #{dir} --unit #{name} --remain-after-exit /bin/bash -c #{Shellwords.escape(command)}"
+  r "sudo systemd-run --working-directory :dir --unit :name --remain-after-exit /bin/bash -c :command", dir: dir, name: name, command: command
 else
   raise "Unknown command #{command}"
 end

--- a/rhizome/common/lib/command.rb
+++ b/rhizome/common/lib/command.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "shellwords"
+
+# Safely build a shell command string from a template containing :placeholder
+# tokens, substituting each with a keyword argument, shell-escaped. Shared
+# between rhizome/common/lib/util.rb's `cmd` and lib/net_ssh.rb's
+# NetSsh::WarnUnsafe.convert, which otherwise duplicated the same algorithm.
+module Command
+  class PotentialInsecurity < StandardError
+  end
+
+  # command: a frozen template string (unless kw is empty, in which case any
+  #   string works) with zero or more :placeholder tokens matching keys in
+  #   kw. A keyword whose name starts with "shelljoin_" is expected to hold
+  #   an Array, joined into multiple shell-escaped words instead of one.
+  #   Placeholders are not allowed inside quotes, since shell-escaping a
+  #   value for unquoted context and then wrapping it in quotes anyway
+  #   produces incorrect (and unsafe) results.
+  # name: label used in error messages to identify the caller (e.g. "cmd" or
+  #   "Sshable#cmd").
+  # wrapper_file: __FILE__ of the method calling into this one, so error
+  #   messages can point at the code that actually called it, by skipping
+  #   both this file's backtrace frames and the wrapper's.
+  # strict: whether to use the (slower) quote-tracking parser that also
+  #   rejects placeholders inside quotes. When false, a plain regex
+  #   substitution is used instead, which is only safe when the template has
+  #   already been verified (e.g. by tests that use the strict parser) to
+  #   never place a placeholder inside quotes.
+  #
+  # name, wrapper_file, and strict are positional (not keyword) arguments so
+  # that a placeholder legitimately named :name, :wrapper_file, or :strict in
+  # kw can never collide with (and silently get absorbed out of kw by) them.
+  def self.build(command, name, wrapper_file, strict, **kw)
+    raise TypeError, "invalid type passed to #{name}: #{command.inspect}" unless command.is_a?(String)
+
+    if command.frozen?
+      return command if kw.empty?
+
+      if strict
+        result = +""
+        mode = :unquoted
+        base_re = Regexp.union(kw.keys.map(&:to_s))
+        unquoted_re, single_re, double_re = nil
+        until command.empty?
+          re = case mode
+          when :unquoted
+            unquoted_re ||= /(\\.|['"]|#.*$)|:(#{base_re})\b/
+          when :single
+            single_re ||= /(')|:(#{base_re})\b/
+          else # :double
+            double_re ||= /(\\.|")|:(#{base_re})\b/
+          end
+
+          pre, _, command = command.partition(re)
+          ch = $1
+          q = $2
+
+          if ch
+            case mode
+            when :unquoted
+              case ch
+              when "'"
+                mode = :single
+              when '"'
+                mode = :double
+              end
+            when :single
+              mode = :unquoted
+            else # :double
+              mode = :unquoted if ch == '"'
+            end
+            result << pre << ch
+          elsif mode != :unquoted
+            if q && !q.empty?
+              raise PotentialInsecurity, "Placeholder '#{q}' inside #{mode} quote in command#{at(wrapper_file)}\nFix command to move the placeholder outside quotes, because shell escaping does not work correctly inside quotes."
+            end
+          else
+            result << pre
+            if q && !q.empty?
+              v = kw[q.to_sym]
+              result << if q.start_with?("shelljoin_")
+                v.shelljoin
+              else
+                v.to_s.shellescape
+              end
+            end
+          end
+        end
+
+        unless mode == :unquoted
+          raise PotentialInsecurity, "Unterminated #{mode} quote in command#{at(wrapper_file)}\nFix command syntax."
+        end
+      else
+        re = /:(#{Regexp.union(kw.keys.map(&:to_s))})\b/
+        result = +""
+        until command.empty?
+          pre, _, command = command.partition(re)
+          q = $1
+          result << pre
+          if q && !q.empty?
+            v = kw[q.to_sym]
+            result << if q.start_with?("shelljoin_")
+              v.shelljoin
+            else
+              v.to_s.shellescape
+            end
+          end
+        end
+      end
+
+      command = result.freeze
+    else
+      raise PotentialInsecurity, "Interpolated string passed to #{name}#{at(wrapper_file)}\nReplace interpolation with :placeholders and provide values for placeholders in keyword arguments."
+    end
+
+    command
+  end
+
+  # Returns " at file:line:in `method'" for the first backtrace location
+  # outside this file and wrapper_file, or "" if that can't be determined
+  # (Thread.each_caller_location was added in Ruby 3.2).
+  def self.at(wrapper_file)
+    return "" unless Thread.respond_to?(:each_caller_location)
+
+    Thread.each_caller_location do |loc|
+      return " at #{loc}" unless loc.path == __FILE__ || loc.path == wrapper_file
+    end
+
+    ""
+  end
+end

--- a/rhizome/common/lib/command.rb
+++ b/rhizome/common/lib/command.rb
@@ -3,20 +3,18 @@
 require "shellwords"
 
 # Safely build a shell command string from a template containing :placeholder
-# tokens, substituting each with a keyword argument, shell-escaped. Shared
-# between rhizome/common/lib/util.rb's `cmd` and lib/net_ssh.rb's
-# NetSsh::WarnUnsafe.convert, which otherwise duplicated the same algorithm.
+# tokens and keyword arguments for the placeholder values, performing shell
+# escaping for each value. Used by both rhizome and clover.
 module Command
+  extend self
+
   class PotentialInsecurity < StandardError
   end
 
-  # command: a frozen template string (unless kw is empty, in which case any
-  #   string works) with zero or more :placeholder tokens matching keys in
-  #   kw. A keyword whose name starts with "shelljoin_" is expected to hold
-  #   an Array, joined into multiple shell-escaped words instead of one.
-  #   Placeholders are not allowed inside quotes, since shell-escaping a
-  #   value for unquoted context and then wrapping it in quotes anyway
-  #   produces incorrect (and unsafe) results.
+  # command: a template command string with zero or more :placeholder tokens
+  #   matching arguments in kw.  A keyword argument whose name starts with
+  #   "shelljoin_" is expected to hold an Array, and is joined into multiple
+  #   shell-escaped words instead of one.
   # name: label used in error messages to identify the caller (e.g. "cmd" or
   #   "Sshable#cmd").
   # wrapper_file: __FILE__ of the method calling into this one, so error
@@ -27,11 +25,7 @@ module Command
   #   substitution is used instead, which is only safe when the template has
   #   already been verified (e.g. by tests that use the strict parser) to
   #   never place a placeholder inside quotes.
-  #
-  # name, wrapper_file, and strict are positional (not keyword) arguments so
-  # that a placeholder legitimately named :name, :wrapper_file, or :strict in
-  # kw can never collide with (and silently get absorbed out of kw by) them.
-  def self.build(command, name, wrapper_file, strict, **kw)
+  def build(command, name, wrapper_file, strict, **kw)
     raise TypeError, "invalid type passed to #{name}: #{command.inspect}" unless command.is_a?(String)
 
     if command.frozen?
@@ -91,7 +85,10 @@ module Command
         unless mode == :unquoted
           raise PotentialInsecurity, "Unterminated #{mode} quote in command#{at(wrapper_file)}\nFix command syntax."
         end
+        # :nocov:
       else
+        # This branch is covered by the clover specs, but not by the rhizome specs.
+        # It's marked nocov so the rhizome specs don't fail due to coverage reasons.
         re = /:(#{Regexp.union(kw.keys.map(&:to_s))})\b/
         result = +""
         until command.empty?
@@ -108,6 +105,7 @@ module Command
           end
         end
       end
+      # :nocov:
 
       command = result.freeze
     else
@@ -117,16 +115,20 @@ module Command
     command
   end
 
-  # Returns " at file:line:in `method'" for the first backtrace location
-  # outside this file and wrapper_file, or "" if that can't be determined
-  # (Thread.each_caller_location was added in Ruby 3.2).
-  def self.at(wrapper_file)
-    return "" unless Thread.respond_to?(:each_caller_location)
+  if Thread.respond_to?(:each_caller_location)
+    # Returns string for location of method call that is causing a PotentialInsecurity
+    def at(wrapper_file)
+      Thread.each_caller_location do |loc|
+        return " at #{loc}" unless loc.path == __FILE__ || loc.path == wrapper_file
+      end
 
-    Thread.each_caller_location do |loc|
-      return " at #{loc}" unless loc.path == __FILE__ || loc.path == wrapper_file
+      # :nocov:
+      ""
     end
-
-    ""
+  else
+    def at(wrapper_file)
+      ""
+    end
   end
+  # :nocov:
 end

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -26,11 +26,22 @@ class FsyncFail < Exception
 end
 # rubocop:enable Lint/InheritException
 
-def r(*command, stdin: "", expect: [0])
+class MissingMock < StandardError
+end
+
+def _run_command(*command, stdin: "", expect: [0], _skip_command_checking: false)
+  if !_skip_command_checking && defined?(RSpec)
+    raise MissingMock, "_run_command not mocked. You must add a spec that checks for the expected command. Command: #{command.inspect}"
+  end
+
   stdout, stderr, status = Open3.capture3(*command, stdin_data: stdin)
   fail CommandFail.new("command failed: " + command.join(" "), stdout, stderr) unless expect.include?(status.exitstatus)
 
   stdout
+end
+
+def r(*command, **kw)
+  _run_command(*command, **kw)
 end
 
 def rm_if_exists(path)

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -113,6 +113,10 @@ def _run_command(*command, stdin: "", expect: [0], _skip_command_checking: false
 end
 
 def r(*command, **kw)
+  if command.length == 1 && command[0].is_a?(String) && !command[0].frozen?
+    raise PotentialInsecurity, "Interpolated string passed to r at #{caller(1, 1).first}\nReplace interpolation with cmd and :placeholders, or use separate positional arguments instead."
+  end
+
   _run_command(*command, **kw)
 end
 

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -126,11 +126,7 @@ module Kernel
   end
 end
 
-def r(*command, **kw)
-  pass_kw = {}
-  pass_kw[:stdin] = kw.delete(:stdin) if kw.key?(:stdin)
-  pass_kw[:expect] = kw.delete(:expect) if kw.key?(:expect)
-
+def r(*command, stdin: nil, expect: nil, **kw)
   unless kw.empty?
     raise ArgumentError, "placeholder keywords require a single shell command string" unless command.length == 1 && command[0].is_a?(String)
     command = [cmd(command[0], **kw)]
@@ -140,7 +136,9 @@ def r(*command, **kw)
     raise PotentialInsecurity, "Interpolated string passed to r at #{caller(1, 1).first}\nReplace interpolation with :placeholders passed directly to r, or use separate positional arguments instead."
   end
 
-  _run_command(*command, **pass_kw)
+  kw = {stdin: stdin, expect: expect}
+  kw.compact!
+  _run_command(*command, **kw)
 end
 
 def rm_if_exists(path)

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -26,9 +26,6 @@ class FsyncFail < Exception
 end
 # rubocop:enable Lint/InheritException
 
-class MissingMock < StandardError
-end
-
 class PotentialInsecurity < StandardError
 end
 
@@ -101,15 +98,32 @@ def cmd(command, **kw)
   result.freeze
 end
 
-def _run_command(*command, stdin: "", expect: [0], _skip_command_checking: false)
-  if !_skip_command_checking && defined?(RSpec)
-    raise MissingMock, "_run_command not mocked. You must add a spec that checks for the expected command. Command: #{command.inspect}"
+# :nocov:
+if defined?(RSpec)
+  class MissingMock < StandardError
   end
 
-  stdout, stderr, status = Open3.capture3(*command, stdin_data: stdin)
-  fail CommandFail.new("command failed: " + command.join(" "), stdout, stderr) unless expect.include?(status.exitstatus)
+  # :nocov:
+  class Object
+    private
 
-  stdout
+    def _run_command(*command, _skip_command_checking: false, **kw)
+      unless _skip_command_checking
+        raise MissingMock, "_run_command not mocked. You must add a spec that checks for the expected command. Command: #{command.inspect}"
+      end
+
+      super(*command, **kw)
+    end
+  end
+end
+
+module Kernel
+  def _run_command(*command, stdin: "", expect: [0])
+    stdout, stderr, status = Open3.capture3(*command, stdin_data: stdin)
+    fail CommandFail.new("command failed: " + command.join(" "), stdout, stderr) unless expect.include?(status.exitstatus)
+
+    stdout
+  end
 end
 
 def r(*command, **kw)

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -6,6 +6,7 @@ require "bundler/setup" if File.directory?(File.expand_path("../../host", __dir_
 require "open3"
 require "shellwords"
 require "openssl"
+require_relative "command"
 
 class CommandFail < RuntimeError
   attr_reader :stdout, :stderr
@@ -26,76 +27,13 @@ class FsyncFail < Exception
 end
 # rubocop:enable Lint/InheritException
 
-class PotentialInsecurity < StandardError
-end
+PotentialInsecurity = Command::PotentialInsecurity
 
 # Safely build a shell command string from a template containing
 # :placeholder tokens, substituting each with the corresponding keyword
-# argument, shell-escaped. A keyword whose name starts with "shelljoin_"
-# is expected to hold an Array, joined into multiple shell-escaped words
-# instead of a single escaped word. Placeholders are not allowed inside
-# quotes, since shell-escaping a value for unquoted context and then
-# wrapping it in quotes anyway produces incorrect (and unsafe) results.
+# argument, shell-escaped. See Command.build for details.
 def cmd(command, **kw)
-  raise TypeError, "invalid type passed to cmd: #{command.inspect}" unless command.is_a?(String)
-  return command if kw.empty?
-  raise PotentialInsecurity, "Interpolated string passed to cmd at #{caller(1, 1).first}\nReplace interpolation with :placeholders and provide values for placeholders in keyword arguments." unless command.frozen?
-
-  result = +""
-  mode = :unquoted
-  base_re = Regexp.union(kw.keys.map(&:to_s))
-  unquoted_re, single_re, double_re = nil
-  until command.empty?
-    re = case mode
-    when :unquoted
-      unquoted_re ||= /(\\.|['"]|#.*$)|:(#{base_re})\b/
-    when :single
-      single_re ||= /(')|:(#{base_re})\b/
-    else # :double
-      double_re ||= /(\\.|")|:(#{base_re})\b/
-    end
-
-    pre, _, command = command.partition(re)
-    ch = $1
-    q = $2
-
-    if ch
-      case mode
-      when :unquoted
-        case ch
-        when "'"
-          mode = :single
-        when '"'
-          mode = :double
-        end
-      when :single
-        mode = :unquoted
-      else # :double
-        mode = :unquoted if ch == '"'
-      end
-      result << pre << ch
-    elsif mode != :unquoted
-      if q && !q.empty?
-        raise PotentialInsecurity, "Placeholder '#{q}' inside #{mode} quote in command at #{caller(1, 1).first}\nFix command to move the placeholder outside quotes, because shell escaping does not work correctly inside quotes."
-      end
-    else
-      result << pre
-      if q && !q.empty?
-        v = kw[q.to_sym]
-        result << if q.start_with?("shelljoin_")
-          v.shelljoin
-        else
-          v.to_s.shellescape
-        end
-      end
-    end
-  end
-
-  unless mode == :unquoted
-    raise PotentialInsecurity, "Unterminated #{mode} quote in command at #{caller(1, 1).first}\nFix command syntax."
-  end
-
-  result.freeze
+  Command.build(command, "cmd", __FILE__, true, **kw)
 end
 
 # :nocov:

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -127,11 +127,20 @@ module Kernel
 end
 
 def r(*command, **kw)
-  if command.length == 1 && command[0].is_a?(String) && !command[0].frozen?
-    raise PotentialInsecurity, "Interpolated string passed to r at #{caller(1, 1).first}\nReplace interpolation with cmd and :placeholders, or use separate positional arguments instead."
+  pass_kw = {}
+  pass_kw[:stdin] = kw.delete(:stdin) if kw.key?(:stdin)
+  pass_kw[:expect] = kw.delete(:expect) if kw.key?(:expect)
+
+  unless kw.empty?
+    raise ArgumentError, "placeholder keywords require a single shell command string" unless command.length == 1 && command[0].is_a?(String)
+    command = [cmd(command[0], **kw)]
   end
 
-  _run_command(*command, **kw)
+  if command.length == 1 && command[0].is_a?(String) && !command[0].frozen?
+    raise PotentialInsecurity, "Interpolated string passed to r at #{caller(1, 1).first}\nReplace interpolation with :placeholders passed directly to r, or use separate positional arguments instead."
+  end
+
+  _run_command(*command, **pass_kw)
 end
 
 def rm_if_exists(path)
@@ -191,7 +200,7 @@ end
 
 def curl_file(url, path)
   inner = cmd("curl -f -L3 :url | tee >(openssl dgst -sha256) > :path", url: url, path: path)
-  r(cmd("bash -c :inner", inner: inner)).split(" ").last
+  r("bash -c :inner", inner: inner).split(" ").last
 end
 
 def validate_keys(context, required_keys, optional_keys, hash)

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -29,6 +29,78 @@ end
 class MissingMock < StandardError
 end
 
+class PotentialInsecurity < StandardError
+end
+
+# Safely build a shell command string from a template containing
+# :placeholder tokens, substituting each with the corresponding keyword
+# argument, shell-escaped. A keyword whose name starts with "shelljoin_"
+# is expected to hold an Array, joined into multiple shell-escaped words
+# instead of a single escaped word. Placeholders are not allowed inside
+# quotes, since shell-escaping a value for unquoted context and then
+# wrapping it in quotes anyway produces incorrect (and unsafe) results.
+def cmd(command, **kw)
+  raise TypeError, "invalid type passed to cmd: #{command.inspect}" unless command.is_a?(String)
+  return command if kw.empty?
+  raise PotentialInsecurity, "Interpolated string passed to cmd at #{caller(1, 1).first}\nReplace interpolation with :placeholders and provide values for placeholders in keyword arguments." unless command.frozen?
+
+  result = +""
+  mode = :unquoted
+  base_re = Regexp.union(kw.keys.map(&:to_s))
+  unquoted_re, single_re, double_re = nil
+  until command.empty?
+    re = case mode
+    when :unquoted
+      unquoted_re ||= /(\\.|['"]|#.*$)|:(#{base_re})\b/
+    when :single
+      single_re ||= /(')|:(#{base_re})\b/
+    else # :double
+      double_re ||= /(\\.|")|:(#{base_re})\b/
+    end
+
+    pre, _, command = command.partition(re)
+    ch = $1
+    q = $2
+
+    if ch
+      case mode
+      when :unquoted
+        case ch
+        when "'"
+          mode = :single
+        when '"'
+          mode = :double
+        end
+      when :single
+        mode = :unquoted
+      else # :double
+        mode = :unquoted if ch == '"'
+      end
+      result << pre << ch
+    elsif mode != :unquoted
+      if q && !q.empty?
+        raise PotentialInsecurity, "Placeholder '#{q}' inside #{mode} quote in command at #{caller(1, 1).first}\nFix command to move the placeholder outside quotes, because shell escaping does not work correctly inside quotes."
+      end
+    else
+      result << pre
+      if q && !q.empty?
+        v = kw[q.to_sym]
+        result << if q.start_with?("shelljoin_")
+          v.shelljoin
+        else
+          v.to_s.shellescape
+        end
+      end
+    end
+  end
+
+  unless mode == :unquoted
+    raise PotentialInsecurity, "Unterminated #{mode} quote in command at #{caller(1, 1).first}\nFix command syntax."
+  end
+
+  result.freeze
+end
+
 def _run_command(*command, stdin: "", expect: [0], _skip_command_checking: false)
   if !_skip_command_checking && defined?(RSpec)
     raise MissingMock, "_run_command not mocked. You must add a spec that checks for the expected command. Command: #{command.inspect}"
@@ -100,8 +172,8 @@ def safe_write_to_file(filename, content = nil, perm: nil)
 end
 
 def curl_file(url, path)
-  cmd = "curl -f -L3 #{url.shellescape} | tee >(openssl dgst -sha256) > #{path.shellescape}"
-  r("bash -c #{cmd.shellescape}").split(" ").last
+  inner = cmd("curl -f -L3 :url | tee >(openssl dgst -sha256) > :path", url: url, path: path)
+  r(cmd("bash -c :inner", inner: inner)).split(" ").last
 end
 
 def validate_keys(context, required_keys, optional_keys, hash)

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -218,6 +218,22 @@ RSpec.describe "util" do
       expect(self).to receive(:_run_command).with("echo -n a", stdin: "x", expect: [0, 2]).and_return("a")
       expect(r("echo -n a", stdin: "x", expect: [0, 2])).to eq "a"
     end
+
+    it "raises for an interpolated (non-frozen) single-string command" do
+      x = "a"
+      expect { r("echo #{x}") }.to raise_error(PotentialInsecurity)
+    end
+
+    it "does not raise for a non-frozen string built via cmd" do
+      expect(self).to receive(:_run_command).with("echo a").and_return("a")
+      expect(r(cmd("echo :x", x: "a"))).to eq "a"
+    end
+
+    it "does not raise for multiple positional arguments" do
+      x = "a"
+      expect(self).to receive(:_run_command).with("echo", x).and_return("a")
+      expect(r("echo", x)).to eq "a"
+    end
   end
 
   describe "_run_command" do

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -143,6 +143,62 @@ RSpec.describe "util" do
     end
   end
 
+  describe "cmd" do
+    it "interpolates variables into string" do
+      expect(cmd("a :b :c d", b: 1, c: "e f")).to eq "a 1 e\\ f d"
+    end
+
+    it "handles shelljoin interpolation" do
+      expect(cmd("a :b :shelljoin_c d", b: 1, shelljoin_c: ["e f", "g"])).to eq "a 1 e\\ f g d"
+    end
+
+    it "returns string when not given keyword" do
+      s = "a d"
+      expect(cmd(s)).to be s
+    end
+
+    it "raises for interpolated strings with keywords" do
+      c = ":c"
+      expect { cmd("a :b #{c} d", b: 1, c: "e f") }.to raise_error(PotentialInsecurity)
+      expect { cmd("a #{c}", c: "e f") }.to raise_error(PotentialInsecurity)
+    end
+
+    it "raises for non-strings" do
+      o = Object.new
+      expect { cmd(o) }.to raise_error(TypeError)
+      expect { cmd(o, b: 1) }.to raise_error(TypeError)
+    end
+
+    it "raises for placeholder inside quotes" do
+      expect { cmd("a ':c'", c: "a") }.to raise_error(PotentialInsecurity)
+      expect { cmd('a ":c"', c: "a") }.to raise_error(PotentialInsecurity)
+    end
+
+    it "raises for unterminated quotes" do
+      expect { cmd(":c '", c: "a") }.to raise_error(PotentialInsecurity)
+      expect { cmd(':c "', c: "a") }.to raise_error(PotentialInsecurity)
+      expect { cmd(":c 'a", c: "a") }.to raise_error(PotentialInsecurity)
+      expect { cmd(':c "a', c: "a") }.to raise_error(PotentialInsecurity)
+    end
+
+    it "works with comments with '" do
+      expect(cmd("# isn't it fun\n:c", c: "e f")).to eq "# isn't it fun\ne\\ f"
+    end
+
+    it "works for placeholders after quotes" do
+      c = "e f"
+      expect(cmd("'' :c a", c: c)).to eq "'' e\\ f a"
+      expect(cmd('"" :c', c: c)).to eq "\"\" e\\ f"
+      expect(cmd("\\' :c", c: c)).to eq "\\' e\\ f"
+      expect(cmd('\\" :c', c: c)).to eq "\\\" e\\ f"
+      expect(cmd("'\"' :c", c: c)).to eq "'\"' e\\ f"
+      expect(cmd('"\'" :c', c: c)).to eq "\"'\" e\\ f"
+      expect(cmd('"\\"" :c', c: c)).to eq "\"\\\"\" e\\ f"
+      expect(cmd("'\"'\"'\" :c", c: c)).to eq "'\"'\"'\" e\\ f"
+      expect(cmd("'\\\"'\"'\" :c", c: c)).to eq "'\\\"'\"'\" e\\ f"
+    end
+  end
+
   describe "curl_file" do
     it "calls r with curl command and returns the sha256 hash" do
       url = "https://example.com/file.gz"

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -234,6 +234,20 @@ RSpec.describe "util" do
       expect(self).to receive(:_run_command).with("echo", x).and_return("a")
       expect(r("echo", x)).to eq "a"
     end
+
+    it "builds the command via cmd when placeholder keywords are given" do
+      expect(self).to receive(:_run_command).with("echo a\\ b").and_return("a b")
+      expect(r("echo :x", x: "a b")).to eq "a b"
+    end
+
+    it "separates stdin/expect keywords from placeholder keywords" do
+      expect(self).to receive(:_run_command).with("echo a", stdin: "in", expect: [0, 2]).and_return("a")
+      expect(r("echo :x", x: "a", stdin: "in", expect: [0, 2])).to eq "a"
+    end
+
+    it "raises ArgumentError when placeholder keywords are given with multiple positional arguments" do
+      expect { r("echo", "a", x: "b") }.to raise_error(ArgumentError)
+    end
   end
 
   describe "_run_command" do

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -147,23 +147,39 @@ RSpec.describe "util" do
     it "calls r with curl command and returns the sha256 hash" do
       url = "https://example.com/file.gz"
       path = "/tmp/file.gz"
-      expect(self).to receive(:r).with("bash -c curl\\ -f\\ -L3\\ https://example.com/file.gz\\ \\|\\ tee\\ \\>\\(openssl\\ dgst\\ -sha256\\)\\ \\>\\ /tmp/file.gz").and_return("SHA2-256(stdin)= #{"a" * 64}")
+      expect(self).to receive(:_run_command).with("bash -c curl\\ -f\\ -L3\\ https://example.com/file.gz\\ \\|\\ tee\\ \\>\\(openssl\\ dgst\\ -sha256\\)\\ \\>\\ /tmp/file.gz").and_return("SHA2-256(stdin)= #{"a" * 64}")
       expect(curl_file(url, path)).to eq("a" * 64)
     end
   end
 
   describe "r" do
+    it "delegates to _run_command" do
+      expect(self).to receive(:_run_command).with("echo -n a").and_return("a")
+      expect(r("echo -n a")).to eq "a"
+    end
+
+    it "passes through stdin and expect keywords unchanged" do
+      expect(self).to receive(:_run_command).with("echo -n a", stdin: "x", expect: [0, 2]).and_return("a")
+      expect(r("echo -n a", stdin: "x", expect: [0, 2])).to eq "a"
+    end
+  end
+
+  describe "_run_command" do
+    it "raises MissingMock when not mocked and not explicitly skipped" do
+      expect { _run_command("echo -n a") }.to raise_error(MissingMock, /_run_command not mocked/)
+    end
+
     it "raises CommandFail when command exits with non-zero status" do
-      expect { r("false") }.to raise_error(CommandFail, /command failed: false/)
+      expect { _run_command("false", _skip_command_checking: true) }.to raise_error(CommandFail, /command failed: false/)
     end
 
     it "executes command as a string using a shell" do
-      expect(r("echo -n a")).to eq "a"
-      expect(r("true && echo -n a")).to eq "a"
+      expect(_run_command("echo -n a", _skip_command_checking: true)).to eq "a"
+      expect(_run_command("true && echo -n a", _skip_command_checking: true)).to eq "a"
     end
 
     it "executes program directly without a shell when given multiple arguments" do
-      expect(r("echo", "-n", "$$")).to eq "$$"
+      expect(_run_command("echo", "-n", "$$", _skip_command_checking: true)).to eq "$$"
     end
   end
 

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -24,7 +24,7 @@ original_hostname = Socket.gethostname
 is_prod_env = (env_type == "production")
 
 safe_write_to_file("/etc/hosts", File.read("/etc/hosts").gsub(original_hostname, hostname))
-r "sudo hostnamectl set-hostname " + hostname
+r "sudo", "hostnamectl", "set-hostname", hostname
 
 # Color prompt and MOTD to cue operators as to production-level
 # status.
@@ -104,7 +104,7 @@ r "apt-get -y install nvme-cli systemd-coredump" if is_prod_env
 r "apt-get -y install smartmontools nvme-cli jq"
 
 # htcat is able to download a file from signed URLs concurrently
-r "curl -fsSL -o htcat.tar.gz https://github.com/ubicloud/htcat/releases/download/v2.0.0-ubi1/htcat_2.0.0-ubi1_linux_#{Arch.render(x64: "amd64", arm64: "arm64")}.tar.gz"
+r "curl", "-fsSL", "-o", "htcat.tar.gz", "https://github.com/ubicloud/htcat/releases/download/v2.0.0-ubi1/htcat_2.0.0-ubi1_linux_#{Arch.render(x64: "amd64", arm64: "arm64")}.tar.gz"
 r "tar xvf htcat.tar.gz -C /usr/local/bin/"
 
 SpdkSetup.prep

--- a/rhizome/host/bin/setup-grafana
+++ b/rhizome/host/bin/setup-grafana
@@ -24,7 +24,7 @@ r "curl -fsSL https://apt.grafana.com/gpg.key | gpg --dearmor | sudo tee /etc/ap
 r "echo \"deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main\" | sudo tee -a /etc/apt/sources.list.d/grafana.list"
 
 r "sudo apt update"
-r "sudo apt install -y grafana=#{GRAFANA_VERSION}"
+r "sudo", "apt", "install", "-y", "grafana=#{GRAFANA_VERSION}"
 
 r "sudo", "cp", grafana_ini, "#{grafana_ini}.bak"
 

--- a/rhizome/host/bin/setup-grafana
+++ b/rhizome/host/bin/setup-grafana
@@ -26,12 +26,12 @@ r "echo \"deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com 
 r "sudo apt update"
 r "sudo apt install -y grafana=#{GRAFANA_VERSION}"
 
-r "sudo cp #{grafana_ini} #{grafana_ini}.bak"
+r "sudo", "cp", grafana_ini, "#{grafana_ini}.bak"
 
-r "sudo sed -i \
-  -e 's/;admin_user = admin/admin_user = admin/' \
-  -e 's/;admin_password = admin/admin_password = #{admin_password}/' \
-  #{grafana_ini}"
+r "sudo", "sed", "-i",
+  "-e", "s/;admin_user = admin/admin_user = admin/",
+  "-e", "s/;admin_password = admin/admin_password = #{admin_password}/",
+  grafana_ini
 
 r "sudo mkdir -p /var/www/html"
 
@@ -55,12 +55,12 @@ server {
 }
 EOF
 )
-r "sudo sed -i 's|{{DOMAIN}}|'#{domain.shellescape}'|' /etc/nginx/sites-available/grafana.conf"
+r "sudo", "sed", "-i", "s|{{DOMAIN}}|#{domain}|", "/etc/nginx/sites-available/grafana.conf"
 
 r "sudo ln -s /etc/nginx/sites-available/grafana.conf /etc/nginx/sites-enabled/"
 r "sudo systemctl start nginx"
 
-r "sudo certbot --nginx -d #{domain.shellescape} --non-interactive --agree-tos --email #{cert_email.shellescape}"
+r "sudo", "certbot", "--nginx", "-d", domain, "--non-interactive", "--agree-tos", "--email", cert_email
 r "sudo apt install -y ufw"
 r "sudo ufw allow 22"
 r "sudo ufw allow 80"

--- a/rhizome/host/bin/setup-node-exporter
+++ b/rhizome/host/bin/setup-node-exporter
@@ -12,10 +12,10 @@ end
 file_name = "node_exporter-#{version}.linux-#{Arch.render(x64: "amd64", arm64: "arm64")}"
 url = "https://github.com/prometheus/node_exporter/releases/download/v#{version}/#{file_name}.tar.gz"
 
-r "curl -fsSLO \"#{url}\""
-r "tar xvfz #{file_name}.tar.gz"
-r "sudo mv #{file_name}/node_exporter /usr/local/bin/"
-r "sudo rm -rf #{file_name}*"
+r "curl", "-fsSLO", url
+r "tar", "xvfz", "#{file_name}.tar.gz"
+r "sudo", "mv", "#{file_name}/node_exporter", "/usr/local/bin/"
+r "sudo rm -rf :prefix*", prefix: file_name
 
 safe_write_to_file("/etc/systemd/system/node_exporter.service", <<NODEEXPORTERCONFIG)
 [Unit]

--- a/rhizome/host/lib/boot_image.rb
+++ b/rhizome/host/lib/boot_image.rb
@@ -76,7 +76,7 @@ class BootImage
       else
         cmd("curl -f -L10 :url | tee >(openssl dgst -sha256) > :temp_path", url: url, temp_path: temp_path)
       end
-      digest_out = r cmd("bash -c :inner", inner: inner)
+      digest_out = r "bash -c :inner", inner: inner
       sha256_sum = digest_out.split(" ").last
     end
     sha256_sum
@@ -86,7 +86,7 @@ class BootImage
     sha256_sum = nil
     File.open(temp_path, File::RDWR | File::CREAT | File::EXCL, 0o644) do
       inner = cmd("htcat -parallelism=12 -max-fragment-size=32 :url | tee >(openssl dgst -sha256) > :temp_path", url: url, temp_path: temp_path)
-      digest_out = r cmd("bash -c :inner", inner: inner)
+      digest_out = r "bash -c :inner", inner: inner
       sha256_sum = digest_out.split(" ").last
     end
     sha256_sum

--- a/rhizome/host/lib/boot_image.rb
+++ b/rhizome/host/lib/boot_image.rb
@@ -69,10 +69,14 @@ class BootImage
   end
 
   def curl_image(url, temp_path, ca_path)
-    ca_arg = ca_path ? " --cacert #{ca_path.shellescape}" : ""
     sha256_sum = nil
     File.open(temp_path, File::RDWR | File::CREAT | File::EXCL, 0o644) do
-      digest_out = r "bash -c 'curl -f -L10 #{url.shellescape}#{ca_arg} | tee >(openssl dgst -sha256) > #{temp_path.shellescape}'"
+      inner = if ca_path
+        cmd("curl -f -L10 :url --cacert :ca_path | tee >(openssl dgst -sha256) > :temp_path", url: url, ca_path: ca_path, temp_path: temp_path)
+      else
+        cmd("curl -f -L10 :url | tee >(openssl dgst -sha256) > :temp_path", url: url, temp_path: temp_path)
+      end
+      digest_out = r cmd("bash -c :inner", inner: inner)
       sha256_sum = digest_out.split(" ").last
     end
     sha256_sum
@@ -81,7 +85,8 @@ class BootImage
   def htcat_image(url, temp_path)
     sha256_sum = nil
     File.open(temp_path, File::RDWR | File::CREAT | File::EXCL, 0o644) do
-      digest_out = r "bash -c 'htcat -parallelism=12 -max-fragment-size=32 #{url.shellescape} | tee >(openssl dgst -sha256) > #{temp_path.shellescape}'"
+      inner = cmd("htcat -parallelism=12 -max-fragment-size=32 :url | tee >(openssl dgst -sha256) > :temp_path", url: url, temp_path: temp_path)
+      digest_out = r cmd("bash -c :inner", inner: inner)
       sha256_sum = digest_out.split(" ").last
     end
     sha256_sum

--- a/rhizome/host/lib/boot_image.rb
+++ b/rhizome/host/lib/boot_image.rb
@@ -3,6 +3,7 @@
 require "fileutils"
 require "uri"
 require_relative "../../common/lib/arch"
+require_relative "../../common/lib/util"
 
 class BootImage
   def initialize(name, version, image_root: "/var/storage/images")
@@ -96,7 +97,7 @@ class BootImage
     else
       # Images are presumed to be atomically renamed into the path,
       # i.e. no partial images will be passed to qemu-image.
-      r "qemu-img convert -p -f #{initial_format.shellescape} -O raw #{temp_path.shellescape} #{image_path.shellescape}"
+      r "qemu-img", "convert", "-p", "-f", initial_format, "-O", "raw", temp_path, image_path
     end
   end
 end

--- a/rhizome/host/lib/cert_server_setup.rb
+++ b/rhizome/host/lib/cert_server_setup.rb
@@ -16,7 +16,7 @@ class CertServerSetup
   end
 
   def cert_folder
-    vp.q_cert
+    vp.cert
   end
 
   def cert_path

--- a/rhizome/host/lib/cert_server_setup.rb
+++ b/rhizome/host/lib/cert_server_setup.rb
@@ -69,17 +69,17 @@ class CertServerSetup
     end
 
     create_cert_folder
-    r "cp #{server_main_path}/metadata-endpoint #{vm_server_path}" unless File.exist?(vm_server_path)
-    r "sudo chown #{@vm_name}:#{@vm_name} #{vm_server_path}"
+    r "cp", "#{server_main_path}/metadata-endpoint", vm_server_path unless File.exist?(vm_server_path)
+    r "sudo", "chown", "#{@vm_name}:#{@vm_name}", vm_server_path
   end
 
   def download_server
     temp_tarball = "/tmp/metadata-endpoint-#{server_version}.tar.gz"
-    r "curl -L3 -o #{temp_tarball} #{package_url}"
+    r "curl", "-L3", "-o", temp_tarball, package_url
 
     FileUtils.mkdir_p(server_main_path)
     FileUtils.cd server_main_path do
-      r "tar -xzf #{temp_tarball}"
+      r "tar", "-xzf", temp_tarball
     end
 
     FileUtils.rm_f(temp_tarball)
@@ -122,11 +122,11 @@ CERT_SERVICE
   end
 
   def enable_and_start_service
-    r "systemctl enable --now #{service_name}"
+    r "systemctl", "enable", "--now", service_name
   end
 
   def stop_and_remove_service
-    r "systemctl disable --now #{service_name}" if File.exist?(service_file_path)
+    r "systemctl", "disable", "--now", service_name if File.exist?(service_file_path)
     r "systemctl daemon-reload"
     FileUtils.rm_f(service_file_path)
   end

--- a/rhizome/host/lib/leaseweb_networking_setup.rb
+++ b/rhizome/host/lib/leaseweb_networking_setup.rb
@@ -29,7 +29,7 @@ class LeasewebNetworkingSetup
     FileUtils.mkdir_p(staged, mode: 0o700)
     File.write(staged_path, @netplan)
     FileUtils.chmod(0o600, staged_path)
-    r "netplan generate --root-dir #{STAGING_DIR}"
+    r "netplan", "generate", "--root-dir", STAGING_DIR
     FileUtils.rm_rf(STAGING_DIR)
   end
 

--- a/rhizome/host/lib/slice_setup.rb
+++ b/rhizome/host/lib/slice_setup.rb
@@ -20,7 +20,7 @@ class SliceSetup
   end
 
   def purge
-    r("systemctl stop #{@slice_name.shellescape}", expect: [0, 5])
+    r("systemctl", "stop", @slice_name, expect: [0, 5])
     rm_if_exists systemd_service
     r "systemctl daemon-reload"
   end
@@ -46,7 +46,7 @@ SLICE_CONFIG
   end
 
   def start_systemd_unit
-    r "systemctl start #{@slice_name}"
+    r "systemctl", "start", @slice_name
     cpuset_path = File.join("/sys/fs/cgroup", @slice_name, "cpuset.cpus.partition")
     File.write(cpuset_path, "member")
   end

--- a/rhizome/host/lib/spdk_setup.rb
+++ b/rhizome/host/lib/spdk_setup.rb
@@ -15,7 +15,7 @@ class SpdkSetup
     r "apt-get -y install libaio-dev libssl-dev libnuma-dev libjson-c-dev uuid-dev libiscsi-dev"
 
     begin
-      r "adduser #{SpdkPath.user.shellescape} --disabled-password --gecos '' --home #{SpdkPath.home.shellescape}"
+      r "adduser", SpdkPath.user, "--disabled-password", "--gecos", "", "--home", SpdkPath.home
     rescue CommandFail => ex
       raise unless /The user `.*' already exists\./.match?(ex.message)
     end
@@ -70,11 +70,11 @@ class SpdkSetup
     temp_tarball = "/tmp/spdk.tar.gz"
     url = package_url(os_version: os_version)
     puts "Downloading SPDK package from #{url}"
-    r "curl -L3 -o #{temp_tarball} #{url}"
+    r "curl", "-L3", "-o", temp_tarball, url
 
     FileUtils.mkdir_p(install_path)
     FileUtils.cd install_path do
-      r "tar -xzf #{temp_tarball} --strip-components=1"
+      r "tar", "-xzf", temp_tarball, "--strip-components=1"
     end
   end
 
@@ -119,7 +119,7 @@ SPDK_SERVICE
     hugepages = cpu_count
 
     user = SpdkPath.user
-    r "sudo --user=#{user.shellescape} mkdir -p #{hugepages_dir.shellescape}"
+    r "sudo", "--user=#{user}", "mkdir", "-p", hugepages_dir
 
     File.write("/lib/systemd/system/#{hugepages_mount_service}", <<SPDK_HUGEPAGES_MOUNT,
 [Unit]
@@ -204,20 +204,20 @@ SPDK_HUGEPAGES_MOUNT
   end
 
   def enable_services
-    r "systemctl enable #{hugepages_mount_service}"
-    r "systemctl enable #{spdk_service}"
+    r "systemctl", "enable", hugepages_mount_service
+    r "systemctl", "enable", spdk_service
   end
 
   def start_services
-    r "systemctl start #{hugepages_mount_service}"
-    r "systemctl start #{spdk_service}"
+    r "systemctl", "start", hugepages_mount_service
+    r "systemctl", "start", spdk_service
   end
 
   def stop_and_remove_services
-    r "systemctl stop #{spdk_service}"
-    r "systemctl stop #{hugepages_mount_service}"
-    r "systemctl disable #{spdk_service}"
-    r "systemctl disable #{hugepages_mount_service}"
+    r "systemctl", "stop", spdk_service
+    r "systemctl", "stop", hugepages_mount_service
+    r "systemctl", "disable", spdk_service
+    r "systemctl", "disable", hugepages_mount_service
     FileUtils.rm_f("/lib/systemd/system/#{spdk_service}")
     FileUtils.rm_f("/lib/systemd/system/#{hugepages_mount_service}")
   end
@@ -229,7 +229,7 @@ SPDK_HUGEPAGES_MOUNT
   end
 
   def verify_spdk
-    status = (r "systemctl is-active #{spdk_service}").strip
+    status = r("systemctl", "is-active", spdk_service).strip
     fail "SPDK failed to start" unless status == "active"
   end
 end

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -619,14 +619,15 @@ class StorageVolume
     # so it doesn't error out in concurrent VM creations.
     rpc_socket = "/var/tmp/spdk_dd.sock.#{@vm_name}"
 
-    count_param = count.nil? ? "" : "--count #{count}"
+    cmd = [SpdkPath.bin(@spdk_version, "spdk_dd"), "--config", "/dev/stdin",
+      "--disable-cpumask-locks",
+      "--rpc-socket", rpc_socket,
+      "--if", input_file,
+      "--ob", "crypt0",
+      "--bs=#{block_size}"]
+    cmd += ["--count", count.to_s] unless count.nil?
 
-    r("#{SpdkPath.bin(@spdk_version, "spdk_dd")} --config /dev/stdin " \
-    "--disable-cpumask-locks " \
-    "--rpc-socket #{rpc_socket.shellescape} " \
-    "--if #{input_file.shellescape} " \
-    "--ob crypt0 " \
-    "--bs=#{block_size} #{count_param}", stdin: spdk_config_json)
+    r(*cmd, stdin: spdk_config_json)
   end
 
   def create_ubi_writespace(encryption_key)
@@ -649,7 +650,7 @@ class StorageVolume
     FileUtils.chmod "u=rw,g=r,o=", disk_file
 
     # allow spdk to access the image
-    r "setfacl -m u:spdk:rw #{disk_file.shellescape}"
+    r "setfacl", "-m", "u:spdk:rw", disk_file
   end
 
   def setup_spdk_bdev(encryption_key)
@@ -691,7 +692,7 @@ class StorageVolume
     FileUtils.chmod "u=rw,g=r,o=", spdk_vhost_sock
 
     # allow vm user to access the vhost socket
-    r "setfacl -m u:#{@vm_name}:rw #{spdk_vhost_sock.shellescape}"
+    r "setfacl", "-m", "u:#{@vm_name}:rw", spdk_vhost_sock
 
     # create a symlink to the socket in the per vm storage dir
     rm_if_exists(vhost_sock)

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -714,10 +714,6 @@ class StorageVolume
     @vhost_user_block_service ||= "#{@vm_name}-#{@disk_index}-storage.service" if @vhost_backend_version
   end
 
-  def q_vhost_user_block_service
-    @q_vhost_user_block_service ||= vhost_user_block_service.shellescape if vhost_user_block_service
-  end
-
   def sp
     @sp ||= StoragePath.new(@vm_name, @device, @disk_index)
   end

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -625,7 +625,7 @@ class StorageVolume
       "--if", input_file,
       "--ob", "crypt0",
       "--bs=#{block_size}"]
-    cmd += ["--count", count.to_s] unless count.nil?
+    cmd.push("--count", count.to_s) unless count.nil?
 
     r(*cmd, stdin: spdk_config_json)
   end

--- a/rhizome/host/lib/vhost_block_backend.rb
+++ b/rhizome/host/lib/vhost_block_backend.rb
@@ -71,7 +71,7 @@ class VhostBlockBackend
     fail "Invalid SHA-256 digest" unless downloaded_sha256 == sha256
     FileUtils.mkdir_p(dir)
     FileUtils.cd dir do
-      r "tar -xzf #{temp_tarball}"
+      r "tar", "-xzf", temp_tarball
     end
     FileUtils.rm_f temp_tarball
   end

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -28,8 +28,7 @@ class VmPath
   end
 
   def systemd_service
-    File.join("/etc/systemd/system",
-      IO.popen(["systemd-escape", @vm_name + ".service"]) { _1.read.chomp })
+    "/etc/systemd/system/#{@vm_name}.service"
   end
 
   def write_systemd_service(s)

--- a/rhizome/host/lib/vm_path.rb
+++ b/rhizome/host/lib/vm_path.rb
@@ -45,7 +45,7 @@ class VmPath
     define_method(m, &block)
   end
 
-  # Define path, q_path, read, write methods for files in
+  # Define path, read, write methods for files in
   # `/vm/#{vm_name}`
   %w[
     guest_ephemeral
@@ -68,11 +68,6 @@ class VmPath
     # Method producing a path, e.g. #user_data
     define_new_method method_name do
       home(file_name)
-    end
-
-    # Method producing a shell-quoted path, e.g. #q_user_data.
-    define_new_method("q_" + method_name) do
-      home(file_name).shellescape
     end
 
     # Method reading the file's contents, e.g. #read_user_data

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -158,7 +158,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     block_ip4
 
     begin
-      r "ip netns del #{q_vm}"
+      r "ip", "netns", "del", @vm_name
     rescue CommandFail => ex
       raise unless /Cannot remove namespace file ".*": No such file or directory/.match?(ex.stderr)
     end
@@ -174,7 +174,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
   end
 
   def purge_user
-    r "deluser --remove-home #{q_vm}"
+    r "deluser", "--remove-home", @vm_name
   rescue CommandFail => ex
     raise unless /The user `.*' does not exist./.match?(ex.stderr)
   end
@@ -207,7 +207,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
   def unmount_hugepages
     return unless @hugepages
 
-    r "umount #{vp.q_hugepages}"
+    r "umount", vp.hugepages
   rescue CommandFail => ex
     raise unless /(no mount point specified)|(not mounted)|(No such file or directory)/.match?(ex.stderr)
   end
@@ -227,7 +227,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
 
     FileUtils.mkdir_p vp.hugepages
     FileUtils.chown @vm_name, @vm_name, vp.hugepages
-    r "mount -t hugetlbfs -o uid=#{q_vm},size=#{mem_gib}G nodev #{vp.q_hugepages}"
+    r "mount", "-t", "hugetlbfs", "-o", "uid=#{@vm_name},size=#{mem_gib}G", "nodev", vp.hugepages
   end
 
   def interfaces(nics, multiqueue)
@@ -238,7 +238,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     # which makes it unsuitable for error message matching. Deleting
     # and recreating the network namespace seems easier and safer.
     begin
-      r "ip netns del #{q_vm}"
+      r "ip", "netns", "del", @vm_name
     rescue CommandFail => ex
       raise unless /Cannot remove namespace file ".*": No such file or directory/.match?(ex.stderr)
     end
@@ -250,26 +250,27 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     # interface to disappear before going ahead because the ip link add command
     # is not idempotent, either.
     5.times do
-      if File.exist?("/sys/class/net/vetho#{q_vm}")
+      if File.exist?("/sys/class/net/vetho#{@vm_name}")
         sleep 0.1
       else
         break
       end
     end
 
-    r "ip netns add #{q_vm}"
+    r "ip", "netns", "add", @vm_name
 
     # Generate MAC addresses rather than letting Linux do it to avoid
     # a vexing bug whereby a freshly created link will, at least once,
     # spontaneously change its MAC address sometime soon after
     # creation, as caught by instrumenting reads of
-    # /sys/class/net/vethi#{q_vm}/address at two points in time.  The
+    # /sys/class/net/vethi#{@vm_name}/address at two points in time.  The
     # result is a race condition that *sometimes* worked.
-    r "ip link add vetho#{q_vm} addr #{gen_mac.shellescape} type veth peer name vethi#{q_vm} addr #{gen_mac.shellescape} netns #{q_vm}"
-    multiqueue_fragment = multiqueue ? " multi_queue vnet_hdr " : " "
+    r "ip", "link", "add", "vetho#{@vm_name}", "addr", gen_mac, "type", "veth", "peer", "name", "vethi#{@vm_name}", "addr", gen_mac, "netns", @vm_name
     nics.each do |nic|
-      r "ip -n #{q_vm} tuntap add dev #{nic.tap} mode tap user #{q_vm} #{multiqueue_fragment}"
-      r "ip -n #{q_vm} addr replace #{nic.private_ipv4_gateway} dev #{nic.tap}"
+      cmd = ["ip", "-n", @vm_name, "tuntap", "add", "dev", nic.tap, "mode", "tap", "user", @vm_name]
+      cmd += ["multi_queue", "vnet_hdr"] if multiqueue
+      r(*cmd)
+      r "ip", "-n", @vm_name, "addr", "replace", nic.private_ipv4_gateway, "dev", nic.tap
     end
   end
 
@@ -281,25 +282,25 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
 
   def setup_veths_6(guest_ephemeral, clover_ephemeral, gua, ndp_needed)
     # Routing: from host to subordinate.
-    vethi_ll = mac_to_ipv6_link_local(r("ip netns exec #{q_vm} cat /sys/class/net/vethi#{q_vm}/address").chomp)
-    r "ip link set dev vetho#{q_vm} up"
-    r "ip route replace #{gua.shellescape} via #{vethi_ll.shellescape} dev vetho#{q_vm}"
+    vethi_ll = mac_to_ipv6_link_local(r("ip", "netns", "exec", @vm_name, "cat", "/sys/class/net/vethi#{@vm_name}/address").chomp)
+    r "ip", "link", "set", "dev", "vetho#{@vm_name}", "up"
+    r "ip", "route", "replace", gua, "via", vethi_ll, "dev", "vetho#{@vm_name}"
 
     if ndp_needed
       routes = r "ip -j route"
       main_device = parse_routes(routes)
-      r "ip -6 neigh add proxy #{guest_ephemeral.nth(2)} dev #{main_device}"
-      r "ip -6 neigh add proxy #{clover_ephemeral.nth(0)} dev #{main_device}"
+      r "ip", "-6", "neigh", "add", "proxy", guest_ephemeral.nth(2).to_s, "dev", main_device
+      r "ip", "-6", "neigh", "add", "proxy", clover_ephemeral.nth(0).to_s, "dev", main_device
     end
 
     # Accept clover traffic within the namespace (don't just let it
     # enter a default routing loop via forwarding)
-    r "ip -n #{q_vm} addr replace #{clover_ephemeral.to_s.shellescape} dev vethi#{q_vm}"
+    r "ip", "-n", @vm_name, "addr", "replace", clover_ephemeral.to_s, "dev", "vethi#{@vm_name}"
 
     # Routing: from subordinate to host.
-    vetho_ll = mac_to_ipv6_link_local(File.read("/sys/class/net/vetho#{q_vm}/address").chomp)
-    r "ip -n #{q_vm} link set dev vethi#{q_vm} up"
-    r "ip -n #{q_vm} route replace 2000::/3 via #{vetho_ll.shellescape} dev vethi#{q_vm}"
+    vetho_ll = mac_to_ipv6_link_local(File.read("/sys/class/net/vetho#{@vm_name}/address").chomp)
+    r "ip", "-n", @vm_name, "link", "set", "dev", "vethi#{@vm_name}", "up"
+    r "ip", "-n", @vm_name, "route", "replace", "2000::/3", "via", vetho_ll, "dev", "vethi#{@vm_name}"
   end
 
   def setup_taps_6(gua, nics, dns_ipv4)
@@ -311,25 +312,25 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     # Allocate ::1 in the guest network for DHCPv6.
     guest_intrusion = guest_ephemeral.nth(1).to_s + "/" + guest_ephemeral.netmask.prefix_len.to_s
     nics.each do |nic|
-      r "ip -n #{q_vm} addr replace #{guest_intrusion.shellescape} dev #{nic.tap}"
+      r "ip", "-n", @vm_name, "addr", "replace", guest_intrusion, "dev", nic.tap
 
-      r "ip -n #{q_vm} addr replace #{dns_ipv4} dev #{nic.tap}"
+      r "ip", "-n", @vm_name, "addr", "replace", dns_ipv4, "dev", nic.tap
 
       # Route ephemeral address to tap.
-      r "ip -n #{q_vm} link set dev #{nic.tap} up"
-      r "ip -n #{q_vm} route replace #{guest_ephemeral.to_s.shellescape} via #{mac_to_ipv6_link_local(nic.mac)} dev #{nic.tap}"
-      r "ip -n #{q_vm} route del #{guest_ephemeral.to_s.shellescape} dev #{nic.tap}"
+      r "ip", "-n", @vm_name, "link", "set", "dev", nic.tap, "up"
+      r "ip", "-n", @vm_name, "route", "replace", guest_ephemeral.to_s, "via", mac_to_ipv6_link_local(nic.mac), "dev", nic.tap
+      r "ip", "-n", @vm_name, "route", "del", guest_ephemeral.to_s, "dev", nic.tap
 
       # Route private subnet addresses to tap.
       ip6 = NetAddr::IPv6Net.parse(nic.net6)
 
       # Allocate ::1 in the guest network for DHCPv6.
-      r "ip -n #{q_vm} addr replace #{ip6.nth(1)}/#{ip6.netmask.prefix_len} dev #{nic.tap} noprefixroute"
-      r "ip -n #{q_vm} route replace #{ip6.to_s.shellescape} via #{mac_to_ipv6_link_local(nic.mac)} dev #{nic.tap}"
+      r "ip", "-n", @vm_name, "addr", "replace", "#{ip6.nth(1)}/#{ip6.netmask.prefix_len}", "dev", nic.tap, "noprefixroute"
+      r "ip", "-n", @vm_name, "route", "replace", ip6.to_s, "via", mac_to_ipv6_link_local(nic.mac), "dev", nic.tap
     end
 
-    r "ip -n #{q_vm} addr replace fd00:0b1c:100d:5AFE:CE:: dev #{nics.first.tap}"
-    r "ip -n #{q_vm} addr replace fd00:0b1c:100d:53:: dev #{nics.first.tap}"
+    r "ip", "-n", @vm_name, "addr", "replace", "fd00:0b1c:100d:5AFE:CE::", "dev", nics.first.tap
+    r "ip", "-n", @vm_name, "addr", "replace", "fd00:0b1c:100d:53::", "dev", nics.first.tap
   end
 
   def parse_routes(routes)
@@ -347,17 +348,17 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     vetho, vethi = [local_ip.network.to_s,
       local_ip.next_sib.network.to_s]
 
-    r "ip addr replace #{vetho}/32 dev vetho#{q_vm}"
-    r "ip route replace #{vm} dev vetho#{q_vm}" if ip4
+    r "ip", "addr", "replace", "#{vetho}/32", "dev", "vetho#{@vm_name}"
+    r "ip", "route", "replace", vm, "dev", "vetho#{@vm_name}" if ip4
     r "echo 1 > /proc/sys/net/ipv4/conf/vetho#{q_vm}/proxy_arp"
 
-    r "ip -n #{q_vm} addr replace #{vethi}/32 dev vethi#{q_vm}"
+    r "ip", "-n", @vm_name, "addr", "replace", "#{vethi}/32", "dev", "vethi#{@vm_name}"
     # default?
-    r "ip -n #{q_vm} route replace #{vetho} dev vethi#{q_vm}"
+    r "ip", "-n", @vm_name, "route", "replace", vetho, "dev", "vethi#{@vm_name}"
 
     nics.each do |nic|
-      r "ip -n #{q_vm} route replace #{vm} dev #{nic.tap}" if ip4
-      r "ip -n #{q_vm} route replace default via #{vetho} dev vethi#{q_vm}"
+      r "ip", "-n", @vm_name, "route", "replace", vm, "dev", nic.tap if ip4
+      r "ip", "-n", @vm_name, "route", "replace", "default", "via", vetho, "dev", "vethi#{@vm_name}"
 
       r "ip netns exec #{q_vm} bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethi#{q_vm}/proxy_arp'"
       r "ip netns exec #{q_vm} bash -c 'echo 1 > /proc/sys/net/ipv4/conf/#{nic.tap}/proxy_arp'"
@@ -385,7 +386,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
 
     nics.each do |nic|
       local_ip4 = NetAddr::IPv4Net.parse(nic.net4)
-      r "ip -n #{q_vm} route replace #{local_ip4.to_s.shellescape} via #{local_ip4.nth(1).to_s.shellescape} dev #{nic.tap}" unless local_ip4.netmask.prefix_len == 32
+      r "ip", "-n", @vm_name, "route", "replace", local_ip4.to_s, "via", local_ip4.nth(1).to_s, "dev", nic.tap unless local_ip4.netmask.prefix_len == 32
     end
   end
 
@@ -483,8 +484,8 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
   end
 
   def apply_nftables
-    r "ip netns exec #{q_vm} nft flush ruleset"
-    r "ip netns exec #{q_vm} nft -f #{vp.q_nftables_conf}"
+    r "ip", "netns", "exec", @vm_name, "nft", "flush", "ruleset"
+    r "ip", "netns", "exec", @vm_name, "nft", "-f", vp.nftables_conf
   end
 
   def cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4, ipv6_disabled:, init_script: nil)
@@ -565,10 +566,10 @@ DNSMASQ_CONF
     write_user_data(unix_user, public_keys, swap_size_bytes, boot_image, init_script: init_script)
 
     FileUtils.rm_rf(vp.cloudinit_img)
-    r "mkdosfs -n CIDATA -C #{vp.q_cloudinit_img} 128"
-    r "mcopy -oi #{vp.q_cloudinit_img} -s #{vp.q_user_data} ::"
-    r "mcopy -oi #{vp.q_cloudinit_img} -s #{vp.q_meta_data} ::"
-    r "mcopy -oi #{vp.q_cloudinit_img} -s #{vp.q_network_config} ::"
+    r "mkdosfs", "-n", "CIDATA", "-C", vp.cloudinit_img, "128"
+    r "mcopy", "-oi", vp.cloudinit_img, "-s", vp.user_data, "::"
+    r "mcopy", "-oi", vp.cloudinit_img, "-s", vp.meta_data, "::"
+    r "mcopy", "-oi", vp.cloudinit_img, "-s", vp.network_config, "::"
     FileUtils.chown @vm_name, @vm_name, vp.cloudinit_img
   end
 
@@ -628,9 +629,9 @@ DNSMASQ_CONF
   # Unnecessary if host has this set before creating the netns, but
   # harmless and fast enough to double up.
   def forwarding
-    r("ip netns exec #{q_vm} sysctl -w net.ipv6.conf.all.forwarding=1")
-    r("ip netns exec #{q_vm} sysctl -w net.ipv4.conf.all.forwarding=1")
-    r("ip netns exec #{q_vm} sysctl -w net.ipv4.ip_forward=1")
+    r("ip", "netns", "exec", @vm_name, "sysctl", "-w", "net.ipv6.conf.all.forwarding=1")
+    r("ip", "netns", "exec", @vm_name, "sysctl", "-w", "net.ipv4.conf.all.forwarding=1")
+    r("ip", "netns", "exec", @vm_name, "sysctl", "-w", "net.ipv4.ip_forward=1")
   end
 
   def prepare_gpus(pci_devices, gpu_partition_id)
@@ -749,11 +750,11 @@ DNSMASQ_SERVICE
   end
 
   def start_systemd_unit
-    r "systemctl start #{q_vm}"
+    r "systemctl", "start", @vm_name
   end
 
   def restart_systemd_unit
-    r "systemctl restart #{q_vm}"
+    r "systemctl", "restart", @vm_name
   end
 
   def build_ch_service(header:, footer:, slice_name:, mem_gib:, max_vcpus:, cpu_topology:, storage_volumes:, storage_params:, nics:, pci_devices:)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -346,7 +346,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
 
     r "ip", "addr", "replace", "#{vetho}/32", "dev", "vetho#{@vm_name}"
     r "ip", "route", "replace", vm, "dev", "vetho#{@vm_name}" if ip4
-    r cmd("echo 1 > :path", path: "/proc/sys/net/ipv4/conf/vetho#{@vm_name}/proxy_arp")
+    r "echo 1 > :path", path: "/proc/sys/net/ipv4/conf/vetho#{@vm_name}/proxy_arp"
 
     r "ip", "-n", @vm_name, "addr", "replace", "#{vethi}/32", "dev", "vethi#{@vm_name}"
     # default?
@@ -357,9 +357,9 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
       r "ip", "-n", @vm_name, "route", "replace", "default", "via", vetho, "dev", "vethi#{@vm_name}"
 
       inner = cmd("echo 1 > :path", path: "/proc/sys/net/ipv4/conf/vethi#{@vm_name}/proxy_arp")
-      r cmd("ip netns exec :vm bash -c :inner", vm: @vm_name, inner: inner)
+      r "ip netns exec :vm bash -c :inner", vm: @vm_name, inner: inner
       inner = cmd("echo 1 > :path", path: "/proc/sys/net/ipv4/conf/#{nic.tap}/proxy_arp")
-      r cmd("ip netns exec :vm bash -c :inner", vm: @vm_name, inner: inner)
+      r "ip netns exec :vm bash -c :inner", vm: @vm_name, inner: inner
     end
   end
 
@@ -372,7 +372,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     # device is created or not and then proceed to modify the routes.
     success = false
     5.times do
-      if r(cmd("ip -n :vm link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN", vm: @vm_name)).chomp == "UP"
+      if r("ip -n :vm link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN", vm: @vm_name).chomp == "UP"
         success = true
         break
       end

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -264,7 +264,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     r "ip", "link", "add", "vetho#{@vm_name}", "addr", gen_mac, "type", "veth", "peer", "name", "vethi#{@vm_name}", "addr", gen_mac, "netns", @vm_name
     nics.each do |nic|
       cmd = ["ip", "-n", @vm_name, "tuntap", "add", "dev", nic.tap, "mode", "tap", "user", @vm_name]
-      cmd += ["multi_queue", "vnet_hdr"] if multiqueue
+      cmd.push("multi_queue", "vnet_hdr") if multiqueue
       r(*cmd)
       r "ip", "-n", @vm_name, "addr", "replace", nic.private_ipv4_gateway, "dev", nic.tap
     end

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -34,10 +34,6 @@ class VmSetup
     raise("no valid cloud hypervisor firmware version")
   end
 
-  def q_vm
-    @q_vm ||= @vm_name.shellescape
-  end
-
   def vp
     @vp ||= VmPath.new(@vm_name)
   end
@@ -124,7 +120,7 @@ class VmSetup
 
   def unblock_ip4(ip4)
     ip_net = NetAddr::IPv4Net.parse(ip4).network.to_s
-    filename = "/etc/nftables.d/#{q_vm}.conf"
+    filename = "/etc/nftables.d/#{@vm_name}.conf"
     temp_filename = "#{filename}.tmp"
     File.open(temp_filename, File::RDWR | File::CREAT) do |f|
       f.flock(File::LOCK_EX | File::LOCK_NB)
@@ -139,7 +135,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
   end
 
   def block_ip4
-    FileUtils.rm_f("/etc/nftables.d/#{q_vm}.conf")
+    FileUtils.rm_f("/etc/nftables.d/#{@vm_name}.conf")
     reload_nftables
   end
 
@@ -383,7 +379,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
       sleep 0.5
     end
     unless success
-      raise "VM #{q_vm} tap device not ready after 5 retries."
+      raise "VM #{@vm_name} tap device not ready after 5 retries."
     end
 
     nics.each do |nic|
@@ -427,7 +423,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
   end
 
   def generate_dhcp_filter_rule
-    "oifname vethi#{q_vm} udp sport { 67, 68 } udp dport { 67, 68 } drop"
+    "oifname vethi#{@vm_name} udp sport { 67, 68 } udp dport { 67, 68 } drop"
   end
 
   def generate_ip6_public_filter(nic_first, guest_ephemeral)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -350,7 +350,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
 
     r "ip", "addr", "replace", "#{vetho}/32", "dev", "vetho#{@vm_name}"
     r "ip", "route", "replace", vm, "dev", "vetho#{@vm_name}" if ip4
-    r "echo 1 > /proc/sys/net/ipv4/conf/vetho#{q_vm}/proxy_arp"
+    r cmd("echo 1 > :path", path: "/proc/sys/net/ipv4/conf/vetho#{@vm_name}/proxy_arp")
 
     r "ip", "-n", @vm_name, "addr", "replace", "#{vethi}/32", "dev", "vethi#{@vm_name}"
     # default?
@@ -360,8 +360,10 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
       r "ip", "-n", @vm_name, "route", "replace", vm, "dev", nic.tap if ip4
       r "ip", "-n", @vm_name, "route", "replace", "default", "via", vetho, "dev", "vethi#{@vm_name}"
 
-      r "ip netns exec #{q_vm} bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethi#{q_vm}/proxy_arp'"
-      r "ip netns exec #{q_vm} bash -c 'echo 1 > /proc/sys/net/ipv4/conf/#{nic.tap}/proxy_arp'"
+      inner = cmd("echo 1 > :path", path: "/proc/sys/net/ipv4/conf/vethi#{@vm_name}/proxy_arp")
+      r cmd("ip netns exec :vm bash -c :inner", vm: @vm_name, inner: inner)
+      inner = cmd("echo 1 > :path", path: "/proc/sys/net/ipv4/conf/#{nic.tap}/proxy_arp")
+      r cmd("ip netns exec :vm bash -c :inner", vm: @vm_name, inner: inner)
     end
   end
 
@@ -374,7 +376,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     # device is created or not and then proceed to modify the routes.
     success = false
     5.times do
-      if r("ip -n #{q_vm} link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN").chomp == "UP"
+      if r(cmd("ip -n :vm link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN", vm: @vm_name)).chomp == "UP"
         success = true
         break
       end

--- a/rhizome/host/spec/boot_image_spec.rb
+++ b/rhizome/host/spec/boot_image_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe BootImage do
 
   describe "#convert_image" do
     it "can convert image" do
-      expect(bi).to receive(:_run_command).with("qemu-img convert -p -f qcow2 -O raw /var/storage/images/ubuntu-jammy-20240110.img.tmp /var/storage/images/ubuntu-jammy-20240110.raw")
+      expect(bi).to receive(:_run_command).with("qemu-img", "convert", "-p", "-f", "qcow2", "-O", "raw", "/var/storage/images/ubuntu-jammy-20240110.img.tmp", "/var/storage/images/ubuntu-jammy-20240110.raw")
       bi.convert_image("/var/storage/images/ubuntu-jammy-20240110.img.tmp", "qcow2")
     end
 

--- a/rhizome/host/spec/boot_image_spec.rb
+++ b/rhizome/host/spec/boot_image_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe BootImage do
         expect(path).to eq("/var/storage/images/ubuntu-jammy-20240110.img.tmp")
       end.and_yield
 
-      expect(bi).to receive(:r).with(
+      expect(bi).to receive(:_run_command).with(
         "bash -c 'curl -f -L10 url | tee >(openssl dgst -sha256) > /var/storage/images/ubuntu-jammy-20240110.img.tmp'",
       ).and_return("SHA2-256(stdin)= 81fae9cc21e2b1e3a9a4526c7dad3131b668e346c580702235ad4d02645d9455\n")
 
@@ -121,7 +121,7 @@ RSpec.describe BootImage do
         expect(path).to eq("/var/storage/images/ubuntu-jammy-20240110.img.tmp")
       end.and_yield
 
-      expect(bi).to receive(:r).with(
+      expect(bi).to receive(:_run_command).with(
         "bash -c 'curl -f -L10 url --cacert ca_path | tee >(openssl dgst -sha256) > /var/storage/images/ubuntu-jammy-20240110.img.tmp'",
       ).and_return("SHA2-256(stdin)= 81fae9cc21e2b1e3a9a4526c7dad3131b668e346c580702235ad4d02645d9455\n")
 
@@ -135,7 +135,7 @@ RSpec.describe BootImage do
         expect(path).to eq("/var/storage/images/ubuntu-jammy-20240110.img.tmp")
       end.and_yield
 
-      expect(bi).to receive(:r).with(
+      expect(bi).to receive(:_run_command).with(
         "bash -c 'htcat -parallelism=12 -max-fragment-size=32 URL | tee >(openssl dgst -sha256) > /var/storage/images/ubuntu-jammy-20240110.img.tmp'",
       ).and_return("SHA2-256(stdin)= 81fae9cc21e2b1e3a9a4526c7dad3131b668e346c580702235ad4d02645d9455\n")
 
@@ -159,7 +159,7 @@ RSpec.describe BootImage do
 
   describe "#convert_image" do
     it "can convert image" do
-      expect(bi).to receive(:r).with("qemu-img convert -p -f qcow2 -O raw /var/storage/images/ubuntu-jammy-20240110.img.tmp /var/storage/images/ubuntu-jammy-20240110.raw")
+      expect(bi).to receive(:_run_command).with("qemu-img convert -p -f qcow2 -O raw /var/storage/images/ubuntu-jammy-20240110.img.tmp /var/storage/images/ubuntu-jammy-20240110.raw")
       bi.convert_image("/var/storage/images/ubuntu-jammy-20240110.img.tmp", "qcow2")
     end
 

--- a/rhizome/host/spec/boot_image_spec.rb
+++ b/rhizome/host/spec/boot_image_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe BootImage do
       end.and_yield
 
       expect(bi).to receive(:_run_command).with(
-        "bash -c 'curl -f -L10 url | tee >(openssl dgst -sha256) > /var/storage/images/ubuntu-jammy-20240110.img.tmp'",
+        "bash -c curl\\ -f\\ -L10\\ url\\ \\|\\ tee\\ \\>\\(openssl\\ dgst\\ -sha256\\)\\ \\>\\ /var/storage/images/ubuntu-jammy-20240110.img.tmp",
       ).and_return("SHA2-256(stdin)= 81fae9cc21e2b1e3a9a4526c7dad3131b668e346c580702235ad4d02645d9455\n")
 
       expect(
@@ -122,7 +122,7 @@ RSpec.describe BootImage do
       end.and_yield
 
       expect(bi).to receive(:_run_command).with(
-        "bash -c 'curl -f -L10 url --cacert ca_path | tee >(openssl dgst -sha256) > /var/storage/images/ubuntu-jammy-20240110.img.tmp'",
+        "bash -c curl\\ -f\\ -L10\\ url\\ --cacert\\ ca_path\\ \\|\\ tee\\ \\>\\(openssl\\ dgst\\ -sha256\\)\\ \\>\\ /var/storage/images/ubuntu-jammy-20240110.img.tmp",
       ).and_return("SHA2-256(stdin)= 81fae9cc21e2b1e3a9a4526c7dad3131b668e346c580702235ad4d02645d9455\n")
 
       bi.curl_image("url", "/var/storage/images/ubuntu-jammy-20240110.img.tmp", "ca_path")
@@ -136,7 +136,7 @@ RSpec.describe BootImage do
       end.and_yield
 
       expect(bi).to receive(:_run_command).with(
-        "bash -c 'htcat -parallelism=12 -max-fragment-size=32 URL | tee >(openssl dgst -sha256) > /var/storage/images/ubuntu-jammy-20240110.img.tmp'",
+        "bash -c htcat\\ -parallelism\\=12\\ -max-fragment-size\\=32\\ URL\\ \\|\\ tee\\ \\>\\(openssl\\ dgst\\ -sha256\\)\\ \\>\\ /var/storage/images/ubuntu-jammy-20240110.img.tmp",
       ).and_return("SHA2-256(stdin)= 81fae9cc21e2b1e3a9a4526c7dad3131b668e346c580702235ad4d02645d9455\n")
 
       bi.htcat_image("URL", "/var/storage/images/ubuntu-jammy-20240110.img.tmp")

--- a/rhizome/host/spec/cert_server_setup_spec.rb
+++ b/rhizome/host/spec/cert_server_setup_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe CertServerSetup do
       expect(File).to receive(:exist?).with("/vm/test-vm/cert/metadata-endpoint-0.1.6").and_return(false)
       expect(cert_server_setup).to receive(:download_server)
       expect(FileUtils).to receive(:mkdir).with("/vm/test-vm/cert")
-      expect(cert_server_setup).to receive(:r).with("cp /opt/metadata-endpoint-0.1.6/metadata-endpoint /vm/test-vm/cert/metadata-endpoint-0.1.6")
-      expect(cert_server_setup).to receive(:r).with("sudo chown test-vm:test-vm /vm/test-vm/cert/metadata-endpoint-0.1.6")
+      expect(cert_server_setup).to receive(:_run_command).with("cp /opt/metadata-endpoint-0.1.6/metadata-endpoint /vm/test-vm/cert/metadata-endpoint-0.1.6")
+      expect(cert_server_setup).to receive(:_run_command).with("sudo chown test-vm:test-vm /vm/test-vm/cert/metadata-endpoint-0.1.6")
       expect { cert_server_setup.copy_server }.not_to raise_error
     end
 
@@ -40,8 +40,8 @@ RSpec.describe CertServerSetup do
       expect(File).to receive(:exist?).with("/vm/test-vm/cert/metadata-endpoint-0.1.6").and_return(false)
       expect(cert_server_setup).not_to receive(:download_server)
       expect(FileUtils).to receive(:mkdir).with("/vm/test-vm/cert")
-      expect(cert_server_setup).to receive(:r).with("cp /opt/metadata-endpoint-0.1.6/metadata-endpoint /vm/test-vm/cert/metadata-endpoint-0.1.6")
-      expect(cert_server_setup).to receive(:r).with("sudo chown test-vm:test-vm /vm/test-vm/cert/metadata-endpoint-0.1.6")
+      expect(cert_server_setup).to receive(:_run_command).with("cp /opt/metadata-endpoint-0.1.6/metadata-endpoint /vm/test-vm/cert/metadata-endpoint-0.1.6")
+      expect(cert_server_setup).to receive(:_run_command).with("sudo chown test-vm:test-vm /vm/test-vm/cert/metadata-endpoint-0.1.6")
       expect { cert_server_setup.copy_server }.not_to raise_error
     end
 
@@ -50,7 +50,7 @@ RSpec.describe CertServerSetup do
       expect(File).to receive(:exist?).with("/vm/test-vm/cert/metadata-endpoint-0.1.6").and_return(true)
       expect(cert_server_setup).not_to receive(:download_server)
       expect(FileUtils).to receive(:mkdir).with("/vm/test-vm/cert")
-      expect(cert_server_setup).not_to receive(:r).with("cp /opt/metadata-endpoint-0.1.6/metadata-endpoint /vm/test-vm/cert/metadata-endpoint-0.1.6")
+      expect(cert_server_setup).not_to receive(:_run_command).with("cp /opt/metadata-endpoint-0.1.6/metadata-endpoint /vm/test-vm/cert/metadata-endpoint-0.1.6")
       expect { cert_server_setup.copy_server }.not_to raise_error
     end
   end
@@ -58,20 +58,20 @@ RSpec.describe CertServerSetup do
   describe "#download_server" do
     it "downloads the server, extracts it, and removes the tarball" do
       expect(Arch).to receive(:render).with(x64: "x86_64", arm64: "arm64").and_return("arm64")
-      expect(cert_server_setup).to receive(:r).with("curl -L3 -o /tmp/metadata-endpoint-0.1.6.tar.gz https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_arm64.tar.gz")
+      expect(cert_server_setup).to receive(:_run_command).with("curl -L3 -o /tmp/metadata-endpoint-0.1.6.tar.gz https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_arm64.tar.gz")
       expect(FileUtils).to receive(:mkdir_p).with("/opt/metadata-endpoint-0.1.6")
       expect(FileUtils).to receive(:cd).with("/opt/metadata-endpoint-0.1.6").and_yield
-      expect(cert_server_setup).to receive(:r).with("tar -xzf /tmp/metadata-endpoint-0.1.6.tar.gz")
+      expect(cert_server_setup).to receive(:_run_command).with("tar -xzf /tmp/metadata-endpoint-0.1.6.tar.gz")
       expect(FileUtils).to receive(:rm_f).with("/tmp/metadata-endpoint-0.1.6.tar.gz")
       expect { cert_server_setup.download_server }.not_to raise_error
     end
 
     it "downloads the server for x64" do
       expect(Arch).to receive(:render).with(x64: "x86_64", arm64: "arm64").and_return("x86_64")
-      expect(cert_server_setup).to receive(:r).with("curl -L3 -o /tmp/metadata-endpoint-0.1.6.tar.gz https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_x86_64.tar.gz")
+      expect(cert_server_setup).to receive(:_run_command).with("curl -L3 -o /tmp/metadata-endpoint-0.1.6.tar.gz https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_x86_64.tar.gz")
       expect(FileUtils).to receive(:mkdir_p).with("/opt/metadata-endpoint-0.1.6")
       expect(FileUtils).to receive(:cd).with("/opt/metadata-endpoint-0.1.6").and_yield
-      expect(cert_server_setup).to receive(:r).with("tar -xzf /tmp/metadata-endpoint-0.1.6.tar.gz")
+      expect(cert_server_setup).to receive(:_run_command).with("tar -xzf /tmp/metadata-endpoint-0.1.6.tar.gz")
       expect(FileUtils).to receive(:rm_f).with("/tmp/metadata-endpoint-0.1.6.tar.gz")
       expect { cert_server_setup.download_server }.not_to raise_error
     end
@@ -108,7 +108,7 @@ Environment=GOMAXPROCS=1
 CPUQuota=50%
 MemoryLimit=10M
       SERVICE
-      expect(cert_server_setup).to receive(:r).with("systemctl daemon-reload")
+      expect(cert_server_setup).to receive(:_run_command).with("systemctl daemon-reload")
 
       expect { cert_server_setup.create_service }.not_to raise_error
     end
@@ -116,7 +116,7 @@ MemoryLimit=10M
 
   describe "#enable_and_start_service" do
     it "enables and starts the service" do
-      expect(cert_server_setup).to receive(:r).with("systemctl enable --now test-vm-metadata-endpoint")
+      expect(cert_server_setup).to receive(:_run_command).with("systemctl enable --now test-vm-metadata-endpoint")
       cert_server_setup.enable_and_start_service
       # expect { cert_server_setup.enable_and_start_service }.not_to raise_error
     end
@@ -125,16 +125,16 @@ MemoryLimit=10M
   describe "#stop_and_remove_service" do
     it "stops and removes the service" do
       expect(File).to receive(:exist?).with("/etc/systemd/system/test-vm-metadata-endpoint.service").and_return(true)
-      expect(cert_server_setup).to receive(:r).with("systemctl disable --now test-vm-metadata-endpoint")
-      expect(cert_server_setup).to receive(:r).with("systemctl daemon-reload")
+      expect(cert_server_setup).to receive(:_run_command).with("systemctl disable --now test-vm-metadata-endpoint")
+      expect(cert_server_setup).to receive(:_run_command).with("systemctl daemon-reload")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-vm-metadata-endpoint.service")
       expect { cert_server_setup.stop_and_remove_service }.not_to raise_error
     end
 
     it "doesn't stop and remove the service if it doesn't exist" do
       expect(File).to receive(:exist?).with("/etc/systemd/system/test-vm-metadata-endpoint.service").and_return(false)
-      expect(cert_server_setup).not_to receive(:r).with("systemctl disable --now test-vm-metadata-endpoint")
-      expect(cert_server_setup).to receive(:r).with("systemctl daemon-reload")
+      expect(cert_server_setup).not_to receive(:_run_command).with("systemctl disable --now test-vm-metadata-endpoint")
+      expect(cert_server_setup).to receive(:_run_command).with("systemctl daemon-reload")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-vm-metadata-endpoint.service")
       expect { cert_server_setup.stop_and_remove_service }.not_to raise_error
     end

--- a/rhizome/host/spec/cert_server_setup_spec.rb
+++ b/rhizome/host/spec/cert_server_setup_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe CertServerSetup do
       expect(File).to receive(:exist?).with("/vm/test-vm/cert/metadata-endpoint-0.1.6").and_return(false)
       expect(cert_server_setup).to receive(:download_server)
       expect(FileUtils).to receive(:mkdir).with("/vm/test-vm/cert")
-      expect(cert_server_setup).to receive(:_run_command).with("cp /opt/metadata-endpoint-0.1.6/metadata-endpoint /vm/test-vm/cert/metadata-endpoint-0.1.6")
-      expect(cert_server_setup).to receive(:_run_command).with("sudo chown test-vm:test-vm /vm/test-vm/cert/metadata-endpoint-0.1.6")
+      expect(cert_server_setup).to receive(:_run_command).with("cp", "/opt/metadata-endpoint-0.1.6/metadata-endpoint", "/vm/test-vm/cert/metadata-endpoint-0.1.6")
+      expect(cert_server_setup).to receive(:_run_command).with("sudo", "chown", "test-vm:test-vm", "/vm/test-vm/cert/metadata-endpoint-0.1.6")
       expect { cert_server_setup.copy_server }.not_to raise_error
     end
 
@@ -40,8 +40,8 @@ RSpec.describe CertServerSetup do
       expect(File).to receive(:exist?).with("/vm/test-vm/cert/metadata-endpoint-0.1.6").and_return(false)
       expect(cert_server_setup).not_to receive(:download_server)
       expect(FileUtils).to receive(:mkdir).with("/vm/test-vm/cert")
-      expect(cert_server_setup).to receive(:_run_command).with("cp /opt/metadata-endpoint-0.1.6/metadata-endpoint /vm/test-vm/cert/metadata-endpoint-0.1.6")
-      expect(cert_server_setup).to receive(:_run_command).with("sudo chown test-vm:test-vm /vm/test-vm/cert/metadata-endpoint-0.1.6")
+      expect(cert_server_setup).to receive(:_run_command).with("cp", "/opt/metadata-endpoint-0.1.6/metadata-endpoint", "/vm/test-vm/cert/metadata-endpoint-0.1.6")
+      expect(cert_server_setup).to receive(:_run_command).with("sudo", "chown", "test-vm:test-vm", "/vm/test-vm/cert/metadata-endpoint-0.1.6")
       expect { cert_server_setup.copy_server }.not_to raise_error
     end
 
@@ -50,7 +50,7 @@ RSpec.describe CertServerSetup do
       expect(File).to receive(:exist?).with("/vm/test-vm/cert/metadata-endpoint-0.1.6").and_return(true)
       expect(cert_server_setup).not_to receive(:download_server)
       expect(FileUtils).to receive(:mkdir).with("/vm/test-vm/cert")
-      expect(cert_server_setup).not_to receive(:_run_command).with("cp /opt/metadata-endpoint-0.1.6/metadata-endpoint /vm/test-vm/cert/metadata-endpoint-0.1.6")
+      expect(cert_server_setup).not_to receive(:_run_command).with("cp", "/opt/metadata-endpoint-0.1.6/metadata-endpoint", "/vm/test-vm/cert/metadata-endpoint-0.1.6")
       expect { cert_server_setup.copy_server }.not_to raise_error
     end
   end
@@ -58,20 +58,20 @@ RSpec.describe CertServerSetup do
   describe "#download_server" do
     it "downloads the server, extracts it, and removes the tarball" do
       expect(Arch).to receive(:render).with(x64: "x86_64", arm64: "arm64").and_return("arm64")
-      expect(cert_server_setup).to receive(:_run_command).with("curl -L3 -o /tmp/metadata-endpoint-0.1.6.tar.gz https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_arm64.tar.gz")
+      expect(cert_server_setup).to receive(:_run_command).with("curl", "-L3", "-o", "/tmp/metadata-endpoint-0.1.6.tar.gz", "https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_arm64.tar.gz")
       expect(FileUtils).to receive(:mkdir_p).with("/opt/metadata-endpoint-0.1.6")
       expect(FileUtils).to receive(:cd).with("/opt/metadata-endpoint-0.1.6").and_yield
-      expect(cert_server_setup).to receive(:_run_command).with("tar -xzf /tmp/metadata-endpoint-0.1.6.tar.gz")
+      expect(cert_server_setup).to receive(:_run_command).with("tar", "-xzf", "/tmp/metadata-endpoint-0.1.6.tar.gz")
       expect(FileUtils).to receive(:rm_f).with("/tmp/metadata-endpoint-0.1.6.tar.gz")
       expect { cert_server_setup.download_server }.not_to raise_error
     end
 
     it "downloads the server for x64" do
       expect(Arch).to receive(:render).with(x64: "x86_64", arm64: "arm64").and_return("x86_64")
-      expect(cert_server_setup).to receive(:_run_command).with("curl -L3 -o /tmp/metadata-endpoint-0.1.6.tar.gz https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_x86_64.tar.gz")
+      expect(cert_server_setup).to receive(:_run_command).with("curl", "-L3", "-o", "/tmp/metadata-endpoint-0.1.6.tar.gz", "https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_x86_64.tar.gz")
       expect(FileUtils).to receive(:mkdir_p).with("/opt/metadata-endpoint-0.1.6")
       expect(FileUtils).to receive(:cd).with("/opt/metadata-endpoint-0.1.6").and_yield
-      expect(cert_server_setup).to receive(:_run_command).with("tar -xzf /tmp/metadata-endpoint-0.1.6.tar.gz")
+      expect(cert_server_setup).to receive(:_run_command).with("tar", "-xzf", "/tmp/metadata-endpoint-0.1.6.tar.gz")
       expect(FileUtils).to receive(:rm_f).with("/tmp/metadata-endpoint-0.1.6.tar.gz")
       expect { cert_server_setup.download_server }.not_to raise_error
     end
@@ -116,7 +116,7 @@ MemoryLimit=10M
 
   describe "#enable_and_start_service" do
     it "enables and starts the service" do
-      expect(cert_server_setup).to receive(:_run_command).with("systemctl enable --now test-vm-metadata-endpoint")
+      expect(cert_server_setup).to receive(:_run_command).with("systemctl", "enable", "--now", "test-vm-metadata-endpoint")
       cert_server_setup.enable_and_start_service
       # expect { cert_server_setup.enable_and_start_service }.not_to raise_error
     end
@@ -125,7 +125,7 @@ MemoryLimit=10M
   describe "#stop_and_remove_service" do
     it "stops and removes the service" do
       expect(File).to receive(:exist?).with("/etc/systemd/system/test-vm-metadata-endpoint.service").and_return(true)
-      expect(cert_server_setup).to receive(:_run_command).with("systemctl disable --now test-vm-metadata-endpoint")
+      expect(cert_server_setup).to receive(:_run_command).with("systemctl", "disable", "--now", "test-vm-metadata-endpoint")
       expect(cert_server_setup).to receive(:_run_command).with("systemctl daemon-reload")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-vm-metadata-endpoint.service")
       expect { cert_server_setup.stop_and_remove_service }.not_to raise_error
@@ -133,7 +133,7 @@ MemoryLimit=10M
 
     it "doesn't stop and remove the service if it doesn't exist" do
       expect(File).to receive(:exist?).with("/etc/systemd/system/test-vm-metadata-endpoint.service").and_return(false)
-      expect(cert_server_setup).not_to receive(:_run_command).with("systemctl disable --now test-vm-metadata-endpoint")
+      expect(cert_server_setup).not_to receive(:_run_command).with("systemctl", "disable", "--now", "test-vm-metadata-endpoint")
       expect(cert_server_setup).to receive(:_run_command).with("systemctl daemon-reload")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-vm-metadata-endpoint.service")
       expect { cert_server_setup.stop_and_remove_service }.not_to raise_error

--- a/rhizome/host/spec/crypt_swap_setup_spec.rb
+++ b/rhizome/host/spec/crypt_swap_setup_spec.rb
@@ -31,18 +31,18 @@ RSpec.describe CryptSwapSetup do
       expect(File).to receive(:realpath).with("/dev/disk/by-id/nvme-eui.12345678").and_return("/dev/nvme0n1p2")
       expect(File).to receive(:stat).with("/dev/nvme0n1p2").twice.and_return(instance_double(File::Stat, rdev_major: 259, rdev_minor: 2))
 
-      expect(described_class).to receive(:r).with("swapoff", "/dev/nvme0n1p2")
+      expect(described_class).to receive(:_run_command).with("swapoff", "/dev/nvme0n1p2")
       expect(File).to receive(:exist?).with(CryptSwapSetup::CRYPTTAB).and_return(false)
       expect(described_class).to receive(:safe_write_to_file).with(CryptSwapSetup::CRYPTTAB, "cryptswap /dev/disk/by-id/nvme-eui.12345678 /dev/urandom cipher=aes-xts-plain64,size=512,swap,discard\n")
       expect(Time).to receive(:now).and_return(Time.at(1_700_000_000))
       expect(FileUtils).to receive(:cp).with(CryptSwapSetup::FSTAB, "#{CryptSwapSetup::FSTAB}.bak.1700000000")
       expect(described_class).to receive(:safe_write_to_file).with(CryptSwapSetup::FSTAB, fstab.sub("UUID=4c4fe278-d132-4136-8073-b1242eacf5eb none swap sw 0 0\n", "/dev/mapper/cryptswap none swap sw 0 0\n"))
 
-      expect(described_class).to receive(:r).with("wipefs", "-a", "/dev/nvme0n1p2")
-      expect(described_class).to receive(:r).with("systemctl", "daemon-reload")
-      expect(described_class).to receive(:r).with("systemctl", "restart", "systemd-cryptsetup@cryptswap.service")
-      expect(described_class).to receive(:r).with("mkswap", "-f", CryptSwapSetup::CRYPTSWAP_DEVICE)
-      expect(described_class).to receive(:r).with("swapon", "-a")
+      expect(described_class).to receive(:_run_command).with("wipefs", "-a", "/dev/nvme0n1p2")
+      expect(described_class).to receive(:_run_command).with("systemctl", "daemon-reload")
+      expect(described_class).to receive(:_run_command).with("systemctl", "restart", "systemd-cryptsetup@cryptswap.service")
+      expect(described_class).to receive(:_run_command).with("mkswap", "-f", CryptSwapSetup::CRYPTSWAP_DEVICE)
+      expect(described_class).to receive(:_run_command).with("swapon", "-a")
 
       described_class.run
     end

--- a/rhizome/host/spec/leaseweb_networking_setup_spec.rb
+++ b/rhizome/host/spec/leaseweb_networking_setup_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe LeasewebNetworkingSetup do
       expect(FileUtils).to receive(:mkdir_p).with("/var/tmp/leaseweb-netplan/etc/netplan", mode: 0o700)
       expect(File).to receive(:write).with("/var/tmp/leaseweb-netplan/etc/netplan/01-netcfg.yaml", "netplan-yaml")
       expect(FileUtils).to receive(:chmod).with(0o600, "/var/tmp/leaseweb-netplan/etc/netplan/01-netcfg.yaml")
-      expect(setup).to receive(:r).with("netplan generate --root-dir /var/tmp/leaseweb-netplan")
+      expect(setup).to receive(:_run_command).with("netplan", "generate", "--root-dir", "/var/tmp/leaseweb-netplan")
 
       setup.send(:generate)
     end
@@ -109,8 +109,8 @@ RSpec.describe LeasewebNetworkingSetup do
 
   describe "#apply" do
     it "generates and applies the live config" do
-      expect(setup).to receive(:r).with("netplan generate").ordered
-      expect(setup).to receive(:r).with("netplan apply").ordered
+      expect(setup).to receive(:_run_command).with("netplan generate").ordered
+      expect(setup).to receive(:_run_command).with("netplan apply").ordered
 
       setup.send(:apply)
     end

--- a/rhizome/host/spec/slice_setup_spec.rb
+++ b/rhizome/host/spec/slice_setup_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe SliceSetup do
 
   describe "#purge" do
     it "stops the systemd unit and removes the systemd service file" do
-      expect(slice_setup).to receive(:r).with("systemctl stop slice_name.slice", expect: [0, 5])
+      expect(slice_setup).to receive(:_run_command).with("systemctl stop slice_name.slice", expect: [0, 5])
       expect(slice_setup).to receive(:rm_if_exists).with(slice_setup.systemd_service)
-      expect(slice_setup).to receive(:r).with("systemctl daemon-reload")
+      expect(slice_setup).to receive(:_run_command).with("systemctl daemon-reload")
       slice_setup.purge
     end
   end
@@ -39,7 +39,7 @@ RSpec.describe SliceSetup do
     it "writes the slice configuration to the systemd service file" do
       expect(File).to receive(:exist?).with(slice_setup.systemd_service).and_return(false)
       expect(slice_setup).to receive(:safe_write_to_file)
-      expect(slice_setup).to receive(:r).with("systemctl daemon-reload")
+      expect(slice_setup).to receive(:_run_command).with("systemctl daemon-reload")
       slice_setup.install_systemd_unit("3-4")
     end
 
@@ -79,7 +79,7 @@ RSpec.describe SliceSetup do
 
   describe "#start_systemd_unit" do
     it "starts the systemd unit and writes to the cpuset.cpus.partition file" do
-      expect(slice_setup).to receive(:r).with("systemctl start slice_name.slice")
+      expect(slice_setup).to receive(:_run_command).with("systemctl start slice_name.slice")
       expect(File).to receive(:write).with("/sys/fs/cgroup/slice_name.slice/cpuset.cpus.partition", "member")
       slice_setup.start_systemd_unit
     end

--- a/rhizome/host/spec/slice_setup_spec.rb
+++ b/rhizome/host/spec/slice_setup_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SliceSetup do
 
   describe "#purge" do
     it "stops the systemd unit and removes the systemd service file" do
-      expect(slice_setup).to receive(:_run_command).with("systemctl stop slice_name.slice", expect: [0, 5])
+      expect(slice_setup).to receive(:_run_command).with("systemctl", "stop", "slice_name.slice", expect: [0, 5])
       expect(slice_setup).to receive(:rm_if_exists).with(slice_setup.systemd_service)
       expect(slice_setup).to receive(:_run_command).with("systemctl daemon-reload")
       slice_setup.purge
@@ -79,7 +79,7 @@ RSpec.describe SliceSetup do
 
   describe "#start_systemd_unit" do
     it "starts the systemd unit and writes to the cpuset.cpus.partition file" do
-      expect(slice_setup).to receive(:_run_command).with("systemctl start slice_name.slice")
+      expect(slice_setup).to receive(:_run_command).with("systemctl", "start", "slice_name.slice")
       expect(File).to receive(:write).with("/sys/fs/cgroup/slice_name.slice/cpuset.cpus.partition", "member")
       slice_setup.start_systemd_unit
     end

--- a/rhizome/host/spec/spdk_setup_spec.rb
+++ b/rhizome/host/spec/spdk_setup_spec.rb
@@ -9,18 +9,18 @@ RSpec.describe SpdkSetup do
 
   describe "#prep" do
     before do
-      expect(described_class).to receive(:r).with("apt-get -y install libaio-dev libssl-dev libnuma-dev libjson-c-dev uuid-dev libiscsi-dev")
+      expect(described_class).to receive(:_run_command).with("apt-get -y install libaio-dev libssl-dev libnuma-dev libjson-c-dev uuid-dev libiscsi-dev")
     end
 
     it "can prep host for spdk" do
-      expect(described_class).to receive(:r).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
+      expect(described_class).to receive(:_run_command).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
       expect(FileUtils).to receive(:mkdir_p).with(SpdkPath.vhost_dir)
       expect(FileUtils).to receive(:chown).with("spdk", "spdk", SpdkPath.vhost_dir)
       described_class.prep
     end
 
     it "continues if user already exists (ubuntu 22.04)" do
-      expect(described_class).to receive(:r).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
+      expect(described_class).to receive(:_run_command).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
         .and_raise CommandFail.new("Warning: The home dir /home/spdk you specified already exists.\nadduser: The user `spdk' already exists.", "", "")
       expect(FileUtils).to receive(:mkdir_p).with(SpdkPath.vhost_dir)
       expect(FileUtils).to receive(:chown).with("spdk", "spdk", SpdkPath.vhost_dir)
@@ -28,7 +28,7 @@ RSpec.describe SpdkSetup do
     end
 
     it "continues if user already exists (ubuntu 24.04)" do
-      expect(described_class).to receive(:r).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
+      expect(described_class).to receive(:_run_command).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
         .and_raise CommandFail.new("info: The home dir /home/spdk you specified already exists.\n\nfatal: The user `spdk' already exists.", "", "")
       expect(FileUtils).to receive(:mkdir_p).with(SpdkPath.vhost_dir)
       expect(FileUtils).to receive(:chown).with("spdk", "spdk", SpdkPath.vhost_dir)
@@ -36,7 +36,7 @@ RSpec.describe SpdkSetup do
     end
 
     it "fails if adduser fails with an unexpected error" do
-      expect(described_class).to receive(:r).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
+      expect(described_class).to receive(:_run_command).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
         .and_raise CommandFail.new("adduser: some other error.", "", "")
       expect { described_class.prep }.to raise_error CommandFail
     end
@@ -64,10 +64,10 @@ RSpec.describe SpdkSetup do
       expect(spdk_setup).to receive(:package_url).and_return("package_url")
       expect(spdk_setup).to receive(:puts).with("Downloading SPDK package from package_url")
       expect(spdk_setup).to receive(:install_path).and_return("install_path").at_least(:once)
-      expect(spdk_setup).to receive(:r).with("curl -L3 -o /tmp/spdk.tar.gz package_url")
+      expect(spdk_setup).to receive(:_run_command).with("curl -L3 -o /tmp/spdk.tar.gz package_url")
       expect(FileUtils).to receive(:mkdir_p).with("install_path")
       expect(FileUtils).to receive(:cd).with("install_path").and_yield
-      expect(spdk_setup).to receive(:r).with("tar -xzf /tmp/spdk.tar.gz --strip-components=1")
+      expect(spdk_setup).to receive(:_run_command).with("tar -xzf /tmp/spdk.tar.gz --strip-components=1")
       spdk_setup.install_package(os_version: "ubuntu-22.04")
     end
   end
@@ -81,7 +81,7 @@ RSpec.describe SpdkSetup do
 
   describe "#create_hugepages_mount" do
     it "creates the hugepages mount" do
-      expect(spdk_setup).to receive(:r).with("sudo --user=spdk mkdir -p /home/spdk/hugepages.#{spdk_version.tr("-", ".")}")
+      expect(spdk_setup).to receive(:_run_command).with("sudo --user=spdk mkdir -p /home/spdk/hugepages.#{spdk_version.tr("-", ".")}")
       expect(File).to receive(:write).with("/lib/systemd/system/home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount", /.*/)
       spdk_setup.create_hugepages_mount(cpu_count: 4)
     end
@@ -103,10 +103,10 @@ RSpec.describe SpdkSetup do
 
   describe "#stop_and_remove_services" do
     it "stops and removes services and unit files" do
-      expect(spdk_setup).to receive(:r).with("systemctl stop spdk-#{spdk_version}.service")
-      expect(spdk_setup).to receive(:r).with("systemctl stop home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
-      expect(spdk_setup).to receive(:r).with("systemctl disable spdk-#{spdk_version}.service")
-      expect(spdk_setup).to receive(:r).with("systemctl disable home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl stop spdk-#{spdk_version}.service")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl stop home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl disable spdk-#{spdk_version}.service")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl disable home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
       expect(FileUtils).to receive(:rm_f).with("/lib/systemd/system/spdk-#{spdk_version}.service")
       expect(FileUtils).to receive(:rm_f).with("/lib/systemd/system/home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
       spdk_setup.stop_and_remove_services
@@ -124,16 +124,16 @@ RSpec.describe SpdkSetup do
 
   describe "#enable_services" do
     it "enables services" do
-      expect(spdk_setup).to receive(:r).with("systemctl enable spdk-#{spdk_version}.service")
-      expect(spdk_setup).to receive(:r).with("systemctl enable home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl enable spdk-#{spdk_version}.service")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl enable home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
       expect { spdk_setup.enable_services }.not_to raise_error
     end
   end
 
   describe "#start_services" do
     it "starts services" do
-      expect(spdk_setup).to receive(:r).with("systemctl start spdk-#{spdk_version}.service")
-      expect(spdk_setup).to receive(:r).with("systemctl start home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl start spdk-#{spdk_version}.service")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl start home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
       expect { spdk_setup.start_services }.not_to raise_error
     end
   end
@@ -151,12 +151,12 @@ RSpec.describe SpdkSetup do
 
   describe "#verify_spdk" do
     it "succeeds if is active" do
-      expect(spdk_setup).to receive(:r).with("systemctl is-active spdk-#{spdk_version}.service").and_return("active\n")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl is-active spdk-#{spdk_version}.service").and_return("active\n")
       expect { spdk_setup.verify_spdk }.not_to raise_error
     end
 
     it "fails if not active" do
-      expect(spdk_setup).to receive(:r).with("systemctl is-active spdk-#{spdk_version}.service").and_return("inactive\n")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl is-active spdk-#{spdk_version}.service").and_return("inactive\n")
       expect { spdk_setup.verify_spdk }.to raise_error RuntimeError, "SPDK failed to start"
     end
   end

--- a/rhizome/host/spec/spdk_setup_spec.rb
+++ b/rhizome/host/spec/spdk_setup_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe SpdkSetup do
     end
 
     it "can prep host for spdk" do
-      expect(described_class).to receive(:_run_command).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
+      expect(described_class).to receive(:_run_command).with("adduser", "spdk", "--disabled-password", "--gecos", "", "--home", "/home/spdk")
       expect(FileUtils).to receive(:mkdir_p).with(SpdkPath.vhost_dir)
       expect(FileUtils).to receive(:chown).with("spdk", "spdk", SpdkPath.vhost_dir)
       described_class.prep
     end
 
     it "continues if user already exists (ubuntu 22.04)" do
-      expect(described_class).to receive(:_run_command).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
+      expect(described_class).to receive(:_run_command).with("adduser", "spdk", "--disabled-password", "--gecos", "", "--home", "/home/spdk")
         .and_raise CommandFail.new("Warning: The home dir /home/spdk you specified already exists.\nadduser: The user `spdk' already exists.", "", "")
       expect(FileUtils).to receive(:mkdir_p).with(SpdkPath.vhost_dir)
       expect(FileUtils).to receive(:chown).with("spdk", "spdk", SpdkPath.vhost_dir)
@@ -28,7 +28,7 @@ RSpec.describe SpdkSetup do
     end
 
     it "continues if user already exists (ubuntu 24.04)" do
-      expect(described_class).to receive(:_run_command).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
+      expect(described_class).to receive(:_run_command).with("adduser", "spdk", "--disabled-password", "--gecos", "", "--home", "/home/spdk")
         .and_raise CommandFail.new("info: The home dir /home/spdk you specified already exists.\n\nfatal: The user `spdk' already exists.", "", "")
       expect(FileUtils).to receive(:mkdir_p).with(SpdkPath.vhost_dir)
       expect(FileUtils).to receive(:chown).with("spdk", "spdk", SpdkPath.vhost_dir)
@@ -36,7 +36,7 @@ RSpec.describe SpdkSetup do
     end
 
     it "fails if adduser fails with an unexpected error" do
-      expect(described_class).to receive(:_run_command).with("adduser spdk --disabled-password --gecos '' --home /home/spdk")
+      expect(described_class).to receive(:_run_command).with("adduser", "spdk", "--disabled-password", "--gecos", "", "--home", "/home/spdk")
         .and_raise CommandFail.new("adduser: some other error.", "", "")
       expect { described_class.prep }.to raise_error CommandFail
     end
@@ -64,10 +64,10 @@ RSpec.describe SpdkSetup do
       expect(spdk_setup).to receive(:package_url).and_return("package_url")
       expect(spdk_setup).to receive(:puts).with("Downloading SPDK package from package_url")
       expect(spdk_setup).to receive(:install_path).and_return("install_path").at_least(:once)
-      expect(spdk_setup).to receive(:_run_command).with("curl -L3 -o /tmp/spdk.tar.gz package_url")
+      expect(spdk_setup).to receive(:_run_command).with("curl", "-L3", "-o", "/tmp/spdk.tar.gz", "package_url")
       expect(FileUtils).to receive(:mkdir_p).with("install_path")
       expect(FileUtils).to receive(:cd).with("install_path").and_yield
-      expect(spdk_setup).to receive(:_run_command).with("tar -xzf /tmp/spdk.tar.gz --strip-components=1")
+      expect(spdk_setup).to receive(:_run_command).with("tar", "-xzf", "/tmp/spdk.tar.gz", "--strip-components=1")
       spdk_setup.install_package(os_version: "ubuntu-22.04")
     end
   end
@@ -81,7 +81,7 @@ RSpec.describe SpdkSetup do
 
   describe "#create_hugepages_mount" do
     it "creates the hugepages mount" do
-      expect(spdk_setup).to receive(:_run_command).with("sudo --user=spdk mkdir -p /home/spdk/hugepages.#{spdk_version.tr("-", ".")}")
+      expect(spdk_setup).to receive(:_run_command).with("sudo", "--user=spdk", "mkdir", "-p", "/home/spdk/hugepages.#{spdk_version.tr("-", ".")}")
       expect(File).to receive(:write).with("/lib/systemd/system/home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount", /.*/)
       spdk_setup.create_hugepages_mount(cpu_count: 4)
     end
@@ -103,10 +103,10 @@ RSpec.describe SpdkSetup do
 
   describe "#stop_and_remove_services" do
     it "stops and removes services and unit files" do
-      expect(spdk_setup).to receive(:_run_command).with("systemctl stop spdk-#{spdk_version}.service")
-      expect(spdk_setup).to receive(:_run_command).with("systemctl stop home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
-      expect(spdk_setup).to receive(:_run_command).with("systemctl disable spdk-#{spdk_version}.service")
-      expect(spdk_setup).to receive(:_run_command).with("systemctl disable home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl", "stop", "spdk-#{spdk_version}.service")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl", "stop", "home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl", "disable", "spdk-#{spdk_version}.service")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl", "disable", "home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
       expect(FileUtils).to receive(:rm_f).with("/lib/systemd/system/spdk-#{spdk_version}.service")
       expect(FileUtils).to receive(:rm_f).with("/lib/systemd/system/home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
       spdk_setup.stop_and_remove_services
@@ -124,16 +124,16 @@ RSpec.describe SpdkSetup do
 
   describe "#enable_services" do
     it "enables services" do
-      expect(spdk_setup).to receive(:_run_command).with("systemctl enable spdk-#{spdk_version}.service")
-      expect(spdk_setup).to receive(:_run_command).with("systemctl enable home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl", "enable", "spdk-#{spdk_version}.service")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl", "enable", "home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
       expect { spdk_setup.enable_services }.not_to raise_error
     end
   end
 
   describe "#start_services" do
     it "starts services" do
-      expect(spdk_setup).to receive(:_run_command).with("systemctl start spdk-#{spdk_version}.service")
-      expect(spdk_setup).to receive(:_run_command).with("systemctl start home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl", "start", "spdk-#{spdk_version}.service")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl", "start", "home-spdk-hugepages.#{spdk_version.tr("-", ".")}.mount")
       expect { spdk_setup.start_services }.not_to raise_error
     end
   end
@@ -151,12 +151,12 @@ RSpec.describe SpdkSetup do
 
   describe "#verify_spdk" do
     it "succeeds if is active" do
-      expect(spdk_setup).to receive(:_run_command).with("systemctl is-active spdk-#{spdk_version}.service").and_return("active\n")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl", "is-active", "spdk-#{spdk_version}.service").and_return("active\n")
       expect { spdk_setup.verify_spdk }.not_to raise_error
     end
 
     it "fails if not active" do
-      expect(spdk_setup).to receive(:_run_command).with("systemctl is-active spdk-#{spdk_version}.service").and_return("inactive\n")
+      expect(spdk_setup).to receive(:_run_command).with("systemctl", "is-active", "spdk-#{spdk_version}.service").and_return("inactive\n")
       expect { spdk_setup.verify_spdk }.to raise_error RuntimeError, "SPDK failed to start"
     end
   end

--- a/rhizome/host/spec/storage_archive_spec.rb
+++ b/rhizome/host/spec/storage_archive_spec.rb
@@ -150,7 +150,7 @@ allow_inline_plaintext_secrets = true
       built_config = "[target]\n"
       allow(archive).to receive(:build_target_config).and_return(built_config)
 
-      expect(archive).to receive(:r).with(
+      expect(archive).to receive(:_run_command).with(
         {"RUST_LOG" => "info"},
         "/opt/vhost-block-backend/v0.4.0/archive",
         "--config", disk_config_path,
@@ -174,9 +174,12 @@ allow_inline_plaintext_secrets = true
           File.write("#{tmpdir}/image.raw", "x" * (1024 * 1024 * 5 + 1))
         end
 
-        expect(described_class).to receive(:r).with("truncate", "-s", "6M", "#{tmpdir}/disk.raw").and_call_original
-        expect(described_class).to receive(:r).with({"RUST_LOG" => "info"}, "/opt/vhost-block-backend/v0.4.0/init-metadata", "--config", "#{tmpdir}/vhost-backend.conf")
-        expect_any_instance_of(described_class).to receive(:r).with(
+        expect(described_class).to receive(:_run_command).with("truncate", "-s", "6M", "#{tmpdir}/disk.raw") do
+          FileUtils.touch("#{tmpdir}/disk.raw")
+          File.truncate("#{tmpdir}/disk.raw", 6 * 1024 * 1024)
+        end
+        expect(described_class).to receive(:_run_command).with({"RUST_LOG" => "info"}, "/opt/vhost-block-backend/v0.4.0/init-metadata", "--config", "#{tmpdir}/vhost-backend.conf")
+        expect_any_instance_of(described_class).to receive(:_run_command).with(
           {"RUST_LOG" => "info"},
           "/opt/vhost-block-backend/v0.4.0/archive",
           "--config", "#{tmpdir}/vhost-backend.conf",

--- a/rhizome/host/spec/storage_disk_formatter_spec.rb
+++ b/rhizome/host/spec/storage_disk_formatter_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe StorageDiskFormatter do
 
   describe "#boot_disk" do
     it "returns the parent disk of the /boot partition" do
-      expect(formatter).to receive(:r).with("findmnt", "-n", "-o", "SOURCE", "/boot").and_return("/dev/nvme0n1p2\n")
-      expect(formatter).to receive(:r).with("lsblk", "-no", "PKNAME", "/dev/nvme0n1p2").and_return("nvme0n1\n")
+      expect(formatter).to receive(:_run_command).with("findmnt", "-n", "-o", "SOURCE", "/boot").and_return("/dev/nvme0n1p2\n")
+      expect(formatter).to receive(:_run_command).with("lsblk", "-no", "PKNAME", "/dev/nvme0n1p2").and_return("nvme0n1\n")
       expect(formatter.boot_disk).to eq("nvme0n1")
     end
 
     it "fails if the boot disk cannot be determined" do
-      expect(formatter).to receive(:r).with("findmnt", "-n", "-o", "SOURCE", "/boot").and_return("/dev/nvme0n1p2\n")
-      expect(formatter).to receive(:r).with("lsblk", "-no", "PKNAME", "/dev/nvme0n1p2").and_return("\n")
+      expect(formatter).to receive(:_run_command).with("findmnt", "-n", "-o", "SOURCE", "/boot").and_return("/dev/nvme0n1p2\n")
+      expect(formatter).to receive(:_run_command).with("lsblk", "-no", "PKNAME", "/dev/nvme0n1p2").and_return("\n")
       expect { formatter.boot_disk }.to raise_error RuntimeError, "could not determine the boot disk"
     end
   end
@@ -22,7 +22,7 @@ RSpec.describe StorageDiskFormatter do
   describe "#data_disks" do
     it "returns all disks except the boot disk, sorted by name" do
       expect(formatter).to receive(:boot_disk).and_return("nvme0n1")
-      expect(formatter).to receive(:r).with("lsblk", "-ndo", "NAME,TYPE").and_return(<<~OUTPUT)
+      expect(formatter).to receive(:_run_command).with("lsblk", "-ndo", "NAME,TYPE").and_return(<<~OUTPUT)
         nvme2n1 disk
         nvme0n1 disk
         loop0 loop
@@ -37,7 +37,7 @@ RSpec.describe StorageDiskFormatter do
       expect(formatter).to receive(:data_disks).and_return(["/dev/nvme1n1", "/dev/nvme2n1"])
       expect(formatter).to receive(:format_disk).with("/dev/nvme1n1", "/var/storage/devices/disk1")
       expect(formatter).to receive(:format_disk).with("/dev/nvme2n1", "/var/storage/devices/disk2")
-      expect(formatter).to receive(:r).with("mount", "-a")
+      expect(formatter).to receive(:_run_command).with("mount", "-a")
       formatter.format
     end
   end
@@ -45,25 +45,25 @@ RSpec.describe StorageDiskFormatter do
   describe "#format_disk" do
     it "skips disks already recorded in fstab" do
       expect(File).to receive(:read).with("/etc/fstab").and_return("UUID=123-abc /var/storage/devices/disk1 ext4 defaults 0 2\n")
-      expect(formatter).not_to receive(:r)
+      expect(formatter).not_to receive(:_run_command)
       formatter.format_disk("/dev/nvme1n1", "/var/storage/devices/disk1")
     end
 
     it "skips a disk that is already mounted" do
       expect(File).to receive(:read).with("/etc/fstab").and_return("UUID=y / ext4 defaults 0 1\n")
-      expect(formatter).to receive(:r).with("lsblk", "-no", "MOUNTPOINTS", "/dev/nvme1n1").and_return("/var/foo\n")
-      expect(formatter).not_to receive(:r).with("wipefs", "-fa", "/dev/nvme1n1")
+      expect(formatter).to receive(:_run_command).with("lsblk", "-no", "MOUNTPOINTS", "/dev/nvme1n1").and_return("/var/foo\n")
+      expect(formatter).not_to receive(:_run_command).with("wipefs", "-fa", "/dev/nvme1n1")
       formatter.format_disk("/dev/nvme1n1", "/var/storage/devices/disk1")
     end
 
     it "wipes, formats, mounts the disk and persists it in fstab" do
       expect(File).to receive(:read).with("/etc/fstab").and_return("UUID=y / ext4 defaults 0 1\n")
-      expect(formatter).to receive(:r).with("lsblk", "-no", "MOUNTPOINTS", "/dev/nvme1n1").and_return("\n")
-      expect(formatter).to receive(:r).with("wipefs", "-fa", "/dev/nvme1n1")
-      expect(formatter).to receive(:r).with("mkfs.ext4", "/dev/nvme1n1")
+      expect(formatter).to receive(:_run_command).with("lsblk", "-no", "MOUNTPOINTS", "/dev/nvme1n1").and_return("\n")
+      expect(formatter).to receive(:_run_command).with("wipefs", "-fa", "/dev/nvme1n1")
+      expect(formatter).to receive(:_run_command).with("mkfs.ext4", "/dev/nvme1n1")
       expect(FileUtils).to receive(:mkdir_p).with("/var/storage/devices/disk1")
-      expect(formatter).to receive(:r).with("mount", "/dev/nvme1n1", "/var/storage/devices/disk1")
-      expect(formatter).to receive(:r).with("blkid", "-s", "UUID", "-o", "value", "/dev/nvme1n1").and_return("123-abc\n")
+      expect(formatter).to receive(:_run_command).with("mount", "/dev/nvme1n1", "/var/storage/devices/disk1")
+      expect(formatter).to receive(:_run_command).with("blkid", "-s", "UUID", "-o", "value", "/dev/nvme1n1").and_return("123-abc\n")
 
       fstab_file = instance_double(File)
       expect(fstab_file).to receive(:flock).with(File::LOCK_EX)

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -313,13 +313,13 @@ RSpec.describe StorageVolume do
   describe "#encrypted_image_copy" do
     it "can copy an image to an encrypted volume" do
       encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
-      expect(encrypted_sv).to receive(:_run_command).with("/opt/spdk-/bin/spdk_dd --config /dev/stdin --disable-cpumask-locks --rpc-socket /var/tmp/spdk_dd.sock.test --if /var/storage/images/kubuntu.raw --ob crypt0 --bs=2097152 ", stdin: /{.*}/)
+      expect(encrypted_sv).to receive(:_run_command).with("/opt/spdk-/bin/spdk_dd", "--config", "/dev/stdin", "--disable-cpumask-locks", "--rpc-socket", "/var/tmp/spdk_dd.sock.test", "--if", "/var/storage/images/kubuntu.raw", "--ob", "crypt0", "--bs=2097152", stdin: /{.*}/)
       encrypted_sv.encrypted_image_copy(encryption_key, image_path)
     end
 
     it "includes count parameter when specified" do
       encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
-      expect(encrypted_sv).to receive(:_run_command).with("/opt/spdk-/bin/spdk_dd --config /dev/stdin --disable-cpumask-locks --rpc-socket /var/tmp/spdk_dd.sock.test --if /var/storage/images/kubuntu.raw --ob crypt0 --bs=2097152 --count 4", stdin: /{.*}/)
+      expect(encrypted_sv).to receive(:_run_command).with("/opt/spdk-/bin/spdk_dd", "--config", "/dev/stdin", "--disable-cpumask-locks", "--rpc-socket", "/var/tmp/spdk_dd.sock.test", "--if", "/var/storage/images/kubuntu.raw", "--ob", "crypt0", "--bs=2097152", "--count", "4", stdin: /{.*}/)
       encrypted_sv.encrypted_image_copy(encryption_key, image_path, count: 4)
     end
   end
@@ -350,7 +350,7 @@ RSpec.describe StorageVolume do
     it "can set disk file permissions" do
       expect(FileUtils).to receive(:chown).with("test", "test", disk_file)
       expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", disk_file)
-      expect(encrypted_sv).to receive(:_run_command).with("setfacl -m u:spdk:rw /var/storage/test/2/disk.raw")
+      expect(encrypted_sv).to receive(:_run_command).with("setfacl", "-m", "u:spdk:rw", "/var/storage/test/2/disk.raw")
 
       encrypted_sv.set_disk_file_permissions
     end
@@ -423,7 +423,7 @@ RSpec.describe StorageVolume do
       expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", spdk_vhost_sock)
       expect(FileUtils).to receive(:ln_s).with(spdk_vhost_sock, vm_vhost_sock)
       expect(FileUtils).to receive(:chown).with("test", "test", vm_vhost_sock)
-      expect(encrypted_sv).to receive(:_run_command).with("setfacl -m u:test:rw /var/storage/vhost/test_2")
+      expect(encrypted_sv).to receive(:_run_command).with("setfacl", "-m", "u:test:rw", "/var/storage/vhost/test_2")
 
       encrypted_sv.setup_spdk_vhost
     end

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -313,13 +313,13 @@ RSpec.describe StorageVolume do
   describe "#encrypted_image_copy" do
     it "can copy an image to an encrypted volume" do
       encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
-      expect(encrypted_sv).to receive(:r).with("/opt/spdk-/bin/spdk_dd --config /dev/stdin --disable-cpumask-locks --rpc-socket /var/tmp/spdk_dd.sock.test --if /var/storage/images/kubuntu.raw --ob crypt0 --bs=2097152 ", stdin: /{.*}/)
+      expect(encrypted_sv).to receive(:_run_command).with("/opt/spdk-/bin/spdk_dd --config /dev/stdin --disable-cpumask-locks --rpc-socket /var/tmp/spdk_dd.sock.test --if /var/storage/images/kubuntu.raw --ob crypt0 --bs=2097152 ", stdin: /{.*}/)
       encrypted_sv.encrypted_image_copy(encryption_key, image_path)
     end
 
     it "includes count parameter when specified" do
       encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
-      expect(encrypted_sv).to receive(:r).with("/opt/spdk-/bin/spdk_dd --config /dev/stdin --disable-cpumask-locks --rpc-socket /var/tmp/spdk_dd.sock.test --if /var/storage/images/kubuntu.raw --ob crypt0 --bs=2097152 --count 4", stdin: /{.*}/)
+      expect(encrypted_sv).to receive(:_run_command).with("/opt/spdk-/bin/spdk_dd --config /dev/stdin --disable-cpumask-locks --rpc-socket /var/tmp/spdk_dd.sock.test --if /var/storage/images/kubuntu.raw --ob crypt0 --bs=2097152 --count 4", stdin: /{.*}/)
       encrypted_sv.encrypted_image_copy(encryption_key, image_path, count: 4)
     end
   end
@@ -350,7 +350,7 @@ RSpec.describe StorageVolume do
     it "can set disk file permissions" do
       expect(FileUtils).to receive(:chown).with("test", "test", disk_file)
       expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", disk_file)
-      expect(encrypted_sv).to receive(:r).with("setfacl -m u:spdk:rw /var/storage/test/2/disk.raw")
+      expect(encrypted_sv).to receive(:_run_command).with("setfacl -m u:spdk:rw /var/storage/test/2/disk.raw")
 
       encrypted_sv.set_disk_file_permissions
     end
@@ -423,7 +423,7 @@ RSpec.describe StorageVolume do
       expect(FileUtils).to receive(:chmod).with("u=rw,g=r,o=", spdk_vhost_sock)
       expect(FileUtils).to receive(:ln_s).with(spdk_vhost_sock, vm_vhost_sock)
       expect(FileUtils).to receive(:chown).with("test", "test", vm_vhost_sock)
-      expect(encrypted_sv).to receive(:r).with("setfacl -m u:test:rw /var/storage/vhost/test_2")
+      expect(encrypted_sv).to receive(:_run_command).with("setfacl -m u:test:rw /var/storage/vhost/test_2")
 
       encrypted_sv.setup_spdk_vhost
     end
@@ -813,8 +813,8 @@ RSpec.describe StorageVolume do
       rpc_sock = "/var/storage/test/2/rpc.sock"
       expect(encrypted_vhost_sv).to receive(:rm_if_exists).with(vhost_sock)
       expect(encrypted_vhost_sv).to receive(:rm_if_exists).with(rpc_sock)
-      expect(encrypted_vhost_sv).to receive(:r).with("systemctl", "stop", "test-2-storage.service")
-      expect(encrypted_vhost_sv).to receive(:r).with("systemctl", "start", "test-2-storage.service")
+      expect(encrypted_vhost_sv).to receive(:_run_command).with("systemctl", "stop", "test-2-storage.service")
+      expect(encrypted_vhost_sv).to receive(:_run_command).with("systemctl", "start", "test-2-storage.service")
       expect(encrypted_vhost_sv).to receive(:with_kek_pipe).with(kek_pipe, owner: "test").and_yield(kek_pipe)
       expect(encrypted_vhost_sv).to receive(:write_kek_to_pipe).with(kek_pipe, /aes256-gcm/)
       encrypted_vhost_sv.vhost_backend_start(key_wrapping_secrets)
@@ -927,18 +927,18 @@ RSpec.describe StorageVolume do
 
   describe "#stop_service_if_loaded" do
     it "stops the service if it is loaded" do
-      expect(encrypted_vhost_sv).to receive(:r).with("systemctl", "stop", "test-2-storage.service")
+      expect(encrypted_vhost_sv).to receive(:_run_command).with("systemctl", "stop", "test-2-storage.service")
       encrypted_vhost_sv.stop_service_if_loaded("test-2-storage.service")
     end
 
     it "does nothing if the service is not loaded" do
-      expect(encrypted_vhost_sv).to receive(:r).with("systemctl", "stop", "test-2-storage.service")
+      expect(encrypted_vhost_sv).to receive(:_run_command).with("systemctl", "stop", "test-2-storage.service")
         .and_raise(CommandFail.new("error", "", "Unit test-2-storage.service not loaded."))
       encrypted_vhost_sv.stop_service_if_loaded("test-2-storage.service")
     end
 
     it "raises an error for unexpected command failures" do
-      expect(encrypted_vhost_sv).to receive(:r).with("systemctl", "stop", "test-2-storage.service")
+      expect(encrypted_vhost_sv).to receive(:_run_command).with("systemctl", "stop", "test-2-storage.service")
         .and_raise(CommandFail.new("unexpected error", "some output", "Some error"))
       expect { encrypted_vhost_sv.stop_service_if_loaded("test-2-storage.service") }.to raise_error(CommandFail, /unexpected error/)
     end

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -782,19 +782,19 @@ RSpec.describe StorageVolume do
     end
   end
 
-  describe "#q_vhost_user_block_service" do
-    it "returns the shellescape-safe service name" do
+  describe "#vhost_user_block_service" do
+    it "returns the service name" do
       sv = described_class.new("a'b", {
         "disk_index" => 2,
         "encrypted" => true,
         "vhost_block_backend_version" => "v0.4.0",
       })
-      expect(sv.send(:q_vhost_user_block_service)).to eq("a\\'b-2-storage.service")
+      expect(sv.send(:vhost_user_block_service)).to eq("a'b-2-storage.service")
     end
 
     it "returns nil when there is no vhost backend version" do
       sv = described_class.new("test", {"disk_index" => 0, "encrypted" => true})
-      expect(sv.send(:q_vhost_user_block_service)).to be_nil
+      expect(sv.send(:vhost_user_block_service)).to be_nil
     end
   end
 

--- a/rhizome/host/spec/vhost_block_backend_spec.rb
+++ b/rhizome/host/spec/vhost_block_backend_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe VhostBlockBackend do
         .and_return("e7e430f2e722a2d5d7c18a4f609360e003798d481e26da6db380e698ccb079eb")
       expect(FileUtils).to receive(:mkdir_p).with(dir)
       expect(FileUtils).to receive(:cd).with(dir).and_yield
-      expect(v042).to receive(:r).with("tar -xzf #{temp_tarball}")
+      expect(v042).to receive(:_run_command).with("tar -xzf #{temp_tarball}")
       expect(FileUtils).to receive(:rm_f).with(temp_tarball)
 
       v042.download

--- a/rhizome/host/spec/vhost_block_backend_spec.rb
+++ b/rhizome/host/spec/vhost_block_backend_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe VhostBlockBackend do
         .and_return("e7e430f2e722a2d5d7c18a4f609360e003798d481e26da6db380e698ccb079eb")
       expect(FileUtils).to receive(:mkdir_p).with(dir)
       expect(FileUtils).to receive(:cd).with(dir).and_yield
-      expect(v042).to receive(:_run_command).with("tar -xzf #{temp_tarball}")
+      expect(v042).to receive(:_run_command).with("tar", "-xzf", temp_tarball)
       expect(FileUtils).to receive(:rm_f).with(temp_tarball)
 
       v042.download

--- a/rhizome/host/spec/vm_path_spec.rb
+++ b/rhizome/host/spec/vm_path_spec.rb
@@ -13,10 +13,6 @@ RSpec.describe VmPath do
     expect(vp.guest_ephemeral).to eq("/vm/test'vm/guest_ephemeral")
   end
 
-  it "can escape a path" do
-    expect(vp.q_guest_ephemeral).to eq("/vm/test\\'vm/guest_ephemeral")
-  end
-
   it "snakifies difficult characters" do
     expect(vp.serial_log).to eq("/vm/test'vm/serial.log")
   end

--- a/rhizome/host/spec/vm_path_spec.rb
+++ b/rhizome/host/spec/vm_path_spec.rb
@@ -3,18 +3,18 @@
 require_relative "../lib/vm_path"
 
 RSpec.describe VmPath do
-  subject(:vp) { described_class.new("test'vm") }
+  subject(:vp) { described_class.new("vm123456") }
 
   it ".define_new_method raises if the method is already defined" do
     expect { described_class.define_new_method(:inspect) {} }.to raise_error(RuntimeError, "BUG")
   end
 
   it "can compute a path" do
-    expect(vp.guest_ephemeral).to eq("/vm/test'vm/guest_ephemeral")
+    expect(vp.guest_ephemeral).to eq("/vm/vm123456/guest_ephemeral")
   end
 
   it "snakifies difficult characters" do
-    expect(vp.serial_log).to eq("/vm/test'vm/serial.log")
+    expect(vp.serial_log).to eq("/vm/vm123456/serial.log")
   end
 
   it "can read file contents" do
@@ -35,29 +35,27 @@ RSpec.describe VmPath do
   end
 
   describe "#systemd_service" do
-    it "returns escaped systemd service path" do
-      expect(IO).to receive(:popen).with(["systemd-escape", "test'vm.service"]).and_yield(StringIO.new("test\\x27vm.service\n"))
-      expect(vp.systemd_service).to eq("/etc/systemd/system/test\\x27vm.service")
+    it "returns systemd service path" do
+      expect(vp.systemd_service).to eq("/etc/systemd/system/vm123456.service")
     end
   end
 
   describe "#write_systemd_service" do
-    it "writes to the escaped systemd service path" do
-      expect(IO).to receive(:popen).with(["systemd-escape", "test'vm.service"]).and_yield(StringIO.new("test\\x27vm.service\n"))
-      expect(File).to receive(:write).with("/etc/systemd/system/test\\x27vm.service", "unit content\n")
+    it "writes to the systemd service path" do
+      expect(File).to receive(:write).with("/etc/systemd/system/vm123456.service", "unit content\n")
       vp.write_systemd_service("unit content")
     end
   end
 
   describe "#dnsmasq_service" do
     it "returns dnsmasq service path" do
-      expect(vp.dnsmasq_service).to eq("/etc/systemd/system/test'vm-dnsmasq.service")
+      expect(vp.dnsmasq_service).to eq("/etc/systemd/system/vm123456-dnsmasq.service")
     end
   end
 
   describe "#write_dnsmasq_service" do
     it "writes to the dnsmasq service path" do
-      expect(File).to receive(:write).with("/etc/systemd/system/test'vm-dnsmasq.service", "dnsmasq content\n")
+      expect(File).to receive(:write).with("/etc/systemd/system/vm123456-dnsmasq.service", "dnsmasq content\n")
       vp.write_dnsmasq_service("dnsmasq content")
     end
   end

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -268,7 +268,6 @@ RSpec.describe VmSetup do
       expect(vs).to receive(:purge_storage)
       expect(vs).to receive(:unmount_hugepages)
       expect(vs).to receive(:_run_command).with("deluser", "--remove-home", "test")
-      expect(IO).to receive(:popen).with(["systemd-escape", "test.service"]).and_return("test.service")
       expect(vs).to receive(:block_ip4)
 
       vs.purge
@@ -778,7 +777,6 @@ NFTABLES_CONF
 
   describe "#purge_without_network" do
     it "removes service files, reloads daemon, purges storage and hugepages" do
-      expect(IO).to receive(:popen).with(["systemd-escape", "test.service"]).and_yield(StringIO.new("test.service\n"))
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test.service")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-dnsmasq.service")
       expect(vs).to receive(:_run_command).with("systemctl daemon-reload")

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -199,10 +199,10 @@ RSpec.describe VmSetup do
     before do
       allow(vs).to receive(:vp).and_return(vps)
       allow(vs).to receive(:write_user_data)
-      expect(vs).to receive(:r).with("mkdosfs -n CIDATA -C /vm/test/cloudinit.img 128")
-      expect(vs).to receive(:r).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/user-data ::")
-      expect(vs).to receive(:r).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/meta-data ::")
-      expect(vs).to receive(:r).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/network-config ::")
+      expect(vs).to receive(:_run_command).with("mkdosfs -n CIDATA -C /vm/test/cloudinit.img 128")
+      expect(vs).to receive(:_run_command).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/user-data ::")
+      expect(vs).to receive(:_run_command).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/meta-data ::")
+      expect(vs).to receive(:_run_command).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/network-config ::")
       allow(FileUtils).to receive(:rm_rf)
       allow(FileUtils).to receive(:chmod)
       allow(FileUtils).to receive(:chown)
@@ -261,13 +261,13 @@ RSpec.describe VmSetup do
 
   describe "#purge" do
     it "can purge" do
-      expect(vs).to receive(:r).with("ip netns del test")
+      expect(vs).to receive(:_run_command).with("ip netns del test")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test.service")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-dnsmasq.service")
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       expect(vs).to receive(:purge_storage)
       expect(vs).to receive(:unmount_hugepages)
-      expect(vs).to receive(:r).with("deluser --remove-home test")
+      expect(vs).to receive(:_run_command).with("deluser --remove-home test")
       expect(IO).to receive(:popen).with(["systemd-escape", "test.service"]).and_return("test.service")
       expect(vs).to receive(:block_ip4)
 
@@ -278,22 +278,22 @@ RSpec.describe VmSetup do
   describe "#unmount_hugepages" do
     it "returns early when hugepages is disabled" do
       vs.instance_variable_set(:@hugepages, false)
-      expect(vs).not_to receive(:r)
+      expect(vs).not_to receive(:_run_command)
       vs.unmount_hugepages
     end
 
     it "can unmount hugepages" do
-      expect(vs).to receive(:r).with("umount /vm/test/hugepages")
+      expect(vs).to receive(:_run_command).with("umount /vm/test/hugepages")
       vs.unmount_hugepages
     end
 
     it "exits silently if hugepages isn't mounted" do
-      expect(vs).to receive(:r).with("umount /vm/test/hugepages").and_raise(CommandFail.new("", "", "/vm/test/hugepages: no mount point specified."))
+      expect(vs).to receive(:_run_command).with("umount /vm/test/hugepages").and_raise(CommandFail.new("", "", "/vm/test/hugepages: no mount point specified."))
       vs.unmount_hugepages
     end
 
     it "fails if umount fails with an unexpected error" do
-      expect(vs).to receive(:r).with("umount /vm/test/hugepages").and_raise(CommandFail.new("", "", "/vm/test/hugepages: wait, what?"))
+      expect(vs).to receive(:_run_command).with("umount /vm/test/hugepages").and_raise(CommandFail.new("", "", "/vm/test/hugepages: wait, what?"))
       expect { vs.unmount_hugepages }.to raise_error CommandFail
     end
   end
@@ -343,7 +343,7 @@ RSpec.describe VmSetup do
       vps = instance_spy(VmPath)
       expect(vs).to receive(:vp).and_return(vps).at_least(:once)
       expect(vs).to receive(:build_ch_service).and_return("CH_SERVICE")
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
 
       vs.send(:install_systemd_unit, *args)
 
@@ -356,7 +356,7 @@ RSpec.describe VmSetup do
       vps = instance_spy(VmPath)
       expect(vs).to receive(:vp).and_return(vps).at_least(:once)
       expect(vs).to receive(:build_qemu_service).and_return("QEMU_SERVICE")
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
 
       vs.send(:install_systemd_unit, *args)
 
@@ -376,7 +376,7 @@ RSpec.describe VmSetup do
       vs.instance_variable_set(:@firmware_version,
         CloudHypervisor::Firmware.new("202311", "sha256"))
 
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       vs.send(:install_systemd_unit, *args)
 
       expect(vps).to have_received(:write_systemd_service) { |content|
@@ -419,7 +419,7 @@ RSpec.describe VmSetup do
       vs.instance_variable_set(:@firmware_version,
         CloudHypervisor::Firmware.new("202311", "sha256"))
 
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       expect(vs).to receive(:cpu_vendor).and_return("GenuineIntel")
       vs.send(:install_systemd_unit, *args)
 
@@ -471,7 +471,7 @@ RSpec.describe VmSetup do
       vs.instance_variable_set(:@firmware_version,
         CloudHypervisor::Firmware.new("202311", "sha256"))
 
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       expect(vs).to receive(:cpu_vendor).and_return("AuthenticAMD")
 
       vs.send(:install_systemd_unit, *args)
@@ -698,21 +698,21 @@ NFTABLES_CONF
     it "can setup hugepages" do
       expect(FileUtils).to receive(:mkdir_p).with("/vm/test/hugepages")
       expect(FileUtils).to receive(:chown).with("test", "test", "/vm/test/hugepages")
-      expect(vs).to receive(:r).with("mount -t hugetlbfs -o uid=test,size=2G nodev /vm/test/hugepages")
+      expect(vs).to receive(:_run_command).with("mount -t hugetlbfs -o uid=test,size=2G nodev /vm/test/hugepages")
       vs.hugepages(2)
     end
   end
 
   describe "#start_systemd_unit" do
     it "can start systemd unit" do
-      expect(vs).to receive(:r).with("systemctl start test")
+      expect(vs).to receive(:_run_command).with("systemctl start test")
       vs.start_systemd_unit
     end
   end
 
   describe "#restart_systemd_unit" do
     it "can restart systemd unit" do
-      expect(vs).to receive(:r).with("systemctl restart test")
+      expect(vs).to receive(:_run_command).with("systemctl restart test")
       vs.restart_systemd_unit
     end
   end
@@ -731,7 +731,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { 1.1.1.1 }
 NFTABLES_CONF
       expect(File).to receive(:rename).with("/etc/nftables.d/test.conf.tmp", "/etc/nftables.d/test.conf")
 
-      expect(vs).to receive(:r).with("systemctl reload nftables")
+      expect(vs).to receive(:_run_command).with("systemctl reload nftables")
 
       vs.unblock_ip4("1.1.1.1/32")
     end
@@ -740,7 +740,7 @@ NFTABLES_CONF
   describe "#block_ip4" do
     it "can block ip4" do
       expect(FileUtils).to receive(:rm_f).with("/etc/nftables.d/test.conf")
-      expect(vs).to receive(:r).with("systemctl reload nftables")
+      expect(vs).to receive(:_run_command).with("systemctl reload nftables")
 
       vs.block_ip4
     end
@@ -761,7 +761,7 @@ NFTABLES_CONF
   describe "#purge_network" do
     it "ignores 'no such file or directory' error when deleting netns" do
       expect(vs).to receive(:block_ip4)
-      expect(vs).to receive(:r).with("ip netns del test").and_raise(
+      expect(vs).to receive(:_run_command).with("ip netns del test").and_raise(
         CommandFail.new("err", "", 'Cannot remove namespace file "/var/run/netns/test": No such file or directory'),
       )
       expect { vs.purge_network }.not_to raise_error
@@ -769,7 +769,7 @@ NFTABLES_CONF
 
     it "re-raises unexpected errors when deleting netns" do
       expect(vs).to receive(:block_ip4)
-      expect(vs).to receive(:r).with("ip netns del test").and_raise(
+      expect(vs).to receive(:_run_command).with("ip netns del test").and_raise(
         CommandFail.new("err", "", "some unexpected error"),
       )
       expect { vs.purge_network }.to raise_error(CommandFail)
@@ -781,7 +781,7 @@ NFTABLES_CONF
       expect(IO).to receive(:popen).with(["systemd-escape", "test.service"]).and_yield(StringIO.new("test.service\n"))
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test.service")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-dnsmasq.service")
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       expect(vs).to receive(:purge_storage)
       expect(vs).to receive(:unmount_hugepages)
       vs.purge_without_network
@@ -790,14 +790,14 @@ NFTABLES_CONF
 
   describe "#purge_user" do
     it "silently ignores 'user does not exist' error" do
-      expect(vs).to receive(:r).with("deluser --remove-home test").and_raise(
+      expect(vs).to receive(:_run_command).with("deluser --remove-home test").and_raise(
         CommandFail.new("err", "", "The user `test' does not exist."),
       )
       expect { vs.purge_user }.not_to raise_error
     end
 
     it "re-raises unexpected deluser errors" do
-      expect(vs).to receive(:r).with("deluser --remove-home test").and_raise(
+      expect(vs).to receive(:_run_command).with("deluser --remove-home test").and_raise(
         CommandFail.new("err", "", "some unexpected error"),
       )
       expect { vs.purge_user }.to raise_error(CommandFail)
@@ -905,28 +905,28 @@ NFTABLES_CONF
     let(:gua) { "fddf:53d2:4c89:2305:46a0::/79" }
 
     it "sets up veths without ndp" do
-      expect(vs).to receive(:r).with("ip netns exec test cat /sys/class/net/vethitest/address").and_return("3e:bd:a5:96:f7:b9\n")
+      expect(vs).to receive(:_run_command).with("ip netns exec test cat /sys/class/net/vethitest/address").and_return("3e:bd:a5:96:f7:b9\n")
       expect(File).to receive(:read).with("/sys/class/net/vethotest/address").and_return("3e:bd:a5:96:f7:b9\n")
-      expect(vs).to receive(:r).with("ip link set dev vethotest up")
-      expect(vs).to receive(:r).with("ip route replace fddf:53d2:4c89:2305:46a0::/79 via fe80::3cbd:a5ff:fe96:f7b9 dev vethotest")
-      expect(vs).to receive(:r).with("ip -n test addr replace fddf:53d2:4c89:2305:8000::/65 dev vethitest")
-      expect(vs).to receive(:r).with("ip -n test link set dev vethitest up")
-      expect(vs).to receive(:r).with("ip -n test route replace 2000::/3 via fe80::3cbd:a5ff:fe96:f7b9 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip link set dev vethotest up")
+      expect(vs).to receive(:_run_command).with("ip route replace fddf:53d2:4c89:2305:46a0::/79 via fe80::3cbd:a5ff:fe96:f7b9 dev vethotest")
+      expect(vs).to receive(:_run_command).with("ip -n test addr replace fddf:53d2:4c89:2305:8000::/65 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip -n test link set dev vethitest up")
+      expect(vs).to receive(:_run_command).with("ip -n test route replace 2000::/3 via fe80::3cbd:a5ff:fe96:f7b9 dev vethitest")
       vs.setup_veths_6(guest_ephemeral, clover_ephemeral, gua, false)
     end
 
     it "sets up ndp proxy routes when ndp_needed is true" do
-      expect(vs).to receive(:r).with("ip netns exec test cat /sys/class/net/vethitest/address").and_return("3e:bd:a5:96:f7:b9\n")
+      expect(vs).to receive(:_run_command).with("ip netns exec test cat /sys/class/net/vethitest/address").and_return("3e:bd:a5:96:f7:b9\n")
       expect(File).to receive(:read).with("/sys/class/net/vethotest/address").and_return("3e:bd:a5:96:f7:b9\n")
-      expect(vs).to receive(:r).with("ip -6 neigh add proxy fddf:53d2:4c89:2305::2 dev eth0")
-      expect(vs).to receive(:r).with("ip -6 neigh add proxy fddf:53d2:4c89:2305:8000:: dev eth0")
-      expect(vs).to receive(:r).with("ip -n test addr replace fddf:53d2:4c89:2305:8000::/65 dev vethitest")
-      expect(vs).to receive(:r).with("ip -n test link set dev vethitest up")
-      expect(vs).to receive(:r).with("ip -n test route replace 2000::/3 via fe80::3cbd:a5ff:fe96:f7b9 dev vethitest")
-      expect(vs).to receive(:r).with("ip link set dev vethotest up")
+      expect(vs).to receive(:_run_command).with("ip -6 neigh add proxy fddf:53d2:4c89:2305::2 dev eth0")
+      expect(vs).to receive(:_run_command).with("ip -6 neigh add proxy fddf:53d2:4c89:2305:8000:: dev eth0")
+      expect(vs).to receive(:_run_command).with("ip -n test addr replace fddf:53d2:4c89:2305:8000::/65 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip -n test link set dev vethitest up")
+      expect(vs).to receive(:_run_command).with("ip -n test route replace 2000::/3 via fe80::3cbd:a5ff:fe96:f7b9 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip link set dev vethotest up")
       routes = JSON.generate([{"dst" => "default", "dev" => "eth0"}])
-      expect(vs).to receive(:r).with("ip -j route").and_return(routes)
-      expect(vs).to receive(:r).with("ip route replace fddf:53d2:4c89:2305:46a0::/79 via fe80::3cbd:a5ff:fe96:f7b9 dev vethotest")
+      expect(vs).to receive(:_run_command).with("ip -j route").and_return(routes)
+      expect(vs).to receive(:_run_command).with("ip route replace fddf:53d2:4c89:2305:46a0::/79 via fe80::3cbd:a5ff:fe96:f7b9 dev vethotest")
       vs.setup_veths_6(guest_ephemeral, clover_ephemeral, gua, true)
     end
   end
@@ -935,15 +935,15 @@ NFTABLES_CONF
     it "sets up tap routes for each NIC" do
       gua = "fddf:53d2:4c89:2305:46a0::/79"
       nics = [VmSetup::Nic.new("fd48:666c:a296:ce4b:2cc6::/79", "192.168.5.50/32", "nctest", "3e:bd:a5:96:f7:b9", "10.0.0.254/32")]
-      expect(vs).to receive(:r).with("ip -n test addr replace fddf:53d2:4c89:2305:46a0::1/80 dev nctest")
-      expect(vs).to receive(:r).with("ip -n test addr replace 10.0.0.2 dev nctest")
-      expect(vs).to receive(:r).with("ip -n test route replace fddf:53d2:4c89:2305:46a0::/80 via fe80::3cbd:a5ff:fe96:f7b9 dev nctest")
-      expect(vs).to receive(:r).with("ip -n test route del fddf:53d2:4c89:2305:46a0::/80 dev nctest")
-      expect(vs).to receive(:r).with("ip -n test link set dev nctest up")
-      expect(vs).to receive(:r).with("ip -n test addr replace fd48:666c:a296:ce4b:2cc6::1/79 dev nctest noprefixroute")
-      expect(vs).to receive(:r).with("ip -n test route replace fd48:666c:a296:ce4b:2cc6::/79 via fe80::3cbd:a5ff:fe96:f7b9 dev nctest")
-      expect(vs).to receive(:r).with("ip -n test addr replace fd00:0b1c:100d:5AFE:CE:: dev nctest")
-      expect(vs).to receive(:r).with("ip -n test addr replace fd00:0b1c:100d:53:: dev nctest")
+      expect(vs).to receive(:_run_command).with("ip -n test addr replace fddf:53d2:4c89:2305:46a0::1/80 dev nctest")
+      expect(vs).to receive(:_run_command).with("ip -n test addr replace 10.0.0.2 dev nctest")
+      expect(vs).to receive(:_run_command).with("ip -n test route replace fddf:53d2:4c89:2305:46a0::/80 via fe80::3cbd:a5ff:fe96:f7b9 dev nctest")
+      expect(vs).to receive(:_run_command).with("ip -n test route del fddf:53d2:4c89:2305:46a0::/80 dev nctest")
+      expect(vs).to receive(:_run_command).with("ip -n test link set dev nctest up")
+      expect(vs).to receive(:_run_command).with("ip -n test addr replace fd48:666c:a296:ce4b:2cc6::1/79 dev nctest noprefixroute")
+      expect(vs).to receive(:_run_command).with("ip -n test route replace fd48:666c:a296:ce4b:2cc6::/79 via fe80::3cbd:a5ff:fe96:f7b9 dev nctest")
+      expect(vs).to receive(:_run_command).with("ip -n test addr replace fd00:0b1c:100d:5AFE:CE:: dev nctest")
+      expect(vs).to receive(:_run_command).with("ip -n test addr replace fd00:0b1c:100d:53:: dev nctest")
       vs.setup_taps_6(gua, nics, "10.0.0.2")
     end
   end
@@ -954,26 +954,26 @@ NFTABLES_CONF
     it "sets up routes with ip4" do
       # With ip4="10.0.0.2/32" and ip4_local="10.0.0.0/31":
       #   vm = "10.0.0.2/32", vetho = "10.0.0.0", vethi = "10.0.0.2"
-      expect(vs).to receive(:r).with("ip addr replace 10.0.0.0/32 dev vethotest")
-      expect(vs).to receive(:r).with("ip route replace 10.0.0.2/32 dev vethotest")
-      expect(vs).to receive(:r).with("echo 1 > /proc/sys/net/ipv4/conf/vethotest/proxy_arp")
-      expect(vs).to receive(:r).with("ip -n test addr replace 10.0.0.2/32 dev vethitest")
-      expect(vs).to receive(:r).with("ip -n test route replace 10.0.0.0 dev vethitest")
-      expect(vs).to receive(:r).with("ip -n test route replace 10.0.0.2/32 dev nctest")
-      expect(vs).to receive(:r).with("ip -n test route replace default via 10.0.0.0 dev vethitest")
-      expect(vs).to receive(:r).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/nctest/proxy_arp'")
-      expect(vs).to receive(:r).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethitest/proxy_arp'")
+      expect(vs).to receive(:_run_command).with("ip addr replace 10.0.0.0/32 dev vethotest")
+      expect(vs).to receive(:_run_command).with("ip route replace 10.0.0.2/32 dev vethotest")
+      expect(vs).to receive(:_run_command).with("echo 1 > /proc/sys/net/ipv4/conf/vethotest/proxy_arp")
+      expect(vs).to receive(:_run_command).with("ip -n test addr replace 10.0.0.2/32 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip -n test route replace 10.0.0.0 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip -n test route replace 10.0.0.2/32 dev nctest")
+      expect(vs).to receive(:_run_command).with("ip -n test route replace default via 10.0.0.0 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/nctest/proxy_arp'")
+      expect(vs).to receive(:_run_command).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethitest/proxy_arp'")
       vs.routes4("10.0.0.2/32", "10.0.0.0/31", nics)
     end
 
     it "skips ip4 route when ip4 is nil" do
-      expect(vs).to receive(:r).with("ip addr replace 10.0.0.0/32 dev vethotest")
-      expect(vs).to receive(:r).with("echo 1 > /proc/sys/net/ipv4/conf/vethotest/proxy_arp")
-      expect(vs).to receive(:r).with("ip -n test addr replace 10.0.0.2/32 dev vethitest")
-      expect(vs).to receive(:r).with("ip -n test route replace 10.0.0.0 dev vethitest")
-      expect(vs).to receive(:r).with("ip -n test route replace default via 10.0.0.0 dev vethitest")
-      expect(vs).to receive(:r).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethitest/proxy_arp'")
-      expect(vs).to receive(:r).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/nctest/proxy_arp'")
+      expect(vs).to receive(:_run_command).with("ip addr replace 10.0.0.0/32 dev vethotest")
+      expect(vs).to receive(:_run_command).with("echo 1 > /proc/sys/net/ipv4/conf/vethotest/proxy_arp")
+      expect(vs).to receive(:_run_command).with("ip -n test addr replace 10.0.0.2/32 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip -n test route replace 10.0.0.0 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip -n test route replace default via 10.0.0.0 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethitest/proxy_arp'")
+      expect(vs).to receive(:_run_command).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/nctest/proxy_arp'")
       vs.routes4(nil, "10.0.0.1/31", nics)
     end
   end
@@ -981,20 +981,20 @@ NFTABLES_CONF
   describe "#update_via_routes" do
     it "returns immediately for /32 prefix nics" do
       nics = [VmSetup::Nic.new(nil, "10.0.0.1/32", "nctest", nil, nil)]
-      expect(vs).not_to receive(:r)
+      expect(vs).not_to receive(:_run_command)
       vs.update_via_routes(nics)
     end
 
     it "updates routes for non-/32 nics when tap is ready" do
       nics = [VmSetup::Nic.new(nil, "10.0.0.0/30", "nctest", nil, nil)]
-      expect(vs).to receive(:r).with("ip -n test link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN").and_return("UP\n")
-      expect(vs).to receive(:r).with("ip -n test route replace 10.0.0.0/30 via 10.0.0.1 dev nctest")
+      expect(vs).to receive(:_run_command).with("ip -n test link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN").and_return("UP\n")
+      expect(vs).to receive(:_run_command).with("ip -n test route replace 10.0.0.0/30 via 10.0.0.1 dev nctest")
       vs.update_via_routes(nics)
     end
 
     it "raises when tap never becomes ready" do
       nics = [VmSetup::Nic.new(nil, "10.0.0.0/30", "nctest", nil, nil)]
-      expect(vs).to receive(:r).with("ip -n test link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN").and_return("DOWN\n").at_least(:once)
+      expect(vs).to receive(:_run_command).with("ip -n test link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN").and_return("DOWN\n").at_least(:once)
       expect(vs).to receive(:sleep).at_least(:once)
       expect { vs.update_via_routes(nics) }.to raise_error(/tap device not ready/)
     end
@@ -1004,8 +1004,8 @@ NFTABLES_CONF
         VmSetup::Nic.new(nil, "10.0.0.0/30", "nctest1", nil, nil),
         VmSetup::Nic.new(nil, "10.0.0.5/32", "nctest2", nil, nil),
       ]
-      expect(vs).to receive(:r).with("ip -n test link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN").and_return("UP\n")
-      expect(vs).to receive(:r).with("ip -n test route replace 10.0.0.0/30 via 10.0.0.1 dev nctest1")
+      expect(vs).to receive(:_run_command).with("ip -n test link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN").and_return("UP\n")
+      expect(vs).to receive(:_run_command).with("ip -n test route replace 10.0.0.0/30 via 10.0.0.1 dev nctest1")
       vs.update_via_routes(nics)
     end
   end
@@ -1020,12 +1020,12 @@ NFTABLES_CONF
     end
 
     it "calls fmpm with gpu_partition_id when present" do
-      expect(vs).to receive(:r).with("/usr/bin/fmpm", "-a", "3", expect: [0, 239])
+      expect(vs).to receive(:_run_command).with("/usr/bin/fmpm", "-a", "3", expect: [0, 239])
       vs.prepare_gpus([], 3)
     end
 
     it "does nothing when pci_devices is empty and no gpu_partition_id" do
-      expect(vs).not_to receive(:r)
+      expect(vs).not_to receive(:_run_command)
       expect(File).not_to receive(:write)
       vs.prepare_gpus([], nil)
     end
@@ -1033,7 +1033,7 @@ NFTABLES_CONF
     it "binds gpus to vfio-pci and activates the partition when gpu_partition_id is present" do
       pci_devices = [["00:01.0", "1"], ["00:01.1", "2"]]
       expect(File).to receive(:write).with("/sys/bus/pci/devices/0000:00:01.0/reset", "1")
-      expect(vs).to receive(:r).with("/usr/bin/fmpm", "-a", "3", expect: [0, 239])
+      expect(vs).to receive(:_run_command).with("/usr/bin/fmpm", "-a", "3", expect: [0, 239])
       expect(vs).to receive(:bind_driver).with("00:01.0", "vfio-pci")
       expect(vs).to receive(:chown_vfio).with("1")
       vs.prepare_gpus(pci_devices, 3)
@@ -1041,7 +1041,7 @@ NFTABLES_CONF
 
     it "resets devices before activating the partition" do
       expect(File).to receive(:write).with("/sys/bus/pci/devices/0000:00:01.0/reset", "1").ordered
-      expect(vs).to receive(:r).with("/usr/bin/fmpm", "-a", "3", expect: [0, 239]).ordered
+      expect(vs).to receive(:_run_command).with("/usr/bin/fmpm", "-a", "3", expect: [0, 239]).ordered
       expect(vs).to receive(:bind_driver).with("00:01.0", "vfio-pci").ordered
       expect(vs).to receive(:chown_vfio).with("1").ordered
       vs.prepare_gpus([["00:01.0", "1"]], 3)
@@ -1056,20 +1056,20 @@ NFTABLES_CONF
       })
       expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
       expect(File).to receive(:read).with("/vm/test/prep.json").and_return(params)
-      expect(vs).to receive(:r).with("/usr/bin/fmpm", "-d", "3", expect: [0, 238])
+      expect(vs).to receive(:_run_command).with("/usr/bin/fmpm", "-d", "3", expect: [0, 238])
       vs.deactivate_gpu_partition
     end
 
     it "does nothing when gpu_partition_id is absent" do
       expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(true)
       expect(File).to receive(:read).with("/vm/test/prep.json").and_return(JSON.generate({"storage_volumes" => []}))
-      expect(vs).not_to receive(:r)
+      expect(vs).not_to receive(:_run_command)
       vs.deactivate_gpu_partition
     end
 
     it "exits silently if vm hasn't been created yet" do
       expect(File).to receive(:exist?).with("/vm/test/prep.json").and_return(false)
-      expect(vs).not_to receive(:r)
+      expect(vs).not_to receive(:_run_command)
       expect { vs.deactivate_gpu_partition }.not_to raise_error
     end
   end
@@ -1258,19 +1258,19 @@ NFTABLES_CONF
 
   describe "#apply_nftables" do
     it "flushes and reloads nftables in the vm netns" do
-      expect(vs).to receive(:r).with("ip netns exec test nft flush ruleset")
+      expect(vs).to receive(:_run_command).with("ip netns exec test nft flush ruleset")
       vps = instance_spy(VmPath, q_nftables_conf: "/vm/test/nftables.conf")
       expect(vs).to receive(:vp).and_return(vps)
-      expect(vs).to receive(:r).with("ip netns exec test nft -f /vm/test/nftables.conf")
+      expect(vs).to receive(:_run_command).with("ip netns exec test nft -f /vm/test/nftables.conf")
       vs.send(:apply_nftables)
     end
   end
 
   describe "#forwarding" do
     it "enables forwarding in the vm netns" do
-      expect(vs).to receive(:r).with("ip netns exec test sysctl -w net.ipv6.conf.all.forwarding=1")
-      expect(vs).to receive(:r).with("ip netns exec test sysctl -w net.ipv4.conf.all.forwarding=1")
-      expect(vs).to receive(:r).with("ip netns exec test sysctl -w net.ipv4.ip_forward=1")
+      expect(vs).to receive(:_run_command).with("ip netns exec test sysctl -w net.ipv6.conf.all.forwarding=1")
+      expect(vs).to receive(:_run_command).with("ip netns exec test sysctl -w net.ipv4.conf.all.forwarding=1")
+      expect(vs).to receive(:_run_command).with("ip netns exec test sysctl -w net.ipv4.ip_forward=1")
       vs.send(:forwarding)
     end
   end
@@ -1282,10 +1282,10 @@ NFTABLES_CONF
     before do
       allow(vs).to receive(:vp).and_return(vps)
       allow(vs).to receive(:write_user_data)
-      expect(vs).to receive(:r).with("mkdosfs -n CIDATA -C /vm/test/cloudinit.img 128")
-      expect(vs).to receive(:r).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/user-data ::")
-      expect(vs).to receive(:r).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/meta-data ::")
-      expect(vs).to receive(:r).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/network-config ::")
+      expect(vs).to receive(:_run_command).with("mkdosfs -n CIDATA -C /vm/test/cloudinit.img 128")
+      expect(vs).to receive(:_run_command).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/user-data ::")
+      expect(vs).to receive(:_run_command).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/meta-data ::")
+      expect(vs).to receive(:_run_command).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/network-config ::")
       allow(FileUtils).to receive(:rm_rf)
       allow(FileUtils).to receive(:chmod)
       allow(FileUtils).to receive(:chown)
@@ -1331,7 +1331,7 @@ NFTABLES_CONF
       storage_params = []
       args = [2, "1:1:1:2", 2, storage_params, [], [["00:01.0", "1"], ["00:02.0", "2"]], "system.slice", 0]
 
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       vs.send(:install_systemd_unit, *args)
 
       expect(vps).to have_received(:write_systemd_service) { |content|
@@ -1359,7 +1359,7 @@ NFTABLES_CONF
       ]
       args = [2, "1:1:1:2", 2, storage_params, [VmSetup::Nic.new("fd00::/64", "10.0.0.1/32", "tap0", "02:aa:bb:cc:dd:01", "10.0.0.254/32")], [["00:01.0", "1"]], "system.slice", 0]
 
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       vs.send(:install_systemd_unit, *args)
 
       expect(vps).to have_received(:write_systemd_service) { |content|
@@ -1385,7 +1385,7 @@ NFTABLES_CONF
       vs.instance_variable_set(:@firmware_version,
         CloudHypervisor::Firmware.new("202311", "sha256"))
 
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       vs.send(:install_systemd_unit, 2, "1:1:1:2", 2, [], [], [], "system.slice", 0)
 
       expect(vps).to have_received(:write_systemd_service) { |content|
@@ -1408,7 +1408,7 @@ NFTABLES_CONF
       vs.instance_variable_set(:@firmware_version,
         CloudHypervisor::Firmware.new("202311", "sha256"))
 
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       vs.send(:install_systemd_unit, 2, "1:1:1:2", 2, [], [], [], "system.slice", 50)
 
       expect(vps).to have_received(:write_systemd_service) { |content|
@@ -1429,7 +1429,7 @@ NFTABLES_CONF
       vs.instance_variable_set(:@firmware_version,
         CloudHypervisor::Firmware.new("202311", "sha256"))
 
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       expect(vs).to receive(:cpu_vendor).and_return("GenuineIntel")
 
       storage_params = []
@@ -1454,7 +1454,7 @@ NFTABLES_CONF
       vs.instance_variable_set(:@firmware_version,
         CloudHypervisor::Firmware.new("202311", "sha256"))
 
-      expect(vs).to receive(:r).with("systemctl daemon-reload")
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       expect(vs).to receive(:cpu_vendor).and_return("GenuineIntel")
 
       storage_params = []
@@ -1477,52 +1477,52 @@ NFTABLES_CONF
 
   describe "#cpu_vendor" do
     it "strips the output of lscpu vendor id" do
-      expect(vs).to receive(:r).with("/usr/bin/lscpu | grep -m1 \"Vendor ID\" | cut -d: -f2").and_return("  AuthenticAMD  \n")
+      expect(vs).to receive(:_run_command).with("/usr/bin/lscpu | grep -m1 \"Vendor ID\" | cut -d: -f2").and_return("  AuthenticAMD  \n")
       expect(vs.send(:cpu_vendor)).to eq("AuthenticAMD")
     end
   end
 
   describe "#interfaces" do
     it "can setup interfaces without multiqueue" do
-      expect(vs).to receive(:r).with("ip netns del test")
+      expect(vs).to receive(:_run_command).with("ip netns del test")
       expect(File).to receive(:exist?).with("/sys/class/net/vethotest").and_return(true, false)
       expect(vs).to receive(:sleep).with(0.1).once
 
-      expect(vs).to receive(:r).with("ip netns add test")
+      expect(vs).to receive(:_run_command).with("ip netns add test")
       expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
-      expect(vs).to receive(:r).with("ip link add vethotest addr 00:00:00:00:00:00 type veth peer name vethitest addr 00:00:00:00:00:00 netns test")
+      expect(vs).to receive(:_run_command).with("ip link add vethotest addr 00:00:00:00:00:00 type veth peer name vethitest addr 00:00:00:00:00:00 netns test")
       nics = [VmSetup::Nic.new(nil, nil, "nctest", nil, "1.1.1.1")]
-      expect(vs).to receive(:r).with("ip -n test tuntap add dev nctest mode tap user test  ")
-      expect(vs).to receive(:r).with("ip -n test addr replace 1.1.1.1 dev nctest")
+      expect(vs).to receive(:_run_command).with("ip -n test tuntap add dev nctest mode tap user test  ")
+      expect(vs).to receive(:_run_command).with("ip -n test addr replace 1.1.1.1 dev nctest")
       vs.interfaces(nics, false)
     end
 
     it "can setup interfaces with multiqueue" do
-      expect(vs).to receive(:r).with("ip netns del test")
+      expect(vs).to receive(:_run_command).with("ip netns del test")
       expect(File).to receive(:exist?).with("/sys/class/net/vethotest").and_return(false)
 
-      expect(vs).to receive(:r).with("ip netns add test")
+      expect(vs).to receive(:_run_command).with("ip netns add test")
       expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
-      expect(vs).to receive(:r).with("ip link add vethotest addr 00:00:00:00:00:00 type veth peer name vethitest addr 00:00:00:00:00:00 netns test")
+      expect(vs).to receive(:_run_command).with("ip link add vethotest addr 00:00:00:00:00:00 type veth peer name vethitest addr 00:00:00:00:00:00 netns test")
       nics = [VmSetup::Nic.new(nil, nil, "nctest", nil, "1.1.1.1")]
-      expect(vs).to receive(:r).with("ip -n test tuntap add dev nctest mode tap user test  multi_queue vnet_hdr ")
-      expect(vs).to receive(:r).with("ip -n test addr replace 1.1.1.1 dev nctest")
+      expect(vs).to receive(:_run_command).with("ip -n test tuntap add dev nctest mode tap user test  multi_queue vnet_hdr ")
+      expect(vs).to receive(:_run_command).with("ip -n test addr replace 1.1.1.1 dev nctest")
       vs.interfaces(nics, true)
     end
 
     it "fails if network namespace can not be deleted" do
-      expect(vs).to receive(:r).with("ip netns del test").and_raise(CommandFail.new("", "", "error"))
+      expect(vs).to receive(:_run_command).with("ip netns del test").and_raise(CommandFail.new("", "", "error"))
       expect { vs.interfaces([VmSetup::Nic.new(nil, nil, "nctest", nil, "1.1.1.1")], false) }.to raise_error(CommandFail)
     end
 
     it "ignores 'No such file or directory' error when deleting netns" do
-      expect(vs).to receive(:r).with("ip netns del test").and_raise(
+      expect(vs).to receive(:_run_command).with("ip netns del test").and_raise(
         CommandFail.new("", "", 'Cannot remove namespace file "/var/run/netns/test": No such file or directory'),
       )
       expect(File).to receive(:exist?).with("/sys/class/net/vethotest").and_return(false)
-      expect(vs).to receive(:r).with("ip netns add test")
+      expect(vs).to receive(:_run_command).with("ip netns add test")
       expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
-      expect(vs).to receive(:r).with("ip link add vethotest addr 00:00:00:00:00:00 type veth peer name vethitest addr 00:00:00:00:00:00 netns test")
+      expect(vs).to receive(:_run_command).with("ip link add vethotest addr 00:00:00:00:00:00 type veth peer name vethitest addr 00:00:00:00:00:00 netns test")
       vs.interfaces([], false)
     end
   end

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -961,8 +961,8 @@ NFTABLES_CONF
       expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "10.0.0.0", "dev", "vethitest")
       expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "10.0.0.2/32", "dev", "nctest")
       expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "default", "via", "10.0.0.0", "dev", "vethitest")
-      expect(vs).to receive(:_run_command).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/nctest/proxy_arp'")
-      expect(vs).to receive(:_run_command).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethitest/proxy_arp'")
+      expect(vs).to receive(:_run_command).with("ip netns exec test bash -c echo\\ 1\\ \\>\\ /proc/sys/net/ipv4/conf/nctest/proxy_arp")
+      expect(vs).to receive(:_run_command).with("ip netns exec test bash -c echo\\ 1\\ \\>\\ /proc/sys/net/ipv4/conf/vethitest/proxy_arp")
       vs.routes4("10.0.0.2/32", "10.0.0.0/31", nics)
     end
 
@@ -972,8 +972,8 @@ NFTABLES_CONF
       expect(vs).to receive(:_run_command).with("ip", "-n", "test", "addr", "replace", "10.0.0.2/32", "dev", "vethitest")
       expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "10.0.0.0", "dev", "vethitest")
       expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "default", "via", "10.0.0.0", "dev", "vethitest")
-      expect(vs).to receive(:_run_command).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethitest/proxy_arp'")
-      expect(vs).to receive(:_run_command).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/nctest/proxy_arp'")
+      expect(vs).to receive(:_run_command).with("ip netns exec test bash -c echo\\ 1\\ \\>\\ /proc/sys/net/ipv4/conf/vethitest/proxy_arp")
+      expect(vs).to receive(:_run_command).with("ip netns exec test bash -c echo\\ 1\\ \\>\\ /proc/sys/net/ipv4/conf/nctest/proxy_arp")
       vs.routes4(nil, "10.0.0.1/31", nics)
     end
   end

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -199,10 +199,10 @@ RSpec.describe VmSetup do
     before do
       allow(vs).to receive(:vp).and_return(vps)
       allow(vs).to receive(:write_user_data)
-      expect(vs).to receive(:_run_command).with("mkdosfs -n CIDATA -C /vm/test/cloudinit.img 128")
-      expect(vs).to receive(:_run_command).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/user-data ::")
-      expect(vs).to receive(:_run_command).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/meta-data ::")
-      expect(vs).to receive(:_run_command).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/network-config ::")
+      expect(vs).to receive(:_run_command).with("mkdosfs", "-n", "CIDATA", "-C", "/vm/test/cloudinit.img", "128")
+      expect(vs).to receive(:_run_command).with("mcopy", "-oi", "/vm/test/cloudinit.img", "-s", "/vm/test/user-data", "::")
+      expect(vs).to receive(:_run_command).with("mcopy", "-oi", "/vm/test/cloudinit.img", "-s", "/vm/test/meta-data", "::")
+      expect(vs).to receive(:_run_command).with("mcopy", "-oi", "/vm/test/cloudinit.img", "-s", "/vm/test/network-config", "::")
       allow(FileUtils).to receive(:rm_rf)
       allow(FileUtils).to receive(:chmod)
       allow(FileUtils).to receive(:chown)
@@ -261,13 +261,13 @@ RSpec.describe VmSetup do
 
   describe "#purge" do
     it "can purge" do
-      expect(vs).to receive(:_run_command).with("ip netns del test")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "del", "test")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test.service")
       expect(FileUtils).to receive(:rm_f).with("/etc/systemd/system/test-dnsmasq.service")
       expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       expect(vs).to receive(:purge_storage)
       expect(vs).to receive(:unmount_hugepages)
-      expect(vs).to receive(:_run_command).with("deluser --remove-home test")
+      expect(vs).to receive(:_run_command).with("deluser", "--remove-home", "test")
       expect(IO).to receive(:popen).with(["systemd-escape", "test.service"]).and_return("test.service")
       expect(vs).to receive(:block_ip4)
 
@@ -283,17 +283,17 @@ RSpec.describe VmSetup do
     end
 
     it "can unmount hugepages" do
-      expect(vs).to receive(:_run_command).with("umount /vm/test/hugepages")
+      expect(vs).to receive(:_run_command).with("umount", "/vm/test/hugepages")
       vs.unmount_hugepages
     end
 
     it "exits silently if hugepages isn't mounted" do
-      expect(vs).to receive(:_run_command).with("umount /vm/test/hugepages").and_raise(CommandFail.new("", "", "/vm/test/hugepages: no mount point specified."))
+      expect(vs).to receive(:_run_command).with("umount", "/vm/test/hugepages").and_raise(CommandFail.new("", "", "/vm/test/hugepages: no mount point specified."))
       vs.unmount_hugepages
     end
 
     it "fails if umount fails with an unexpected error" do
-      expect(vs).to receive(:_run_command).with("umount /vm/test/hugepages").and_raise(CommandFail.new("", "", "/vm/test/hugepages: wait, what?"))
+      expect(vs).to receive(:_run_command).with("umount", "/vm/test/hugepages").and_raise(CommandFail.new("", "", "/vm/test/hugepages: wait, what?"))
       expect { vs.unmount_hugepages }.to raise_error CommandFail
     end
   end
@@ -698,21 +698,21 @@ NFTABLES_CONF
     it "can setup hugepages" do
       expect(FileUtils).to receive(:mkdir_p).with("/vm/test/hugepages")
       expect(FileUtils).to receive(:chown).with("test", "test", "/vm/test/hugepages")
-      expect(vs).to receive(:_run_command).with("mount -t hugetlbfs -o uid=test,size=2G nodev /vm/test/hugepages")
+      expect(vs).to receive(:_run_command).with("mount", "-t", "hugetlbfs", "-o", "uid=test,size=2G", "nodev", "/vm/test/hugepages")
       vs.hugepages(2)
     end
   end
 
   describe "#start_systemd_unit" do
     it "can start systemd unit" do
-      expect(vs).to receive(:_run_command).with("systemctl start test")
+      expect(vs).to receive(:_run_command).with("systemctl", "start", "test")
       vs.start_systemd_unit
     end
   end
 
   describe "#restart_systemd_unit" do
     it "can restart systemd unit" do
-      expect(vs).to receive(:_run_command).with("systemctl restart test")
+      expect(vs).to receive(:_run_command).with("systemctl", "restart", "test")
       vs.restart_systemd_unit
     end
   end
@@ -761,7 +761,7 @@ NFTABLES_CONF
   describe "#purge_network" do
     it "ignores 'no such file or directory' error when deleting netns" do
       expect(vs).to receive(:block_ip4)
-      expect(vs).to receive(:_run_command).with("ip netns del test").and_raise(
+      expect(vs).to receive(:_run_command).with("ip", "netns", "del", "test").and_raise(
         CommandFail.new("err", "", 'Cannot remove namespace file "/var/run/netns/test": No such file or directory'),
       )
       expect { vs.purge_network }.not_to raise_error
@@ -769,7 +769,7 @@ NFTABLES_CONF
 
     it "re-raises unexpected errors when deleting netns" do
       expect(vs).to receive(:block_ip4)
-      expect(vs).to receive(:_run_command).with("ip netns del test").and_raise(
+      expect(vs).to receive(:_run_command).with("ip", "netns", "del", "test").and_raise(
         CommandFail.new("err", "", "some unexpected error"),
       )
       expect { vs.purge_network }.to raise_error(CommandFail)
@@ -790,14 +790,14 @@ NFTABLES_CONF
 
   describe "#purge_user" do
     it "silently ignores 'user does not exist' error" do
-      expect(vs).to receive(:_run_command).with("deluser --remove-home test").and_raise(
+      expect(vs).to receive(:_run_command).with("deluser", "--remove-home", "test").and_raise(
         CommandFail.new("err", "", "The user `test' does not exist."),
       )
       expect { vs.purge_user }.not_to raise_error
     end
 
     it "re-raises unexpected deluser errors" do
-      expect(vs).to receive(:_run_command).with("deluser --remove-home test").and_raise(
+      expect(vs).to receive(:_run_command).with("deluser", "--remove-home", "test").and_raise(
         CommandFail.new("err", "", "some unexpected error"),
       )
       expect { vs.purge_user }.to raise_error(CommandFail)
@@ -905,28 +905,28 @@ NFTABLES_CONF
     let(:gua) { "fddf:53d2:4c89:2305:46a0::/79" }
 
     it "sets up veths without ndp" do
-      expect(vs).to receive(:_run_command).with("ip netns exec test cat /sys/class/net/vethitest/address").and_return("3e:bd:a5:96:f7:b9\n")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "exec", "test", "cat", "/sys/class/net/vethitest/address").and_return("3e:bd:a5:96:f7:b9\n")
       expect(File).to receive(:read).with("/sys/class/net/vethotest/address").and_return("3e:bd:a5:96:f7:b9\n")
-      expect(vs).to receive(:_run_command).with("ip link set dev vethotest up")
-      expect(vs).to receive(:_run_command).with("ip route replace fddf:53d2:4c89:2305:46a0::/79 via fe80::3cbd:a5ff:fe96:f7b9 dev vethotest")
-      expect(vs).to receive(:_run_command).with("ip -n test addr replace fddf:53d2:4c89:2305:8000::/65 dev vethitest")
-      expect(vs).to receive(:_run_command).with("ip -n test link set dev vethitest up")
-      expect(vs).to receive(:_run_command).with("ip -n test route replace 2000::/3 via fe80::3cbd:a5ff:fe96:f7b9 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip", "link", "set", "dev", "vethotest", "up")
+      expect(vs).to receive(:_run_command).with("ip", "route", "replace", "fddf:53d2:4c89:2305:46a0::/79", "via", "fe80::3cbd:a5ff:fe96:f7b9", "dev", "vethotest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "addr", "replace", "fddf:53d2:4c89:2305:8000::/65", "dev", "vethitest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "link", "set", "dev", "vethitest", "up")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "2000::/3", "via", "fe80::3cbd:a5ff:fe96:f7b9", "dev", "vethitest")
       vs.setup_veths_6(guest_ephemeral, clover_ephemeral, gua, false)
     end
 
     it "sets up ndp proxy routes when ndp_needed is true" do
-      expect(vs).to receive(:_run_command).with("ip netns exec test cat /sys/class/net/vethitest/address").and_return("3e:bd:a5:96:f7:b9\n")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "exec", "test", "cat", "/sys/class/net/vethitest/address").and_return("3e:bd:a5:96:f7:b9\n")
       expect(File).to receive(:read).with("/sys/class/net/vethotest/address").and_return("3e:bd:a5:96:f7:b9\n")
-      expect(vs).to receive(:_run_command).with("ip -6 neigh add proxy fddf:53d2:4c89:2305::2 dev eth0")
-      expect(vs).to receive(:_run_command).with("ip -6 neigh add proxy fddf:53d2:4c89:2305:8000:: dev eth0")
-      expect(vs).to receive(:_run_command).with("ip -n test addr replace fddf:53d2:4c89:2305:8000::/65 dev vethitest")
-      expect(vs).to receive(:_run_command).with("ip -n test link set dev vethitest up")
-      expect(vs).to receive(:_run_command).with("ip -n test route replace 2000::/3 via fe80::3cbd:a5ff:fe96:f7b9 dev vethitest")
-      expect(vs).to receive(:_run_command).with("ip link set dev vethotest up")
+      expect(vs).to receive(:_run_command).with("ip", "-6", "neigh", "add", "proxy", "fddf:53d2:4c89:2305::2", "dev", "eth0")
+      expect(vs).to receive(:_run_command).with("ip", "-6", "neigh", "add", "proxy", "fddf:53d2:4c89:2305:8000::", "dev", "eth0")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "addr", "replace", "fddf:53d2:4c89:2305:8000::/65", "dev", "vethitest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "link", "set", "dev", "vethitest", "up")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "2000::/3", "via", "fe80::3cbd:a5ff:fe96:f7b9", "dev", "vethitest")
+      expect(vs).to receive(:_run_command).with("ip", "link", "set", "dev", "vethotest", "up")
       routes = JSON.generate([{"dst" => "default", "dev" => "eth0"}])
       expect(vs).to receive(:_run_command).with("ip -j route").and_return(routes)
-      expect(vs).to receive(:_run_command).with("ip route replace fddf:53d2:4c89:2305:46a0::/79 via fe80::3cbd:a5ff:fe96:f7b9 dev vethotest")
+      expect(vs).to receive(:_run_command).with("ip", "route", "replace", "fddf:53d2:4c89:2305:46a0::/79", "via", "fe80::3cbd:a5ff:fe96:f7b9", "dev", "vethotest")
       vs.setup_veths_6(guest_ephemeral, clover_ephemeral, gua, true)
     end
   end
@@ -935,15 +935,15 @@ NFTABLES_CONF
     it "sets up tap routes for each NIC" do
       gua = "fddf:53d2:4c89:2305:46a0::/79"
       nics = [VmSetup::Nic.new("fd48:666c:a296:ce4b:2cc6::/79", "192.168.5.50/32", "nctest", "3e:bd:a5:96:f7:b9", "10.0.0.254/32")]
-      expect(vs).to receive(:_run_command).with("ip -n test addr replace fddf:53d2:4c89:2305:46a0::1/80 dev nctest")
-      expect(vs).to receive(:_run_command).with("ip -n test addr replace 10.0.0.2 dev nctest")
-      expect(vs).to receive(:_run_command).with("ip -n test route replace fddf:53d2:4c89:2305:46a0::/80 via fe80::3cbd:a5ff:fe96:f7b9 dev nctest")
-      expect(vs).to receive(:_run_command).with("ip -n test route del fddf:53d2:4c89:2305:46a0::/80 dev nctest")
-      expect(vs).to receive(:_run_command).with("ip -n test link set dev nctest up")
-      expect(vs).to receive(:_run_command).with("ip -n test addr replace fd48:666c:a296:ce4b:2cc6::1/79 dev nctest noprefixroute")
-      expect(vs).to receive(:_run_command).with("ip -n test route replace fd48:666c:a296:ce4b:2cc6::/79 via fe80::3cbd:a5ff:fe96:f7b9 dev nctest")
-      expect(vs).to receive(:_run_command).with("ip -n test addr replace fd00:0b1c:100d:5AFE:CE:: dev nctest")
-      expect(vs).to receive(:_run_command).with("ip -n test addr replace fd00:0b1c:100d:53:: dev nctest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "addr", "replace", "fddf:53d2:4c89:2305:46a0::1/80", "dev", "nctest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "addr", "replace", "10.0.0.2", "dev", "nctest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "fddf:53d2:4c89:2305:46a0::/80", "via", "fe80::3cbd:a5ff:fe96:f7b9", "dev", "nctest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "del", "fddf:53d2:4c89:2305:46a0::/80", "dev", "nctest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "link", "set", "dev", "nctest", "up")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "addr", "replace", "fd48:666c:a296:ce4b:2cc6::1/79", "dev", "nctest", "noprefixroute")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "fd48:666c:a296:ce4b:2cc6::/79", "via", "fe80::3cbd:a5ff:fe96:f7b9", "dev", "nctest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "addr", "replace", "fd00:0b1c:100d:5AFE:CE::", "dev", "nctest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "addr", "replace", "fd00:0b1c:100d:53::", "dev", "nctest")
       vs.setup_taps_6(gua, nics, "10.0.0.2")
     end
   end
@@ -954,24 +954,24 @@ NFTABLES_CONF
     it "sets up routes with ip4" do
       # With ip4="10.0.0.2/32" and ip4_local="10.0.0.0/31":
       #   vm = "10.0.0.2/32", vetho = "10.0.0.0", vethi = "10.0.0.2"
-      expect(vs).to receive(:_run_command).with("ip addr replace 10.0.0.0/32 dev vethotest")
-      expect(vs).to receive(:_run_command).with("ip route replace 10.0.0.2/32 dev vethotest")
+      expect(vs).to receive(:_run_command).with("ip", "addr", "replace", "10.0.0.0/32", "dev", "vethotest")
+      expect(vs).to receive(:_run_command).with("ip", "route", "replace", "10.0.0.2/32", "dev", "vethotest")
       expect(vs).to receive(:_run_command).with("echo 1 > /proc/sys/net/ipv4/conf/vethotest/proxy_arp")
-      expect(vs).to receive(:_run_command).with("ip -n test addr replace 10.0.0.2/32 dev vethitest")
-      expect(vs).to receive(:_run_command).with("ip -n test route replace 10.0.0.0 dev vethitest")
-      expect(vs).to receive(:_run_command).with("ip -n test route replace 10.0.0.2/32 dev nctest")
-      expect(vs).to receive(:_run_command).with("ip -n test route replace default via 10.0.0.0 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "addr", "replace", "10.0.0.2/32", "dev", "vethitest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "10.0.0.0", "dev", "vethitest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "10.0.0.2/32", "dev", "nctest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "default", "via", "10.0.0.0", "dev", "vethitest")
       expect(vs).to receive(:_run_command).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/nctest/proxy_arp'")
       expect(vs).to receive(:_run_command).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethitest/proxy_arp'")
       vs.routes4("10.0.0.2/32", "10.0.0.0/31", nics)
     end
 
     it "skips ip4 route when ip4 is nil" do
-      expect(vs).to receive(:_run_command).with("ip addr replace 10.0.0.0/32 dev vethotest")
+      expect(vs).to receive(:_run_command).with("ip", "addr", "replace", "10.0.0.0/32", "dev", "vethotest")
       expect(vs).to receive(:_run_command).with("echo 1 > /proc/sys/net/ipv4/conf/vethotest/proxy_arp")
-      expect(vs).to receive(:_run_command).with("ip -n test addr replace 10.0.0.2/32 dev vethitest")
-      expect(vs).to receive(:_run_command).with("ip -n test route replace 10.0.0.0 dev vethitest")
-      expect(vs).to receive(:_run_command).with("ip -n test route replace default via 10.0.0.0 dev vethitest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "addr", "replace", "10.0.0.2/32", "dev", "vethitest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "10.0.0.0", "dev", "vethitest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "default", "via", "10.0.0.0", "dev", "vethitest")
       expect(vs).to receive(:_run_command).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/vethitest/proxy_arp'")
       expect(vs).to receive(:_run_command).with("ip netns exec test bash -c 'echo 1 > /proc/sys/net/ipv4/conf/nctest/proxy_arp'")
       vs.routes4(nil, "10.0.0.1/31", nics)
@@ -988,7 +988,7 @@ NFTABLES_CONF
     it "updates routes for non-/32 nics when tap is ready" do
       nics = [VmSetup::Nic.new(nil, "10.0.0.0/30", "nctest", nil, nil)]
       expect(vs).to receive(:_run_command).with("ip -n test link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN").and_return("UP\n")
-      expect(vs).to receive(:_run_command).with("ip -n test route replace 10.0.0.0/30 via 10.0.0.1 dev nctest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "10.0.0.0/30", "via", "10.0.0.1", "dev", "nctest")
       vs.update_via_routes(nics)
     end
 
@@ -1005,7 +1005,7 @@ NFTABLES_CONF
         VmSetup::Nic.new(nil, "10.0.0.5/32", "nctest2", nil, nil),
       ]
       expect(vs).to receive(:_run_command).with("ip -n test link | grep -E '^[0-9]+: nc[^:]+:' | grep -q 'state UP' && echo UP || echo DOWN").and_return("UP\n")
-      expect(vs).to receive(:_run_command).with("ip -n test route replace 10.0.0.0/30 via 10.0.0.1 dev nctest1")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "route", "replace", "10.0.0.0/30", "via", "10.0.0.1", "dev", "nctest1")
       vs.update_via_routes(nics)
     end
   end
@@ -1258,19 +1258,19 @@ NFTABLES_CONF
 
   describe "#apply_nftables" do
     it "flushes and reloads nftables in the vm netns" do
-      expect(vs).to receive(:_run_command).with("ip netns exec test nft flush ruleset")
-      vps = instance_spy(VmPath, q_nftables_conf: "/vm/test/nftables.conf")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "exec", "test", "nft", "flush", "ruleset")
+      vps = instance_spy(VmPath, nftables_conf: "/vm/test/nftables.conf")
       expect(vs).to receive(:vp).and_return(vps)
-      expect(vs).to receive(:_run_command).with("ip netns exec test nft -f /vm/test/nftables.conf")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "exec", "test", "nft", "-f", "/vm/test/nftables.conf")
       vs.send(:apply_nftables)
     end
   end
 
   describe "#forwarding" do
     it "enables forwarding in the vm netns" do
-      expect(vs).to receive(:_run_command).with("ip netns exec test sysctl -w net.ipv6.conf.all.forwarding=1")
-      expect(vs).to receive(:_run_command).with("ip netns exec test sysctl -w net.ipv4.conf.all.forwarding=1")
-      expect(vs).to receive(:_run_command).with("ip netns exec test sysctl -w net.ipv4.ip_forward=1")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "exec", "test", "sysctl", "-w", "net.ipv6.conf.all.forwarding=1")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "exec", "test", "sysctl", "-w", "net.ipv4.conf.all.forwarding=1")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "exec", "test", "sysctl", "-w", "net.ipv4.ip_forward=1")
       vs.send(:forwarding)
     end
   end
@@ -1282,10 +1282,10 @@ NFTABLES_CONF
     before do
       allow(vs).to receive(:vp).and_return(vps)
       allow(vs).to receive(:write_user_data)
-      expect(vs).to receive(:_run_command).with("mkdosfs -n CIDATA -C /vm/test/cloudinit.img 128")
-      expect(vs).to receive(:_run_command).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/user-data ::")
-      expect(vs).to receive(:_run_command).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/meta-data ::")
-      expect(vs).to receive(:_run_command).with("mcopy -oi /vm/test/cloudinit.img -s /vm/test/network-config ::")
+      expect(vs).to receive(:_run_command).with("mkdosfs", "-n", "CIDATA", "-C", "/vm/test/cloudinit.img", "128")
+      expect(vs).to receive(:_run_command).with("mcopy", "-oi", "/vm/test/cloudinit.img", "-s", "/vm/test/user-data", "::")
+      expect(vs).to receive(:_run_command).with("mcopy", "-oi", "/vm/test/cloudinit.img", "-s", "/vm/test/meta-data", "::")
+      expect(vs).to receive(:_run_command).with("mcopy", "-oi", "/vm/test/cloudinit.img", "-s", "/vm/test/network-config", "::")
       allow(FileUtils).to receive(:rm_rf)
       allow(FileUtils).to receive(:chmod)
       allow(FileUtils).to receive(:chown)
@@ -1484,45 +1484,45 @@ NFTABLES_CONF
 
   describe "#interfaces" do
     it "can setup interfaces without multiqueue" do
-      expect(vs).to receive(:_run_command).with("ip netns del test")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "del", "test")
       expect(File).to receive(:exist?).with("/sys/class/net/vethotest").and_return(true, false)
       expect(vs).to receive(:sleep).with(0.1).once
 
-      expect(vs).to receive(:_run_command).with("ip netns add test")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "add", "test")
       expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
-      expect(vs).to receive(:_run_command).with("ip link add vethotest addr 00:00:00:00:00:00 type veth peer name vethitest addr 00:00:00:00:00:00 netns test")
+      expect(vs).to receive(:_run_command).with("ip", "link", "add", "vethotest", "addr", "00:00:00:00:00:00", "type", "veth", "peer", "name", "vethitest", "addr", "00:00:00:00:00:00", "netns", "test")
       nics = [VmSetup::Nic.new(nil, nil, "nctest", nil, "1.1.1.1")]
-      expect(vs).to receive(:_run_command).with("ip -n test tuntap add dev nctest mode tap user test  ")
-      expect(vs).to receive(:_run_command).with("ip -n test addr replace 1.1.1.1 dev nctest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "tuntap", "add", "dev", "nctest", "mode", "tap", "user", "test")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "addr", "replace", "1.1.1.1", "dev", "nctest")
       vs.interfaces(nics, false)
     end
 
     it "can setup interfaces with multiqueue" do
-      expect(vs).to receive(:_run_command).with("ip netns del test")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "del", "test")
       expect(File).to receive(:exist?).with("/sys/class/net/vethotest").and_return(false)
 
-      expect(vs).to receive(:_run_command).with("ip netns add test")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "add", "test")
       expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
-      expect(vs).to receive(:_run_command).with("ip link add vethotest addr 00:00:00:00:00:00 type veth peer name vethitest addr 00:00:00:00:00:00 netns test")
+      expect(vs).to receive(:_run_command).with("ip", "link", "add", "vethotest", "addr", "00:00:00:00:00:00", "type", "veth", "peer", "name", "vethitest", "addr", "00:00:00:00:00:00", "netns", "test")
       nics = [VmSetup::Nic.new(nil, nil, "nctest", nil, "1.1.1.1")]
-      expect(vs).to receive(:_run_command).with("ip -n test tuntap add dev nctest mode tap user test  multi_queue vnet_hdr ")
-      expect(vs).to receive(:_run_command).with("ip -n test addr replace 1.1.1.1 dev nctest")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "tuntap", "add", "dev", "nctest", "mode", "tap", "user", "test", "multi_queue", "vnet_hdr")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "addr", "replace", "1.1.1.1", "dev", "nctest")
       vs.interfaces(nics, true)
     end
 
     it "fails if network namespace can not be deleted" do
-      expect(vs).to receive(:_run_command).with("ip netns del test").and_raise(CommandFail.new("", "", "error"))
+      expect(vs).to receive(:_run_command).with("ip", "netns", "del", "test").and_raise(CommandFail.new("", "", "error"))
       expect { vs.interfaces([VmSetup::Nic.new(nil, nil, "nctest", nil, "1.1.1.1")], false) }.to raise_error(CommandFail)
     end
 
     it "ignores 'No such file or directory' error when deleting netns" do
-      expect(vs).to receive(:_run_command).with("ip netns del test").and_raise(
+      expect(vs).to receive(:_run_command).with("ip", "netns", "del", "test").and_raise(
         CommandFail.new("", "", 'Cannot remove namespace file "/var/run/netns/test": No such file or directory'),
       )
       expect(File).to receive(:exist?).with("/sys/class/net/vethotest").and_return(false)
-      expect(vs).to receive(:_run_command).with("ip netns add test")
+      expect(vs).to receive(:_run_command).with("ip", "netns", "add", "test")
       expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
-      expect(vs).to receive(:_run_command).with("ip link add vethotest addr 00:00:00:00:00:00 type veth peer name vethitest addr 00:00:00:00:00:00 netns test")
+      expect(vs).to receive(:_run_command).with("ip", "link", "add", "vethotest", "addr", "00:00:00:00:00:00", "type", "veth", "peer", "name", "vethitest", "addr", "00:00:00:00:00:00", "netns", "test")
       vs.interfaces([], false)
     end
   end

--- a/rhizome/host/spec/vm_stats_spec.rb
+++ b/rhizome/host/spec/vm_stats_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe VmStats do
   let(:vm_stats) { described_class.new("vmh6b1sz") }
 
   before do
-    allow(vm_stats).to receive(:r).with("getconf", "CLK_TCK").and_return("100\n")
+    allow(vm_stats).to receive(:_run_command).with("getconf", "CLK_TCK").and_return("100\n")
   end
 
   def stub_unit_property(unit, property, value)
-    allow(vm_stats).to receive(:r)
+    allow(vm_stats).to receive(:_run_command)
       .with("systemctl", "show", unit, "--property", property)
       .and_return("#{property}=#{value}\n")
   end
@@ -109,7 +109,7 @@ RSpec.describe VmStats do
     end
 
     it "raises an error if the property is not found" do
-      expect(vm_stats).to receive(:r).with("systemctl", "show", "my-unit", "--property", "MainPID").and_return("\n")
+      expect(vm_stats).to receive(:_run_command).with("systemctl", "show", "my-unit", "--property", "MainPID").and_return("\n")
       expect { vm_stats.unit_property("my-unit", "MainPID") }.to raise_error(RuntimeError, "unexpected output from systemctl show: \"\"")
     end
   end
@@ -130,7 +130,7 @@ RSpec.describe VmStats do
 
   describe "#clk_tick" do
     it "returns the number of clock ticks per second" do
-      expect(vm_stats).to receive(:r).with("getconf", "CLK_TCK").and_return("234\n")
+      expect(vm_stats).to receive(:_run_command).with("getconf", "CLK_TCK").and_return("234\n")
       expect(vm_stats.clk_tick).to eq(234)
     end
   end

--- a/rhizome/inference_endpoint/spec/replica_setup_spec.rb
+++ b/rhizome/inference_endpoint/spec/replica_setup_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe ReplicaSetup do
       expect(rs).to receive(:write_inference_engine_service).with(satisfy { |s|
         s.include?("/usr/bin/start-engine") && s.include?("multi-user.target")
       })
-      expect(rs).to receive(:r).with("systemctl daemon-reload")
+      expect(rs).to receive(:_run_command).with("systemctl daemon-reload")
 
       rs.install_systemd_units("/usr/bin/start-engine")
     end
@@ -115,8 +115,8 @@ RSpec.describe ReplicaSetup do
 
   describe "#start_systemd_units" do
     it "enables and starts the required systemd units" do
-      expect(rs).to receive(:r).with("systemctl enable --now lb-cert-download.timer")
-      expect(rs).to receive(:r).with("systemctl enable --now inference-engine.service")
+      expect(rs).to receive(:_run_command).with("systemctl enable --now lb-cert-download.timer")
+      expect(rs).to receive(:_run_command).with("systemctl enable --now inference-engine.service")
       rs.start_systemd_units
     end
   end

--- a/rhizome/kubernetes/bin/backup-etcd
+++ b/rhizome/kubernetes/bin/backup-etcd
@@ -16,7 +16,7 @@ EXPECTED_HASH = "01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e89
 unless File.exist?(MC_PATH)
   puts "Installing mc..."
   Tempfile.create("mc") do |tmp_mc|
-    r(*%W[curl -sL #{MC_RELEASE_URL} -o #{tmp_mc.path}])
+    r "curl", "-sL", MC_RELEASE_URL, "-o", tmp_mc.path
 
     actual_hash = OpenSSL::Digest::SHA256.file(tmp_mc.path).hexdigest
 
@@ -25,8 +25,8 @@ unless File.exist?(MC_PATH)
       exit 1
     end
 
-    r(*%W[mv #{tmp_mc.path} #{MC_PATH}])
-    r(*%W[chmod +x #{MC_PATH}])
+    r "mv", tmp_mc.path, MC_PATH
+    r "chmod", "+x", MC_PATH
   end
 end
 
@@ -46,14 +46,14 @@ end
 puts "Found etcd container: #{etcd_container_id}"
 puts "Taking snapshot..."
 
-r(*%W[sudo crictl exec #{etcd_container_id}
-  etcdctl snapshot save /var/lib/etcd/backups/#{backup_file}
-  --cacert=/etc/kubernetes/pki/etcd/ca.crt
-  --cert=/etc/kubernetes/pki/etcd/server.crt
-  --key=/etc/kubernetes/pki/etcd/server.key])
+r "sudo", "crictl", "exec", etcd_container_id,
+  "etcdctl", "snapshot", "save", "/var/lib/etcd/backups/#{backup_file}",
+  "--cacert=/etc/kubernetes/pki/etcd/ca.crt",
+  "--cert=/etc/kubernetes/pki/etcd/server.crt",
+  "--key=/etc/kubernetes/pki/etcd/server.key"
 
 puts "Changing permission from root to ubi."
-r(*%W[sudo chown ubi:ubi #{host_backup_path}])
+r "sudo", "chown", "ubi:ubi", host_backup_path
 
 if File.exist?(host_backup_path)
   puts "Backup successfully created at #{host_backup_path}"
@@ -70,9 +70,9 @@ if File.exist?(host_backup_path)
 
   begin
     alias_name = "minio-target"
-    r env_vars, "#{MC_PATH} alias remove #{alias_name} > /dev/null 2>&1 || true"
-    r env_vars, *%W[#{MC_PATH} alias set #{alias_name} #{input["endpoint"]} #{input["access_key"]} #{input["secret_key"]}]
-    r env_vars, *%W[#{MC_PATH} cp #{host_backup_path} #{alias_name}/#{input["bucket"]}/#{backup_file}]
+    r env_vars, cmd(":mc alias remove :alias_name > /dev/null 2>&1 || true", mc: MC_PATH, alias_name: alias_name)
+    r env_vars, MC_PATH, "alias", "set", alias_name, input["endpoint"], input["access_key"], input["secret_key"]
+    r env_vars, MC_PATH, "cp", host_backup_path, "#{alias_name}/#{input["bucket"]}/#{backup_file}"
     puts "Backup uploaded successfully."
   ensure
     root_cert_file&.unlink
@@ -86,6 +86,6 @@ puts "Cleaning up old backups."
 backups = Dir.glob(File.join(BACKUP_DIR, "etcd-snapshot-*.db")).sort
 if backups.size >= 7
   backups.first(backups.size - 7 + 1).each do |f|
-    r(*%W[sudo rm -f #{f}])
+    r "sudo", "rm", "-f", f
   end
 end

--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -92,7 +92,7 @@ File.open(config_path, "w") do |file|
   file.write(kubelet_config.to_yaml)
 end
 
-r("sudo kubeadm init --config #{config_path} --node-name #{node_name}")
+r("sudo", "kubeadm", "init", "--config", config_path, "--node-name", node_name)
 r("sudo /home/ubi/kubernetes/bin/setup-cni")
 
 api_server_up = false
@@ -110,16 +110,15 @@ unless api_server_up
   exit 1
 end
 
-r "kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system create serviceaccount #{service_account_name}"
-r "kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system create clusterrolebinding #{service_account_name}-binding --clusterrole=cluster-admin --serviceaccount=kube-system:#{service_account_name}"
-r "kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f - <<EOF
-apiVersion: v1
-kind: Secret
-metadata:
-  name: #{secret_name}
-  namespace: kube-system
-  annotations:
-    kubernetes.io/service-account.name: #{service_account_name}
-type: kubernetes.io/service-account-token
-EOF
-"
+r "kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "create", "serviceaccount", service_account_name
+r "kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "create", "clusterrolebinding", "#{service_account_name}-binding", "--clusterrole=cluster-admin", "--serviceaccount=kube-system:#{service_account_name}"
+r "kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "apply", "-f", "-", stdin: <<~YAML
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: #{secret_name}
+    namespace: kube-system
+    annotations:
+      kubernetes.io/service-account.name: #{service_account_name}
+  type: kubernetes.io/service-account-token
+YAML

--- a/rhizome/kubernetes/bin/join-node
+++ b/rhizome/kubernetes/bin/join-node
@@ -56,6 +56,6 @@ end
 
 config_path = "/tmp/join-config.yaml"
 safe_write_to_file(config_path, config.to_yaml)
-r("kubeadm join --config #{config_path}")
+r("kubeadm", "join", "--config", config_path)
 
 r("sudo /home/ubi/kubernetes/bin/setup-cni")

--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -161,7 +161,7 @@ options ndots:5
     r "ip", "-n", cni_netns, "route", "replace", "default", "via", gateway_ip.to_s
 
     r "ip", "route", "replace", "#{container_ip}/#{container_ip.prefix}", "via", gateway_ip.to_s, "dev", outer_ifname
-    r cmd("echo 1 > :path", path: "/proc/sys/net/ipv4/conf/#{outer_ifname}/proxy_arp")
+    r "echo 1 > :path", path: "/proc/sys/net/ipv4/conf/#{outer_ifname}/proxy_arp"
   end
 
   def handle_del

--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -161,7 +161,7 @@ options ndots:5
     r "ip", "-n", cni_netns, "route", "replace", "default", "via", gateway_ip.to_s
 
     r "ip", "route", "replace", "#{container_ip}/#{container_ip.prefix}", "via", gateway_ip.to_s, "dev", outer_ifname
-    r "echo 1 > /proc/sys/net/ipv4/conf/#{outer_ifname}/proxy_arp"
+    r cmd("echo 1 > :path", path: "/proc/sys/net/ipv4/conf/#{outer_ifname}/proxy_arp")
   end
 
   def handle_del

--- a/rhizome/kubernetes/lib/ubi_cni.rb
+++ b/rhizome/kubernetes/lib/ubi_cni.rb
@@ -63,7 +63,7 @@ class UbiCNI
     setup_dns(cni_netns)
 
     @logger.info "Setting up veth pair for container #{container_id}"
-    r "ip link add #{outer_ifname} addr #{outer_mac} type veth peer name #{inner_ifname} addr #{inner_mac} netns #{cni_netns}"
+    r "ip", "link", "add", outer_ifname, "addr", outer_mac, "type", "veth", "peer", "name", inner_ifname, "addr", inner_mac, "netns", cni_netns
 
     @logger.info "Allocating IP addresses for container #{container_id}"
     ipv4_container_ip, ipv4_gateway_ip, container_ula_ipv6, container_ipv6 = allocate_ips_for_pod(container_id, subnet_ula_ipv6, subnet_ipv6, subnet_ipv4)
@@ -142,25 +142,25 @@ options ndots:5
   end
 
   def setup_ipv6(container_ip, inner_link_local, outer_link_local, cni_netns, inner_ifname, outer_ifname, setup_default_route: false)
-    r "ip -6 -n #{cni_netns} addr replace #{container_ip}/#{container_ip.prefix} dev #{inner_ifname}"
-    r "ip -6 -n #{cni_netns} link set #{inner_ifname} mtu #{MTU} up"
+    r "ip", "-6", "-n", cni_netns, "addr", "replace", "#{container_ip}/#{container_ip.prefix}", "dev", inner_ifname
+    r "ip", "-6", "-n", cni_netns, "link", "set", inner_ifname, "mtu", MTU.to_s, "up"
     if setup_default_route
-      r "ip -6 -n #{cni_netns} route replace default via #{outer_link_local} dev #{inner_ifname}"
+      r "ip", "-6", "-n", cni_netns, "route", "replace", "default", "via", outer_link_local, "dev", inner_ifname
     end
 
-    r "ip -6 link set #{outer_ifname} mtu #{MTU} up"
-    r "ip -6 route replace #{container_ip}/#{container_ip.prefix} via #{inner_link_local} dev #{outer_ifname} mtu #{MTU}"
+    r "ip", "-6", "link", "set", outer_ifname, "mtu", MTU.to_s, "up"
+    r "ip", "-6", "route", "replace", "#{container_ip}/#{container_ip.prefix}", "via", inner_link_local, "dev", outer_ifname, "mtu", MTU.to_s
   end
 
   def setup_ipv4(container_ip, gateway_ip, prefix, cni_netns, inner_ifname, outer_ifname)
-    r "ip addr replace #{gateway_ip}/#{prefix} dev #{outer_ifname}"
-    r "ip link set #{outer_ifname} mtu #{MTU} up"
+    r "ip", "addr", "replace", "#{gateway_ip}/#{prefix}", "dev", outer_ifname
+    r "ip", "link", "set", outer_ifname, "mtu", MTU.to_s, "up"
 
-    r "ip -n #{cni_netns} addr replace #{container_ip}/#{prefix} dev #{inner_ifname}"
-    r "ip -n #{cni_netns} link set #{inner_ifname} mtu #{MTU} up"
-    r "ip -n #{cni_netns} route replace default via #{gateway_ip}"
+    r "ip", "-n", cni_netns, "addr", "replace", "#{container_ip}/#{prefix}", "dev", inner_ifname
+    r "ip", "-n", cni_netns, "link", "set", inner_ifname, "mtu", MTU.to_s, "up"
+    r "ip", "-n", cni_netns, "route", "replace", "default", "via", gateway_ip.to_s
 
-    r "ip route replace #{container_ip}/#{container_ip.prefix} via #{gateway_ip} dev #{outer_ifname}"
+    r "ip", "route", "replace", "#{container_ip}/#{container_ip.prefix}", "via", gateway_ip.to_s, "dev", outer_ifname
     r "echo 1 > /proc/sys/net/ipv4/conf/#{outer_ifname}/proxy_arp"
   end
 

--- a/rhizome/kubernetes/spec/ubi_cni_spec.rb
+++ b/rhizome/kubernetes/spec/ubi_cni_spec.rb
@@ -83,25 +83,25 @@ RSpec.describe UbiCNI do
       expect(ubicni).to receive(:check_required_env_vars).with(["CNI_CONTAINERID", "CNI_NETNS", "CNI_IFNAME"])
       expect(ubicni).to receive(:validate_input_ranges)
 
-      expect_run = ->(cmd) { expect(ubicni).to receive(:_run_command).with(cmd) }
-      expect_run["ip link add veth_abcdef12 addr 00:aa:bb:cc:dd:ee type veth peer name eth0 addr 00:11:22:33:44:55 netns testnetns"]
-      expect_run["ip -6 -n testnetns addr replace 2001:db8::2/128 dev eth0"]
-      expect_run["ip -6 -n testnetns link set eth0 mtu 1400 up"]
-      expect_run["ip -6 -n testnetns route replace default via fe80::02aa:bbff:fecc:ddee dev eth0"]
-      expect_run["ip -6 link set veth_abcdef12 mtu 1400 up"]
-      expect_run["ip -6 route replace 2001:db8::2/128 via fe80::0211:22ff:fe33:4455 dev veth_abcdef12 mtu 1400"]
+      expect_run = ->(*cmd) { expect(ubicni).to receive(:_run_command).with(*cmd) }
+      expect_run["ip", "link", "add", "veth_abcdef12", "addr", "00:aa:bb:cc:dd:ee", "type", "veth", "peer", "name", "eth0", "addr", "00:11:22:33:44:55", "netns", "testnetns"]
+      expect_run["ip", "-6", "-n", "testnetns", "addr", "replace", "2001:db8::2/128", "dev", "eth0"]
+      expect_run["ip", "-6", "-n", "testnetns", "link", "set", "eth0", "mtu", "1400", "up"]
+      expect_run["ip", "-6", "-n", "testnetns", "route", "replace", "default", "via", "fe80::02aa:bbff:fecc:ddee", "dev", "eth0"]
+      expect_run["ip", "-6", "link", "set", "veth_abcdef12", "mtu", "1400", "up"]
+      expect_run["ip", "-6", "route", "replace", "2001:db8::2/128", "via", "fe80::0211:22ff:fe33:4455", "dev", "veth_abcdef12", "mtu", "1400"]
 
-      expect_run["ip -6 -n testnetns addr replace fd00::2/128 dev eth0"]
-      expect_run["ip -6 -n testnetns link set eth0 mtu 1400 up"]
-      expect_run["ip -6 link set veth_abcdef12 mtu 1400 up"]
-      expect_run["ip -6 route replace fd00::2/128 via fe80::0211:22ff:fe33:4455 dev veth_abcdef12 mtu 1400"]
+      expect_run["ip", "-6", "-n", "testnetns", "addr", "replace", "fd00::2/128", "dev", "eth0"]
+      expect_run["ip", "-6", "-n", "testnetns", "link", "set", "eth0", "mtu", "1400", "up"]
+      expect_run["ip", "-6", "link", "set", "veth_abcdef12", "mtu", "1400", "up"]
+      expect_run["ip", "-6", "route", "replace", "fd00::2/128", "via", "fe80::0211:22ff:fe33:4455", "dev", "veth_abcdef12", "mtu", "1400"]
 
-      expect_run["ip addr replace 192.168.1.1/24 dev veth_abcdef12"]
-      expect_run["ip link set veth_abcdef12 mtu 1400 up"]
-      expect_run["ip -n testnetns addr replace 192.168.1.100/24 dev eth0"]
-      expect_run["ip -n testnetns link set eth0 mtu 1400 up"]
-      expect_run["ip -n testnetns route replace default via 192.168.1.1"]
-      expect_run["ip route replace 192.168.1.100/32 via 192.168.1.1 dev veth_abcdef12"]
+      expect_run["ip", "addr", "replace", "192.168.1.1/24", "dev", "veth_abcdef12"]
+      expect_run["ip", "link", "set", "veth_abcdef12", "mtu", "1400", "up"]
+      expect_run["ip", "-n", "testnetns", "addr", "replace", "192.168.1.100/24", "dev", "eth0"]
+      expect_run["ip", "-n", "testnetns", "link", "set", "eth0", "mtu", "1400", "up"]
+      expect_run["ip", "-n", "testnetns", "route", "replace", "default", "via", "192.168.1.1"]
+      expect_run["ip", "route", "replace", "192.168.1.100/32", "via", "192.168.1.1", "dev", "veth_abcdef12"]
       expect_run["echo 1 > /proc/sys/net/ipv4/conf/veth_abcdef12/proxy_arp"]
 
       output = ubicni.handle_add
@@ -152,25 +152,25 @@ RSpec.describe UbiCNI do
         expect(ubicni).to receive(:check_required_env_vars).with(["CNI_CONTAINERID", "CNI_NETNS", "CNI_IFNAME"])
         expect(ubicni).to receive(:validate_input_ranges)
 
-        expect_run = ->(cmd) { expect(ubicni).to receive(:_run_command).with(cmd) }
-        expect_run["ip link add veth_abcdef12 addr 00:aa:bb:cc:dd:ee type veth peer name eth0 addr 00:11:22:33:44:55 netns testnetns"]
+        expect_run = ->(*cmd) { expect(ubicni).to receive(:_run_command).with(*cmd) }
+        expect_run["ip", "link", "add", "veth_abcdef12", "addr", "00:aa:bb:cc:dd:ee", "type", "veth", "peer", "name", "eth0", "addr", "00:11:22:33:44:55", "netns", "testnetns"]
 
-        expect_run["ip -6 -n testnetns addr replace 2001:db8::2/128 dev eth0"]
-        expect_run["ip -6 -n testnetns link set eth0 mtu 1400 up"]
-        expect_run["ip -6 -n testnetns route replace default via fe80::02aa:bbff:fecc:ddee dev eth0"]
-        expect_run["ip -6 link set veth_abcdef12 mtu 1400 up"]
-        expect_run["ip -6 route replace 2001:db8::2/128 via fe80::0211:22ff:fe33:4455 dev veth_abcdef12 mtu 1400"]
-        expect_run["ip -6 -n testnetns addr replace fd00::2/128 dev eth0"]
-        expect_run["ip -6 -n testnetns link set eth0 mtu 1400 up"]
-        expect_run["ip -6 link set veth_abcdef12 mtu 1400 up"]
-        expect_run["ip -6 route replace fd00::2/128 via fe80::0211:22ff:fe33:4455 dev veth_abcdef12 mtu 1400"]
+        expect_run["ip", "-6", "-n", "testnetns", "addr", "replace", "2001:db8::2/128", "dev", "eth0"]
+        expect_run["ip", "-6", "-n", "testnetns", "link", "set", "eth0", "mtu", "1400", "up"]
+        expect_run["ip", "-6", "-n", "testnetns", "route", "replace", "default", "via", "fe80::02aa:bbff:fecc:ddee", "dev", "eth0"]
+        expect_run["ip", "-6", "link", "set", "veth_abcdef12", "mtu", "1400", "up"]
+        expect_run["ip", "-6", "route", "replace", "2001:db8::2/128", "via", "fe80::0211:22ff:fe33:4455", "dev", "veth_abcdef12", "mtu", "1400"]
+        expect_run["ip", "-6", "-n", "testnetns", "addr", "replace", "fd00::2/128", "dev", "eth0"]
+        expect_run["ip", "-6", "-n", "testnetns", "link", "set", "eth0", "mtu", "1400", "up"]
+        expect_run["ip", "-6", "link", "set", "veth_abcdef12", "mtu", "1400", "up"]
+        expect_run["ip", "-6", "route", "replace", "fd00::2/128", "via", "fe80::0211:22ff:fe33:4455", "dev", "veth_abcdef12", "mtu", "1400"]
 
-        expect_run["ip addr replace 192.168.1.2/26 dev veth_abcdef12"]
-        expect_run["ip link set veth_abcdef12 mtu 1400 up"]
-        expect_run["ip -n testnetns addr replace 192.168.1.10/26 dev eth0"]
-        expect_run["ip -n testnetns link set eth0 mtu 1400 up"]
-        expect_run["ip -n testnetns route replace default via 192.168.1.2"]
-        expect_run["ip route replace 192.168.1.10/32 via 192.168.1.2 dev veth_abcdef12"]
+        expect_run["ip", "addr", "replace", "192.168.1.2/26", "dev", "veth_abcdef12"]
+        expect_run["ip", "link", "set", "veth_abcdef12", "mtu", "1400", "up"]
+        expect_run["ip", "-n", "testnetns", "addr", "replace", "192.168.1.10/26", "dev", "eth0"]
+        expect_run["ip", "-n", "testnetns", "link", "set", "eth0", "mtu", "1400", "up"]
+        expect_run["ip", "-n", "testnetns", "route", "replace", "default", "via", "192.168.1.2"]
+        expect_run["ip", "route", "replace", "192.168.1.10/32", "via", "192.168.1.2", "dev", "veth_abcdef12"]
         expect_run["echo 1 > /proc/sys/net/ipv4/conf/veth_abcdef12/proxy_arp"]
 
         ubicni.handle_add

--- a/rhizome/kubernetes/spec/ubi_cni_spec.rb
+++ b/rhizome/kubernetes/spec/ubi_cni_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe UbiCNI do
       expect(ubicni).to receive(:check_required_env_vars).with(["CNI_CONTAINERID", "CNI_NETNS", "CNI_IFNAME"])
       expect(ubicni).to receive(:validate_input_ranges)
 
-      expect_run = ->(cmd) { expect(ubicni).to receive(:r).with(cmd) }
+      expect_run = ->(cmd) { expect(ubicni).to receive(:_run_command).with(cmd) }
       expect_run["ip link add veth_abcdef12 addr 00:aa:bb:cc:dd:ee type veth peer name eth0 addr 00:11:22:33:44:55 netns testnetns"]
       expect_run["ip -6 -n testnetns addr replace 2001:db8::2/128 dev eth0"]
       expect_run["ip -6 -n testnetns link set eth0 mtu 1400 up"]
@@ -152,7 +152,7 @@ RSpec.describe UbiCNI do
         expect(ubicni).to receive(:check_required_env_vars).with(["CNI_CONTAINERID", "CNI_NETNS", "CNI_IFNAME"])
         expect(ubicni).to receive(:validate_input_ranges)
 
-        expect_run = ->(cmd) { expect(ubicni).to receive(:r).with(cmd) }
+        expect_run = ->(cmd) { expect(ubicni).to receive(:_run_command).with(cmd) }
         expect_run["ip link add veth_abcdef12 addr 00:aa:bb:cc:dd:ee type veth peer name eth0 addr 00:11:22:33:44:55 netns testnetns"]
 
         expect_run["ip -6 -n testnetns addr replace 2001:db8::2/128 dev eth0"]

--- a/rhizome/minio/bin/install_minio
+++ b/rhizome/minio/bin/install_minio
@@ -7,6 +7,6 @@ unless (ver = ARGV.shift)
   fail "No version provided"
 end
 
-r "curl -fsSL -o minio.deb https://dl.min.io/server/minio/release/linux-amd64/archive/#{ver}.deb"
+r "curl", "-fsSL", "-o", "minio.deb", "https://dl.min.io/server/minio/release/linux-amd64/archive/#{ver}.deb"
 r "sudo dpkg -i minio.deb"
 r "systemctl enable minio.service"

--- a/rhizome/parseable/bin/install
+++ b/rhizome/parseable/bin/install
@@ -13,10 +13,10 @@ r "chmod", "+x", "/usr/local/bin/parseable"
 
 node_exporter_version = "1.9.1"
 node_exporter_dir = "node_exporter-#{node_exporter_version}.linux-#{Arch.render(x64: "amd64", arm64: "arm64")}"
-r "curl -fsSLO \"https://github.com/prometheus/node_exporter/releases/download/v#{node_exporter_version}/#{node_exporter_dir}.tar.gz\""
-r "tar xvfz #{node_exporter_dir}.tar.gz"
-r "sudo mv #{node_exporter_dir}/node_exporter /usr/local/bin/"
-r "sudo rm -rf #{node_exporter_dir}*"
+r "curl", "-fsSLO", "https://github.com/prometheus/node_exporter/releases/download/v#{node_exporter_version}/#{node_exporter_dir}.tar.gz"
+r "tar", "xvfz", "#{node_exporter_dir}.tar.gz"
+r "sudo", "mv", "#{node_exporter_dir}/node_exporter", "/usr/local/bin/"
+r "sudo rm -rf :prefix*", prefix: node_exporter_dir
 
 safe_write_to_file("/etc/systemd/system/node_exporter.service", <<NODEEXPORTERCONFIG)
 [Unit]

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -51,7 +51,7 @@ base_lines = File.readlines(base_conf).reject { _1.match?(/\Ainclude_dir\s*=\s*'
 base_lines << "\n" unless base_lines.last&.end_with?("\n")
 base_lines << "include_dir = 'conf.d'\n"
 safe_write_to_file(base_conf, base_lines.join)
-r "chown postgres:postgres #{base_conf}"
+r "chown", "postgres:postgres", base_conf
 
 # Update pg_hba.conf
 private_subnets = configure_hash["private_subnets"].flat_map {
@@ -182,10 +182,10 @@ safe_write_to_file("/etc/systemd/system/io-throttle@.timer", <<~TIMER)
 TIMER
 
 r "systemctl daemon-reload"
-r "systemctl enable --now io-throttle@#{v}-main.timer"
+r "systemctl", "enable", "--now", "io-throttle@#{v}-main.timer"
 
 # Reload the postmaster to apply changes
-r "pg_ctlcluster #{v} main reload || pg_ctlcluster #{v} main restart"
+r "pg_ctlcluster :v main reload || pg_ctlcluster :v main restart", v: v
 
 if configure_hash["physical_slots"]
   if configure_hash["physical_slots"].size == 0

--- a/rhizome/postgres/bin/initialize-database-from-backup
+++ b/rhizome/postgres/bin/initialize-database-from-backup
@@ -19,22 +19,22 @@ pg_setup.configure_memory_overcommit(strict: strict_overcommit)
 pg_setup.configure_tcp_keepalive
 pg_setup.setup_data_directory
 
-r "sudo -u postgres wal-g backup-fetch /dat/#{v}/data #{backup_label} --config /etc/postgresql/wal-g.env"
+r "sudo", "-u", "postgres", "wal-g", "backup-fetch", "/dat/#{v}/data", backup_label, "--config", "/etc/postgresql/wal-g.env"
 
 # We want to use pg_createcluster, even with an existing database folder because
 # pg_createcluster does additonal things like configuring systemd. However, it
 # also expect to see .conf files in the data directory, so that it can move them
 # to /etc/postgresql/$VERSION/main. Thus we create a bunch of .conf files.
-r "sudo -u postgres touch /dat/#{v}/data/pg_ident.conf"
-r "sudo -u postgres touch /dat/#{v}/data/pg_hba.conf"
-r "sudo -u postgres touch /dat/#{v}/data/postgresql.conf"
+r "sudo", "-u", "postgres", "touch", "/dat/#{v}/data/pg_ident.conf"
+r "sudo", "-u", "postgres", "touch", "/dat/#{v}/data/pg_hba.conf"
+r "sudo", "-u", "postgres", "touch", "/dat/#{v}/data/postgresql.conf"
 
 # standby.signal: stay in recovery forever, follow streaming primary (HA replica,
 # read replica). recovery.signal: replay all available WAL, then exit recovery
 # and promote (PITR, unarchive from cold archive -- no live primary to follow).
 if recovery_mode == "standby"
-  r "sudo -u postgres touch /dat/#{v}/data/standby.signal"
+  r "sudo", "-u", "postgres", "touch", "/dat/#{v}/data/standby.signal"
 else
-  r "sudo -u postgres touch /dat/#{v}/data/recovery.signal"
+  r "sudo", "-u", "postgres", "touch", "/dat/#{v}/data/recovery.signal"
 end
-r "pg_createcluster #{v} main"
+r "pg_createcluster", v, "main"

--- a/rhizome/postgres/bin/migrate
+++ b/rhizome/postgres/bin/migrate
@@ -25,7 +25,8 @@ ordered_dbs.each do |db|
     key = "/#{db}/#{name}"
     next if applied.include?(key)
     # Apply the migration against its own database, then register it centrally in ubi_admin.
-    r "sudo -u postgres psql -d #{db} -v 'ON_ERROR_STOP=1' --single-transaction", stdin: File.read(File.join(dir, name))
-    r "sudo -u postgres psql -d ubi_admin -v 'ON_ERROR_STOP=1' -c \"INSERT INTO public.migrations (filename) VALUES ('#{key}') ON CONFLICT (filename) DO NOTHING\""
+    r "sudo", "-u", "postgres", "psql", "-d", db, "-v", "ON_ERROR_STOP=1", "--single-transaction", stdin: File.read(File.join(dir, name))
+    sql = "INSERT INTO public.migrations (filename) VALUES ('#{key}') ON CONFLICT (filename) DO NOTHING"
+    r "sudo -u postgres psql -d ubi_admin -v 'ON_ERROR_STOP=1' -c :sql", sql: sql
   end
 end

--- a/rhizome/postgres/bin/restart
+++ b/rhizome/postgres/bin/restart
@@ -12,6 +12,6 @@ v = ARGV[0]
 # We don't change the user to postgres here. Instead we run the below
 # command as root, because the cluster is running from systemd, and can
 # only be restarted as root.
-r "sudo pg_ctlcluster #{v} main restart"
+r "sudo", "pg_ctlcluster", v, "main", "restart"
 r "sudo systemctl restart pgbouncer@*.service"
 r "sudo systemctl restart postgres-metrics.timer"

--- a/rhizome/postgres/bin/setup-hugepages
+++ b/rhizome/postgres/bin/setup-hugepages
@@ -12,7 +12,7 @@ memory_total_kib = Integer(meminfo[/^MemTotal:\s*(\d+)\s*kB/, 1], 10)
 target_hugepages_size_kib = memory_total_kib / 4
 target_hugepages = target_hugepages_size_kib / hugepage_size_kib
 
-r "echo 'vm.nr_hugepages = #{target_hugepages}' | sudo tee /etc/sysctl.d/10-hugepages.conf"
+r "echo :line | sudo tee /etc/sysctl.d/10-hugepages.conf", line: "vm.nr_hugepages = #{target_hugepages}"
 
 r "sync"
 r "echo 3 | sudo tee /proc/sys/vm/drop_caches"

--- a/rhizome/postgres/bin/take-backup
+++ b/rhizome/postgres/bin/take-backup
@@ -11,10 +11,9 @@ v = ARGV[0]
 cpu_weight = ARGV[1]
 
 # start backup with cpu.weight limiting scope if the corresponding parameter passed
-cmd_args = []
+cmd_args = ["sudo", "-u", "postgres", "wal-g", "backup-push", "/dat/#{v}/data", "--config", "/etc/postgresql/wal-g.env", "--verify"]
 if cpu_weight.to_s.match?(/\A\d+\z/) && cpu_weight.to_i.positive?
-  cmd_args += ["systemd-run", "--scope", "--collect", "-p", "CPUWeight=#{cpu_weight}"]
+  cmd_args.unshift("systemd-run", "--scope", "--collect", "-p", "CPUWeight=#{cpu_weight}")
 end
-cmd_args += ["sudo", "-u", "postgres", "wal-g", "backup-push", "/dat/#{v}/data", "--config", "/etc/postgresql/wal-g.env", "--verify"]
 
 r(*cmd_args)

--- a/rhizome/postgres/bin/take-backup
+++ b/rhizome/postgres/bin/take-backup
@@ -11,6 +11,10 @@ v = ARGV[0]
 cpu_weight = ARGV[1]
 
 # start backup with cpu.weight limiting scope if the corresponding parameter passed
-scope = (cpu_weight.to_s.match?(/\A\d+\z/) && cpu_weight.to_i.positive?) ? "systemd-run --scope --collect -p CPUWeight=#{cpu_weight} " : ""
+cmd_args = []
+if cpu_weight.to_s.match?(/\A\d+\z/) && cpu_weight.to_i.positive?
+  cmd_args += ["systemd-run", "--scope", "--collect", "-p", "CPUWeight=#{cpu_weight}"]
+end
+cmd_args += ["sudo", "-u", "postgres", "wal-g", "backup-push", "/dat/#{v}/data", "--config", "/etc/postgresql/wal-g.env", "--verify"]
 
-r "#{scope}sudo -u postgres wal-g backup-push /dat/#{v}/data --config /etc/postgresql/wal-g.env --verify"
+r(*cmd_args)

--- a/rhizome/postgres/lib/hugepages_setup.rb
+++ b/rhizome/postgres/lib/hugepages_setup.rb
@@ -10,7 +10,7 @@ class HugepagesSetup
   end
 
   def get_postgres_param(param)
-    Integer(r("sudo -u postgres /usr/lib/postgresql/#{@version.shellescape}/bin/postgres -D /dat/#{@version.shellescape}/data -c config_file=/etc/postgresql/#{@version.shellescape}/#{@cluster.shellescape}/postgresql.conf -C #{param.shellescape}"), 10)
+    Integer(r("sudo", "-u", "postgres", "/usr/lib/postgresql/#{@version}/bin/postgres", "-D", "/dat/#{@version}/data", "-c", "config_file=/etc/postgresql/#{@version}/#{@cluster}/postgresql.conf", "-C", param), 10)
   end
 
   def hugepage_info
@@ -21,7 +21,7 @@ class HugepagesSetup
   end
 
   def stop_postgres_cluster
-    r "sudo pg_ctlcluster stop #{@version} #{@cluster}", expect: [0, 2] # 2 is "not running"
+    r "sudo", "pg_ctlcluster", "stop", @version, @cluster, expect: [0, 2] # 2 is "not running"
   end
 
   def setup_postgres_hugepages
@@ -58,7 +58,7 @@ CONF
   end
 
   def postgres_running?
-    r "sudo pg_ctlcluster status #{@version} #{@cluster}", expect: [3]
+    r "sudo", "pg_ctlcluster", "status", @version, @cluster, expect: [3]
     false
   rescue CommandFail
     true

--- a/rhizome/postgres/lib/io_throttle.rb
+++ b/rhizome/postgres/lib/io_throttle.rb
@@ -71,7 +71,7 @@ class IoThrottle
   end
 
   def find_postmaster_pid
-    output = r("systemctl show postgresql@#{@instance}.service --property=MainPID --value").strip
+    output = r("systemctl", "show", "postgresql@#{@instance}.service", "--property=MainPID", "--value").strip
     pid = Integer(output, 10)
     fail "postgresql@#{@instance}.service is not running" if pid == 0
     pid
@@ -130,7 +130,7 @@ class IoThrottle
   end
 
   def find_device_id(mount_path)
-    data_disk = File.realpath(r("findmnt -n -o SOURCE #{mount_path}").strip)
+    data_disk = File.realpath(r("findmnt", "-n", "-o", "SOURCE", mount_path).strip)
     dev_stat = File.stat(data_disk)
     "#{dev_stat.rdev_major}:#{dev_stat.rdev_minor}"
   end

--- a/rhizome/postgres/lib/pg_bouncer_setup.rb
+++ b/rhizome/postgres/lib/pg_bouncer_setup.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../../common/lib/util"
+
 class PgBouncerSetup
   def initialize(version, max_connections, num_instances, user_config)
     @version = version
@@ -134,7 +136,8 @@ PGBOUNCER_CONFIG
 
   def enable_and_start_service
     (1..@num_instances.to_i).each do |i|
-      r "systemctl reload #{service_template_name}#{port_num(i)} || systemctl enable --now #{service_template_name}#{port_num(i)}"
+      unit = "#{service_template_name}#{port_num(i)}"
+      r cmd("systemctl reload :unit || systemctl enable --now :unit", unit: unit)
     end
   end
 

--- a/rhizome/postgres/lib/pg_bouncer_setup.rb
+++ b/rhizome/postgres/lib/pg_bouncer_setup.rb
@@ -137,7 +137,7 @@ PGBOUNCER_CONFIG
   def enable_and_start_service
     (1..@num_instances.to_i).each do |i|
       unit = "#{service_template_name}#{port_num(i)}"
-      r cmd("systemctl reload :unit || systemctl enable --now :unit", unit: unit)
+      r "systemctl reload :unit || systemctl enable --now :unit", unit: unit
     end
   end
 

--- a/rhizome/postgres/lib/postgres_lockout.rb
+++ b/rhizome/postgres/lib/postgres_lockout.rb
@@ -38,7 +38,7 @@ hostssl postgres        ubi_replication all                     cert map=standby
   def write_lockout_pg_hba
     safe_write_to_file("/etc/postgresql/#{@version}/main/pg_hba.conf", PostgresLockout.lockout_pg_hba)
     @logger.info("Written lockout pg_hba.conf for PostgreSQL #{@version}")
-    r "sudo pg_ctlcluster #{@version} main reload"
+    r "sudo", "pg_ctlcluster", @version.to_s, "main", "reload"
     @logger.info("Reloaded PostgreSQL #{@version} configuration to apply lockout pg_hba.conf")
   end
 

--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -19,7 +19,7 @@ class PostgresSetup
   def install_packages
     # Check if the packages exist in the cache, if so, install them.
     if File.exist?("/var/cache/postgresql-packages/#{@version}")
-      r "sudo install-postgresql-packages #{@version}"
+      r "sudo", "install-postgresql-packages", @version.to_s
     end
   end
 
@@ -54,7 +54,7 @@ class PostgresSetup
       MemoryMax=2560M
     SLICE
     GO_SERVICES.each do |svc, gomemlimit|
-      r "mkdir -p /etc/systemd/system/#{svc}.service.d"
+      r "mkdir", "-p", "/etc/systemd/system/#{svc}.service.d"
       safe_write_to_file("/etc/systemd/system/#{svc}.service.d/override.conf", <<~OVERRIDE)
         [Service]
         Slice=system-go_services.slice
@@ -66,9 +66,9 @@ class PostgresSetup
     # so only restart services not yet in slice.
     r "systemctl set-property system-go_services.slice MemoryHigh=2G MemoryMax=2560M"
     GO_SERVICES.each_key do |svc|
-      current_slice = r("systemctl show #{svc}.service -p Slice --value").strip
+      current_slice = r("systemctl", "show", "#{svc}.service", "-p", "Slice", "--value").strip
       next if current_slice == "system-go_services.slice"
-      r "systemctl try-restart #{svc}.service"
+      r "systemctl", "try-restart", "#{svc}.service"
     end
   end
 
@@ -76,18 +76,18 @@ class PostgresSetup
     r "chown postgres /dat"
 
     # Below commands are required for idempotency
-    r "rm -rf /dat/#{@version}"
-    r "rm -rf /etc/postgresql/#{@version}"
+    r "rm", "-rf", "/dat/#{@version}"
+    r "rm", "-rf", "/etc/postgresql/#{@version}"
 
     r "echo \"data_directory = '/dat/#{@version}/data'\" | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf"
 
     # Install to path postgres can access
-    r "install -m 0755 #{File.expand_path("../bin/disk-full-check", __dir__).shellescape} /usr/local/sbin/disk-full-check"
+    r "install", "-m", "0755", File.expand_path("../bin/disk-full-check", __dir__), "/usr/local/sbin/disk-full-check"
 
     # Stage pg_log_throttle conf outside conf.d/ so PG does not load it
     # until disk-full-check symlinks it in at the restart threshold.
-    r "install -d -m 0755 /etc/postgresql-common/pg-logs-throttle"
-    r "install -m 0644 #{File.expand_path("../lib/pg-logs-throttle/991-pg-logs-throttle.conf", __dir__).shellescape} /etc/postgresql-common/pg-logs-throttle/991-pg-logs-throttle.conf"
+    r "install", "-d", "-m", "0755", "/etc/postgresql-common/pg-logs-throttle"
+    r "install", "-m", "0644", File.expand_path("../lib/pg-logs-throttle/991-pg-logs-throttle.conf", __dir__), "/etc/postgresql-common/pg-logs-throttle/991-pg-logs-throttle.conf"
 
     safe_write_to_file("/etc/systemd/system/disk-full-check@.service", <<~DISKFULL)
       [Unit]
@@ -118,10 +118,10 @@ class PostgresSetup
     DISKFULL
 
     r "sudo systemctl daemon-reload"
-    r "sudo systemctl enable --now disk-full-check@#{@version}.timer"
+    r "sudo", "systemctl", "enable", "--now", "disk-full-check@#{@version}.timer"
   end
 
   def create_cluster
-    r "pg_createcluster #{@version} main --port=5432 --locale=C.UTF8"
+    r "pg_createcluster", @version.to_s, "main", "--port=5432", "--locale=C.UTF8"
   end
 end

--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -79,7 +79,7 @@ class PostgresSetup
     r "rm", "-rf", "/dat/#{@version}"
     r "rm", "-rf", "/etc/postgresql/#{@version}"
 
-    r cmd("echo :line | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf", line: "data_directory = '/dat/#{@version}/data'")
+    r "echo :line | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf", line: "data_directory = '/dat/#{@version}/data'"
 
     # Install to path postgres can access
     r "install", "-m", "0755", File.expand_path("../bin/disk-full-check", __dir__), "/usr/local/sbin/disk-full-check"

--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -79,7 +79,7 @@ class PostgresSetup
     r "rm", "-rf", "/dat/#{@version}"
     r "rm", "-rf", "/etc/postgresql/#{@version}"
 
-    r "echo \"data_directory = '/dat/#{@version}/data'\" | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf"
+    r cmd("echo :line | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf", line: "data_directory = '/dat/#{@version}/data'")
 
     # Install to path postgres can access
     r "install", "-m", "0755", File.expand_path("../bin/disk-full-check", __dir__), "/usr/local/sbin/disk-full-check"

--- a/rhizome/postgres/lib/postgres_upgrade.rb
+++ b/rhizome/postgres/lib/postgres_upgrade.rb
@@ -20,7 +20,7 @@ class PostgresUpgrade
   end
 
   def disable_archiving(version, reload: false)
-    r "echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/#{version}/main/conf.d/100-upgrade.conf"
+    r cmd("echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/:version/main/conf.d/100-upgrade.conf", version: version)
     r "sudo", "pg_ctlcluster", version.to_s, "main", "reload" if reload
   end
 

--- a/rhizome/postgres/lib/postgres_upgrade.rb
+++ b/rhizome/postgres/lib/postgres_upgrade.rb
@@ -15,13 +15,13 @@ class PostgresUpgrade
   end
 
   def create_upgrade_dir
-    r "sudo mkdir -p /dat/upgrade/#{@version}"
-    r "sudo chown postgres:postgres /dat/upgrade/#{@version}"
+    r "sudo", "mkdir", "-p", "/dat/upgrade/#{@version}"
+    r "sudo", "chown", "postgres:postgres", "/dat/upgrade/#{@version}"
   end
 
   def disable_archiving(version, reload: false)
     r "echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/#{version}/main/conf.d/100-upgrade.conf"
-    r "sudo pg_ctlcluster #{version} main reload" if reload
+    r "sudo", "pg_ctlcluster", version.to_s, "main", "reload" if reload
   end
 
   def remove_walg_credentials
@@ -40,8 +40,8 @@ class PostgresUpgrade
   end
 
   def disable_previous_version
-    r "sudo systemctl disable --now disk-full-check@#{@version}.timer"
-    r "sudo systemctl disable --now postgresql@#{@prev_version}-main"
+    r "sudo", "systemctl", "disable", "--now", "disk-full-check@#{@version}.timer"
+    r "sudo", "systemctl", "disable", "--now", "postgresql@#{@prev_version}-main"
   end
 
   def initialize_new_version
@@ -67,8 +67,8 @@ class PostgresUpgrade
   end
 
   def enable_new_version
-    r "sudo systemctl enable --now postgresql@#{@version}-main"
-    r "sudo systemctl enable --now disk-full-check@#{@version}.timer"
+    r "sudo", "systemctl", "enable", "--now", "postgresql@#{@version}-main"
+    r "sudo", "systemctl", "enable", "--now", "disk-full-check@#{@version}.timer"
   end
 
   def wait_for_postgres_to_start
@@ -85,7 +85,7 @@ class PostgresUpgrade
 
   def run_post_upgrade_scripts
     Dir.glob("/dat/upgrade/#{@version}/*.sql") do |script|
-      r "sudo -u postgres psql -v 'ON_ERROR_STOP=1' -f #{script.shellescape}"
+      r "sudo", "-u", "postgres", "psql", "-v", "ON_ERROR_STOP=1", "-f", script
     end
   end
 
@@ -96,10 +96,10 @@ class PostgresUpgrade
     scripts.each do |extension, script|
       @logger.info("Running post upgrade extension update for #{extension}")
       databases.each do |database|
-        installed = r("sudo -u postgres psql -d #{database.shellescape} -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = '#{extension.gsub("'", "''")}'").strip
+        installed = r("sudo", "-u", "postgres", "psql", "-d", database, "-v", "ON_ERROR_STOP=1", "-t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = '#{extension.gsub("'", "''")}'").strip
         if installed == "1"
           @logger.info("Running post upgrade extension update for #{extension} on database #{database}")
-          r("sudo -u postgres psql -d #{database.shellescape} -v 'ON_ERROR_STOP=1'", stdin: script)
+          r("sudo", "-u", "postgres", "psql", "-d", database, "-v", "ON_ERROR_STOP=1", stdin: script)
         end
       end
     end
@@ -138,11 +138,16 @@ class PostgresUpgrade
 
   def run_pg_upgrade_cmd(arg)
     Dir.chdir("/dat/upgrade/#{@version}") do
-      r pg_upgrade_cmdline(arg)
+      r(*pg_upgrade_cmdline(arg))
     end
   end
 
   def pg_upgrade_cmdline(arg)
-    "sudo -u postgres /usr/lib/postgresql/#{@version}/bin/pg_upgrade --old-bindir /usr/lib/postgresql/#{@prev_version}/bin --old-datadir /etc/postgresql/#{@prev_version}/main/ --new-bindir /usr/lib/postgresql/#{@version}/bin --new-datadir /etc/postgresql/#{@version}/main/ #{arg}"
+    ["sudo", "-u", "postgres", "/usr/lib/postgresql/#{@version}/bin/pg_upgrade",
+      "--old-bindir", "/usr/lib/postgresql/#{@prev_version}/bin",
+      "--old-datadir", "/etc/postgresql/#{@prev_version}/main/",
+      "--new-bindir", "/usr/lib/postgresql/#{@version}/bin",
+      "--new-datadir", "/etc/postgresql/#{@version}/main/",
+      arg]
   end
 end

--- a/rhizome/postgres/lib/postgres_upgrade.rb
+++ b/rhizome/postgres/lib/postgres_upgrade.rb
@@ -20,7 +20,7 @@ class PostgresUpgrade
   end
 
   def disable_archiving(version, reload: false)
-    r cmd("echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/:version/main/conf.d/100-upgrade.conf", version: version)
+    r "echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/:version/main/conf.d/100-upgrade.conf", version: version
     r "sudo", "pg_ctlcluster", version.to_s, "main", "reload" if reload
   end
 

--- a/rhizome/postgres/spec/hugepages_setup_spec.rb
+++ b/rhizome/postgres/spec/hugepages_setup_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe HugepagesSetup do
   describe "#get_postgres_param" do
     it "returns the integer value of a postgres parameter" do
       expect(hugepages_setup).to receive(:_run_command).with(
-        "sudo -u postgres /usr/lib/postgresql/17/bin/postgres -D /dat/17/data -c config_file=/etc/postgresql/17/main/postgresql.conf -C shared_buffers",
+        "sudo", "-u", "postgres", "/usr/lib/postgresql/17/bin/postgres", "-D", "/dat/17/data", "-c", "config_file=/etc/postgresql/17/main/postgresql.conf", "-C", "shared_buffers",
       ).and_return("131072\n")
       expect(hugepages_setup.get_postgres_param("shared_buffers")).to eq(131072)
     end
@@ -66,7 +66,7 @@ RSpec.describe HugepagesSetup do
 
   describe "#stop_postgres_cluster" do
     it "stops the postgres cluster (exit 0 or 2)" do
-      expect(hugepages_setup).to receive(:_run_command).with("sudo pg_ctlcluster stop 17 main", expect: [0, 2])
+      expect(hugepages_setup).to receive(:_run_command).with("sudo", "pg_ctlcluster", "stop", "17", "main", expect: [0, 2])
       hugepages_setup.stop_postgres_cluster
     end
   end
@@ -83,12 +83,12 @@ RSpec.describe HugepagesSetup do
 
   describe "#postgres_running?" do
     it "returns false when postgres is not running (exit 3)" do
-      expect(hugepages_setup).to receive(:_run_command).with("sudo pg_ctlcluster status 17 main", expect: [3]).and_return("")
+      expect(hugepages_setup).to receive(:_run_command).with("sudo", "pg_ctlcluster", "status", "17", "main", expect: [3]).and_return("")
       expect(hugepages_setup.postgres_running?).to be false
     end
 
     it "returns true when postgres is running (r raises CommandFail)" do
-      expect(hugepages_setup).to receive(:_run_command).with("sudo pg_ctlcluster status 17 main", expect: [3]).and_raise(CommandFail.new("error", "", ""))
+      expect(hugepages_setup).to receive(:_run_command).with("sudo", "pg_ctlcluster", "status", "17", "main", expect: [3]).and_raise(CommandFail.new("error", "", ""))
       expect(hugepages_setup.postgres_running?).to be true
     end
   end

--- a/rhizome/postgres/spec/hugepages_setup_spec.rb
+++ b/rhizome/postgres/spec/hugepages_setup_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe HugepagesSetup do
 
   describe "#get_postgres_param" do
     it "returns the integer value of a postgres parameter" do
-      expect(hugepages_setup).to receive(:r).with(
+      expect(hugepages_setup).to receive(:_run_command).with(
         "sudo -u postgres /usr/lib/postgresql/17/bin/postgres -D /dat/17/data -c config_file=/etc/postgresql/17/main/postgresql.conf -C shared_buffers",
       ).and_return("131072\n")
       expect(hugepages_setup.get_postgres_param("shared_buffers")).to eq(131072)
@@ -66,7 +66,7 @@ RSpec.describe HugepagesSetup do
 
   describe "#stop_postgres_cluster" do
     it "stops the postgres cluster (exit 0 or 2)" do
-      expect(hugepages_setup).to receive(:r).with("sudo pg_ctlcluster stop 17 main", expect: [0, 2])
+      expect(hugepages_setup).to receive(:_run_command).with("sudo pg_ctlcluster stop 17 main", expect: [0, 2])
       hugepages_setup.stop_postgres_cluster
     end
   end
@@ -83,12 +83,12 @@ RSpec.describe HugepagesSetup do
 
   describe "#postgres_running?" do
     it "returns false when postgres is not running (exit 3)" do
-      expect(hugepages_setup).to receive(:r).with("sudo pg_ctlcluster status 17 main", expect: [3]).and_return("")
+      expect(hugepages_setup).to receive(:_run_command).with("sudo pg_ctlcluster status 17 main", expect: [3]).and_return("")
       expect(hugepages_setup.postgres_running?).to be false
     end
 
     it "returns true when postgres is running (r raises CommandFail)" do
-      expect(hugepages_setup).to receive(:r).with("sudo pg_ctlcluster status 17 main", expect: [3]).and_raise(CommandFail.new("error", "", ""))
+      expect(hugepages_setup).to receive(:_run_command).with("sudo pg_ctlcluster status 17 main", expect: [3]).and_raise(CommandFail.new("error", "", ""))
       expect(hugepages_setup.postgres_running?).to be true
     end
   end

--- a/rhizome/postgres/spec/io_throttle_spec.rb
+++ b/rhizome/postgres/spec/io_throttle_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe IoThrottle do
 
   describe "#find_postmaster_pid" do
     it "reads PID from systemctl" do
-      expect(throttle).to receive(:_run_command).with("systemctl show postgresql@17-main.service --property=MainPID --value").and_return("5913\n")
+      expect(throttle).to receive(:_run_command).with("systemctl", "show", "postgresql@17-main.service", "--property=MainPID", "--value").and_return("5913\n")
       expect(throttle.find_postmaster_pid).to eq(5913)
     end
 
     it "fails if service is not running" do
-      expect(throttle).to receive(:_run_command).with("systemctl show postgresql@17-main.service --property=MainPID --value").and_return("0\n")
+      expect(throttle).to receive(:_run_command).with("systemctl", "show", "postgresql@17-main.service", "--property=MainPID", "--value").and_return("0\n")
       expect { throttle.find_postmaster_pid }.to raise_error(/is not running/)
     end
   end
@@ -231,7 +231,7 @@ RSpec.describe IoThrottle do
 
   describe "#find_device_id" do
     it "finds the device major:minor from mount path" do
-      expect(throttle).to receive(:_run_command).with("findmnt -n -o SOURCE /dat").and_return("/dev/sda\n")
+      expect(throttle).to receive(:_run_command).with("findmnt", "-n", "-o", "SOURCE", "/dat").and_return("/dev/sda\n")
       expect(File).to receive(:realpath).with("/dev/sda").and_return("/dev/sda")
       stat = instance_double(File::Stat, rdev_major: 8, rdev_minor: 0)
       expect(File).to receive(:stat).with("/dev/sda").and_return(stat)

--- a/rhizome/postgres/spec/io_throttle_spec.rb
+++ b/rhizome/postgres/spec/io_throttle_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe IoThrottle do
 
   describe "#find_postmaster_pid" do
     it "reads PID from systemctl" do
-      expect(throttle).to receive(:r).with("systemctl show postgresql@17-main.service --property=MainPID --value").and_return("5913\n")
+      expect(throttle).to receive(:_run_command).with("systemctl show postgresql@17-main.service --property=MainPID --value").and_return("5913\n")
       expect(throttle.find_postmaster_pid).to eq(5913)
     end
 
     it "fails if service is not running" do
-      expect(throttle).to receive(:r).with("systemctl show postgresql@17-main.service --property=MainPID --value").and_return("0\n")
+      expect(throttle).to receive(:_run_command).with("systemctl show postgresql@17-main.service --property=MainPID --value").and_return("0\n")
       expect { throttle.find_postmaster_pid }.to raise_error(/is not running/)
     end
   end
@@ -144,44 +144,44 @@ RSpec.describe IoThrottle do
     end
 
     it "returns nil when disk usage is below 91%" do
-      expect(throttle).to receive(:r).with("df --output=pcent /dat | tail -n 1").and_return("  90%\n")
+      expect(throttle).to receive(:_run_command).with("df --output=pcent /dat | tail -n 1").and_return("  90%\n")
       expect(throttle.send(:calculate_disk_usage_throttle)).to be_nil
     end
 
     it "returns baseline at 91% disk" do
-      expect(throttle).to receive(:r).with("df --output=pcent /dat | tail -n 1").and_return("  91%\n")
+      expect(throttle).to receive(:_run_command).with("df --output=pcent /dat | tail -n 1").and_return("  91%\n")
       # ratio = 1.0 - 0.11 * 0 = 1.0 -> 100
       expect(throttle.send(:calculate_disk_usage_throttle)).to eq(100)
     end
 
     it "returns 34 MB/s at 97% disk" do
-      expect(throttle).to receive(:r).with("df --output=pcent /dat | tail -n 1").and_return("  97%\n")
+      expect(throttle).to receive(:_run_command).with("df --output=pcent /dat | tail -n 1").and_return("  97%\n")
       # ratio = 1.0 - 0.11 * 6 = 0.34 -> 34
       expect(throttle.send(:calculate_disk_usage_throttle)).to eq(34)
     end
 
     it "descends to 1% of baseline at 100% disk" do
-      expect(throttle).to receive(:r).with("df --output=pcent /dat | tail -n 1").and_return(" 100%\n")
+      expect(throttle).to receive(:_run_command).with("df --output=pcent /dat | tail -n 1").and_return(" 100%\n")
       # ratio = 1.0 - 0.11 * 9 = 0.01 -> 1
       expect(throttle.send(:calculate_disk_usage_throttle)).to eq(1)
     end
 
     it "scales with disk throughput baseline" do
       throttle_aws = described_class.new("17-main", logger, 448)
-      expect(throttle_aws).to receive(:r).with("df --output=pcent /dat | tail -n 1").and_return("  97%\n")
+      expect(throttle_aws).to receive(:_run_command).with("df --output=pcent /dat | tail -n 1").and_return("  97%\n")
       # ratio = 0.34 -> 448 * 0.34 = 152.32 -> 152
       expect(throttle_aws.send(:calculate_disk_usage_throttle)).to eq(152)
     end
 
     it "returns nil when standby.signal exists" do
       allow(File).to receive(:exist?).with("/dat/17/data/standby.signal").and_return(true)
-      expect(throttle).not_to receive(:r)
+      expect(throttle).not_to receive(:_run_command)
       expect(throttle.send(:calculate_disk_usage_throttle)).to be_nil
     end
 
     it "returns nil when recovery.signal exists" do
       allow(File).to receive(:exist?).with("/dat/17/data/recovery.signal").and_return(true)
-      expect(throttle).not_to receive(:r)
+      expect(throttle).not_to receive(:_run_command)
       expect(throttle.send(:calculate_disk_usage_throttle)).to be_nil
     end
   end
@@ -231,7 +231,7 @@ RSpec.describe IoThrottle do
 
   describe "#find_device_id" do
     it "finds the device major:minor from mount path" do
-      expect(throttle).to receive(:r).with("findmnt -n -o SOURCE /dat").and_return("/dev/sda\n")
+      expect(throttle).to receive(:_run_command).with("findmnt -n -o SOURCE /dat").and_return("/dev/sda\n")
       expect(File).to receive(:realpath).with("/dev/sda").and_return("/dev/sda")
       stat = instance_double(File::Stat, rdev_major: 8, rdev_minor: 0)
       expect(File).to receive(:stat).with("/dev/sda").and_return(stat)

--- a/rhizome/postgres/spec/pg_bouncer_setup_spec.rb
+++ b/rhizome/postgres/spec/pg_bouncer_setup_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe PgBouncerSetup do
     it "writes service and socket templates and reloads systemd" do
       expect(File).to receive(:write).with("/etc/systemd/system/pgbouncer@.service", pgbouncer_setup.service_template_content)
       expect(File).to receive(:write).with("/etc/systemd/system/pgbouncer@.socket", pgbouncer_setup.socket_template_content)
-      expect(pgbouncer_setup).to receive(:r).with("systemctl daemon-reload")
+      expect(pgbouncer_setup).to receive(:_run_command).with("systemctl daemon-reload")
       pgbouncer_setup.create_service_templates
     end
   end
@@ -138,15 +138,15 @@ RSpec.describe PgBouncerSetup do
 
   describe "#disable_default_pgbouncer" do
     it "disables and stops the default pgbouncer service" do
-      expect(pgbouncer_setup).to receive(:r).with("systemctl disable --now pgbouncer")
+      expect(pgbouncer_setup).to receive(:_run_command).with("systemctl disable --now pgbouncer")
       pgbouncer_setup.disable_default_pgbouncer
     end
   end
 
   describe "#enable_and_start_service" do
     it "reloads or enables and starts each pgbouncer instance" do
-      expect(pgbouncer_setup).to receive(:r).with("systemctl reload pgbouncer@50001 || systemctl enable --now pgbouncer@50001")
-      expect(pgbouncer_setup).to receive(:r).with("systemctl reload pgbouncer@50002 || systemctl enable --now pgbouncer@50002")
+      expect(pgbouncer_setup).to receive(:_run_command).with("systemctl reload pgbouncer@50001 || systemctl enable --now pgbouncer@50001")
+      expect(pgbouncer_setup).to receive(:_run_command).with("systemctl reload pgbouncer@50002 || systemctl enable --now pgbouncer@50002")
       pgbouncer_setup.enable_and_start_service
     end
   end

--- a/rhizome/postgres/spec/postgres_lockout_spec.rb
+++ b/rhizome/postgres/spec/postgres_lockout_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe PostgresLockout do
         described_class.lockout_pg_hba,
       )
       expect(logger).to receive(:info).with("Written lockout pg_hba.conf for PostgreSQL 17")
-      expect(lockout).to receive(:_run_command).with("sudo pg_ctlcluster 17 main reload")
+      expect(lockout).to receive(:_run_command).with("sudo", "pg_ctlcluster", "17", "main", "reload")
       expect(logger).to receive(:info).with("Reloaded PostgreSQL 17 configuration to apply lockout pg_hba.conf")
       lockout.write_lockout_pg_hba
     end

--- a/rhizome/postgres/spec/postgres_lockout_spec.rb
+++ b/rhizome/postgres/spec/postgres_lockout_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PostgresLockout do
     it "terminates connections except ubi_replication and current session" do
       expect(logger).to receive(:info)
         .with("Terminating all existing connections except for the current session and ubi_replication user...")
-      expect(lockout).to receive(:r)
+      expect(lockout).to receive(:_run_command)
         .with('sudo -u postgres psql -c "SELECT pg_catalog.pg_terminate_backend(pid) FROM pg_catalog.pg_stat_activity WHERE usename != \'ubi_replication\' AND pid <> pg_catalog.pg_backend_pid();"')
 
       lockout.terminate_external_connections
@@ -38,7 +38,7 @@ RSpec.describe PostgresLockout do
         described_class.lockout_pg_hba,
       )
       expect(logger).to receive(:info).with("Written lockout pg_hba.conf for PostgreSQL 17")
-      expect(lockout).to receive(:r).with("sudo pg_ctlcluster 17 main reload")
+      expect(lockout).to receive(:_run_command).with("sudo pg_ctlcluster 17 main reload")
       expect(logger).to receive(:info).with("Reloaded PostgreSQL 17 configuration to apply lockout pg_hba.conf")
       lockout.write_lockout_pg_hba
     end

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe PostgresSetup do
       expect(pg_setup).to receive(:_run_command).with("chown postgres /dat")
       expect(pg_setup).to receive(:_run_command).with("rm", "-rf", "/dat/17")
       expect(pg_setup).to receive(:_run_command).with("rm", "-rf", "/etc/postgresql/17")
-      expect(pg_setup).to receive(:_run_command).with("echo \"data_directory = '/dat/17/data'\" | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf")
+      expect(pg_setup).to receive(:_run_command).with("echo data_directory\\ \\=\\ \\'/dat/17/data\\' | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf")
       expect(pg_setup).to receive(:_run_command).with("install", "-m", "0755", File.expand_path("../bin/disk-full-check", __dir__), "/usr/local/sbin/disk-full-check")
       expect(pg_setup).to receive(:_run_command).with("install", "-d", "-m", "0755", "/etc/postgresql-common/pg-logs-throttle")
       expect(pg_setup).to receive(:_run_command).with("install", "-m", "0644", File.expand_path("../lib/pg-logs-throttle/991-pg-logs-throttle.conf", __dir__), "/etc/postgresql-common/pg-logs-throttle/991-pg-logs-throttle.conf")

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -14,19 +14,19 @@ RSpec.describe PostgresSetup do
       # 8 GB = 8388608 KB -> kbytes = 8388608 * 0.75 * 0.8 + 2 * 1048576 = 7130317
       allow(File).to receive(:read).with("/proc/meminfo").and_return("MemTotal:        8388608 kB\n")
       expect(pg_setup).to receive(:safe_write_to_file).with("/etc/sysctl.d/99-overcommit.conf", "vm.overcommit_memory=2\nvm.overcommit_kbytes=7130317\n")
-      expect(pg_setup).to receive(:r).with("sudo sysctl --system")
+      expect(pg_setup).to receive(:_run_command).with("sudo sysctl --system")
       pg_setup.configure_memory_overcommit(strict: true)
     end
 
     it "removes overcommit config when strict is false" do
-      expect(pg_setup).to receive(:r).with("sudo rm -f /etc/sysctl.d/99-overcommit.conf")
-      expect(pg_setup).to receive(:r).with("sudo sysctl --system")
+      expect(pg_setup).to receive(:_run_command).with("sudo rm -f /etc/sysctl.d/99-overcommit.conf")
+      expect(pg_setup).to receive(:_run_command).with("sudo sysctl --system")
       pg_setup.configure_memory_overcommit(strict: false)
     end
 
     it "defaults to non-strict" do
-      expect(pg_setup).to receive(:r).with("sudo rm -f /etc/sysctl.d/99-overcommit.conf")
-      expect(pg_setup).to receive(:r).with("sudo sysctl --system")
+      expect(pg_setup).to receive(:_run_command).with("sudo rm -f /etc/sysctl.d/99-overcommit.conf")
+      expect(pg_setup).to receive(:_run_command).with("sudo sysctl --system")
       pg_setup.configure_memory_overcommit
     end
   end
@@ -38,7 +38,7 @@ RSpec.describe PostgresSetup do
         net.ipv4.tcp_keepalive_probes=3
         net.ipv4.tcp_keepalive_intvl=10
       SYSCTL
-      expect(pg_setup).to receive(:r).with("sudo sysctl --system")
+      expect(pg_setup).to receive(:_run_command).with("sudo sysctl --system")
       pg_setup.configure_tcp_keepalive
     end
   end
@@ -58,37 +58,37 @@ RSpec.describe PostgresSetup do
   describe "#install_packages" do
     it "installs packages when the cache directory exists" do
       expect(File).to receive(:exist?).with("/var/cache/postgresql-packages/17").and_return(true)
-      expect(pg_setup).to receive(:r).with("sudo install-postgresql-packages 17")
+      expect(pg_setup).to receive(:_run_command).with("sudo install-postgresql-packages 17")
       pg_setup.install_packages
     end
 
     it "does nothing when the cache directory does not exist" do
       expect(File).to receive(:exist?).with("/var/cache/postgresql-packages/17").and_return(false)
-      expect(pg_setup).not_to receive(:r)
+      expect(pg_setup).not_to receive(:_run_command)
       pg_setup.install_packages
     end
   end
 
   describe "#setup_data_directory" do
     it "sets up data directory with correct structure" do
-      expect(pg_setup).to receive(:r).with("chown postgres /dat")
-      expect(pg_setup).to receive(:r).with("rm -rf /dat/17")
-      expect(pg_setup).to receive(:r).with("rm -rf /etc/postgresql/17")
-      expect(pg_setup).to receive(:r).with("echo \"data_directory = '/dat/17/data'\" | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf")
-      expect(pg_setup).to receive(:r).with("install -m 0755 #{File.expand_path("../bin/disk-full-check", __dir__).shellescape} /usr/local/sbin/disk-full-check")
-      expect(pg_setup).to receive(:r).with("install -d -m 0755 /etc/postgresql-common/pg-logs-throttle")
-      expect(pg_setup).to receive(:r).with("install -m 0644 #{File.expand_path("../lib/pg-logs-throttle/991-pg-logs-throttle.conf", __dir__).shellescape} /etc/postgresql-common/pg-logs-throttle/991-pg-logs-throttle.conf")
+      expect(pg_setup).to receive(:_run_command).with("chown postgres /dat")
+      expect(pg_setup).to receive(:_run_command).with("rm -rf /dat/17")
+      expect(pg_setup).to receive(:_run_command).with("rm -rf /etc/postgresql/17")
+      expect(pg_setup).to receive(:_run_command).with("echo \"data_directory = '/dat/17/data'\" | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf")
+      expect(pg_setup).to receive(:_run_command).with("install -m 0755 #{File.expand_path("../bin/disk-full-check", __dir__).shellescape} /usr/local/sbin/disk-full-check")
+      expect(pg_setup).to receive(:_run_command).with("install -d -m 0755 /etc/postgresql-common/pg-logs-throttle")
+      expect(pg_setup).to receive(:_run_command).with("install -m 0644 #{File.expand_path("../lib/pg-logs-throttle/991-pg-logs-throttle.conf", __dir__).shellescape} /etc/postgresql-common/pg-logs-throttle/991-pg-logs-throttle.conf")
       expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/disk-full-check@.service", satisfy { |s| s.include?("disk-full-check") })
       expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/disk-full-check@.timer", satisfy { |s| s.include?("OnBootSec=30s") })
-      expect(pg_setup).to receive(:r).with("sudo systemctl daemon-reload")
-      expect(pg_setup).to receive(:r).with("sudo systemctl enable --now disk-full-check@17.timer")
+      expect(pg_setup).to receive(:_run_command).with("sudo systemctl daemon-reload")
+      expect(pg_setup).to receive(:_run_command).with("sudo systemctl enable --now disk-full-check@17.timer")
       pg_setup.setup_data_directory
     end
   end
 
   describe "#create_cluster" do
     it "creates a postgres cluster" do
-      expect(pg_setup).to receive(:r).with("pg_createcluster 17 main --port=5432 --locale=C.UTF8")
+      expect(pg_setup).to receive(:_run_command).with("pg_createcluster 17 main --port=5432 --locale=C.UTF8")
       pg_setup.create_cluster
     end
   end
@@ -101,23 +101,23 @@ RSpec.describe PostgresSetup do
         MemoryMax=2560M
       SLICE
       PostgresSetup::GO_SERVICES.each do |svc, lim|
-        expect(pg_setup).to receive(:r).with("mkdir -p /etc/systemd/system/#{svc}.service.d")
+        expect(pg_setup).to receive(:_run_command).with("mkdir -p /etc/systemd/system/#{svc}.service.d")
         expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/#{svc}.service.d/override.conf", <<~OVERRIDE)
           [Service]
           Slice=system-go_services.slice
           Environment=GOMEMLIMIT=#{lim}
         OVERRIDE
       end
-      expect(pg_setup).to receive(:r).with("systemctl daemon-reload")
-      expect(pg_setup).to receive(:r).with("systemctl set-property system-go_services.slice MemoryHigh=2G MemoryMax=2560M")
+      expect(pg_setup).to receive(:_run_command).with("systemctl daemon-reload")
+      expect(pg_setup).to receive(:_run_command).with("systemctl set-property system-go_services.slice MemoryHigh=2G MemoryMax=2560M")
 
       # First two services already in system-go_services.slice -> skip restart.
       # Last two still in system.slice / missing -> try-restart.
       slices = ["system-go_services.slice", "system-go_services.slice", "system.slice", ""]
       PostgresSetup::GO_SERVICES.each_key.with_index do |svc, i|
-        expect(pg_setup).to receive(:r).with("systemctl show #{svc}.service -p Slice --value").and_return("#{slices[i]}\n")
+        expect(pg_setup).to receive(:_run_command).with("systemctl show #{svc}.service -p Slice --value").and_return("#{slices[i]}\n")
         if slices[i] != "system-go_services.slice"
-          expect(pg_setup).to receive(:r).with("systemctl try-restart #{svc}.service")
+          expect(pg_setup).to receive(:_run_command).with("systemctl try-restart #{svc}.service")
         end
       end
 

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe PostgresSetup do
   describe "#install_packages" do
     it "installs packages when the cache directory exists" do
       expect(File).to receive(:exist?).with("/var/cache/postgresql-packages/17").and_return(true)
-      expect(pg_setup).to receive(:_run_command).with("sudo install-postgresql-packages 17")
+      expect(pg_setup).to receive(:_run_command).with("sudo", "install-postgresql-packages", "17")
       pg_setup.install_packages
     end
 
@@ -72,23 +72,23 @@ RSpec.describe PostgresSetup do
   describe "#setup_data_directory" do
     it "sets up data directory with correct structure" do
       expect(pg_setup).to receive(:_run_command).with("chown postgres /dat")
-      expect(pg_setup).to receive(:_run_command).with("rm -rf /dat/17")
-      expect(pg_setup).to receive(:_run_command).with("rm -rf /etc/postgresql/17")
+      expect(pg_setup).to receive(:_run_command).with("rm", "-rf", "/dat/17")
+      expect(pg_setup).to receive(:_run_command).with("rm", "-rf", "/etc/postgresql/17")
       expect(pg_setup).to receive(:_run_command).with("echo \"data_directory = '/dat/17/data'\" | sudo tee /etc/postgresql-common/createcluster.d/data-dir.conf")
-      expect(pg_setup).to receive(:_run_command).with("install -m 0755 #{File.expand_path("../bin/disk-full-check", __dir__).shellescape} /usr/local/sbin/disk-full-check")
-      expect(pg_setup).to receive(:_run_command).with("install -d -m 0755 /etc/postgresql-common/pg-logs-throttle")
-      expect(pg_setup).to receive(:_run_command).with("install -m 0644 #{File.expand_path("../lib/pg-logs-throttle/991-pg-logs-throttle.conf", __dir__).shellescape} /etc/postgresql-common/pg-logs-throttle/991-pg-logs-throttle.conf")
+      expect(pg_setup).to receive(:_run_command).with("install", "-m", "0755", File.expand_path("../bin/disk-full-check", __dir__), "/usr/local/sbin/disk-full-check")
+      expect(pg_setup).to receive(:_run_command).with("install", "-d", "-m", "0755", "/etc/postgresql-common/pg-logs-throttle")
+      expect(pg_setup).to receive(:_run_command).with("install", "-m", "0644", File.expand_path("../lib/pg-logs-throttle/991-pg-logs-throttle.conf", __dir__), "/etc/postgresql-common/pg-logs-throttle/991-pg-logs-throttle.conf")
       expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/disk-full-check@.service", satisfy { |s| s.include?("disk-full-check") })
       expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/disk-full-check@.timer", satisfy { |s| s.include?("OnBootSec=30s") })
       expect(pg_setup).to receive(:_run_command).with("sudo systemctl daemon-reload")
-      expect(pg_setup).to receive(:_run_command).with("sudo systemctl enable --now disk-full-check@17.timer")
+      expect(pg_setup).to receive(:_run_command).with("sudo", "systemctl", "enable", "--now", "disk-full-check@17.timer")
       pg_setup.setup_data_directory
     end
   end
 
   describe "#create_cluster" do
     it "creates a postgres cluster" do
-      expect(pg_setup).to receive(:_run_command).with("pg_createcluster 17 main --port=5432 --locale=C.UTF8")
+      expect(pg_setup).to receive(:_run_command).with("pg_createcluster", "17", "main", "--port=5432", "--locale=C.UTF8")
       pg_setup.create_cluster
     end
   end
@@ -101,7 +101,7 @@ RSpec.describe PostgresSetup do
         MemoryMax=2560M
       SLICE
       PostgresSetup::GO_SERVICES.each do |svc, lim|
-        expect(pg_setup).to receive(:_run_command).with("mkdir -p /etc/systemd/system/#{svc}.service.d")
+        expect(pg_setup).to receive(:_run_command).with("mkdir", "-p", "/etc/systemd/system/#{svc}.service.d")
         expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/#{svc}.service.d/override.conf", <<~OVERRIDE)
           [Service]
           Slice=system-go_services.slice
@@ -115,9 +115,9 @@ RSpec.describe PostgresSetup do
       # Last two still in system.slice / missing -> try-restart.
       slices = ["system-go_services.slice", "system-go_services.slice", "system.slice", ""]
       PostgresSetup::GO_SERVICES.each_key.with_index do |svc, i|
-        expect(pg_setup).to receive(:_run_command).with("systemctl show #{svc}.service -p Slice --value").and_return("#{slices[i]}\n")
+        expect(pg_setup).to receive(:_run_command).with("systemctl", "show", "#{svc}.service", "-p", "Slice", "--value").and_return("#{slices[i]}\n")
         if slices[i] != "system-go_services.slice"
-          expect(pg_setup).to receive(:_run_command).with("systemctl try-restart #{svc}.service")
+          expect(pg_setup).to receive(:_run_command).with("systemctl", "try-restart", "#{svc}.service")
         end
       end
 

--- a/rhizome/postgres/spec/postgres_upgrade_spec.rb
+++ b/rhizome/postgres/spec/postgres_upgrade_spec.rb
@@ -31,42 +31,42 @@ RSpec.describe PostgresUpgrade do
 
   describe "#create_upgrade_dir" do
     it "creates upgrade directory with correct permissions" do
-      expect(postgres_upgrade).to receive(:r).with("sudo mkdir -p /dat/upgrade/17")
-      expect(postgres_upgrade).to receive(:r).with("sudo chown postgres:postgres /dat/upgrade/17")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo mkdir -p /dat/upgrade/17")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo chown postgres:postgres /dat/upgrade/17")
       postgres_upgrade.create_upgrade_dir
     end
   end
 
   describe "#disable_archiving" do
     it "disables archiving without reload by default" do
-      expect(postgres_upgrade).to receive(:r).with("echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/17/main/conf.d/100-upgrade.conf")
-      expect(postgres_upgrade).not_to receive(:r).with("sudo pg_ctlcluster 17 main reload")
+      expect(postgres_upgrade).to receive(:_run_command).with("echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/17/main/conf.d/100-upgrade.conf")
+      expect(postgres_upgrade).not_to receive(:_run_command).with("sudo pg_ctlcluster 17 main reload")
       postgres_upgrade.disable_archiving(17)
     end
 
     it "disables archiving and reloads when reload: true" do
-      expect(postgres_upgrade).to receive(:r).with("echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/16/main/conf.d/100-upgrade.conf")
-      expect(postgres_upgrade).to receive(:r).with("sudo pg_ctlcluster 16 main reload")
+      expect(postgres_upgrade).to receive(:_run_command).with("echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/16/main/conf.d/100-upgrade.conf")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo pg_ctlcluster 16 main reload")
       postgres_upgrade.disable_archiving(16, reload: true)
     end
   end
 
   describe "#promote" do
     it "promotes server using pg_promote" do
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT pg_catalog.pg_is_in_recovery();' 2>/dev/null || echo 't'").and_return("t\n")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c \"SELECT pg_promote(true, 300)\"").and_return("t\n")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -t -c 'SELECT pg_catalog.pg_is_in_recovery();' 2>/dev/null || echo 't'").and_return("t\n")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -t -c \"SELECT pg_promote(true, 300)\"").and_return("t\n")
       postgres_upgrade.promote(16)
     end
 
     it "fails when pg_promote returns false" do
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT pg_catalog.pg_is_in_recovery();' 2>/dev/null || echo 't'").and_return("t\n")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c \"SELECT pg_promote(true, 300)\"").and_return("f\n")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -t -c 'SELECT pg_catalog.pg_is_in_recovery();' 2>/dev/null || echo 't'").and_return("t\n")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -t -c \"SELECT pg_promote(true, 300)\"").and_return("f\n")
       expect { postgres_upgrade.promote(16) }.to raise_error(RuntimeError, /pg_promote returned "f"/)
     end
 
     it "skips promotion if server is already promoted" do
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT pg_catalog.pg_is_in_recovery();' 2>/dev/null || echo 't'").and_return("f\n")
-      expect(postgres_upgrade).not_to receive(:r).with("sudo -u postgres psql -t -c \"SELECT pg_promote(true, 300)\"")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -t -c 'SELECT pg_catalog.pg_is_in_recovery();' 2>/dev/null || echo 't'").and_return("f\n")
+      expect(postgres_upgrade).not_to receive(:_run_command).with("sudo -u postgres psql -t -c \"SELECT pg_promote(true, 300)\"")
       expect(logger).to receive(:info).with("Server is already promoted (not in recovery mode)")
       postgres_upgrade.promote(16)
     end
@@ -74,16 +74,16 @@ RSpec.describe PostgresUpgrade do
 
   describe "#remove_walg_credentials" do
     it "stops wal-g daemon and removes credentials file" do
-      expect(postgres_upgrade).to receive(:r).with("sudo systemctl stop wal-g", expect: [0, 1, 4, 5])
-      expect(postgres_upgrade).to receive(:r).with("sudo rm -f /etc/postgresql/wal-g.env")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl stop wal-g", expect: [0, 1, 4, 5])
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo rm -f /etc/postgresql/wal-g.env")
       postgres_upgrade.remove_walg_credentials
     end
   end
 
   describe "#disable_previous_version" do
     it "disables and stops previous version service" do
-      expect(postgres_upgrade).to receive(:r).with("sudo systemctl disable --now postgresql@16-main")
-      expect(postgres_upgrade).to receive(:r).with("sudo systemctl disable --now disk-full-check@17.timer")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl disable --now postgresql@16-main")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl disable --now disk-full-check@17.timer")
       postgres_upgrade.disable_previous_version
     end
   end
@@ -95,8 +95,8 @@ RSpec.describe PostgresUpgrade do
       expect(pg_setup).to receive(:install_packages)
       expect(pg_setup).to receive(:setup_data_directory)
       expect(pg_setup).to receive(:create_cluster)
-      expect(postgres_upgrade).to receive(:r).with("sudo systemctl disable --now postgresql@16-main")
-      expect(postgres_upgrade).to receive(:r).with("sudo systemctl disable --now disk-full-check@17.timer")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl disable --now postgresql@16-main")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl disable --now disk-full-check@17.timer")
       postgres_upgrade.initialize_new_version
     end
   end
@@ -129,23 +129,23 @@ RSpec.describe PostgresUpgrade do
 
   describe "#enable_new_version" do
     it "enables and starts new version service" do
-      expect(postgres_upgrade).to receive(:r).with("sudo systemctl enable --now postgresql@17-main")
-      expect(postgres_upgrade).to receive(:r).with("sudo systemctl enable --now disk-full-check@17.timer")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl enable --now postgresql@17-main")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl enable --now disk-full-check@17.timer")
       postgres_upgrade.enable_new_version
     end
   end
 
   describe "#wait_for_postgres_to_start" do
     it "waits for postgres to become ready" do
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres pg_isready").and_raise(StandardError).once
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres pg_isready").and_return("")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres pg_isready").and_raise(StandardError).once
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres pg_isready").and_return("")
       expect(postgres_upgrade).to receive(:sleep).with(1)
 
       postgres_upgrade.wait_for_postgres_to_start
     end
 
     it "raises when postgres fails to start before deadline" do
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres pg_isready").and_raise(StandardError)
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres pg_isready").and_raise(StandardError)
       expect(Time).to receive(:now).and_return(Time.at(0), Time.at(61))
       expect { postgres_upgrade.wait_for_postgres_to_start }.to raise_error("Postgres failed to start")
     end
@@ -154,18 +154,18 @@ RSpec.describe PostgresUpgrade do
   describe "#run_post_upgrade_scripts" do
     it "executes all SQL scripts in upgrade directory" do
       expect(Dir).to receive(:glob).with("/dat/upgrade/17/*.sql").and_yield("/dat/upgrade/17/script1.sql").and_yield("/dat/upgrade/17/script2.sql")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -v 'ON_ERROR_STOP=1' -f /dat/upgrade/17/script1.sql")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -v 'ON_ERROR_STOP=1' -f /dat/upgrade/17/script2.sql")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -v 'ON_ERROR_STOP=1' -f /dat/upgrade/17/script1.sql")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -v 'ON_ERROR_STOP=1' -f /dat/upgrade/17/script2.sql")
       postgres_upgrade.run_post_upgrade_scripts
     end
   end
 
   describe "#run_post_upgrade_extension_update" do
     it "updates extensions on databases where they are installed" do
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").and_return("postgres\nmydb\n")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("1")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d mydb -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1'", stdin: "SELECT postgis_extensions_upgrade();")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").and_return("postgres\nmydb\n")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("1")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -d mydb -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1'", stdin: "SELECT postgis_extensions_upgrade();")
       expect(logger).to receive(:info).with("Running post upgrade extension update for postgis")
       expect(logger).to receive(:info).with("Running post upgrade extension update for postgis on database postgres")
 
@@ -173,9 +173,9 @@ RSpec.describe PostgresUpgrade do
     end
 
     it "skips databases where extension is not installed" do
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").and_return("postgres\n")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("")
-      expect(postgres_upgrade).not_to receive(:r).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1'", stdin: anything)
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").and_return("postgres\n")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("")
+      expect(postgres_upgrade).not_to receive(:_run_command).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1'", stdin: anything)
       expect(logger).to receive(:info).with("Running post upgrade extension update for postgis")
 
       postgres_upgrade.run_post_upgrade_extension_update
@@ -187,10 +187,10 @@ RSpec.describe PostgresUpgrade do
           "ext'sname" => "ALTER EXTENSION \"ext'sname\" UPDATE;",
         },
       })
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").and_return("mydb$(pwd)\n")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").and_return("mydb$(pwd)\n")
       expect(logger).to receive(:info).with("Running post upgrade extension update for ext'sname")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d mydb\\$\\(pwd\\) -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'ext''sname'").and_return("1")
-      expect(postgres_upgrade).to receive(:r).with("sudo -u postgres psql -d mydb\\$\\(pwd\\) -v 'ON_ERROR_STOP=1'", stdin: "ALTER EXTENSION \"ext'sname\" UPDATE;")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -d mydb\\$\\(pwd\\) -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'ext''sname'").and_return("1")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -d mydb\\$\\(pwd\\) -v 'ON_ERROR_STOP=1'", stdin: "ALTER EXTENSION \"ext'sname\" UPDATE;")
       expect(logger).to receive(:info).with("Running post upgrade extension update for ext'sname on database mydb$(pwd)")
 
       postgres_upgrade.run_post_upgrade_extension_update
@@ -201,7 +201,7 @@ RSpec.describe PostgresUpgrade do
     it "changes directory and runs pg_upgrade command" do
       expect(Dir).to receive(:chdir).with("/dat/upgrade/17").and_yield
       expect(postgres_upgrade).to receive(:pg_upgrade_cmdline).with("--check").and_return("pg_upgrade_command")
-      expect(postgres_upgrade).to receive(:r).with("pg_upgrade_command")
+      expect(postgres_upgrade).to receive(:_run_command).with("pg_upgrade_command")
 
       postgres_upgrade.run_pg_upgrade_cmd("--check")
     end

--- a/rhizome/postgres/spec/postgres_upgrade_spec.rb
+++ b/rhizome/postgres/spec/postgres_upgrade_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe PostgresUpgrade do
 
   describe "#create_upgrade_dir" do
     it "creates upgrade directory with correct permissions" do
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo mkdir -p /dat/upgrade/17")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo chown postgres:postgres /dat/upgrade/17")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "mkdir", "-p", "/dat/upgrade/17")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "chown", "postgres:postgres", "/dat/upgrade/17")
       postgres_upgrade.create_upgrade_dir
     end
   end
@@ -40,13 +40,13 @@ RSpec.describe PostgresUpgrade do
   describe "#disable_archiving" do
     it "disables archiving without reload by default" do
       expect(postgres_upgrade).to receive(:_run_command).with("echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/17/main/conf.d/100-upgrade.conf")
-      expect(postgres_upgrade).not_to receive(:_run_command).with("sudo pg_ctlcluster 17 main reload")
+      expect(postgres_upgrade).not_to receive(:_run_command).with("sudo", "pg_ctlcluster", "17", "main", "reload")
       postgres_upgrade.disable_archiving(17)
     end
 
     it "disables archiving and reloads when reload: true" do
       expect(postgres_upgrade).to receive(:_run_command).with("echo 'archive_mode = on\narchive_command = false' | sudo tee /etc/postgresql/16/main/conf.d/100-upgrade.conf")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo pg_ctlcluster 16 main reload")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "pg_ctlcluster", "16", "main", "reload")
       postgres_upgrade.disable_archiving(16, reload: true)
     end
   end
@@ -82,8 +82,8 @@ RSpec.describe PostgresUpgrade do
 
   describe "#disable_previous_version" do
     it "disables and stops previous version service" do
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl disable --now postgresql@16-main")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl disable --now disk-full-check@17.timer")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "systemctl", "disable", "--now", "postgresql@16-main")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "systemctl", "disable", "--now", "disk-full-check@17.timer")
       postgres_upgrade.disable_previous_version
     end
   end
@@ -95,8 +95,8 @@ RSpec.describe PostgresUpgrade do
       expect(pg_setup).to receive(:install_packages)
       expect(pg_setup).to receive(:setup_data_directory)
       expect(pg_setup).to receive(:create_cluster)
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl disable --now postgresql@16-main")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl disable --now disk-full-check@17.timer")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "systemctl", "disable", "--now", "postgresql@16-main")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "systemctl", "disable", "--now", "disk-full-check@17.timer")
       postgres_upgrade.initialize_new_version
     end
   end
@@ -129,8 +129,8 @@ RSpec.describe PostgresUpgrade do
 
   describe "#enable_new_version" do
     it "enables and starts new version service" do
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl enable --now postgresql@17-main")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo systemctl enable --now disk-full-check@17.timer")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "systemctl", "enable", "--now", "postgresql@17-main")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "systemctl", "enable", "--now", "disk-full-check@17.timer")
       postgres_upgrade.enable_new_version
     end
   end
@@ -154,8 +154,8 @@ RSpec.describe PostgresUpgrade do
   describe "#run_post_upgrade_scripts" do
     it "executes all SQL scripts in upgrade directory" do
       expect(Dir).to receive(:glob).with("/dat/upgrade/17/*.sql").and_yield("/dat/upgrade/17/script1.sql").and_yield("/dat/upgrade/17/script2.sql")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -v 'ON_ERROR_STOP=1' -f /dat/upgrade/17/script1.sql")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -v 'ON_ERROR_STOP=1' -f /dat/upgrade/17/script2.sql")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "-u", "postgres", "psql", "-v", "ON_ERROR_STOP=1", "-f", "/dat/upgrade/17/script1.sql")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "-u", "postgres", "psql", "-v", "ON_ERROR_STOP=1", "-f", "/dat/upgrade/17/script2.sql")
       postgres_upgrade.run_post_upgrade_scripts
     end
   end
@@ -163,9 +163,9 @@ RSpec.describe PostgresUpgrade do
   describe "#run_post_upgrade_extension_update" do
     it "updates extensions on databases where they are installed" do
       expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").and_return("postgres\nmydb\n")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("1")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -d mydb -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1'", stdin: "SELECT postgis_extensions_upgrade();")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "-u", "postgres", "psql", "-d", "postgres", "-v", "ON_ERROR_STOP=1", "-t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("1")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "-u", "postgres", "psql", "-d", "mydb", "-v", "ON_ERROR_STOP=1", "-t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "-u", "postgres", "psql", "-d", "postgres", "-v", "ON_ERROR_STOP=1", stdin: "SELECT postgis_extensions_upgrade();")
       expect(logger).to receive(:info).with("Running post upgrade extension update for postgis")
       expect(logger).to receive(:info).with("Running post upgrade extension update for postgis on database postgres")
 
@@ -174,8 +174,8 @@ RSpec.describe PostgresUpgrade do
 
     it "skips databases where extension is not installed" do
       expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").and_return("postgres\n")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("")
-      expect(postgres_upgrade).not_to receive(:_run_command).with("sudo -u postgres psql -d postgres -v 'ON_ERROR_STOP=1'", stdin: anything)
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "-u", "postgres", "psql", "-d", "postgres", "-v", "ON_ERROR_STOP=1", "-t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'postgis'").and_return("")
+      expect(postgres_upgrade).not_to receive(:_run_command).with("sudo", "-u", "postgres", "psql", "-d", "postgres", "-v", "ON_ERROR_STOP=1", stdin: anything)
       expect(logger).to receive(:info).with("Running post upgrade extension update for postgis")
 
       postgres_upgrade.run_post_upgrade_extension_update
@@ -189,8 +189,8 @@ RSpec.describe PostgresUpgrade do
       })
       expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -t -c 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;'").and_return("mydb$(pwd)\n")
       expect(logger).to receive(:info).with("Running post upgrade extension update for ext'sname")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -d mydb\\$\\(pwd\\) -v 'ON_ERROR_STOP=1' -t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'ext''sname'").and_return("1")
-      expect(postgres_upgrade).to receive(:_run_command).with("sudo -u postgres psql -d mydb\\$\\(pwd\\) -v 'ON_ERROR_STOP=1'", stdin: "ALTER EXTENSION \"ext'sname\" UPDATE;")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "-u", "postgres", "psql", "-d", "mydb$(pwd)", "-v", "ON_ERROR_STOP=1", "-t", stdin: "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'ext''sname'").and_return("1")
+      expect(postgres_upgrade).to receive(:_run_command).with("sudo", "-u", "postgres", "psql", "-d", "mydb$(pwd)", "-v", "ON_ERROR_STOP=1", stdin: "ALTER EXTENSION \"ext'sname\" UPDATE;")
       expect(logger).to receive(:info).with("Running post upgrade extension update for ext'sname on database mydb$(pwd)")
 
       postgres_upgrade.run_post_upgrade_extension_update
@@ -200,7 +200,7 @@ RSpec.describe PostgresUpgrade do
   describe "#run_pg_upgrade_cmd" do
     it "changes directory and runs pg_upgrade command" do
       expect(Dir).to receive(:chdir).with("/dat/upgrade/17").and_yield
-      expect(postgres_upgrade).to receive(:pg_upgrade_cmdline).with("--check").and_return("pg_upgrade_command")
+      expect(postgres_upgrade).to receive(:pg_upgrade_cmdline).with("--check").and_return(["pg_upgrade_command"])
       expect(postgres_upgrade).to receive(:_run_command).with("pg_upgrade_command")
 
       postgres_upgrade.run_pg_upgrade_cmd("--check")
@@ -209,7 +209,12 @@ RSpec.describe PostgresUpgrade do
 
   describe "#pg_upgrade_cmdline" do
     it "constructs correct pg_upgrade command" do
-      expected_cmd = "sudo -u postgres /usr/lib/postgresql/17/bin/pg_upgrade --old-bindir /usr/lib/postgresql/16/bin --old-datadir /etc/postgresql/16/main/ --new-bindir /usr/lib/postgresql/17/bin --new-datadir /etc/postgresql/17/main/ --check"
+      expected_cmd = ["sudo", "-u", "postgres", "/usr/lib/postgresql/17/bin/pg_upgrade",
+        "--old-bindir", "/usr/lib/postgresql/16/bin",
+        "--old-datadir", "/etc/postgresql/16/main/",
+        "--new-bindir", "/usr/lib/postgresql/17/bin",
+        "--new-datadir", "/etc/postgresql/17/main/",
+        "--check"]
       expect(postgres_upgrade.pg_upgrade_cmdline("--check")).to eq(expected_cmd)
     end
   end

--- a/rhizome/victoria_metrics/bin/install
+++ b/rhizome/victoria_metrics/bin/install
@@ -7,8 +7,8 @@ unless (ver = ARGV.shift)
   fail "No version provided"
 end
 
-r "curl -fsSL -o victoria-metrics.tar.gz https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/#{ver}/victoria-metrics-linux-amd64-#{ver}.tar.gz"
-r "tar xvf victoria-metrics.tar.gz -C /usr/local/bin/"
+r "curl", "-fsSL", "-o", "victoria-metrics.tar.gz", "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/#{ver}/victoria-metrics-linux-amd64-#{ver}.tar.gz"
+r "tar", "xvf", "victoria-metrics.tar.gz", "-C", "/usr/local/bin/"
 
-r "curl -fsSL -o vmutils.tar.gz https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/#{ver}/vmutils-linux-amd64-#{ver}.tar.gz"
-r "tar xvf vmutils.tar.gz -C /usr/local/bin/"
+r "curl", "-fsSL", "-o", "vmutils.tar.gz", "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/#{ver}/vmutils-linux-amd64-#{ver}.tar.gz"
+r "tar", "xvf", "vmutils.tar.gz", "-C", "/usr/local/bin/"


### PR DESCRIPTION
This uses the same approach for both, and eventually merges things
so the same method is used for both.

The changes to the rhizome bin files need careful review, as those
files do not have any tests (other than E2E tests, which I'll run).

A lot of the heavy lifting by Claude, but a number of changes by
me as separate commits.

In terms of reviews:

* Mohi: Kubernetes
* Shikhar: Postgres/Parseable/Grafana/VictoriaMetrics
* Furkan: Certs/Minio
* Ben: Inference Endpoint
* Hadi: VM/Storage (files in host except as mentioned above)
* Enes: Common