### PR TITLE
Use the builtin C.UTF-8 locale provider for new PG17/PG18 clusters

### DIFF
--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -122,6 +122,11 @@ class PostgresSetup
   end
 
   def create_cluster
-    r "pg_createcluster", @version.to_s, "main", "--port=5432", "--locale=C.UTF8"
+    # Use builtin collation for PG 17+
+    if @version.to_i >= 17
+      r "pg_createcluster", @version.to_s, "main", "--port=5432", "--", "--locale-provider=builtin", "--builtin-locale=C.UTF-8"
+    else
+      r "pg_createcluster", @version.to_s, "main", "--port=5432", "--locale=C.UTF8"
+    end
   end
 end

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -87,8 +87,28 @@ RSpec.describe PostgresSetup do
   end
 
   describe "#create_cluster" do
-    it "creates a postgres cluster" do
-      expect(pg_setup).to receive(:_run_command).with("pg_createcluster", "17", "main", "--port=5432", "--locale=C.UTF8")
+    builtin = ["--", "--locale-provider=builtin", "--builtin-locale=C.UTF-8"]
+
+    it "creates a postgres cluster with the builtin C.UTF-8 provider" do
+      expect(pg_setup).to receive(:_run_command).with("pg_createcluster", "17", "main", "--port=5432", *builtin)
+      pg_setup.create_cluster
+    end
+
+    it "uses the builtin provider on 18" do
+      pg_setup = described_class.new("18")
+      expect(pg_setup).to receive(:_run_command).with("pg_createcluster", "18", "main", "--port=5432", *builtin)
+      pg_setup.create_cluster
+    end
+
+    it "handles the integer version passed by the upgrade path" do
+      pg_setup = described_class.new(18)
+      expect(pg_setup).to receive(:_run_command).with("pg_createcluster", "18", "main", "--port=5432", *builtin)
+      pg_setup.create_cluster
+    end
+
+    it "keeps the libc provider on 16, which has no builtin provider" do
+      pg_setup = described_class.new("16")
+      expect(pg_setup).to receive(:_run_command).with("pg_createcluster", "16", "main", "--port=5432", "--locale=C.UTF8")
       pg_setup.create_cluster
     end
   end


### PR DESCRIPTION
PG17 added the builtin provider, with byte-identical sort to libc UTF-8,
but guaranteed by Postgres community to be stable over major versions
and OS versions.
Builtin provider minimizes potential issues from OS upgrades in the
future.