### PR TITLE
Order Option.locations by display_name to fix flaky VM create specs

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -7,7 +7,7 @@ module Option
   AI_MODELS = ai_models.select { it["enabled"] }.freeze
 
   def self.locations(only_visible: true, feature_flags: {})
-    Location.where(project_id: nil).all.select { |pl| !only_visible || (pl.visible || feature_flags["visible_locations"]&.include?(pl.name)) }
+    Location.where(project_id: nil).order(:display_name).all.select { |pl| !only_visible || (pl.visible || feature_flags["visible_locations"]&.include?(pl.name)) }
   end
 
   def self.kubernetes_locations

--- a/spec/lib/option_spec.rb
+++ b/spec/lib/option_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe Option do
     end
   end
 
+  describe ".locations" do
+    it "orders visible locations by display name so the default location is stable" do
+      expect(described_class.locations.map(&:display_name)).to eq(%w[eu-central-h1 eu-north-h1 us-east-a2])
+    end
+  end
+
   describe "GCP Postgres options" do
     it "defines all GCP family options" do
       expect(Option::GCP_FAMILY_OPTIONS).to eq(["c4a-standard", "c4a-highmem"])


### PR DESCRIPTION
Option.locations had no ORDER BY, so row order depended on the plan Postgres chose. Create forms default to the first location, and under rack_test the location-parented options (machine-image/GPU cards, per-location subnets) render disabled for any non-default location. When the planner picked an index scan (id order, hetzner-hel1 first) over a seq scan (heap order, hetzner-fsn1 first), every spec assuming fsn1 is the default failed intermittently.

Ordering by display_name keeps the current prod order (eu-central-h1, eu-north-h1, us-east-a2). Note the default is now the alphabetically first display_name, so a future location sorting before eu-central-h1 would become the default.

Flaky run example: https://github.com/ubicloud/ubicloud/actions/runs/30358882070/job/90273446073
Forced failure with making location order unexpected: https://github.com/ubicloud/ubicloud/pull/5982

All failures in the Flaky run exist in the forced failure (+2 in other rspec files)
- Clover vm authenticated create can create a virtual machine with gpu
- Clover vm authenticated create can create new virtual machine with chosen private subnet
- Clover vm authenticated create can create new virtual machine in a new private subnet
- Clover vm authenticated create with a published machine image rejects the Machine Image card without a machine_image selection
- Clover vm authenticated create with a published machine image creates a vm from the picked machine image
- Clover vm authenticated create with a published machine image shows an actionable inline error when the boot disk is smaller than the machine image
- Clover vm authenticated create with a published machine image rejects a submission naming an MI the user cannot view
- Clover vm authenticated create with a published machine image shows the Machine Image boot card and machine_image select


