### PR TITLE
Size wal-g config from the server being configured

### DIFF
--- a/model/postgres/aws/postgres_timeline.rb
+++ b/model/postgres/aws/postgres_timeline.rb
@@ -21,7 +21,7 @@ class PostgresTimeline < Sequel::Model
 
     private
 
-    def aws_generate_walg_config(version)
+    def aws_generate_walg_config(version, server)
       walg_credentials = if access_key
         <<-WALG_CONF
 AWS_ACCESS_KEY_ID=#{access_key}
@@ -38,12 +38,12 @@ PGHOST=/var/run/postgresql
 PGDATA=/dat/#{version}/data
       WALG_CONF
       # Append the hardware-sized wal-g knobs (empty unless the feature is enabled).
-      config + walg_config_env_contents
+      config + walg_config_env_contents(server)
     end
 
-    def aws_walg_config_params
-      return nil unless (vm = leader.vm)
-      family = leader.resource.target_vm_size.split(".").first
+    def aws_walg_config_params(server)
+      return nil unless (vm = server.vm)
+      family = server.resource.target_vm_size.split(".").first
 
       # dense NVMe = storage-optimized "i" families, allows more concurrency.
       {vcpu_count: vm.vcpus, memory_mib: vm.memory_gib * 1024,

--- a/model/postgres/gcp/postgres_timeline.rb
+++ b/model/postgres/gcp/postgres_timeline.rb
@@ -7,18 +7,18 @@ class PostgresTimeline < Sequel::Model
   module Gcp
     private
 
-    def gcp_generate_walg_config(version)
+    def gcp_generate_walg_config(version, server)
       config = <<-WALG_CONF
 WALG_GS_PREFIX=gs://#{ubid}
 GOOGLE_APPLICATION_CREDENTIALS=/etc/postgresql/gcs-sa-key.json
 PGHOST=/var/run/postgresql
 PGDATA=/dat/#{version}/data
       WALG_CONF
-      config + walg_config_env_contents
+      config + walg_config_env_contents(server)
     end
 
-    def gcp_walg_config_params
-      return nil unless (vm = leader.vm)
+    def gcp_walg_config_params(server)
+      return nil unless (vm = server.vm)
 
       {vcpu_count: vm.vcpus, memory_mib: vm.memory_gib * 1024}
     end

--- a/model/postgres/metal/postgres_timeline.rb
+++ b/model/postgres/metal/postgres_timeline.rb
@@ -4,7 +4,7 @@ class PostgresTimeline < Sequel::Model
   module Metal
     private
 
-    def metal_generate_walg_config(version)
+    def metal_generate_walg_config(version, server)
       walg_credentials = if access_key
         <<-WALG_CONF
 AWS_ACCESS_KEY_ID=#{access_key}
@@ -20,10 +20,10 @@ AWS_S3_FORCE_PATH_STYLE=true
 PGHOST=/var/run/postgresql
 PGDATA=/dat/#{version}/data
       WALG_CONF
-      config + walg_config_env_contents
+      config + walg_config_env_contents(server)
     end
 
-    def metal_walg_config_params
+    def metal_walg_config_params(_server)
       nil
     end
 

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -587,7 +587,7 @@ class PostgresServer < Sequel::Model
   def refresh_walg_credentials
     return if timeline.blob_storage.nil?
 
-    walg_config = timeline.generate_walg_config(version)
+    walg_config = timeline.generate_walg_config(version, self)
     vm.sshable.cmd("sudo -u postgres tee /etc/postgresql/wal-g.env > /dev/null", stdin: walg_config)
     refresh_walg_blob_storage_credentials
     unless resource.use_old_walg_command_set?

--- a/model/postgres/postgres_timeline.rb
+++ b/model/postgres/postgres_timeline.rb
@@ -19,12 +19,12 @@ class PostgresTimeline < Sequel::Model
     ubid
   end
 
-  def walg_config_env_contents
+  def walg_config_env_contents(server)
     return "" unless walg_optimized_config_enabled?
-    return "" unless (params = walg_config_params)
+    return "" unless (params = walg_config_params(server))
 
     direct_io = walg_direct_io_enabled?
-    direct_io_drive_count = leader.storage_device_paths.count if direct_io
+    direct_io_drive_count = server.storage_device_paths.count if direct_io
     WalgConfig.config_env_contents(**params, direct_io:, direct_io_drive_count:)
   end
 

--- a/spec/model/postgres/gcp/postgres_timeline_spec.rb
+++ b/spec/model/postgres/gcp/postgres_timeline_spec.rb
@@ -42,28 +42,27 @@ PGHOST=/var/run/postgresql
 PGDATA=/dat/17/data
         WALG_CONF
 
-        expect(postgres_timeline.generate_walg_config(17)).to eq(walg_config)
+        expect(postgres_timeline.generate_walg_config(17, instance_double(PostgresServer))).to eq(walg_config)
       end
 
       it "appends the hardware-sized config on local-SSD instances when enabled" do
-        leader = instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 8, memory_gib: 32),
+        allow(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer,
+          resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: false, get_ff_postgres_walg_direct_io_disabled: false))))
+        server = instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 8, memory_gib: 32),
           storage_device_paths: ["/dev/nvme0n1", "/dev/nvme1n1"],
-          resource: instance_double(PostgresResource, target_vm_size: "c4a-standard-8",
-            project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: false, get_ff_postgres_walg_direct_io_disabled: false)))
-        allow(postgres_timeline).to receive(:leader).and_return(leader)
+          resource: instance_double(PostgresResource, target_vm_size: "c4a-standard-8"))
 
-        config = postgres_timeline.generate_walg_config(17)
+        config = postgres_timeline.generate_walg_config(17, server)
         expect(config).to include("WALG_UPLOAD_DISK_CONCURRENCY=4")   # floor(0.50*8)
         expect(config).to include("WALG_DIRECT_IO=true")
         expect(config).to include("WALG_DIRECT_IO_BLOCK_COUNT=512")   # 2 local SSDs * 256
       end
 
-      it "leaves stock config (no hardware knobs) when the leader has no vm yet" do
-        leader = instance_double(PostgresServer, vm: nil,
-          resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: nil)))
-        allow(postgres_timeline).to receive(:leader).and_return(leader)
+      it "leaves stock config (no hardware knobs) when the server has no vm yet" do
+        allow(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer,
+          resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: nil))))
 
-        expect(postgres_timeline.generate_walg_config(17)).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
+        expect(postgres_timeline.generate_walg_config(17, instance_double(PostgresServer, vm: nil))).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
       end
     end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -1007,7 +1007,7 @@ RSpec.describe PostgresServer do
 
     it "refreshes walg credentials if timeline has blob storage not on aws" do
       expect(timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, root_certs: "root_certs")).at_least(:once)
-      expect(timeline).to receive(:generate_walg_config).and_return("walg_config")
+      expect(timeline).to receive(:generate_walg_config).with(postgres_server.version, postgres_server).and_return("walg_config")
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo -u postgres tee /etc/postgresql/wal-g.env > /dev/null", stdin: "walg_config")
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo tee /usr/lib/ssl/certs/blob_storage_ca.crt > /dev/null", stdin: "root_certs")
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo mkdir -p /etc/systemd/system/wal-g.service.d")
@@ -1020,7 +1020,7 @@ RSpec.describe PostgresServer do
     it "refreshes walg credentials if timeline has blob storage on aws" do
       location.update(provider: "aws")
       expect(timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, root_certs: "root_certs")).at_least(:once)
-      expect(timeline).to receive(:generate_walg_config).and_return("walg_config")
+      expect(timeline).to receive(:generate_walg_config).with(postgres_server.version, postgres_server).and_return("walg_config")
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo -u postgres tee /etc/postgresql/wal-g.env > /dev/null", stdin: "walg_config")
       expect(postgres_server.vm.sshable).not_to receive(:_cmd).with("sudo tee /usr/lib/ssl/certs/blob_storage_ca.crt > /dev/null", stdin: "root_certs")
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo mkdir -p /etc/systemd/system/wal-g.service.d")

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -36,7 +36,7 @@ PGHOST=/var/run/postgresql
 PGDATA=/dat/16/data
     WALG_CONF
 
-    expect(postgres_timeline.generate_walg_config(16)).to eq(walg_config)
+    expect(postgres_timeline.generate_walg_config(16, instance_double(PostgresServer))).to eq(walg_config)
   end
 
   it "returns walg config for aws" do
@@ -55,7 +55,7 @@ PGHOST=/var/run/postgresql
 PGDATA=/dat/16/data
     WALG_CONF
 
-    expect(postgres_timeline.generate_walg_config(16)).to eq(walg_config)
+    expect(postgres_timeline.generate_walg_config(16, instance_double(PostgresServer))).to eq(walg_config)
   end
 
   it "returns walg config without keys when vm has iam_role for metal" do
@@ -72,7 +72,7 @@ PGHOST=/var/run/postgresql
 PGDATA=/dat/17/data
     WALG_CONF
 
-    expect(postgres_timeline.generate_walg_config(17)).to eq(walg_config)
+    expect(postgres_timeline.generate_walg_config(17, instance_double(PostgresServer))).to eq(walg_config)
   end
 
   it "returns walg config without keys when vm has iam_role for aws" do
@@ -89,19 +89,19 @@ PGHOST=/var/run/postgresql
 PGDATA=/dat/17/data
     WALG_CONF
 
-    expect(postgres_timeline.generate_walg_config(17)).to eq(walg_config)
+    expect(postgres_timeline.generate_walg_config(17, instance_double(PostgresServer))).to eq(walg_config)
   end
 
   it "appends hardware-sized wal-g config for aws when the feature is enabled (O_DIRECT on)" do
     postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
-    leader = instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 48, memory_gib: 384),
+    allow(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer,
+      resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: false, get_ff_postgres_walg_direct_io_disabled: false))))
+    server = instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 48, memory_gib: 384),
       storage_device_paths: ["/dev/nvme1n1", "/dev/nvme2n1", "/dev/nvme3n1"],
-      resource: instance_double(PostgresResource, target_vm_size: "i8ge.12xlarge",
-        project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: false, get_ff_postgres_walg_direct_io_disabled: false)))
-    allow(postgres_timeline).to receive(:leader).and_return(leader)
+      resource: instance_double(PostgresResource, target_vm_size: "i8ge.12xlarge"))
 
-    config = postgres_timeline.generate_walg_config(17)
+    config = postgres_timeline.generate_walg_config(17, server)
     expect(config).to include("WALG_UPLOAD_DISK_CONCURRENCY=48")   # i8ge dense NVMe -> vCPU under O_DIRECT
     expect(config).to include("WALG_S3_MAX_PART_SIZE=#{64 * 1024 * 1024}")
     expect(config).to include("WALG_DOWNLOAD_CONCURRENCY=48")
@@ -112,12 +112,12 @@ PGDATA=/dat/17/data
   it "uses buffered config (no O_DIRECT) when walg_config is on but direct_io is off" do
     postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
-    leader = instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 48, memory_gib: 384),
-      resource: instance_double(PostgresResource, target_vm_size: "i8ge.12xlarge",
-        project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: nil, get_ff_postgres_walg_direct_io_disabled: true)))
-    allow(postgres_timeline).to receive(:leader).and_return(leader)
+    allow(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer,
+      resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: nil, get_ff_postgres_walg_direct_io_disabled: true))))
+    server = instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 48, memory_gib: 384),
+      resource: instance_double(PostgresResource, target_vm_size: "i8ge.12xlarge"))
 
-    config = postgres_timeline.generate_walg_config(17)
+    config = postgres_timeline.generate_walg_config(17, server)
     expect(config).to include("WALG_UPLOAD_DISK_CONCURRENCY=24")   # 1/2 vCPU (buffered; cpu.weight governs impact)
     expect(config).not_to include("WALG_DIRECT_IO")
   end
@@ -125,32 +125,30 @@ PGDATA=/dat/17/data
   it "omits wal-g config for aws when the feature is disabled (default no-op)" do
     postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
-    allow(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer, vm: instance_double(Vm, vcpus: 48, memory_gib: 384)))
-    leader = instance_double(PostgresServer, vm: nil,
-      resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: true)))
-    allow(postgres_timeline).to receive(:leader).and_return(leader)
+    allow(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer,
+      resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: true))))
 
-    expect(postgres_timeline.generate_walg_config(17)).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
+    expect(postgres_timeline.generate_walg_config(17, instance_double(PostgresServer))).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
   end
 
-  it "leaves stock config for aws when enabled but the leader has no vm yet" do
+  it "leaves stock config for aws when enabled but the server has no vm yet" do
     postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
-    leader = instance_double(PostgresServer, vm: nil,
-      resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: false)))
-    allow(postgres_timeline).to receive(:leader).and_return(leader)
+    allow(postgres_timeline).to receive(:leader).and_return(instance_double(PostgresServer,
+      resource: instance_double(PostgresResource, project: instance_double(Project, get_ff_postgres_walg_optimized_config_disabled: false))))
 
-    expect(postgres_timeline.generate_walg_config(17)).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
+    expect(postgres_timeline.generate_walg_config(17, instance_double(PostgresServer, vm: nil))).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
   end
 
-  it "leaves stock config when enabled but the timeline has no push-leader yet" do
+  it "leaves stock config when the timeline has no push-leader yet" do
+    postgres_timeline.update(location_id: create_aws_location(name: "us-east-2").id)
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint"))
 
-    expect(postgres_timeline.generate_walg_config(17)).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
+    expect(postgres_timeline.generate_walg_config(17, instance_double(PostgresServer))).not_to include("WALG_UPLOAD_DISK_CONCURRENCY")
   end
 
   it "returns nil walg_config_params for metal (stock config, no hardware sizing)" do
-    expect(postgres_timeline.walg_config_params).to be_nil
+    expect(postgres_timeline.walg_config_params(instance_double(PostgresServer))).to be_nil
   end
 
   it "returns walg_config_region for metal" do


### PR DESCRIPTION
wal-g hardware sizing read disk info from the timeline leader instead of the server being configured. On AWS that goes over SSH, so an unreachable timeline leader breaks refresh_walg_credentials. It is also wrong whenever the server differs from the leader, such as a server being resized.

Pass the server into generate_walg_config so the vcpu, memory, and disk count come from its own VM. The feature-flag checks still use the leader, since they are timeline-wide and only hit the database.