### PR TITLE
Fix unreachable restarting display state for Postgres

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -60,7 +60,7 @@ class PostgresResource < Sequel::Model
     return "restoring_backup" if server_strand_label == "initialize_database_from_backup"
     return "replaying_wal" if ["wait_catch_up", "wait_synchronization"].include?(server_strand_label)
     return "finalizing_restore" if server_strand_label == "wait_recovery_completion"
-    return "restarting" if server_strand_label == "restart"
+    return "restarting" if server_strand_label == "wait" && representative_server.restart_set?
     return "running" if ["wait", "refresh_certificates", "refresh_dns_record"].include?(strand.label) && !initial_provisioning_set?
 
     "creating"

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -246,9 +246,9 @@ class PostgresServer < Sequel::Model
 
   def display_state
     label = strand.label
+    return "restarting" if label == "wait" && restart_set?
     return "running" if label == "wait"
     return "unavailable" if label == "unavailable"
-    return "restarting" if label == "restart"
     return "failing_over" if FAILOVER_LABELS.include?(label)
     return "synchronizing" if ["wait_catch_up", "wait_synchronization"].include?(label)
     return "deleting" if ["destroy", "wait_children_destroy", "destroy_vm_and_pg"].include?(label)

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -785,8 +785,9 @@ RSpec.describe PostgresResource do
       expect(postgres_resource.display_state).to eq("finalizing_restore")
     end
 
-    it "returns 'restarting' when representative server's strand label is 'restart'" do
-      create_representative_server(strand_label: "restart")
+    it "returns 'restarting' while the representative server has a restart pending" do
+      create_representative_server(strand_label: "wait")
+      postgres_resource.representative_server.incr_restart
       expect(postgres_resource.display_state).to eq("restarting")
     end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -1650,8 +1650,9 @@ RSpec.describe PostgresServer do
       expect(postgres_server.display_state).to eq("failing_over")
     end
 
-    it "returns restarting for restart label" do
-      postgres_server.strand.update(label: "restart")
+    it "returns restarting while a restart is pending" do
+      postgres_server.strand.update(label: "wait")
+      postgres_server.incr_restart
       expect(postgres_server.display_state).to eq("restarting")
     end
 


### PR DESCRIPTION
## Summary

d945d4444 removed the `restart` strand label and moved restart handling inline into `wait` (`when_restart_set?` + `daemonized_restart`), but both `PostgresServer#display_state` and `PostgresResource#display_state` still check for the removed label. The branch is unreachable, so a restarting database reports `running` for the entire restart, even a slow one gated by `restart_sensitive_params_safe?`.

This keys the `restarting` state on the `restart` semaphore instead: it is what is actually set while a restart is pending, and the same signal `wait`'s checkup guard already trusts (`unless restart_set? || available?`). The check sits before the `wait` branch since the strand label stays `wait` throughout.

## Test plan

- Updated the two existing display_state specs, which were asserting the unreachable label; they now set the semaphore on a `wait`-labeled strand and fail against main (`expected "restarting", got "running"`)
- `rspec spec/model/postgres/postgres_server_spec.rb spec/model/postgres/postgres_resource_spec.rb`: 336 examples, 0 failures