### PR TITLE
Clean the migrate daemon on success so later migrations get applied

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -555,6 +555,7 @@ SQL
 
     case vm.sshable.d_check("migrate")
     when "Succeeded"
+      vm.sshable.d_clean("migrate")
       hop_wait
     when "Failed", "NotStarted"
       vm.sshable.d_run("migrate", "sudo", "postgres/bin/migrate")

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -306,10 +306,11 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.run_migrations }.to nap(5)
     end
 
-    it "hops to wait once the migrator succeeds on the primary" do
+    it "cleans the daemon and hops to wait once the migrator succeeds on the primary" do
       expect(server).to receive(:read_replica?).and_return(false)
       expect(server).to receive(:primary?).and_return(true)
       expect(sshable).to receive(:d_check).with("migrate").and_return("Succeeded")
+      expect(sshable).to receive(:d_clean).with("migrate")
       expect { nx.run_migrations }.to hop("wait")
     end
   end


### PR DESCRIPTION
## Problem

`run_migrations` left the `migrate` daemon in `Succeeded` forever — its state lives in a systemd transient unit that only resets on VM reboot. So once a server had migrated, the strand never ran `bin/migrate` again.

## Fix

Clean the daemon on `Succeeded` (matching `take_backup` and the other daemonized steps) so the next `install_rhizome` pass re-runs the migrator and applies any newly-deployed migrations.