### PR TITLE
Format storage regardless of provider

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -85,7 +85,7 @@ class Prog::Vm::HostNexus < Prog::Base
     bud Prog::LearnMemory
     bud Prog::LearnOs
     bud Prog::LearnCpu
-    bud Prog::LearnStorage, {"format_storage" => install_os && vm_host.provider_name == HostProvider::HETZNER_PROVIDER_NAME}
+    bud Prog::LearnStorage, {"format_storage" => install_os}
     bud Prog::LearnPci
     bud Prog::InstallDnsmasq
     bud Prog::SetupSysstat

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -222,8 +222,8 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(child_progs).to include("LearnNetwork")
     end
 
-    it "passes format_storage to LearnStorage for a Hetzner host with install_os" do
-      st = assemble_hetzner_host(install_os: true)
+    it "passes format_storage to LearnStorage when assembled with install_os, regardless of provider" do
+      st = described_class.assemble("192.168.0.2", install_os: true)
       expect { described_class.new(st).prep }.to hop("wait_prep")
       learn_storage = Strand.where(parent_id: st.id, prog: "LearnStorage").first
       expect(learn_storage.stack.first["format_storage"]).to be true


### PR DESCRIPTION
The disk formatting done by LearnStorage is provider-agnostic, so gate it only on the install_os flag instead of also requiring a Hetzner host. This lets Leaseweb hosts assembled with install_os format their extra disks the same way.