### PR TITLE
Add network traffic metering for Postgres VMs

### DIFF
--- a/lib/network_metering_methods.rb
+++ b/lib/network_metering_methods.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "ipaddr"
+require "json"
+
+# Ships the metering rule set to the VM as config.json and triggers
+# apply-metering-config. Rhizome owns the nftables render.
+module NetworkMeteringMethods
+  CONFIG_PATH = "/etc/pg-metering/config.json"
+
+  INTERNAL_CIDRS = {
+    "v4" => %w[10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 169.254.0.0/16].freeze,
+    "v6" => %w[fc00::/7 fe80::/10].freeze,
+  }.freeze
+
+  # No-op on rhizome trees without the metering bins.
+  def install_network_metering(provider)
+    return unless vm.sshable.cmd("test -x postgres/bin/apply-metering-config && test -x postgres/bin/refresh-network-sets && test -x postgres/bin/export-network-metrics && echo YES || echo NO").strip == "YES"
+
+    vm.sshable.cmd("sudo install -d -m 0755 /etc/pg-metering")
+    vm.sshable.write_file(CONFIG_PATH, JSON.generate(network_metering_config(provider)))
+    vm.sshable.cmd("sudo /home/ubi/postgres/bin/apply-metering-config")
+
+    render_network_metering_units.each { |path, content| vm.sshable.write_file(path, content) }
+    vm.sshable.cmd("sudo systemctl daemon-reload")
+    vm.sshable.cmd("sudo systemctl enable pg-metering.service")
+    vm.sshable.cmd("sudo systemctl enable --now pg-metering-export.timer pg-metering-refresh.timer")
+    # Prime provider sets now; otherwise all traffic hits public_internet
+    # until the refresh timer fires.
+    vm.sshable.cmd("sudo systemctl start pg-metering-refresh.service || true")
+  end
+
+  def network_metering_config(provider)
+    {
+      "version" => 1,
+      "region" => (resource || vm).location.name.sub(/^gcp-/, ""),
+      "provider" => provider,
+      "rules" => base_rules.sort_by { |r| r["priority"] },
+      "provider_config" => {},
+    }
+  end
+
+  def base_rules
+    [
+      {"id" => "internal", "priority" => 10, "label" => "internal", "cidrs" => INTERNAL_CIDRS},
+      {"id" => "control_plane", "priority" => 20, "label" => "control_plane", "cidrs" => control_plane_cidrs},
+      {"id" => "excluded_svc", "priority" => 40, "label" => "excluded", "source" => "provider"},
+      {"id" => "intra_region", "priority" => 50, "label" => "intra_region", "source" => "provider"},
+      {"id" => "inter_region_t1", "priority" => 61, "label" => "inter_region_t1", "source" => "provider"},
+      {"id" => "public_internet", "priority" => 999, "label" => "public_internet", "type" => "catchall"},
+    ]
+  end
+
+  # 0.0.0.0/0 and ::/0 are the Config defaults; drop those supernets or every
+  # packet would be metered as control_plane and downstream billing buckets
+  # would go dark.
+  def control_plane_cidrs
+    cidrs = Config.control_plane_outbound_cidrs.reject { |c| c == "0.0.0.0/0" || c == "::/0" }
+    split_ips_by_version(cidrs)
+  end
+
+  # nft sets are family-typed; partition v4/v6 before rendering.
+  def split_ips_by_version(ips)
+    grouped = {"v4" => [], "v6" => []}
+    ips.each do |ip|
+      grouped[IPAddr.new(ip).ipv4? ? "v4" : "v6"] << ip
+    rescue IPAddr::Error => e
+      raise "invalid IP entry #{ip.inspect}: #{e.message}"
+    end
+    grouped
+  end
+
+  def render_network_metering_units
+    {
+      "/etc/systemd/system/pg-metering.service" => <<~UNIT,
+        [Unit]
+        Description=Load pg network metering nftables table
+        After=network-pre.target
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/home/ubi/postgres/bin/apply-metering-config
+
+        [Install]
+        WantedBy=multi-user.target
+      UNIT
+      "/etc/systemd/system/pg-metering-export.service" => <<~UNIT,
+        [Unit]
+        Description=Export pg network metering counters to node_exporter textfile
+
+        [Service]
+        Type=oneshot
+        ExecStart=/home/ubi/postgres/bin/export-network-metrics
+      UNIT
+      "/etc/systemd/system/pg-metering-export.timer" => <<~UNIT,
+        [Unit]
+        Description=Schedule pg network metering export
+
+        [Timer]
+        OnBootSec=60s
+        OnUnitActiveSec=60s
+
+        [Install]
+        WantedBy=timers.target
+      UNIT
+      "/etc/systemd/system/pg-metering-refresh.service" => <<~UNIT,
+        [Unit]
+        Description=Refresh provider IP range sets for pg network metering
+        Wants=network-online.target
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        ExecStart=/home/ubi/postgres/bin/refresh-network-sets
+      UNIT
+      "/etc/systemd/system/pg-metering-refresh.timer" => <<~UNIT,
+        [Unit]
+        Description=Schedule provider IP range refresh
+
+        [Timer]
+        OnBootSec=120s
+        OnCalendar=daily
+        RandomizedDelaySec=1h
+        Persistent=true
+
+        [Install]
+        WantedBy=timers.target
+      UNIT
+    }
+  end
+end

--- a/loader.rb
+++ b/loader.rb
@@ -156,6 +156,7 @@ AUTOLOAD_CONSTANTS.freeze
 
 Unreloader.record_dependency("lib/authorization.rb", "model")
 Unreloader.record_dependency("lib/health_monitor_methods.rb", "model")
+Unreloader.record_dependency("lib/network_metering_methods.rb", "model")
 Unreloader.record_dependency("lib/resource_methods.rb", "model")
 Unreloader.record_dependency("lib/semaphore_methods.rb", "model")
 

--- a/model/postgres/aws/postgres_server.rb
+++ b/model/postgres/aws/postgres_server.rb
@@ -38,6 +38,10 @@ class PostgresServer < Sequel::Model
       incr_configure_s3_new_timeline
     end
 
+    def aws_setup_network_metering
+      install_network_metering("aws")
+    end
+
     def client
       @client ||= timeline.location.location_credential_aws.iam_client
     end

--- a/model/postgres/gcp/postgres_server.rb
+++ b/model/postgres/gcp/postgres_server.rb
@@ -115,5 +115,9 @@ class PostgresServer < Sequel::Model
     def gcp_increment_s3_new_timeline
       incr_configure_s3_new_timeline
     end
+
+    def gcp_setup_network_metering
+      install_network_metering("gcp")
+    end
   end
 end

--- a/model/postgres/metal/postgres_server.rb
+++ b/model/postgres/metal/postgres_server.rb
@@ -22,5 +22,9 @@ class PostgresServer < Sequel::Model
 
     def metal_increment_s3_new_timeline
     end
+
+    def metal_setup_network_metering
+      # No cloud metering on non-cloud (Hetzner etc.) providers.
+    end
   end
 end

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -21,6 +21,7 @@ class PostgresServer < Sequel::Model
     :configure_logs, :ignore_instance_size_mismatch, :install_rhizome, :unarchive
   include HealthMonitorMethods
   include MetricsTargetMethods
+  include NetworkMeteringMethods
 
   def self.victoria_metrics_client
     VictoriaMetricsResource.client_for_project(Config.postgres_service_project_id)
@@ -33,6 +34,10 @@ class PostgresServer < Sequel::Model
 
   def aws?
     (vm || timeline).location.aws?
+  end
+
+  def gcp?
+    (vm || timeline).location.gcp?
   end
 
   def provider_dispatcher_group_name

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -385,6 +385,8 @@ WantedBy=timers.target
 TIMER
     vm.sshable.write_file("/etc/systemd/system/pg-collect-metrics.timer", pg_metrics_timer)
 
+    postgres_server.setup_network_metering
+
     vm.sshable.cmd("sudo systemctl daemon-reload")
     # The old User=ubi unit leaves its safe_write_to_file lock and possibly
     # a stale tmp file owned ubi:ubi 0644, which the new user cannot write.

--- a/rhizome/postgres/bin/apply-metering-config
+++ b/rhizome/postgres/bin/apply-metering-config
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/network_metering"
+require "logger"
+
+NetworkMetering.new(Logger.new($stdout)).apply

--- a/rhizome/postgres/bin/export-network-metrics
+++ b/rhizome/postgres/bin/export-network-metrics
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/network_metering"
+require "logger"
+
+NetworkMetering.new(Logger.new($stdout)).export

--- a/rhizome/postgres/bin/refresh-network-sets
+++ b/rhizome/postgres/bin/refresh-network-sets
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/network_metering"
+require "logger"
+
+NetworkMetering.new(Logger.new($stdout)).refresh

--- a/rhizome/postgres/lib/network_metering.rb
+++ b/rhizome/postgres/lib/network_metering.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+require "digest"
+require "json"
+require_relative "../../common/lib/util"
+
+# Renders nftables from config.json, refreshes provider ranges,
+# exports counters as node_exporter textfile metrics.
+class NetworkMetering
+  CONFIG_PATH = "/etc/pg-metering/config.json"
+  TABLE_PATH = "/etc/pg-metering/table.nft"
+  RANGES_SETS_PATH = "/etc/pg-metering/ranges-sets.nft"
+  SCHEMA_HASH_PATH = "/etc/pg-metering/schema.hash"
+  PROM_PATH = "/var/lib/node_exporter/pg_net.prom"
+
+  IP_VERSIONS = {"v4" => "ipv4", "v6" => "ipv6"}.freeze
+  DIRECTIONS = {"in" => "ingress", "out" => "egress"}.freeze
+
+  module Provider; end
+  module CidrSource; end
+
+  PROVIDERS = {}
+  CIDR_SOURCES = {}
+
+  def self.provider_for(name)
+    PROVIDERS.fetch(name) { raise "unknown metering provider #{name.inspect}" }.new
+  end
+
+  def self.feeder_for(source_name, config)
+    if source_name == "provider"
+      provider_for(config.fetch("provider"))
+    elsif CIDR_SOURCES.key?(source_name)
+      CIDR_SOURCES.fetch(source_name).new
+    else
+      raise "unknown CIDR source #{source_name.inspect} (not in PROVIDERS or CIDR_SOURCES)"
+    end
+  end
+
+  def initialize(logger)
+    @logger = logger
+  end
+
+  def load_config
+    config = JSON.parse(File.read(CONFIG_PATH))
+    raise "unsupported config version #{config["version"].inspect}" unless config["version"] == 1
+    config
+  end
+
+  def apply
+    config = load_config
+    rules = config.fetch("rules").sort_by { |r| r["priority"] }
+
+    txt = render_table(rules)
+    new_hash = Digest::SHA256.hexdigest(txt)
+    live_hash = File.exist?(SCHEMA_HASH_PATH) ? File.read(SCHEMA_HASH_PATH).strip : ""
+
+    if live_hash == new_hash && File.exist?(TABLE_PATH) && table_loaded_in_kernel?
+      @logger.info("apply: no change, skipping (hash=#{new_hash[0, 8]})")
+      return
+    end
+
+    safe_write_to_file(TABLE_PATH, txt)
+    r "nft -f #{TABLE_PATH}"
+    # Restore the last-good ranges cache. If it references dropped sets
+    # after a schema change, swallow; the next refresh will repopulate.
+    if File.exist?(RANGES_SETS_PATH)
+      begin
+        r "nft -f #{RANGES_SETS_PATH}"
+      rescue => ex
+        @logger.warn("apply: stale ranges-sets cache failed to reapply: #{ex.message}")
+      end
+    end
+    safe_write_to_file(SCHEMA_HASH_PATH, new_hash)
+    @logger.info("apply: reloaded (hash=#{new_hash[0, 8]}, rules=#{rules.size})")
+  end
+
+  def refresh
+    config = load_config
+    merged = {"v4" => {}, "v6" => {}}
+    all_ids = []
+
+    rules_by_source(config).each do |source_name, source_rule_ids|
+      feeder = self.class.feeder_for(source_name, config)
+      unknown = source_rule_ids - feeder.class.provided_ids(config["provider_config"] || {})
+      raise "feeder #{feeder.class.name} does not know how to populate #{unknown.inspect}" unless unknown.empty?
+
+      parts = feeder.classify_ranges(feeder.fetch_ranges, config.fetch("region"), config["provider_config"] || {})
+
+      # Add-on feeders may be sparse; only guard the main provider.
+      guard_degenerate_partition(parts, source_rule_ids) if source_name == "provider"
+
+      IP_VERSIONS.each_key { |fam| merged[fam].merge!((parts[fam] || {}).slice(*source_rule_ids)) }
+      all_ids.concat(source_rule_ids)
+    end
+
+    txn = render_sets_transaction(merged, all_ids)
+
+    # Stage first so a failed nft -f preserves the last-good cache.
+    staging = "#{RANGES_SETS_PATH}.new"
+    safe_write_to_file(staging, txn)
+    r "nft -f #{staging}"
+    File.rename(staging, RANGES_SETS_PATH)
+
+    sizes = IP_VERSIONS.keys.map { |fam| merged[fam].map { |k, v| "#{fam}.#{k}=#{v.size}" } }.flatten.join(" ")
+    @logger.info("refreshed ranges sets: region=#{config["region"]} #{sizes}")
+  end
+
+  def rules_by_source(config)
+    config.fetch("rules")
+      .select { |r| r["source"] }
+      .group_by { |r| r["source"] }
+      .transform_values { |rs| rs.map { |r| r["id"] } }
+  end
+
+  def export
+    counters = JSON.parse(r("nft -j list counters table inet pg_metering"))["nftables"]
+      .filter_map { |o| o["counter"] }
+      .to_h { |c| [c["name"], c["bytes"]] }
+
+    lines = [
+      "# HELP pg_net_bytes_total Bytes per billing bucket, direction and IP version (cumulative).",
+      "# TYPE pg_net_bytes_total counter",
+    ]
+    counters.each do |name, bytes|
+      md = name.match(/\A(?<label>.+)_(?<fam>v[46])_(?<dir>in|out)\z/)
+      next unless md
+      lines << %(pg_net_bytes_total{bucket="#{md[:label]}",direction="#{DIRECTIONS[md[:dir]]}",ip_version="#{IP_VERSIONS[md[:fam]]}"} #{bytes})
+    end
+
+    age = File.exist?(RANGES_SETS_PATH) ? (Time.now - File.mtime(RANGES_SETS_PATH)).to_i : -1
+    lines << "# HELP pg_net_ranges_sets_age_seconds Seconds since provider IP range sets were refreshed."
+    lines << "# TYPE pg_net_ranges_sets_age_seconds gauge"
+    lines << "pg_net_ranges_sets_age_seconds #{age}"
+
+    File.write("#{PROM_PATH}.tmp", lines.join("\n") + "\n")
+    File.rename("#{PROM_PATH}.tmp", PROM_PATH)
+  end
+
+  def render_table(rules)
+    body = [
+      render_sets(rules),
+      render_counters(rules),
+      render_dispatch("ingress", "input", "iifname"),
+      render_dispatch("egress", "output", "oifname"),
+      render_version_chains(rules),
+    ].join("\n\n")
+
+    <<~NFT
+      table inet pg_metering;
+      delete table inet pg_metering;
+      table inet pg_metering {
+      #{body}
+      }
+    NFT
+  end
+
+  def render_sets_transaction(parts, generated_ids)
+    IP_VERSIONS.keys.flat_map { |fam|
+      generated_ids.map { |id| "flush set inet pg_metering #{id}_#{fam}\n" }
+    }.join + IP_VERSIONS.each_key.flat_map { |fam|
+      (parts[fam] || {}).map { |id, cidrs|
+        cidrs.empty? ? "" : "add element inet pg_metering #{id}_#{fam} { #{cidrs.join(", ")} }\n"
+      }
+    }.join
+  end
+
+  private
+
+  def table_loaded_in_kernel?
+    r("nft list table inet pg_metering > /dev/null 2>&1 && echo YES || echo NO").strip == "YES"
+  end
+
+  # v4 must be fully populated (else traffic drops to public_internet).
+  # v6 may be sparse but not entirely empty.
+  def guard_degenerate_partition(parts, source_rule_ids)
+    v4 = (parts["v4"] || {}).slice(*source_rule_ids)
+    if v4.empty? || v4.values.any?(&:empty?)
+      raise "refusing to apply degenerate range sets (v4: #{(parts["v4"] || {}).map { |k, v| "#{k}=#{v.size}" }.join(" ")})"
+    end
+    v6 = (parts["v6"] || {}).slice(*source_rule_ids)
+    if v6.empty? || v6.values.all?(&:empty?)
+      raise "refusing to apply degenerate range sets (v6: #{(parts["v6"] || {}).map { |k, v| "#{k}=#{v.size}" }.join(" ")})"
+    end
+  end
+
+  def render_sets(rules)
+    rules.reject { |r| r["type"] == "catchall" }.flat_map { |r|
+      IP_VERSIONS.keys.map { |fam| render_set(r, fam) }
+    }.join("\n")
+  end
+
+  def render_set(rule, fam)
+    addr_type = (fam == "v4") ? "ipv4_addr" : "ipv6_addr"
+    elements = rule.dig("cidrs", fam) || []
+    return "set #{rule["id"]}_#{fam} { type #{addr_type}; flags interval; auto-merge; }" if elements.empty?
+    <<~SET
+      set #{rule["id"]}_#{fam} {
+        type #{addr_type}
+        flags interval
+        auto-merge
+        elements = { #{elements.join(", ")} }
+      }
+    SET
+  end
+
+  def render_counters(rules)
+    rules.map { |r| r["label"] }.uniq.flat_map { |label|
+      IP_VERSIONS.keys.flat_map { |fam| ["counter #{label}_#{fam}_in {}", "counter #{label}_#{fam}_out {}"] }
+    }.join("\n")
+  end
+
+  def render_dispatch(direction, hook, iface)
+    <<~CHAIN
+      chain #{direction} {
+        type filter hook #{hook} priority filter; policy accept;
+        #{iface} "lo" accept
+        meta l4proto != tcp accept
+        meta nfproto ipv4 goto #{direction}_v4
+        meta nfproto ipv6 goto #{direction}_v6
+      }
+    CHAIN
+  end
+
+  def render_version_chains(rules)
+    IP_VERSIONS.keys.flat_map { |fam|
+      [render_version_chain("ingress", fam, :saddr, "in", rules),
+        render_version_chain("egress", fam, :daddr, "out", rules)]
+    }.join("\n")
+  end
+
+  ADDR_EXPRS = {
+    ["v4", :saddr] => "ip saddr", ["v4", :daddr] => "ip daddr",
+    ["v6", :saddr] => "ip6 saddr", ["v6", :daddr] => "ip6 daddr",
+  }.freeze
+
+  def render_version_chain(direction, fam, addr_key, dir_suffix, rules)
+    addr = ADDR_EXPRS.fetch([fam, addr_key])
+    lines = rules.map { |r|
+      counter = "#{r["label"]}_#{fam}_#{dir_suffix}"
+      if r["type"] == "catchall"
+        "  counter name #{counter}"
+      else
+        "  #{addr} @#{r["id"]}_#{fam} counter name #{counter} accept"
+      end
+    }
+    <<~CHAIN
+      chain #{direction}_#{fam} {
+      #{lines.join("\n")}
+      }
+    CHAIN
+  end
+end
+
+Dir[File.join(__dir__, "network_metering", "**", "*.rb")].sort.each { |f| require_relative f }

--- a/rhizome/postgres/lib/network_metering/provider/aws.rb
+++ b/rhizome/postgres/lib/network_metering/provider/aws.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "uri"
+
+class NetworkMetering
+  module Provider
+    # Flat inter-region pricing. AMAZON/S3 prefixes are AWS-internal
+    # and land in excluded_svc.
+    class Aws
+      IP_RANGES_URL = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+      # Lower wins on co-tagged prefixes.
+      SERVICE_PRIORITIES = {"S3" => -1, "AMAZON" => 1, "EC2" => 2}.freeze
+      EXCLUDED_SERVICES = ["S3", "AMAZON"].freeze
+      # Rank unlisted services above EC2 so they can't displace AMAZON.
+      UNLISTED_PRIORITY = 100
+
+      IP_VERSION_SOURCES = {
+        "v4" => {top_key: "prefixes", cidr_key: "ip_prefix"},
+        "v6" => {top_key: "ipv6_prefixes", cidr_key: "ipv6_prefix"},
+      }.freeze
+
+      def self.provided_ids(_provider_config = {})
+        %w[intra_region inter_region_t1 excluded_svc]
+      end
+
+      def fetch_ranges
+        JSON.parse(Net::HTTP.get(URI(IP_RANGES_URL)))
+      end
+
+      # GLOBAL is anycast; count it as same-region.
+      def classify_ranges(ranges, region, _provider_config = {})
+        IP_VERSION_SOURCES.transform_values { |src| classify_version_ranges(ranges[src[:top_key]] || [], src[:cidr_key], region) }
+      end
+
+      private
+
+      def classify_version_ranges(entries, cidr_key, region)
+        same_region = {}
+        inter = []
+        entries.each do |p|
+          cidr, svc, reg = p[cidr_key], p["service"], p["region"]
+          next unless cidr
+          if reg == region || reg == "GLOBAL"
+            (same_region[cidr] ||= []) << svc
+          else
+            inter << cidr
+          end
+        end
+        excluded, intra = [], []
+        same_region.each do |cidr, svcs|
+          winner = svcs.min_by { |s| SERVICE_PRIORITIES.fetch(s, UNLISTED_PRIORITY) }
+          (EXCLUDED_SERVICES.include?(winner) ? excluded : intra) << cidr
+        end
+        # Same-region wins over inter for prefixes listed under both.
+        inter -= same_region.keys
+        {"intra_region" => intra.uniq.sort, "inter_region_t1" => inter.uniq.sort, "excluded_svc" => excluded.uniq.sort}
+      end
+    end
+  end
+
+  PROVIDERS["aws"] = Provider::Aws
+end

--- a/rhizome/postgres/lib/network_metering/provider/gcp.rb
+++ b/rhizome/postgres/lib/network_metering/provider/gcp.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "uri"
+
+class NetworkMetering
+  module Provider
+    # cloud.json (per-region ranges) + goog.json (public services).
+    # Tiered inter-region buckets when gcp_tier_map is present, flat otherwise.
+    class Gcp
+      CLOUD_RANGES_URL = "https://www.gstatic.com/ipranges/cloud.json"
+      GOOG_RANGES_URL = "https://www.gstatic.com/ipranges/goog.json"
+
+      IP_VERSION_CIDR_KEYS = {"v4" => "ipv4Prefix", "v6" => "ipv6Prefix"}.freeze
+
+      def self.provided_ids(provider_config = {})
+        base = %w[intra_region inter_region_t1 excluded_svc]
+        return base unless provider_config && provider_config["gcp_tier_map"]
+        base + %w[inter_region_t2 inter_region_t3 inter_region_t4 inter_region_unknown]
+      end
+
+      def fetch_ranges
+        {
+          "cloud" => JSON.parse(Net::HTTP.get(URI(CLOUD_RANGES_URL))),
+          "goog" => JSON.parse(Net::HTTP.get(URI(GOOG_RANGES_URL))),
+        }
+      end
+
+      def classify_ranges(ranges, region, provider_config = {})
+        tier_map = provider_config&.[]("gcp_tier_map")
+        IP_VERSION_CIDR_KEYS.transform_values { |cidr_key| classify_version_ranges(ranges, cidr_key, region, tier_map) }
+      end
+
+      private
+
+      def classify_version_ranges(ranges, cidr_key, region, tier_map)
+        excluded_cidrs = ranges["goog"]["prefixes"].filter_map { |p| p[cidr_key] }
+        excluded_lookup = excluded_cidrs.each_with_object({}) { |c, h| h[c] = true }
+        intra = []
+        inter_tiered = {1 => [], 2 => [], 3 => [], 4 => []}
+        inter_flat = []
+        unknown = []
+
+        regions_to_continents = tier_map&.fetch("regions_to_continents", {}) || {}
+        tiers = if tier_map
+          local_continent = regions_to_continents.fetch(region) { raise "region #{region.inspect} missing from GCP tier map" }
+          tier_map.fetch("continents_to_continents_to_tiers").fetch(local_continent)
+        end
+
+        ranges["cloud"]["prefixes"].each do |p|
+          cidr = p[cidr_key]
+          next unless cidr
+          # Present in both feeds: excluded_svc.
+          next if excluded_lookup[cidr]
+          scope = p["scope"].to_s
+          if scope == region || scope == "global"
+            intra << cidr
+          elsif tier_map
+            remote_continent = regions_to_continents[scope]
+            tier = remote_continent && tiers[remote_continent]
+            if tier
+              inter_tiered[tier] << cidr
+            else
+              # Unmapped scope or missing tier row: leave it in
+              # `unknown` for ops instead of guessing a band.
+              unknown << cidr
+            end
+          else
+            inter_flat << cidr
+          end
+        end
+
+        parts = {"intra_region" => intra.uniq.sort, "excluded_svc" => excluded_cidrs.uniq.sort}
+        if tier_map
+          inter_tiered.each { |t, cidrs| parts["inter_region_t#{t}"] = cidrs.uniq.sort unless cidrs.empty? }
+          parts["inter_region_unknown"] = unknown.uniq.sort unless unknown.empty?
+        else
+          parts["inter_region_t1"] = inter_flat.uniq.sort
+        end
+        parts
+      end
+    end
+  end
+
+  PROVIDERS["gcp"] = Provider::Gcp
+end

--- a/rhizome/postgres/spec/network_metering/provider/aws_spec.rb
+++ b/rhizome/postgres/spec/network_metering/provider/aws_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "logger"
+require "net/http"
+require_relative "../../../lib/network_metering"
+
+RSpec.describe NetworkMetering::Provider::Aws do
+  let(:aws) { described_class.new }
+
+  describe ".provided_ids" do
+    it "advertises the flat AWS taxonomy (intra, tier1, excluded_svc)" do
+      expect(described_class.provided_ids).to contain_exactly("intra_region", "inter_region_t1", "excluded_svc")
+    end
+
+    it "ignores provider_config (AWS has no config-dependent taxonomy)" do
+      expect(described_class.provided_ids({"foo" => "bar"})).to contain_exactly("intra_region", "inter_region_t1", "excluded_svc")
+    end
+  end
+
+  describe "#partition" do
+    let(:ranges) do
+      {
+        "prefixes" => [
+          {"ip_prefix" => "3.248.0.0/13", "region" => "eu-west-1", "service" => "EC2"},
+          {"ip_prefix" => "52.218.0.0/17", "region" => "eu-west-1", "service" => "S3"},
+          {"ip_prefix" => "3.0.0.0/9", "region" => "eu-west-1", "service" => "AMAZON"},
+          {"ip_prefix" => "13.248.0.0/14", "region" => "GLOBAL", "service" => "AMAZON"},
+          {"ip_prefix" => "205.251.192.0/19", "region" => "GLOBAL", "service" => "ROUTE53"},
+          {"ip_prefix" => "3.5.140.0/22", "region" => "ap-northeast-2", "service" => "S3"},
+          {"ip_prefix" => "13.124.0.0/16", "region" => "ap-northeast-2", "service" => "EC2"},
+          {"ip_prefix" => "3.248.0.0/13", "region" => "eu-west-1", "service" => "EC2"}, # dup
+        ],
+        "ipv6_prefixes" => [
+          {"ipv6_prefix" => "2a05:d018::/29", "region" => "eu-west-1", "service" => "EC2"},
+          {"ipv6_prefix" => "2600:1f00::/33", "region" => "GLOBAL", "service" => "AMAZON"},
+          {"ipv6_prefix" => "2001:4860::/32", "region" => "eu-west-1", "service" => "AMAZON"},
+          {"ipv6_prefix" => "2406:da14::/32", "region" => "ap-northeast-2", "service" => "EC2"},
+        ],
+      }
+    end
+    let(:parts) { aws.classify_ranges(ranges, "eu-west-1") }
+
+    it "puts same-region + GLOBAL S3/AMAZON into excluded_svc (v4)" do
+      expect(parts["v4"]["excluded_svc"]).to contain_exactly("52.218.0.0/17", "3.0.0.0/9", "13.248.0.0/14")
+    end
+
+    it "puts same-region + GLOBAL non-excluded into intra_region (v4)" do
+      expect(parts["v4"]["intra_region"]).to contain_exactly("3.248.0.0/13", "205.251.192.0/19")
+    end
+
+    it "puts all other-region v4 into inter_region (flat, no tier)" do
+      expect(parts["v4"]["inter_region_t1"]).to contain_exactly("3.5.140.0/22", "13.124.0.0/16")
+    end
+
+    it "partitions v6 into the same buckets" do
+      expect(parts["v6"]["intra_region"]).to include("2a05:d018::/29")
+      expect(parts["v6"]["excluded_svc"]).to include("2600:1f00::/33", "2001:4860::/32")
+      expect(parts["v6"]["inter_region_t1"]).to include("2406:da14::/32")
+    end
+
+    it "returns bucket keys for every set the rhizome expects" do
+      %w[v4 v6].each do |fam|
+        expect(parts[fam].keys).to contain_exactly("intra_region", "inter_region_t1", "excluded_svc")
+      end
+    end
+
+    it "resolves AMAZON priority over EC2 when co-tagged" do
+      ranges_dual = {"prefixes" => [
+        {"ip_prefix" => "52.12.0.0/15", "region" => "us-west-2", "service" => "AMAZON"},
+        {"ip_prefix" => "52.12.0.0/15", "region" => "us-west-2", "service" => "EC2"},
+        {"ip_prefix" => "10.0.0.0/16", "region" => "us-west-2", "service" => "EC2"},
+      ]}
+      p = aws.classify_ranges(ranges_dual, "us-west-2")
+      expect(p["v4"]["excluded_svc"]).to include("52.12.0.0/15")
+      expect(p["v4"]["intra_region"]).not_to include("52.12.0.0/15")
+      expect(p["v4"]["intra_region"]).to include("10.0.0.0/16")
+    end
+
+    it "excludes a prefix from inter_region when the same prefix is also listed for the local region" do
+      overlap = {"prefixes" => [
+        {"ip_prefix" => "3.5.140.0/22", "region" => "eu-west-1", "service" => "EC2"},
+        {"ip_prefix" => "3.5.140.0/22", "region" => "ap-northeast-2", "service" => "EC2"},
+      ]}
+      p = aws.classify_ranges(overlap, "eu-west-1")
+      expect(p["v4"]["intra_region"]).to include("3.5.140.0/22")
+      expect(p["v4"]["inter_region_t1"]).not_to include("3.5.140.0/22")
+    end
+
+    it "skips entries with missing cidr" do
+      p = aws.classify_ranges({"prefixes" => [{"region" => "eu-west-1", "service" => "EC2"}]}, "eu-west-1")
+      expect(p["v4"]["intra_region"]).to eq([])
+    end
+  end
+
+  describe "#fetch_ranges" do
+    it "fetches and parses JSON from IP_RANGES_URL" do
+      payload = '{"prefixes":[]}'
+      expect(Net::HTTP).to receive(:get).and_return(payload)
+      expect(aws.fetch_ranges).to eq({"prefixes" => []})
+    end
+  end
+end

--- a/rhizome/postgres/spec/network_metering/provider/gcp_spec.rb
+++ b/rhizome/postgres/spec/network_metering/provider/gcp_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "net/http"
+require_relative "../../../lib/network_metering"
+
+RSpec.describe NetworkMetering::Provider::Gcp do
+  let(:gcp) { described_class.new }
+  let(:tier_map) do
+    {
+      "regions_to_continents" => {
+        "us-east1" => "northamerica", "us-west2" => "northamerica",
+        "europe-west4" => "europe", "asia-east1" => "asia",
+        "me-central1" => "middleeast",
+      },
+      "continents_to_continents_to_tiers" => {
+        "northamerica" => {"northamerica" => 1, "europe" => 2, "asia" => 3, "middleeast" => 4},
+        "europe" => {"northamerica" => 2, "europe" => 1, "asia" => 3, "middleeast" => 4},
+      },
+    }
+  end
+
+  describe ".provided_ids" do
+    it "returns the flat taxonomy when no tier map supplied" do
+      expect(described_class.provided_ids({})).to contain_exactly("intra_region", "inter_region_t1", "excluded_svc")
+    end
+
+    it "adds the tier ladder when provider_config['gcp_tier_map'] is present" do
+      expect(described_class.provided_ids({"gcp_tier_map" => tier_map})).to include(
+        "inter_region_t2", "inter_region_t3", "inter_region_t4", "inter_region_unknown",
+      )
+    end
+  end
+
+  describe "#partition (flat, no tier map)" do
+    let(:cloud_prefixes) do
+      [
+        {"ipv4Prefix" => "34.1.0.0/16", "scope" => "us-east1"},
+        {"ipv4Prefix" => "8.8.8.0/24", "scope" => "global"},
+        {"ipv4Prefix" => "34.90.0.0/16", "scope" => "europe-west4"},
+        {"ipv4Prefix" => "34.2.0.0/16", "scope" => "us-west2"},
+      ]
+    end
+    let(:goog_prefixes) { [{"ipv4Prefix" => "8.8.4.0/24"}, {"ipv4Prefix" => "8.8.8.0/24"}] }
+    let(:ranges) { {"cloud" => {"prefixes" => cloud_prefixes}, "goog" => {"prefixes" => goog_prefixes}} }
+    let(:parts) { gcp.classify_ranges(ranges, "us-east1", {}) }
+
+    it "puts same-region into intra_region" do
+      expect(parts["v4"]["intra_region"]).to include("34.1.0.0/16")
+    end
+
+    it "puts other-region into flat inter_region_t1" do
+      expect(parts["v4"]["inter_region_t1"]).to contain_exactly("34.90.0.0/16", "34.2.0.0/16")
+    end
+
+    it "prefers excluded_svc over intra_region for overlapping prefixes" do
+      expect(parts["v4"]["excluded_svc"]).to include("8.8.8.0/24")
+      expect(parts["v4"]["intra_region"]).not_to include("8.8.8.0/24")
+    end
+  end
+
+  describe "#partition (tiered, with tier map)" do
+    let(:cloud_prefixes) do
+      [
+        {"ipv4Prefix" => "34.1.0.0/16", "scope" => "us-east1"},
+        {"ipv4Prefix" => "34.2.0.0/16", "scope" => "us-west2"},
+        {"ipv4Prefix" => "34.90.0.0/16", "scope" => "europe-west4"},
+        {"ipv4Prefix" => "34.80.0.0/16", "scope" => "asia-east1"},
+        {"ipv4Prefix" => "34.101.0.0/16", "scope" => "me-central1"},
+        {"ipv4Prefix" => "34.99.0.0/16", "scope" => "unknown-newregion1"},
+      ]
+    end
+    let(:ranges) { {"cloud" => {"prefixes" => cloud_prefixes}, "goog" => {"prefixes" => []}} }
+    let(:parts) { gcp.classify_ranges(ranges, "us-east1", {"gcp_tier_map" => tier_map}) }
+
+    it "classifies us-west2 as tier1 from us-east1 (same continent)" do
+      expect(parts["v4"]["inter_region_t1"]).to include("34.2.0.0/16")
+    end
+
+    it "classifies europe-west4 as tier2 from us-east1" do
+      expect(parts["v4"]["inter_region_t2"]).to include("34.90.0.0/16")
+    end
+
+    it "classifies asia-east1 as tier3 from us-east1" do
+      expect(parts["v4"]["inter_region_t3"]).to include("34.80.0.0/16")
+    end
+
+    it "classifies me-central1 as tier4 from us-east1" do
+      expect(parts["v4"]["inter_region_t4"]).to include("34.101.0.0/16")
+    end
+
+    it "puts unmapped scope into inter_region_unknown" do
+      expect(parts["v4"]["inter_region_unknown"]).to include("34.99.0.0/16")
+    end
+
+    it "routes a known continent with no tier row to inter_region_unknown" do
+      # us-east1 is in northamerica; if the northamerica-to-middleeast row
+      # is missing, the prefix must stay visible in `unknown` instead of
+      # being silently billed at a guessed tier.
+      stripped = {"regions_to_continents" => tier_map["regions_to_continents"],
+                  "continents_to_continents_to_tiers" => {"northamerica" => {"northamerica" => 1}}}
+      p = gcp.classify_ranges(ranges, "us-east1", {"gcp_tier_map" => stripped})
+      expect(p["v4"]["inter_region_unknown"]).to include("34.101.0.0/16")
+      expect(p["v4"]["inter_region_t4"] || []).not_to include("34.101.0.0/16")
+    end
+
+    it "raises when local region is missing from the tier map" do
+      expect { gcp.classify_ranges(ranges, "fictional-1", {"gcp_tier_map" => tier_map}) }.to raise_error(/missing from GCP tier map/)
+    end
+  end
+
+  describe "provider registration" do
+    it "registers itself under 'gcp'" do
+      expect(NetworkMetering::PROVIDERS["gcp"]).to eq(described_class)
+    end
+  end
+
+  describe "#classify_ranges with nil provider_config" do
+    it "treats nil provider_config as flat (no tier map)" do
+      ranges = {"cloud" => {"prefixes" => [{"ipv4Prefix" => "34.1.0.0/16", "scope" => "us-east1"}]}, "goog" => {"prefixes" => []}}
+      p = gcp.classify_ranges(ranges, "us-east1", nil)
+      expect(p["v4"]["intra_region"]).to include("34.1.0.0/16")
+    end
+  end
+
+  describe "#fetch_ranges" do
+    it "fetches cloud.json and goog.json" do
+      expect(Net::HTTP).to receive(:get).with(URI(described_class::CLOUD_RANGES_URL)).and_return('{"prefixes":[]}')
+      expect(Net::HTTP).to receive(:get).with(URI(described_class::GOOG_RANGES_URL)).and_return('{"prefixes":[]}')
+      expect(gcp.fetch_ranges).to eq({"cloud" => {"prefixes" => []}, "goog" => {"prefixes" => []}})
+    end
+  end
+end

--- a/rhizome/postgres/spec/network_metering_spec.rb
+++ b/rhizome/postgres/spec/network_metering_spec.rb
@@ -1,0 +1,350 @@
+# frozen_string_literal: true
+
+require "logger"
+require "json"
+require_relative "../lib/network_metering"
+
+RSpec.describe NetworkMetering do
+  let(:logger) { instance_double(Logger, info: nil, warn: nil, error: nil) }
+  let(:nm) { described_class.new(logger) }
+
+  let(:base_config) do
+    {
+      "version" => 1,
+      "region" => "eu-west-1",
+      "provider" => "aws",
+      "rules" => [
+        {"id" => "internal", "priority" => 10, "label" => "internal",
+         "cidrs" => {"v4" => ["10.0.0.0/8"], "v6" => ["fc00::/7"]}},
+        {"id" => "public_internet", "priority" => 999, "label" => "public_internet", "type" => "catchall"},
+      ],
+      "provider_config" => {},
+    }
+  end
+
+  describe ".provider_for" do
+    it "returns an instance for a known provider name" do
+      expect(described_class.provider_for("aws")).to be_a(NetworkMetering::Provider::Aws)
+    end
+
+    it "raises for an unknown provider name" do
+      expect { described_class.provider_for("azure") }.to raise_error(/unknown metering provider "azure"/)
+    end
+  end
+
+  describe ".feeder_for" do
+    it "returns the main provider for source='provider'" do
+      expect(described_class.feeder_for("provider", "provider" => "aws")).to be_a(NetworkMetering::Provider::Aws)
+    end
+
+    it "resolves a named source from CIDR_SOURCES" do
+      fake_feeder = Class.new
+      stub_const("NetworkMetering::CIDR_SOURCES", {"clickpipes" => fake_feeder})
+      expect(described_class.feeder_for("clickpipes", {})).to be_a(fake_feeder)
+    end
+
+    it "raises loudly on an unknown source name" do
+      expect { described_class.feeder_for("bogus", {}) }.to raise_error(/unknown CIDR source "bogus"/)
+    end
+  end
+
+  describe "#load_config" do
+    it "parses the config file" do
+      allow(File).to receive(:read).with(described_class::CONFIG_PATH).and_return(JSON.generate(base_config))
+      expect(nm.load_config).to include("version" => 1, "region" => "eu-west-1")
+    end
+
+    it "raises on unsupported version" do
+      allow(File).to receive(:read).with(described_class::CONFIG_PATH).and_return(JSON.generate(base_config.merge("version" => 2)))
+      expect { nm.load_config }.to raise_error(/unsupported config version 2/)
+    end
+  end
+
+  describe "#render_table" do
+    it "declares atomic table+delete+define prefix" do
+      table = nm.render_table(base_config["rules"])
+      expect(table).to start_with("table inet pg_metering;\ndelete table inet pg_metering;\ntable inet pg_metering {\n")
+    end
+
+    it "renders a set per non-catchall rule × IP version" do
+      table = nm.render_table(base_config["rules"])
+      expect(table).to include("set internal_v4 {")
+      expect(table).to include("set internal_v6 {")
+      # catchall does NOT get a set
+      expect(table).not_to include("set public_internet_v4")
+      expect(table).not_to include("set public_internet_v6")
+    end
+
+    it "embeds cidrs into non-catchall sets" do
+      table = nm.render_table(base_config["rules"])
+      expect(table).to include("elements = { 10.0.0.0/8 }")
+      expect(table).to include("elements = { fc00::/7 }")
+    end
+
+    it "declares counters for every unique label × ip_version × direction" do
+      table = nm.render_table(base_config["rules"])
+      # 2 labels × 2 v × 2 dir = 8
+      expect(table.scan(/^counter /).size).to eq(8)
+    end
+
+    it "renders catchall as counter-only rule (no set match, no accept)" do
+      table = nm.render_table(base_config["rules"])
+      expect(table).to match(/chain ingress_v4 \{[^}]*  counter name public_internet_v4_in\n\}/m)
+      expect(table).to match(/chain egress_v6 \{[^}]*  counter name public_internet_v6_out\n\}/m)
+    end
+
+    it "orders chain rules by priority (low first)" do
+      rules = [
+        {"id" => "z", "priority" => 500, "label" => "z", "cidrs" => {"v4" => ["1.2.3.4/32"], "v6" => []}},
+        {"id" => "a", "priority" => 5, "label" => "a", "cidrs" => {"v4" => ["5.6.7.8/32"], "v6" => []}},
+      ]
+      table = nm.render_table(rules.sort_by { |r| r["priority"] })
+      v4_chain = table[/chain ingress_v4 \{[^}]+\}/m]
+      expect(v4_chain.index("@a_v4")).to be < v4_chain.index("@z_v4")
+    end
+
+    it "handles empty cidrs for a family with an empty-body set declaration" do
+      rules = [{"id" => "control_plane", "priority" => 20, "label" => "control_plane",
+                "cidrs" => {"v4" => ["1.2.3.4/32"], "v6" => []}}]
+      table = nm.render_table(rules)
+      expect(table).to include("set control_plane_v6 { type ipv6_addr; flags interval; auto-merge; }")
+    end
+  end
+
+  describe "#render_sets_transaction" do
+    it "flushes every generated set × family and adds elements for non-empty entries" do
+      parts = {
+        "v4" => {"intra_region" => ["4.5.0.0/16"], "inter_region" => ["9.8.0.0/14"], "excluded_svc" => ["1.2.3.0/24"]},
+        "v6" => {"intra_region" => ["2600:1f00::/33"], "excluded_svc" => ["2001:4860::/32"]},
+      }
+      gen_ids = %w[intra_region inter_region excluded_svc]
+      txn = nm.render_sets_transaction(parts, gen_ids)
+      %w[v4 v6].each do |fam|
+        gen_ids.each do |id|
+          expect(txn).to include("flush set inet pg_metering #{id}_#{fam}")
+        end
+      end
+      expect(txn).to include("add element inet pg_metering intra_region_v4 { 4.5.0.0/16 }")
+      expect(txn).to include("add element inet pg_metering excluded_svc_v6 { 2001:4860::/32 }")
+      expect(txn).not_to include("add element inet pg_metering inter_region_v6")
+    end
+  end
+
+  describe "#apply" do
+    before { allow(nm).to receive(:load_config).and_return(base_config) }
+
+    it "renders and applies when hash differs" do
+      allow(File).to receive(:exist?).and_return(false)
+      expect(nm).to receive(:safe_write_to_file).with(described_class::TABLE_PATH, anything)
+      expect(nm).to receive(:r).with("nft -f #{described_class::TABLE_PATH}")
+      expect(nm).to receive(:safe_write_to_file).with(described_class::SCHEMA_HASH_PATH, /\A[0-9a-f]{64}\z/)
+      nm.apply
+    end
+
+    it "skips when hash matches and the kernel table is loaded" do
+      cur_hash = Digest::SHA256.hexdigest(nm.render_table(base_config["rules"]))
+      allow(File).to receive(:exist?).and_return(true)
+      allow(File).to receive(:read).with(described_class::SCHEMA_HASH_PATH).and_return(cur_hash)
+      allow(nm).to receive(:r).with(/nft list table/).and_return("YES\n")
+      expect(nm).not_to receive(:safe_write_to_file)
+      expect(nm).not_to receive(:r).with(/nft -f/)
+      nm.apply
+    end
+
+    it "reloads when the hash matches but the kernel table is missing" do
+      cur_hash = Digest::SHA256.hexdigest(nm.render_table(base_config["rules"]))
+      allow(File).to receive(:exist?).with(described_class::SCHEMA_HASH_PATH).and_return(true)
+      allow(File).to receive(:exist?).with(described_class::TABLE_PATH).and_return(true)
+      allow(File).to receive(:exist?).with(described_class::RANGES_SETS_PATH).and_return(false)
+      allow(File).to receive(:read).with(described_class::SCHEMA_HASH_PATH).and_return(cur_hash)
+      allow(nm).to receive(:r).with(/nft list table/).and_return("NO\n")
+      expect(nm).to receive(:safe_write_to_file).with(described_class::TABLE_PATH, anything)
+      expect(nm).to receive(:r).with("nft -f #{described_class::TABLE_PATH}")
+      expect(nm).to receive(:safe_write_to_file).with(described_class::SCHEMA_HASH_PATH, /\A[0-9a-f]{64}\z/)
+      nm.apply
+    end
+
+    it "logs and continues when the stale ranges-sets cache fails to reapply" do
+      allow(File).to receive(:exist?).with(described_class::SCHEMA_HASH_PATH).and_return(false)
+      allow(File).to receive(:exist?).with(described_class::TABLE_PATH).and_return(false)
+      allow(File).to receive(:exist?).with(described_class::RANGES_SETS_PATH).and_return(true)
+      allow(nm).to receive(:safe_write_to_file)
+      allow(nm).to receive(:r).with("nft -f #{described_class::TABLE_PATH}")
+      allow(nm).to receive(:r).with("nft -f #{described_class::RANGES_SETS_PATH}").and_raise("no such set")
+      expect(logger).to receive(:warn).with(/stale ranges-sets cache/)
+      expect { nm.apply }.not_to raise_error
+    end
+  end
+
+  describe "#refresh" do
+    let(:aws_provider) { NetworkMetering::Provider::Aws.new }
+    let(:parts) do
+      {
+        "v4" => {"intra_region" => ["3.248.0.0/13"], "inter_region_t1" => ["13.124.0.0/16"], "excluded_svc" => ["52.218.0.0/17"]},
+        "v6" => {"intra_region" => ["2600:1f00::/33"], "inter_region_t1" => ["2406:da14::/32"], "excluded_svc" => ["2001:4860::/32"]},
+      }
+    end
+    let(:refresh_config) do
+      base_config.merge("rules" => base_config["rules"] + [
+        {"id" => "excluded_svc", "priority" => 40, "label" => "excluded", "source" => "provider"},
+        {"id" => "intra_region", "priority" => 50, "label" => "intra_region", "source" => "provider"},
+        {"id" => "inter_region_t1", "priority" => 61, "label" => "inter_region_t1", "source" => "provider"},
+      ])
+    end
+    let(:staging_path) { "#{described_class::RANGES_SETS_PATH}.new" }
+
+    before do
+      allow(nm).to receive(:load_config).and_return(refresh_config)
+      allow(described_class).to receive(:provider_for).with("aws").and_return(aws_provider)
+      allow(aws_provider).to receive_messages(fetch_ranges: {}, classify_ranges: parts)
+    end
+
+    it "writes staging file, applies nft, then renames to canonical" do
+      expect(nm).to receive(:safe_write_to_file) do |path, _|
+        expect(path).to eq(staging_path)
+      end
+      expect(nm).to receive(:r).with("nft -f #{staging_path}")
+      expect(File).to receive(:rename).with(staging_path, described_class::RANGES_SETS_PATH)
+      nm.refresh
+    end
+
+    it "raises on degenerate v4 partition" do
+      allow(aws_provider).to receive(:classify_ranges).and_return({"v4" => {"intra_region" => [], "inter_region_t1" => [], "excluded_svc" => []}, "v6" => parts["v6"]})
+      expect { nm.refresh }.to raise_error(/refusing to apply degenerate range sets \(v4/)
+    end
+
+    it "raises on degenerate v6 partition (all keys empty)" do
+      allow(aws_provider).to receive(:classify_ranges).and_return({"v4" => parts["v4"], "v6" => {"intra_region" => [], "inter_region_t1" => [], "excluded_svc" => []}})
+      expect { nm.refresh }.to raise_error(/refusing to apply degenerate range sets \(v6/)
+    end
+
+    it "raises when the feeder does not declare the rule ids the config requests" do
+      short_feeder = Class.new do
+        def self.provided_ids(_c) = ["excluded_svc"]
+        def fetch_ranges = nil
+        def classify_ranges(_r, _region, _c) = {"v4" => {}, "v6" => {}}
+      end
+      allow(described_class).to receive(:provider_for).with("aws").and_return(short_feeder.new)
+      expect { nm.refresh }.to raise_error(/does not know how to populate/)
+    end
+
+    it "silently drops partition entries not declared as provider-source in config" do
+      allow(aws_provider).to receive(:classify_ranges).and_return({
+        "v4" => parts["v4"].merge("inter_region_t2" => ["10.0.0.0/8"]),
+        "v6" => parts["v6"],
+      })
+      txn_seen = nil
+      allow(nm).to receive(:safe_write_to_file) { |_, txn| txn_seen = txn }
+      allow(nm).to receive(:r)
+      allow(File).to receive(:rename)
+      nm.refresh
+      expect(txn_seen).not_to include("inter_region_t2")
+    end
+
+    it "iterates named CIDR sources alongside the main provider" do
+      cp_feeder = Class.new do
+        def self.provided_ids(_c)
+          ["clickpipes"]
+        end
+
+        def fetch_ranges
+          nil
+        end
+
+        def classify_ranges(_r, _region, _c)
+          {"v4" => {"clickpipes" => ["54.184.252.4/32"]}, "v6" => {}}
+        end
+      end
+      stub_const("NetworkMetering::CIDR_SOURCES", {"clickpipes" => cp_feeder})
+      config_with_source = refresh_config.merge("rules" => refresh_config["rules"] + [
+        {"id" => "clickpipes", "priority" => 25, "label" => "clickpipes", "source" => "clickpipes"},
+      ])
+      allow(nm).to receive(:load_config).and_return(config_with_source)
+
+      txn_seen = nil
+      allow(nm).to receive(:safe_write_to_file) { |_, txn| txn_seen = txn }
+      allow(nm).to receive(:r)
+      allow(File).to receive(:rename)
+      nm.refresh
+      expect(txn_seen).to include("add element inet pg_metering clickpipes_v4 { 54.184.252.4/32 }")
+    end
+
+    it "does NOT apply the degenerate-v4 guard to add-on feeders (only main provider)" do
+      empty_feeder = Class.new do
+        def self.provided_ids(_c)
+          ["clickpipes"]
+        end
+
+        def fetch_ranges
+          nil
+        end
+
+        def classify_ranges(_r, _region, _c)
+          {"v4" => {"clickpipes" => []}, "v6" => {}}
+        end
+      end
+      stub_const("NetworkMetering::CIDR_SOURCES", {"clickpipes" => empty_feeder})
+      config_with_source = refresh_config.merge("rules" => refresh_config["rules"] + [
+        {"id" => "clickpipes", "priority" => 25, "label" => "clickpipes", "source" => "clickpipes"},
+      ])
+      allow(nm).to receive(:load_config).and_return(config_with_source)
+
+      allow(nm).to receive(:safe_write_to_file)
+      allow(nm).to receive(:r)
+      allow(File).to receive(:rename)
+      expect { nm.refresh }.not_to raise_error
+    end
+  end
+
+  describe "#export" do
+    let(:nft_json) do
+      {"nftables" => [
+        {"counter" => {"family" => "inet", "name" => "internal_v4_in", "table" => "pg_metering", "packets" => 3, "bytes" => 400}},
+        {"counter" => {"family" => "inet", "name" => "public_internet_v6_out", "table" => "pg_metering", "packets" => 2, "bytes" => 99}},
+        {"counter" => {"family" => "inet", "name" => "inter_region_v4_in", "table" => "pg_metering", "packets" => 5, "bytes" => 200}},
+      ]}.to_json
+    end
+
+    it "emits Prom lines with bucket/direction/ip_version labels derived from counter names" do
+      expect(nm).to receive(:r).with("nft -j list counters table inet pg_metering").and_return(nft_json)
+      allow(File).to receive(:exist?).with(described_class::RANGES_SETS_PATH).and_return(true)
+      allow(File).to receive(:mtime).with(described_class::RANGES_SETS_PATH).and_return(Time.now - 42)
+
+      written = nil
+      expect(File).to receive(:write) { |_, content| written = content }
+      expect(File).to receive(:rename)
+      nm.export
+
+      expect(written).to include('pg_net_bytes_total{bucket="internal",direction="ingress",ip_version="ipv4"} 400')
+      expect(written).to include('pg_net_bytes_total{bucket="public_internet",direction="egress",ip_version="ipv6"} 99')
+      expect(written).to include('pg_net_bytes_total{bucket="inter_region",direction="ingress",ip_version="ipv4"} 200')
+    end
+
+    it "skips counters whose name does not match the label_family_direction pattern" do
+      mixed = {"nftables" => [
+        {"counter" => {"name" => "internal_v4_in", "bytes" => 100}},
+        {"counter" => {"name" => "unrelated_counter", "bytes" => 999}},
+      ]}.to_json
+      expect(nm).to receive(:r).with("nft -j list counters table inet pg_metering").and_return(mixed)
+      allow(File).to receive(:exist?).with(described_class::RANGES_SETS_PATH).and_return(true)
+      allow(File).to receive(:mtime).with(described_class::RANGES_SETS_PATH).and_return(Time.now - 1)
+      written = nil
+      expect(File).to receive(:write) { |_, content| written = content }
+      expect(File).to receive(:rename)
+      nm.export
+      expect(written).to include("internal")
+      expect(written).not_to include("unrelated_counter")
+    end
+
+    it "reports age=-1 when the ranges-sets cache file does not exist" do
+      empty = {"nftables" => []}.to_json
+      expect(nm).to receive(:r).with("nft -j list counters table inet pg_metering").and_return(empty)
+      allow(File).to receive(:exist?).with(described_class::RANGES_SETS_PATH).and_return(false)
+      written = nil
+      expect(File).to receive(:write) { |_, content| written = content }
+      expect(File).to receive(:rename)
+      nm.export
+      expect(written).to include("pg_net_ranges_sets_age_seconds -1")
+    end
+  end
+end

--- a/spec/lib/network_metering_methods_spec.rb
+++ b/spec/lib/network_metering_methods_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "network_metering_methods"
+
+class NetworkMeteringMethodsTestClass
+  include NetworkMeteringMethods
+
+  attr_accessor :vm, :resource
+end
+
+RSpec.describe NetworkMeteringMethods do
+  let(:instance) { NetworkMeteringMethodsTestClass.new }
+
+  describe "#split_ips_by_version" do
+    it "groups v4 and v6 CIDRs" do
+      result = instance.split_ips_by_version(["10.0.0.0/8", "2600:1f14::/32", "192.168.0.1", "fc00::/7"])
+      expect(result["v4"]).to eq(["10.0.0.0/8", "192.168.0.1"])
+      expect(result["v6"]).to eq(["2600:1f14::/32", "fc00::/7"])
+    end
+
+    it "returns empty arrays for empty input" do
+      expect(instance.split_ips_by_version([])).to eq({"v4" => [], "v6" => []})
+    end
+
+    it "raises for garbage entries" do
+      expect { instance.split_ips_by_version(["not-an-ip"]) }.to raise_error(/invalid IP entry/)
+    end
+  end
+
+  describe "#base_rules" do
+    before { allow(Config).to receive(:control_plane_outbound_cidrs).and_return(["0.0.0.0/0", "::/0"]) }
+
+    it "returns internal, control_plane, provider-source rules, and public_internet catchall" do
+      ids = instance.base_rules.map { |r| r["id"] }
+      expect(ids).to contain_exactly("internal", "control_plane", "excluded_svc", "intra_region", "inter_region_t1", "public_internet")
+    end
+
+    it "marks intra/inter/excluded rules as provider-source (populated by daily refresh)" do
+      provider_ids = instance.base_rules.select { |r| r["source"] == "provider" }.map { |r| r["id"] }
+      expect(provider_ids).to contain_exactly("excluded_svc", "intra_region", "inter_region_t1")
+    end
+
+    it "declares public_internet as catchall (no cidrs)" do
+      catchall = instance.base_rules.find { |r| r["id"] == "public_internet" }
+      expect(catchall["type"]).to eq("catchall")
+      expect(catchall).not_to have_key("cidrs")
+    end
+
+    it "seeds internal_v4 with RFC1918 + link-local" do
+      internal = instance.base_rules.find { |r| r["id"] == "internal" }
+      expect(internal["cidrs"]["v4"]).to include("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16")
+    end
+
+    it "seeds internal_v6 with ULA + link-local" do
+      internal = instance.base_rules.find { |r| r["id"] == "internal" }
+      expect(internal["cidrs"]["v6"]).to include("fc00::/7", "fe80::/10")
+    end
+  end
+
+  describe "#control_plane_cidrs" do
+    it "returns empty v4/v6 lists when Config only has the default supernets" do
+      allow(Config).to receive(:control_plane_outbound_cidrs).and_return(["0.0.0.0/0", "::/0"])
+      expect(instance.control_plane_cidrs).to eq({"v4" => [], "v6" => []})
+    end
+
+    it "keeps operator-supplied cidrs and drops supernets" do
+      allow(Config).to receive(:control_plane_outbound_cidrs).and_return(["0.0.0.0/0", "3.143.188.173/32", "2600:1f14::/56", "::/0"])
+      expect(instance.control_plane_cidrs).to eq({"v4" => ["3.143.188.173/32"], "v6" => ["2600:1f14::/56"]})
+    end
+  end
+
+  describe "#network_metering_config" do
+    let(:location_double) { double(name: "us-east-1") }
+    let(:resource_double) { double(location: location_double) }
+
+    before do
+      instance.resource = resource_double
+      allow(Config).to receive(:control_plane_outbound_cidrs).and_return(["0.0.0.0/0", "::/0"])
+    end
+
+    it "composes version, region, provider, sorted rules, empty provider_config" do
+      cfg = instance.network_metering_config("aws")
+      expect(cfg["version"]).to eq(1)
+      expect(cfg["region"]).to eq("us-east-1")
+      expect(cfg["provider"]).to eq("aws")
+      priorities = cfg["rules"].map { |r| r["priority"] }
+      expect(priorities).to eq(priorities.sort)
+      expect(cfg["provider_config"]).to eq({})
+    end
+  end
+
+  describe "#render_network_metering_units" do
+    let(:units) { instance.render_network_metering_units }
+
+    it "renders 5 unit files" do
+      expect(units.keys).to contain_exactly(
+        "/etc/systemd/system/pg-metering.service",
+        "/etc/systemd/system/pg-metering-export.service",
+        "/etc/systemd/system/pg-metering-export.timer",
+        "/etc/systemd/system/pg-metering-refresh.service",
+        "/etc/systemd/system/pg-metering-refresh.timer",
+      )
+    end
+
+    it "pg-metering.service invokes apply-metering-config" do
+      expect(units["/etc/systemd/system/pg-metering.service"]).to include("ExecStart=/home/ubi/postgres/bin/apply-metering-config")
+    end
+
+    it "export timer fires every minute" do
+      expect(units["/etc/systemd/system/pg-metering-export.timer"]).to include("OnUnitActiveSec=60s")
+    end
+
+    it "refresh timer is daily with random delay + persistent catch-up" do
+      body = units["/etc/systemd/system/pg-metering-refresh.timer"]
+      expect(body).to include("OnCalendar=daily")
+      expect(body).to include("RandomizedDelaySec=1h")
+      expect(body).to include("Persistent=true")
+    end
+  end
+end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -962,6 +962,68 @@ RSpec.describe PostgresServer do
     expect(postgres_server.aws?).to be(false)
   end
 
+  it "#gcp? delegates to location" do
+    expect(postgres_server.gcp?).to be(false)
+  end
+
+  describe "#install_network_metering" do
+    let(:bin_check_cmd) { "test -x postgres/bin/apply-metering-config && test -x postgres/bin/refresh-network-sets && test -x postgres/bin/export-network-metrics && echo YES || echo NO" }
+
+    before { allow(Config).to receive(:control_plane_outbound_cidrs).and_return(["0.0.0.0/0", "::/0"]) }
+
+    it "skips when the rhizome tree lacks the metering bins" do
+      expect(postgres_server.vm.sshable).to receive(:_cmd).with(bin_check_cmd).and_return("NO\n")
+      expect(postgres_server.vm.sshable).not_to receive(:_cmd).with("sudo install -d -m 0755 /etc/pg-metering")
+      postgres_server.install_network_metering("aws")
+    end
+
+    it "writes config.json, applies it, installs units, and primes the refresh timer" do
+      sshable = postgres_server.vm.sshable
+      allow(sshable).to receive(:_cmd).with(bin_check_cmd).and_return("YES\n")
+      expect(sshable).to receive(:_cmd).with("sudo install -d -m 0755 /etc/pg-metering")
+      expect(sshable).to receive(:_cmd).with("sudo tee #{NetworkMeteringMethods::CONFIG_PATH} > /dev/null", stdin: a_string_matching(/"version":1/))
+      expect(sshable).to receive(:_cmd).with("sudo /home/ubi/postgres/bin/apply-metering-config")
+      %w[pg-metering.service pg-metering-export.service pg-metering-export.timer pg-metering-refresh.service pg-metering-refresh.timer].each do |unit|
+        expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/#{unit} > /dev/null", stdin: anything)
+      end
+      expect(sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl enable pg-metering.service")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now pg-metering-export.timer pg-metering-refresh.timer")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl start pg-metering-refresh.service || true")
+      postgres_server.install_network_metering("aws")
+    end
+  end
+
+  describe "#network_metering_config" do
+    before { allow(Config).to receive(:control_plane_outbound_cidrs).and_return(["0.0.0.0/0", "::/0"]) }
+
+    it "falls back to vm.location when resource is nil" do
+      allow(postgres_server).to receive(:resource).and_return(nil)
+      cfg = postgres_server.network_metering_config("aws")
+      expect(cfg["region"]).to eq(location.name)
+      expect(cfg["provider"]).to eq("aws")
+    end
+  end
+
+  describe "#setup_network_metering" do
+    it "dispatches to metal_setup_network_metering (no-op) for ubicloud provider" do
+      expect(postgres_server).not_to receive(:install_network_metering)
+      postgres_server.setup_network_metering
+    end
+
+    it "dispatches to aws_setup_network_metering for aws provider" do
+      location.update(provider: "aws")
+      expect(postgres_server).to receive(:install_network_metering).with("aws")
+      postgres_server.setup_network_metering
+    end
+
+    it "dispatches to gcp_setup_network_metering for gcp provider" do
+      location.update(provider: "gcp")
+      expect(postgres_server).to receive(:install_network_metering).with("gcp")
+      postgres_server.setup_network_metering
+    end
+  end
+
   describe "#taking_over?" do
     it "returns true if the strand label is 'taking_over'" do
       expect(postgres_server).to receive(:strand).and_return(instance_double(Strand, label: "taking_over"))

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -692,6 +692,13 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   describe "#configure_metrics" do
     let(:metrics_config) { {interval: "30s", endpoints: ["https://localhost:9100/metrics"], metrics_dir: "/home/ubi/postgres/metrics"} }
 
+    before do
+      # Provider-dispatched metering setup lives on the PostgresServer model
+      # and has its own detailed spec coverage; stub it here to keep this
+      # spec focused on the strand-level orchestration.
+      allow(nx.postgres_server).to receive(:setup_network_metering)
+    end
+
     it "configures prometheus and metrics during initial provisioning" do
       nx.incr_initial_provisioning
       expect(sshable).to receive(:_cmd).with("sudo mkdir -p /usr/local/share/postgresql")
@@ -720,6 +727,14 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now postgres-metrics.timer")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now pg-collect-metrics.timer")
 
+      expect { nx.configure_metrics }.to hop("configure_logs")
+    end
+
+    it "invokes setup_network_metering on the postgres_server model" do
+      nx.incr_initial_provisioning
+      expect(nx.postgres_server).to receive(:setup_network_metering)
+      allow(sshable).to receive(:_cmd)
+      allow(nx.postgres_server).to receive(:metrics_config).and_return(metrics_config)
       expect { nx.configure_metrics }.to hop("configure_logs")
     end
 


### PR DESCRIPTION
## Summary

Meters every TCP packet on a managed Postgres VM into billing buckets via an nftables count-only table, backed by a rules-driven config that the control plane composes and ships to the VM. Providers plug in via a `NetworkMetering::PROVIDERS` registry; additional CIDR feeders (e.g. edge/CDN sources) plug in via `NetworkMetering::CIDR_SOURCES` using the same protocol.

## Design

**Control plane** composes `/etc/pg-metering/config.json`: `{version, region, provider, rules[], provider_config}`. Each rule is `{id, priority, label, cidrs?, source?, type?}` where `source: "provider"` marks a rule the daily refresh fills, and `type: "catchall"` marks a chain-only bucket with no set.

**Rhizome** owns the nftables render:
- `apply`: SHA256-hashes the rendered table; no-ops when the hash matches AND the kernel table is loaded. On mismatch, atomically reloads the table (`table ... ; delete table ... ; table ... {...}` idiom) and replays the last-good ranges cache.
- `refresh`: fetches provider IP ranges, partitions them into rule buckets, stages a transaction file, applies via `nft -f`, and only then renames over the canonical cache.
- `export`: reads `nft -j list counters` and writes a Prom textfile with `bucket / direction / ip_version` labels.

**Providers**:
- `Provider::Aws`: fetches ip-ranges.json, resolves per-service priorities (`S3 < AMAZON < EC2 < unlisted`) so AMAZON-tagged prefixes cannot be silently displaced. Flat inter-region tier.
- `Provider::Gcp`: fetches cloud.json + goog.json. Flat inter-region tier by default; tiered by continent pair when `provider_config["gcp_tier_map"]` is supplied. Unmapped scopes land in `inter_region_unknown` for ops visibility.

The `gcp_tier_map` payload has two sub-maps: one that resolves each GCP region to a continent, and one that assigns a pricing tier to every (source-continent, destination-continent) pair, this is done due to similar tiered pricing done by [GCP](https://cloud.google.com/vpc/network-pricing). Concretely:

```yaml
regions_to_continents:
  us-east1:      northamerica
  europe-west4:  europe
  asia-east1:    asia
  me-central1:   middleeast

continents_to_continents_to_tiers:
  northamerica: {northamerica: 1, europe: 2, asia: 3, middleeast: 4}
  europe:       {northamerica: 2, europe: 1, asia: 3, middleeast: 4}

```

At classify time, the local region resolves to a continent (row), the remote scope resolves to another continent (column), and the tier at that cell picks `inter_region_t1..t4`. If either the region or the continent pair is missing, the prefix falls into `inter_region_unknown` so ops can see it. On our ClickHouse fork the actual map lives in `config/network_metering.yml` and is shipped as `provider_config["gcp_tier_map"]`; upstream ships an empty `provider_config`, so a stock deploy just sees flat `inter_region_t1`.

**Safety**:
- Chains are policy-accept with accept-only verdicts, restricted to TCP (`meta l4proto != tcp accept`), so the table cannot drop or reorder traffic.
- **Degenerate-partition guard on refresh:** the daily range refresh calls into a provider feeder that partitions the fetched IP ranges into per-rule buckets (`intra_region`, `inter_region_t1`, `excluded_svc`, ...). If a fetch bug, region typo, or upstream schema change causes any v4 bucket that the config asked for to come back empty, `refresh` refuses to overwrite the last-good cache and raises, otherwise all v4 traffic to that region would silently misroute to `public_internet` and get billed as internet egress.
- **Existing-VM safety:** `install_network_metering` starts by sshing `test -x` on the three rhizome bins (`apply-metering-config`, `refresh-network-sets`, `export-network-metrics`) and returns immediately if any is missing. A control-plane rollout can therefore land on a fleet whose VMs still run the previous rhizome tree without wedging `configure_metrics`; the next `install_rhizome` copies the new bins over, and the following `configure_metrics` converge sees them and sets up the pipeline. No orchestration order dependency between the two rollouts.

## Systemd units (all rendered CP-side)

- `pg-metering.service`: one-shot, runs `apply-metering-config` at boot.
- `pg-metering-export.timer`: fires `export-network-metrics` every 60s.
- `pg-metering-refresh.timer`: daily with a 1h randomized delay + persistent catch-up.

## Test plan
- [x] Rhizome unit specs (`network_metering_spec.rb` + provider specs) cover render, refresh, apply hash gate + kernel-check, degenerate partition guard, provider partitioning + priority resolution, feeder registry.
- [x] CP unit specs (`network_metering_methods_spec.rb`) cover base_rules, config compose, unit rendering, split_ips_by_version.
- [x] Nexus spec (`postgres_server_nexus_spec.rb`) asserts `setup_network_metering` is invoked from `configure_metrics`.
- [x] E2E on a live cell: deployed to our dev environment (AWS us-east-1). Verified config.json shipped with correct base_rules, nft table reloaded via schema-hash gate, counters accumulating, refresh timer running daily and populating provider sets. Iface-vs-bucket delta comparison over a 30s window matched within 3-8% (gap accounted for by non-TCP traffic which the chains skip).

## Grafana demo

<img width="2627" height="931" alt="image" src="https://github.com/user-attachments/assets/229ac64d-ecd6-4dcc-86e8-7344981582f5" />
