### PR TITLE
Add unique tiebreakers to admin autoforme table orders

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -727,7 +727,7 @@ class CloverAdmin < Roda
     end
 
     model Account do
-      order Sequel.desc(Sequel[:accounts][:created_at])
+      order [Sequel.desc(Sequel[:accounts][:created_at]), Sequel.desc(Sequel[:accounts][:id])]
       eager_graph [:identities]
       columns [:name, :email, :status_id, :provider_names, :created_at, :suspended_at]
       column_options email: {type: "text"},
@@ -749,7 +749,7 @@ class CloverAdmin < Roda
     end
 
     model BillingInfo do
-      order Sequel.desc(Sequel[:billing_info][:created_at])
+      order [Sequel.desc(Sequel[:billing_info][:created_at]), Sequel.desc(Sequel[:billing_info][:id])]
       eager_graph [:project]
       columns do |type_symbol, request|
         cs = [:stripe_id, :project, :valid_vat, :created_at]
@@ -770,7 +770,7 @@ class CloverAdmin < Roda
     end
 
     model GithubInstallation do
-      order Sequel.desc(:created_at)
+      order [Sequel.desc(:created_at), Sequel.desc(:id)]
       columns [:name, :installation_id, :type, :cache_enabled, :premium_runner_enabled?, :created_at, :allocator_preferences]
 
       column_options type: {type: "select", options: ["Organization", "User"], add_blank: true},
@@ -794,7 +794,7 @@ class CloverAdmin < Roda
     end
 
     model GithubRepository do
-      order Sequel.desc(:created_at)
+      order [Sequel.desc(:created_at), Sequel.desc(:id)]
       eager [:installation]
       columns do |type_symbol, request|
         if type_symbol == :search_form
@@ -817,7 +817,7 @@ class CloverAdmin < Roda
     end
 
     model GithubRunner do
-      order Sequel.desc(:created_at)
+      order [Sequel.desc(:created_at), Sequel.desc(Sequel[:github_runner][:id])]
       eager_graph [:strand]
       eager [:installation]
       columns do |type_symbol, request|
@@ -845,7 +845,7 @@ class CloverAdmin < Roda
     end
 
     model Invoice do
-      order Sequel.desc(:invoice_number)
+      order [Sequel.desc(:invoice_number), Sequel.desc(Sequel[:invoice][:id])]
       eager_graph [:project]
       columns do |type_symbol, request|
         if type_symbol == :search_form
@@ -866,7 +866,7 @@ class CloverAdmin < Roda
     end
 
     model PaymentMethod do
-      order Sequel.desc(:created_at)
+      order [Sequel.desc(:created_at), Sequel.desc(:id)]
       eager [:billing_info]
       columns do |type_symbol, request|
         if type_symbol == :search_form
@@ -889,7 +889,7 @@ class CloverAdmin < Roda
     end
 
     model PostgresResource do
-      order Sequel.desc(:created_at)
+      order [Sequel.desc(:created_at), Sequel.desc(:id)]
       eager do |type, _request|
         [:location, :parent, :project] unless type == :association
       end
@@ -913,7 +913,7 @@ class CloverAdmin < Roda
     end
 
     model PostgresServer do
-      order Sequel.desc(:created_at)
+      order [Sequel.desc(:created_at), Sequel.desc(:id)]
       eager [:resource, :vm]
       columns do |type_symbol, request|
         cs = [:resource, :timeline_access, :synchronization_status, :version, :is_representative, :created_at]
@@ -940,14 +940,14 @@ class CloverAdmin < Roda
     end
 
     model Project do
-      order Sequel.desc(:created_at)
+      order [Sequel.desc(:created_at), Sequel.desc(:id)]
       columns [:name, :reputation, :billing_info_id, :credit, :created_at]
       column_options reputation: {type: "select", options: %w[new verified limited].freeze, add_blank: true},
         created_at: {type: "text"}
     end
 
     model Strand do
-      order Sequel.desc(:try)
+      order [Sequel.desc(:try), Sequel.desc(:id)]
       columns do |type_symbol, request|
         if type_symbol == :search_form
           [:prog, :label, :try, :parent]
@@ -966,7 +966,7 @@ class CloverAdmin < Roda
     end
 
     model Vm do
-      order Sequel.desc(:created_at)
+      order [Sequel.desc(:created_at), Sequel.desc(:id)]
       eager do |type, _request|
         [:location, :vm_host, :project, :strand, :semaphores] unless type == :association
       end
@@ -981,7 +981,7 @@ class CloverAdmin < Roda
     end
 
     model BootImage do
-      order Sequel.desc(:created_at)
+      order [Sequel.desc(:created_at), Sequel.desc(:id)]
       eager [:vm_host]
       columns [:name, :version, :vm_host, :size_gib, :activated_at, :created_at]
       column_options vm_host: ubid_input.call("VmHost"),

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -518,6 +518,21 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - SshPublicKey #{key.ubid}"
   end
 
+  it "paginates past the first page when browsing a table ordered by a non-unique column" do
+    Array.new(28 - Strand.count) { Strand.create(prog: "Test", label: "test") }
+    expected_second_page = Strand.count - 25
+
+    page.refresh
+    click_link "Strand"
+    first_page = page.all("#autoforme_table a").map { it["href"] }
+    expect(first_page.length).to eq 25
+
+    click_link "Next"
+    second_page = page.all("#autoforme_table a").map { it["href"] }
+    expect(second_page.length).to eq expected_second_page
+    expect(second_page & first_page).to be_empty
+  end
+
   it "ignores bogus ubids when paginating" do
     project_id = Project.create(name: "test").id
     key = SshPublicKey.create(name: "key", public_key: "k v", project_id:)


### PR DESCRIPTION
The admin browse and search tables use autoforme keyset (:filter) pagination, which builds the Next link from the last row's order values and seeks past them. That requires a unique, total order. Several models overrode order with a non-unique column, so the Next cursor matched no further rows and the second page came back empty.

Add an :id tiebreaker to every non-unique order so the ordering is unique. Qualify it as table.id for the models that use eager_graph.

Add a regression test covering pagination past the first page.