### PR TITLE
Surface failover and fence states in resource display_state

### DIFF
--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -61,6 +61,8 @@ class PostgresResource < Sequel::Model
     return "replaying_wal" if ["wait_catch_up", "wait_synchronization"].include?(server_strand_label)
     return "finalizing_restore" if server_strand_label == "wait_recovery_completion"
     return "restarting" if server_strand_label == "restart"
+    return "failing_over" if PostgresServer::FAILOVER_LABELS.include?(server_strand_label) ||
+      ["fence", "wait_in_fence", "wait_locked_out"].include?(server_strand_label)
     return "running" if ["wait", "refresh_certificates", "refresh_dns_record"].include?(strand.label) && !initial_provisioning_set?
 
     "creating"

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -795,6 +795,14 @@ RSpec.describe PostgresResource do
       expect(postgres_resource.display_state).to eq("running")
     end
 
+    it "returns 'failing_over' while the representative server is fenced or failing over" do
+      create_representative_server(strand_label: "wait")
+      ["fence", "wait_in_fence", "wait_locked_out", "taking_over"].each do |label|
+        postgres_resource.representative_server.strand.update(label:)
+        expect(postgres_resource.display_state).to eq("failing_over"), "expected #{label} to display failing_over"
+      end
+    end
+
     it "returns 'creating' when strand is 'wait_server'" do
       create_representative_server(strand_label: "wait")
       postgres_resource.strand.update(label: "wait_server")


### PR DESCRIPTION
## Summary

A resource whose representative server is fenced (`fence` / `wait_in_fence` / `wait_locked_out`, i.e. the old primary's side of a planned takeover or `pg_upgrade`) or in any `FAILOVER_LABELS` state reports `running`: `PostgresResource#display_state` checks no failover-family server labels and falls through to the resource strand label. The customer-visible state says the database is serving while it is deliberately not, for the full length of an upgrade.

This maps that family to `failing_over` at the resource level, consistent with how `PostgresServer#display_state` already reports `FAILOVER_LABELS`. Display-only: `FAILOVER_LABELS` itself is untouched since it also drives `taking_over?` semantics.

Opening as an RFC-flavored draft since this adds a state value to the resource-level vocabulary: if you'd rather expose a different name here (e.g. `upgrading` for the fence case, or keep failovers hidden at resource level and only surface fences), happy to adjust; the mechanical shape stays the same.

## Test plan

- New spec iterates `fence`, `wait_in_fence`, `wait_locked_out`, `taking_over` and fails on main (each displays `running`)
- `rspec spec/model/postgres/postgres_resource_spec.rb`: 143 examples, 0 failures