### PR TITLE
Show failing_over display state during read replica promotion

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -249,7 +249,7 @@ class PostgresServer < Sequel::Model
     return "running" if label == "wait"
     return "unavailable" if label == "unavailable"
     return "restarting" if label == "restart"
-    return "failing_over" if FAILOVER_LABELS.include?(label)
+    return "failing_over" if FAILOVER_LABELS.include?(label) || label == "promote_read_replica"
     return "synchronizing" if ["wait_catch_up", "wait_synchronization"].include?(label)
     return "deleting" if ["destroy", "wait_children_destroy", "destroy_vm_and_pg"].include?(label)
     return "creating" if initial_provisioning_set?

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -1650,6 +1650,11 @@ RSpec.describe PostgresServer do
       expect(postgres_server.display_state).to eq("failing_over")
     end
 
+    it "returns failing_over for promote_read_replica label" do
+      postgres_server.strand.update(label: "promote_read_replica")
+      expect(postgres_server.display_state).to eq("failing_over")
+    end
+
     it "returns restarting for restart label" do
       postgres_server.strand.update(label: "restart")
       expect(postgres_server.display_state).to eq("restarting")


### PR DESCRIPTION
## Summary

`promote_read_replica` maps to no `display_state` branch, so a server mid-promotion falls through to `updating` (and its resource keeps reporting `running`). Promotion is takeover choreography in the same family as the labels already in `FAILOVER_LABELS`, so display it as `failing_over`.

Display-only change: this deliberately does not add the label to `FAILOVER_LABELS` itself, since that constant also drives `taking_over?` semantics.

## Test plan

- New spec fails on main (`expected "failing_over", got "updating"`) and passes with the change
- `rspec spec/model/postgres/postgres_server_spec.rb`: 195 examples, 0 failures