### PR TITLE
Add PostgresResourceNexus.unarchive

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -38,7 +38,7 @@ def test_metal(options, test_cases)
     wait_until(base_machine_images_st, "wait")
   end
 
-  if options[:test_cases].include?("postgres_ha") || options[:test_cases].include?("postgres_upgrade")
+  if options[:test_cases].include?("postgres_ha") || options[:test_cases].include?("postgres_upgrade") || options[:test_cases].include?("postgres_unarchive")
     Project[Config.postgres_service_project_id] ||
       Project.create_with_id(Config.postgres_service_project_id, name: "Postgres-Service-Project")
     minio_cluster_st = Prog::Test::MinioCluster.assemble(Config.postgres_service_project_id)
@@ -87,6 +87,9 @@ def test_metal(options, test_cases)
   end
   if options[:test_cases].include?("postgres_upgrade16")
     tests_to_wait << Prog::Test::UpgradePostgresResource.assemble(start_version: "16")
+  end
+  if options[:test_cases].include?("postgres_unarchive")
+    tests_to_wait << Prog::Test::UnarchivePostgresResource.assemble
   end
 
   # Skip postgres_firewall on metal: the assertion at
@@ -151,6 +154,9 @@ def test_aws(options, test_cases)
   if options[:test_cases].include?("postgres_upgrade16")
     tests_to_wait << Prog::Test::UpgradePostgresResource.assemble(provider: "aws", start_version: "16")
   end
+  if options[:test_cases].include?("postgres_unarchive")
+    tests_to_wait << Prog::Test::UnarchivePostgresResource.assemble(provider: "aws")
+  end
 
   if options[:test_cases].include?("postgres_firewall")
     tests_to_wait << Prog::Test::PostgresFirewall.assemble(provider: "aws")
@@ -172,6 +178,9 @@ def test_gcp(options, test_cases)
   end
   if options[:test_cases].include?("postgres_upgrade")
     tests_to_wait << Prog::Test::UpgradePostgresResource.assemble(provider: "gcp")
+  end
+  if options[:test_cases].include?("postgres_unarchive")
+    tests_to_wait << Prog::Test::UnarchivePostgresResource.assemble(provider: "gcp")
   end
 
   if options[:test_cases].include?("postgres_firewall")

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -6,6 +6,7 @@
 - { name: postgres_upgrade,          images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_upgrade16,        images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_firewall,         images: ["postgres-ubuntu-2204"] }
+- { name: postgres_unarchive,        images: ["postgres-ubuntu-2204"] }
 - { name: kubernetes,                images: ["ubuntu-noble", "kubernetes-v1_35"] }
 - { name: kubernetes_upgrade,        images: ["ubuntu-noble", "kubernetes-v1_35", "kubernetes-v1_36"] }
 - { name: kubernetes_firewall,       images: ["ubuntu-noble", "kubernetes-v1_35"] }

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -18,7 +18,7 @@ class PostgresServer < Sequel::Model
     :restart, :configure, :fence, :unfence, :planned_take_over, :unplanned_take_over, :configure_metrics,
     :destroy, :recycle, :recycle_lagging_read_replica, :recycle_unavailable_server, :recycle_by_user_request,
     :promote_read_replica, :refresh_walg_credentials, :configure_s3_new_timeline, :lockout, :use_physical_slot,
-    :configure_logs, :ignore_instance_size_mismatch, :install_rhizome
+    :configure_logs, :ignore_instance_size_mismatch, :install_rhizome, :unarchive
   include HealthMonitorMethods
   include MetricsTargetMethods
 
@@ -125,7 +125,10 @@ class PostgresServer < Sequel::Model
         configs[:primary_slot_name] = "'#{ubid}'" if physical_slot_ready_id == resource.representative_server.id
       end
 
-      if doing_pitr?
+      if doing_pitr? && resource.restore_target
+        # unarchive_set? path skips this: archive tail can sit inside an
+        # unarchived segment, making a target LSN unreachable. recovery.signal
+        # terminates when WAL is exhausted, then promotes.
         configs[:recovery_target_time] = "'#{resource.restore_target}'"
       end
 

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -45,6 +45,22 @@ class PostgresTimeline < Sequel::Model
     leader.vm.sshable.d_check("take_postgres_backup") != "InProgress"
   end
 
+  # wal-g segment names are `<timeline 8hex><log 8hex><seg 8hex>`; .history
+  # & other objects don't match
+  WAL_SEGMENT_RE = /\A[0-9A-F]{24}\z/
+
+  # To allow overriding in specs
+  def self.any_archived_wal?(timeline)
+    timeline.any_archived_wal?
+  end
+
+  # Whether any WAL segment has been archived. Gates unarchive E2E until
+  # post-backup writes land in the archive, not the live tail segment.
+  def any_archived_wal?
+    return false if blob_storage.nil?
+    list_objects("wal_005/").any? { WAL_SEGMENT_RE.match?(it.key.delete_prefix("wal_005/").split(".").first) }
+  end
+
   def backups
     return @backups if @backups
     return @backups = [] if blob_storage.nil?

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -147,6 +147,70 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     restore_target
   end
 
+  def self.unarchive(postgres_resource_id)
+    if postgres_resource_id.is_a?(String) && postgres_resource_id.bytesize == 26
+      postgres_resource_id = UBID.to_uuid(postgres_resource_id) || fail("Invalid UBID: #{postgres_resource_id}")
+    end
+
+    archived_postgres_resource = ArchivedRecord.find_by_id(postgres_resource_id, model_name: "PostgresResource", days: PostgresTimeline::BACKUP_BUCKET_EXPIRATION_DAYS)
+    fail "No archived PostgresResource for id #{postgres_resource_id}" unless archived_postgres_resource
+
+    last_n_days = Sequel::CURRENT_TIMESTAMP - Sequel.cast("#{PostgresTimeline::BACKUP_BUCKET_EXPIRATION_DAYS} days", :interval)
+    archived_representative_server = DB[:archived_record]
+      .where(model_name: "PostgresServer")
+      .where { archived_at > last_n_days }
+      .where(Sequel.pg_jsonb_op(:model_values).get_text("resource_id") => postgres_resource_id)
+      .where(Sequel.pg_jsonb_op(:model_values).get_text("is_representative") => "true")
+      .first
+    fail "No archived representative PostgresServer for id #{postgres_resource_id}" unless archived_representative_server
+
+    timeline_id = archived_representative_server[:model_values]["timeline_id"]
+    timeline = PostgresTimeline[timeline_id]
+    fail "Original timeline #{timeline_id} no longer exists" unless timeline
+    fail "Original timeline #{timeline_id} has no restorable backup" unless PostgresTimeline.earliest_restore_time(timeline)
+
+    v = archived_postgres_resource[:model_values]
+    DB.transaction do
+      strand = assemble(
+        project_id: v["project_id"],
+        location_id: v["location_id"],
+        name: v["name"],
+        target_vm_size: v["target_vm_size"],
+        target_storage_size_gib: v["target_storage_size_gib"],
+        target_version: v["target_version"],
+        flavor: v["flavor"],
+        ha_type: v["ha_type"],
+        tags: v["tags"] || [],
+        user_config: v["user_config"] || {},
+        pgbouncer_user_config: v["pgbouncer_user_config"] || {},
+        hostname_version: v["hostname_version"],
+        restore_from_timeline_id: timeline_id,
+      )
+
+      postgres_resource = strand.subject
+      # assemble omits these customer-config columns; restore from archive.
+      # Encrypted columns & metric/log destination secrets aren't archived,
+      # and firewall rules are deliberately left at assemble's defaults.
+      postgres_resource.update(
+        maintenance_window_start_at: v["maintenance_window_start_at"],
+        cert_auth_users: v["cert_auth_users"] || [],
+        trusted_ca_certs: v["trusted_ca_certs"],
+      )
+
+      representative_server = postgres_resource.representative_server
+      # Marks the unarchive flow so configure_hash skips recovery_target_time
+      # & initialize_database_from_backup uses LATEST. Recovery terminates
+      # when WAL is exhausted then promotes; no live primary to follow.
+      representative_server.incr_unarchive
+      # WAL replay restores role with old password, but assemble generated a
+      # fresh one. initial_provisioning clears before configure revisits after
+      # promotion, so push new password via semaphore which wait consumes
+      representative_server.incr_update_superuser_password
+
+      strand
+    end
+  end
+
   def before_run
     when_destroy_set? do
       case strand.label

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -18,7 +18,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     target_version: PostgresResource::DEFAULT_VERSION, flavor: PostgresResource::Flavor::STANDARD,
     ha_type: PostgresResource::HaType::NONE, parent_id: nil, tags: [], restore_target: nil, with_firewall_rules: true,
     user_config: {}, pgbouncer_user_config: {}, private_subnet_name: nil, init_script: nil,
-    hostname_version: Config.postgres_hostname_version_default)
+    hostname_version: Config.postgres_hostname_version_default, restore_from_timeline_id: nil)
 
     unless (project = Project[project_id])
       fail "No existing project"
@@ -28,8 +28,20 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       fail "No existing location"
     end
 
+    if restore_from_timeline_id && parent_id
+      fail "Cannot specify both parent_id and restore_from_timeline_id"
+    end
+
     DB.transaction do
-      superuser_password, timeline_id, timeline_access, target_version = if parent_id.nil?
+      superuser_password, timeline_id, timeline_access, target_version = if restore_from_timeline_id
+        unless (timeline = PostgresTimeline[restore_from_timeline_id])
+          fail "No existing timeline"
+        end
+
+        restore_target &&= validate_restore_target(restore_target, timeline)
+
+        [SecureRandom.urlsafe_base64(15), timeline.id, "fetch", target_version]
+      elsif parent_id.nil?
         [SecureRandom.urlsafe_base64(15), Prog::Postgres::PostgresTimelineNexus.assemble(location_id: location.id).id, "push", target_version]
       else
         unless (parent = PostgresResource[parent_id])
@@ -40,16 +52,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
           fail Validation::ValidationFailed.new({version: "Version must be the same as the parent"})
         end
 
-        if restore_target
-          restore_target = Validation.validate_date(restore_target, "restore_target")
-          earliest_restore_time = parent.timeline.earliest_restore_time
-          latest_restore_time = parent.timeline.latest_restore_time
+        restore_target &&= validate_restore_target(restore_target, parent.timeline)
 
-          unless earliest_restore_time && earliest_restore_time <= restore_target &&
-              latest_restore_time && restore_target <= latest_restore_time
-            fail Validation::ValidationFailed.new({restore_target: "Restore target must be between #{earliest_restore_time} and #{latest_restore_time}"})
-          end
-        end
         [parent.superuser_password, parent.timeline.id, "fetch", parent.version]
       end
 
@@ -131,6 +135,16 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
       strand
     end
+  end
+
+  def self.validate_restore_target(restore_target, timeline)
+    restore_target = Validation.validate_date(restore_target, "restore_target")
+    earliest = timeline.earliest_restore_time
+    latest = timeline.latest_restore_time
+    unless earliest && earliest <= restore_target && latest && restore_target <= latest
+      fail Validation::ValidationFailed.new({restore_target: "Restore target must be between #{earliest} and #{latest}"})
+    end
+    restore_target
   end
 
   def before_run

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -215,7 +215,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
       end
       self.initialize_database_from_backup_try_count = previous_try_count + 1
 
-      backup_label = if postgres_server.standby? || postgres_server.read_replica?
+      backup_label = if postgres_server.standby? || postgres_server.read_replica? || postgres_server.unarchive_set?
         "LATEST"
       else
         postgres_server.timeline.latest_backup_label_before_target(target: resource.restore_target)
@@ -223,8 +223,8 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
       recovery_mode = if postgres_server.standby? || postgres_server.read_replica?
         "standby"
       else
-        # PITR terminates recovery once WAL is exhausted; no live primary
-        # to follow.
+        # PITR (restore_target) and unarchive terminate recovery once WAL is
+        # exhausted; no live primary to follow.
         "recovery"
       end
       strict_overcommit = resource.skip_strict_memory_overcommit_set? ? "false" : "true"

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -220,8 +220,15 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
       else
         postgres_server.timeline.latest_backup_label_before_target(target: resource.restore_target)
       end
+      recovery_mode = if postgres_server.standby? || postgres_server.read_replica?
+        "standby"
+      else
+        # PITR terminates recovery once WAL is exhausted; no live primary
+        # to follow.
+        "recovery"
+      end
       strict_overcommit = resource.skip_strict_memory_overcommit_set? ? "false" : "true"
-      vm.sshable.d_run("initialize_database_from_backup", "sudo", "postgres/bin/initialize-database-from-backup", postgres_server.version, backup_label, strict_overcommit)
+      vm.sshable.d_run("initialize_database_from_backup", "sudo", "postgres/bin/initialize-database-from-backup", postgres_server.version, backup_label, strict_overcommit, recovery_mode)
     end
 
     nap 5

--- a/prog/test/unarchive_postgres_resource.rb
+++ b/prog/test/unarchive_postgres_resource.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+class Prog::Test::UnarchivePostgresResource < Prog::Test::PostgresBase
+  semaphore :pause, :destroy
+  frame_accessor :original_resource_id, :original_timeline_id, :backup_deadline
+
+  def self.assemble(provider: "metal", **)
+    super(provider:, project_name: "Postgres-Unarchive-Test-Project", **)
+  end
+
+  label def start
+    super(name: "postgres-test-unarchive")
+  end
+
+  label def wait_postgres_resource
+    nap 10 unless postgres_resource.strand.label == "wait" && representative_server.run_query("SELECT 1") == "1"
+
+    if representative_server.run_query(test_queries_sql) != "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1"
+      self.fail_message = "Failed to seed test data"
+      hop_destroy
+    end
+
+    hop_take_backup
+  end
+
+  label def take_backup
+    self.original_resource_id = postgres_resource.id
+    self.original_timeline_id = representative_server.timeline_id
+    self.backup_deadline = Time.now.to_i + 15 * 60
+    original_timeline.incr_take_backup_for_converge
+    hop_wait_backup
+  end
+
+  label def wait_backup
+    if original_timeline.backups.any?
+      # Force WAL rotation so writes after the basebackup get archived;
+      # recovery.signal replays to end of archived WAL, so the seeded data
+      # must leave the live tail segment before the resource is destroyed.
+      representative_server.run_query("SELECT pg_switch_wal()")
+      hop_wait_wal_archive
+    end
+
+    if Time.now.to_i >= backup_deadline
+      self.fail_message = "Backup did not complete in time"
+      hop_destroy
+    end
+
+    nap 30
+  end
+
+  label def wait_wal_archive
+    nap 10 unless PostgresTimeline.any_archived_wal?(original_timeline)
+
+    # Destroy only the resource; the retained timeline is what unarchive
+    # restores from.
+    postgres_resource.incr_destroy
+    hop_wait_original_destroyed
+  end
+
+  label def wait_original_destroyed
+    nap 10 if PostgresResource[original_resource_id]
+    hop_unarchive
+  end
+
+  label def unarchive
+    st = Prog::Postgres::PostgresResourceNexus.unarchive(original_resource_id)
+    self.postgres_resource_id = st.id
+    self.private_subnet_id = st.subject.private_subnet_id
+    hop_wait_unarchived
+  end
+
+  label def wait_unarchived
+    nap 10 unless postgres_resource.strand.label == "wait" && representative_server.run_query("SELECT 1") == "1"
+
+    if representative_server.run_query(read_queries_sql) != "4159.90\n415.99\n4.1"
+      self.fail_message = "Data missing after unarchive"
+    end
+
+    hop_destroy
+  end
+
+  label def destroy_postgres
+    current_timeline_ids = postgres_resource ? postgres_resource.servers_dataset.distinct.select_map(:timeline_id) : []
+    self.timeline_ids = ([original_timeline_id] + current_timeline_ids).compact.uniq
+    super
+  end
+
+  label def wait_resources_destroyed
+    nap 5 if postgres_resource
+    nap_if_gcp_vpc
+    nap_if_private_subnet
+    verify_timelines_destroyed(timeline_ids)
+
+    hop_finish
+  end
+
+  label :finish
+  label :failed
+  label :destroy
+
+  def original_timeline
+    @original_timeline ||= PostgresTimeline[original_timeline_id]
+  end
+end

--- a/rhizome/postgres/bin/initialize-database-from-backup
+++ b/rhizome/postgres/bin/initialize-database-from-backup
@@ -4,13 +4,14 @@
 require_relative "../../common/lib/util"
 require_relative "../lib/postgres_setup"
 
-if ARGV.count != 3
-  fail "Wrong number of arguments. Expected 3, Given #{ARGV.count}"
+if ARGV.count != 4
+  fail "Wrong number of arguments. Expected 4, Given #{ARGV.count}"
 end
 
 v = ARGV[0]
 backup_label = ARGV[1]
 strict_overcommit = ARGV[2] == "true"
+recovery_mode = ARGV[3]
 
 pg_setup = PostgresSetup.new(v)
 pg_setup.install_packages
@@ -28,10 +29,10 @@ r "sudo -u postgres touch /dat/#{v}/data/pg_ident.conf"
 r "sudo -u postgres touch /dat/#{v}/data/pg_hba.conf"
 r "sudo -u postgres touch /dat/#{v}/data/postgresql.conf"
 
-# Technically LATEST label can be used for PITR as well, but we use the label
-# name from backups in PITR case. So backup_label can be used to decide on
-# which signal file to use.
-if backup_label == "LATEST"
+# standby.signal: stay in recovery forever, follow streaming primary (HA replica,
+# read replica). recovery.signal: replay all available WAL, then exit recovery
+# and promote (PITR, unarchive from cold archive -- no live primary to follow).
+if recovery_mode == "standby"
   r "sudo -u postgres touch /dat/#{v}/data/standby.signal"
 else
   r "sudo -u postgres touch /dat/#{v}/data/recovery.signal"

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -115,10 +115,19 @@ RSpec.describe PostgresServer do
       expect(postgres_server.configure_hash[:configs]).to include(:primary_conninfo, :restore_command)
     end
 
-    it "sets configs that are specific to restoring servers" do
+    it "sets configs that are specific to PITR-by-time restore" do
       postgres_server.update(timeline_access: "fetch")
-      expect(resource).to receive(:restore_target)
+      resource.update(restore_target: Time.now)
       expect(postgres_server.configure_hash[:configs]).to include(:recovery_target_time, :restore_command)
+    end
+
+    it "omits recovery targets for unarchive: archive tail may sit in unarchived segment" do
+      postgres_server.update(timeline_access: "fetch")
+      postgres_server.incr_unarchive
+      configs = postgres_server.configure_hash[:configs]
+      expect(configs).to include(:restore_command)
+      expect(configs).not_to include(:recovery_target_lsn)
+      expect(configs).not_to include(:recovery_target_time)
     end
 
     it "sets primary_slot_name to ubid on standby when physical slot ready" do

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -231,6 +231,38 @@ PGDATA=/dat/17/data
     expect(postgres_timeline.provider_dispatcher_group_name).to eq("metal")
   end
 
+  describe "#any_archived_wal?" do
+    def blob(key)
+      instance_double(Minio::Client::Blob, key: "wal_005/#{key}")
+    end
+
+    it "returns false if blob storage is not configured" do
+      expect(postgres_timeline).to receive(:blob_storage).and_return(nil)
+      expect(described_class.any_archived_wal?(postgres_timeline)).to be false
+    end
+
+    context "with blob storage" do
+      before do
+        allow(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster))
+      end
+
+      it "returns false when no WAL segments archived" do
+        expect(postgres_timeline).to receive(:list_objects).with("wal_005/").and_return([])
+        expect(postgres_timeline.any_archived_wal?).to be false
+      end
+
+      it "returns true when a WAL segment is archived" do
+        expect(postgres_timeline).to receive(:list_objects).with("wal_005/").and_return([blob("000000010000000200000003.lz4")])
+        expect(postgres_timeline.any_archived_wal?).to be true
+      end
+
+      it "ignores non-segment keys like timeline history files" do
+        expect(postgres_timeline).to receive(:list_objects).with("wal_005/").and_return([blob("00000002.history")])
+        expect(postgres_timeline.any_archived_wal?).to be false
+      end
+    end
+  end
+
   describe "#latest_backup_label_before_target" do
     it "returns most recent backup before given target" do
       most_recent_backup_time = Time.now

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -285,6 +285,82 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
     end
   end
 
+  describe ".unarchive" do
+    let(:customer_project) { Project.create(name: "default") }
+
+    it "rejects malformed UBIDs" do
+      expect { described_class.unarchive("u" * 26) }.to raise_error(RuntimeError, /Invalid UBID/)
+    end
+
+    it "fails if archived PostgresResource not found" do
+      id = "00000000-0000-0000-0000-000000000001"
+      expect { described_class.unarchive(id) }.to raise_error(RuntimeError, "No archived PostgresResource for id #{id}")
+    end
+
+    it "fails if archived representative server not found" do
+      pg = create_postgres_resource(project: customer_project, location_id:)
+      id = pg.id
+      pg.destroy
+      expect { described_class.unarchive(id) }.to raise_error(RuntimeError, "No archived representative PostgresServer for id #{id}")
+    end
+
+    it "fails if original timeline no longer exists" do
+      pg = create_postgres_resource(project: customer_project, location_id:)
+      server = create_postgres_server(resource: pg)
+      timeline = server.timeline
+      id = pg.id
+      pg.destroy
+      server.destroy
+      timeline.destroy
+      expect { described_class.unarchive(id) }.to raise_error(RuntimeError, /Original timeline .* no longer exists/)
+    end
+
+    it "fails if original timeline has no restorable backup" do
+      pg = create_postgres_resource(project: customer_project, location_id:)
+      server = create_postgres_server(resource: pg)
+      id = pg.id
+      pg.destroy
+      server.destroy
+      expect { described_class.unarchive(id) }.to raise_error(RuntimeError, /has no restorable backup/)
+    end
+
+    it "accepts a UBID and resolves to UUID" do
+      pg = create_postgres_resource(project: customer_project, location_id:)
+      ubid = pg.ubid
+      id = pg.id
+      pg.destroy
+      expect { described_class.unarchive(ubid) }.to raise_error(RuntimeError, "No archived representative PostgresServer for id #{id}")
+    end
+
+    it "reassembles archived resource fetching from original timeline" do
+      original = described_class.assemble(project_id: customer_project.id, location_id:, name: "pg-archived", target_vm_size: "standard-2", target_storage_size_gib: 128, hostname_version: "v1").subject
+      timeline = original.representative_server.timeline
+      timeline.update(cached_earliest_backup_at: Time.now - 30 * 60)
+      original.update(maintenance_window_start_at: 5, cert_auth_users: ["alice"], trusted_ca_certs: "ca-pem")
+      id = original.id
+      original.representative_server.destroy
+      original.destroy
+
+      strand = described_class.unarchive(id)
+      restored = strand.subject
+
+      expect(restored.name).to eq("pg-archived")
+      expect(restored.project_id).to eq(customer_project.id)
+      expect(restored.id).not_to eq(id)
+      expect(restored.restore_target).to be_nil
+      expect(restored.maintenance_window_start_at).to eq(5)
+      expect(restored.cert_auth_users).to eq(["alice"])
+      expect(restored.trusted_ca_certs).to eq("ca-pem")
+      expect(restored.hostname_version).to eq("v1")
+      expect(restored.representative_server.timeline_id).to eq(timeline.id)
+      expect(restored.representative_server.timeline_access).to eq("fetch")
+      expect(restored.representative_server.unarchive_set?).to be true
+      expect(restored.representative_server.update_superuser_password_set?).to be true
+      # archived firewall rules are not restored, assemble's defaults remain
+      expect(restored.customer_firewall.firewall_rules.count).to eq(4)
+    end
+  end
+
   describe "#before_run" do
     it "hops to destroy and stops billing records when needed" do
       postgres_server

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -86,6 +86,64 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(child.representative_server.timeline_access).to eq("fetch")
     end
 
+    it "uses existing orphaned timeline when restore_from_timeline_id is set" do
+      existing = described_class.assemble(project_id: customer_project.id, location_id:, name: "pg-existing", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
+      timeline = existing.representative_server.timeline
+      restore_target = Time.now
+      timeline.update(cached_earliest_backup_at: restore_target - 15 * 60)
+
+      restored = described_class.assemble(
+        project_id: customer_project.id, location_id:, name: "pg-restored", target_vm_size: "standard-2", target_storage_size_gib: 128,
+        restore_from_timeline_id: timeline.id, restore_target:,
+      ).subject
+
+      expect(restored.representative_server.timeline_id).to eq(timeline.id)
+      expect(restored.representative_server.timeline_access).to eq("fetch")
+      expect(restored.parent_id).to be_nil
+      expect(restored.superuser_password).not_to eq(existing.superuser_password)
+    end
+
+    it "supports PITR via restore_from_timeline_id after the original resource is deleted" do
+      original = described_class.assemble(project_id: customer_project.id, location_id:, name: "pg-deleted", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
+      timeline = original.representative_server.timeline
+      restore_target = Time.now
+      timeline.update(cached_earliest_backup_at: restore_target - 15 * 60)
+      original.representative_server.destroy
+      original.destroy
+
+      restored = described_class.assemble(
+        project_id: customer_project.id, location_id:, name: "pg-pitr", target_vm_size: "standard-2", target_storage_size_gib: 128,
+        restore_from_timeline_id: timeline.id, restore_target:,
+      ).subject
+
+      expect(restored.representative_server.timeline_id).to eq(timeline.id)
+      expect(restored.restore_target).to be_within(1).of(restore_target)
+    end
+
+    it "rejects restore_from_timeline_id with parent_id" do
+      expect {
+        described_class.assemble(project_id: customer_project.id, location_id:, name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128,
+          parent_id: "pgd2m9djgryj6nq73jrdddnkrt", restore_from_timeline_id: "pt00000000000000000000000a")
+      }.to raise_error RuntimeError, "Cannot specify both parent_id and restore_from_timeline_id"
+    end
+
+    it "rejects restore_from_timeline_id referencing a missing timeline" do
+      expect {
+        described_class.assemble(project_id: customer_project.id, location_id:, name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128,
+          restore_from_timeline_id: "00000000-0000-0000-0000-000000000001", restore_target: Time.now)
+      }.to raise_error RuntimeError, "No existing timeline"
+    end
+
+    it "validates restore_target against the orphaned timeline's window" do
+      existing = described_class.assemble(project_id: customer_project.id, location_id:, name: "pg-existing", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
+      timeline = existing.representative_server.timeline
+
+      expect {
+        described_class.assemble(project_id: customer_project.id, location_id:, name: "pg-restored", target_vm_size: "standard-2", target_storage_size_gib: 128,
+          restore_from_timeline_id: timeline.id, restore_target: Time.now)
+      }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: restore_target"
+    end
+
     it "creates internal firewall and customer private subnet and firewall" do
       pg = described_class.assemble(project_id: customer_project.id, location_id:, name: "pg-name", target_vm_size: "standard-2", target_storage_size_gib: 128).subject
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -511,7 +511,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "triggers initialize_database_from_backup if initialize_database_from_backup command is not sent yet or failed" do
       postgres_resource.update(restore_target: Time.now)
       expect(server.timeline).to receive(:latest_backup_label_before_target).and_return("backup-label").twice
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_database_from_backup sudo postgres/bin/initialize-database-from-backup 17 backup-label true", {log: true, stdin: nil}).twice
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_database_from_backup sudo postgres/bin/initialize-database-from-backup 17 backup-label true recovery", {log: true, stdin: nil}).twice
 
       # NotStarted
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_database_from_backup").and_return("NotStarted")
@@ -555,7 +555,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       postgres_resource.incr_skip_strict_memory_overcommit
       expect(server.timeline).to receive(:latest_backup_label_before_target).and_return("backup-label")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_database_from_backup").and_return("NotStarted")
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_database_from_backup sudo postgres/bin/initialize-database-from-backup 17 backup-label false", {log: true, stdin: nil})
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_database_from_backup sudo postgres/bin/initialize-database-from-backup 17 backup-label false recovery", {log: true, stdin: nil})
       expect { nx.initialize_database_from_backup }.to nap(5)
     end
 
@@ -565,7 +565,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       standby_nx = described_class.new(standby.strand)
       standby_sshable = standby_nx.postgres_server.vm.sshable
       expect(standby_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_database_from_backup").and_return("NotStarted")
-      expect(standby_sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_database_from_backup sudo postgres/bin/initialize-database-from-backup 17 LATEST true", {log: true, stdin: nil})
+      expect(standby_sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_database_from_backup sudo postgres/bin/initialize-database-from-backup 17 LATEST true standby", {log: true, stdin: nil})
       expect { standby_nx.initialize_database_from_backup }.to nap(5)
     end
 

--- a/spec/prog/test/unarchive_postgres_resource_spec.rb
+++ b/spec/prog/test/unarchive_postgres_resource_spec.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Test::UnarchivePostgresResource do
+  subject(:nx) { described_class.new(described_class.assemble) }
+
+  let(:test_project) { Project.create(name: "test-project") }
+  let(:service_project) { Project.create(name: "service-project") }
+  let(:location_id) { Location::HETZNER_FSN1_ID }
+  let(:timeline) { create_postgres_timeline(location_id:) }
+  let(:postgres_resource) { create_postgres_resource(project: test_project, location_id:) }
+
+  def setup_postgres_resource(with_server: true)
+    postgres_resource
+    postgres_resource.strand.update(label: "wait")
+    create_postgres_server(resource: postgres_resource, timeline:).strand.update(label: "wait") if with_server
+    refresh_frame(nx, new_values: {"postgres_resource_id" => postgres_resource.id})
+  end
+
+  before do
+    allow(Config).to receive(:postgres_service_project_id).and_return(service_project.id)
+  end
+
+  describe ".assemble" do
+    it "creates a strand at start with its test project" do
+      st = described_class.assemble
+      expect(st).to be_a Strand
+      expect(st.label).to eq("start")
+      expect(Project[name: "Postgres-Unarchive-Test-Project"]).not_to be_nil
+    end
+  end
+
+  describe "#start" do
+    it "assembles a postgres resource and hops to wait_postgres_resource" do
+      expect { nx.start }.to hop("wait_postgres_resource")
+      expect(nx.strand.stack.first["postgres_resource_id"]).not_to be_nil
+    end
+  end
+
+  describe "#wait_postgres_resource" do
+    before { setup_postgres_resource }
+
+    let(:sshable) { nx.representative_server.vm.sshable }
+
+    it "naps if the postgres resource is not ready" do
+      expect(sshable).to receive(:_cmd).and_return("\n")
+      expect { nx.wait_postgres_resource }.to nap(10)
+    end
+
+    it "fails the test if seeding queries fail" do
+      expect(sshable).to receive(:_cmd).and_return("1\n", "\n")
+      expect { nx.wait_postgres_resource }.to hop("destroy")
+      expect(nx.strand.stack.first["fail_message"]).to eq("Failed to seed test data")
+    end
+
+    it "hops to take_backup once seeding succeeds" do
+      expect(sshable).to receive(:_cmd).and_return("1\n", "DROP TABLE\nCREATE TABLE\nINSERT 0 10\n4159.90\n415.99\n4.1\n")
+      expect { nx.wait_postgres_resource }.to hop("take_backup")
+    end
+  end
+
+  describe "#take_backup" do
+    before { setup_postgres_resource }
+
+    it "records the originals, requests a backup, and hops to wait_backup" do
+      expect { nx.take_backup }.to hop("wait_backup")
+      stack = nx.strand.stack.first
+      expect(stack["original_resource_id"]).to eq(postgres_resource.id)
+      expect(stack["original_timeline_id"]).to eq(timeline.id)
+      expect(stack["backup_deadline"]).to be > Time.now.to_i
+      expect(Semaphore.where(strand_id: timeline.id, name: "take_backup_for_converge").count).to eq(1)
+    end
+  end
+
+  describe "#wait_backup" do
+    before do
+      setup_postgres_resource
+      refresh_frame(nx, new_values: {"original_timeline_id" => timeline.id, "backup_deadline" => Time.now.to_i + 600})
+    end
+
+    let(:sshable) { nx.representative_server.vm.sshable }
+
+    it "switches WAL and hops to wait_wal_archive once a backup exists" do
+      expect(nx.original_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster))
+      expect(nx.original_timeline).to receive(:list_objects).with("basebackups_005/", delimiter: "/")
+        .and_return([instance_double(Minio::Client::Blob, key: "basebackups_005/0001_backup_stop_sentinel.json")])
+      expect(sshable).to receive(:_cmd).and_return("0/3000148\n")
+      expect { nx.wait_backup }.to hop("wait_wal_archive")
+    end
+
+    it "fails the test once the deadline passes" do
+      refresh_frame(nx, new_values: {"backup_deadline" => Time.now.to_i - 1})
+      expect { nx.wait_backup }.to hop("destroy")
+      expect(nx.strand.stack.first["fail_message"]).to eq("Backup did not complete in time")
+    end
+
+    it "naps while the backup is still in progress" do
+      expect { nx.wait_backup }.to nap(30)
+    end
+  end
+
+  describe "#wait_wal_archive" do
+    before do
+      setup_postgres_resource
+      refresh_frame(nx, new_values: {"original_timeline_id" => timeline.id})
+    end
+
+    it "destroys only the resource once WAL is archived" do
+      expect(PostgresTimeline).to receive(:any_archived_wal?).with(timeline).and_return(true)
+      expect { nx.wait_wal_archive }.to hop("wait_original_destroyed")
+      expect(Semaphore.where(strand_id: postgres_resource.id, name: "destroy").count).to eq(1)
+      expect(Semaphore.where(strand_id: timeline.id, name: "destroy").count).to eq(0)
+    end
+
+    it "naps if no WAL segment is archived yet" do
+      expect(PostgresTimeline).to receive(:any_archived_wal?).with(timeline).and_return(false)
+      expect { nx.wait_wal_archive }.to nap(10)
+    end
+  end
+
+  describe "#wait_original_destroyed" do
+    it "naps if the original resource is still around" do
+      setup_postgres_resource
+      refresh_frame(nx, new_values: {"original_resource_id" => postgres_resource.id})
+      expect { nx.wait_original_destroyed }.to nap(10)
+    end
+
+    it "hops to unarchive once the original resource is gone" do
+      refresh_frame(nx, new_values: {"original_resource_id" => "00000000-0000-0000-0000-000000000001"})
+      expect { nx.wait_original_destroyed }.to hop("unarchive")
+    end
+  end
+
+  describe "#unarchive" do
+    it "unarchives and adopts the restored resource" do
+      restored = create_postgres_resource(project: test_project, location_id:)
+      subnet = PrivateSubnet.create(name: "restored-subnet", project_id: test_project.id, location_id:, net4: "10.9.0.0/26", net6: "fd00::/64")
+      restored.update(private_subnet_id: subnet.id)
+      refresh_frame(nx, new_values: {"original_resource_id" => "00000000-0000-0000-0000-000000000002"})
+      expect(Prog::Postgres::PostgresResourceNexus).to receive(:unarchive).with("00000000-0000-0000-0000-000000000002").and_return(restored.strand)
+      expect { nx.unarchive }.to hop("wait_unarchived")
+      stack = nx.strand.stack.first
+      expect(stack["postgres_resource_id"]).to eq(restored.id)
+      expect(stack["private_subnet_id"]).to eq(subnet.id)
+    end
+  end
+
+  describe "#wait_unarchived" do
+    before { setup_postgres_resource }
+
+    let(:sshable) { nx.representative_server.vm.sshable }
+
+    it "naps if the restored resource is not ready" do
+      expect(sshable).to receive(:_cmd).and_return("\n")
+      expect { nx.wait_unarchived }.to nap(10)
+    end
+
+    it "fails the test if read queries don't return the seeded data" do
+      expect(sshable).to receive(:_cmd).and_return("1\n", "\n")
+      expect { nx.wait_unarchived }.to hop("destroy")
+      expect(nx.strand.stack.first["fail_message"]).to eq("Data missing after unarchive")
+    end
+
+    it "hops cleanly to destroy when data is intact" do
+      expect(sshable).to receive(:_cmd).and_return("1\n", "4159.90\n415.99\n4.1\n")
+      expect { nx.wait_unarchived }.to hop("destroy")
+      expect(nx.strand.stack.first["fail_message"]).to be_nil
+    end
+  end
+
+  describe "#destroy_postgres" do
+    let(:original_timeline) { create_postgres_timeline(location_id:) }
+
+    it "collects the original and current timelines and destroys the resource" do
+      setup_postgres_resource
+      refresh_frame(nx, new_values: {"original_timeline_id" => original_timeline.id})
+      expect { nx.destroy_postgres }.to hop("wait_resources_destroyed")
+      expect(nx.strand.stack.first["timeline_ids"]).to contain_exactly(original_timeline.id, timeline.id)
+      expect(Semaphore.where(strand_id: postgres_resource.id, name: "destroy").count).to eq(1)
+    end
+
+    it "tolerates an already-destroyed resource" do
+      refresh_frame(nx, new_values: {"postgres_resource_id" => "00000000-0000-0000-0000-000000000001", "original_timeline_id" => original_timeline.id})
+      expect { nx.destroy_postgres }.to hop("wait_resources_destroyed")
+      expect(nx.strand.stack.first["timeline_ids"]).to eq([original_timeline.id])
+    end
+  end
+
+  describe "#wait_resources_destroyed" do
+    it "naps if the postgres resource is still around" do
+      setup_postgres_resource(with_server: false)
+      expect { nx.wait_resources_destroyed }.to nap(5)
+    end
+
+    it "naps if the private subnet is still around" do
+      subnet = PrivateSubnet.create(name: "subnet", project_id: test_project.id, location_id:, net4: "10.0.0.0/26", net6: "fd00::/64")
+      refresh_frame(nx, new_values: {"private_subnet_id" => subnet.id, "timeline_ids" => []})
+      expect { nx.wait_resources_destroyed }.to nap(5)
+    end
+
+    it "requests destruction of retained timelines and naps" do
+      refresh_frame(nx, new_values: {"timeline_ids" => [timeline.id]})
+      expect { nx.wait_resources_destroyed }.to nap(5)
+      expect(Semaphore.where(strand_id: timeline.id, name: "destroy").count).to eq(1)
+    end
+
+    it "hops to finish once everything is gone" do
+      refresh_frame(nx, new_values: {"timeline_ids" => ["00000000-0000-0000-0000-000000000001"]})
+      expect { nx.wait_resources_destroyed }.to hop("finish")
+    end
+  end
+end

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -81,7 +81,7 @@ module ThawedMock
   allow_mocking(PostgresMetricDestination, :generate_uuid)
   allow_mocking(PostgresResource, :[], :generate_uuid)
   allow_mocking(PostgresServer, :[], :create, :create_with_id, :victoria_metrics_client)
-  allow_mocking(PostgresTimeline, :[], :earliest_restore_time)
+  allow_mocking(PostgresTimeline, :[], :earliest_restore_time, :any_archived_wal?)
   allow_mocking(Project, :[], :order_by)
   allow_mocking(Semaphore, :where, :create, :incr)
   allow_mocking(SshPublicKey, :generate_uuid)

--- a/spec/thawed_mock.rb
+++ b/spec/thawed_mock.rb
@@ -108,7 +108,7 @@ module ThawedMock
   allow_mocking(Prog::MachineImage::VersionMetalNexus, :assemble_from_vm, :assemble_from_url)
   allow_mocking(Prog::Minio::MinioClusterNexus, :assemble)
   allow_mocking(Prog::PageNexus, :assemble)
-  allow_mocking(Prog::Postgres::PostgresResourceNexus, :assemble)
+  allow_mocking(Prog::Postgres::PostgresResourceNexus, :assemble, :unarchive)
   allow_mocking(Prog::Postgres::PostgresServerNexus, :assemble)
   allow_mocking(Prog::Postgres::PostgresTimelineNexus, :assemble)
   allow_mocking(Prog::Vm::HostNexus, :assemble)


### PR DESCRIPTION
Carries #5302 by @serprex forward onto current main; all commits keep his authorship. Opening fresh because the branch needed a substantial rebase across two months of drift (Prog::Base lost `update_stack`, `Prog::Test::PostgresBase` was overhauled, `assemble` grew `hostname_version:`).

> This feature has been useful in every past iteration, & always at times where you don't want to piece it together by hand

Review feedback from #5302 was already incorporated there (unarchive semaphore instead of a `restore_target_lsn` column, `&&=` validation idiom, restoring maintenance window / cert users); this branch additionally splits the work into four reviewable commits as requested. Per review here, firewall rules are deliberately *not* restored — the resource comes back with assemble's default rules like a new resource, and the customer revisits network and observability settings in one pass.

## Field validation

We ran this restore flow manually in production on 2026-07-28 (REPL, through the existing PITR machinery). Two findings that confirm and sharpen the design:

- **No recovery target is the only correct behavior.** The restored database had been idle for 8 days before deletion; a `recovery_target_time` is reached only when a commit at-or-past the target replays, so *every* target after its last write was unreachable and PG 18 died with `FATAL: recovery ended before configured recovery target was reached`. This isn't just about the archive tail — any idle database hits it. Documented in the `unarchive` commit message.
- **The `update_superuser_password` semaphore is load-bearing.** `initial_provisioning` is decremented in `wait_recovery_completion` before `configure` revisits, so the provisioning path never runs the password update after promotion and the WAL-replayed old password survives. We hit exactly this in production.

## Changes beyond #5302

- E2E prog rewritten to the current `PostgresBase` framework (`frame_accessor`s, base `assemble`/`start`, backup via the production `take_backup_for_converge` semaphore instead of hand-rolled daemonizer SSH).
- E2E test registered in `config/e2e_test_cases.yml` and `bin/e2e` on all three providers (metal gated on the minio cluster) — previously the prog was never invoked.
- `hostname_version` carried over from the archive so the restored resource keeps the hostname shape its connection strings used.
- `unarchive` wrapped in a `DB.transaction` so a mid-flight failure can't leave a half-restored resource.
- Coverage hole in the `any_archived_wal?` class-method seam closed.

`coverage_pspec` and `frozen_pspec` exit 0 at the tip; each commit passes the postgres spec tree and rubocop in isolation.

Supersedes #5302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

