### PR TITLE
Finish AWS VPC destroy when vpc_id was never set

### DIFF
--- a/prog/vnet/aws/vpc_nexus.rb
+++ b/prog/vnet/aws/vpc_nexus.rb
@@ -254,6 +254,8 @@ class Prog::Vnet::Aws::VpcNexus < Prog::Base
   end
 
   label def delete_vpc
+    hop_finish unless private_subnet_aws_resource.vpc_id
+
     begin
       client.delete_vpc({vpc_id: private_subnet_aws_resource.vpc_id})
     rescue Aws::EC2::Errors::DependencyViolation => e

--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -502,6 +502,12 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
         expect { nx.delete_vpc }.to hop("finish")
       end
 
+      it "hops without calling AWS when vpc was never created" do
+        aws_resource.update(vpc_id: nil)
+        expect(client).not_to receive(:delete_vpc)
+        expect { nx.delete_vpc }.to hop("finish")
+      end
+
       it "raises DependencyViolation for strand retry" do
         client.stub_responses(:delete_vpc, Aws::EC2::Errors::DependencyViolation.new(nil, "VPC has dependencies"))
         expect(Clog).to receive(:emit).with("VPC has dependencies, retrying subnet cleanup", instance_of(Hash)).and_call_original


### PR DESCRIPTION
A PrivateSubnet destroyed before Prog::Vnet::Aws::VpcNexus#start ran (e.g. its owning resource was torn down early) never gets a vpc_id: the PrivateSubnetAwsResource row is created empty in SubnetNexus.assemble and only populated in #start. before_run hops straight to destroy, which flows through to delete_vpc with a nil vpc_id.

Unlike the sibling delete labels, delete_vpc was not guarded, so client.delete_vpc(vpc_id: nil) raised an uncaught ArgumentError on every run, the strand never reached finish, and the destroy deadline expired into an operator page.

Short-circuit to finish when vpc_id is nil, since nothing was ever created in AWS.