### PR TITLE
Fix race condition when deleting github cache entries

### DIFF
--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -145,21 +145,21 @@ class Clover
 
       r.delete web?, "cache" do
         ubids = typecast_params.array(:ubid_uuid, "ubids") || []
-        entries = @installation.cache_entries_dataset.where(Sequel[:github_cache_entry][:id] => ubids).all
+        flash["notice"] = DB.transaction do
+          entries = @installation.cache_entries_dataset.where(Sequel[:github_cache_entry][:id] => ubids).for_update.all
 
-        if entries.empty?
-          no_audit_log
-          flash["notice"] = "No cache entries selected for deletion"
-        else
-          num_entries = entries.size
-          DB.transaction do
+          if entries.empty?
+            no_audit_log
+            "No cache entries selected for deletion"
+          else
+            num_entries = entries.size
             DB.ignore_duplicate_queries do
               entries.each(&:destroy)
             end
             entry = entries.shift
             audit_log(entry, "destroy", entries)
+            "#{num_entries} cache entr#{(num_entries == 1) ? "y" : "ies"} deleted"
           end
-          flash["notice"] = "#{num_entries} cache entr#{(num_entries == 1) ? "y" : "ies"} deleted"
         end
 
         r.redirect @installation, "/cache"


### PR DESCRIPTION
Previously, a cache entry could be deleted between when it was selected and when it was deleted, because the selection was not inside the transaction and didn't use FOR UPDATE. We had a recent production exception related to this.

Best viewed ignoring whitespace differences.