### PR TITLE
Shorten a nap if there is an unnotified deadline

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -193,13 +193,14 @@ SQL
       top_frame.delete("deadline_target")
       top_frame.delete("deadline_at")
       top_frame.delete("deadline_start")
+      top_frame.delete("deadline_notified")
 
       modified!(:stack)
     end
 
     effective_prog = prog
     stack.each do |frame|
-      if (deadline_at = frame["deadline_at"]) && start_time > Time.parse(deadline_at)
+      if (deadline_at = frame["deadline_at"]) && !frame["deadline_notified"] && start_time > Time.parse(deadline_at)
         sbj = subject
         extra_data = case sbj
         when Vm
@@ -218,6 +219,7 @@ SQL
         end
         extra_data.compact!
         Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{effective_prog}.#{label} did not reach #{frame["deadline_target"]} on time", ["Deadline", id, effective_prog, frame["deadline_target"]], ubid, extra_data:)
+        frame["deadline_notified"] = true
         modified!(:stack)
       end
 
@@ -245,10 +247,21 @@ SQL
 
       case prog_action
       when Prog::Base::Nap
-        e = prog_action
         save_changes
+        seconds = prog_action.seconds
+        unless seconds == 0
+          closest_unnotified_deadline = stack.filter_map do |frame|
+            if frame["deadline_at"] && !frame["deadline_notified"]
+              Time.parse(frame["deadline_at"])
+            end
+          end.min
+          if closest_unnotified_deadline
+            deadline_seconds = (closest_unnotified_deadline - Time.now).clamp(0, nil)
+            seconds = seconds.clamp(0, deadline_seconds) + 0.001
+          end
+        end
 
-        scheduled = DB[<<SQL, schedule, e.seconds, id].get
+        scheduled = DB[<<SQL, schedule, seconds, id].get
 UPDATE strand
 SET try = 0,
     schedule = CASE WHEN schedule = ? THEN now() + (? * '1 second'::interval)

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -205,13 +205,14 @@ SQL
       top_frame.delete("deadline_target")
       top_frame.delete("deadline_at")
       top_frame.delete("deadline_start")
+      top_frame.delete("deadline_notified")
 
       modified!(:stack)
     end
 
     effective_prog = prog
     stack.each do |frame|
-      if (deadline_at = frame["deadline_at"]) && start_time > Time.new(deadline_at)
+      if (deadline_at = frame["deadline_at"]) && !frame["deadline_notified"] && start_time > Time.new(deadline_at)
         sbj = subject
         extra_data = case sbj
         when Vm
@@ -230,6 +231,7 @@ SQL
         end
         extra_data.compact!
         Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{effective_prog}.#{label} did not reach #{frame["deadline_target"]} on time", ["Deadline", id, effective_prog, frame["deadline_target"]], ubid, extra_data:)
+        frame["deadline_notified"] = true
         modified!(:stack)
       end
 
@@ -257,15 +259,26 @@ SQL
 
       case prog_action
       when Prog::Base::Nap
-        e = prog_action
         save_changes
+        seconds = prog_action.seconds
+        unless seconds == 0
+          closest_unnotified_deadline = stack.filter_map do |frame|
+            if frame["deadline_at"] && !frame["deadline_notified"]
+              Time.new(frame["deadline_at"])
+            end
+          end.min
+          if closest_unnotified_deadline
+            deadline_seconds = (closest_unnotified_deadline - Time.now).clamp(0, nil)
+            seconds = seconds.clamp(0, deadline_seconds) + 0.001
+          end
+        end
 
         # Compare-and-set with schedule as the optimistic concurrency
         # control key: apply the nap only if schedule still holds the
         # lease-time value. A concurrent wake wrote through
         # SCHEDULE_NO_LATER_THAN_NOW, guaranteed to differ from it, so
         # the wake-up schedule survives the nap.
-        scheduled = DB[<<SQL, schedule, e.seconds, id].get
+        scheduled = DB[<<SQL, schedule, seconds, id].get
 UPDATE strand
 SET try = 0,
     schedule = CASE WHEN schedule = ? THEN now() + (? * '1 second'::interval)

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -143,6 +143,11 @@ class Prog::Test < Prog::Base
     nap 1
   end
 
+  label def nap_with_expired_deadline
+    register_deadline("pusher2", -10)
+    nap(10)
+  end
+
   label def set_expired_deadline
     register_deadline("pusher2", -1)
     hop_pusher1

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -153,6 +153,11 @@ class Prog::Test < Prog::Base
     nap 1
   end
 
+  label def nap_with_expired_deadline
+    register_deadline("pusher2", -10)
+    nap(10)
+  end
+
   label def set_expired_deadline
     register_deadline("pusher2", -1)
     hop_pusher1

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -331,10 +331,32 @@ RSpec.describe Prog::Base do
       expect {
         st.unsynchronized_run
       }.to change { Page.active.count }.from(0).to(1)
+      expect(st.stack.last["deadline_notified"]).to be true
 
+      expect(Prog::PageNexus).not_to receive(:assemble)
       expect {
         st.unsynchronized_run
       }.not_to change { Page.active.count }.from(1)
+    end
+
+    it "automatically shortens nap if there is an unnotified deadline before it" do
+      t = Time.now + 10
+      st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => t.to_s, "deadline_target" => "foo"}])
+      st.unsynchronized_run
+      expect(st.this.get(:schedule)).to be_within(5).of(t)
+    end
+
+    it "uses near the current time for an unnotified deadline in the past" do
+      st = Strand.create(prog: "Test", label: "nap_with_expired_deadline")
+      st.unsynchronized_run
+      expect(st.this.get(:schedule)).to be_within(5).of(Time.now)
+    end
+
+    it "does not automatically shorten nap if there is a notified deadline before it" do
+      t = Time.now + 10
+      st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => t.to_s, "deadline_target" => "foo", "deadline_notified" => true}])
+      st.unsynchronized_run
+      expect(st.this.get(:schedule)).to be_within(5).of(Time.now + 123)
     end
 
     it "resolves the page if the frame is popped" do
@@ -411,6 +433,7 @@ RSpec.describe Prog::Base do
       expect(st.stack.first).to receive(:delete).with("deadline_target")
       expect(st.stack.first).to receive(:delete).with("deadline_at")
       expect(st.stack.first).to receive(:delete).with("deadline_start")
+      expect(st.stack.first).to receive(:delete).with("deadline_notified")
 
       st.unsynchronized_run
     end


### PR DESCRIPTION
Start tracking whether a deadline has been notified using the "deadline_notified" key in each frame. When paging for the deadline, set that it has been notified.

If a strand naps for non-zero seconds, check for a upcoming unnotified deadline, and shorten the nap to just after it. Do not allow backdating the schedule when doing this.

The idea is that you can set a deadline, and even if the strand naps for a year, it will wake it up right after the deadline, so it can page, try again, then actually nap for a year.