### PR TITLE
Re-enable 4096 GB Postgres storage option in hetzner-fsn1

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -646,8 +646,6 @@ class PostgresResource < Sequel::Model
         .flat_map { |h| h.values.flatten }
     storage_size_options.uniq!
     options.add_option(name: "storage_size", values: storage_size_options, parent: "size") do |flavor, location, family, size, storage_size|
-      # Temporary capacity constraint. TODO: remove when resolved.
-      next false if storage_size == 4096 && location.id == Location::HETZNER_FSN1_ID
       vcpu_count = Option::POSTGRES_SIZE_OPTIONS[size].vcpu_count
       storage_sizes(location, family, vcpu_count).include?(storage_size)
     end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -1294,7 +1294,7 @@ RSpec.describe PostgresResource do
 
     it "creates page and sends warning email at 80-89% when at max size" do
       server.vm.update(vcpus: 60, cpu_percent_limit: 6000)
-      server.vm.vm_storage_volumes.find { !it.boot }.update(size_gib: 2048)
+      server.vm.vm_storage_volumes.find { !it.boot }.update(size_gib: 4096)
       expect(server.vm.sshable).to receive(:_cmd).with("df --output=pcent /dat | tail -n 1").and_return("  85%\n")
 
       postgres_resource.handle_storage_auto_scale
@@ -1308,9 +1308,9 @@ RSpec.describe PostgresResource do
     end
 
     it "creates page and sends warning email at 80-89% when quota insufficient" do
-      server.vm.update(vcpus: 8, cpu_percent_limit: 800)
-      server.vm.vm_storage_volumes.find { !it.boot }.update(size_gib: 1024)
-      project.add_quota(quota_id: ProjectQuota.default_quotas["PostgresVCpu"]["id"], value: 8)
+      server.vm.update(vcpus: 16, cpu_percent_limit: 1600)
+      server.vm.vm_storage_volumes.find { !it.boot }.update(size_gib: 2048)
+      project.add_quota(quota_id: ProjectQuota.default_quotas["PostgresVCpu"]["id"], value: 16)
       expect(server.vm.sshable).to receive(:_cmd).with("df --output=pcent /dat | tail -n 1").and_return("  85%\n")
 
       postgres_resource.handle_storage_auto_scale

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Clover, "postgres" do
 
         expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
         expect(page).to have_flash_error("Validation failed for following fields: storage_size")
-        expect(page).to have_content("Invalid storage size. Available options: 1024, 2048")
+        expect(page).to have_content("Invalid storage size. Available options: 1024, 2048, 4096")
         expect(PostgresResource.count).to eq(0)
       end
 


### PR DESCRIPTION
The 4096 GB Postgres storage option was previously disabled in
hetzner-fsn1 due to capacity constraints. Additional capacity has
since been added, allowing this option to be re-enabled.

This reverts commit 4ac145ca01bef86dd7e1814e0d4ae0cc01d0fb0d.
