### PR TITLE
Add VM-size-scaled autovacuum defaults for Postgres

### DIFF
--- a/lib/validation/postgres_config_validator.rb
+++ b/lib/validation/postgres_config_validator.rb
@@ -44,6 +44,10 @@ module Validation
       @config_schema.dig(key, :default)
     end
 
+    def valid_config?(key)
+      @config_schema.key?(key)
+    end
+
     def validate(config)
       errors = validation_errors(config)
 
@@ -73,10 +77,6 @@ module Validation
     end
 
     private
-
-    def valid_config?(key)
-      @config_schema.key?(key)
-    end
 
     def validate_config(key, value)
       config = @config_schema[key]

--- a/lib/validation/postgres_config_validator_schema.rb
+++ b/lib/validation/postgres_config_validator_schema.rb
@@ -2589,6 +2589,13 @@ module Validation
     PG_18_CONFIG_SCHEMA = begin
       removed = ["ssl_ecdh_curve"]
       added_or_modified = {
+        "autovacuum_max_workers" => {
+          description: "Sets the maximum number of simultaneously running autovacuum worker processes.",
+          type: :integer,
+          default: 3,
+          min: 1,
+          max: 262143,
+        },
         "autovacuum_vacuum_max_threshold" => {
           description: "Minimum number of tuple updates or deletes prior to vacuum.",
           type: :integer,

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -84,8 +84,34 @@ class PostgresServer < Sequel::Model
       "cron.use_background_workers" => "on",
     }
 
-    if version.to_i >= 18
-      configs.merge!(autovacuum_configs)
+    # VM-size-scaled autovacuum defaults. Everything here is reloadable on every
+    # supported version except where noted below.
+    validator = Validation::PostgresConfigValidator.new(version)
+    naptime = case vm.vcpus when 0..3 then "30s" when 4..15 then "20s" else "15s" end
+    configs.merge!(
+      "autovacuum_vacuum_cost_delay" => "2ms",
+      "autovacuum_vacuum_cost_limit" => (vm.vcpus * 200).clamp(600, 6000).to_s,
+      "autovacuum_naptime" => naptime,
+      "autovacuum_vacuum_scale_factor" => "0.1",
+      "autovacuum_vacuum_insert_scale_factor" => "0.1",
+    )
+
+    # Raising the worker count needs a restart before PostgreSQL 18, so there we
+    # leave it at the version default rather than writing a value that would sit
+    # dormant until an unrelated restart picked it up.
+    scale_workers = !validator.requires_restart?("autovacuum_max_workers")
+    max_workers = scale_workers ? vm.vcpus.clamp(3, 8) : Integer(validator.default("autovacuum_max_workers"))
+    configs["autovacuum_max_workers"] = max_workers.to_s if scale_workers
+
+    # Ceiling per worker, so the workers that do run stay within 1/4 of VM memory
+    # together. Sized off the count in effect for this version, not the scaled
+    # one, so pre-18 servers are not left with less than they inherit from
+    # maintenance_work_mem today.
+    configs["autovacuum_work_mem"] = "#{vm.memory_gib * 1024 / 4 / max_workers}MB"
+
+    # Introduced in PostgreSQL 18; earlier versions refuse to start on it.
+    if validator.valid_config?("autovacuum_vacuum_max_threshold")
+      configs["autovacuum_vacuum_max_threshold"] = "50000000"
     end
 
     if resource.flavor == PostgresResource::Flavor::PARADEDB
@@ -161,24 +187,6 @@ class PostgresServer < Sequel::Model
       metrics_config:,
       disk_throughput_baseline_mbps:,
       strict_overcommit: !resource.skip_strict_memory_overcommit_set?,
-    }
-  end
-
-  # VM-size-scaled autovacuum defaults, applied on PostgreSQL 18 and up only.
-  def autovacuum_configs
-    c = vm.vcpus
-    naptime = case c when 0..3 then "30s" when 4..15 then "20s" else "15s" end
-    max_workers = c.clamp(3, 8)
-    {
-      "autovacuum_vacuum_cost_delay" => "2ms",
-      "autovacuum_vacuum_cost_limit" => (c * 200).clamp(600, 6000).to_s,
-      "autovacuum_naptime" => naptime,
-      "autovacuum_vacuum_scale_factor" => "0.1",
-      "autovacuum_vacuum_insert_scale_factor" => "0.1",
-      "autovacuum_max_workers" => max_workers.to_s,
-      # Ceiling per worker, so all workers together stay within 1/4 of VM memory.
-      "autovacuum_work_mem" => "#{vm.memory_gib * 1024 / 4 / max_workers}MB",
-      "autovacuum_vacuum_max_threshold" => "50000000",
     }
   end
 

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -84,6 +84,10 @@ class PostgresServer < Sequel::Model
       "cron.use_background_workers" => "on",
     }
 
+    if version.to_i >= 18
+      configs.merge!(autovacuum_configs)
+    end
+
     if resource.flavor == PostgresResource::Flavor::PARADEDB
       configs["shared_preload_libraries"] = "'pg_cron,pg_stat_statements,pg_analytics,pg_search'"
     elsif resource.flavor == PostgresResource::Flavor::LANTERN
@@ -157,6 +161,24 @@ class PostgresServer < Sequel::Model
       metrics_config:,
       disk_throughput_baseline_mbps:,
       strict_overcommit: !resource.skip_strict_memory_overcommit_set?,
+    }
+  end
+
+  # VM-size-scaled autovacuum defaults, applied on PostgreSQL 18 and up only.
+  def autovacuum_configs
+    c = vm.vcpus
+    naptime = case c when 0..3 then "30s" when 4..15 then "20s" else "15s" end
+    max_workers = c.clamp(3, 8)
+    {
+      "autovacuum_vacuum_cost_delay" => "2ms",
+      "autovacuum_vacuum_cost_limit" => (c * 200).clamp(600, 6000).to_s,
+      "autovacuum_naptime" => naptime,
+      "autovacuum_vacuum_scale_factor" => "0.1",
+      "autovacuum_vacuum_insert_scale_factor" => "0.1",
+      "autovacuum_max_workers" => max_workers.to_s,
+      # Ceiling per worker, so all workers together stay within 1/4 of VM memory.
+      "autovacuum_work_mem" => "#{vm.memory_gib * 1024 / 4 / max_workers}MB",
+      "autovacuum_vacuum_max_threshold" => "50000000",
     }
   end
 

--- a/spec/lib/validation/postgres_config_validator_spec.rb
+++ b/spec/lib/validation/postgres_config_validator_spec.rb
@@ -303,4 +303,20 @@ RSpec.describe Validation::PostgresConfigValidator do
       expect(described_class.new("18").requires_restart?("autovacuum_max_workers")).to be false
     end
   end
+
+  describe "#valid_config?" do
+    it "is true for params the version knows" do
+      expect(validator.valid_config?("max_connections")).to be true
+    end
+
+    it "is false for params the version does not know" do
+      expect(described_class.new("16").valid_config?("autovacuum_vacuum_max_threshold")).to be false
+      expect(described_class.new("17").valid_config?("autovacuum_vacuum_max_threshold")).to be false
+      expect(described_class.new("18").valid_config?("autovacuum_vacuum_max_threshold")).to be true
+    end
+
+    it "is false for unknown params" do
+      expect(validator.valid_config?("not_a_real_guc")).to be false
+    end
+  end
 end

--- a/spec/lib/validation/postgres_config_validator_spec.rb
+++ b/spec/lib/validation/postgres_config_validator_spec.rb
@@ -294,5 +294,13 @@ RSpec.describe Validation::PostgresConfigValidator do
       expect(validator.requires_restart?("work_mem")).to be false
       expect(validator.requires_restart?("log_statement")).to be false
     end
+
+    it "tracks a param whose restart requirement changes between versions" do
+      # PG 18 draws autovacuum workers from the autovacuum_worker_slots pool, so
+      # the worker count itself became reloadable.
+      expect(described_class.new("16").requires_restart?("autovacuum_max_workers")).to be true
+      expect(described_class.new("17").requires_restart?("autovacuum_max_workers")).to be true
+      expect(described_class.new("18").requires_restart?("autovacuum_max_workers")).to be false
+    end
   end
 end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -218,32 +218,6 @@ RSpec.describe PostgresServer do
       expect(postgres_server.configure_hash[:user_config]).to have_key("default_transaction_isolation")
     end
 
-    it "merges the VM-size-scaled autovacuum defaults into configs on PostgreSQL 18+" do
-      postgres_server.update(version: "18")
-      expect(postgres_server.configure_hash[:configs]).to include(postgres_server.autovacuum_configs)
-    end
-
-    it "omits the autovacuum defaults below PostgreSQL 18" do
-      expect(postgres_server.version).to eq("16")
-      configs = postgres_server.configure_hash[:configs]
-      expect(configs).not_to have_key("autovacuum_max_workers")
-      expect(configs).not_to have_key("autovacuum_work_mem")
-      expect(configs).not_to have_key("autovacuum_vacuum_max_threshold")
-    end
-
-    it "lets a customer user_config value override the scaled autovacuum default per-GUC" do
-      postgres_server.update(version: "18")
-      resource.update(user_config: {"autovacuum_vacuum_cost_limit" => "9999"})
-      result = postgres_server.configure_hash
-      # The scaled default stays in the platform configs layer while the customer
-      # value goes to user_config; the config renderer loads the platform file
-      # first, so the customer value is the one that takes effect.
-      expect(result[:configs]["autovacuum_vacuum_cost_limit"]).to eq(postgres_server.autovacuum_configs["autovacuum_vacuum_cost_limit"])
-      expect(result[:user_config]["autovacuum_vacuum_cost_limit"]).to eq("9999")
-    end
-  end
-
-  describe "#autovacuum_configs" do
     # max_workers is vcpus.clamp(3, 8), so 1c exercises the floor and 16c/48c
     # the cap. work_mem is 1/4 of VM memory split across those workers.
     {
@@ -252,15 +226,58 @@ RSpec.describe PostgresServer do
       [16, 64] => {"autovacuum_vacuum_cost_limit" => "3200", "autovacuum_naptime" => "15s", "autovacuum_max_workers" => "8", "autovacuum_work_mem" => "2048MB"},
       [48, 192] => {"autovacuum_vacuum_cost_limit" => "6000", "autovacuum_naptime" => "15s", "autovacuum_max_workers" => "8", "autovacuum_work_mem" => "6144MB"},
     }.each do |(vcpus, memory_gib), scaled|
-      it "scales the GUCs for a #{vcpus}c/#{memory_gib}GB VM" do
+      it "scales the autovacuum GUCs for a #{vcpus}c/#{memory_gib}GB VM on PostgreSQL 18+" do
+        postgres_server.update(version: "18")
         allow(postgres_server.vm).to receive_messages(vcpus:, memory_gib:)
-        expect(postgres_server.autovacuum_configs).to eq(scaled.merge(
+        expect(postgres_server.configure_hash[:configs]).to include(scaled.merge(
           "autovacuum_vacuum_cost_delay" => "2ms",
           "autovacuum_vacuum_scale_factor" => "0.1",
           "autovacuum_vacuum_insert_scale_factor" => "0.1",
           "autovacuum_vacuum_max_threshold" => "50000000",
         ))
       end
+    end
+
+    it "applies the reloadable autovacuum defaults below PostgreSQL 18" do
+      expect(postgres_server.version).to eq("16")
+      allow(postgres_server.vm).to receive_messages(vcpus: 16, memory_gib: 64)
+      expect(postgres_server.configure_hash[:configs]).to include(
+        "autovacuum_vacuum_cost_delay" => "2ms",
+        "autovacuum_vacuum_cost_limit" => "3200",
+        "autovacuum_naptime" => "15s",
+        "autovacuum_vacuum_scale_factor" => "0.1",
+        "autovacuum_vacuum_insert_scale_factor" => "0.1",
+      )
+    end
+
+    it "omits the restart-only and 18-only autovacuum GUCs below PostgreSQL 18" do
+      expect(postgres_server.version).to eq("16")
+      configs = postgres_server.configure_hash[:configs]
+      expect(configs).not_to have_key("autovacuum_max_workers")
+      expect(configs).not_to have_key("autovacuum_vacuum_max_threshold")
+    end
+
+    it "sizes autovacuum_work_mem for the workers that actually run below PostgreSQL 18" do
+      expect(postgres_server.version).to eq("16")
+      allow(postgres_server.vm).to receive_messages(vcpus: 48, memory_gib: 192)
+      configs = postgres_server.configure_hash[:configs]
+      # Three workers is the pre-18 default and the count we leave in place, so
+      # the three together stay within 1/4 of VM memory. Sizing off the scaled
+      # count instead would drop this below the maintenance_work_mem these
+      # servers inherit today.
+      expect(configs).to include("autovacuum_work_mem" => "16384MB")
+      expect(configs["autovacuum_work_mem"].to_i).to be > configs["maintenance_work_mem"].to_i
+    end
+
+    it "lets a customer user_config value override the scaled autovacuum default per-GUC" do
+      allow(postgres_server.vm).to receive_messages(vcpus: 4, memory_gib: 16)
+      resource.update(user_config: {"autovacuum_vacuum_cost_limit" => "9999"})
+      result = postgres_server.configure_hash
+      # The scaled default stays in the platform configs layer while the customer
+      # value goes to user_config; the config renderer loads the platform file
+      # first, so the customer value is the one that takes effect.
+      expect(result[:configs]).to include("autovacuum_vacuum_cost_limit" => "800")
+      expect(result[:user_config]["autovacuum_vacuum_cost_limit"]).to eq("9999")
     end
   end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -217,6 +217,51 @@ RSpec.describe PostgresServer do
       allow(resource).to receive(:replication_connection_string).and_return("postgres://ubi_replication@host")
       expect(postgres_server.configure_hash[:user_config]).to have_key("default_transaction_isolation")
     end
+
+    it "merges the VM-size-scaled autovacuum defaults into configs on PostgreSQL 18+" do
+      postgres_server.update(version: "18")
+      expect(postgres_server.configure_hash[:configs]).to include(postgres_server.autovacuum_configs)
+    end
+
+    it "omits the autovacuum defaults below PostgreSQL 18" do
+      expect(postgres_server.version).to eq("16")
+      configs = postgres_server.configure_hash[:configs]
+      expect(configs).not_to have_key("autovacuum_max_workers")
+      expect(configs).not_to have_key("autovacuum_work_mem")
+      expect(configs).not_to have_key("autovacuum_vacuum_max_threshold")
+    end
+
+    it "lets a customer user_config value override the scaled autovacuum default per-GUC" do
+      postgres_server.update(version: "18")
+      resource.update(user_config: {"autovacuum_vacuum_cost_limit" => "9999"})
+      result = postgres_server.configure_hash
+      # The scaled default stays in the platform configs layer while the customer
+      # value goes to user_config; the config renderer loads the platform file
+      # first, so the customer value is the one that takes effect.
+      expect(result[:configs]["autovacuum_vacuum_cost_limit"]).to eq(postgres_server.autovacuum_configs["autovacuum_vacuum_cost_limit"])
+      expect(result[:user_config]["autovacuum_vacuum_cost_limit"]).to eq("9999")
+    end
+  end
+
+  describe "#autovacuum_configs" do
+    # max_workers is vcpus.clamp(3, 8), so 1c exercises the floor and 16c/48c
+    # the cap. work_mem is 1/4 of VM memory split across those workers.
+    {
+      [1, 4] => {"autovacuum_vacuum_cost_limit" => "600", "autovacuum_naptime" => "30s", "autovacuum_max_workers" => "3", "autovacuum_work_mem" => "341MB"},
+      [4, 16] => {"autovacuum_vacuum_cost_limit" => "800", "autovacuum_naptime" => "20s", "autovacuum_max_workers" => "4", "autovacuum_work_mem" => "1024MB"},
+      [16, 64] => {"autovacuum_vacuum_cost_limit" => "3200", "autovacuum_naptime" => "15s", "autovacuum_max_workers" => "8", "autovacuum_work_mem" => "2048MB"},
+      [48, 192] => {"autovacuum_vacuum_cost_limit" => "6000", "autovacuum_naptime" => "15s", "autovacuum_max_workers" => "8", "autovacuum_work_mem" => "6144MB"},
+    }.each do |(vcpus, memory_gib), scaled|
+      it "scales the GUCs for a #{vcpus}c/#{memory_gib}GB VM" do
+        allow(postgres_server.vm).to receive_messages(vcpus:, memory_gib:)
+        expect(postgres_server.autovacuum_configs).to eq(scaled.merge(
+          "autovacuum_vacuum_cost_delay" => "2ms",
+          "autovacuum_vacuum_scale_factor" => "0.1",
+          "autovacuum_vacuum_insert_scale_factor" => "0.1",
+          "autovacuum_vacuum_max_threshold" => "50000000",
+        ))
+      end
+    end
   end
 
   describe "restart-sensitive parameter handling" do

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show-default-config.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg show-default-config.txt
@@ -1,6 +1,12 @@
 archive_command='/usr/bin/walg-daemon-client /tmp/wal-g wal-push %f'
 archive_mode=on
 archive_timeout=60
+autovacuum_naptime=30s
+autovacuum_vacuum_cost_delay=2ms
+autovacuum_vacuum_cost_limit=600
+autovacuum_vacuum_insert_scale_factor=0.1
+autovacuum_vacuum_scale_factor=0.1
+autovacuum_work_mem=682MB
 cron.use_background_workers=on
 default_toast_compression=lz4
 effective_cache_size=6144MB


### PR DESCRIPTION
Current defaults are too conservative, specifically for large
VMs and observability (fast insert or update) workloads,
resulting in 24+ hours vacuum runs and 100s GB of bloat.

For smaller VM change is imcremental to better utilize fast local disk
