### PR TITLE
Run foreman via bundler in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -163,9 +163,6 @@ jobs:
           --setenv="MP_SMTP_AUTH=${{ secrets.MAIL_USER }}:${{ secrets.MAIL_PASSWORD }}" --setenv="MP_SMTP_AUTH_ALLOW_INSECURE=true" \
           --unit mailpit -- mailpit
 
-    - name: Install foreman
-      run: gem install foreman
-
     - name: Modify Procfile to add retry logic
       run: |
         sed -i "s/^\([^:]*\): \(.*\)/\1: bash -c 'for i in {1..4}; do \2 \&\& break || echo \"Attempt \$i failed, retrying...\"; sleep 1; done'/" Procfile
@@ -255,7 +252,7 @@ jobs:
         OPERATOR_SSH_PUBLIC_KEYS: ${{ secrets.OPERATOR_SSH_PUBLIC_KEYS }}
       run: |
         set -o pipefail
-        timeout 60m foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"
+        timeout 60m bundle exec foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"
 
     - name: Print logs
       if: always() && env.METAL_PAUSED != 'true'


### PR DESCRIPTION
The e2e workflow installed foreman with a bare gem install, which zizmor flags as an ad-hoc package installation outside a lockfile (alert https://github.com/ubicloud/ubicloud/security/code-scanning/471). Foreman is already in the Gemfile's development group and pinned in Gemfile.lock, and setup-clover's bundle install brings it in, so the extra step only fetched an unpinned duplicate. Drop the step and start foreman through bundle exec to use the lockfile-pinned version.