### PR TITLE
Sweep leaked S3 buckets and IAM entities by tag

### DIFF
--- a/.github/actions/aws-cleanup-e2e/cleanup.rb
+++ b/.github/actions/aws-cleanup-e2e/cleanup.rb
@@ -21,6 +21,15 @@
 # own tag establishes; untagged ENIs and instances inside such a VPC are
 # reported and left alone.
 #
+# Postgres timelines leave an S3 bucket plus an IAM user and policy behind, and
+# every non-runner AWS VM an IAM role, instance profile and cw-agent policy.
+# Those are swept too, held to the very same gate: S3 per region, right after
+# the EC2 sweeps, and IAM once globally at the end. Both discover by the
+# Ubicloud tag and skip on the same run-id test, so production ("true") and
+# developer resources stay out of reach. The tag is the sole delete authority;
+# a bucket is additionally required to be named like a timeline ubid, and any
+# other tagged bucket is reported rather than removed.
+#
 # Individual AWS failures are logged and stepped over, and every wait is
 # capped. Whatever one run leaves behind the next run's stale sweep collects,
 # so a partial sweep beats hitting the 20 minute job timeout mid-delete.
@@ -31,6 +40,11 @@
 #   GITHUB_REPOSITORY  defaults to ubicloud/ubicloud
 #   DRY_RUN=1          report what would be deleted, delete nothing
 #   CLEANUP_BUDGET_SEC overall budget, default 15 minutes
+#   IAM_TAGGING=1      discover IAM through the tagging API instead of the
+#                      default entity-by-entity listing. Faster, but this
+#                      account's tagging API does not index IAM users or roles,
+#                      so it silently misses them -- set only for an account
+#                      whose tagging API is known to cover every IAM type.
 # plus AWS credentials in the environment, and `aws` on PATH.
 
 require "json"
@@ -94,6 +108,50 @@ module AwsCleanup
   # other only become deletable one pass after their peer.
   DELETE_PASSES = 4
   DELETE_PASS_SLEEP = 20
+
+  # A timeline names its bucket after its own ubid, so only a bucket named in
+  # exactly that shape is one of ours; any other tagged bucket is an anomaly to
+  # report rather than delete.
+  BUCKET_NAME = /\Apt[0-9a-z]{24}\z/
+
+  # A bucket is emptied a page (up to 1000 objects) at a time; the cap stops a
+  # listing that never drains from spinning forever.
+  BUCKET_EMPTY_PASSES = 1000
+
+  # The region the global IAM tagging endpoint answers on.
+  IAM_TAG_REGION = "us-east-1"
+
+  # AWS error codes that mean the delete already happened: benign, not a
+  # failure, for every S3 and IAM call.
+  ALREADY_GONE = %w[NoSuchEntity NoSuchBucket].freeze
+
+  # The IAM entity kinds the sweep deletes, in the order it must delete them --
+  # a policy will not delete while attached and a role not while it sits in a
+  # profile, so users, then roles, then profiles, then policies, each kind
+  # clearing the references the next one waits on. Per kind: the tagging API
+  # filter that finds it; the list call, response key and extra args that
+  # enumerate it when that API is denied; the field naming an entity and the
+  # tag call (with its flag) that reads the entity's tags on that fallback; and
+  # the name shape a reviewer should expect, nil where there is none (a VM role
+  # is named for its VM, with no fixed shape).
+  IAM_KINDS = {
+    user: {
+      filter: "iam:user", list_cmd: "list-users", list_key: "Users", list_args: [].freeze,
+      id: "UserName", tags: "list-user-tags", flag: "--user-name", name: /\Apt[0-9a-z]{24}\z/,
+    },
+    role: {
+      filter: "iam:role", list_cmd: "list-roles", list_key: "Roles", list_args: [].freeze,
+      id: "RoleName", tags: "list-role-tags", flag: "--role-name", name: nil,
+    },
+    instance_profile: {
+      filter: "iam:instance-profile", list_cmd: "list-instance-profiles", list_key: "InstanceProfiles", list_args: [].freeze,
+      id: "InstanceProfileName", tags: "list-instance-profile-tags", flag: "--instance-profile-name", name: /-instance-profile\z/,
+    },
+    policy: {
+      filter: "iam:policy", list_cmd: "list-policies", list_key: "Policies", list_args: %w[--scope Local].freeze,
+      id: "Arn", tags: "list-policy-tags", flag: "--policy-arn", name: /\Apt[0-9a-z]{24}\z|-cw-agent-policy\z/,
+    },
+  }.freeze
 
   def self.now
     Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -160,8 +218,35 @@ module AwsCleanup
       :failed
     end
 
+    # A read-only call to any aws service, for the S3 and IAM sweeps that the
+    # ec2-only `describe` above cannot serve. The full argument vector is
+    # passed through. Returns [parsed body, error message], exactly one nil.
+    # Unlike `describe` it does not warn on failure, because for these sweeps
+    # some errors are control flow -- an AccessDenied that selects a fallback,
+    # a NoSuchEntity that means "already gone" -- rather than warnings.
+    def get(*args)
+      json(args)
+    end
+
+    # A mutating call to any aws service. Returns nil on success, and under a
+    # dry run without calling aws at all; otherwise the AWS error code
+    # ("NoSuchEntity", "BucketNotEmpty", ...), so the caller can tell a benign
+    # already-done from a real failure.
+    def delete(*args)
+      return if dry_run
+      _body, error = json(args)
+      return unless error
+      Cli.error_code(error)
+    end
+
     def self.brief(error)
       error.to_s.lines.map(&:strip).reject(&:empty?).last || "no error output"
+    end
+
+    # The code AWS parenthesizes in a CLI error, e.g. "NoSuchEntity" out of
+    # "An error occurred (NoSuchEntity) when calling ...", or "Unknown".
+    def self.error_code(error)
+      error.to_s[/An error occurred \(([^)]+)\)/, 1] || "Unknown"
     end
 
     private
@@ -526,6 +611,364 @@ module AwsCleanup
     end
   end
 
+  # Discovery by the Ubicloud tag through the Resource Groups Tagging API,
+  # shared by the S3 and IAM sweeps. Both find their resources this way and
+  # then defer every delete to the run-id gate, so neither can reach anything
+  # the EC2 sweep would spare. Includers provide a `cli`.
+  module TagQuery
+    # [arn, tag value] for every Ubicloud-tagged resource of `type` in
+    # `region`, following pagination, or nil if the tagging API itself could
+    # not be reached -- which the caller treats as "ask another way", not
+    # "nothing tagged". The filter is on the key alone, so the value the caller
+    # gates on is whatever the resource actually carries.
+    def tagged(region, type)
+      pairs = []
+      token = nil
+      loop do
+        args = ["resourcegroupstaggingapi", "get-resources", "--region", region, "--tag-filters", "Key=#{TAG_KEY}", "--resource-type-filters", type]
+        args.push("--pagination-token", token) unless token.to_s.empty?
+        body, error = cli.get(*args)
+        unless body
+          puts "  WARN: tagging API get-resources #{type} in #{region} unavailable: #{Cli.brief(error)}"
+          return nil
+        end
+        body.fetch("ResourceTagMappingList", []).each do |resource|
+          pairs << [resource["ResourceARN"], AwsCleanup.tag_value("Tags" => resource["Tags"])]
+        end
+        token = body["PaginationToken"]
+        break if token.to_s.empty?
+      end
+      pairs
+    end
+  end
+
+  # The S3 half of a sweep: every Ubicloud-tagged bucket in one region whose
+  # tag value the gate clears, emptied then deleted. A tagged bucket whose name
+  # is not a timeline ubid is reported and left in place whatever its tag,
+  # since the only writer of these buckets names them after the timeline.
+  class BucketSweep
+    include TagQuery
+
+    attr_reader :cli, :deleted, :failed, :skipped
+
+    def initialize(cli:, region:, permit:, deadline: nil)
+      @cli = cli
+      @region = region
+      @permit = permit
+      @deadline = deadline
+      @deleted = 0
+      @failed = 0
+      @skipped = 0
+    end
+
+    def run
+      buckets = discover
+      return self if buckets.nil? || buckets.empty?
+      puts "#{@region}: #{buckets.size} Ubicloud-tagged bucket(s)"
+      buckets.sort_by { |name, _tag| name }.each do |name, tag|
+        break if AwsCleanup.expired?(@deadline)
+        sweep_bucket(name, tag)
+      end
+      self
+    end
+
+    private
+
+    # [name, tag] for each tagged bucket, via the tagging API, or a
+    # list-buckets + get-bucket-tagging scan of this region if that API is
+    # denied. nil (only the tagging API returns it) means fall back; an empty
+    # list means nothing is tagged and there is nothing to fall back to.
+    def discover
+      pairs = tagged(@region, "s3")
+      pairs &&= pairs.map { |arn, tag| [arn.split(":::").last, tag] }
+      pairs || discover_by_listing
+    end
+
+    # list-buckets is global, so each bucket's region is confirmed before it is
+    # claimed for this region's sweep; without that every region would try to
+    # delete every bucket.
+    def discover_by_listing
+      body, error = cli.get("s3api", "list-buckets")
+      unless body
+        puts "  WARN: s3api list-buckets failed: #{Cli.brief(error)}"
+        return nil
+      end
+      body.fetch("Buckets", []).filter_map do |bucket|
+        name = bucket["Name"]
+        tag = bucket_tag(name)
+        [name, tag] if tag && bucket_region(name) == @region
+      end
+    end
+
+    # The bucket's Ubicloud tag value, or nil if it has none (get-bucket-tagging
+    # raises NoSuchTagSet on an untagged bucket) or the call was denied.
+    def bucket_tag(name)
+      body, = cli.get("s3api", "get-bucket-tagging", "--bucket", name, "--region", @region)
+      AwsCleanup.tag_value("Tags" => body["TagSet"]) if body
+    end
+
+    # us-east-1 reports its buckets with a null LocationConstraint.
+    def bucket_region(name)
+      body, = cli.get("s3api", "get-bucket-location", "--bucket", name, "--region", IAM_TAG_REGION)
+      constraint = body && body["LocationConstraint"]
+      constraint.to_s.empty? ? "us-east-1" : constraint
+    end
+
+    def sweep_bucket(name, tag)
+      unless BUCKET_NAME.match?(name)
+        puts "  REPORT bucket #{name} (#{TAG_KEY}=#{tag}): not a timeline bucket name, left in place"
+        @skipped += 1
+        return
+      end
+      if (refusal = @permit.call(tag))
+        puts "  SKIP bucket #{name}: #{refusal}"
+        @skipped += 1
+        return
+      end
+      announce("Delete bucket #{name} (#{TAG_KEY}=#{tag})")
+      if empty_and_delete(name)
+        @deleted += 1
+      else
+        @failed += 1
+      end
+    end
+
+    # Empty the bucket then remove it. Created unversioned, it empties with
+    # list-objects-v2; only if a delete-bucket still reports BucketNotEmpty do
+    # we pay for the versioned listing, which also sweeps delete markers.
+    # NoSuchBucket at any point means the bucket is already gone: success.
+    def empty_and_delete(name)
+      return true if cli.dry_run
+      empty(name, "list-objects-v2", "Contents")
+      code = cli.delete("s3api", "delete-bucket", "--bucket", name, "--region", @region)
+      if code == "BucketNotEmpty"
+        empty(name, "list-object-versions", "Versions", "DeleteMarkers")
+        code = cli.delete("s3api", "delete-bucket", "--bucket", name, "--region", @region)
+      end
+      return true if code.nil? || code == "NoSuchBucket"
+      puts "  WARN: delete-bucket #{name} failed: #{code}"
+      false
+    end
+
+    # Delete everything the listing command returns, a page (up to 1000) at a
+    # time, until it comes back empty. `keys` are the response members holding
+    # deletable entries: the objects, and for the versioned listing the delete
+    # markers too. Each entry carries a VersionId only in the versioned case,
+    # where it must be passed to delete the right generation.
+    def empty(name, command, *keys)
+      BUCKET_EMPTY_PASSES.times do
+        body, error = cli.get("s3api", command, "--bucket", name, "--region", @region)
+        unless body
+          puts "  WARN: #{command} #{name} failed: #{Cli.brief(error)}" unless ALREADY_GONE.include?(Cli.error_code(error))
+          return
+        end
+        entries = keys.flat_map { |key| body.fetch(key, []) }
+        return if entries.empty?
+        entries.each_slice(1000) do |slice|
+          payload = JSON.dump("Objects" => slice.map { |entry| entry.slice("Key", "VersionId") }, "Quiet" => true)
+          code = cli.delete("s3api", "delete-objects", "--bucket", name, "--region", @region, "--delete", payload)
+          puts "  WARN: delete-objects #{name} failed: #{code}" if code && !ALREADY_GONE.include?(code)
+        end
+      end
+    end
+
+    def announce(description)
+      puts(cli.dry_run ? "  [dry-run] #{description}" : "  #{description}")
+    end
+  end
+
+  # The IAM half of a sweep, run once globally: every Ubicloud-tagged user,
+  # role, instance profile and policy whose tag value the gate clears, deleted
+  # in that order. A name is reported for a human to eyeball but never decides
+  # anything; only the tag and the run-id gate do.
+  class IamSweep
+    include TagQuery
+
+    attr_reader :cli, :deleted, :failed, :skipped
+
+    def initialize(cli:, permit:, deadline: nil, via_listing: true)
+      @cli = cli
+      @permit = permit
+      @deadline = deadline
+      @via_listing = via_listing
+      @deleted = 0
+      @failed = 0
+      @skipped = 0
+    end
+
+    def run
+      IAM_KINDS.each_key do |kind|
+        break if AwsCleanup.expired?(@deadline)
+        sweep_kind(kind)
+      end
+      self
+    end
+
+    private
+
+    def sweep_kind(kind)
+      entities = discover(kind)
+      return if entities.nil? || entities.empty?
+      puts "IAM: #{entities.size} Ubicloud-tagged #{label(kind)}(s)"
+      entities.sort_by { |name, _arn, _tag| name }.each do |name, arn, tag|
+        break if AwsCleanup.expired?(@deadline)
+        act(kind, name, arn, tag)
+      end
+    end
+
+    # [name, arn, tag] for each tagged entity of `kind`. By default this is a
+    # list + per-entity tag scan, because the tagging API does not index users
+    # or roles in this account and would silently miss them; IAM_TAGGING opts
+    # back into the tagging API where it is known to be complete. The name is
+    # the ARN's last segment, which is what every delete call below takes (only
+    # the policy delete needs the ARN itself).
+    def discover(kind)
+      meta = IAM_KINDS.fetch(kind)
+      pairs = @via_listing ? discover_by_listing(kind) : (tagged(IAM_TAG_REGION, meta[:filter]) || discover_by_listing(kind))
+      pairs&.map { |arn, tag| [arn.split("/").last, arn, tag] }
+    end
+
+    # Enumerate the kind and read each entity's tags one call at a time. Slow
+    # -- it walks every entity in the account, not just ours -- but the only
+    # way to see IAM users and roles here; it is the default, and also the
+    # fallback the tagging path drops to when denied.
+    def discover_by_listing(kind)
+      meta = IAM_KINDS.fetch(kind)
+      iam_list(meta[:list_cmd], meta[:list_key], *meta[:list_args]).filter_map do |entity|
+        arn = entity["Arn"]
+        identifier = (meta[:id] == "Arn") ? arn : entity[meta[:id]]
+        tag = AwsCleanup.tag_value("Tags" => iam_list(meta[:tags], "Tags", meta[:flag], identifier))
+        [arn, tag] if tag
+      end
+    end
+
+    def act(kind, name, arn, tag)
+      note = name_note(kind, name)
+      if (refusal = @permit.call(tag))
+        puts "  SKIP #{label(kind)} #{name}#{note}: #{refusal}"
+        @skipped += 1
+        return
+      end
+      announce("Delete #{label(kind)} #{name} (#{TAG_KEY}=#{tag})#{note}")
+      if cli.dry_run
+        @deleted += 1
+      elsif delete_entity(kind, name, arn)
+        @deleted += 1
+      else
+        @failed += 1
+      end
+    end
+
+    # A parenthetical flag for a name that is not the shape its kind usually
+    # takes, drawing a reviewer's eye -- never itself a reason to keep or drop.
+    def name_note(kind, name)
+      shape = IAM_KINDS.fetch(kind)[:name]
+      (shape && !shape.match?(name)) ? " [name unexpected for a #{label(kind)}]" : ""
+    end
+
+    def label(kind)
+      kind.to_s.tr("_", " ")
+    end
+
+    def delete_entity(kind, name, arn)
+      case kind
+      when :user then delete_user(name)
+      when :role then delete_role(name)
+      when :instance_profile then delete_instance_profile(name)
+      when :policy then delete_policy(arn)
+      end
+    end
+
+    def delete_user(name)
+      iam_list("list-access-keys", "AccessKeyMetadata", "--user-name", name).each do |key|
+        tolerate cli.delete("iam", "delete-access-key", "--user-name", name, "--access-key-id", key["AccessKeyId"]), "delete-access-key #{name}"
+      end
+      iam_list("list-attached-user-policies", "AttachedPolicies", "--user-name", name).each do |policy|
+        tolerate cli.delete("iam", "detach-user-policy", "--user-name", name, "--policy-arn", policy["PolicyArn"]), "detach-user-policy #{name}"
+      end
+      finalize cli.delete("iam", "delete-user", "--user-name", name), "delete-user #{name}"
+    end
+
+    def delete_role(name)
+      iam_list("list-instance-profiles-for-role", "InstanceProfiles", "--role-name", name).each do |profile|
+        tolerate cli.delete("iam", "remove-role-from-instance-profile", "--instance-profile-name", profile["InstanceProfileName"], "--role-name", name), "remove-role-from-instance-profile #{name}"
+      end
+      iam_list("list-attached-role-policies", "AttachedPolicies", "--role-name", name).each do |policy|
+        tolerate cli.delete("iam", "detach-role-policy", "--role-name", name, "--policy-arn", policy["PolicyArn"]), "detach-role-policy #{name}"
+      end
+      iam_list("list-role-policies", "PolicyNames", "--role-name", name).each do |inline|
+        tolerate cli.delete("iam", "delete-role-policy", "--role-name", name, "--policy-name", inline), "delete-role-policy #{name}"
+      end
+      finalize cli.delete("iam", "delete-role", "--role-name", name), "delete-role #{name}"
+    end
+
+    def delete_instance_profile(name)
+      body, = cli.get("iam", "get-instance-profile", "--instance-profile-name", name)
+      (body ? body.dig("InstanceProfile", "Roles") || [] : []).each do |role|
+        tolerate cli.delete("iam", "remove-role-from-instance-profile", "--instance-profile-name", name, "--role-name", role["RoleName"]), "remove-role-from-instance-profile #{name}"
+      end
+      finalize cli.delete("iam", "delete-instance-profile", "--instance-profile-name", name), "delete-instance-profile #{name}"
+    end
+
+    def delete_policy(arn)
+      detach_policy(arn)
+      iam_list("list-policy-versions", "Versions", "--policy-arn", arn).each do |version|
+        next if version["IsDefaultVersion"]
+        tolerate cli.delete("iam", "delete-policy-version", "--policy-arn", arn, "--version-id", version["VersionId"]), "delete-policy-version #{arn}"
+      end
+      finalize cli.delete("iam", "delete-policy", "--policy-arn", arn), "delete-policy #{arn}"
+    end
+
+    # Detach the policy from every user, role and group still holding it, so
+    # the delete below is unblocked. In iam-access mode a timeline policy is
+    # attached to server roles rather than a user, so all three are checked.
+    def detach_policy(arn)
+      body, error = cli.get("iam", "list-entities-for-policy", "--policy-arn", arn)
+      unless body
+        puts "  WARN: iam list-entities-for-policy #{arn} failed: #{Cli.brief(error)}" unless ALREADY_GONE.include?(Cli.error_code(error))
+        return
+      end
+      body.fetch("PolicyUsers", []).each { |user| tolerate cli.delete("iam", "detach-user-policy", "--user-name", user["UserName"], "--policy-arn", arn), "detach-user-policy #{user["UserName"]}" }
+      body.fetch("PolicyRoles", []).each { |role| tolerate cli.delete("iam", "detach-role-policy", "--role-name", role["RoleName"], "--policy-arn", arn), "detach-role-policy #{role["RoleName"]}" }
+      body.fetch("PolicyGroups", []).each { |group| tolerate cli.delete("iam", "detach-group-policy", "--group-name", group["GroupName"], "--policy-arn", arn), "detach-group-policy #{group["GroupName"]}" }
+    end
+
+    # An iam list call, following pagination markers, returning the array at
+    # `key` across every page, or [] on NoSuchEntity or any failure -- a
+    # sub-listing we cannot read mid-delete is one we can treat as empty.
+    def iam_list(command, key, *args)
+      items = []
+      marker = nil
+      loop do
+        call = ["iam", command, *args]
+        call.push("--marker", marker) if marker
+        body, error = cli.get(*call)
+        unless body
+          puts "  WARN: iam #{command} failed: #{Cli.brief(error)}" unless ALREADY_GONE.include?(Cli.error_code(error))
+          break
+        end
+        items.concat(body.fetch(key, []))
+        marker = body["Marker"]
+        break unless body["IsTruncated"] && marker
+      end
+      items
+    end
+
+    def tolerate(code, what)
+      puts "  WARN: #{what} failed: #{code}" unless code.nil? || ALREADY_GONE.include?(code)
+    end
+
+    def finalize(code, what)
+      return true if code.nil? || ALREADY_GONE.include?(code)
+      puts "  WARN: #{what} failed: #{code}"
+      false
+    end
+
+    def announce(description)
+      puts(cli.dry_run ? "  [dry-run] #{description}" : "  #{description}")
+    end
+  end
+
   # Drives both sweeps across every region and decides which stale run ids
   # are safe to touch.
   class Runner
@@ -533,13 +976,14 @@ module AwsCleanup
 
     attr_reader :cli
 
-    def initialize(cli:, run_id:, token:, repo: DEFAULT_REPO, api_url: DEFAULT_API_URL, deadline: nil)
+    def initialize(cli:, run_id:, token:, repo: DEFAULT_REPO, api_url: DEFAULT_API_URL, deadline: nil, iam_via_listing: true)
       @cli = cli
       @run_id = run_id
       @token = token
       @repo = repo
       @api_url = api_url
       @deadline = deadline
+      @iam_via_listing = iam_via_listing
       @refusals = {}
       @deleted = 0
       @failed = 0
@@ -553,10 +997,50 @@ module AwsCleanup
       else
         REGIONS.each { |region| stale_sweep(region) }
       end
+      # S3 and IAM gate every value themselves, current run included, so they
+      # run whether or not the token let the stale EC2 sweep proceed: without
+      # it only the current run's own buckets and entities pass the gate.
+      REGIONS.each { |region| bucket_sweep(region) }
+      iam_sweep
       puts "Summary: #{cli.dry_run ? "would delete" : "deleted"} #{@deleted}, skipped #{@skipped}, failed #{@failed}"
     end
 
     private
+
+    def bucket_sweep(region)
+      if AwsCleanup.expired?(@deadline)
+        puts "#{region}: budget spent; leaving its tagged buckets to the next run"
+        return
+      end
+      tally BucketSweep.new(cli:, region:, permit: method(:refusal_for), deadline: @deadline).run
+    end
+
+    def iam_sweep
+      if AwsCleanup.expired?(@deadline)
+        puts "budget spent; leaving tagged IAM entities to the next run"
+        return
+      end
+      tally IamSweep.new(cli:, permit: method(:refusal_for), deadline: @deadline, via_listing: @iam_via_listing).run
+    end
+
+    def tally(sweep)
+      @deleted += sweep.deleted
+      @failed += sweep.failed
+      @skipped += sweep.skipped
+    end
+
+    # Whether a tag value's S3 or IAM resources may be deleted, as a reason
+    # string to skip or nil to permit. The current run is always ours; a
+    # numeric run id is touchable only once the GitHub API vouches it a
+    # completed run of this workflow (the same test the stale EC2 sweep
+    # applies, memoized alongside it); production's "true" and a developer's
+    # name never are.
+    def refusal_for(value)
+      return if value == @run_id
+      return "#{value.inspect} is not a run id" unless RUN_TAG.match?(value)
+      return "no GITHUB_TOKEN to verify the run" if @token.to_s.empty?
+      refusal_to_sweep(value)
+    end
 
     # Enumerating a run's resources costs a dozen or so `aws` calls before
     # a single delete is issued, so the budget has to be checked here too;
@@ -567,10 +1051,7 @@ module AwsCleanup
         puts "#{region}: budget spent; leaving #{TAG_KEY}=#{tag_value} to the next run"
         return false
       end
-      sweep = Sweep.new(cli:, region:, tag_value:, deadline: @deadline).run
-      @deleted += sweep.deleted
-      @failed += sweep.failed
-      @skipped += sweep.skipped
+      tally Sweep.new(cli:, region:, tag_value:, deadline: @deadline).run
       true
     end
 
@@ -660,6 +1141,7 @@ module AwsCleanup
       repo: env("GITHUB_REPOSITORY", DEFAULT_REPO),
       api_url: env("GITHUB_API_URL", DEFAULT_API_URL),
       deadline: now + Integer(env("CLEANUP_BUDGET_SEC", "900")),
+      iam_via_listing: !%w[1 true].include?(env("IAM_TAGGING", "0")),
     ).run
   end
 end

--- a/.github/actions/aws-cleanup-e2e/cleanup.rb
+++ b/.github/actions/aws-cleanup-e2e/cleanup.rb
@@ -40,6 +40,9 @@
 #   GITHUB_REPOSITORY  defaults to ubicloud/ubicloud
 #   DRY_RUN=1          report what would be deleted, delete nothing
 #   CLEANUP_BUDGET_SEC overall budget, default 15 minutes
+#   CLEANUP_CONCURRENCY how many aws calls the S3/IAM sweeps keep in flight at
+#                      once (default 12); the discovery and delete work is the
+#                      slow part and it parallelizes across this many threads
 #   IAM_TAGGING=1      discover IAM through the tagging API instead of the
 #                      default entity-by-entity listing. Faster, but this
 #                      account's tagging API does not index IAM users or roles,
@@ -125,6 +128,13 @@ module AwsCleanup
   # failure, for every S3 and IAM call.
   ALREADY_GONE = %w[NoSuchEntity NoSuchBucket].freeze
 
+  # How many aws calls the S3 and IAM sweeps keep in flight at once. Each call
+  # is its own process, so a large sweep's wall-clock is dominated by spawning
+  # them one at a time; a bounded pool of concurrent ones is the whole speedup.
+  # Capped so a big backlog cannot fork a thousand processes or trip AWS
+  # request throttling.
+  CONCURRENCY = (ENV["CLEANUP_CONCURRENCY"] || "12").to_i.clamp(1, 64)
+
   # The IAM entity kinds the sweep deletes, in the order it must delete them --
   # a policy will not delete while attached and a role not while it sits in a
   # profile, so users, then roles, then profiles, then policies, each kind
@@ -155,6 +165,36 @@ module AwsCleanup
 
   def self.now
     Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  # One lock so concurrent workers' log lines never interleave mid-line.
+  OUTPUT = Mutex.new
+  def self.say(line)
+    OUTPUT.synchronize { puts line }
+  end
+
+  # Map the block over items with at most CONCURRENCY threads in flight,
+  # preserving order. Every aws call blocks on its own subprocess and releases
+  # the GVL while it waits, so the threads genuinely overlap -- this is what
+  # turns a serial spawn-per-call sweep into a concurrent one. The block must be
+  # thread-safe and must not raise (ours only issues aws calls, each its own
+  # process, and returns a value); a raised error would surface on join.
+  def self.parallel_map(items)
+    return items.map { |item| yield item } if items.size <= 1 || CONCURRENCY <= 1
+    queue = Queue.new
+    items.each_with_index { |item, i| queue << [i, item] }
+    results = Array.new(items.size)
+    Array.new([CONCURRENCY, items.size].min) do
+      Thread.new do
+        loop do
+          i, item = queue.pop(true)
+          results[i] = yield(item)
+        end
+      rescue ThreadError
+        nil
+      end
+    end.each(&:join)
+    results
   end
 
   def self.tag_value(resource, key = TAG_KEY)
@@ -591,7 +631,7 @@ module AwsCleanup
     end
 
     def announce(description)
-      puts(cli.dry_run ? "  [dry-run] #{description}" : "  #{description}")
+      AwsCleanup.say(cli.dry_run ? "  [dry-run] #{description}" : "  #{description}")
     end
 
     def out_of_time?
@@ -629,7 +669,7 @@ module AwsCleanup
         args.push("--pagination-token", token) unless token.to_s.empty?
         body, error = cli.get(*args)
         unless body
-          puts "  WARN: tagging API get-resources #{type} in #{region} unavailable: #{Cli.brief(error)}"
+          AwsCleanup.say "  WARN: tagging API get-resources #{type} in #{region} unavailable: #{Cli.brief(error)}"
           return nil
         end
         body.fetch("ResourceTagMappingList", []).each do |resource|
@@ -664,11 +704,18 @@ module AwsCleanup
     def run
       buckets = discover
       return self if buckets.nil? || buckets.empty?
-      puts "#{@region}: #{buckets.size} Ubicloud-tagged bucket(s)"
-      buckets.sort_by { |name, _tag| name }.each do |name, tag|
-        break if AwsCleanup.expired?(@deadline)
-        sweep_bucket(name, tag)
+      AwsCleanup.say "#{@region}: #{buckets.size} Ubicloud-tagged bucket(s)"
+      # Name-check and gate serially -- the gate memoizes GitHub lookups -- then
+      # empty and delete the survivors concurrently, tallying afterward so no
+      # counter is touched from a worker thread.
+      deletable = buckets.sort_by { |name, _tag| name }.filter_map { |name, tag| classify(name, tag) }
+      outcomes = AwsCleanup.parallel_map(deletable) do |name, tag|
+        next :deferred if AwsCleanup.expired?(@deadline)
+        announce("Delete bucket #{name} (#{TAG_KEY}=#{tag})")
+        empty_and_delete(name) ? :deleted : :failed
       end
+      @deleted += outcomes.count(:deleted)
+      @failed += outcomes.count(:failed)
       self
     end
 
@@ -690,7 +737,7 @@ module AwsCleanup
     def discover_by_listing
       body, error = cli.get("s3api", "list-buckets")
       unless body
-        puts "  WARN: s3api list-buckets failed: #{Cli.brief(error)}"
+        AwsCleanup.say "  WARN: s3api list-buckets failed: #{Cli.brief(error)}"
         return nil
       end
       body.fetch("Buckets", []).filter_map do |bucket|
@@ -714,23 +761,21 @@ module AwsCleanup
       constraint.to_s.empty? ? "us-east-1" : constraint
     end
 
-    def sweep_bucket(name, tag)
+    # nil for a bucket to leave alone -- logging the reason and counting the
+    # skip -- or [name, tag] for one to delete. Runs in the serial partition, so
+    # the skip counter is safe to touch here.
+    def classify(name, tag)
       unless BUCKET_NAME.match?(name)
-        puts "  REPORT bucket #{name} (#{TAG_KEY}=#{tag}): not a timeline bucket name, left in place"
+        AwsCleanup.say "  REPORT bucket #{name} (#{TAG_KEY}=#{tag}): not a timeline bucket name, left in place"
         @skipped += 1
         return
       end
       if (refusal = @permit.call(tag))
-        puts "  SKIP bucket #{name}: #{refusal}"
+        AwsCleanup.say "  SKIP bucket #{name}: #{refusal}"
         @skipped += 1
         return
       end
-      announce("Delete bucket #{name} (#{TAG_KEY}=#{tag})")
-      if empty_and_delete(name)
-        @deleted += 1
-      else
-        @failed += 1
-      end
+      [name, tag]
     end
 
     # Empty the bucket then remove it. Created unversioned, it empties with
@@ -746,7 +791,7 @@ module AwsCleanup
         code = cli.delete("s3api", "delete-bucket", "--bucket", name, "--region", @region)
       end
       return true if code.nil? || code == "NoSuchBucket"
-      puts "  WARN: delete-bucket #{name} failed: #{code}"
+      AwsCleanup.say "  WARN: delete-bucket #{name} failed: #{code}"
       false
     end
 
@@ -759,7 +804,7 @@ module AwsCleanup
       BUCKET_EMPTY_PASSES.times do
         body, error = cli.get("s3api", command, "--bucket", name, "--region", @region)
         unless body
-          puts "  WARN: #{command} #{name} failed: #{Cli.brief(error)}" unless ALREADY_GONE.include?(Cli.error_code(error))
+          AwsCleanup.say "  WARN: #{command} #{name} failed: #{Cli.brief(error)}" unless ALREADY_GONE.include?(Cli.error_code(error))
           return
         end
         entries = keys.flat_map { |key| body.fetch(key, []) }
@@ -767,13 +812,13 @@ module AwsCleanup
         entries.each_slice(1000) do |slice|
           payload = JSON.dump("Objects" => slice.map { |entry| entry.slice("Key", "VersionId") }, "Quiet" => true)
           code = cli.delete("s3api", "delete-objects", "--bucket", name, "--region", @region, "--delete", payload)
-          puts "  WARN: delete-objects #{name} failed: #{code}" if code && !ALREADY_GONE.include?(code)
+          AwsCleanup.say "  WARN: delete-objects #{name} failed: #{code}" if code && !ALREADY_GONE.include?(code)
         end
       end
     end
 
     def announce(description)
-      puts(cli.dry_run ? "  [dry-run] #{description}" : "  #{description}")
+      AwsCleanup.say(cli.dry_run ? "  [dry-run] #{description}" : "  #{description}")
     end
   end
 
@@ -809,11 +854,18 @@ module AwsCleanup
     def sweep_kind(kind)
       entities = discover(kind)
       return if entities.nil? || entities.empty?
-      puts "IAM: #{entities.size} Ubicloud-tagged #{label(kind)}(s)"
-      entities.sort_by { |name, _arn, _tag| name }.each do |name, arn, tag|
-        break if AwsCleanup.expired?(@deadline)
-        act(kind, name, arn, tag)
+      AwsCleanup.say "IAM: #{entities.size} Ubicloud-tagged #{label(kind)}(s)"
+      # Gate serially -- the gate memoizes GitHub lookups -- then delete the
+      # survivors concurrently, tallying afterward so no counter is touched from
+      # a worker thread.
+      actionable = entities.sort_by { |name, _arn, _tag| name }.filter_map { |name, arn, tag| classify(kind, name, arn, tag) }
+      outcomes = AwsCleanup.parallel_map(actionable) do |name, arn, tag, note|
+        next :deferred if AwsCleanup.expired?(@deadline)
+        announce("Delete #{label(kind)} #{name} (#{TAG_KEY}=#{tag})#{note}")
+        (cli.dry_run || delete_entity(kind, name, arn)) ? :deleted : :failed
       end
+      @deleted += outcomes.count(:deleted)
+      @failed += outcomes.count(:failed)
     end
 
     # [name, arn, tag] for each tagged entity of `kind`. By default this is a
@@ -834,29 +886,26 @@ module AwsCleanup
     # fallback the tagging path drops to when denied.
     def discover_by_listing(kind)
       meta = IAM_KINDS.fetch(kind)
-      iam_list(meta[:list_cmd], meta[:list_key], *meta[:list_args]).filter_map do |entity|
+      entities = iam_list(meta[:list_cmd], meta[:list_key], *meta[:list_args])
+      AwsCleanup.parallel_map(entities) do |entity|
         arn = entity["Arn"]
         identifier = (meta[:id] == "Arn") ? arn : entity[meta[:id]]
         tag = AwsCleanup.tag_value("Tags" => iam_list(meta[:tags], "Tags", meta[:flag], identifier))
         [arn, tag] if tag
-      end
+      end.compact
     end
 
-    def act(kind, name, arn, tag)
+    # nil for an entity to leave alone -- logging the skip and counting it -- or
+    # [name, arn, tag, note] for one to delete. Runs in the serial partition, so
+    # the skip counter and the gate's memoized GitHub lookups are safe here.
+    def classify(kind, name, arn, tag)
       note = name_note(kind, name)
       if (refusal = @permit.call(tag))
-        puts "  SKIP #{label(kind)} #{name}#{note}: #{refusal}"
+        AwsCleanup.say "  SKIP #{label(kind)} #{name}#{note}: #{refusal}"
         @skipped += 1
         return
       end
-      announce("Delete #{label(kind)} #{name} (#{TAG_KEY}=#{tag})#{note}")
-      if cli.dry_run
-        @deleted += 1
-      elsif delete_entity(kind, name, arn)
-        @deleted += 1
-      else
-        @failed += 1
-      end
+      [name, arn, tag, note]
     end
 
     # A parenthetical flag for a name that is not the shape its kind usually
@@ -925,7 +974,7 @@ module AwsCleanup
     def detach_policy(arn)
       body, error = cli.get("iam", "list-entities-for-policy", "--policy-arn", arn)
       unless body
-        puts "  WARN: iam list-entities-for-policy #{arn} failed: #{Cli.brief(error)}" unless ALREADY_GONE.include?(Cli.error_code(error))
+        AwsCleanup.say "  WARN: iam list-entities-for-policy #{arn} failed: #{Cli.brief(error)}" unless ALREADY_GONE.include?(Cli.error_code(error))
         return
       end
       body.fetch("PolicyUsers", []).each { |user| tolerate cli.delete("iam", "detach-user-policy", "--user-name", user["UserName"], "--policy-arn", arn), "detach-user-policy #{user["UserName"]}" }
@@ -944,7 +993,7 @@ module AwsCleanup
         call.push("--marker", marker) if marker
         body, error = cli.get(*call)
         unless body
-          puts "  WARN: iam #{command} failed: #{Cli.brief(error)}" unless ALREADY_GONE.include?(Cli.error_code(error))
+          AwsCleanup.say "  WARN: iam #{command} failed: #{Cli.brief(error)}" unless ALREADY_GONE.include?(Cli.error_code(error))
           break
         end
         items.concat(body.fetch(key, []))
@@ -955,17 +1004,17 @@ module AwsCleanup
     end
 
     def tolerate(code, what)
-      puts "  WARN: #{what} failed: #{code}" unless code.nil? || ALREADY_GONE.include?(code)
+      AwsCleanup.say "  WARN: #{what} failed: #{code}" unless code.nil? || ALREADY_GONE.include?(code)
     end
 
     def finalize(code, what)
       return true if code.nil? || ALREADY_GONE.include?(code)
-      puts "  WARN: #{what} failed: #{code}"
+      AwsCleanup.say "  WARN: #{what} failed: #{code}"
       false
     end
 
     def announce(description)
-      puts(cli.dry_run ? "  [dry-run] #{description}" : "  #{description}")
+      AwsCleanup.say(cli.dry_run ? "  [dry-run] #{description}" : "  #{description}")
     end
   end
 


### PR DESCRIPTION
Follow-up to #5937 (merged): extends the same tag-driven e2e cleanup to the S3
buckets and IAM users/roles/instance-profiles/policies that Postgres timelines
and AWS VMs leak, under the exact same run-id gate.

## What it does

- **S3**, per region, right after the EC2 sweeps: buckets discovered by the
  `Ubicloud` tag via the Resource Groups Tagging API (falling back to
  `list-buckets` + `get-bucket-tagging`). Only a bucket named like a timeline
  ubid (`^pt[0-9a-z]{24}$`) is deletable; any other tagged bucket is reported,
  never removed. Emptied a page at a time, with a versioned-listing fallback
  for `BucketNotEmpty`.
- **IAM**, once globally at the end, in dependency order (users -> roles ->
  instance profiles -> policies), mirroring the VM's own `cleanup_roles`
  teardown. Entities are discovered by **listing each kind and reading its
  tags** -- because this account's tagging API doesn't index IAM users or roles
  (verified: it returns 0 of ~1,050 users and ~301 roles), so relying on it
  would silently leave them behind. `IAM_TAGGING=1` opts back into the faster
  tagging API for an account where it's known to be complete.
- The tag + run-id gate (the current run, or a numeric id the GitHub API
  reports `completed` for `e2e.yml`) is the **sole** delete authority. `true`
  (production) and developer sandboxes (tagged with `$USER`) are never in
  reach; names are reported for review but grant no delete permission.

The EC2 sweep behaviour is unchanged.

## Validated against live AWS (report-only)

Ran the S3/IAM sweeps report-only against the shared account (a CI run plus a
local pass):

- **Safety gate confirmed live:** every `true` (prod/CH), `burak`/`clover`
  (dev `$USER`), and in-progress-run tag was skipped; only numeric
  completed-e2e run ids were marked for deletion. This holds per resource, on
  each entity's own tag, right before its own delete.
- **Backlog:** ~2,866 leaked resources -- ~138 buckets, ~1,023 users, ~296
  roles, ~285 instance profiles, ~1,124 policies -- all attributable to
  completed e2e runs, none prod/dev.
- **Permissions:** `e2e-user` is `allowed` all 33 read/delete actions the
  sweep uses (`iam simulate-principal-policy`), and already deletes these same
  resource types during normal e2e teardown.

## Backlog drain (operational)

The first non-dry runs clear ~2,866 items -- more than the 20-minute job fits
in one pass -- so it drains cumulatively across runs (each deletes what it can,
the per-run budget defers the rest). Because list-scan enumerates the whole
account, its cost is dominated by the backlog and settles to a few minutes once
drained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
