### PR TITLE
Fix host-attached monitoring when VmHost is scanned via dataset

### DIFF
--- a/lib/monitor_resource_type.rb
+++ b/lib/monitor_resource_type.rb
@@ -106,7 +106,7 @@ MonitorResourceType = Struct.new(:wrapper_class, :resources, :types, :host_attac
     hosts = {} unless host_attached_types.empty?
 
     types.each do |type|
-      populate_hosts = hosts && type == VmHost
+      populate_hosts = hosts && (type.is_a?(Sequel::Dataset) ? type.model : type) == VmHost
 
       type.where_each(id: id_range) do
         unless (v = resources[it.id])

--- a/spec/lib/monitor_resource_type_spec.rb
+++ b/spec/lib/monitor_resource_type_spec.rb
@@ -257,22 +257,12 @@ RSpec.describe MonitorResourceType do
     it "works as expected" do
       vm_host = create_vm_host
       vm_host2 = create_vm_host
+      # A plain dataset, as bin/monitor uses since VM hosts in the "unprepared"
+      # allocation state were excluded from monitoring. Attached resources must
+      # still be populated for hosts scanned through a dataset.
       ds = VmHost.exclude(id: vm_host2.id)
-      wrapped_ds = Struct.new(:ds) do
-        def ==(other)
-          true if other.equal?(VmHost)
-        end
 
-        def respond_to_missing?(m)
-          ds.respond_to?(m)
-        end
-
-        def method_missing(...)
-          ds.send(...)
-        end
-      end.new(ds)
-
-      @mrt = described_class.create(MonitorableResource, [5, "stuck", :stuck], 2, [wrapped_ds], host_attached_types: [Vm])
+      @mrt = described_class.create(MonitorableResource, [5, "stuck", :stuck], 2, [ds], host_attached_types: [Vm])
 
       @mrt.scan(vm_host.id.."ffffffff-ffff-ffff-ffff-ffffffffffff")
       expect(@mrt.resources.keys).to eq [vm_host.id]


### PR DESCRIPTION
Since 81caef074 excluded unprepared hosts from monitoring, bin/monitor passes a Sequel dataset instead of the VmHost class in monitor_models. The scan's `type == VmHost` identity check is always false for a dataset, so no host ever got its attached resources populated. This silently disabled Vm and VmHostSlice health monitoring fleet-wide: the checkup semaphore was never set, guest-initiated shutdowns were never detected, and VM strands stayed in the wait label indefinitely. It surfaced in e2e, where Prog::Test::Vm's shutdown-command check polled forever and the suite timed out after 60 minutes.

Compare against the dataset's model so both the bare class and any filtered dataset of VmHost populate attached resources.

The existing spec masked the bug by wrapping the dataset in a struct whose == returns true for VmHost. Use a plain dataset instead, so the spec exercises the same shape bin/monitor passes and fails without this fix.