### PR TITLE
Add KubernetesNodepool#request_upgrade & KubernetesCluster#request_upgrade

### DIFF
--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -244,6 +244,18 @@ class KubernetesCluster < Sequel::Model
   def ready_for_upgrade?
     !available_upgrade_version.nil? && idle?
   end
+
+  def request_upgrade
+    fail "Cluster #{ubid} has nodepools more than two minor versions behind" unless nodepools_within_version_skew?
+    fail "Cluster #{ubid} is not ready to be upgraded" unless ready_for_upgrade?
+
+    DB.transaction do
+      update(version: available_upgrade_version)
+      incr_upgrade
+    end
+
+    version
+  end
 end
 
 # Table: kubernetes_cluster

--- a/model/kubernetes/kubernetes_nodepool.rb
+++ b/model/kubernetes/kubernetes_nodepool.rb
@@ -44,6 +44,18 @@ class KubernetesNodepool < Sequel::Model
   def ready_for_upgrade?
     !available_upgrade_version.nil? && cluster.idle?
   end
+
+  def request_upgrade
+    fail "Nodepool #{ubid} is not ready to be upgraded" unless ready_for_upgrade?
+
+    DB.transaction do
+      update(version: available_upgrade_version)
+      incr_upgrade_requested
+      cluster.incr_upgrade_nodepools
+    end
+
+    version
+  end
 end
 
 # Table: kubernetes_nodepool

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -184,9 +184,7 @@ class Clover
 
           upgrade_candidate = kn.available_upgrade_version
           DB.transaction do
-            kn.update(version: upgrade_candidate)
-            kn.incr_upgrade_requested
-            kc.incr_upgrade_nodepools
+            kn.request_upgrade
             audit_log(kn, "upgrade", [kc])
           end
 

--- a/routes/project/location/kubernetes_cluster.rb
+++ b/routes/project/location/kubernetes_cluster.rb
@@ -264,8 +264,7 @@ class Clover
 
         upgrade_candidate = kc.available_upgrade_version
         DB.transaction do
-          kc.update(version: upgrade_candidate)
-          kc.incr_upgrade
+          kc.request_upgrade
           audit_log(kc, "upgrade")
         end
 

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -72,6 +72,38 @@ RSpec.describe KubernetesCluster do
     expect(kc.display_state).to eq "deleting"
   end
 
+  describe "#request_upgrade" do
+    before do
+      kc.strand.update(label: "wait")
+      kc.update(version: Option.selectable_kubernetes_versions[1])
+    end
+
+    it "sets the target version and the upgrade semaphore" do
+      candidate = kc.available_upgrade_version
+
+      expect(kc.reload.request_upgrade).to eq(candidate)
+      expect(kc.reload.version).to eq(candidate)
+      expect(kc.upgrade_set?).to be true
+    end
+
+    it "raises when the cluster is not idle" do
+      kc.strand.update(label: "upgrade")
+
+      expect { kc.reload.request_upgrade }.to raise_error(RuntimeError, "Cluster #{kc.ubid} is not ready to be upgraded")
+      expect(kc.reload.version).to eq(Option.selectable_kubernetes_versions[1])
+    end
+
+    it "raises when a nodepool is more than two minor versions behind" do
+      kc.update(version: Option.kubernetes_versions.first)
+      np = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np", node_count: 1, kubernetes_cluster_id: kc.id).subject
+      np.update(version: Option.kubernetes_versions.last)
+
+      expect { kc.reload.request_upgrade }.to raise_error(RuntimeError, "Cluster #{kc.ubid} has nodepools more than two minor versions behind")
+      expect(kc.reload.version).to eq(Option.kubernetes_versions.first)
+      expect(kc.upgrade_set?).to be false
+    end
+  end
+
   it "#ready_for_upgrade? is true only when an upgrade is available and the whole cluster is idle" do
     np1 = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np1", node_count: 1, kubernetes_cluster_id: kc.id).subject
     np2 = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np2", node_count: 1, kubernetes_cluster_id: kc.id).subject

--- a/spec/model/kubernetes/kubernetes_nodepool_spec.rb
+++ b/spec/model/kubernetes/kubernetes_nodepool_spec.rb
@@ -122,4 +122,28 @@ RSpec.describe KubernetesNodepool do
       expect(kn.reload.ready_for_upgrade?).to be true
     end
   end
+
+  describe "#request_upgrade" do
+    before do
+      kc.strand.update(label: "wait")
+      kn.strand.update(label: "wait")
+      Semaphore.where(strand_id: kn.id, name: "start_bootstrapping").destroy
+      kn.update(version: Option.kubernetes_versions[1])
+    end
+
+    it "sets the target version and the semaphores the cluster nexus needs" do
+      expect(kn.reload.request_upgrade).to eq(kc.version)
+      expect(kn.reload.version).to eq(kc.version)
+      expect(kn.upgrade_requested_set?).to be true
+      expect(kc.reload.upgrade_nodepools_set?).to be true
+    end
+
+    it "raises when the nodepool is not ready to be upgraded" do
+      kc.strand.update(label: "upgrade")
+
+      expect { kn.reload.request_upgrade }.to raise_error(RuntimeError, "Nodepool #{kn.ubid} is not ready to be upgraded")
+      expect(kn.reload.version).to eq(Option.kubernetes_versions[1])
+      expect(kn.upgrade_requested_set?).to be false
+    end
+  end
 end


### PR DESCRIPTION
**Add KubernetesNodepool#request_upgrade**
A nodepool upgrade needs the target version, the nodepool's upgrade_requested semaphore, and the cluster's upgrade_nodepools semaphore set together; the cluster nexus is what serializes pool upgrades, so setting upgrade_requested alone never wakes it.

Wrap the three in one method so operators can trigger an upgrade without reconstructing the sequence, and reuse it in the API route.

**Add KubernetesCluster#request_upgrade**
Wrap the version update and the semaphore in a method that checks the version skew and idle preconditions and raises, so operators can trigger a control plane upgrade without reconstructing the sequence, and reuse it in the API route.