### PR TITLE
Add more Hetzner power actions

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -574,6 +574,9 @@ class CloverAdmin < Roda
       "reset" => object_action("Hardware Reset", flash: "Hardware reset scheduled for VmHost", &:incr_hardware_reset),
       "reboot" => object_action("Reboot", flash: "Reboot scheduled for VmHost", &:incr_reboot),
       "power_button" => object_action("Power Button", flash: "Power button pressed for VmHost", &:power_button),
+      "power_status" => object_action("Power Status", type: :content) do |obj|
+        "Power status: #{Erubi.h(obj.power_status)}"
+      end,
       "move_location" => object_action("Move to Location", flash: "Location updated and missing boot image downloads started", params: {
         location: {
           typecast: :ubid_uuid!,
@@ -1131,6 +1134,8 @@ class CloverAdmin < Roda
               if action_type == :direct
                 url = action.call(@obj) || fail(CloverError.new(400, "InvalidRequest", "Action link is not available"))
                 r.redirect url
+              elsif action_type == :content && @params.empty?
+                next view(content: action.call(@obj))
               end
               view("object_action")
             end

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -573,6 +573,7 @@ class CloverAdmin < Roda
       end,
       "reset" => object_action("Hardware Reset", flash: "Hardware reset scheduled for VmHost", &:incr_hardware_reset),
       "reboot" => object_action("Reboot", flash: "Reboot scheduled for VmHost", &:incr_reboot),
+      "power_button" => object_action("Power Button", flash: "Power button pressed for VmHost", &:power_button),
       "move_location" => object_action("Move to Location", flash: "Location updated and missing boot image downloads started", params: {
         location: {
           typecast: :ubid_uuid!,

--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -38,6 +38,13 @@ class Hosting::HetznerApis < Hosting::ProviderApis
     nil
   end
 
+  # Returns the operating status of the server, one of "running", "shut off"
+  # or "not supported".
+  def power_status
+    response = create_connection.get(path: "/reset/#{server_id}", expects: 200)
+    JSON.parse(response.body).dig("reset", "operating_status")
+  end
+
   def get_main_ip4
     response = create_connection.get(path: "/server/#{server_id}", expects: 200)
     response_hash = JSON.parse(response.body)

--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -30,6 +30,14 @@ class Hosting::HetznerApis < Hosting::ProviderApis
     nil
   end
 
+  # Presses the power button of the server. If the server is powered off, it
+  # is powered on. If it is powered on, the ACPI signal asks the operating
+  # system to shut down gracefully.
+  def power_button
+    create_connection.post(path: "/reset/#{server_id}", body: "type=power", expects: 200)
+    nil
+  end
+
   def get_main_ip4
     response = create_connection.get(path: "/server/#{server_id}", expects: 200)
     response_hash = JSON.parse(response.body)

--- a/lib/hosting/leaseweb_apis.rb
+++ b/lib/hosting/leaseweb_apis.rb
@@ -7,6 +7,13 @@ class Hosting::LeasewebApis < Hosting::ProviderApis
     nil
   end
 
+  # Leaseweb has no power button API, so this maps to the powerOn call and
+  # cannot power off a running server.
+  def power_button
+    create_connection.post(path: "/bareMetals/v2/servers/#{@provider.server_identifier}/powerOn", expects: 204)
+    nil
+  end
+
   def set_server_name(server_name)
     create_connection.put(path: "/bareMetals/v2/servers/#{@provider.server_identifier}",
       body: JSON.generate(reference: server_name),

--- a/lib/hosting/leaseweb_apis.rb
+++ b/lib/hosting/leaseweb_apis.rb
@@ -14,6 +14,14 @@ class Hosting::LeasewebApis < Hosting::ProviderApis
     nil
   end
 
+  # Returns the power status reported by the PDU, "on" or "off". The server
+  # can still be powered off while the PDU reports "on", e.g. if it was shut
+  # down via IPMI.
+  def power_status
+    response = create_connection.get(path: "/bareMetals/v2/servers/#{@provider.server_identifier}/powerInfo", expects: 200)
+    JSON.parse(response.body).dig("pdu", "status")
+  end
+
   def set_server_name(server_name)
     create_connection.put(path: "/bareMetals/v2/servers/#{@provider.server_identifier}",
       body: JSON.generate(reference: server_name),

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -283,6 +283,10 @@ class VmHost < Sequel::Model
     provider.api.hardware_reset
   end
 
+  def power_button
+    provider.api.power_button
+  end
+
   def check_storage_smart(ssh_session, devices)
     devices.map { |device_name|
       if device_name.start_with?("nvme")

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -287,6 +287,10 @@ class VmHost < Sequel::Model
     provider.api.power_button
   end
 
+  def power_status
+    provider.api.power_status
+  end
+
   def check_storage_smart(ssh_session, devices)
     devices.map { |device_name|
       if device_name.start_with?("nvme")

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -76,6 +76,18 @@ RSpec.describe Hosting::HetznerApis do
     end
   end
 
+  describe "power_button" do
+    it "can press the power button of a server" do
+      Excon.stub({path: "/reset/123", method: :post, body: "type=power"}, {status: 200, body: ""})
+      expect(hetzner_apis.power_button).to be_nil
+    end
+
+    it "raises an error if pressing the power button fails" do
+      Excon.stub({path: "/reset/123", method: :post, body: "type=power"}, {status: 400, body: ""})
+      expect { hetzner_apis.power_button }.to raise_error Excon::Error::BadRequest
+    end
+  end
+
   describe "get_main_ip4" do
     it "can get the main ip4" do
       Excon.stub({path: "/server/123", method: :get}, {status: 200, body: "{\"server\": {\"server_ip\": \"1.2.3.4\"}}"})

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe Hosting::HetznerApis do
     end
   end
 
+  describe "power_status" do
+    it "returns the operating status of a server" do
+      Excon.stub({path: "/reset/123", method: :get}, {status: 200, body: JSON.generate(reset: {operating_status: "running"})})
+      expect(hetzner_apis.power_status).to eq "running"
+    end
+
+    it "raises an error if getting the power status fails" do
+      Excon.stub({path: "/reset/123", method: :get}, {status: 404, body: ""})
+      expect { hetzner_apis.power_status }.to raise_error Excon::Error::NotFound
+    end
+  end
+
   describe "get_main_ip4" do
     it "can get the main ip4" do
       Excon.stub({path: "/server/123", method: :get}, {status: 200, body: "{\"server\": {\"server_ip\": \"1.2.3.4\"}}"})

--- a/spec/lib/hosting/leaseweb_apis_spec.rb
+++ b/spec/lib/hosting/leaseweb_apis_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Hosting::LeasewebApis do
     end
   end
 
+  describe "power_button" do
+    it "can power on a server" do
+      Excon.stub({path: "/bareMetals/v2/servers/123/powerOn", method: :post}, {status: 204, body: ""})
+      expect(leaseweb_apis.power_button).to be_nil
+    end
+  end
+
   describe "set_server_name" do
     it "updates the server reference" do
       Excon.stub({path: "/bareMetals/v2/servers/123", method: :put, body: JSON.generate(reference: "vh123")}, {status: 204, body: ""})

--- a/spec/lib/hosting/leaseweb_apis_spec.rb
+++ b/spec/lib/hosting/leaseweb_apis_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe Hosting::LeasewebApis do
     end
   end
 
+  describe "power_status" do
+    it "returns the pdu power status of a server" do
+      Excon.stub({path: "/bareMetals/v2/servers/123/powerInfo", method: :get}, {status: 200, body: JSON.generate(ipmi: {status: "off"}, pdu: {status: "on"})})
+      expect(leaseweb_apis.power_status).to eq "on"
+    end
+  end
+
   describe "set_server_name" do
     it "updates the server reference" do
       Excon.stub({path: "/bareMetals/v2/servers/123", method: :put, body: JSON.generate(reference: "vh123")}, {status: 204, body: ""})

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -233,6 +233,13 @@ RSpec.describe VmHost do
     end
   end
 
+  describe "#power_status" do
+    it "returns the power status of the server" do
+      expect(provider_api).to receive(:power_status).with(no_args).and_return("running")
+      expect(vm_host.power_status).to eq "running"
+    end
+  end
+
   describe "#create_addresses" do
     let(:hetzner_ips) {
       [

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -226,6 +226,13 @@ RSpec.describe VmHost do
     end
   end
 
+  describe "#power_button" do
+    it "presses the power button of the server" do
+      expect(provider_api).to receive(:power_button).with(no_args)
+      vm_host.power_button
+    end
+  end
+
   describe "#create_addresses" do
     let(:hetzner_ips) {
       [

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1315,6 +1315,30 @@ RSpec.describe CloverAdmin do
     expect(vmh.semaphores_dataset.select_map(:name)).to eq ["hardware_reset"]
   end
 
+  it "supports pressing power button of VmHosts" do
+    vmh = Prog::Vm::HostNexus.assemble("127.0.0.2").subject
+    HostProvider.create do
+      it.id = vmh.id
+      it.server_identifier = "123"
+      it.provider_name = HostProvider::HETZNER_PROVIDER_NAME
+    end
+    allow(Config).to receive_messages(
+      hetzner_connection_string: "https://robot-ws.your-server.de",
+      hetzner_user: "user1",
+      hetzner_password: "pass",
+    )
+    Excon.stub({path: "/reset/123", method: :post, body: "type=power"}, {status: 200, body: ""})
+
+    fill_in "UBID, UUID, or prefix:term", with: vmh.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+
+    click_link "Power Button"
+    click_button "Power Button"
+    expect(page).to have_flash_notice("Power button pressed for VmHost")
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+  end
+
   it "supports moving VmHost to a non-github location and downloading boot images" do
     vmh = Prog::Vm::HostNexus.assemble("127.0.0.2").subject
     target_location = Location[Location::HETZNER_HEL1_ID]

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1339,6 +1339,28 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
   end
 
+  it "supports showing power status of VmHosts" do
+    vmh = Prog::Vm::HostNexus.assemble("127.0.0.2").subject
+    HostProvider.create do
+      it.id = vmh.id
+      it.server_identifier = "123"
+      it.provider_name = HostProvider::HETZNER_PROVIDER_NAME
+    end
+    allow(Config).to receive_messages(
+      hetzner_connection_string: "https://robot-ws.your-server.de",
+      hetzner_user: "user1",
+      hetzner_password: "pass",
+    )
+    Excon.stub({path: "/reset/123", method: :get}, {status: 200, body: JSON.generate(reset: {operating_status: "shut off"})})
+
+    fill_in "UBID, UUID, or prefix:term", with: vmh.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+
+    click_link "Power Status"
+    expect(page).to have_content("Power status: shut off")
+  end
+
   it "supports moving VmHost to a non-github location and downloading boot images" do
     vmh = Prog::Vm::HostNexus.assemble("127.0.0.2").subject
     target_location = Location[Location::HETZNER_HEL1_ID]


### PR DESCRIPTION
- **Add power button support to VmHost providers**
  Pressing the power button is a softer alternative to a hardware reset:
  it can power on a server that is shut off, and on Hetzner the ACPI
  signal asks a running operating system to shut down gracefully. Hetzner
  implements it via the reset endpoint with type=power; Leaseweb has no
  power button API, so the powerOn call is used as the closest
  equivalent.
  
  Expose it as a VmHost admin action so operators can press the power
  button from the admin panel.
  
  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
  

- **Show VmHost power status via admin action**
  When a host is unreachable, it is useful to know whether the machine is
  actually powered on before deciding to press the power button or issue
  a hardware reset. Hetzner reports the operating status via the reset
  endpoint, and Leaseweb reports the PDU status via the powerInfo
  endpoint.
  
  Since this requires a provider API call, it is exposed as an on-demand
  admin action that displays the response, rather than being fetched
  every time the VmHost page is opened.
  
  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
  