### PR TITLE
Protect large disks in protected locations using score

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -237,6 +237,7 @@ module Config
   override :allocator_target_premium_host_utilization, 0.85, float
   override :allocator_max_random_score, 0.1, float
   override :allocator_large_storage_device_gib, 4096, int
+  override :allocator_protected_large_storage_location_ids, "caa7a807-36c5-8420-a75c-f906839dad71", array(uuid)
 
   # e2e
   override :e2e_hetzner_server_id, nil, string

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -108,8 +108,6 @@ module Scheduling::Allocator
       Location[location_filter.first].provider == "ubicloud"
     end
 
-    # True if the request has a volume large enough to require a large storage
-    # device (>= the reserved-device threshold).
     def needs_large_storage_device?
       storage_volumes.any? { |_, v| v["size_gib"] >= Config.allocator_large_storage_device_gib }
     end
@@ -197,9 +195,6 @@ module Scheduling::Allocator
               .select_append { sum(total_storage_gib).as(total_storage_gib) }
               .select_append { json_agg(json_build_object(Sequel.lit("'id'"), Sequel[:storage_device][:id], Sequel.lit("'total_storage_gib'"), total_storage_gib, Sequel.lit("'available_storage_gib'"), available_storage_gib)).order(available_storage_gib).as(storage_devices) }
               .where(enabled: true)
-              # TEMPORARY: protect scarce 4TB disk resources. A request that doesn't need a large disk
-              # may not use storage devices with >= allocator_large_storage_device_gib available.
-              .where { request.needs_large_storage_device? || (available_storage_gib < Config.allocator_large_storage_device_gib) }
               .having { sum(available_storage_gib) >= request.storage_gib }
               .having { count.function.* >= (request.distinct_storage_devices ? request.storage_volumes.count : 1) })
             .with(:gpus, DB[:pci_device]
@@ -424,10 +419,23 @@ module Scheduling::Allocator
       # penalty of 5 if host has a GPU but VM doesn't require a GPU
       score += 5 unless @request.gpu_count > 0 || @candidate_host[:num_gpus] == 0
 
+      # penalty of 5 for breaking up protected large storage devices
+      score += 5 if breaks_up_protected_large_storage_device?
+
       # penalty of 10 if location preference is not honored
       score += 10 unless @request.location_preference.empty? || @request.location_preference.include?(@candidate_host[:location_id])
 
       score
+    end
+
+    def breaks_up_protected_large_storage_device?
+      large = Config.allocator_large_storage_device_gib
+      storage_allocation = @device_allocations.first
+
+      Config.allocator_protected_large_storage_location_ids.include?(@candidate_host[:location_id]) &&
+        @candidate_host[:storage_devices].any? { it["available_storage_gib"] >= large } &&
+        !@request.needs_large_storage_device? &&
+        storage_allocation.reduces_large_device_multiples?
     end
   end
 
@@ -702,6 +710,18 @@ module Scheduling::Allocator
 
     def utilization
       1 - (@candidate_host[:available_storage_gib] - @request.storage_gib).fdiv(@candidate_host[:total_storage_gib])
+    end
+
+    def reduces_large_device_multiples?
+      return false unless @storage_device_allocations
+
+      large = Config.allocator_large_storage_device_gib
+
+      @storage_device_allocations.any? do |dev|
+        available_before = dev.available_storage_gib + dev.allocated_storage_gib
+        next false if available_before < large
+        (dev.available_storage_gib / large).floor < (available_before / large).floor
+      end
     end
 
     def self.allocate_spdk_installation(spdk_installations)

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -199,45 +199,13 @@ RSpec.describe Scheduling::Allocator do
                  family: "standard"}])
     end
 
-    it "reserves large-available storage devices: a small request cannot use a device with >= threshold available" do
+    it "does not filter out storage devices with >= threshold available for a small request" do
       large = Config.allocator_large_storage_device_gib
       vmh = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
       Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
       StorageDevice.create(vm_host_id: vmh.id, name: "big", available_storage_gib: large, total_storage_gib: large)
       BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
-
-      expect(Al::Allocation.candidate_hosts(req)).to eq([])
-    end
-
-    it "lets a small request use a device with less than the threshold available" do
-      large = Config.allocator_large_storage_device_gib
-      vmh = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
-      StorageDevice.create(vm_host_id: vmh.id, name: "medium", available_storage_gib: large - 1, total_storage_gib: large)
-      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
-
-      expect(Al::Allocation.candidate_hosts(req).map { it[:vm_host_id] }).to eq([vmh.id])
-    end
-
-    it "lets a small request use a host with two sub-threshold devices totaling more than the threshold" do
-      large = Config.allocator_large_storage_device_gib
-      vmh = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
-      StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: large - 1, total_storage_gib: large - 1)
-      StorageDevice.create(vm_host_id: vmh.id, name: "stor2", available_storage_gib: large - 1, total_storage_gib: large - 1)
-      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
-
-      expect(Al::Allocation.candidate_hosts(req).map { it[:vm_host_id] }).to eq([vmh.id])
-    end
-
-    it "lets a request that needs a large device use a device with >= threshold available" do
-      large = Config.allocator_large_storage_device_gib
-      vmh = create_vm_host(total_cpus: 14, total_cores: 7, used_cores: 3, total_hugepages_1g: 10, used_hugepages_1g: 2)
-      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: vmh.id)
-      StorageDevice.create(vm_host_id: vmh.id, name: "big", available_storage_gib: large, total_storage_gib: large)
-      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
-      req.storage_gib = large
-      req.storage_volumes = [[0, {"use_bdev_ubi" => false, "size_gib" => large, "boot" => true}]]
+      req.location_filter = [Location::HETZNER_FSN1_ID]
 
       expect(Al::Allocation.candidate_hosts(req).map { it[:vm_host_id] }).to eq([vmh.id])
     end
@@ -624,6 +592,50 @@ RSpec.describe Scheduling::Allocator do
       expect(Al::Allocation.new(vmhds, req).score).to eq(5.0)
     end
 
+    it "penalizes breaking up a large storage device in a protected location" do
+      large = Config.allocator_large_storage_device_gib
+      vmhds[:location_id] = Config.allocator_protected_large_storage_location_ids.first
+      vmhds[:storage_devices] = [{"available_storage_gib" => 10, "id" => "sd1id", "total_storage_gib" => 10},
+        {"available_storage_gib" => large, "id" => "sd2id", "total_storage_gib" => large}]
+      vmhds[:available_storage_gib] = large + 10
+      vmhds[:total_storage_gib] = large + 10
+
+      score_protected = Al::Allocation.new(vmhds, req).score
+
+      vmhds[:location_id] = Location::HETZNER_HEL1_ID
+      score_unprotected = Al::Allocation.new(vmhds, req).score
+
+      expect(score_protected - score_unprotected).to be_within(0.0001).of(5)
+    end
+
+    it "does not penalize an allocation that keeps the large storage device's whole multiples intact" do
+      large = Config.allocator_large_storage_device_gib
+      vmhds[:location_id] = Config.allocator_protected_large_storage_location_ids.first
+      vmhds[:storage_devices] = [{"available_storage_gib" => 2 * large + 100, "id" => "sd1id", "total_storage_gib" => 2 * large + 100}]
+      vmhds[:available_storage_gib] = 2 * large + 100
+      vmhds[:total_storage_gib] = 2 * large + 100
+
+      score_protected = Al::Allocation.new(vmhds, req).score
+
+      vmhds[:location_id] = Location::HETZNER_HEL1_ID
+      expect(score_protected).to be_within(0.0001).of(Al::Allocation.new(vmhds, req).score)
+    end
+
+    it "does not penalize a request that needs a large storage device" do
+      large = Config.allocator_large_storage_device_gib
+      vmhds[:location_id] = Config.allocator_protected_large_storage_location_ids.first
+      vmhds[:storage_devices] = [{"available_storage_gib" => 2 * large, "id" => "sd1id", "total_storage_gib" => 2 * large}]
+      vmhds[:available_storage_gib] = 2 * large
+      vmhds[:total_storage_gib] = 2 * large
+      req.storage_gib = large
+      req.storage_volumes = [[0, {"use_bdev_ubi" => false, "size_gib" => large, "boot" => true}]]
+
+      score_protected = Al::Allocation.new(vmhds, req).score
+
+      vmhds[:location_id] = Location::HETZNER_HEL1_ID
+      expect(score_protected).to be_within(0.0001).of(Al::Allocation.new(vmhds, req).score)
+    end
+
     it "penalizes concurrent provisioning for github runners" do
       expect(Al::VmHostCpuAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization, true))
       expect(Al::VmHostAllocation).to receive(:new).and_return(TestResourceAllocation.new(req.target_host_utilization, true))
@@ -738,6 +750,13 @@ RSpec.describe Scheduling::Allocator do
       req.storage_gib = 10000
       storage_allocation = Al::StorageAllocation.new(vmhds, req)
       expect(storage_allocation.is_valid).to be_falsey
+    end
+
+    it "reduces_large_device_multiples? is false when volumes were never mapped to devices" do
+      req.storage_gib = 10000
+      storage_allocation = Al::StorageAllocation.new(vmhds, req)
+      expect(storage_allocation.is_valid).to be_falsey
+      expect(storage_allocation.reduces_large_device_multiples?).to be false
     end
 
     it "fails if distinct devices are requested but not available" do


### PR DESCRIPTION
This change removes the hard filter for small requests on large storage
devices and instead uses the allocator's scoring system to avoid having
small storage requests eating away at large available storage blocks. It
allows configuring both the 'large storage block' threshold (currently
4TB) and the areas in which these large storage blocks are protected
(currently only FSN1).

With this change, Github Runners can still spill over to FSN1 if their
intended location is full. When spillover happens, this change causes
the allocator to prefer placements that do not reduce the number of free
4TB blocks (in practice currently at most 1) on the disk.

For example, if there are two hosts, one with 4TB of free disk space,
and another with 5TB of free disk space, and a request of ≤1TB, the
allocator will place it on the host with 5TB of free diskspace, because
it does not reduce the number of free large (4TB) blocks.