### PR TITLE
Dynamic reservation in csi

### DIFF
--- a/kubernetes/csi/Gemfile.lock
+++ b/kubernetes/csi/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ubi-csi (0.11.0)
+    ubi-csi (0.12.0)
       base64
       grpc (= 1.83.0)
       grpc-tools (= 1.83.0)

--- a/kubernetes/csi/Gemfile.lock
+++ b/kubernetes/csi/Gemfile.lock
@@ -3,8 +3,8 @@ PATH
   specs:
     ubi-csi (0.11.0)
       base64
-      grpc (= 1.78.1)
-      grpc-tools (= 1.78.1)
+      grpc (= 1.83.0)
+      grpc-tools (= 1.83.0)
       logger
 
 GEM
@@ -12,32 +12,32 @@ GEM
   specs:
     ansi (1.6.0)
     base64 (0.3.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     diff-lcs (1.6.2)
     docile (1.4.1)
-    google-protobuf (4.34.1-aarch64-linux-gnu)
+    google-protobuf (4.35.1-aarch64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.34.1-arm64-darwin)
+    google-protobuf (4.35.1-arm64-darwin)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.34.1-x86_64-linux-gnu)
+    google-protobuf (4.35.1-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos-types (1.22.0)
+    googleapis-common-protos-types (1.23.0)
       google-protobuf (~> 4.26)
-    grpc (1.78.1-aarch64-linux-gnu)
+    grpc (1.83.0-aarch64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc (1.78.1-arm64-darwin)
+    grpc (1.83.0-arm64-darwin)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc (1.78.1-x86_64-linux-gnu)
+    grpc (1.83.0-x86_64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-tools (1.78.1)
+    grpc-tools (1.83.0)
     logger (1.7.0)
-    rake (13.3.1)
+    rake (13.4.2)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)

--- a/kubernetes/csi/lib/ubi_csi.rb
+++ b/kubernetes/csi/lib/ubi_csi.rb
@@ -5,7 +5,7 @@ require "csi_pb"
 require "csi_services_pb"
 
 module Csi
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end
 
 require_relative "ubi_csi/identity_service"

--- a/kubernetes/csi/lib/ubi_csi/capacity_manager.rb
+++ b/kubernetes/csi/lib/ubi_csi/capacity_manager.rb
@@ -26,7 +26,8 @@ module Csi
     # overhead (a 10 GiB sparse PV ends up ~11 GiB once written) and
     # any customer ephemeral storage; otherwise full PVs trip
     # DiskPressure and trap themselves on the tainted node.
-    RESERVE_PERCENT = 25
+    # Overridable per deployment via the RESERVE_PERCENT env var.
+    DEFAULT_RESERVE_PERCENT = 20
 
     # Pending reservations expire if the volume never gets staged. This
     # bounds the damage from CreateVolumes that succeed but never have a
@@ -87,9 +88,10 @@ module Csi
       end
     end
 
-    def initialize(logger:, max_volume_size:)
+    def initialize(logger:, max_volume_size:, reserve_percent: DEFAULT_RESERVE_PERCENT)
       @logger = logger
       @max_volume_size = max_volume_size
+      @reserve_percent = reserve_percent
       @pending = {}  # hostname => {vol_id => {size:, created_at:}}
       @known = {}    # hostname => {storage_class => {object_name:, base_capacity:, last_published:}}
       @mutex = Mutex.new
@@ -101,7 +103,7 @@ module Csi
     def start
       @owner_ref = kubernetes_client.get_provisioner_deployment_owner_ref
       spawn_reconcile_thread
-      @logger.info("[CapacityManager] Started capacity manager")
+      @logger.info("[CapacityManager] Started capacity manager (reserve_percent=#{@reserve_percent})")
     end
 
     def shutdown!
@@ -214,7 +216,7 @@ module Csi
     end
 
     def upsert_capacity(client, hostname, storage_class, cap, existing_obj)
-      reserve_bytes = cap[:df_total] * RESERVE_PERCENT / 100
+      reserve_bytes = cap[:df_total] * @reserve_percent / 100
       base_capacity = [cap[:df_avail] - cap[:uncommitted] - reserve_bytes, 0].max
 
       pending_sum = @mutex.synchronize { pending_sum_for(hostname) }

--- a/kubernetes/csi/lib/ubi_csi/controller_service.rb
+++ b/kubernetes/csi/lib/ubi_csi/controller_service.rb
@@ -21,6 +21,14 @@ module Csi
         end
       end
 
+      def reserve_percent
+        @reserve_percent ||= begin
+          percent = Integer(ENV.fetch("RESERVE_PERCENT", CapacityManager::DEFAULT_RESERVE_PERCENT.to_s), 10)
+          raise "RESERVE_PERCENT (#{percent}) must be between 10 and 50" unless (10..50).cover?(percent)
+          percent
+        end
+      end
+
       def initialize(logger:)
         @logger = logger
         @volume_store = {} # Maps volume name to volume details
@@ -35,7 +43,7 @@ module Csi
       end
 
       def start_capacity_manager
-        @capacity_manager = Csi::CapacityManager.new(logger: @logger, max_volume_size:)
+        @capacity_manager = Csi::CapacityManager.new(logger: @logger, max_volume_size:, reserve_percent:)
         @capacity_manager.start
       end
 

--- a/kubernetes/csi/spec/csi/v1/controller_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/controller_service_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Csi::V1::ControllerService do
 
   before do
     allow(Csi::StuckVolumeDetector).to receive(:new).and_return(stuck_volume_detector)
-    expect(Csi::CapacityManager).to receive(:new).and_return(capacity_manager)
-    expect(capacity_manager).to receive(:start)
+    allow(Csi::CapacityManager).to receive(:new).and_return(capacity_manager)
+    allow(capacity_manager).to receive(:start)
   end
 
   describe "#log_with_id" do
@@ -32,6 +32,28 @@ RSpec.describe Csi::V1::ControllerService do
       service.instance_variable_set(:@stuck_volume_detector, nil)
       service.instance_variable_set(:@capacity_manager, nil)
       expect { service.shutdown! }.not_to raise_error
+    end
+  end
+
+  describe "#reserve_percent" do
+    it "defaults to 20 and is passed to the capacity manager" do
+      expect(Csi::CapacityManager).to receive(:new).with(logger:, max_volume_size: 10 * 1024 * 1024 * 1024, reserve_percent: 20).and_return(capacity_manager)
+      expect(service.reserve_percent).to eq(20)
+    end
+
+    it "reads RESERVE_PERCENT from the environment" do
+      ENV["RESERVE_PERCENT"] = "35"
+      expect(Csi::CapacityManager).to receive(:new).with(logger:, max_volume_size: 10 * 1024 * 1024 * 1024, reserve_percent: 35).and_return(capacity_manager)
+      expect(service.reserve_percent).to eq(35)
+    ensure
+      ENV.delete("RESERVE_PERCENT")
+    end
+
+    it "raises when RESERVE_PERCENT is outside 10..50" do
+      ENV["RESERVE_PERCENT"] = "60"
+      expect { service }.to raise_error(RuntimeError, "RESERVE_PERCENT (60) must be between 10 and 50")
+    ensure
+      ENV.delete("RESERVE_PERCENT")
     end
   end
 

--- a/kubernetes/csi/spec/csi/v1/identity_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/identity_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Csi::V1::IdentityService do
       request = Csi::V1::GetPluginInfoRequest.new
       response = service.get_plugin_info(request, call)
       expect(response.name).to eq("csi.ubicloud.com")
-      expect(response.vendor_version).to eq("0.11.0")
+      expect(response.vendor_version).to eq("0.12.0")
     end
   end
 

--- a/kubernetes/csi/spec/ubi_csi/capacity_manager_spec.rb
+++ b/kubernetes/csi/spec/ubi_csi/capacity_manager_spec.rb
@@ -233,8 +233,8 @@ RSpec.describe Csi::CapacityManager do
       ]})
     end
     let(:node_yaml) { YAML.dump({"status" => {"addresses" => [{"address" => "10.0.0.1"}]}}) }
-    # 100 GiB total, 50 GiB available, 10 GiB uncommitted, 25% reserve, no pendings:
-    # base = 50 - 10 - 25 = 15 GiB = 16_106_127_360 bytes.
+    # 100 GiB total, 50 GiB available, 10 GiB uncommitted, default 20% reserve, no pendings:
+    # base = 50 - 10 - 20 = 20 GiB = 21_474_836_480 bytes.
     let(:capacity_output) { "107374182400 53687091200 10737418240\nvol-a\n" }
     let(:create_object) do
       {
@@ -247,7 +247,7 @@ RSpec.describe Csi::CapacityManager do
         },
         "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
         "storageClassName" => "ubicloud-standard",
-        "capacity" => "16106127360",
+        "capacity" => "21474836480",
         "maximumVolumeSize" => "10737418240",
       }
     end
@@ -273,7 +273,24 @@ RSpec.describe Csi::CapacityManager do
 
       manager.reconcile
 
-      expect(manager.instance_variable_get(:@known)["worker-1"]["ubicloud-standard"][:last_published]).to eq(15 * 1024 * 1024 * 1024)
+      expect(manager.instance_variable_get(:@known)["worker-1"]["ubicloud-standard"][:last_published]).to eq(20 * 1024 * 1024 * 1024)
+    end
+
+    it "applies a custom reserve_percent to the capacity math" do
+      # 25% reserve: base = 50 - 10 - 25 = 15 GiB = 16_106_127_360 bytes.
+      custom = described_class.new(logger:, max_volume_size:, reserve_percent: 25)
+      custom.instance_variable_set(:@owner_ref, {"name" => "ubicsi-provisioner"})
+      stub_baseline
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "node", "worker-1", "-oyaml", stdin_data: nil).and_return([node_yaml, success_status])
+      expect(Open3).to receive(:capture2e).with(
+        "ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+        "-o", "LogLevel=ERROR", "-i", "/ssh/id_ed25519", "ubi@10.0.0.1", described_class.capacity_script,
+      ).and_return([capacity_output, success_status])
+      expect(Open3).to receive(:capture2e).with("kubectl", "create", "-f", "-", stdin_data: YAML.dump(create_object.merge("capacity" => "16106127360"))).and_return(["created", success_status])
+
+      custom.reconcile
+
+      expect(custom.instance_variable_get(:@known)["worker-1"]["ubicloud-standard"][:last_published]).to eq(15 * 1024 * 1024 * 1024)
     end
 
     it "patches an existing object when the capacity has changed" do
@@ -292,7 +309,7 @@ RSpec.describe Csi::CapacityManager do
       ).and_return([capacity_output, success_status])
       expect(Open3).to receive(:capture2e).with(
         "kubectl", "-n", "ubicsi", "patch", "csistoragecapacity", "csisc-existing",
-        "--type=merge", "-p", '{"capacity":"16106127360","maximumVolumeSize":"10737418240"}',
+        "--type=merge", "-p", '{"capacity":"21474836480","maximumVolumeSize":"10737418240"}',
         stdin_data: nil,
       ).and_return(["patched", success_status])
 
@@ -301,14 +318,14 @@ RSpec.describe Csi::CapacityManager do
 
     it "does not patch when the capacity matches the published value" do
       # kube-apiserver normalizes raw byte counts into resource.Quantity
-      # form on read-back: "16106127360" -> "15Gi", "10737418240" -> "10Gi".
+      # form on read-back: "21474836480" -> "20Gi", "10737418240" -> "10Gi".
       # parse_quantity has to handle that round-trip or we'd patch every
       # reconcile (or worse, crash on Integer()).
       existing = [{
         "metadata" => {"name" => "csisc-existing"},
         "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
         "storageClassName" => "ubicloud-standard",
-        "capacity" => "15Gi",
+        "capacity" => "20Gi",
         "maximumVolumeSize" => "10Gi",
       }]
       stub_baseline(existing:)
@@ -337,7 +354,7 @@ RSpec.describe Csi::CapacityManager do
           "metadata" => {"name" => "csisc-keep"},
           "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
           "storageClassName" => "ubicloud-standard",
-          "capacity" => "15Gi",
+          "capacity" => "20Gi",
           "maximumVolumeSize" => "10Gi",
         },
       ]

--- a/kubernetes/csi/ubi-csi.gemspec
+++ b/kubernetes/csi/ubi-csi.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "ubi-csi"
-  spec.version = "0.11.0"
+  spec.version = "0.12.0"
   spec.authors = ["Ubicloud"]
   spec.email = ["support@ubicloud.com"]
 

--- a/kubernetes/csi/ubi-csi.gemspec
+++ b/kubernetes/csi/ubi-csi.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "base64"
   spec.add_dependency "logger"
-  spec.add_dependency "grpc", "1.78.1"
-  spec.add_dependency "grpc-tools", "1.78.1"
+  spec.add_dependency "grpc", "1.83.0"
+  spec.add_dependency "grpc-tools", "1.83.0"
 
   spec.add_development_dependency "rspec", "~> 3.12"
   spec.add_development_dependency "simplecov", "~> 0.22"

--- a/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:v0.11.0
+          image: ubicloud/ubicsi:v0.12.0
           imagePullPolicy: IfNotPresent
           args: ["node"]
           env:

--- a/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:v0.11.0
+          image: ubicloud/ubicsi:v0.12.0
           imagePullPolicy: IfNotPresent
           args: ["controller"]
           env:


### PR DESCRIPTION
**Make CSI capacity reserve percent configurable, default 20%**
Read RESERVE_PERCENT from the environment in ControllerService, following the DISK_LIMIT_GB pattern, validate it to 10..50, and thread it into CapacityManager. Lower the default from 25 to 20.

**Bump grpc and grpc-tools versions in Ubicsi**

**Bump Ubicsi to v0.12.0**