### PR TITLE
Restrict access to grafana metrics

### DIFF
--- a/rhizome/host/bin/setup-grafana
+++ b/rhizome/host/bin/setup-grafana
@@ -41,6 +41,10 @@ server {
     listen 80;
     server_name {{DOMAIN}};
 
+    location /metrics {
+        deny all;
+    }
+
     location / {
         proxy_pass http://localhost:3000;
         proxy_set_header Host $host;

--- a/rhizome/host/bin/setup-grafana
+++ b/rhizome/host/bin/setup-grafana
@@ -4,6 +4,8 @@
 require_relative "../../common/lib/util"
 require "securerandom"
 
+GRAFANA_VERSION = "13.1.1"
+
 domain = ARGV.shift.to_s.strip
 cert_email = ARGV.shift.to_s.strip
 if domain.empty? || cert_email.empty?
@@ -22,7 +24,7 @@ r "curl -fsSL https://apt.grafana.com/gpg.key | gpg --dearmor | sudo tee /etc/ap
 r "echo \"deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main\" | sudo tee -a /etc/apt/sources.list.d/grafana.list"
 
 r "sudo apt update"
-r "sudo apt install -y grafana"
+r "sudo apt install -y grafana=#{GRAFANA_VERSION}"
 
 r "sudo cp #{grafana_ini} #{grafana_ini}.bak"
 


### PR DESCRIPTION
**Pin Grafana to an explicit version**
setup-grafana installed whatever apt.grafana.com stable currently served, so hosts provisioned at different times ran different Grafana builds. Pin the version so installs are reproducible and upgrades are an explicit change.

**Deny public access to Grafana metrics**