### PR TITLE
Increase timeout of daily CI

### DIFF
--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
     name: Daily CI
     runs-on: ubicloud-standard-8
-    timeout-minutes: 35
+    timeout-minutes: 45
 
     steps:
     - name: Check out code


### PR DESCRIPTION
Daily CI jobs have started failing due to timeouts occasionally. The runtime is very close to the limit.

Since it's a daily job, we can increase the timeout to give it more time to complete.

<img width="2246" height="1566" alt="CleanShot 2026-08-01 at 22 20 11@2x" src="https://github.com/user-attachments/assets/e2af20b2-aeea-47c4-80f8-a2de885f6527" />
