### PR TITLE
Strand wakeup nudge commitmessage comment

### DIFF
--- a/lib/sem_snap.rb
+++ b/lib/sem_snap.rb
@@ -45,7 +45,10 @@ class SemSnap
   end
 
   def incr(name)
-    if (semaphore = Semaphore.incr(@strand_id, name))
+    # Don't wake the current strand again over a semaphore increment
+    # mid-run: the prog's own nap or other flow control is
+    # authoritative.
+    if (semaphore = Semaphore.incr(@strand_id, name, wake: false))
       add_semaphore_instance_to_snapshot(Semaphore.with_pk(semaphore))
     end
   end

--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -5,7 +5,7 @@ require_relative "../model"
 class Semaphore < Sequel::Model
   plugin ResourceMethods
 
-  def self.incr(id, name)
+  def self.incr(id, name, wake: true)
     case name
     when Symbol
       name = name.to_s
@@ -15,13 +15,18 @@ class Semaphore < Sequel::Model
       raise "invalid name given to Semaphore.incr: #{name.inspect}"
     end
 
-    with(:updated_strand,
-      Strand
-        .where(id:)
-        .returning(:id)
-        .with_sql(:update_sql, schedule: Strand::SCHEDULE_NO_LATER_THAN_NOW))
-      .insert([:id, :strand_id, :name],
-        DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
+    if wake
+      with(:updated_strand,
+        Strand
+          .where(id:)
+          .returning(:id)
+          .with_sql(:update_sql, schedule: Strand::SCHEDULE_NO_LATER_THAN_NOW))
+        .insert([:id, :strand_id, :name],
+          DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
+    else
+      insert([:id, :strand_id, :name],
+        Strand.where(id:).select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
+    end
   end
 
   def self.set_at(id)

--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -15,18 +15,17 @@ class Semaphore < Sequel::Model
       raise "invalid name given to Semaphore.incr: #{name.inspect}"
     end
 
+    values_ds = Strand.where(id:)
+    insert_ds = self
     if wake
-      with(:updated_strand,
-        Strand
-          .where(id:)
+      insert_ds = with(:updated_strand,
+        values_ds
           .returning(:id)
           .with_sql(:update_sql, schedule: Strand::SCHEDULE_NO_LATER_THAN_NOW))
-        .insert([:id, :strand_id, :name],
-          DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
-    else
-      insert([:id, :strand_id, :name],
-        Strand.where(id:).select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
+      values_ds = DB[:updated_strand]
     end
+    insert_ds.insert([:id, :strand_id, :name],
+      values_ds.select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
   end
 
   def self.set_at(id)

--- a/model/semaphore.rb
+++ b/model/semaphore.rb
@@ -19,7 +19,7 @@ class Semaphore < Sequel::Model
       Strand
         .where(id:)
         .returning(:id)
-        .with_sql(:update_sql, schedule: Sequel::CURRENT_TIMESTAMP))
+        .with_sql(:update_sql, schedule: Strand::SCHEDULE_NO_LATER_THAN_NOW))
       .insert([:id, :strand_id, :name],
         DB[:updated_strand].select(Sequel[:gen_timestamp_ubid_uuid].function(820), :id, name))
   end

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -94,6 +94,19 @@ class Strand < Sequel::Model
     Sequel.function(:least, Sequel[2]**Sequel.function(:least, :try, 20), 600) * Sequel.function(:random)
   end
 
+  # schedule also is an optimistic concurrency control key for the nap
+  # handler's compare-and-set in #unsynchronized_run, which detects a
+  # mid-run wake-up only by the stored value having changed.
+  #
+  # Subtracting a microsecond makes every wake write strictly smaller
+  # than the value it read, so the comparison always fails after a
+  # wake, at a microsecond's cost to dispatch order.
+  #
+  # Finally, the LEAST expression prevents starvation: overwriting an
+  # old schedule with now() would demote an overdue strand in dispatch
+  # priority, e.g. when strand handling is running behind.
+  SCHEDULE_NO_LATER_THAN_NOW = Sequel.function(:least, Sequel[:schedule], Sequel::CURRENT_TIMESTAMP) - Sequel.cast("1 microsecond", :interval)
+
   TAKE_LEASE_PS = DB[:strand]
     .returning
     .where(
@@ -159,8 +172,7 @@ SQL
             Strand
               .where(id: parent_id)
               .exclude(unfinished_siblings_ds.exists)
-              .where(Sequel[:schedule] > Sequel::CURRENT_TIMESTAMP)
-              .update(schedule: Sequel::CURRENT_TIMESTAMP)
+              .update(schedule: SCHEDULE_NO_LATER_THAN_NOW)
           end
         end
       end
@@ -248,6 +260,11 @@ SQL
         e = prog_action
         save_changes
 
+        # Compare-and-set with schedule as the optimistic concurrency
+        # control key: apply the nap only if schedule still holds the
+        # lease-time value. A concurrent wake wrote through
+        # SCHEDULE_NO_LATER_THAN_NOW, guaranteed to differ from it, so
+        # the wake-up schedule survives the nap.
         scheduled = DB[<<SQL, schedule, e.seconds, id].get
 UPDATE strand
 SET try = 0,

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -106,6 +106,11 @@ class Prog::Test < Prog::Base
     nap(123)
   end
 
+  label def snap_signal_napper
+    incr_test_semaphore
+    nap(123)
+  end
+
   label def popper
     pop({msg: "popped"})
   end

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -101,6 +101,11 @@ class Prog::Test < Prog::Base
     nap(123)
   end
 
+  label def late_signal_napper
+    Semaphore.incr(strand.id, "late_signal")
+    nap(123)
+  end
+
   label def popper
     pop({msg: "popped"})
   end

--- a/spec/model/semaphore_spec.rb
+++ b/spec/model/semaphore_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe Semaphore do
     expect { described_class.incr(st.id, nil) }.to raise_error(RuntimeError)
   end
 
+  it ".incr wakes the strand without demoting an overdue schedule" do
+    st.update(schedule: overdue = Time.now - 100)
+    described_class.incr(st.id, "foo")
+    expect(st.reload.schedule).to be_within(1).of(overdue)
+  end
+
+  it ".incr pulls a future schedule to now" do
+    st.update(schedule: Time.now + 1000)
+    described_class.incr(st.id, "foo")
+    expect(st.reload.schedule).to be_within(2).of(Time.now)
+  end
+
   it ".set_at returns the Time the given semaphore id was set at" do
     time = described_class.set_at(described_class.generate_uuid)
     expect(time).to be_within(1).of(Time.now)

--- a/spec/model/semaphore_spec.rb
+++ b/spec/model/semaphore_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe Semaphore do
     expect(st.reload.schedule).to be_within(1).of(overdue)
   end
 
+  it ".incr with wake: false does not change the schedule" do
+    st.update(schedule: future = Time.now + 1000)
+    expect(described_class.incr(st.id, "foo", wake: false)).not_to be_nil
+    expect(st.reload.schedule).to be_within(1).of(future)
+  end
+
   it ".incr pulls a future schedule to now" do
     st.update(schedule: Time.now + 1000)
     described_class.incr(st.id, "foo")

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -111,6 +111,16 @@ RSpec.describe Strand do
     end
   end
 
+  it "keeps the nap when the prog increments its own semaphore through the snap" do
+    st.update(label: "snap_signal_napper", schedule: Time.now - 100)
+
+    ret = st.unsynchronized_run
+    expect(ret).to be_a(Prog::Base::Nap)
+
+    expect(st.reload.schedule).to be > Time.now + 100
+    expect(Semaphore.where(strand_id: st.id, name: "test_semaphore")).not_to be_empty
+  end
+
   it "stays runnable when a semaphore arrives mid-run on an overdue strand" do
     st.update(label: "late_signal_napper", schedule: Time.now - 100)
 

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -98,7 +98,8 @@ RSpec.describe Strand do
 
     st.take_lease_and_reload do
       # Simulate concurrent Signal between TAKE_LEASE_PS and nap handler.
-      # LEAST(schedule, NOW()) = NOW() since TAKE_LEASE_PS set schedule > NOW().
+      # The wake must fail the nap handler's compare-and-set; see
+      # Strand::SCHEDULE_NO_LATER_THAN_NOW.
       Semaphore.incr(st.id, "test")
 
       ret = st.unsynchronized_run
@@ -108,6 +109,16 @@ RSpec.describe Strand do
       # signal's value (~NOW), NOT set to 123 seconds in the future.
       expect(st.schedule).to be < Time.now + 60
     end
+  end
+
+  it "stays runnable when a semaphore arrives mid-run on an overdue strand" do
+    st.update(label: "late_signal_napper", schedule: Time.now - 100)
+
+    ret = st.unsynchronized_run
+    expect(ret).to be_a(Prog::Base::Nap)
+
+    expect(st.reload.schedule).to be <= Time.now
+    expect(Semaphore.where(strand_id: st.id, name: "late_signal")).not_to be_empty
   end
 
   it "logs end of strand if it took long" do


### PR DESCRIPTION
This is the same code as #5932 , run git diff against it (I made the base the same to make it easier); I changed the commit message and comments. Some changes I am more ambivalent about, but I think the commit message is the biggest improvement. It's a subtle part of the design. I suppose by my having submitted it this way, I implicitly endorse everything in the other branch for implementation too.