### PR TITLE
Return 422 instead of 503 when kubeconfig is not ready

### DIFF
--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -110,7 +110,7 @@ class Clover
         handle_validation_failure("kubernetes-cluster/show") { @page = "overview" }
 
         unless kc.kubeconfig
-          raise CloverError.new(503, "ServiceUnavailable", "Temporary error downloading kubeconfig.yaml. Please try again.")
+          fail_kubernetes_unprocessable("Cluster is not ready, kubeconfig is not available yet")
         end
 
         response.attachment "#{kc.name}-kubeconfig.yaml"

--- a/sdk/ruby/lib/ubicloud/model/kubernetes_cluster.rb
+++ b/sdk/ruby/lib/ubicloud/model/kubernetes_cluster.rb
@@ -9,6 +9,7 @@ module Ubicloud
     set_columns :id, :name, :state, :location, :version
 
     # Return string with the contents of kubeconfig.yaml for the Kubernetes cluster.
+    # Raises an Error with code 422 until the cluster finishes provisioning.
     def kubeconfig
       adapter.get(_path("/kubeconfig"))
     end

--- a/spec/routes/api/project/location/kubernetes_cluster_spec.rb
+++ b/spec/routes/api/project/location/kubernetes_cluster_spec.rb
@@ -124,6 +124,25 @@ RSpec.describe Clover, "kubernetes-cluster" do
       end
     end
 
+    describe "kubeconfig" do
+      it "success" do
+        kc.update(kubeconfig: "kubeconfig content")
+
+        get "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.name}/kubeconfig"
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq("kubeconfig content")
+      end
+
+      it "fails when the cluster has not generated a kubeconfig yet" do
+        kc.update(kubeconfig: nil)
+
+        get "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.name}/kubeconfig"
+
+        expect(last_response).to have_api_error(422, "Cluster is not ready, kubeconfig is not available yet")
+      end
+    end
+
     describe "delete" do
       it "success" do
         delete "/project/#{project.ubid}/location/#{kc.display_location}/kubernetes-cluster/#{kc.name}"

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -346,10 +346,11 @@ RSpec.describe Clover, "Kubernetes" do
 
         visit "#{project.path}#{kc.path}/kubeconfig"
 
+        expect(page.status_code).to eq(422)
         expect(page.response_headers["Content-Type"]).to include("text/html")
         expect(page.response_headers["Content-Disposition"]).to be_nil
         expect(page.title).to eq "Ubicloud - myk8s"
-        expect(page).to have_flash_error("Temporary error downloading kubeconfig.yaml. Please try again.")
+        expect(page).to have_flash_error("Cluster is not ready, kubeconfig is not available yet")
       end
 
       it "raises forbidden error when user does not have permission" do


### PR DESCRIPTION
The kubeconfig column is only nil while a cluster is still bootstrapping, since sync_kubeconfig populates it once the control plane is up. Returning 503 ServiceUnavailable framed a normal lifecycle state as a server outage, which pollutes error-rate metrics and invites clients and proxies to auto-retry.

Use fail_kubernetes_unprocessable, matching the other not-ready checks in this file, and reword the message so it describes the cluster state rather than a download failure that never happened. Document the raise on KubernetesCluster#kubeconfig in the SDK, since hitting it right after create is the common case.