### PR TITLE
Blacklist the irdma driver on VM hosts

### DIFF
--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -79,6 +79,14 @@ net.ipv4.ip_forward=1
 CONF
 r "sysctl --system"
 
+# VmHosts make no use of RDMA, and the irdma driver that auto-loads on
+# Intel E810/X710 NICs preallocates gigabytes of DMA memory, starving
+# the non-hugepage remainder the host OS runs in.
+File.write("/etc/modprobe.d/blacklist-irdma.conf", <<CONF)
+blacklist irdma
+CONF
+r "update-initramfs -u"
+
 # OS images.
 
 # For qemu-image convert and mcopy for cloud-init with the nocloud


### PR DESCRIPTION
Empirically verified on the new bacloud NL host (Intel ice/i40e NICs): with `hugepages=120` on 128 GB, booting with irdma loaded left `MemAvailable` at 0 kB and OOM-killed udev workers during boot; the identical reservation with irdma blacklisted boots at 4.0 GiB `MemAvailable` with zero OOM kills. The driver was loaded with refcount 0 — nothing uses RDMA on VM hosts.

Complements #5996: that PR makes hugepage setup measure and verify the OS remainder; this one removes the largest known hidden consumer of it on this hardware class. Existing hosts don't re-run prep_host, so this applies to newly cloudified hosts; the affected host already has the blacklist applied manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)