### PR TITLE
Swallow SSH failures in Postgres daemonized_restart

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -1029,5 +1029,8 @@ SQL
     end
 
     false
+  rescue *Sshable::SSH_CONNECTION_ERRORS => ex
+    Clog.emit("Postgres restart failed", Util.exception_to_hash(ex, into: {postgres_server_id: postgres_server.id}))
+    false
   end
 end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1550,6 +1550,13 @@ CMD
       expect(postgres_server.reload.recycle_unavailable_server_set?).to be true
     end
 
+    it "keeps recycling the server when a dead host makes the restart raise" do
+      expect(nx).to receive(:available?).and_return(false)
+      expect(sshable).to receive(:d_check).with("postgres_restart").and_raise(Net::SSH::Disconnect)
+      expect { nx.unavailable }.to nap(5)
+      expect(postgres_server.reload.recycle_unavailable_server_set?).to be true
+    end
+
     it "trigger_failover succeeds, naps 0" do
       standby = create_postgres_server(resource: postgres_resource, timeline: postgres_timeline, is_representative: false)
       standby.strand.update(label: "wait")
@@ -1977,6 +1984,12 @@ CMD
 
     it "returns false when restart is in progress" do
       expect(sshable).to receive(:d_check).with("postgres_restart").and_return("InProgress")
+      expect(nx.daemonized_restart).to be false
+    end
+
+    it "logs and returns false when the host is unreachable" do
+      expect(sshable).to receive(:d_check).with("postgres_restart").and_raise(Net::SSH::Disconnect)
+      expect(Clog).to receive(:emit).with("Postgres restart failed", instance_of(Hash)).and_call_original
       expect(nx.daemonized_restart).to be false
     end
   end


### PR DESCRIPTION
An unreachable VM made `d_check` and `d_run` raise, aborting the unavailable strand run and rolling back its `recycle_unavailable_server` increment, so a permanently-dead primary never began recycling. Non-HA primaries always reach `daemonized_restart`, so they always hit this. HA primaries reach it only when no standby can take over, because a successful unplanned failover ends the run first. Rescue connection and command errors, log them, and return false from `daemonized_restart`.