### PR TITLE
Drop setup-only values from the host stack after setup

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -288,7 +288,10 @@ class Prog::Vm::HostNexus < Prog::Base
       end
     end
 
-    vm_host.update(allocation_state: "accepting") if vm_host.allocation_state == "unprepared"
+    if vm_host.allocation_state == "unprepared"
+      vm_host.update(allocation_state: "accepting")
+      delete_from_stack("install_os", "default_boot_images", "vhost_block_backend_version")
+    end
 
     hop_configure_metrics
   end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -592,9 +592,11 @@ RSpec.describe Prog::Vm::HostNexus do
       vm_host.update(allocation_state: "unprepared")
       vm = create_vm(vm_host_id: vm_host.id)
       Strand.create(id: vm.id, prog: "Vm::Nexus", label: "wait")
+      expect(nx.strand.stack.first.keys).to include("install_os", "default_boot_images", "vhost_block_backend_version")
       expect { nx.start_vms }.to hop("configure_metrics")
       expect(vm_host.reload.allocation_state).to eq("accepting")
       expect(vm.start_after_host_reboot_set?).to be true
+      expect(nx.strand.stack.first.keys).not_to include("install_os", "default_boot_images", "vhost_block_backend_version")
     end
 
     it "start_vms starts vms & becomes accepting & hops to configure_metrics if was draining and in graceful reboot" do


### PR DESCRIPTION
Once a VmHost finishes setup and becomes accepting, the install_os, default_boot_images, and vhost_block_backend_version stack values are no longer read. Keeping them around lets them go stale, and a stray re-run of prep while install_os is still set would reformat the host's disks. Remove them on the unprepared to accepting transition.