### PR TITLE
Show running display state during public certificate renewal

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -61,7 +61,7 @@ class PostgresResource < Sequel::Model
     return "replaying_wal" if ["wait_catch_up", "wait_synchronization"].include?(server_strand_label)
     return "finalizing_restore" if server_strand_label == "wait_recovery_completion"
     return "restarting" if server_strand_label == "wait" && representative_server.restart_set?
-    return "running" if ["wait", "refresh_certificates", "refresh_dns_record"].include?(strand.label) && !initial_provisioning_set?
+    return "running" if ["wait", "refresh_certificates", "wait_refresh_public_cert", "refresh_dns_record"].include?(strand.label) && !initial_provisioning_set?
 
     "creating"
   end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -796,6 +796,12 @@ RSpec.describe PostgresResource do
       expect(postgres_resource.display_state).to eq("running")
     end
 
+    it "returns 'running' while waiting for a public certificate renewal" do
+      create_representative_server(strand_label: "wait")
+      postgres_resource.strand.update(label: "wait_refresh_public_cert")
+      expect(postgres_resource.display_state).to eq("running")
+    end
+
     it "returns 'creating' when strand is 'wait_server'" do
       create_representative_server(strand_label: "wait")
       postgres_resource.strand.update(label: "wait_server")


### PR DESCRIPTION
## Summary

When a resource with publicly signed certificates renews (`refresh_certificates` hops to `wait_refresh_public_cert` and waits on CertNexus in `nap(10 * 60)` cycles), the database serves traffic normally the entire time, but `PostgresResource#display_state` does not recognize the label and falls through to `creating` for the 10-20 minutes the renewal takes. With `hostname_version` defaulting to v3, every new resource is on this path, roughly once per ~77 days per resource.

Adds `wait_refresh_public_cert` to the labels that report `running`, alongside `refresh_certificates` which is already there.

## Test plan

- New spec fails on main (`expected "running", got "creating"`) and passes with the change
- `rspec spec/model/postgres/postgres_resource_spec.rb`: 143 examples, 0 failures