### PR TITLE
Exclude unprepared VM hosts from monitoring

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -49,7 +49,7 @@ if Config.test?
 else
   runner_args = {ignore_threads: 2}
   monitor_models = [
-    VmHost,
+    VmHost.exclude(allocation_state: "unprepared"),
     PostgresServer.exclude(id: Semaphore.where(name: "initial_provisioning").where(strand_id: PostgresServer.select(:id)).select(:strand_id)),
     MinioServer,
     GithubRunner.exclude(ready_at: nil),
@@ -67,7 +67,7 @@ else
 
   metric_export_models = [
     PostgresServer.exclude(id: Semaphore.where(name: "initial_provisioning").where(strand_id: PostgresServer.select(:id)).select(:strand_id)),
-    VmHost,
+    VmHost.exclude(allocation_state: "unprepared"),
     ParseableServer.exclude(id: Semaphore.where(name: "initial_provisioning").where(strand_id: ParseableServer.select(:id)).select(:strand_id)),
   ]
 end


### PR DESCRIPTION
Hosts in the "unprepared" allocation state are still being set up, so health checks and metrics export against them are not meaningful: storage devices may not be registered yet and node_exporter is not installed until preparation completes. Skip them in both the health monitor and metrics export model lists; they get picked up automatically once HostNexus moves them to "accepting".