### PR TITLE
Inline code and remove methods from webhook github route

### DIFF
--- a/helpers/webhook_github.rb
+++ b/helpers/webhook_github.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+class Clover
+  def handle_webhook_github_installation(data)
+    installation = GithubInstallation.with_github_installation_id(data.dig("installation", "id"))
+    case data["action"]
+    when "deleted"
+      return {error: {message: "Unregistered installation"}} unless installation
+      return {error: {message: "Inactive project"}} unless installation.project.active?
+
+      Prog::Github::DestroyGithubInstallation.assemble(installation)
+      return {message: "GithubInstallation[#{installation.ubid}] deleted"}
+    end
+
+    {error: {message: "Unhandled installation action"}}
+  end
+
+  def handle_webhook_github_workflow_job(data)
+    unless (installation_id = data.dig("installation", "id")) && (installation = GithubInstallation.with_github_installation_id(installation_id))
+      Clog.emit("Unregistered installation", {unregistered_installation: {installation_id:, repository_name: data.dig("repository", "full_name")}})
+      return {error: {message: "Unregistered installation"}}
+    end
+
+    unless (job = data["workflow_job"])
+      Clog.emit("No workflow_job in the payload", {workflow_job_missing: {installation_id: installation.id, action: data["action"]}})
+      return {error: {message: "No workflow_job in the payload"}}
+    end
+
+    job_labels = job.fetch("labels")
+
+    if (label = job_labels.find { Github.runner_labels.key?(it) })
+      actual_label = label
+    elsif (custom_label = installation.custom_labels_dataset.first(name: job_labels))
+      actual_label = custom_label.name
+      label = custom_label.alias_for
+    end
+
+    repository_name = data["repository"]["full_name"]
+    unless label
+      if data["action"] == "completed"
+        Clog.emit("Unmatched label", {
+          unmatched_label: {
+            repository_name:,
+            labels: job_labels,
+            started_in: Time.new(job["started_at"]) - Time.new(job["created_at"]),
+            completed_in: job["completed_at"] ? (Time.new(job["completed_at"]) - Time.new(job["started_at"])) : nil,
+            conclusion: job["conclusion"],
+          },
+        })
+      end
+      return {error: {message: "Unmatched label"}}
+    end
+
+    if data["action"] == "queued"
+      runner = Prog::Github::GithubRunnerNexus.assemble(
+        installation,
+        repository_name:,
+        label:,
+        actual_label:,
+        default_branch: data["repository"]["default_branch"],
+      ).subject
+
+      return {message: "GithubRunner[#{runner.ubid}] created"}
+    end
+
+    unless (runner_id = job.fetch("runner_id"))
+      return {error: {message: "A workflow_job without runner_id"}}
+    end
+
+    runner = installation.runners_dataset.first(
+      repository_name:,
+      runner_id:,
+    )
+
+    return {error: {message: "Unregistered runner"}} unless runner
+
+    runner.this.update(workflow_job: Sequel.pg_jsonb(job.except("steps")))
+
+    case data["action"]
+    when "in_progress"
+      runner.log_duration("runner_started", Time.new(job["started_at"]) - Time.new(job["created_at"]))
+      {message: "GithubRunner[#{runner.ubid}] picked job #{job.fetch("id")}"}
+    when "completed"
+      runner.incr_destroy
+
+      {message: "GithubRunner[#{runner.ubid}] deleted"}
+    else
+      {error: {message: "Unhandled workflow_job action"}}
+    end
+  end
+end

--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -4,123 +4,22 @@ class Clover
   hash_branch(:webhook_prefix, "github") do |r|
     r.post true do
       body = r.body.read
-      next 401 unless check_signature(r.headers["x-hub-signature-256"], body)
+      next 401 unless (signature = r.headers["x-hub-signature-256"])
+      method, actual_digest = signature.split("=")
+      expected_digest = OpenSSL::HMAC.hexdigest(method, Config.github_app_webhook_secret, body)
+      next 401 unless Rack::Utils.secure_compare(actual_digest, expected_digest)
 
       response.content_type = :json
 
       data = JSON.parse(body)
       case r.headers["x-github-event"]
       when "installation"
-        handle_installation(data)
+        handle_webhook_github_installation(data)
       when "workflow_job"
-        handle_workflow_job(data)
+        handle_webhook_github_workflow_job(data)
       else
-        error("Unhandled event")
+        {error: {message: "Unhandled event"}}
       end
-    end
-  end
-
-  def error(msg)
-    {error: {message: msg}}
-  end
-
-  def success(msg)
-    {message: msg}
-  end
-
-  def check_signature(signature, body)
-    return false unless signature
-
-    method, actual_digest = signature.split("=")
-    expected_digest = OpenSSL::HMAC.hexdigest(method, Config.github_app_webhook_secret, body)
-    Rack::Utils.secure_compare(actual_digest, expected_digest)
-  end
-
-  def handle_installation(data)
-    installation = GithubInstallation.with_github_installation_id(data.dig("installation", "id"))
-    case data["action"]
-    when "deleted"
-      return error("Unregistered installation") unless installation
-      return error("Inactive project") unless installation.project.active?
-
-      Prog::Github::DestroyGithubInstallation.assemble(installation)
-      return success("GithubInstallation[#{installation.ubid}] deleted")
-    end
-
-    error("Unhandled installation action")
-  end
-
-  def handle_workflow_job(data)
-    unless (installation_id = data.dig("installation", "id")) && (installation = GithubInstallation.with_github_installation_id(installation_id))
-      Clog.emit("Unregistered installation", {unregistered_installation: {installation_id:, repository_name: data.dig("repository", "full_name")}})
-      return error("Unregistered installation")
-    end
-
-    unless (job = data["workflow_job"])
-      Clog.emit("No workflow_job in the payload", {workflow_job_missing: {installation_id: installation.id, action: data["action"]}})
-      return error("No workflow_job in the payload")
-    end
-
-    job_labels = job.fetch("labels")
-
-    if (label = job_labels.find { Github.runner_labels.key?(it) })
-      actual_label = label
-    elsif (custom_label = installation.custom_labels_dataset.first(name: job_labels))
-      actual_label = custom_label.name
-      label = custom_label.alias_for
-    end
-
-    repository_name = data["repository"]["full_name"]
-    unless label
-      if data["action"] == "completed"
-        Clog.emit("Unmatched label", {
-          unmatched_label: {
-            repository_name:,
-            labels: job_labels,
-            started_in: Time.new(job["started_at"]) - Time.new(job["created_at"]),
-            completed_in: job["completed_at"] ? (Time.new(job["completed_at"]) - Time.new(job["started_at"])) : nil,
-            conclusion: job["conclusion"],
-          },
-        })
-      end
-      return error("Unmatched label")
-    end
-
-    if data["action"] == "queued"
-      runner = Prog::Github::GithubRunnerNexus.assemble(
-        installation,
-        repository_name:,
-        label:,
-        actual_label:,
-        default_branch: data["repository"]["default_branch"],
-      ).subject
-
-      return success("GithubRunner[#{runner.ubid}] created")
-    end
-
-    unless (runner_id = job.fetch("runner_id"))
-      return error("A workflow_job without runner_id")
-    end
-
-    runner = installation.runners_dataset.first(
-      repository_name:,
-      runner_id:,
-    )
-
-    return error("Unregistered runner") unless runner
-
-    runner.this.update(workflow_job: Sequel.pg_jsonb(job.except("steps")))
-
-    case data["action"]
-    when "in_progress"
-      runner.log_duration("runner_started", Time.new(job["started_at"]) - Time.new(job["created_at"]))
-      success("GithubRunner[#{runner.ubid}] picked job #{job.fetch("id")}")
-    when "completed"
-      runner.incr_destroy
-
-      success("GithubRunner[#{runner.ubid}] deleted")
-    else
-      error("Unhandled workflow_job action")
     end
   end
 end

--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -37,7 +37,7 @@ class Clover
   end
 
   def handle_installation(data)
-    installation = GithubInstallation.with_github_installation_id(data["installation"]["id"])
+    installation = GithubInstallation.with_github_installation_id(data.dig("installation", "id"))
     case data["action"]
     when "deleted"
       return error("Unregistered installation") unless installation


### PR DESCRIPTION
These methods were specific to the webhook github routes. In some
cases, they were only called once. The error/success methods were
called more than once, but the issue with defining them is that the
method names are quite generic, but would be valid names anywhere in
Clover's routing tree. They were also simple enough that it was easy
to inline them. I'd be fine with adding a method for them, but names
like webhook_github_error/webhook_github_success.

The first commit fixes a production NoMethodError.

Best viewed ignoring whitespace differences.