### PR TITLE
Harden AWS Postgres timeline blob-storage teardown

### DIFF
--- a/model/postgres/aws/postgres_timeline.rb
+++ b/model/postgres/aws/postgres_timeline.rb
@@ -2,6 +2,11 @@
 
 class PostgresTimeline < Sequel::Model
   module Aws
+    # How many times a bucket that still reports BucketNotEmpty is re-emptied
+    # and re-deleted before the destroy gives up: a couple of passes clears the
+    # brief listing/delete race, and more would only spin.
+    AWS_BUCKET_DELETE_ATTEMPTS = 3
+
     def aws_s3_policy_name
       ubid
     end
@@ -97,9 +102,15 @@ PGDATA=/dat/#{version}/data
       })
     end
 
+    # Tear down the bucket, then the IAM user, then the policy. The IAM half is
+    # existence-driven, not mode-driven: it removes whatever is actually there
+    # rather than what the live aws_postgres_iam_access says should be, so a
+    # mode flip between create and destroy cannot orphan the half the new mode
+    # no longer expects.
     def aws_destroy_blob_storage
+      s3_client = blob_storage_client
+      attempts = 0
       begin
-        s3_client = blob_storage_client
         loop do
           objects = s3_client.list_objects_v2(bucket: ubid).contents
           break if objects.empty?
@@ -108,22 +119,39 @@ PGDATA=/dat/#{version}/data
         s3_client.delete_bucket(bucket: ubid)
       rescue ::Aws::S3::Errors::NoSuchBucket
         nil
+      rescue ::Aws::S3::Errors::BucketNotEmpty
+        # A race between the final listing and the delete, not a standing
+        # condition: re-empty and retry a bounded number of times.
+        retry if (attempts += 1) < AWS_BUCKET_DELETE_ATTEMPTS
+        raise
       end
 
       iam_client = location.location_credential_aws.iam_client
-      if Config.aws_postgres_iam_access
-        iam_client.delete_policy(policy_arn: aws_s3_policy_arn)
-      else
-        iam_client.list_attached_user_policies(user_name: ubid).attached_policies.each do
-          iam_client.detach_user_policy(user_name: ubid, policy_arn: it.policy_arn)
-          iam_client.delete_policy(policy_arn: it.policy_arn)
-        end
 
-        iam_client.list_access_keys(user_name: ubid).access_key_metadata.each do
-          iam_client.delete_access_key(user_name: ubid, access_key_id: it.access_key_id)
-        end
-        iam_client.delete_user(user_name: ubid)
+      (ignore_missing_entity { iam_client.list_access_keys(user_name: ubid).access_key_metadata } || []).each do |key|
+        ignore_missing_entity { iam_client.delete_access_key(user_name: ubid, access_key_id: key.access_key_id) }
       end
+      (ignore_missing_entity { iam_client.list_attached_user_policies(user_name: ubid).attached_policies } || []).each do |policy|
+        ignore_missing_entity { iam_client.detach_user_policy(user_name: ubid, policy_arn: policy.policy_arn) }
+      end
+      ignore_missing_entity { iam_client.delete_user(user_name: ubid) }
+
+      # The policy goes last, whichever mode created it. A policy will not
+      # delete while attached, and in iam-access mode it is attached to server
+      # roles rather than a user, so detach every holder that remains first.
+      if (entities = ignore_missing_entity { iam_client.list_entities_for_policy(policy_arn: aws_s3_policy_arn) })
+        entities.policy_users.each { |user| ignore_missing_entity { iam_client.detach_user_policy(user_name: user.user_name, policy_arn: aws_s3_policy_arn) } }
+        entities.policy_roles.each { |role| ignore_missing_entity { iam_client.detach_role_policy(role_name: role.role_name, policy_arn: aws_s3_policy_arn) } }
+        entities.policy_groups.each { |group| ignore_missing_entity { iam_client.detach_group_policy(group_name: group.group_name, policy_arn: aws_s3_policy_arn) } }
+      end
+      ignore_missing_entity { iam_client.delete_policy(policy_arn: aws_s3_policy_arn) }
+    end
+
+    # Tolerate an IAM entity already being gone. Wrapping each call separately,
+    # not the whole teardown, is what keeps one already-deleted entity from
+    # abandoning the deletions that would have followed it.
+    def ignore_missing_entity
+      yield
     rescue ::Aws::IAM::Errors::NoSuchEntity
       nil
     end

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -387,6 +387,112 @@ PGDATA=/dat/17/data
         expect(postgres_timeline.set_lifecycle_policy(expiration_days: 30)).to be(true)
       end
     end
+
+    describe "#destroy_blob_storage" do
+      let(:iam_client) { Aws::IAM::Client.new(stub_responses: true) }
+      let(:policy_arn) { "arn:aws:iam::123456789012:policy/#{postgres_timeline.ubid}" }
+
+      before do
+        postgres_timeline.update(location_id: create_aws_location.id)
+        allow(Aws::IAM::Client).to receive(:new).and_return(iam_client)
+        sts_client = Aws::STS::Client.new(stub_responses: true)
+        sts_client.stub_responses(:get_caller_identity, account: "123456789012")
+        allow(Aws::STS::Client).to receive(:new).and_return(sts_client)
+        # A clean bucket and an unattached policy unless a test overrides them,
+        # so each test states only the partial state it is about.
+        s3_client.stub_responses(:list_objects_v2, {contents: []})
+        s3_client.stub_responses(:delete_bucket)
+        iam_client.stub_responses(:list_access_keys, access_key_metadata: [])
+        iam_client.stub_responses(:list_attached_user_policies, attached_policies: [])
+        iam_client.stub_responses(:list_entities_for_policy, policy_users: [], policy_roles: [], policy_groups: [])
+      end
+
+      it "empties the bucket, then tears down the user and its policy" do
+        s3_client.stub_responses(:list_objects_v2, {contents: [{key: "basebackups_005/backup"}]}, {contents: []})
+        iam_client.stub_responses(:list_access_keys, access_key_metadata: [{access_key_id: "AKIA"}])
+        iam_client.stub_responses(:list_attached_user_policies, attached_policies: [{policy_arn:}])
+
+        expect(s3_client).to receive(:delete_objects).with(bucket: postgres_timeline.ubid, delete: {objects: [{key: "basebackups_005/backup"}]})
+        expect(s3_client).to receive(:delete_bucket).with(bucket: postgres_timeline.ubid)
+        expect(iam_client).to receive(:delete_access_key).with(user_name: postgres_timeline.ubid, access_key_id: "AKIA")
+        expect(iam_client).to receive(:detach_user_policy).with(user_name: postgres_timeline.ubid, policy_arn:)
+        expect(iam_client).to receive(:delete_user).with(user_name: postgres_timeline.ubid)
+        expect(iam_client).to receive(:delete_policy).with(policy_arn:)
+
+        postgres_timeline.destroy_blob_storage
+      end
+
+      it "detaches the policy from its server role and deletes it (iam-access mode)" do
+        # iam-access mode creates no user, and attaches the policy to a server
+        # role instead; the unconditional user teardown no-ops on the absent
+        # user while the policy is detached and deleted.
+        gone = Aws::IAM::Errors::NoSuchEntity.new(nil, "NoSuchEntity")
+        expect(iam_client).to receive(:list_access_keys).and_raise(gone)
+        expect(iam_client).to receive(:list_attached_user_policies).and_raise(gone)
+        expect(iam_client).to receive(:delete_user).and_raise(gone)
+        iam_client.stub_responses(:list_entities_for_policy, policy_users: [], policy_roles: [{role_name: "server-role"}], policy_groups: [])
+
+        expect(iam_client).to receive(:detach_role_policy).with(role_name: "server-role", policy_arn:)
+        expect(iam_client).to receive(:delete_policy).with(policy_arn:)
+
+        postgres_timeline.destroy_blob_storage
+      end
+
+      it "detaches every remaining user, role and group before deleting the policy" do
+        iam_client.stub_responses(:list_entities_for_policy, policy_users: [{user_name: "u"}], policy_roles: [{role_name: "r"}], policy_groups: [{group_name: "g"}])
+
+        expect(iam_client).to receive(:detach_user_policy).with(user_name: "u", policy_arn:)
+        expect(iam_client).to receive(:detach_role_policy).with(role_name: "r", policy_arn:)
+        expect(iam_client).to receive(:detach_group_policy).with(group_name: "g", policy_arn:)
+        expect(iam_client).to receive(:delete_policy).with(policy_arn:)
+
+        postgres_timeline.destroy_blob_storage
+      end
+
+      it "completes the policy teardown when the user is already gone" do
+        gone = Aws::IAM::Errors::NoSuchEntity.new(nil, "NoSuchEntity")
+        expect(iam_client).to receive(:list_access_keys).and_raise(gone)
+        expect(iam_client).to receive(:list_attached_user_policies).and_raise(gone)
+        expect(iam_client).to receive(:delete_user).and_raise(gone)
+
+        expect(iam_client).to receive(:delete_policy).with(policy_arn:)
+
+        postgres_timeline.destroy_blob_storage
+      end
+
+      it "tolerates a policy that is already gone" do
+        gone = Aws::IAM::Errors::NoSuchEntity.new(nil, "NoSuchEntity")
+        expect(iam_client).to receive(:list_entities_for_policy).and_raise(gone)
+        expect(iam_client).to receive(:delete_policy).and_raise(gone)
+
+        postgres_timeline.destroy_blob_storage
+      end
+
+      it "treats a missing bucket as already deleted" do
+        s3_client.stub_responses(:list_objects_v2, "NoSuchBucket")
+
+        expect(iam_client).to receive(:delete_policy).with(policy_arn:)
+
+        postgres_timeline.destroy_blob_storage
+      end
+
+      it "re-empties and retries a bucket that briefly reports BucketNotEmpty" do
+        s3_client.stub_responses(:delete_bucket, "BucketNotEmpty", {})
+
+        expect(s3_client).to receive(:delete_bucket).twice.and_call_original
+        expect(iam_client).to receive(:delete_policy).with(policy_arn:)
+
+        postgres_timeline.destroy_blob_storage
+      end
+
+      it "gives up on a bucket that never empties, after a bounded number of tries" do
+        s3_client.stub_responses(:delete_bucket, "BucketNotEmpty")
+
+        expect(s3_client).to receive(:delete_bucket).exactly(PostgresTimeline::Aws::AWS_BUCKET_DELETE_ATTEMPTS).times.and_call_original
+
+        expect { postgres_timeline.destroy_blob_storage }.to raise_error(Aws::S3::Errors::BucketNotEmpty)
+      end
+    end
   end
 
   describe "minio" do

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -223,42 +223,6 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       postgres_timeline.setup_blob_storage
     end
 
-    it "destroys AWS S3 blob storage when aws_postgres_iam_access configured" do
-      expect(Config).to receive(:aws_postgres_iam_access).and_return(true)
-      aws_location = create_aws_location
-      postgres_timeline.update(location_id: aws_location.id)
-
-      s3_client = Aws::S3::Client.new(stub_responses: true)
-      s3_client.stub_responses(:list_objects_v2, {contents: []})
-      s3_client.stub_responses(:delete_bucket)
-      allow(postgres_timeline).to receive(:blob_storage_client).and_return(s3_client)
-
-      iam_client = Aws::IAM::Client.new(stub_responses: true)
-      expect(postgres_timeline.location.location_credential_aws).to receive(:iam_client).and_return(iam_client).at_least(:once)
-      expect(postgres_timeline.location.location_credential_aws).to receive(:aws_iam_account_id).and_return("123456789012")
-
-      expect(iam_client).to receive(:delete_policy).with(policy_arn: "arn:aws:iam::123456789012:policy/#{postgres_timeline.ubid}")
-
-      postgres_timeline.destroy_blob_storage
-    end
-
-    it "destroy_blob_storage ignores NoSuchEntity error" do
-      aws_location = create_aws_location
-      postgres_timeline.update(location_id: aws_location.id)
-
-      s3_client = Aws::S3::Client.new(stub_responses: true)
-      s3_client.stub_responses(:list_objects_v2, {contents: []})
-      s3_client.stub_responses(:delete_bucket)
-      allow(postgres_timeline).to receive(:blob_storage_client).and_return(s3_client)
-
-      iam_client = Aws::IAM::Client.new(stub_responses: true)
-      expect(postgres_timeline.location.location_credential_aws).to receive(:iam_client).and_return(iam_client).at_least(:once)
-
-      expect(iam_client).to receive(:list_attached_user_policies).and_raise(Aws::IAM::Errors::NoSuchEntity.new(nil, "NoSuchEntity"))
-
-      postgres_timeline.destroy_blob_storage
-    end
-
     it "naps if aws and the key is not available" do
       aws_location = create_aws_location
       postgres_timeline.update(location_id: aws_location.id, access_key: "not-access-key")
@@ -536,39 +500,26 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
 
     describe "when blob storage is aws s3" do
       let(:aws_location) { create_aws_location }
-      let(:iam_client) { Aws::IAM::Client.new(stub_responses: true) }
+      let(:s3_client) { Aws::S3::Client.new(stub_responses: true) }
 
       before do
         postgres_timeline.update(location_id: aws_location.id)
+        allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
+        allow(Aws::IAM::Client).to receive(:new).and_return(Aws::IAM::Client.new(stub_responses: true))
+        sts_client = Aws::STS::Client.new(stub_responses: true)
+        sts_client.stub_responses(:get_caller_identity, account: "123456789012")
+        allow(Aws::STS::Client).to receive(:new).and_return(sts_client)
       end
 
       it "empties and deletes the bucket, then destroys blob storage and timeline" do
-        s3_client = Aws::S3::Client.new(stub_responses: true)
         s3_client.stub_responses(:list_objects_v2, {contents: [{key: "basebackups_005/backup"}]}, {contents: []})
-        s3_client.stub_responses(:delete_objects)
-        s3_client.stub_responses(:delete_bucket)
-        allow(nx.postgres_timeline).to receive(:blob_storage_client).and_return(s3_client)
-
-        iam_client.stub_responses(:delete_user)
-        iam_client.stub_responses(:list_attached_user_policies, attached_policies: [{policy_arn: "arn:aws:iam::aws:policy/AmazonS3FullAccess"}])
-        iam_client.stub_responses(:delete_policy)
-        iam_client.stub_responses(:list_access_keys, access_key_metadata: [{access_key_id: "access-key"}])
-        iam_client.stub_responses(:delete_access_key)
-        expect(nx.postgres_timeline.location.location_credential_aws).to receive(:iam_client).and_return(iam_client).at_least(:once)
 
         expect { nx.destroy }.to exit({"msg" => "postgres timeline is deleted"})
         expect(postgres_timeline).not_to exist
       end
 
       it "ignores a missing bucket (NoSuchBucket) during teardown" do
-        s3_client = Aws::S3::Client.new(stub_responses: true)
         s3_client.stub_responses(:list_objects_v2, "NoSuchBucket")
-        allow(nx.postgres_timeline).to receive(:blob_storage_client).and_return(s3_client)
-
-        iam_client.stub_responses(:delete_user)
-        iam_client.stub_responses(:list_attached_user_policies, attached_policies: [])
-        iam_client.stub_responses(:list_access_keys, access_key_metadata: [])
-        expect(nx.postgres_timeline.location.location_credential_aws).to receive(:iam_client).and_return(iam_client).at_least(:once)
 
         expect { nx.destroy }.to exit({"msg" => "postgres timeline is deleted"})
         expect(postgres_timeline).not_to exist


### PR DESCRIPTION
`aws_destroy_blob_storage` had three bugs that leaked or wedged on teardown:

1. It branched on the **live** `Config.aws_postgres_iam_access`, so a config
   flip between create and destroy tore down the wrong half and orphaned the
   other (consistent with the observed ~1,005 users vs ~843 policies).
2. A single method-wide `rescue NoSuchEntity` meant one already-deleted key or
   user abandoned every remaining IAM deletion, deleting the DB row while the
   rest leaked permanently.
3. An unrescued `BucketNotEmpty` (and `DeleteConflict` on the policy) raised
   out of the destroy strand's transaction, rolling back the row delete and
   retrying forever.

## Fix

Make the teardown **existence-driven and mode-agnostic** -- it removes whatever
is actually present rather than what the live config says should be, which
makes the config-flip bug structurally impossible with no persisted mode flag
and no schema change:

- Empty and delete the bucket, with a bounded retry for the transient
  `BucketNotEmpty` race; `NoSuchBucket` stays non-fatal.
- Tear down the user (access keys, attached policies, the user itself), then
  the policy -- detaching it from every remaining holder first (server roles,
  in iam-access mode) so `DeleteConflict` cannot fire.
- Each call tolerates only its **own** entity being already gone, so no partial
  state strands the rest. No method-wide rescue, no `Config` branch.

The clean-path AWS calls are equivalent to before plus the added
detach-before-delete-policy, so the `destroy` label and the self-destruct path
are untouched.

## Tests

An 8-case partial-state matrix in the model spec: full user+policy teardown,
iam-access role-attached policy, detach-from-all-holders, user already gone,
policy already gone, missing bucket, bounded BucketNotEmpty retry, and
persistent BucketNotEmpty. `cberp` green (100% line + branch), rubocop clean.

Scoped per the spec: no `resource_id` ownership migration and no change to the
resource/server destroy flow -- the tag-driven sweep (separate PR) is the
backstop for the orphan/backlog side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
