### PR TITLE
REPRO (do not merge): force reverse location order to expose flaky specs

### DIFF
--- a/lib/option.rb
+++ b/lib/option.rb
@@ -7,7 +7,7 @@ module Option
   AI_MODELS = ai_models.select { it["enabled"] }.freeze
 
   def self.locations(only_visible: true, feature_flags: {})
-    Location.where(project_id: nil).all.select { |pl| !only_visible || (pl.visible || feature_flags["visible_locations"]&.include?(pl.name)) }
+    Location.where(project_id: nil).order(Sequel.desc(:display_name)).all.select { |pl| !only_visible || (pl.visible || feature_flags["visible_locations"]&.include?(pl.name)) }
   end
 
   def self.kubernetes_locations


### PR DESCRIPTION
Pins Option.locations to descending display_name so the default location is us-east-a2 instead of hetzner-fsn1, making the intermittent VM create failures deterministic. Reproduces all 8 reported failures in spec/routes/web/vm_spec.rb 'authenticated create'. See branch loc-order for the real fix (order by display_name ascending).