### PR TITLE
Convert Time.parse calls

### DIFF
--- a/.github/actions/gcp-cleanup-e2e/cleanup.rb
+++ b/.github/actions/gcp-cleanup-e2e/cleanup.rb
@@ -259,7 +259,7 @@ rescue JSON::ParserError
 end
 
 def stale?(ts)
-  ts && Time.parse(ts) < Time.now - STALE_AFTER
+  ts && Time.new(ts) < Time.now - STALE_AFTER
 rescue ArgumentError, TypeError
   false
 end

--- a/lib/minio/client.rb
+++ b/lib/minio/client.rb
@@ -217,7 +217,7 @@ class Minio::Client
 
     def self.from_xml(element, bucket_name, encoding_type: nil, is_delete_marker: false)
       last_modified = element.at_xpath("xmlns:LastModified")&.text
-      last_modified = Time.parse(last_modified) if last_modified
+      last_modified = Time.new(last_modified) if last_modified
       etag = element.at_xpath("xmlns:ETag")&.text&.delete('"')
       size = element.at_xpath("xmlns:Size")&.text&.to_i
       owner = element.at_xpath("xmlns:Owner")

--- a/model/github/github_installation.rb
+++ b/model/github/github_installation.rb
@@ -28,7 +28,7 @@ class GithubInstallation < Sequel::Model
 
   def free_runner_upgrade_expires_at
     if (upgrade_until = project.get_ff_free_runner_upgrade_until)
-      Time.parse(upgrade_until)
+      Time.new(upgrade_until)
     end
   end
 

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -211,7 +211,7 @@ SQL
 
     effective_prog = prog
     stack.each do |frame|
-      if (deadline_at = frame["deadline_at"]) && start_time > Time.parse(deadline_at)
+      if (deadline_at = frame["deadline_at"]) && start_time > Time.new(deadline_at)
         sbj = subject
         extra_data = case sbj
         when Vm
@@ -280,7 +280,7 @@ SQL
         changed_columns.delete(:schedule)
       when Prog::Base::Hop
         hp = prog_action
-        last_changed_at = Time.parse(top_frame["last_label_changed_at"])
+        last_changed_at = Time.new(top_frame["last_label_changed_at"])
         Clog.emit("hopped", {strand_hopped: {strand: ubid, duration: Time.now - last_changed_at, from: prog_label, to: "#{hp.new_prog}.#{hp.new_label}"}})
         top_frame["last_label_changed_at"] = Time.now.to_s
         modified!(:stack)
@@ -288,7 +288,7 @@ SQL
         update(**hp.strand_update_args, try: 0)
       when Prog::Base::Exit
         ext = prog_action
-        last_changed_at = Time.parse(top_frame["last_label_changed_at"])
+        last_changed_at = Time.new(top_frame["last_label_changed_at"])
         Clog.emit("exited", {strand_exited: {strand: ubid, duration: Time.now - last_changed_at, from: prog_label}})
 
         update(exitval: ext.exitval, retval: nil)

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -401,7 +401,7 @@ end
     if deadline_at.nil? ||
         deadline_target != new_deadline_target ||
         allow_extension ||
-        Time.parse(deadline_at) > new_deadline
+        Time.new(deadline_at) > new_deadline
 
       resolve_deadline_target(deadline_target) if deadline_target != new_deadline_target
 
@@ -409,7 +409,7 @@ end
 
       if allow_extension.is_a?(Integer)
         self.deadline_start ||= time_string(time)
-        cap = Time.parse(deadline_start) + allow_extension
+        cap = Time.new(deadline_start) + allow_extension
         new_deadline = [new_deadline, cap].min
       end
 

--- a/prog/github/delete_cache_entries.rb
+++ b/prog/github/delete_cache_entries.rb
@@ -30,6 +30,6 @@ class Prog::Github::DeleteCacheEntries < Prog::Base
     github_repository
       .cache_entries_dataset
       .order(:created_at)
-      .first(Sequel[:created_at] < Time.parse(initiated_at))
+      .first(Sequel[:created_at] < Time.new(initiated_at))
   end
 end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -896,7 +896,7 @@ SQL
     representative_server = resource.representative_server
     hop_prepare_taking_over if representative_server.strand.label == "wait_in_fence"
 
-    if deadline_at && Time.now > Time.parse(deadline_at.to_s)
+    if deadline_at && Time.now > Time.new(deadline_at.to_s)
       representative_server.incr_lockout
       hop_wait_representative_lockout
     end

--- a/prog/redeliver_github_failures.rb
+++ b/prog/redeliver_github_failures.rb
@@ -5,7 +5,7 @@ class Prog::RedeliverGithubFailures < Prog::Base
   frame_accessor :last_check_at
 
   label def wait
-    last_check_time = Time.parse(last_check_at)
+    last_check_time = Time.new(last_check_at)
     remaining_seconds = 2 * 60 - (Time.now - last_check_time)
     nap remaining_seconds.to_i + 1 if remaining_seconds > 0
     failures = failed_deliveries(last_check_time)

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -33,7 +33,7 @@ class Prog::Test::Kubernetes < Prog::Test::KubernetesBase
   label def wait_for_renew_certs
     cp_node = kubernetes_cluster.nodes.first
     nap 10 unless cp_node.strand.label == "wait" && cp_node.state == "active" && !cp_node.renew_certs_set?
-    nap 10 unless cp_node.cert_expire_at > Time.parse(cert_expire_at_before_renew)
+    nap 10 unless cp_node.cert_expire_at > Time.new(cert_expire_at_before_renew)
     hop_test_nodes
   end
 

--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -77,8 +77,8 @@ class Clover
           unmatched_label: {
             repository_name:,
             labels: job_labels,
-            started_in: Time.parse(job["started_at"]) - Time.parse(job["created_at"]),
-            completed_in: job["completed_at"] ? (Time.parse(job["completed_at"]) - Time.parse(job["started_at"])) : nil,
+            started_in: Time.new(job["started_at"]) - Time.new(job["created_at"]),
+            completed_in: job["completed_at"] ? (Time.new(job["completed_at"]) - Time.new(job["started_at"])) : nil,
             conclusion: job["conclusion"],
           },
         })
@@ -113,7 +113,7 @@ class Clover
 
     case data["action"]
     when "in_progress"
-      runner.log_duration("runner_started", Time.parse(job["started_at"]) - Time.parse(job["created_at"]))
+      runner.log_duration("runner_started", Time.new(job["started_at"]) - Time.new(job["created_at"]))
       success("GithubRunner[#{runner.ubid}] picked job #{job.fetch("id")}")
     when "completed"
       runner.incr_destroy

--- a/spec/lib/clog_spec.rb
+++ b/spec/lib/clog_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Clog do
-  let(:now) { Time.parse("2023-01-17 12:10:54 -0800") }
+  let(:now) { Time.utc(2023, 1, 17, 20, 10, 54) }
 
   before do
     allow(Time).to receive(:now).and_return(now)

--- a/spec/model/load_balancer_vm_port_spec.rb
+++ b/spec/model/load_balancer_vm_port_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe LoadBalancerVmPort do
         expect(lb_vm_port).to receive(:check_probe).with(session, :ipv4).and_return("up")
         expect(lb_vm_port).not_to receive(:update)
         expect(lb_vm_port.load_balancer_port.load_balancer).not_to receive(:incr_update_load_balancer)
-        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "up", reading_rpt: 1, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})).to eq({reading: "up", reading_rpt: 2, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})
+        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "up", reading_rpt: 1, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})).to eq({reading: "up", reading_rpt: 2, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})
       end
 
       it "doesn't perform update if the state is up, the pulse is down, but the reading repeat is below the threshold" do
@@ -151,8 +151,8 @@ RSpec.describe LoadBalancerVmPort do
         expect(lb_vm_port).to receive(:check_probe).with(session, :ipv4).and_return("down")
         expect(lb_vm_port).not_to receive(:update)
         expect(lb_vm_port.load_balancer_port.load_balancer).not_to receive(:incr_update_load_balancer)
-        expect(Time).to receive(:now).and_return(Time.parse("2025-01-28 13:15:20.049434 +0100")).at_least(:once)
-        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "up", reading_rpt: 1, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})).to eq({reading: "down", reading_rpt: 1, reading_chg: Time.parse("2025-01-28 13:15:20.049434 +0100")})
+        expect(Time).to receive(:now).and_return(Time.utc(2025, 1, 28, 12, 15, 20, 49434)).at_least(:once)
+        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "up", reading_rpt: 1, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})).to eq({reading: "down", reading_rpt: 1, reading_chg: Time.utc(2025, 1, 28, 12, 15, 20, 49434)})
       end
 
       it "doesn't perform update if the state is up, the pulse is down, but the reading count is above the threshold but the reading change is too recent" do
@@ -162,8 +162,8 @@ RSpec.describe LoadBalancerVmPort do
         expect(lb_vm_port).to receive(:check_probe).with(session, :ipv4).and_return("down")
         expect(lb_vm_port).not_to receive(:update)
         expect(lb_vm_port.load_balancer_port.load_balancer).not_to receive(:incr_update_load_balancer)
-        expect(Time).to receive(:now).and_return(Time.parse("2025-01-28 13:15:20.049434 +0100")).at_least(:once)
-        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "down", reading_rpt: 4, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})).to eq({reading: "down", reading_rpt: 5, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})
+        expect(Time).to receive(:now).and_return(Time.utc(2025, 1, 28, 12, 15, 20, 49434)).at_least(:once)
+        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "down", reading_rpt: 4, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})).to eq({reading: "down", reading_rpt: 5, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})
       end
 
       it "doesn't perform update if the state is up, the pulse is up, but the reading count is above the threshold but the reading didn't change recently but the load balancer is set to update" do
@@ -172,9 +172,9 @@ RSpec.describe LoadBalancerVmPort do
         lb_vm_port.load_balancer_port.load_balancer.update(health_check_interval: 30)
         expect(lb_vm_port).to receive(:check_probe).with(session, :ipv4).and_return("down")
         expect(lb_vm_port).not_to receive(:update)
-        expect(Time).to receive(:now).and_return(Time.parse("2025-01-28 13:15:50.049434 +0100")).at_least(:once)
+        expect(Time).to receive(:now).and_return(Time.utc(2025, 1, 28, 12, 15, 50, 49434)).at_least(:once)
         lb_vm_port.load_balancer_port.load_balancer.incr_update_load_balancer
-        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "down", reading_rpt: 4, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})).to eq({reading: "down", reading_rpt: 5, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})
+        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "down", reading_rpt: 4, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})).to eq({reading: "down", reading_rpt: 5, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})
       end
 
       it "performs update if the state is down, the pulse is up, the reading count is above the threshold and the reading didn't change recently and the load balancer is not set to update" do
@@ -184,8 +184,8 @@ RSpec.describe LoadBalancerVmPort do
         expect(lb_vm_port).to receive(:check_probe).with(session, :ipv4).and_return("down")
         expect(lb_vm_port).to receive(:update).with(state: "down")
         expect(lb_vm_port.load_balancer_port.load_balancer).to receive(:incr_update_load_balancer)
-        expect(Time).to receive(:now).and_return(Time.parse("2025-01-28 13:15:50.049434 +0100")).at_least(:once)
-        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "down", reading_rpt: 4, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})).to eq({reading: "down", reading_rpt: 5, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})
+        expect(Time).to receive(:now).and_return(Time.utc(2025, 1, 28, 12, 15, 50, 49434)).at_least(:once)
+        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "down", reading_rpt: 4, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})).to eq({reading: "down", reading_rpt: 5, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})
       end
 
       it "doesn't perform update if the state is down and the pulse is also down" do
@@ -193,7 +193,7 @@ RSpec.describe LoadBalancerVmPort do
         expect(lb_vm_port).to receive(:check_probe).with(session, :ipv4).and_return("down")
         expect(lb_vm_port).not_to receive(:update)
         expect(lb_vm_port.load_balancer_port.load_balancer).not_to receive(:incr_update_load_balancer)
-        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "down", reading_rpt: 1, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})).to eq({reading: "down", reading_rpt: 2, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})
+        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "down", reading_rpt: 1, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})).to eq({reading: "down", reading_rpt: 2, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})
       end
 
       it "doesn't perform update if the state is down, the pulse is up, but the reading repeat is below the threshold" do
@@ -201,8 +201,8 @@ RSpec.describe LoadBalancerVmPort do
         expect(lb_vm_port).to receive(:check_probe).with(session, :ipv4).and_return("up")
         expect(lb_vm_port).not_to receive(:update)
         expect(lb_vm_port.load_balancer_port.load_balancer).not_to receive(:incr_update_load_balancer)
-        expect(Time).to receive(:now).and_return(Time.parse("2025-01-28 13:15:20.049434 +0100")).at_least(:once)
-        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "down", reading_rpt: 1, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})).to eq({reading: "up", reading_rpt: 1, reading_chg: Time.parse("2025-01-28 13:15:20.049434 +0100")})
+        expect(Time).to receive(:now).and_return(Time.utc(2025, 1, 28, 12, 15, 20, 49434)).at_least(:once)
+        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "down", reading_rpt: 1, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})).to eq({reading: "up", reading_rpt: 1, reading_chg: Time.utc(2025, 1, 28, 12, 15, 20, 49434)})
       end
 
       it "doesn't perform update if the state is down, the pulse is up, but the reading count is above the threshold and the reading change is too recent" do
@@ -212,8 +212,8 @@ RSpec.describe LoadBalancerVmPort do
         expect(lb_vm_port).to receive(:check_probe).with(session, :ipv4).and_return("up")
         expect(lb_vm_port).not_to receive(:update)
         expect(lb_vm_port.load_balancer_port.load_balancer).not_to receive(:incr_update_load_balancer)
-        expect(Time).to receive(:now).and_return(Time.parse("2025-01-28 13:15:20.049434 +0100")).at_least(:once)
-        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "up", reading_rpt: 4, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})).to eq({reading: "up", reading_rpt: 5, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})
+        expect(Time).to receive(:now).and_return(Time.utc(2025, 1, 28, 12, 15, 20, 49434)).at_least(:once)
+        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "up", reading_rpt: 4, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})).to eq({reading: "up", reading_rpt: 5, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})
       end
 
       it "doesn't perform update if the state is down, the pulse is up, the reading count is above the threshold and the reading change is too recent and the load balancer is set to update" do
@@ -222,9 +222,9 @@ RSpec.describe LoadBalancerVmPort do
         lb_vm_port.load_balancer_port.load_balancer.update(health_check_interval: 30)
         expect(lb_vm_port).to receive(:check_probe).with(session, :ipv4).and_return("up")
         expect(lb_vm_port).not_to receive(:update)
-        expect(Time).to receive(:now).and_return(Time.parse("2025-01-28 13:15:50.049434 +0100")).at_least(:once)
+        expect(Time).to receive(:now).and_return(Time.utc(2025, 1, 28, 12, 15, 50, 49434)).at_least(:once)
         lb_vm_port.load_balancer_port.load_balancer.incr_update_load_balancer
-        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "up", reading_rpt: 4, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})).to eq({reading: "up", reading_rpt: 5, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})
+        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "up", reading_rpt: 4, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})).to eq({reading: "up", reading_rpt: 5, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})
       end
 
       it "performs update if the state is down, the pulse is up, the reading count is above the threshold and the reading change is too recent and the load balancer is not set to update" do
@@ -234,8 +234,8 @@ RSpec.describe LoadBalancerVmPort do
         expect(lb_vm_port).to receive(:check_probe).with(session, :ipv4).and_return("up")
         expect(lb_vm_port).to receive(:update).with(state: "up")
         expect(lb_vm_port.load_balancer_port.load_balancer).to receive(:incr_update_load_balancer)
-        expect(Time).to receive(:now).and_return(Time.parse("2025-01-28 13:15:50.049434 +0100")).at_least(:once)
-        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "up", reading_rpt: 4, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})).to eq({reading: "up", reading_rpt: 5, reading_chg: Time.parse("2025-01-28 13:15:10.049434 +0100")})
+        expect(Time).to receive(:now).and_return(Time.utc(2025, 1, 28, 12, 15, 50, 49434)).at_least(:once)
+        expect(lb_vm_port.check_pulse(session:, previous_pulse: {reading: "up", reading_rpt: 4, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})).to eq({reading: "up", reading_rpt: 5, reading_chg: Time.utc(2025, 1, 28, 12, 15, 10, 49434)})
       end
     end
   end

--- a/spec/model/semaphore_spec.rb
+++ b/spec/model/semaphore_spec.rb
@@ -46,6 +46,6 @@ RSpec.describe Semaphore do
 
   it "#inspect_values_hash includes set_at" do
     sem = described_class.create(name: "foo", strand_id: st.id)
-    expect(Time.parse(sem.inspect_values_hash[:set_at] + " UTC")).to be_within(2).of(Time.now)
+    expect(Time.new(sem.inspect_values_hash[:set_at] + " UTC")).to be_within(2).of(Time.now)
   end
 end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -308,8 +308,8 @@ RSpec.describe Prog::Base do
       st = Strand.create(prog: "Test", label: :extend_deadline_with_limit)
       st.unsynchronized_run
 
-      deadline_start = Time.parse(st.stack.first["deadline_start"])
-      deadline_at = Time.parse(st.stack.first["deadline_at"])
+      deadline_start = Time.new(st.stack.first["deadline_start"])
+      deadline_at = Time.new(st.stack.first["deadline_at"])
       expect(deadline_start).to be_within(1).of(Time.now)
       expect(deadline_at).to be_within(1).of(deadline_start + 10 * 60)
 
@@ -319,8 +319,8 @@ RSpec.describe Prog::Base do
       st.stack.first["deadline_start"] = st.time_string(deadline_start)
       st.unsynchronized_run
 
-      new_deadline_start = Time.parse(st.stack.first["deadline_start"])
-      new_deadline_at = Time.parse(st.stack.first["deadline_at"])
+      new_deadline_start = Time.new(st.stack.first["deadline_start"])
+      new_deadline_at = Time.new(st.stack.first["deadline_at"])
       expect(new_deadline_start).to eq(deadline_start)
       expect(new_deadline_at).to be_within(1).of(deadline_start + 30 * 60)
     end

--- a/spec/prog/github/delete_cache_entries_spec.rb
+++ b/spec/prog/github/delete_cache_entries_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Prog::Github::DeleteCacheEntries do
       expect(st.prog).to eq "Github::DeleteCacheEntries"
       expect(st.label).to eq "delete_entries"
       expect(st.stack[0]["subject_id"]).to eq repository.id
-      expect(Time.parse(st.stack[0]["initiated_at"])).to be_within(10).of(Time.now)
+      expect(Time.new(st.stack[0]["initiated_at"])).to be_within(10).of(Time.now)
     end
 
     it "accepts an initiated_at Time" do
@@ -35,7 +35,7 @@ RSpec.describe Prog::Github::DeleteCacheEntries do
       expect(st.prog).to eq "Github::DeleteCacheEntries"
       expect(st.label).to eq "delete_entries"
       expect(st.stack[0]["subject_id"]).to eq repository.id
-      expect(Time.parse(st.stack[0]["initiated_at"])).to eq initiated_at
+      expect(Time.new(st.stack[0]["initiated_at"])).to eq initiated_at
     end
   end
 

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -796,7 +796,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       refresh_frame(nx, new_values: {"deadline_target" => "wait", "deadline_at" => (now - 5 * 60).to_s})
       expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests.new({body: "API rate limit exceeded"}) } }.to nap(300)
         .and change { Page.count }.by(1)
-      expect(Time.parse(nx.frame["deadline_at"])).to eq(now + 10 * 60)
+      expect(Time.new(nx.frame["deadline_at"])).to eq(now + 10 * 60)
       expect(Page.first).to have_attributes(
         summary: "GitHub API rate limit exceeded for installation #{installation.ubid}",
         tag: Page.generate_tag(["GithubRateLimitExceeded", installation.ubid]),
@@ -809,7 +809,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       nx.incr_destroying
       refresh_frame(nx, new_values: {"deadline_target" => nil, "deadline_at" => (now - 5 * 60).to_s})
       expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests.new({body: "API rate limit exceeded"}) } }.to nap(30)
-      expect(Time.parse(nx.frame["deadline_at"])).to eq(now + 15 * 60)
+      expect(Time.new(nx.frame["deadline_at"])).to eq(now + 15 * 60)
     end
 
     it "destroys the runner if the rate limit reset is more than 10 minutes away while provisioning" do

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
     it "registers deadline and hops" do
       expect { nx.start }.to hop("create_load_balancers")
       expect(nx.strand.stack.first["deadline_target"]).to eq "wait"
-      expect(Time.parse(nx.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 120 * 60)
+      expect(Time.new(nx.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 120 * 60)
       expect(nx.install_metrics_server_set?).to be true
       expect(nx.sync_worker_mesh_set?).to be true
       expect(nx.sync_internal_dns_config_set?).to be true

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       expect { nx.renew_certs }.to nap(30)
       frame = nx.strand.stack.first
       expect(frame["deadline_target"]).to eq("wait")
-      expect(Time.parse(frame["deadline_at"].to_s)).to be_within(3).of(Time.now + 10 * 60)
+      expect(Time.new(frame["deadline_at"].to_s)).to be_within(3).of(Time.now + 10 * 60)
     end
 
     it "starts the daemonizer, marks the node renewing_certs and naps when not started" do
@@ -180,7 +180,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       expect { nx.unavailable }.to nap(15)
       frame = nx.strand.stack.first
       expect(frame["deadline_target"]).to eq("wait")
-      expect(Time.parse(frame["deadline_at"].to_s)).to be_within(3).of(Time.now + 15 * 60)
+      expect(Time.new(frame["deadline_at"].to_s)).to be_within(3).of(Time.now + 15 * 60)
     end
   end
 

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       prog = described_class.new(kn.strand)
       expect { prog.start }.to hop("bootstrap_worker_nodes")
         .and change { Semaphore.where(strand_id: kn.id, name: "start_bootstrapping").count }.from(1).to(0)
-      expect(Time.parse(prog.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 120 * 60)
+      expect(Time.new(prog.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 120 * 60)
     end
 
     it "hops when the cluster is in wait even without the semaphore" do

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   describe "#start" do
     it "registers the deadline and hops to create_node" do
       expect { prog.start }.to hop("create_node")
-      expect(Time.parse(prog.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 20 * 60)
+      expect(Time.new(prog.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 20 * 60)
     end
   end
 

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -1019,7 +1019,7 @@ usermod -L ubuntu
       expect(Time).to receive(:now).at_least(:once).and_return(now)
       expect { nx.prevent_destroy }.to nap(30)
       expect(nx.strand.stack.first["deadline_target"]).to eq("destroy")
-      expect(Time.parse(nx.strand.stack.first["deadline_at"])).to be_within(0.00001).of(now + 24 * 60 * 60)
+      expect(Time.new(nx.strand.stack.first["deadline_at"])).to be_within(0.00001).of(now + 24 * 60 * 60)
     end
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -408,7 +408,7 @@ RSpec.describe Prog::Vm::HostNexus do
           .and not_change { nx.graceful_reboot_set? }
           .and change { nx.patch_set? }.from(true).to(false)
           .and change { nx.strand.stack[0]["deadline_target"] }.from(nil).to("prep_reboot")
-        expect(Time.parse(nx.strand.stack[0]["deadline_at"])).to be_within(5).of(Time.now + 600)
+        expect(Time.new(nx.strand.stack[0]["deadline_at"])).to be_within(5).of(Time.now + 600)
       end
 
       it "sets graceful_restart semaphore if host was in accepting before patch" do
@@ -419,7 +419,7 @@ RSpec.describe Prog::Vm::HostNexus do
           .and change { nx.patch_set? }.from(true).to(false)
           .and change { nx.graceful_reboot_set? }.from(false).to(true)
           .and change { nx.strand.stack[0]["deadline_target"] }.from(nil).to("prep_reboot")
-        expect(Time.parse(nx.strand.stack[0]["deadline_at"])).to be_within(5).of(Time.now + 600)
+        expect(Time.new(nx.strand.stack[0]["deadline_at"])).to be_within(5).of(Time.now + 600)
       end
     end
   end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -1143,7 +1143,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect { nx.stopped }.to hop("restart")
       frame = st.stack[0]
       expect(frame["deadline_target"]).to eq "wait"
-      expect(Time.parse(frame["deadline_at"])).to be_within(10).of(Time.now + 300)
+      expect(Time.new(frame["deadline_at"])).to be_within(10).of(Time.now + 300)
     end
 
     it "stops the vm and hops to stopped_by_admin with admin_stop semaphore" do
@@ -1209,7 +1209,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect { nx.stopped }.to hop("start_after_stop")
       frame = st.stack[0]
       expect(frame["deadline_target"]).to eq "wait"
-      expect(Time.parse(frame["deadline_at"])).to be_within(10).of(Time.now + 300)
+      expect(Time.new(frame["deadline_at"])).to be_within(10).of(Time.now + 300)
     end
 
     it "does not stop if already stopped" do
@@ -1250,7 +1250,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect { nx.unavailable }.to hop("start_after_stop")
       frame = st.stack[0]
       expect(frame["deadline_target"]).to eq "wait"
-      expect(Time.parse(frame["deadline_at"])).to be_within(10).of(Time.now + 300)
+      expect(Time.new(frame["deadline_at"])).to be_within(10).of(Time.now + 300)
     end
 
     it "hops to stopped when needed" do

--- a/spec/prog/vnet/aws/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/aws/vpc_nexus_spec.rb
@@ -395,7 +395,7 @@ RSpec.describe Prog::Vnet::Aws::VpcNexus do
       vm.incr_prevent_destroy
 
       expect { nx.destroy }.to nap(5)
-      expect(Time.parse(nx.strand.stack.first["deadline_at"])).to be_within(5).of(Time.now + 10 * 60)
+      expect(Time.new(nx.strand.stack.first["deadline_at"])).to be_within(5).of(Time.now + 10 * 60)
       expect(nx.strand.stack.first.fetch("deadline_target")).to be_nil
     end
 

--- a/spec/prog/vnet/gcp/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_nexus_spec.rb
@@ -656,7 +656,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
   describe "#destroy" do
     it "registers deadline and hops to enumerate_destroy_state when no subnets remain" do
       expect { nx.destroy }.to hop("enumerate_destroy_state")
-      expect(Time.parse(nx.strand.stack.first["deadline_at"])).to be_within(10).of(Time.now + 10 * 60)
+      expect(Time.new(nx.strand.stack.first["deadline_at"])).to be_within(10).of(Time.now + 10 * 60)
       expect(nx.strand.stack.first["deadline_target"]).to eq("destroy")
     end
 

--- a/spec/prog/vnet/maintain_presigned_load_balancer_certs_spec.rb
+++ b/spec/prog/vnet/maintain_presigned_load_balancer_certs_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Prog::Vnet::MaintainPresignedLoadBalancerCerts do
       expect(cert.private_hostname).to eq "*.#{lb_ubid}.private.lb2.ubicloud.com"
       expect(cert.dns_zone_id).to eq dns_zone.id
       expect(frame["deadline_target"]).to eq "wait"
-      expect(Time.parse(frame["deadline_at"])).to be_within(5).of(Time.now + 60 * 45)
+      expect(Time.new(frame["deadline_at"])).to be_within(5).of(Time.now + 60 * 45)
       expect(last_cert_created).to be_within(5).of(Time.now.to_i)
     end
   end

--- a/spec/prog/vnet/maintain_presigned_postgres_certs_spec.rb
+++ b/spec/prog/vnet/maintain_presigned_postgres_certs_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Prog::Vnet::MaintainPresignedPostgresCerts do
       expect(cert.private_hostname).to eq "*.#{pg_ubid}.private.pg.ubicloud.app"
       expect(cert.dns_zone_id).to eq dns_zone.id
       expect(frame["deadline_target"]).to eq "wait"
-      expect(Time.parse(frame["deadline_at"])).to be_within(5).of(Time.now + 60 * 45)
+      expect(Time.new(frame["deadline_at"])).to be_within(5).of(Time.now + 60 * 45)
       expect(last_cert_created).to be_within(5).of(Time.now.to_i)
     end
   end

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
 
       expect { nx.destroy }.to nap(5)
       expect(nx.strand.stack.first["deadline_target"]).to be_nil
-      expect(Time.parse(nx.strand.stack.first["deadline_at"])).to be_within(5).of(Time.now + 10 * 60)
+      expect(Time.new(nx.strand.stack.first["deadline_at"])).to be_within(5).of(Time.now + 10 * 60)
     end
 
     it "fails if there are active resources" do

--- a/views/github/runner.erb
+++ b/views/github/runner.erb
@@ -104,8 +104,8 @@
             if (job = runner.workflow_job)
               [
                 [
-                  "Running for #{format_time_diff(Time.parse(job["started_at"]), Time.now)}",
-                  "Started in #{format_time_diff(Time.parse(job["created_at"]), Time.parse(job["started_at"]))}"
+                  "Running for #{format_time_diff(Time.new(job["started_at"]), Time.now)}",
+                  "Started in #{format_time_diff(Time.new(job["created_at"]), Time.new(job["started_at"]))}"
                 ], {}
               ]
             else


### PR DESCRIPTION
Time.parse is fairly slow. Time.new in modern Ruby is significantly faster. In cases where static strings are used (some specs), it's better to use Time.utc with integer arguments. This converts the Time.parse calls to Time.new or Time.utc. In some cases in the specs, the Time.utc code looses the timezone offset, but that doesn't affect the spec's behavior.

Written by Claude with a couple prompts:

```
Run `git grep -l Time.parse` to find a list files with of `Time.parse`.
For each `Time.parse` call site:

* If called with a static string without a timezone or with a UTC
  timezone:
  * Convert it to use `Time.utc` with integer arguments.
* If called with something other than a static string:
  * If the format used can be determined:
    * If `Time.new` handles the format, convert the call site to use
      that method.
    * Otherwise, convert the call site to use `Time.strptime` with an
      appropriate format.
  * If the format cannot be determined, do not modify the call site.
```

```
`spec/lib/clog_spec.rb` and `spec/model/load_balancer_vm_port_spec.rb`
both contain `Time.parse` calls with static strings. Convert those to
use `Time.utc` with separate arguments.
```