### PR TITLE
Show machine image storage limit in UI

### DIFF
--- a/views/machine_image/create.erb
+++ b/views/machine_image/create.erb
@@ -15,7 +15,7 @@ option_tree, option_parents = generate_machine_image_options %>
   form_elements = [
     {name: "name", type: "text", label: "Name", placeholder: "Enter name", required: "required", opening_tag: "<div class='sm:col-span-3'>"},
     {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::Vm.method(:location)},
-    {name: "vm", type: "select", label: "Source VM (stopped)", required: "required", placeholder: "Select a stopped VM", content_generator: ->(_location, vm) { vm[:display_name] }},
+    {name: "vm", type: "select", label: "Source VM (stopped, #{Config.machine_image_max_size_gib}GB or less)", required: "required", placeholder: "Select a stopped VM", content_generator: ->(_location, vm) { vm[:display_name] }},
     {name: "version", type: "text", label: "Version Label", placeholder: "(optional, defaults to timestamp)", opening_tag: "<div class='sm:col-span-3'>"},
     {name: "destroy_source", type: "checkbox", default_unchecked: true, content_generator: ->(_value) { "Destroy source VM after capture" }}
   ]


### PR DESCRIPTION
We explain the limit in the docs, but a reminder in the UI is helpful to users to indicate why a VM they stopped may not be eligible for creating a machine image.