### PR TITLE
Show a clear error when boot disk is smaller than the image

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -254,9 +254,12 @@ class Prog::Vm::Nexus < Prog::Base
       MachineImageVersion.first(machine_image_id: mi.id, version:)
     end
 
-    return miv_validation_failed(name, location_id, is_base_boot_image, {machine_image_version: "Version \"#{version}\" does not exist for machine image \"#{name}\""}) unless miv
-    return miv_validation_failed(name, location_id, is_base_boot_image, {machine_image_version: "Machine image version \"#{version}\" does not have an active metal version"}) unless miv.metal&.status == "ready"
-    return miv_validation_failed(name, location_id, is_base_boot_image, {machine_image_version: "Machine image version \"#{version}\" is larger than the VM boot disk size"}) if miv.actual_size_mib > vm_boot_disk_size_gib * 1024
+    return miv_validation_failed(name, location_id, is_base_boot_image, {machine_image: "Version \"#{version}\" does not exist for machine image \"#{name}\""}) unless miv
+    return miv_validation_failed(name, location_id, is_base_boot_image, {machine_image: "Machine image version \"#{version}\" does not have an active metal version"}) unless miv.metal&.status == "ready"
+    if miv.actual_size_mib > vm_boot_disk_size_gib * 1024
+      required_gib = (miv.actual_size_mib/1024r).ceil
+      return miv_validation_failed(name, location_id, is_base_boot_image, {storage_size: "Machine image \"#{name}@#{version}\" requires at least #{required_gib} GiB of storage"})
+    end
 
     miv
   end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       create_machine_image_version_metal(project_id: project.id)
       expect {
         Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "test-mi@latest")
-      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image_version]).to include('Version "latest" does not exist') }
+      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image]).to eq('Version "latest" does not exist for machine image "test-mi"') }
     end
 
     it "fails if machine image version has no metal record" do
@@ -146,7 +146,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       miv.metal.destroy
       expect {
         Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "test-mi@v1")
-      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image_version]).to include("does not have an active metal") }
+      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image]).to eq('Machine image version "v1" does not have an active metal version') }
     end
 
     it "fails if machine image version metal is destroying" do
@@ -154,7 +154,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       miv.update(status: "destroying")
       expect {
         Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "test-mi@v1")
-      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image_version]).to include("does not have an active metal") }
+      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image]).to eq('Machine image version "v1" does not have an active metal version') }
     end
 
     it "fails if machine image version size exceeds VM boot disk size" do
@@ -162,7 +162,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       miv.update(actual_size_mib: 21 * 1024)
       expect {
         Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "test-mi@v1", storage_volumes: [{size_gib: 20}])
-      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image_version]).to include("is larger than the VM boot disk size") }
+      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:storage_size]).to eq('Machine image "test-mi@v1" requires at least 21 GiB of storage') }
     end
 
     it "fails if machine image version size exceeds the selected boot disk size for non-default boot_disk_index" do
@@ -176,7 +176,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
           storage_volumes: [{size_gib: 30}, {size_gib: 20}],
           boot_disk_index: 1,
         )
-      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:machine_image_version]).to include("is larger than the VM boot disk size") }
+      }.to raise_error(Validation::ValidationFailed) { |e| expect(e.details[:storage_size]).to eq('Machine image "test-mi@v1" requires at least 21 GiB of storage') }
     end
 
     it "uses a machine image in hetzner-hel1 if it doesn't exist in hetzner-fsn1" do
@@ -339,7 +339,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
         base_machine_image_version_not_found: {
           boot_image: "ubuntu-noble",
           location_id: Location::HETZNER_FSN1_ID,
-          error: {machine_image_version: "Version \"latest\" does not exist for machine image \"ubuntu-noble\""},
+          error: {machine_image: "Version \"latest\" does not exist for machine image \"ubuntu-noble\""},
         },
       }).and_call_original
       expect(Prog::Vm::Nexus.lookup_machine_image_version(project_id, Location::HETZNER_FSN1_ID, "ubuntu-noble", "latest", 10, true)).to be_nil
@@ -351,7 +351,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
         base_machine_image_version_not_found: {
           boot_image: "ubuntu-jammy",
           location_id: Location::HETZNER_FSN1_ID,
-          error: {machine_image_version: "Machine image version \"latest\" does not have an active metal version"},
+          error: {machine_image: "Machine image version \"latest\" does not have an active metal version"},
         },
       }).and_call_original
       expect(Prog::Vm::Nexus.lookup_machine_image_version(project_id, Location::HETZNER_FSN1_ID, "ubuntu-jammy", "latest", 10, true)).to be_nil
@@ -363,7 +363,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
         base_machine_image_version_not_found: {
           boot_image: "ubuntu-jammy",
           location_id: Location::HETZNER_FSN1_ID,
-          error: {machine_image_version: "Machine image version \"latest\" does not have an active metal version"},
+          error: {machine_image: "Machine image version \"latest\" does not have an active metal version"},
         },
       }).and_call_original
       expect(Prog::Vm::Nexus.lookup_machine_image_version(project_id, Location::HETZNER_FSN1_ID, "ubuntu-jammy", "latest", 10, true)).to be_nil
@@ -375,7 +375,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
         base_machine_image_version_not_found: {
           boot_image: "ubuntu-jammy",
           location_id: Location::HETZNER_FSN1_ID,
-          error: {machine_image_version: "Machine image version \"latest\" is larger than the VM boot disk size"},
+          error: {storage_size: "Machine image \"ubuntu-jammy@latest\" requires at least 20 GiB of storage"},
         },
       }).and_call_original
       expect(Prog::Vm::Nexus.lookup_machine_image_version(project_id, Location::HETZNER_FSN1_ID, "ubuntu-jammy", "latest", 10, true)).to be_nil

--- a/spec/routes/web/vm_spec.rb
+++ b/spec/routes/web/vm_spec.rb
@@ -305,6 +305,22 @@ RSpec.describe Clover, "vm" do
           expect(Vm.first.boot_image).to eq("my-image@latest")
         end
 
+        it "shows an actionable inline error when the boot disk is smaller than the machine image" do
+          miv.update(actual_size_mib: 100 * 1024)
+          visit "#{project.path}/vm/create"
+          fill_in "Name", with: "dummy-vm"
+          fill_in "SSH Public Key", with: "a a"
+          choose option: Location::HETZNER_FSN1_UBID
+          choose option: "__machine_image"
+          select "my-image@latest", from: "machine_image"
+          choose option: "standard-2"
+          click_button "Create"
+
+          expect(page).to have_flash_error("Validation failed for following fields: storage_size")
+          expect(page).to have_css("#storage_size-error", exact_text: "Machine image \"my-image@latest\" requires at least 100 GiB of storage")
+          expect(Vm.count).to eq(0)
+        end
+
         it "ignores machine_image when a base boot image is picked" do
           visit "#{project.path}/vm/create"
           fill_in "Name", with: "dummy-vm"


### PR DESCRIPTION
Creating a VM from a machine image whose version is larger than the selected boot disk only showed the generic banner "Validation failed for following fields: machine_image_version" in the web console, with no explanation. The descriptive detail was keyed under machine_image_version, which is not a form field, so the per-field inline error was never rendered (only keys matching a form field name are shown).

Key the machine-image lookup errors to real form fields so they render inline, and make the too-small-disk message actionable:

- "too large" errors now key to storage_size and state the required size ("...  requires at least N GiB of storage.")
- "version does not exist" / "not ready" errors key to machine_image, matching the existing "machine image does not exist" error.

API responses already include these under error.details and the CLI already prints details, so both now carry the improved message and field key as well.