### PR TITLE
Gcp timeline parent sa related fixes

### DIFF
--- a/model/postgres/gcp/postgres_server.rb
+++ b/model/postgres/gcp/postgres_server.rb
@@ -93,23 +93,6 @@ class PostgresServer < Sequel::Model
       key_json = key.private_key_data.force_encoding("UTF-8")
 
       timeline.update(access_key: service_account.email, secret_key: key_json)
-
-      # Clean up old timeline's service account if it exists. Best-effort, runs after
-      # timeline.update so retries won't re-enter (access_key guard above).
-      cleanup_old_timeline_service_account(credential)
-    end
-
-    def cleanup_old_timeline_service_account(credential)
-      if (old_timeline = timeline.parent) && old_timeline.access_key
-        begin
-          credential.iam_client.delete_project_service_account(
-            "projects/-/serviceAccounts/#{old_timeline.access_key}",
-          )
-        rescue Google::Apis::ClientError => e
-          raise unless e.status_code == 404
-          nil
-        end
-      end
     end
 
     def gcp_increment_s3_new_timeline

--- a/model/postgres/gcp/postgres_timeline.rb
+++ b/model/postgres/gcp/postgres_timeline.rb
@@ -84,8 +84,7 @@ PGDATA=/dat/#{version}/data
             "projects/-/serviceAccounts/#{access_key}",
           )
         rescue Google::Apis::ClientError => e
-          raise unless e.status_code == 404
-          # SA already deleted. idempotent path
+          raise unless [403, 404].include?(e.status_code)
           nil
         end
       end

--- a/spec/model/postgres/gcp/postgres_server_spec.rb
+++ b/spec/model/postgres/gcp/postgres_server_spec.rb
@@ -354,102 +354,40 @@ RSpec.describe PostgresServer do
         postgres_server.attach_s3_policy_if_needed
       end
 
-      context "with old timeline SA cleanup" do
-        let(:new_sa) {
-          instance_double(Google::Apis::IamV1::ServiceAccount,
-            email: "pg-tl-newsa123@test-project.iam.gserviceaccount.com",
-            name: "projects/test-project/serviceAccounts/pg-tl-newsa123@test-project.iam.gserviceaccount.com")
-        }
+      it "does not delete the parent timeline's service account" do
+        parent_timeline = PostgresTimeline.create(
+          location_id: location.id,
+          access_key: "parent-sa@test-project.iam.gserviceaccount.com",
+          secret_key: '{"type":"service_account","key":"parent"}',
+        )
+        timeline.update(access_key: nil, secret_key: nil, parent_id: parent_timeline.id)
 
-        let(:new_key) {
-          instance_double(Google::Apis::IamV1::ServiceAccountKey,
-            private_key_data: '{"type":"service_account","private_key":"new"}'.b)
-        }
+        sa_resource_name = "projects/test-project/serviceAccounts/#{timeline.ubid}@test-project.iam.gserviceaccount.com"
+        sa = instance_double(Google::Apis::IamV1::ServiceAccount,
+          email: "#{timeline.ubid}@test-project.iam.gserviceaccount.com",
+          name: sa_resource_name)
+        key = instance_double(Google::Apis::IamV1::ServiceAccountKey,
+          private_key_data: '{"type":"service_account","private_key":"new"}'.b)
 
-        before do
-          allow(location_credential_gcp).to receive_messages(iam_client:, storage_client:)
+        allow(location_credential_gcp).to receive_messages(iam_client:, storage_client:)
+        allow(iam_client).to receive(:get_project_service_account).and_raise(Google::Apis::ClientError.new("Not Found", status_code: 404))
+        allow(iam_client).to receive_messages(create_service_account: sa, create_service_account_key: key)
+        allow(iam_client).to receive(:get_project_service_account_iam_policy).and_return(Google::Apis::IamV1::Policy.new(bindings: []))
+        allow(iam_client).to receive(:set_service_account_iam_policy)
+        allow(timeline).to receive(:create_bucket)
 
-          bucket = instance_double(Google::Cloud::Storage::Bucket)
-          policy = instance_double(Google::Cloud::Storage::PolicyV3)
-          bindings = instance_double(Google::Cloud::Storage::PolicyV3::Bindings)
-          allow(storage_client).to receive_messages(create_bucket: bucket, bucket:)
-          allow(bucket).to receive(:policy).and_return(policy)
-          allow(policy).to receive(:bindings).and_return(bindings)
-          allow(bindings).to receive(:insert)
-          allow(bucket).to receive(:policy=)
-          allow(timeline).to receive(:create_bucket)
+        bucket = instance_double(Google::Cloud::Storage::Bucket)
+        policy = instance_double(Google::Cloud::Storage::PolicyV3)
+        bindings = instance_double(Google::Cloud::Storage::PolicyV3::Bindings)
+        allow(storage_client).to receive(:bucket).and_return(bucket)
+        allow(bucket).to receive(:policy).and_return(policy)
+        allow(policy).to receive(:bindings).and_return(bindings)
+        allow(bindings).to receive(:insert)
+        allow(bucket).to receive(:policy=)
 
-          allow(iam_client).to receive(:get_project_service_account_iam_policy).and_return(Google::Apis::IamV1::Policy.new(bindings: []))
-          allow(iam_client).to receive(:set_service_account_iam_policy)
-          allow(iam_client).to receive(:get_project_service_account).and_raise(Google::Apis::ClientError.new("Not Found", status_code: 404))
-          allow(iam_client).to receive_messages(create_service_account: new_sa, create_service_account_key: new_key)
-        end
+        expect(iam_client).not_to receive(:delete_project_service_account)
 
-        it "deletes old timeline's SA when parent timeline has access_key" do
-          parent_timeline = PostgresTimeline.create(
-            location_id: location.id,
-            access_key: "old-sa@test-project.iam.gserviceaccount.com",
-            secret_key: '{"type":"service_account","key":"old"}',
-          )
-          timeline.update(access_key: nil, secret_key: nil, parent_id: parent_timeline.id)
-
-          expect(iam_client).to receive(:delete_project_service_account).with(
-            "projects/-/serviceAccounts/old-sa@test-project.iam.gserviceaccount.com",
-          )
-
-          postgres_server.attach_s3_policy_if_needed
-        end
-
-        it "does not delete old SA when parent timeline has no access_key" do
-          parent_timeline = PostgresTimeline.create(
-            location_id: location.id,
-            access_key: nil,
-            secret_key: nil,
-          )
-          timeline.update(access_key: nil, secret_key: nil, parent_id: parent_timeline.id)
-
-          expect(iam_client).not_to receive(:delete_project_service_account)
-
-          postgres_server.attach_s3_policy_if_needed
-        end
-
-        it "ignores errors when deleting an already-deleted SA" do
-          parent_timeline = PostgresTimeline.create(
-            location_id: location.id,
-            access_key: "deleted-sa@test-project.iam.gserviceaccount.com",
-            secret_key: '{"type":"service_account","key":"old"}',
-          )
-          timeline.update(access_key: nil, secret_key: nil, parent_id: parent_timeline.id)
-
-          expect(iam_client).to receive(:delete_project_service_account).and_raise(
-            Google::Apis::ClientError.new("Not Found", status_code: 404),
-          )
-
-          postgres_server.attach_s3_policy_if_needed
-        end
-
-        it "re-raises non-404 errors when deleting old SA" do
-          parent_timeline = PostgresTimeline.create(
-            location_id: location.id,
-            access_key: "broken-sa@test-project.iam.gserviceaccount.com",
-            secret_key: '{"type":"service_account","key":"old"}',
-          )
-          timeline.update(access_key: nil, secret_key: nil, parent_id: parent_timeline.id)
-
-          expect(iam_client).to receive(:delete_project_service_account).and_raise(
-            Google::Apis::ClientError.new("Forbidden", status_code: 403),
-          )
-
-          expect { postgres_server.attach_s3_policy_if_needed }.to raise_error(Google::Apis::ClientError, /Forbidden/)
-        end
-
-        it "does not attempt to delete when there is no parent timeline" do
-          timeline.update(access_key: nil, secret_key: nil)
-
-          expect(iam_client).not_to receive(:delete_project_service_account)
-
-          postgres_server.attach_s3_policy_if_needed
-        end
+        postgres_server.attach_s3_policy_if_needed
       end
     end
   end

--- a/spec/model/postgres/gcp/postgres_timeline_spec.rb
+++ b/spec/model/postgres/gcp/postgres_timeline_spec.rb
@@ -258,7 +258,7 @@ PGDATA=/dat/17/data
         postgres_timeline.destroy_blob_storage
       end
 
-      it "re-raises non-404 ClientError during SA delete" do
+      it "handles missing SA reported as 403 gracefully" do
         storage_client = instance_double(Google::Cloud::Storage::Project)
         iam_client = instance_double(Google::Apis::IamV1::IamService)
         expect(postgres_timeline).to receive(:blob_storage_client).and_return(storage_client)
@@ -269,8 +269,22 @@ PGDATA=/dat/17/data
         expect(iam_client).to receive(:delete_project_service_account)
           .and_raise(Google::Apis::ClientError.new("permission denied", status_code: 403))
 
+        postgres_timeline.destroy_blob_storage
+      end
+
+      it "re-raises non-403/404 ClientError during SA delete" do
+        storage_client = instance_double(Google::Cloud::Storage::Project)
+        iam_client = instance_double(Google::Apis::IamV1::IamService)
+        expect(postgres_timeline).to receive(:blob_storage_client).and_return(storage_client)
+        expect(storage_client).to receive(:bucket).with(postgres_timeline.ubid).and_return(nil)
+
+        expect(postgres_timeline.location).to receive(:location_credential_gcp).and_return(location_credential_gcp)
+        expect(location_credential_gcp).to receive(:iam_client).and_return(iam_client)
+        expect(iam_client).to receive(:delete_project_service_account)
+          .and_raise(Google::Apis::ClientError.new("internal error", status_code: 500))
+
         expect { postgres_timeline.destroy_blob_storage }
-          .to raise_error(Google::Apis::ClientError, /permission denied/)
+          .to raise_error(Google::Apis::ClientError, /internal error/)
       end
 
       it "skips SA deletion when access_key is nil" do


### PR DESCRIPTION
## Tolerate 403 when deleting a GCP service account in timeline destroy

GCP's IAM API reports deletion of a service account that no longer
exists as 403 PERMISSION_DENIED ("Permission
'iam.serviceAccounts.delete' denied on resource (or it may not
exist)."), not 404.  The existing rescue only handled 404, so timeline
destroy wedged permanently on any timeline whose SA had already been
removed -- the strand retried destroy hundreds of times until the E2E
job hit its 60-minute wall clock.

Widen the rescue to include 403.  The trade-off: a genuine IAM
permission misconfiguration now silently leaks the SA instead of
blocking destroy forever.  This is acceptable because leaked SAs are
visible in the GCP console, bounded by timeline count, and convergence
(letting the timeline finish destroying) is strictly better than an
infinite retry loop that blocks the entire test run.

## Remove cleanup_old_timeline_service_account from GCP server

Every switch_to_new_timeline call that records a parent does so on a
server that was handed another resource's timeline row in "fetch" mode:
PITR/fork and read-replica creation share the source's live timeline,
and unarchive shares the deliberately retained archive timeline. The
upgrade path passes parent_id: nil, so the helper was a no-op there.
Wherever it did fire, timeline.parent was a timeline that still
mattered: deleting its service account silently killed WAL archiving on
the still-running source resource and wedged the parent timeline's
eventual destroy (the stale access_key references a deleted SA, and GCP
reports the deletion attempt as 403, not 404).

The deletion buys nothing in any case:

- The promoted server stops using the old credentials on the same code
  path: refresh_walg_blob_storage_credentials overwrites its key file
  with the new timeline's key. That is a local key swap on the VM, not
  revocation in GCP -- and none is needed, since parent and child
  belong to the same customer.
- The SA is the timeline's own resource; gcp_destroy_blob_storage
  deletes it when the timeline is destroyed. Abandoned timelines
  self-destruct after their backups expire, so removing this helper
  leaks nothing unbounded.
- AWS parity: _aws_detach_parent_s3_policy only detaches the parent
  policy from this VM's role; it never deletes the parent's
  credentials.