### PR TITLE
Fix admin usage spec failure at the start of each month

### DIFF
--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -760,6 +760,9 @@ RSpec.describe CloverAdmin do
   end
 
   it "shows current usage for project as extra" do
+    now = Time.now.utc.round
+    expect(Time).to receive(:now).and_return([now, Time.utc(now.year, now.month) + 3600].max).at_least(:once)
+
     project = Project.create(name: "test")
     vm = create_vm(project_id: project.id)
     BillingRecord.create(
@@ -775,7 +778,7 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - Project #{project.ubid}"
     find("summary", text: /Current Usage \(subtotal: \$[\d.]+, cost: \$[\d.]+\)/).click
     expect(page.all(".project-usage-table tbody tr").count).to eq 1
-    expect(page.all(".project-usage-table tbody tr").first.all("td").map(&:text)).to eq ["test-vm", "VmVCpu", "standard", "61 minutes", "$0.047"]
+    expect(page.all(".project-usage-table tbody tr").first.all("td").map(&:text)).to eq ["test-vm", "VmVCpu", "standard", "60 minutes", "$0.046"]
   end
 
   it "shows hosted resources and utilized VM hosts for a Project as extra" do


### PR DESCRIPTION
The spec created a billing record spanning the last hour, but Project#current_invoice starts the billing window at the beginning of the current month. During the first hour of a month, most of that span fell into the previous month and was clipped by the invoice generator, so the rendered usage showed "1 minutes" instead of "61 minutes".

Freeze Time.now to a whole-second instant at least an hour into the current month so the span never crosses the month boundary. The frozen time stays within an hour of real time to keep the admin session valid. With time frozen, the duration is exactly 60 minutes rather than 60 minutes plus a few seconds ceiled to 61, so the expected usage and cost change accordingly.