### PR TITLE
Improve CSI

### DIFF
--- a/kubernetes/csi/Gemfile.lock
+++ b/kubernetes/csi/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ubi-csi (0.12.0)
+    ubi-csi (0.13.0)
       base64
       grpc (= 1.83.0)
       grpc-tools (= 1.83.0)

--- a/kubernetes/csi/lib/ubi_csi.rb
+++ b/kubernetes/csi/lib/ubi_csi.rb
@@ -5,7 +5,7 @@ require "csi_pb"
 require "csi_services_pb"
 
 module Csi
-  VERSION = "0.12.0"
+  VERSION = "0.13.0"
 end
 
 require_relative "ubi_csi/identity_service"

--- a/kubernetes/csi/lib/ubi_csi/capacity_manager.rb
+++ b/kubernetes/csi/lib/ubi_csi/capacity_manager.rb
@@ -17,8 +17,11 @@ module Csi
   # fresh data on the very next decision and the burst race closes.
   #
   # Each (hostname x storage_class) pair gets one CSIStorageCapacity. We
-  # baseline-from-disk on a slow timer (`reconcile`) and adjust by
-  # in-flight pending reservations on every reserve / release.
+  # baseline on a slow timer (`reconcile`) from the node's disk plus the
+  # PVs bound to it, and adjust by in-flight pending reservations on every
+  # reserve / release. Only the reservations for volumes whose PV object
+  # does not exist yet live in memory, so a controller restart cannot
+  # forget space that is already spoken for.
   class CapacityManager
     include ServiceHelper
 
@@ -29,42 +32,44 @@ module Csi
     # Overridable per deployment via the RESERVE_PERCENT env var.
     DEFAULT_RESERVE_PERCENT = 20
 
-    # Pending reservations expire if the volume never gets staged. This
-    # bounds the damage from CreateVolumes that succeed but never have a
-    # backing file created on the node (e.g. the PV is deleted before
-    # NodeStageVolume runs).
+    # Backstop for a reservation whose PV object never shows up, e.g. a
+    # CreateVolume that succeeded but whose caller went away before
+    # external-provisioner wrote the PV. Once the PV exists the
+    # reservation is dropped and the PV itself carries the accounting.
     RESERVATION_TTL_SECONDS = 600
 
     # How often the background thread re-baselines capacity from disk.
     RECONCILE_INTERVAL_SECONDS = 30
 
-    # The script emits raw building blocks rather than computing capacity
-    # itself so callers can also see which backing files are already on
-    # disk. We use that list to drop pending entries whose vol_id has
-    # been staged (and is therefore now reflected in `uncommitted`).
+    # A single `find` feeds both the uncommitted total and the staged-id
+    # list, so the two can never disagree about a file that appears or
+    # vanishes between scans.
     #
     # Output:
-    #   line 1: "<df_total> <df_avail> <uncommitted>" (all bytes)
-    #   line 2..N: one vol-id per backing file (sorted)
+    #   line 1: "<df_total> <df_avail>" (bytes)
+    #   line 2..N: "<vol-id>.img <apparent_bytes> <allocated_512b_blocks>"
     def self.capacity_script
       @capacity_script ||= <<~SH.freeze
         set -e
-        df_total=$(df --output=size -B1 #{V1::NodeService::VOLUME_BASE_PATH} | tail -n1)
-        df_avail=$(df --output=avail -B1 #{V1::NodeService::VOLUME_BASE_PATH} | tail -n1)
-        uncommitted=$(find #{V1::NodeService::VOLUME_BASE_PATH} -maxdepth 1 -name '*.img' -printf '%s %b\\n' | awk 'BEGIN{u=0} {u += $1 - $2*512} END{print int(u+0)}')
-        echo "$df_total $df_avail $uncommitted"
-        find #{V1::NodeService::VOLUME_BASE_PATH} -maxdepth 1 -name '*.img' -printf '%f\\n' | sed 's/\\.img$//' | sort
+        df --output=size,avail -B1 #{V1::NodeService::VOLUME_BASE_PATH} | tail -n1
+        find #{V1::NodeService::VOLUME_BASE_PATH} -maxdepth 1 -name '*.img' -printf '%f %s %b\\n' | sort
       SH
     end
 
     def self.parse_capacity_output(output)
       lines = output.lines.map(&:strip).delete_if(&:empty?)
       header = lines.first.to_s.split
-      unless header.size == 3
+      unless header.size == 2
         raise "Unexpected capacity output: #{output.inspect}"
       end
-      df_total, df_avail, uncommitted = header.map! { |s| Integer(s, 10) }
-      {df_total:, df_avail:, uncommitted:, staged_ids: lines[1..]}
+      df_total, df_avail = header.map! { |s| Integer(s, 10) }
+      # A file can report more allocated blocks than its apparent size once
+      # the filesystem adds extent metadata, so clamp each hole at zero.
+      files = lines[1..].map do |line|
+        name, size, blocks = line.split
+        [name.delete_suffix(".img"), [Integer(size, 10) - Integer(blocks, 10) * 512, 0].max]
+      end
+      {df_total:, df_avail:, uncommitted: files.sum(&:last), staged_ids: files.map(&:first)}
     end
 
     # The kube-apiserver normalizes resource.Quantity fields, so a
@@ -164,6 +169,7 @@ module Csi
       hostnames = client.list_csi_nodes_with_driver
       storage_classes = client.list_storage_classes_for_driver
       existing_objects = client.list_csi_storage_capacities
+      pvs_by_host = client.list_driver_pvs.group_by { |pv| pv[:node] }
 
       existing_by_key = existing_objects.to_h do |obj|
         host = obj.dig("nodeTopology", "matchLabels", "kubernetes.io/hostname")
@@ -171,26 +177,33 @@ module Csi
         [[host, sc].freeze, obj]
       end
 
-      expected_keys = []
+      # Computed before the per-host capacity fetch: a host we happen not
+      # to reach this round is still a host we expect an object for.
+      # Deleting it leaves the node with no CSIStorageCapacity at all, and
+      # CSIDriver.storageCapacity makes the scheduler read that as "no
+      # room here" until the next reconcile puts it back.
+      expected_keys = hostnames.product(storage_classes)
+
       hostnames.each do |hostname|
         cap = fetch_node_capacity(client, hostname)
         next unless cap
 
-        prune_pending(hostname, cap[:staged_ids])
-
+        base_capacity = base_capacity_for(hostname, cap, pvs_by_host[hostname] || [])
         storage_classes.each do |sc|
-          expected_keys << [hostname, sc]
-          upsert_capacity(client, hostname, sc, cap, existing_by_key[[hostname, sc]])
+          upsert_capacity(client, hostname, sc, base_capacity, existing_by_key[[hostname, sc]])
         end
       end
 
       existing_by_key.each do |key, obj|
         next if expected_keys.include?(key)
-        client.delete_csi_storage_capacity(name: obj.dig("metadata", "name"))
+        name = obj.dig("metadata", "name")
+        @logger.info("[CapacityManager] Deleting orphaned CSIStorageCapacity #{name}")
+        client.delete_csi_storage_capacity(name:)
       end
 
       @mutex.synchronize do
         @known.delete_if { |host, _| !hostnames.include?(host) }
+        @pending.delete_if { |host, _| !hostnames.include?(host) }
       end
     end
 
@@ -205,20 +218,37 @@ module Csi
       @pending[hostname].values.sum { |e| e[:size] }
     end
 
-    def prune_pending(hostname, staged_ids)
+    # A PV whose backing file is not on the node yet still owns its full
+    # size, but nothing in the df/uncommitted snapshot accounts for it.
+    # Deriving that set from the PV objects rather than from in-memory
+    # reservations is what keeps the accounting honest across a controller
+    # restart, and what stops a volume that is slow to stage from
+    # reappearing as free space when its reservation ages out.
+    def base_capacity_for(hostname, cap, pvs)
+      pv_ids = pvs.map { |pv| pv[:volume_handle] }
+      unstaged = pvs.reject { |pv| cap[:staged_ids].include?(pv[:volume_handle]) }
+      prune_pending(hostname, cap[:staged_ids], pv_ids)
+
+      unstaged_bytes = unstaged.sum { |pv| self.class.parse_quantity(pv[:capacity]) }
+      reserve_bytes = cap[:df_total] * @reserve_percent / 100
+      [cap[:df_avail] - cap[:uncommitted] - unstaged_bytes - reserve_bytes, 0].max
+    end
+
+    # Drops reservations the durable state has caught up with: either the
+    # backing file is on disk, or the PV object exists and base_capacity_for
+    # counts it from here on.
+    def prune_pending(hostname, staged_ids, pv_ids)
       @mutex.synchronize do
         now = Time.now
         bucket = @pending[hostname] ||= {}
         bucket.delete_if do |vol_id, entry|
-          staged_ids.include?(vol_id) || (now - entry[:created_at]) > RESERVATION_TTL_SECONDS
+          staged_ids.include?(vol_id) || pv_ids.include?(vol_id) ||
+            (now - entry[:created_at]) > RESERVATION_TTL_SECONDS
         end
       end
     end
 
-    def upsert_capacity(client, hostname, storage_class, cap, existing_obj)
-      reserve_bytes = cap[:df_total] * @reserve_percent / 100
-      base_capacity = [cap[:df_avail] - cap[:uncommitted] - reserve_bytes, 0].max
-
+    def upsert_capacity(client, hostname, storage_class, base_capacity, existing_obj)
       pending_sum = @mutex.synchronize { pending_sum_for(hostname) }
       published = [base_capacity - pending_sum, 0].max
       # The kube-scheduler's VolumeBinding plugin uses maximumVolumeSize

--- a/kubernetes/csi/lib/ubi_csi/kubernetes_client.rb
+++ b/kubernetes/csi/lib/ubi_csi/kubernetes_client.rb
@@ -166,6 +166,20 @@ module Csi
       end
     end
 
+    def list_driver_pvs
+      list = yaml_load_kubectl("get", "pv")
+      list["items"].filter_map do |pv|
+        next unless pv.dig("spec", "csi", "driver") == DRIVER_NAME
+        node = extract_node_from_pv(pv)
+        next unless node
+        {
+          node:,
+          volume_handle: pv.dig("spec", "csi", "volumeHandle"),
+          capacity: pv.dig("spec", "capacity", "storage"),
+        }
+      end
+    end
+
     # Returns CSIStorageCapacity objects in the controller's namespace
     # that belong to a StorageClass for our driver.
     def list_csi_storage_capacities

--- a/kubernetes/csi/spec/csi/v1/identity_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/identity_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Csi::V1::IdentityService do
       request = Csi::V1::GetPluginInfoRequest.new
       response = service.get_plugin_info(request, call)
       expect(response.name).to eq("csi.ubicloud.com")
-      expect(response.vendor_version).to eq("0.12.0")
+      expect(response.vendor_version).to eq("0.13.0")
     end
   end
 

--- a/kubernetes/csi/spec/ubi_csi/capacity_manager_spec.rb
+++ b/kubernetes/csi/spec/ubi_csi/capacity_manager_spec.rb
@@ -13,25 +13,30 @@ RSpec.describe Csi::CapacityManager do
   after { manager.shutdown! }
 
   describe ".parse_capacity_output" do
-    it "parses header and staged ids" do
-      result = described_class.parse_capacity_output("100 50 10\nvol-a\nvol-b\n")
-      expect(result).to eq(df_total: 100, df_avail: 50, uncommitted: 10, staged_ids: ["vol-a", "vol-b"])
+    it "sums the holes of each backing file into uncommitted and lists their ids" do
+      result = described_class.parse_capacity_output("100 50\nvol-a.img 2048 2\nvol-b.img 1024 1\n")
+      expect(result).to eq(df_total: 100, df_avail: 50, uncommitted: 1536, staged_ids: ["vol-a", "vol-b"])
     end
 
-    it "returns empty staged_ids when no backing files" do
-      expect(described_class.parse_capacity_output("100 50 10\n")[:staged_ids]).to eq([])
+    it "clamps a file whose allocation exceeds its apparent size at zero" do
+      expect(described_class.parse_capacity_output("100 50\nvol-a.img 512 4\n")[:uncommitted]).to eq(0)
+    end
+
+    it "returns empty staged_ids and no uncommitted bytes when there are no backing files" do
+      result = described_class.parse_capacity_output("100 50\n")
+      expect(result).to eq(df_total: 100, df_avail: 50, uncommitted: 0, staged_ids: [])
     end
 
     it "tolerates trailing whitespace and blank lines" do
-      expect(described_class.parse_capacity_output("100 50 10\n\nvol-a\n  \nvol-b\n")[:staged_ids]).to eq(["vol-a", "vol-b"])
+      expect(described_class.parse_capacity_output("100 50\n\nvol-a.img 1024 0\n  \nvol-b.img 1024 0\n")[:staged_ids]).to eq(["vol-a", "vol-b"])
     end
 
     it "raises when the header has the wrong arity" do
-      expect { described_class.parse_capacity_output("100 50\nvol-a\n") }.to raise_error(RuntimeError, "Unexpected capacity output: \"100 50\\nvol-a\\n\"")
+      expect { described_class.parse_capacity_output("100 50 10\nvol-a.img 1024 0\n") }.to raise_error(RuntimeError, "Unexpected capacity output: \"100 50 10\\nvol-a.img 1024 0\\n\"")
     end
 
     it "raises when the header is non-numeric" do
-      expect { described_class.parse_capacity_output("a b c\n") }.to raise_error(ArgumentError, 'invalid value for Integer(): "a"')
+      expect { described_class.parse_capacity_output("a b\n") }.to raise_error(ArgumentError, 'invalid value for Integer(): "a"')
     end
   end
 
@@ -233,9 +238,11 @@ RSpec.describe Csi::CapacityManager do
       ]})
     end
     let(:node_yaml) { YAML.dump({"status" => {"addresses" => [{"address" => "10.0.0.1"}]}}) }
-    # 100 GiB total, 50 GiB available, 10 GiB uncommitted, default 20% reserve, no pendings:
-    # base = 50 - 10 - 20 = 20 GiB = 21_474_836_480 bytes.
-    let(:capacity_output) { "107374182400 53687091200 10737418240\nvol-a\n" }
+    let(:pvs_yaml) { YAML.dump({"items" => []}) }
+    # 100 GiB total, 50 GiB available, vol-a staged with a 10 GiB hole,
+    # default 20% reserve, no pendings: base = 50 - 10 - 20 = 20 GiB.
+    let(:capacity_output) { "107374182400 53687091200\nvol-a.img 10737418240 0\n" }
+
     let(:create_object) do
       {
         "apiVersion" => "storage.k8s.io/v1",
@@ -260,15 +267,28 @@ RSpec.describe Csi::CapacityManager do
       expect(Open3).to receive(:capture2e).with("kubectl", "get", "csinodes", "-oyaml", stdin_data: nil).and_return([csinodes_yaml, success_status])
       expect(Open3).to receive(:capture2e).with("kubectl", "get", "storageclasses", "-oyaml", stdin_data: nil).twice.and_return([storageclasses_yaml, success_status])
       expect(Open3).to receive(:capture2e).with("kubectl", "-n", "ubicsi", "get", "csistoragecapacities", "-oyaml", stdin_data: nil).and_return([YAML.dump({"items" => existing}), success_status])
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).and_return([pvs_yaml, success_status])
     end
 
-    it "creates a CSIStorageCapacity object when none exists for the (host, sc) pair" do
-      stub_baseline
+    def stub_node_capacity
       expect(Open3).to receive(:capture2e).with("kubectl", "get", "node", "worker-1", "-oyaml", stdin_data: nil).and_return([node_yaml, success_status])
       expect(Open3).to receive(:capture2e).with(
         "ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
         "-o", "LogLevel=ERROR", "-i", "/ssh/id_ed25519", "ubi@10.0.0.1", described_class.capacity_script,
       ).and_return([capacity_output, success_status])
+    end
+
+    def pv_item(volume_handle:, storage:, node: "worker-1")
+      {"spec" => {
+        "capacity" => {"storage" => storage},
+        "csi" => {"driver" => "csi.ubicloud.com", "volumeHandle" => volume_handle},
+        "nodeAffinity" => {"required" => {"nodeSelectorTerms" => [{"matchExpressions" => [{"values" => [node]}]}]}},
+      }}
+    end
+
+    it "creates a CSIStorageCapacity object when none exists for the (host, sc) pair" do
+      stub_baseline
+      stub_node_capacity
       expect(Open3).to receive(:capture2e).with("kubectl", "create", "-f", "-", stdin_data: YAML.dump(create_object)).and_return(["created", success_status])
 
       manager.reconcile
@@ -281,11 +301,7 @@ RSpec.describe Csi::CapacityManager do
       custom = described_class.new(logger:, max_volume_size:, reserve_percent: 25)
       custom.instance_variable_set(:@owner_ref, {"name" => "ubicsi-provisioner"})
       stub_baseline
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "node", "worker-1", "-oyaml", stdin_data: nil).and_return([node_yaml, success_status])
-      expect(Open3).to receive(:capture2e).with(
-        "ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
-        "-o", "LogLevel=ERROR", "-i", "/ssh/id_ed25519", "ubi@10.0.0.1", described_class.capacity_script,
-      ).and_return([capacity_output, success_status])
+      stub_node_capacity
       expect(Open3).to receive(:capture2e).with("kubectl", "create", "-f", "-", stdin_data: YAML.dump(create_object.merge("capacity" => "16106127360"))).and_return(["created", success_status])
 
       custom.reconcile
@@ -302,11 +318,7 @@ RSpec.describe Csi::CapacityManager do
         "maximumVolumeSize" => "999",
       }]
       stub_baseline(existing:)
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "node", "worker-1", "-oyaml", stdin_data: nil).and_return([node_yaml, success_status])
-      expect(Open3).to receive(:capture2e).with(
-        "ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
-        "-o", "LogLevel=ERROR", "-i", "/ssh/id_ed25519", "ubi@10.0.0.1", described_class.capacity_script,
-      ).and_return([capacity_output, success_status])
+      stub_node_capacity
       expect(Open3).to receive(:capture2e).with(
         "kubectl", "-n", "ubicsi", "patch", "csistoragecapacity", "csisc-existing",
         "--type=merge", "-p", '{"capacity":"21474836480","maximumVolumeSize":"10737418240"}',
@@ -329,11 +341,7 @@ RSpec.describe Csi::CapacityManager do
         "maximumVolumeSize" => "10Gi",
       }]
       stub_baseline(existing:)
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "node", "worker-1", "-oyaml", stdin_data: nil).and_return([node_yaml, success_status])
-      expect(Open3).to receive(:capture2e).with(
-        "ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
-        "-o", "LogLevel=ERROR", "-i", "/ssh/id_ed25519", "ubi@10.0.0.1", described_class.capacity_script,
-      ).and_return([capacity_output, success_status])
+      stub_node_capacity
 
       expect(manager.kubernetes_client).not_to receive(:patch_csi_storage_capacity)
       expect(manager.kubernetes_client).not_to receive(:create_csi_storage_capacity)
@@ -359,11 +367,8 @@ RSpec.describe Csi::CapacityManager do
         },
       ]
       stub_baseline(existing:)
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "node", "worker-1", "-oyaml", stdin_data: nil).and_return([node_yaml, success_status])
-      expect(Open3).to receive(:capture2e).with(
-        "ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
-        "-o", "LogLevel=ERROR", "-i", "/ssh/id_ed25519", "ubi@10.0.0.1", described_class.capacity_script,
-      ).and_return([capacity_output, success_status])
+      stub_node_capacity
+      expect(logger).to receive(:info).with("[CapacityManager] Deleting orphaned CSIStorageCapacity csisc-orphan")
       expect(Open3).to receive(:capture2e).with(
         "kubectl", "-n", "ubicsi", "delete", "csistoragecapacity", "csisc-orphan", "--ignore-not-found=true",
         stdin_data: nil,
@@ -377,11 +382,7 @@ RSpec.describe Csi::CapacityManager do
     it "drops pending entries whose vol_id has been staged" do
       manager.instance_variable_set(:@pending, {"worker-1" => {"vol-a" => {size: 5_000_000, created_at: Time.now}}})
       stub_baseline
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "node", "worker-1", "-oyaml", stdin_data: nil).and_return([node_yaml, success_status])
-      expect(Open3).to receive(:capture2e).with(
-        "ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
-        "-o", "LogLevel=ERROR", "-i", "/ssh/id_ed25519", "ubi@10.0.0.1", described_class.capacity_script,
-      ).and_return([capacity_output, success_status])
+      stub_node_capacity
       expect(Open3).to receive(:capture2e).with("kubectl", "create", "-f", "-", stdin_data: YAML.dump(create_object)).and_return(["created", success_status])
 
       manager.reconcile
@@ -394,11 +395,7 @@ RSpec.describe Csi::CapacityManager do
         "worker-1" => {"vol-old" => {size: 5_000_000, created_at: Time.now - 700}},
       })
       stub_baseline
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "node", "worker-1", "-oyaml", stdin_data: nil).and_return([node_yaml, success_status])
-      expect(Open3).to receive(:capture2e).with(
-        "ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
-        "-o", "LogLevel=ERROR", "-i", "/ssh/id_ed25519", "ubi@10.0.0.1", described_class.capacity_script,
-      ).and_return(["107374182400 53687091200 10737418240\n", success_status])
+      stub_node_capacity
       expect(Open3).to receive(:capture2e).with("kubectl", "create", "-f", "-", stdin_data: YAML.dump(create_object)).and_return(["created", success_status])
 
       manager.reconcile
@@ -406,8 +403,53 @@ RSpec.describe Csi::CapacityManager do
       expect(manager.instance_variable_get(:@pending)["worker-1"]).to be_empty
     end
 
-    it "skips a host when the capacity script fails" do
-      stub_baseline
+    context "when a PV has no backing file on its node yet" do
+      let(:pvs_yaml) { YAML.dump({"items" => [pv_item(volume_handle: "vol-unstaged", storage: "5Gi")]}) }
+
+      it "subtracts the PV's full size from the baseline so a restart cannot forget it" do
+        stub_baseline
+        stub_node_capacity
+        # base = 20 GiB - 5 GiB = 15 GiB = 16_106_127_360 bytes.
+        expect(Open3).to receive(:capture2e).with("kubectl", "create", "-f", "-", stdin_data: YAML.dump(create_object.merge("capacity" => "16106127360"))).and_return(["created", success_status])
+
+        manager.reconcile
+
+        expect(manager.instance_variable_get(:@known)["worker-1"]["ubicloud-standard"][:last_published]).to eq(15 * 1024 * 1024 * 1024)
+      end
+
+      it "drops the in-memory reservation for that PV so the two are not counted twice" do
+        manager.instance_variable_set(:@pending, {"worker-1" => {"vol-unstaged" => {size: 5 * 1024**3, created_at: Time.now}}})
+        stub_baseline
+        stub_node_capacity
+        expect(Open3).to receive(:capture2e).with("kubectl", "create", "-f", "-", stdin_data: YAML.dump(create_object.merge("capacity" => "16106127360"))).and_return(["created", success_status])
+
+        manager.reconcile
+
+        expect(manager.instance_variable_get(:@pending)["worker-1"]).to be_empty
+      end
+    end
+
+    it "ignores PVs pinned to another node" do
+      pvs = YAML.dump({"items" => [pv_item(volume_handle: "vol-elsewhere", storage: "5Gi", node: "worker-2")]})
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "csinodes", "-oyaml", stdin_data: nil).and_return([csinodes_yaml, success_status])
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "storageclasses", "-oyaml", stdin_data: nil).twice.and_return([storageclasses_yaml, success_status])
+      expect(Open3).to receive(:capture2e).with("kubectl", "-n", "ubicsi", "get", "csistoragecapacities", "-oyaml", stdin_data: nil).and_return([YAML.dump({"items" => []}), success_status])
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).and_return([pvs, success_status])
+      stub_node_capacity
+      expect(Open3).to receive(:capture2e).with("kubectl", "create", "-f", "-", stdin_data: YAML.dump(create_object)).and_return(["created", success_status])
+
+      manager.reconcile
+    end
+
+    it "keeps the existing object for a host whose capacity script fails" do
+      existing = [{
+        "metadata" => {"name" => "csisc-existing"},
+        "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
+        "storageClassName" => "ubicloud-standard",
+        "capacity" => "20Gi",
+        "maximumVolumeSize" => "10Gi",
+      }]
+      stub_baseline(existing:)
       expect(Open3).to receive(:capture2e).with("kubectl", "get", "node", "worker-1", "-oyaml", stdin_data: nil).and_return([node_yaml, success_status])
       expect(Open3).to receive(:capture2e).with(
         "ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
@@ -415,6 +457,7 @@ RSpec.describe Csi::CapacityManager do
       ).and_return(["ssh: connect failed", failure_status])
       expect(manager.kubernetes_client).not_to receive(:create_csi_storage_capacity)
       expect(manager.kubernetes_client).not_to receive(:patch_csi_storage_capacity)
+      expect(manager.kubernetes_client).not_to receive(:delete_csi_storage_capacity)
       expect(logger).to receive(:error).with("[CapacityManager] capacity script on worker-1 failed: ssh: connect failed")
 
       manager.reconcile

--- a/kubernetes/csi/spec/ubi_csi/kubernetes_client_spec.rb
+++ b/kubernetes/csi/spec/ubi_csi/kubernetes_client_spec.rb
@@ -350,6 +350,31 @@ RSpec.describe Csi::KubernetesClient do
     end
   end
 
+  describe "#list_driver_pvs" do
+    def pv(name, driver, node)
+      affinity = node ? {"required" => {"nodeSelectorTerms" => [{"matchExpressions" => [{"values" => [node]}]}]}} : nil
+      {
+        "metadata" => {"name" => name},
+        "spec" => {
+          "capacity" => {"storage" => "5Gi"},
+          "csi" => {"driver" => driver, "volumeHandle" => "vol-#{name}"},
+          "nodeAffinity" => affinity,
+        },
+      }
+    end
+
+    it "returns the node, handle and size of each PV our driver pinned to a node" do
+      pv_list = {"items" => [
+        pv("a", "csi.ubicloud.com", "worker-1"),
+        pv("b", "other.example.com", "worker-1"),
+        pv("c", "csi.ubicloud.com", nil),
+      ]}
+      expect(client).to receive(:run_kubectl).with("get", "pv", "-oyaml").and_return(YAML.dump(pv_list))
+
+      expect(client.list_driver_pvs).to eq([{node: "worker-1", volume_handle: "vol-a", capacity: "5Gi"}])
+    end
+  end
+
   describe "#list_csi_storage_capacities" do
     let(:sc_list) { {"items" => [{"metadata" => {"name" => "ubicloud-standard"}, "provisioner" => "csi.ubicloud.com"}]} }
 

--- a/kubernetes/csi/ubi-csi.gemspec
+++ b/kubernetes/csi/ubi-csi.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "ubi-csi"
-  spec.version = "0.12.0"
+  spec.version = "0.13.0"
   spec.authors = ["Ubicloud"]
   spec.email = ["support@ubicloud.com"]
 

--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -78,6 +78,9 @@ kubelet_config = {
   "apiVersion" => "kubelet.config.k8s.io/v1beta1",
   "kind" => "KubeletConfiguration",
   "serverTLSBootstrap" => true,
+  "imageGCHighThresholdPercent" => 60,
+  "imageGCLowThresholdPercent" => 50,
+  "imageMaximumGCAge" => "168h",
 }
 
 config_path = "/tmp/kubeadm-config.yaml"

--- a/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:v0.12.0
+          image: ubicloud/ubicsi:v0.13.0
           imagePullPolicy: IfNotPresent
           args: ["node"]
           env:

--- a/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:v0.12.0
+          image: ubicloud/ubicsi:v0.13.0
           imagePullPolicy: IfNotPresent
           args: ["controller"]
           env:


### PR DESCRIPTION
**Stop the CSI capacity manager from forgetting in-flight reservations**
A volume between CreateVolume and NodeStageVolume was tracked only in the controller's memory, so restarting the provisioner pod republished its size as free space until the backing file appeared, and left the admission check unaware of it. The reservation TTL had the same effect on a volume that was slow to stage.

Take the durable answer from the API instead: any PV pinned to the node whose backing file is not on disk yet owns its full size. In-memory reservations now only cover the window before the PV object exists.

Also stop deleting a node's CSIStorageCapacity when its capacity script happens to fail - with CSIDriver.storageCapacity the scheduler reads a missing object as "no room here" until the next reconcile puts it back - and scan the backing files once rather than twice, so the uncommitted total and the staged-id list cannot disagree.

**Collect container images before CSI capacity starves**
Kubelet's default image GC does not run until the imagefs is 85% full, but the CSI capacity manager publishes zero once free space drops below its reserve plus the space owed to thin-provisioned and unstaged PVs. That point is always reached first, so a node fills with unused images, every PVC becomes unschedulable, and the pending pods stop pulling the images that would otherwise push usage to the GC threshold. Nothing breaks the loop without manual intervention.

Trigger collection at 60% and target 50%, which puts image reclamation well ahead of the reserve, and set imageMaximumGCAge so unused images are also collected on age alone, independent of disk usage, in case a node's unstaged PVs push the zero point back above the trigger.

**Bump Ubicsi version**