### PR TITLE
Sweep leaked GCS buckets and service accounts on GCP

### DIFF
--- a/.github/actions/gcp-cleanup-e2e/cleanup.rb
+++ b/.github/actions/gcp-cleanup-e2e/cleanup.rb
@@ -244,6 +244,9 @@ STALE_AFTER = Integer(ENV["STALE_AFTER"] || 6 * 60 * 60)
 SWEEP_CAP = Integer(ENV["SWEEP_CAP"] || 150)
 TAG_CAP_WARN = 800
 UBID_NAME = /\A(?:vm|pv|nc)[0-9a-z]{20,}\z/
+# A postgres timeline's GCS bucket is named for the timeline ubid, and so is
+# its service account once the pg-tl- names are retired.
+TIMELINE_UBID = /\Apt[0-9a-z]{20,}\z/
 
 require "json"
 require "time"
@@ -263,6 +266,15 @@ end
 
 def pick_stale(items, time_key)
   items.select { |i| stale?(i[time_key]) }.sort_by { |i| i[time_key] }.first(SWEEP_CAP)
+end
+
+# A service account carries no creation time, so age it by its oldest
+# user-managed key -- minted at timeline setup, right after the bucket. An
+# account still mid-setup has no user key yet, so this returns nil and the
+# caller leaves it alone rather than deleting a live timeline's account.
+def sa_oldest_key_time(email)
+  gcloud_json("iam", "service-accounts", "keys", "list", "--iam-account=#{email}", "--managed-by=user")
+    .filter_map { |k| k["validAfterTime"] }.min
 end
 
 sweep = []
@@ -330,6 +342,29 @@ pick_stale(
   sweep << {desc: "Sweeping stale VPC #{n["name"]}",
             args: ["compute", "networks", "delete", n["name"], "--project=#{PROJECT}"]}
 end
+
+# Postgres timelines leave a GCS bucket and a service account behind; the
+# log-grep phase clears a live run's, but a run whose cleanup died leaks them
+# and nothing above reclaims those. The bucket ages on its creation time
+# directly; the account has none, so it ages on its oldest key (above), which
+# also keeps a still-provisioning account -- created before its key -- safe.
+pick_stale(
+  gcloud_json("storage", "buckets", "list", "--project=#{PROJECT}")
+    .select { |b| b["name"].to_s.match?(TIMELINE_UBID) }, "creation_time",
+).each do |b|
+  sweep << {desc: "Sweeping stale bucket gs://#{b["name"]}",
+            args: ["storage", "rm", "-r", "gs://#{b["name"]}", "--project=#{PROJECT}"]}
+end
+
+gcloud_json("iam", "service-accounts", "list", "--project=#{PROJECT}")
+  .filter_map { |s| s["email"] }
+  .select { |e| e.split("@").first.match?(/\A(?:pt[0-9a-z]|pg-tl-)/) }
+  .select { |e| stale?(sa_oldest_key_time(e)) }
+  .first(SWEEP_CAP)
+  .each do |email|
+    sweep << {desc: "Sweeping stale service account #{email}",
+              args: ["iam", "service-accounts", "delete", email, "--project=#{PROJECT}"]}
+  end
 
 if sweep.empty?
   puts "No stale resources to sweep"

--- a/model/postgres/gcp/postgres_server.rb
+++ b/model/postgres/gcp/postgres_server.rb
@@ -25,7 +25,11 @@ class PostgresServer < Sequel::Model
       return if timeline.access_key # service account already exists for this timeline
 
       credential = resource.location.location_credential_gcp
-      service_account_name = "pg-tl-#{timeline.ubid[0..7]}"
+      # Name the account for the timeline ubid, like its bucket. The ubid is 26
+      # chars, within GCP's 30-char account id limit, so no truncation and no
+      # prefix -- which also keeps two timelines sharing a ubid prefix from
+      # colliding on one account.
+      service_account_name = timeline.ubid
       service_account_email = "#{service_account_name}@#{credential.project_id}.iam.gserviceaccount.com"
       begin
         service_account = credential.iam_client.get_project_service_account("projects/#{credential.project_id}/serviceAccounts/#{service_account_email}")

--- a/spec/model/postgres/gcp/postgres_server_spec.rb
+++ b/spec/model/postgres/gcp/postgres_server_spec.rb
@@ -135,9 +135,9 @@ RSpec.describe PostgresServer do
       it "creates SA, ensures bucket exists, binds to bucket IAM, generates key, and stores in timeline" do
         timeline.update(access_key: nil, secret_key: nil)
 
-        sa_resource_name = "projects/test-project/serviceAccounts/pg-tl-abcd1234@test-project.iam.gserviceaccount.com"
+        sa_resource_name = "projects/test-project/serviceAccounts/#{timeline.ubid}@test-project.iam.gserviceaccount.com"
         sa = instance_double(Google::Apis::IamV1::ServiceAccount,
-          email: "pg-tl-abcd1234@test-project.iam.gserviceaccount.com",
+          email: "#{timeline.ubid}@test-project.iam.gserviceaccount.com",
           name: sa_resource_name)
         key = instance_double(Google::Apis::IamV1::ServiceAccountKey,
           private_key_data: '{"type":"service_account","private_key":"pk"}'.b)
@@ -153,10 +153,11 @@ RSpec.describe PostgresServer do
           "projects/test-project",
           an_instance_of(Google::Apis::IamV1::CreateServiceAccountRequest),
         ) do |_, req|
+          expect(req.account_id).to eq(timeline.ubid)
           expect(req.service_account.description).to include("[Ubicloud=4242]")
           sa
         end
-        expect(Clog).to receive(:emit).with("GCP service account created", hash_including(gcp_service_account_created: "pg-tl-abcd1234@test-project.iam.gserviceaccount.com")).and_call_original
+        expect(Clog).to receive(:emit).with("GCP service account created", hash_including(gcp_service_account_created: "#{timeline.ubid}@test-project.iam.gserviceaccount.com")).and_call_original
 
         # Fresh service accounts return a Policy with bindings unset (nil),
         # not an empty array. Exercise that path so the || [] fallback is tested.
@@ -182,7 +183,7 @@ RSpec.describe PostgresServer do
         expect(policy).to receive(:bindings).and_return(bindings)
         expect(bindings).to receive(:insert).with(
           role: "roles/storage.objectAdmin",
-          members: ["serviceAccount:pg-tl-abcd1234@test-project.iam.gserviceaccount.com"],
+          members: ["serviceAccount:#{timeline.ubid}@test-project.iam.gserviceaccount.com"],
         )
         expect(bucket).to receive(:policy=).with(policy)
 
@@ -193,7 +194,7 @@ RSpec.describe PostgresServer do
         postgres_server.attach_s3_policy_if_needed
 
         timeline.reload
-        expect(timeline.access_key).to eq("pg-tl-abcd1234@test-project.iam.gserviceaccount.com")
+        expect(timeline.access_key).to eq("#{timeline.ubid}@test-project.iam.gserviceaccount.com")
         expect(timeline.secret_key).to eq('{"type":"service_account","private_key":"pk"}')
       end
 
@@ -213,9 +214,9 @@ RSpec.describe PostgresServer do
       it "uses existing SA when get_project_service_account succeeds" do
         timeline.update(access_key: nil, secret_key: nil)
 
-        sa_resource_name = "projects/test-project/serviceAccounts/pg-tl-abcd1234@test-project.iam.gserviceaccount.com"
+        sa_resource_name = "projects/test-project/serviceAccounts/#{timeline.ubid}@test-project.iam.gserviceaccount.com"
         sa = instance_double(Google::Apis::IamV1::ServiceAccount,
-          email: "pg-tl-abcd1234@test-project.iam.gserviceaccount.com",
+          email: "#{timeline.ubid}@test-project.iam.gserviceaccount.com",
           name: sa_resource_name)
         key = instance_double(Google::Apis::IamV1::ServiceAccountKey,
           private_key_data: '{"type":"service_account","private_key":"pk"}'.b)
@@ -227,7 +228,7 @@ RSpec.describe PostgresServer do
         expect(iam_client).not_to receive(:create_service_account)
         # Even on the existing-SA path, emit the email so a partial-restart
         # caller surfaces the name to e2e cleanup's grep.
-        expect(Clog).to receive(:emit).with("GCP service account created", hash_including(gcp_service_account_created: "pg-tl-abcd1234@test-project.iam.gserviceaccount.com")).and_call_original
+        expect(Clog).to receive(:emit).with("GCP service account created", hash_including(gcp_service_account_created: "#{timeline.ubid}@test-project.iam.gserviceaccount.com")).and_call_original
 
         empty_policy = Google::Apis::IamV1::Policy.new(bindings: [])
         expect(iam_client).to receive(:get_project_service_account_iam_policy).with(sa_resource_name).and_return(empty_policy)
@@ -248,15 +249,15 @@ RSpec.describe PostgresServer do
         postgres_server.attach_s3_policy_if_needed
 
         timeline.reload
-        expect(timeline.access_key).to eq("pg-tl-abcd1234@test-project.iam.gserviceaccount.com")
+        expect(timeline.access_key).to eq("#{timeline.ubid}@test-project.iam.gserviceaccount.com")
       end
 
       it "preserves existing bindings on SA IAM policy and does not duplicate members" do
         timeline.update(access_key: nil, secret_key: nil)
 
-        sa_resource_name = "projects/test-project/serviceAccounts/pg-tl-abcd1234@test-project.iam.gserviceaccount.com"
+        sa_resource_name = "projects/test-project/serviceAccounts/#{timeline.ubid}@test-project.iam.gserviceaccount.com"
         sa = instance_double(Google::Apis::IamV1::ServiceAccount,
-          email: "pg-tl-abcd1234@test-project.iam.gserviceaccount.com",
+          email: "#{timeline.ubid}@test-project.iam.gserviceaccount.com",
           name: sa_resource_name)
         key = instance_double(Google::Apis::IamV1::ServiceAccountKey,
           private_key_data: '{"type":"service_account","private_key":"pk"}'.b)
@@ -307,9 +308,9 @@ RSpec.describe PostgresServer do
       it "adds member to existing role binding when member is absent" do
         timeline.update(access_key: nil, secret_key: nil)
 
-        sa_resource_name = "projects/test-project/serviceAccounts/pg-tl-abcd1234@test-project.iam.gserviceaccount.com"
+        sa_resource_name = "projects/test-project/serviceAccounts/#{timeline.ubid}@test-project.iam.gserviceaccount.com"
         sa = instance_double(Google::Apis::IamV1::ServiceAccount,
-          email: "pg-tl-abcd1234@test-project.iam.gserviceaccount.com",
+          email: "#{timeline.ubid}@test-project.iam.gserviceaccount.com",
           name: sa_resource_name)
         key = instance_double(Google::Apis::IamV1::ServiceAccountKey,
           private_key_data: '{"type":"service_account","private_key":"pk"}'.b)


### PR DESCRIPTION
The GCP counterpart of the AWS S3/IAM leak. GCP Postgres timelines create a
GCS bucket and a service account; the e2e cleanup's **log-grep phase** deletes
a live run's, but the **stale sweep** -- the backstop for a run whose cleanup
died -- covered only compute, network and tag resources. So a cancelled or
failed run leaks its bucket and service account permanently.

Measured in `ubicloud-e2e` right now: **164 GCS buckets** (all `pt`-named
timeline buckets, median 27 days old, oldest 65) and **~120 `pg-tl-` service
accounts** (past GCP's default 100/project limit).

## Commit 1 — sweep stale buckets + service accounts

Extends the stale sweep to both, matching its existing per-category shape:
- **Buckets** are named for the timeline ubid and carry a creation time, so
  they age directly (`pick_stale` on `creation_time`).
- **Service accounts** carry no creation time, so they age on their **oldest
  user-managed key** -- minted at setup right after the bucket. A still
  provisioning account, created before its key, has no key yet, so it is left
  alone rather than swept mid-setup. Matches both the legacy `pg-tl-` names and
  the bare-ubid names from commit 2.

Validated read-only against `ubicloud-e2e`: it selects all 164 stale buckets
(SWEEP_CAP 150/run drains in two runs) and the keyed stale accounts, correctly
skipping an account that has no key.

## Commit 2 — name the service account for its ubid

The account was `pg-tl-` + the first 8 ubid chars, truncated because the prefix
left no room for the full 26-char ubid under GCP's 30-char account-id limit.
The bare ubid fits, so drop the prefix: the account now matches its bucket, is
fully attributable, and two timelines sharing an 8-char ubid prefix can no
longer collide onto one account.

**Safe for existing accounts:** they are looked up and deleted by the email
stored on the timeline, never by recomputing the name, and the naming path runs
only for a timeline that has no account yet. Only new accounts get the ubid
name; the sweep in commit 1 matches both.

`ruby -w` + rubocop clean; `cberp` green (100% line + branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
