### PR TITLE
Answer neighbor solicitations by route rather than by registry

### DIFF
--- a/doc/ndp_proxy.md
+++ b/doc/ndp_proxy.md
@@ -1,0 +1,132 @@
+# Route-following NDP proxy
+
+## Problem
+
+Some providers deliver a host's IPv6 network on-link instead of routing
+it: their router multicasts a Neighbor Solicitation for every individual
+destination address and only delivers traffic after receiving a Neighbor
+Advertisement. Such hosts have `vm_host.ndp_needed` set.
+
+None of the addresses delegated to VMs are configured on any host
+interface; they exist only as routes into each VM's network namespace
+(`route <ephemeral_net6> via <vethi link-local> dev vetho<vm>`). The
+kernel therefore answers NS for none of them. Linux's built-in remedy,
+`proxy_ndp`, is an exact-match /128 registry (`ip -6 neigh add proxy`)
+with no prefix or route-following mode, so it forces the control plane
+to enumerate every address a guest may use. That caps guests at the two
+enumerated addresses and is exactly the per-address bookkeeping IPv4
+never needed: proxy ARP answers by consulting the routing table.
+
+## Design
+
+An eBPF program on the uplink's tc ingress hook gives NDP the same
+routing-driven semantics. The program, its map layouts, and the loader
+that writes them live together in [ubicloud/host-ebpf][host-ebpf],
+released as a static binary; nothing about the eBPF is split across
+repositories.
+
+[host-ebpf]: https://github.com/ubicloud/host-ebpf
+
+```
+NS "who has T?"  ->  bpf_fib_lookup(T)  ->  egress != uplink?  ->  NA "T is at <uplink MAC>"
+                                        ->  anything else      ->  pass to the kernel stack
+```
+
+Case analysis for a host with `net6 = 2a01:db8:aa::/64`:
+
+| NS target                | best FIB match             | action |
+|--------------------------|----------------------------|--------|
+| addr in a live VM's /79  | `/79 dev vetho<vm>`        | answer |
+| unallocated addr in net6 | on-link /64 on the uplink  | silent |
+| host's own address       | local (`NOT_FWDED`)        | silent; the kernel answers natively |
+| anything else            | default route (uplink)     | silent |
+
+The routing table is the only registry: VM create/destroy already
+installs and removes the routes, so delegating the guest's entire /80
+requires no additional state anywhere. An LPM map holding the host's
+`net6` bounds what the program may ever answer, independent of FIB
+content.
+
+Protocol rules, all matching what the kernel responder this preempts
+would do: a solicitation is ignored unless its hop limit is 255
+(RFC 4861 7.1.1, rejecting off-link forgery) and its ICMPv6 checksum
+verifies. NS with an unspecified source is duplicate address detection
+and is never defended, so a node that legitimately holds a delegated
+address can still claim it. The NA carries Router|Solicited with
+Override clear (RFC 4861 7.2.4: a proxy must let an actual owner win
+the neighbor cache), is sourced from the target, and mirrors the
+solicitation's source link-layer option as a target link-layer option.
+An optionless NS - a unicast NUD probe - is answered without a TLL,
+keeping the rewrite size-preserving; a multicast solicitation without
+that option is left alone, since its advertisement would be required
+to carry a TLL that does not fit. The program never drops: every non-answer path returns `TC_ACT_UNSPEC` so
+the stack still sees the packet, and when it does answer, the redirect
+consumes the NS so static proxy entries cannot double-answer.
+
+The uplink runs with allmulticast on: initial solicitations arrive on
+solicited-node multicast groups derived from the target's low 24 bits,
+which cannot be joined ahead of time for a /80, and the NIC's hardware
+filter would otherwise drop them before tc runs.
+
+## Operational surface
+
+`Prog::SetupNdpProxy` (budded from `Prog::Vm::HostNexus#prep` when
+`ndp_needed`) runs `host/bin/setup-ndp-proxy install <net6>`, which
+downloads the pinned host-ebpf release, verifies its SHA-256 the way
+`CloudHypervisor` does, and writes and enables the units below. The
+binary refuses to attach on kernels older than 6.6, which TCX links
+require.
+
+- `ndp-proxy.service` (oneshot, at boot): `setup-ndp-proxy apply`,
+  which resolves the uplink from the IPv6 default route and runs
+  `host-ebpf ndp-proxy apply`. Program and maps are pinned under
+  `/sys/fs/bpf/ndp-proxy`, and neither pins nor attachments survive a
+  reboot, so this unit restores them with no control-plane
+  involvement.
+- `ndp-proxy-watch.timer`, and the `ndp-proxy-watch.service` it
+  triggers every minute: `setup-ndp-proxy verify`, which runs
+  `host-ebpf ndp-proxy verify -heal`. That prints the counters when
+  nothing drifted; on drift it names what drifted, prints the counters
+  it is about to lose, re-applies, and exits non-zero so the unit
+  failure stays visible in `systemctl --failed`.
+
+Both units fetch the release themselves rather than assuming an
+install placed it, so bumping `NdpProxySetup::VERSION` and rolling out
+rhizome upgrades hosts that were provisioned before the bump.
+
+Rhizome owns only host policy: which hosts get the proxy, which device
+is the uplink, and when to install. Everything about the eBPF itself is
+behind the binary's command line.
+
+An attached program cannot crash; the failure modes are "never
+attached", "detached", and "allmulticast cleared", all of which decay
+slowly as the provider router's neighbor cache expires - hence the
+watch timer rather than a liveness check on a daemon.
+
+## Migration
+
+The proxy coexists with the legacy per-/128 entries `vm_setup.rb` adds
+for `ndp_needed` VMs (`guest_ephemeral.nth(2)`,
+`clover_ephemeral.nth(0)`). Once every `ndp_needed` host runs the
+proxy, those `ip -6 neigh add proxy` calls and the `ndp_needed`
+plumbing through `params_json`/`setup-vm` can be deleted; stale kernel
+entries are harmless and die on reboot. `vm_host.ndp_needed` remains as
+the host-scoped "install the responder" flag.
+
+## Testing
+
+The program's own tests live in host-ebpf: a two-netns rig that drives
+the released binary on the wire, plus unit tests pinning the map
+layouts against the compiled object. Rhizome's specs cover what
+rhizome owns - digest-verified download, unit contents, and the
+commands handed to the binary.
+
+## Boundary
+
+This is the first consumer of host-ebpf. The standing rule for what
+else may move there: stateless per-packet decisions at the uplink edge
+(next: the `drop_unused_ip_packets` nftables table, whose per-VM
+allowlist becomes atomic pinned-map updates instead of
+`/etc/nftables.d` fragments plus a global `systemctl reload`).
+Anything that relies on conntrack - NAT44, the load balancer DNAT
+mesh, established/related firewall semantics - stays in nftables.

--- a/prog/setup_ndp_proxy.rb
+++ b/prog/setup_ndp_proxy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Prog::SetupNdpProxy < Prog::Base
+  subject_is :sshable, :vm_host
+
+  label def start
+    pop "ndp proxy not needed" unless vm_host.ndp_needed
+
+    unless vm_host.net6
+      # LearnNetwork is budded alongside this prog and fills net6 in, so the
+      # program's prefix guard has to wait for it rather than skip the host.
+      # It can also pop having learned nothing, which leaves nothing else to
+      # bound the wait.
+      register_deadline(nil, 10 * 60)
+      nap 5
+    end
+
+    sshable.cmd("sudo host/bin/setup-ndp-proxy install :net6", net6: vm_host.net6.to_s)
+
+    pop "ndp proxy was setup"
+  end
+end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -90,6 +90,7 @@ class Prog::Vm::HostNexus < Prog::Base
     bud Prog::InstallDnsmasq
     bud Prog::SetupSysstat
     bud Prog::SetupNftables
+    bud Prog::SetupNdpProxy if vm_host.ndp_needed
     bud Prog::SetupNodeExporter
     hop_wait_prep
   end

--- a/rhizome/common/lib/network.rb
+++ b/rhizome/common/lib/network.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "json"
+
 # By reading the mac address from an interface, compute its ipv6
 # link local address that it would have if its device state were set
 # to up. From RFC 4291 Section 2.5.1 & Appendix A.
@@ -22,4 +24,14 @@ def gen_mac
   ([rand(256) & 0xFE | 0x02] + Array.new(5) { rand(256) }).map {
     "%0.2X" % _1
   }.join(":").downcase
+end
+
+def default_route_device(routes_json)
+  routes = JSON.parse(routes_json)
+  # A multipath default route carries its devices under nexthops instead,
+  # and picking one of them is not something callers can do blindly.
+  device = routes.find { |route| route["dst"] == "default" }&.fetch("dev", nil)
+  return device if device
+
+  fail "No default route found in #{routes.inspect}"
 end

--- a/rhizome/common/spec/network_spec.rb
+++ b/rhizome/common/spec/network_spec.rb
@@ -28,4 +28,20 @@ RSpec.describe "network" do
       end
     end
   end
+
+  describe "default_route_device" do
+    it "returns the device of the default route" do
+      routes = '[{"dst": "10.0.0.0/8", "dev": "eth1"}, {"dst": "default", "dev": "eth0"}]'
+      expect(default_route_device(routes)).to eq("eth0")
+    end
+
+    it "fails when there is no default route" do
+      expect { default_route_device('[{"dst": "10.0.0.0/8", "dev": "eth1"}]') }.to raise_error(/No default route found/)
+    end
+
+    it "fails when the default route has no device of its own" do
+      routes = '[{"dst": "default", "nexthops": [{"dev": "eth0"}, {"dev": "eth1"}]}]'
+      expect { default_route_device(routes) }.to raise_error(/No default route found/)
+    end
+  end
 end

--- a/rhizome/host/bin/setup-ndp-proxy
+++ b/rhizome/host/bin/setup-ndp-proxy
@@ -1,0 +1,28 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/ndp_proxy_setup"
+
+unless (action = ARGV.shift)
+  puts "expected action as argument"
+  exit 1
+end
+
+unless (net6 = ARGV.shift)
+  puts "expected net6 as argument"
+  exit 1
+end
+
+setup = NdpProxySetup.new(net6)
+
+case action
+when "install"
+  setup.install
+when "apply"
+  setup.apply
+when "verify"
+  setup.verify
+else
+  puts "invalid action #{action}"
+  exit 1
+end

--- a/rhizome/host/lib/ndp_proxy_setup.rb
+++ b/rhizome/host/lib/ndp_proxy_setup.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require_relative "../../common/lib/arch"
+require_relative "../../common/lib/network"
+require "fileutils"
+
+# Installs the route-following NDP proxy on hosts whose provider treats the
+# host's IPv6 network as on-link. The eBPF program and everything that
+# configures it live in the host-ebpf binary; this class owns when to install
+# it, and the systemd units that re-apply and watch it.
+class NdpProxySetup
+  VERSION = "0.1.0"
+
+  PACKAGE_SHA256 = Arch.render(
+    x64: "05835a138677ea3899e7e257deb4e2886ea25789ba00a20eceedbc5e7ea89646",
+    arm64: "28631e4abb6b6300743b7883f2afbb2ccca311a5d47a6c780025a886819e7395",
+  )
+
+  UNIT_DIR = "/etc/systemd/system"
+  SETUP_BIN = "/home/rhizome/host/bin/setup-ndp-proxy"
+
+  def initialize(net6)
+    @net6 = net6
+  end
+
+  def install_dir
+    "/opt/host-ebpf-#{VERSION}"
+  end
+
+  def bin
+    File.join(install_dir, "host-ebpf")
+  end
+
+  def package_url
+    arch = Arch.render(x64: "x86_64", arm64: "arm64")
+    "https://github.com/ubicloud/host-ebpf/releases/download/v#{VERSION}/host-ebpf_Linux_#{arch}.tar.gz"
+  end
+
+  def install
+    download_binary
+    write_units
+    r "systemctl daemon-reload"
+    r "systemctl enable ndp-proxy.service"
+    # Starting an active RemainAfterExit oneshot is a no-op, so restart to
+    # re-run apply against a new binary or a corrected net6.
+    r "systemctl restart ndp-proxy.service"
+    r "systemctl enable --now ndp-proxy-watch.timer"
+  end
+
+  # Extraction goes through a temporary path because the units resolve bin
+  # from VERSION on every boot and every tick, so a truncated file left at
+  # that path by an interrupted run would be trusted forever.
+  def download_binary
+    return if File.exist?(bin)
+
+    FileUtils.mkdir_p(install_dir)
+    tarball = "/tmp/host-ebpf-#{VERSION}.tar.gz"
+    safe_write_to_file(tarball) do |f|
+      unless curl_file(package_url, f.path) == PACKAGE_SHA256
+        fail "Invalid SHA-256 digest"
+      end
+    end
+    safe_write_to_file(bin) do |f|
+      r "tar -xzOf #{tarball} host-ebpf > #{f.path}"
+      FileUtils.chmod("a+x", f.path)
+    end
+    FileUtils.rm_f(tarball)
+  end
+
+  # Rhizome reaches already-provisioned hosts, but HostNexus#prep does not
+  # run again on them, so the units fetch the version they were written for
+  # rather than assuming an install placed it.
+  def apply
+    download_binary
+    r "#{bin} ndp-proxy apply -uplink #{uplink} -prefix #{@net6}"
+  end
+
+  def verify
+    download_binary
+    r "#{bin} ndp-proxy verify -uplink #{uplink} -prefix #{@net6} -heal"
+  end
+
+  # Neighbor discovery is IPv6 only, and a host can route the two families
+  # out different devices.
+  def uplink
+    default_route_device(r("ip -6 -j route"))
+  end
+
+  def write_units
+    safe_write_to_file(File.join(UNIT_DIR, "ndp-proxy.service"), <<UNIT)
+[Unit]
+Description=Route-following NDP proxy for delegated VM prefixes
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/home/rhizome
+ExecStart=#{SETUP_BIN} apply #{@net6}
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+    safe_write_to_file(File.join(UNIT_DIR, "ndp-proxy-watch.service"), <<UNIT)
+[Unit]
+Description=Re-attach the NDP proxy if its uplink state drifted
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/rhizome
+ExecStart=#{SETUP_BIN} verify #{@net6}
+UNIT
+    safe_write_to_file(File.join(UNIT_DIR, "ndp-proxy-watch.timer"), <<UNIT)
+[Unit]
+Description=Periodic NDP proxy attachment check
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1min
+
+[Install]
+WantedBy=timers.target
+UNIT
+  end
+end

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -286,8 +286,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     r "ip route replace #{gua.shellescape} via #{vethi_ll.shellescape} dev vetho#{q_vm}"
 
     if ndp_needed
-      routes = r "ip -j route"
-      main_device = parse_routes(routes)
+      main_device = default_route_device(r("ip -j route"))
       r "ip -6 neigh add proxy #{guest_ephemeral.nth(2)} dev #{main_device}"
       r "ip -6 neigh add proxy #{clover_ephemeral.nth(0)} dev #{main_device}"
     end
@@ -330,14 +329,6 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
 
     r "ip -n #{q_vm} addr replace fd00:0b1c:100d:5AFE:CE:: dev #{nics.first.tap}"
     r "ip -n #{q_vm} addr replace fd00:0b1c:100d:53:: dev #{nics.first.tap}"
-  end
-
-  def parse_routes(routes)
-    routes_j = JSON.parse(routes)
-    default_route = routes_j.find { |route| route["dst"] == "default" }
-    return default_route["dev"] if default_route
-
-    fail "No default route found in #{routes_j.inspect}"
   end
 
   def routes4(ip4, ip4_local, nics)

--- a/rhizome/host/spec/ndp_proxy_setup_spec.rb
+++ b/rhizome/host/spec/ndp_proxy_setup_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require_relative "../lib/ndp_proxy_setup"
+
+RSpec.describe NdpProxySetup do
+  subject(:nps) { described_class.new("2a01:4f8:10a:128b::/64") }
+
+  let(:bin) { "/opt/host-ebpf-#{described_class::VERSION}/host-ebpf" }
+  let(:tarball) { "/tmp/host-ebpf-#{described_class::VERSION}.tar.gz" }
+
+  describe "#install" do
+    it "downloads the binary, writes units, and enables them" do
+      calls = []
+      expect(nps).to receive(:download_binary) { calls << :download }
+      expect(nps).to receive(:write_units) { calls << :units }
+      expect(nps).to receive(:r).with("systemctl daemon-reload") { calls << :reload }
+      expect(nps).to receive(:r).with("systemctl enable ndp-proxy.service")
+      expect(nps).to receive(:r).with("systemctl restart ndp-proxy.service")
+      expect(nps).to receive(:r).with("systemctl enable --now ndp-proxy-watch.timer")
+
+      nps.install
+      expect(calls).to eq([:download, :units, :reload])
+    end
+  end
+
+  describe "#download_binary" do
+    it "verifies the digest, extracts, and marks the binary executable" do
+      expect(File).to receive(:exist?).with(bin).and_return(false)
+      expect(FileUtils).to receive(:mkdir_p).with(File.dirname(bin))
+      expect(nps).to receive(:safe_write_to_file).with(tarball) do |_, &blk|
+        expect(nps).to receive(:curl_file).with(nps.package_url, "#{tarball}.tmp")
+          .and_return(described_class::PACKAGE_SHA256)
+        blk.call(instance_double(File, path: "#{tarball}.tmp"))
+      end
+      expect(nps).to receive(:safe_write_to_file).with(bin) do |_, &blk|
+        expect(nps).to receive(:r).with("tar -xzOf #{tarball} host-ebpf > #{bin}.tmp")
+        expect(FileUtils).to receive(:chmod).with("a+x", "#{bin}.tmp")
+        blk.call(instance_double(File, path: "#{bin}.tmp"))
+      end
+      expect(FileUtils).to receive(:rm_f).with(tarball)
+
+      nps.download_binary
+    end
+
+    it "leaves nothing at the trusted path when extraction fails" do
+      expect(File).to receive(:exist?).with(bin).and_return(false)
+      expect(FileUtils).to receive(:mkdir_p).with(File.dirname(bin))
+      expect(nps).to receive(:safe_write_to_file).with(tarball) do |_, &blk|
+        expect(nps).to receive(:curl_file).and_return(described_class::PACKAGE_SHA256)
+        blk.call(instance_double(File, path: "#{tarball}.tmp"))
+      end
+      expect(nps).to receive(:safe_write_to_file).with(bin) do |_, &blk|
+        expect(nps).to receive(:r).and_raise(CommandFail.new("tar died", "", ""))
+        blk.call(instance_double(File, path: "#{bin}.tmp"))
+      end
+
+      expect { nps.download_binary }.to raise_error(CommandFail)
+    end
+
+    it "fails when the digest does not match" do
+      expect(File).to receive(:exist?).with(bin).and_return(false)
+      expect(FileUtils).to receive(:mkdir_p).with(File.dirname(bin))
+      expect(nps).to receive(:safe_write_to_file).with(tarball) do |_, &blk|
+        expect(nps).to receive(:curl_file).and_return("deadbeef")
+        blk.call(instance_double(File, path: "#{tarball}.tmp"))
+      end
+
+      expect { nps.download_binary }.to raise_error(/Invalid SHA-256 digest/)
+    end
+
+    it "does not download when the binary is already present" do
+      expect(File).to receive(:exist?).with(bin).and_return(true)
+      expect(nps).not_to receive(:safe_write_to_file)
+
+      nps.download_binary
+    end
+  end
+
+  describe "PACKAGE_SHA256" do
+    it "is a sha256 digest for the host architecture" do
+      expect(described_class::PACKAGE_SHA256).to match(/\A[0-9a-f]{64}\z/)
+    end
+  end
+
+  describe "#package_url" do
+    it "names the release asset for the host architecture" do
+      arch = Arch.render(x64: "x86_64", arm64: "arm64")
+      expect(nps.package_url).to eq(
+        "https://github.com/ubicloud/host-ebpf/releases/download/v#{described_class::VERSION}/" \
+        "host-ebpf_Linux_#{arch}.tar.gz",
+      )
+    end
+  end
+
+  describe "#write_units" do
+    it "writes the service, watch service, and watch timer" do
+      expect(nps).to receive(:safe_write_to_file).with("/etc/systemd/system/ndp-proxy.service", <<UNIT)
+[Unit]
+Description=Route-following NDP proxy for delegated VM prefixes
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/home/rhizome
+ExecStart=/home/rhizome/host/bin/setup-ndp-proxy apply 2a01:4f8:10a:128b::/64
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+      expect(nps).to receive(:safe_write_to_file).with("/etc/systemd/system/ndp-proxy-watch.service", <<UNIT)
+[Unit]
+Description=Re-attach the NDP proxy if its uplink state drifted
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/rhizome
+ExecStart=/home/rhizome/host/bin/setup-ndp-proxy verify 2a01:4f8:10a:128b::/64
+UNIT
+      expect(nps).to receive(:safe_write_to_file).with("/etc/systemd/system/ndp-proxy-watch.timer", <<UNIT)
+[Unit]
+Description=Periodic NDP proxy attachment check
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1min
+
+[Install]
+WantedBy=timers.target
+UNIT
+
+      nps.write_units
+    end
+  end
+
+  describe "#apply" do
+    it "fetches the pinned version and points the binary at the default route device" do
+      expect(nps).to receive(:download_binary)
+      expect(nps).to receive(:r).with("ip -6 -j route").and_return('[{"dst": "default", "dev": "eth0"}]')
+      expect(nps).to receive(:r).with("#{bin} ndp-proxy apply -uplink eth0 -prefix 2a01:4f8:10a:128b::/64")
+
+      nps.apply
+    end
+  end
+
+  describe "#verify" do
+    it "fetches the pinned version and asks the binary to heal any drift" do
+      expect(nps).to receive(:download_binary)
+      expect(nps).to receive(:r).with("ip -6 -j route").and_return('[{"dst": "default", "dev": "eth0"}]')
+      expect(nps).to receive(:r).with("#{bin} ndp-proxy verify -uplink eth0 -prefix 2a01:4f8:10a:128b::/64 -heal")
+
+      nps.verify
+    end
+  end
+end

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -746,18 +746,6 @@ NFTABLES_CONF
     end
   end
 
-  describe "#parse_routes" do
-    it "returns the device of the default route" do
-      routes = JSON.generate([{"dst" => "default", "dev" => "eth0"}, {"dst" => "10.0.0.0/8", "dev" => "eth1"}])
-      expect(vs.parse_routes(routes)).to eq("eth0")
-    end
-
-    it "raises when no default route is found" do
-      routes = JSON.generate([{"dst" => "10.0.0.0/8", "dev" => "eth1"}])
-      expect { vs.parse_routes(routes) }.to raise_error(/No default route found/)
-    end
-  end
-
   describe "#purge_network" do
     it "ignores 'no such file or directory' error when deleting netns" do
       expect(vs).to receive(:block_ip4)

--- a/spec/prog/setup_ndp_proxy_spec.rb
+++ b/spec/prog/setup_ndp_proxy_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::SetupNdpProxy do
+  subject(:snp) {
+    described_class.new(Strand.new(stack: [{"subject_id" => vmh.id}], prog: "SetupNdpProxy"))
+  }
+
+  let(:vmh) { Prog::Vm::HostNexus.assemble("1.1.1.1", net6: "2a01:4f8:10a:128b::/64", ndp_needed: true).subject }
+
+  describe "#start" do
+    it "installs the ndp proxy and pops" do
+      expect(snp.sshable).to receive(:_cmd).with("sudo host/bin/setup-ndp-proxy install 2a01:4f8:10a:128b::/64")
+
+      expect { snp.start }.to exit({"msg" => "ndp proxy was setup"})
+    end
+
+    it "pops without installing when the host does not need ndp" do
+      vmh.update(ndp_needed: false)
+      expect(snp.sshable).not_to receive(:_cmd)
+
+      expect { snp.start }.to exit({"msg" => "ndp proxy not needed"})
+    end
+
+    it "waits for LearnNetwork when the host has no net6 yet, under a deadline" do
+      vmh.update(net6: nil)
+      expect(snp.sshable).not_to receive(:_cmd)
+
+      expect { snp.start }.to nap(5)
+      expect(snp.deadline_at).not_to be_nil
+    end
+  end
+end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -215,6 +215,23 @@ RSpec.describe Prog::Vm::HostNexus do
       ])
     end
 
+    it "sets up the ndp proxy when the host needs ndp" do
+      vm_host.update(net6: "2a01:4f9:2b:35a::/64", ndp_needed: true)
+
+      expect { nx.prep }.to hop("wait_prep")
+
+      expect(Strand.where(parent_id: st.id).select_map(:prog)).to include("SetupNdpProxy")
+    end
+
+    it "sets up the ndp proxy alongside LearnNetwork when net6 is not known yet" do
+      vm_host.update(ndp_needed: true)
+
+      expect { nx.prep }.to hop("wait_prep")
+
+      child_progs = Strand.where(parent_id: st.id).select_map(:prog)
+      expect(child_progs).to include("SetupNdpProxy", "LearnNetwork")
+    end
+
     it "learns the network from the host if it is not set a-priori" do
       expect { nx.prep }.to hop("wait_prep")
 


### PR DESCRIPTION
## Problem

Some providers deliver a host's IPv6 network on-link: their router solicits for
every individual destination address before forwarding to it. Ubicloud
configures none of a VM's addresses on a host interface -- a VM's
`ephemeral_net6` exists only as a route into its network namespace -- so the
kernel answers no solicitation for any of them.

Linux's remedy, `proxy_ndp`, is an exact-match /128 registry. `VmSetup`
therefore registers the two addresses Clover itself uses and no others, so a
guest cannot use the rest of its delegated /80, and every address that is
reachable is reachable only because something enumerated it.

IPv4 never needed that bookkeeping: proxy ARP consults the routing table, which
is the same condition that makes forwarding work, so the routes `VmSetup`
already installs are the whole configuration.

## Approach

Give NDP the same shape. The `host-ebpf ndp-proxy` program runs the kernel's own
FIB lookup per solicitation from the uplink's ingress hook and answers when the
target routes off some other interface, which on these hosts means into a VM.

| NS target | best FIB match | action |
|---|---|---|
| address in a live VM's /79 | `/79 dev vetho<vm>` | answer |
| unallocated address in net6 | on-link /64 on the uplink | silent |
| host's own address | local (`NOT_FWDED`) | silent; the kernel answers |
| anything else | default route (uplink) | silent |

The answerable set is exactly the routed set, so it needs no maintenance: VM
create and destroy already move those routes, and a guest may use any address in
its prefix without telling anyone. An LPM map holding the host's own network
bounds what may ever be answered even if the routing table says otherwise.

## What lives where

The program, its map layouts, and the code that writes those maps ship together
as a released binary from [ubicloud/host-ebpf](https://github.com/ubicloud/host-ebpf),
so a layout change never spans two repositories. This PR pins v0.1.0 and
verifies its SHA-256 on download, the way `CloudHypervisor` does, since the
artifact is loaded into the kernel.

What stays here is host policy: which hosts get the proxy (`vm_host.ndp_needed`),
which device is the uplink, and when to install. Neither the attachment nor its
pins survive a reboot, so a oneshot unit re-applies at boot and a timer
re-applies on drift; both failure modes decay slowly as the provider's neighbor
cache expires, which is why they are watched rather than merely logged.

## Deferred

The per-address entries in `VmSetup` stay for now. They are harmless alongside
the proxy, which consumes a solicitation before the kernel sees it, and removing
them (with the `ndp_needed` plumbing through `params_json`/`setup-vm`) is a
separate change once every host that needs NDP runs the proxy.

## Testing

- `rake coverage_pspec`: 7564 examples, 0 failures, 100% line and branch
- rhizome specs: 442 examples, 0 failures
- host-ebpf CI is green on `ubicloud` and `ubicloud-arm`; its netns rig drives
  the released binary on the wire, covering each row of the table above plus
  hop-limit rejection, checksum rejection, DAD transparency, drift, heal, and
  detach
- The published v0.1.0 x86_64 artifact was downloaded, digest-checked against
  the constant in `NdpProxySetup`, and run through that rig

Rollout for existing hosts is a detached strand per host, the same shape
`VmHost#create_addresses` uses for `SetupNftables`:

```ruby
Strand.create(prog: "SetupNdpProxy", label: "start", stack: [{subject_id: vm_host.id}])
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)