### PR TITLE
Set up e2e Hetzner host from rescue mode

### DIFF
--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -3,20 +3,21 @@
 require "excon"
 class Hosting::HetznerApis < Hosting::ProviderApis
   def reimage(hetzner_ssh_public_key: Config.hetzner_ssh_public_key, dist: "Ubuntu 24.04 LTS base")
-    unless hetzner_ssh_public_key
-      raise "hetzner_ssh_public_key is not set"
-    end
-
-    key_data = hetzner_ssh_public_key.split(" ")[1]
-    decoded_data = Base64.decode64(key_data)
-    fingerprint = OpenSSL::Digest::MD5.new(decoded_data).hexdigest
-    formatted_fingerprint = fingerprint.scan(/../).join(":")
+    authorized_key = ssh_key_fingerprint(hetzner_ssh_public_key)
     connection = create_connection
     connection.post(path: "/boot/#{server_id}/linux",
-      body: URI.encode_www_form(dist:, lang: "en", authorized_key: formatted_fingerprint),
+      body: URI.encode_www_form(dist:, lang: "en", authorized_key:),
       expects: 200)
 
     connection.post(path: "/reset/#{server_id}", body: "type=hw", expects: 200)
+    nil
+  end
+
+  # Enables the rescue system for the next boot. A reboot is required afterwards.
+  def enable_rescue(hetzner_ssh_public_key: Config.hetzner_ssh_public_key)
+    create_connection.post(path: "/boot/#{server_id}/rescue",
+      body: URI.encode_www_form(os: "linux", authorized_key: ssh_key_fingerprint(hetzner_ssh_public_key)),
+      expects: 200)
     nil
   end
 
@@ -131,6 +132,15 @@ class Hosting::HetznerApis < Hosting::ProviderApis
   end
 
   private
+
+  def ssh_key_fingerprint(hetzner_ssh_public_key)
+    raise "hetzner_ssh_public_key is not set" unless hetzner_ssh_public_key
+
+    key_data = hetzner_ssh_public_key.split(" ")[1]
+    decoded_data = Base64.decode64(key_data)
+    fingerprint = OpenSSL::Digest::MD5.new(decoded_data).hexdigest
+    fingerprint.scan(/../).join(":")
+  end
 
   def server_id
     @provider.server_identifier

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -46,20 +46,21 @@ class Prog::Test::HetznerServer < Prog::Test::Base
   label def fetch_hostname
     self.hostname = hetzner_api.get_main_ip4
 
-    hop_reimage
+    hop_enable_rescue
   end
 
-  label def reimage
-    hetzner_api.reimage(dist: "Ubuntu 24.04 LTS base")
+  label def enable_rescue
+    hetzner_api.enable_rescue
+    hetzner_api.hardware_reset
 
-    hop_wait_reimage
+    hop_wait_rescue
   end
 
-  label def wait_reimage
+  label def wait_rescue
     begin
-      Util.rootish_ssh(hostname, "root", [Config.hetzner_ssh_private_key], "echo 1")
+      Util.rootish_ssh(hostname, "root", [Config.hetzner_ssh_private_key], '[ "$(hostname)" = "rescue" ]')
     rescue
-      nap 15
+      nap 5
     end
 
     hop_setup_host
@@ -71,6 +72,7 @@ class Prog::Test::HetznerServer < Prog::Test::Base
       provider_name: HostProvider::HETZNER_PROVIDER_NAME,
       server_identifier: server_id,
       default_boot_images:,
+      install_os: true,
     ).subject
     self.vm_host_id = vm_host.id
 
@@ -120,7 +122,7 @@ class Prog::Test::HetznerServer < Prog::Test::Base
   label def verify_storage_files_purged
     sshable = vm_host.sshable
 
-    vm_disks = sshable.cmd("sudo ls -1 /var/storage").split("\n").reject { ["vhost", "images"].include? it }
+    vm_disks = sshable.cmd("sudo ls -1 /var/storage").split("\n").reject { ["vhost", "images", "devices"].include? it }
     fail_test "VM disks not empty: #{vm_disks}" unless vm_disks.empty?
 
     vhost_dir_content = sshable.cmd("sudo ls -1 /var/storage/vhost").split("\n")

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -47,6 +47,23 @@ RSpec.describe Hosting::HetznerApis do
     end
   end
 
+  describe "enable_rescue" do
+    it "can enable the rescue system" do
+      Excon.stub({path: "/boot/123/rescue", method: :post}, {status: 200, body: ""})
+      expect(hetzner_apis.enable_rescue).to be_nil
+    end
+
+    it "raises an error if the ssh key is not set" do
+      expect(Config).to receive(:hetzner_ssh_public_key).and_return(nil)
+      expect { hetzner_apis.enable_rescue }.to raise_error RuntimeError, "hetzner_ssh_public_key is not set"
+    end
+
+    it "raises an error if enabling rescue fails" do
+      Excon.stub({path: "/boot/123/rescue", method: :post}, {status: 400, body: ""})
+      expect { hetzner_apis.enable_rescue }.to raise_error Excon::Error::BadRequest
+    end
+  end
+
   describe "hardware_reset" do
     it "can reset a server" do
       Excon.stub({path: "/reset/123", method: :post, body: "type=hw"}, {status: 200, body: ""})

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -55,36 +55,48 @@ RSpec.describe Prog::Test::HetznerServer do
   describe "#fetch_hostname" do
     it "can fetch hostname" do
       expect(hetzner_api).to receive(:get_main_ip4)
-      expect { hs_test.fetch_hostname }.to hop("reimage")
+      expect { hs_test.fetch_hostname }.to hop("enable_rescue")
     end
   end
 
-  describe "#reimage" do
-    it "can reimage" do
-      expect(hetzner_api).to receive(:reimage).with(dist: "Ubuntu 24.04 LTS base")
-      expect { hs_test.reimage }.to hop("wait_reimage")
+  describe "#enable_rescue" do
+    it "enables rescue mode and triggers a hardware reset" do
+      expect(hetzner_api).to receive(:enable_rescue)
+      expect(hetzner_api).to receive(:hardware_reset)
+      expect { hs_test.enable_rescue }.to hop("wait_rescue")
     end
   end
 
-  describe "#wait_reimage" do
-    it "hops to setup_host if the server is up" do
+  describe "#wait_rescue" do
+    it "hops to setup_host once the server is in rescue mode" do
       session = Net::SSH::Connection::Session.allocate
       expect(Net::SSH).to receive(:start).and_yield(session)
-      expect(session).to receive(:_exec!).with("echo 1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))
-      expect { hs_test.wait_reimage }.to hop("setup_host")
+      expect(session).to receive(:_exec!).with('[ "$(hostname)" = "rescue" ]').and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))
+      expect { hs_test.wait_rescue }.to hop("setup_host")
     end
 
-    it "naps if the server is not up yet" do
+    it "naps if the server is not reachable yet" do
       session = Net::SSH::Connection::Session.allocate
       expect(Net::SSH).to receive(:start).and_yield(session)
       expect(session).to receive(:_exec!).and_raise(RuntimeError, "ssh failed")
-      expect { hs_test.wait_reimage }.to nap(15)
+      expect { hs_test.wait_rescue }.to nap(5)
+    end
+
+    it "naps if the server is up but not in rescue mode yet" do
+      session = Net::SSH::Connection::Session.allocate
+      expect(Net::SSH).to receive(:start).and_yield(session)
+      expect(session).to receive(:_exec!).with('[ "$(hostname)" = "rescue" ]').and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 1))
+      expect { hs_test.wait_rescue }.to nap(5)
     end
   end
 
   describe "#setup_host" do
-    it "hops to wait_setup_host" do
-      expect(Prog::Vm::HostNexus).to receive(:assemble).and_return(vm_host.strand)
+    it "assembles the vm host with install_os and hops to wait_setup_host" do
+      expect(Prog::Vm::HostNexus).to receive(:assemble) do |_hostname, **kwargs|
+        expect(kwargs[:install_os]).to be(true)
+        expect(kwargs[:provider_name]).to eq(HostProvider::HETZNER_PROVIDER_NAME)
+        vm_host.strand
+      end
       expect { hs_test.setup_host }.to hop("wait_setup_host")
     end
   end
@@ -158,19 +170,19 @@ RSpec.describe Prog::Test::HetznerServer do
 
   describe "#verify_storage_files_purged" do
     it "succeeds if /var/storage and /var/storage/vhost are empty" do
-      expect(hs_test.vm_host.sshable).to receive(:_cmd).with("sudo ls -1 /var/storage").and_return("vhost\nimages\n")
+      expect(hs_test.vm_host.sshable).to receive(:_cmd).with("sudo ls -1 /var/storage").and_return("vhost\nimages\ndevices\n")
       expect(hs_test.vm_host.sshable).to receive(:_cmd).with("sudo ls -1 /var/storage/vhost").and_return("")
       expect { hs_test.verify_storage_files_purged }.to hop("verify_slices_purged")
     end
 
     it "fails if /var/storage has disks" do
-      expect(hs_test.vm_host.sshable).to receive(:_cmd).with("sudo ls -1 /var/storage").and_return("vhost\nimages\ndisk1\ndisk2\n")
+      expect(hs_test.vm_host.sshable).to receive(:_cmd).with("sudo ls -1 /var/storage").and_return("vhost\nimages\ndevices\ndisk1\ndisk2\n")
       expect { hs_test.verify_storage_files_purged }.to hop("failed")
       expect(strand.reload.exitval).to eq({"msg" => "VM disks not empty: [\"disk1\", \"disk2\"]"})
     end
 
     it "fails if /var/storage/vhost has files" do
-      expect(hs_test.vm_host.sshable).to receive(:_cmd).with("sudo ls -1 /var/storage").and_return("vhost\nimages\n")
+      expect(hs_test.vm_host.sshable).to receive(:_cmd).with("sudo ls -1 /var/storage").and_return("vhost\nimages\ndevices\n")
       expect(hs_test.vm_host.sshable).to receive(:_cmd).with("sudo ls -1 /var/storage/vhost").and_return("file1\nfile2\n")
       expect { hs_test.verify_storage_files_purged }.to hop("failed")
       expect(strand.reload.exitval).to eq({"msg" => "vhost directory not empty: [\"file1\", \"file2\"]"})


### PR DESCRIPTION
The e2e test provisioned its Vm host with Hetzner's reimage endpoint, which installs the OS directly and diverges from how we provision production hosts. Production boots the server into the rescue system and installs the OS from there.

Make the test mirror production: add an enable_rescue call to HetznerApis that boots the server into the rescue system on the next boot, trigger a hardware reset to enter it, then assemble the Vm host with install_os set so Prog::Hetzner::InstallOs runs installimage and formats the disks. The reimage API method is kept for development use.