### PR TITLE
Eagerly load Aws::EC2::Client in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,9 @@ require "logger"
 require "sequel/core"
 require "webmock/rspec"
 
+require "aws-sdk-ec2"
+Aws::EC2.const_get(:Client)
+
 RSpec::Matchers.define_negated_matcher :not_change, :change
 
 def Object.method_added(method)


### PR DESCRIPTION
aws-sdk-ec2 sets up Aws::EC2::Client as an autoload, and resolving it pulls in the 27k-line client_api.rb. When the first reference happens deep inside an example's call stack, compiling that file can exhaust the VM stack and raise SystemStackError, failing whichever spec happened to touch the constant first under random ordering. Load it at boot instead, where the stack is shallow.