### PR TITLE
Make superuser_reserved_connections configurable

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -187,6 +187,7 @@ module Config
   # Postgres
   optional :postgres_service_project_id, uuid
   override :postgres_boot_disk_size_gib, 16, int
+  override :postgres_superuser_reserved_connections, 3, int
   override :postgres_service_hostname, "postgres.ubicloud.com", string
   override :postgres_service_hostname_v3, "pg.ubicloud.app", string
   override :postgres_hostname_version_default, "v3", string

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -43,7 +43,7 @@ class PostgresServer < Sequel::Model
     configs = {
       "listen_addresses" => "'*'",
       "max_connections" => "500",
-      "superuser_reserved_connections" => "3",
+      "superuser_reserved_connections" => Config.postgres_superuser_reserved_connections.to_s,
       "shared_buffers" => "#{vm.memory_gib * 1024 / 4}MB",
       "work_mem" => "#{[vm.memory_gib / 8, 1].max}MB",
       "maintenance_work_mem" => "#{vm.memory_gib * 1024 / 16}MB",

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -182,6 +182,15 @@ RSpec.describe PostgresServer do
       expect(postgres_server.configure_hash[:configs]["max_connections"]).to eq(Validation::PostgresConfigValidator.new(postgres_server.version).default("max_connections").to_s)
     end
 
+    it "defaults superuser_reserved_connections to the Config value" do
+      expect(postgres_server.configure_hash[:configs]).to include("superuser_reserved_connections" => Config.postgres_superuser_reserved_connections.to_s)
+    end
+
+    it "honors an overridden superuser_reserved_connections" do
+      allow(Config).to receive(:postgres_superuser_reserved_connections).and_return(10)
+      expect(postgres_server.configure_hash[:configs]).to include("superuser_reserved_connections" => "10")
+    end
+
     it "sets strict_overcommit to true by default" do
       expect(postgres_server.configure_hash[:strict_overcommit]).to be true
     end


### PR DESCRIPTION
The number of internal operations need connections tend to creep up
over time. Making the default number of reserved connections
configurable to bump it if critical superuser connection blocked
is detected.


## Test plan

- [x] `spec/model/postgres/postgres_server_spec.rb` — the rendered value tracks the `Config` value, and a stubbed override of `10` renders `"10"`.
- [x] Full `bundle exec rake`, both phases, exit 0: coverage 7572 examples / 0 failures at 100.0% line (25382/25382) and 100.0% branch (7805/7805); `frozen_spec` 7550 examples / 0 failures.
- [x] End-to-end on a real `m8gd.large` PG 17 instance with `POSTGRES_SUPERUSER_RESERVED_CONNECTIONS=17`:
  - rendered platform config on the VM — `conf.d/001-service.conf` → `superuser_reserved_connections = 17`
  - running server — `SHOW superuser_reserved_connections` → `17`
  - `GET .../config` — `default_pg_config.superuser_reserved_connections` → `17`, with `pg_config` empty, confirming the value comes from the platform layer rather than a customer override
  - `max_connections` unchanged at `500`

The default is unchanged at `3`, so no existing database sees a different value and the CLI golden file needed no regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
