### PR TITLE
Add a second leaseweb organization

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -107,6 +107,7 @@ module Config
   optional :hetzner_password, string, clear: true
   override :hetzner_connection_string, "https://robot-ws.your-server.de", string
   optional :leaseweb_api_key, string, clear: true
+  optional :leaseweb_eu_api_key, string, clear: true
   override :leaseweb_connection_string, "https://api.leaseweb.com", string
   override :managed_service, false, bool
   override :sanctioned_countries, "CU,IR,KP,SY", array(string)

--- a/lib/hosting/leaseweb_apis.rb
+++ b/lib/hosting/leaseweb_apis.rb
@@ -133,8 +133,20 @@ class Hosting::LeasewebApis < Hosting::ProviderApis
     ips
   end
 
+  # Both orgs share Leaseweb's endpoint; only the key differs.
+  def api_key
+    case @provider.provider_name
+    when HostProvider::LEASEWEB_PROVIDER_NAME
+      Config.leaseweb_api_key
+    when HostProvider::LEASEWEB_EU_PROVIDER_NAME
+      Config.leaseweb_eu_api_key
+    else
+      fail "unknown provider #{@provider.provider_name}"
+    end
+  end
+
   def create_connection
     Excon.new(Config.leaseweb_connection_string,
-      headers: {"X-Lsw-Auth" => Config.leaseweb_api_key, "Content-Type" => "application/json"})
+      headers: {"X-Lsw-Auth" => api_key, "Content-Type" => "application/json"})
   end
 end

--- a/lib/hosting/provider_apis.rb
+++ b/lib/hosting/provider_apis.rb
@@ -2,7 +2,9 @@
 
 class Hosting::ProviderApis
   def self.for(provider)
-    Object.const_get("Hosting::#{provider.provider_name.capitalize}Apis").new(provider)
+    # A dash suffix picks the org within a provider kind; the API class is
+    # shared per kind, so it resolves from the prefix alone.
+    Object.const_get("Hosting::#{provider.provider_name.split("-").first.capitalize}Apis").new(provider)
   rescue NameError
     raise "unknown provider #{provider.provider_name}"
   end

--- a/model/address.rb
+++ b/model/address.rb
@@ -36,7 +36,7 @@ class Address < Sequel::Model
     # included; neither is usable by a VM. A block of one or two addresses is
     # not a block but a standalone address Leaseweb routes here, so it has no
     # network or broadcast address to drop.
-    if vm_host.provider_name == "leaseweb" && addresses.length > 2
+    if vm_host.leaseweb? && addresses.length > 2
       addresses.shift
       addresses.pop
     end

--- a/model/host_provider.rb
+++ b/model/host_provider.rb
@@ -7,6 +7,8 @@ class HostProvider < Sequel::Model
 
   HETZNER_PROVIDER_NAME = "hetzner"
   LEASEWEB_PROVIDER_NAME = "leaseweb"
+  LEASEWEB_EU_PROVIDER_NAME = "leaseweb-eu"
+  LEASEWEB_PROVIDER_NAMES = [LEASEWEB_PROVIDER_NAME, LEASEWEB_EU_PROVIDER_NAME].freeze
   AWS_PROVIDER_NAME = "aws"
 
   def api

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -37,6 +37,8 @@ class VmHost < Sequel::Model
     provider&.provider_name
   end
 
+  def leaseweb? = HostProvider::LEASEWEB_PROVIDER_NAMES.include?(provider_name)
+
   def sshable_host
     sshable.host
   end

--- a/prog/learn_network.rb
+++ b/prog/learn_network.rb
@@ -6,7 +6,7 @@ class Prog::LearnNetwork < Prog::Base
   subject_is :sshable, :vm_host
 
   label def start
-    if vm_host.provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
+    if vm_host.leaseweb?
       hop_learn_ip6 if retval&.dig("msg") == "leaseweb networking configured"
       register_deadline("learn_ip6", 5 * 60)
       push Prog::Leaseweb::SetupNetworking

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -15,7 +15,7 @@ class Prog::Vm::HostNexus < Prog::Base
       Sshable.create_with_id(id, host: sshable_hostname)
       vmh = VmHost.create_with_id(id, location_id:, family:, net6:, ndp_needed:)
 
-      if provider_name == HostProvider::HETZNER_PROVIDER_NAME || provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
+      if [HostProvider::HETZNER_PROVIDER_NAME, *HostProvider::LEASEWEB_PROVIDER_NAMES].include?(provider_name)
         HostProvider.create do |hp|
           hp.id = id
           hp.provider_name = provider_name
@@ -23,7 +23,7 @@ class Prog::Vm::HostNexus < Prog::Base
         end
       end
 
-      if provider_name == HostProvider::HETZNER_PROVIDER_NAME || provider_name == HostProvider::LEASEWEB_PROVIDER_NAME
+      if [HostProvider::HETZNER_PROVIDER_NAME, *HostProvider::LEASEWEB_PROVIDER_NAMES].include?(provider_name)
         vmh.create_addresses
         vmh.set_data_center
         # Avoid overriding custom server names for development hosts.

--- a/spec/lib/hosting/leaseweb_apis_spec.rb
+++ b/spec/lib/hosting/leaseweb_apis_spec.rb
@@ -19,6 +19,39 @@ RSpec.describe Hosting::LeasewebApis do
     )
   end
 
+  describe "org key selection" do
+    let(:leaseweb_eu_apis) do
+      vmh = create_vm_host
+      provider = HostProvider.create do
+        it.id = vmh.id
+        it.server_identifier = "123"
+        it.provider_name = HostProvider::LEASEWEB_EU_PROVIDER_NAME
+      end
+      described_class.new(provider)
+    end
+
+    it "sends the base org's key" do
+      Excon.stub({path: "/bareMetals/v2/servers/123", method: :get, headers: {"X-Lsw-Auth" => "key123"}},
+        {status: 200, body: JSON.generate(location: {site: "WDC-01", suite: "8", rack: "9"})})
+      expect(leaseweb_apis.pull_data_center).to eq("WDC-01-8-9")
+    end
+
+    it "sends the eu org's key" do
+      allow(Config).to receive(:leaseweb_eu_api_key).and_return("eu-key")
+      Excon.stub({path: "/bareMetals/v2/servers/123", method: :get, headers: {"X-Lsw-Auth" => "eu-key"}},
+        {status: 200, body: JSON.generate(location: {site: "FRA-10", suite: "2", rack: "11"})})
+      expect(leaseweb_eu_apis.pull_data_center).to eq("FRA-10-2-11")
+    end
+
+    it "fails for a provider without an org key" do
+      provider = HostProvider.new do
+        it.provider_name = "aws"
+        it.server_identifier = "123"
+      end
+      expect { described_class.new(provider).pull_data_center }.to raise_error RuntimeError, "unknown provider aws"
+    end
+  end
+
   def ip_row(ip, prefix_length:, type: "NORMAL_IP", network_type: "PUBLIC", main_ip: false, gateway: "")
     {"ip" => ip, "prefixLength" => prefix_length, "type" => type, "networkType" => network_type,
      "mainIp" => main_ip, "gateway" => gateway}

--- a/spec/model/address_spec.rb
+++ b/spec/model/address_spec.rb
@@ -37,10 +37,11 @@ RSpec.describe Address do
   describe "leaseweb" do
     # Leaseweb routes whole blocks to the host, so assemble pulls them from the
     # API rather than deriving one address from the sshable host.
-    def assemble_leaseweb_host
+    def assemble_leaseweb_host(provider_name: HostProvider::LEASEWEB_PROVIDER_NAME)
       allow(Config).to receive_messages(
         leaseweb_connection_string: "https://api.leaseweb.com",
         leaseweb_api_key: "key123",
+        leaseweb_eu_api_key: "eu-key",
       )
       Excon.stub({path: "/bareMetals/v2/servers/1/ips", query: {limit: 50, offset: 0}},
         {status: 200, body: JSON.generate(
@@ -50,7 +51,13 @@ RSpec.describe Address do
       Excon.stub({path: "/bareMetals/v2/servers/1", method: :get},
         {status: 200, body: JSON.generate(location: {site: "AMS-01", suite: "8", rack: "9200"})})
       Excon.stub({path: "/bareMetals/v2/servers/1", method: :put}, {status: 204})
-      Prog::Vm::HostNexus.assemble("1.2.3.4", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "1").subject
+      Prog::Vm::HostNexus.assemble("1.2.3.4", provider_name:, server_identifier: "1").subject
+    end
+
+    it "drops network and broadcast for the eu org too" do
+      vm_host = assemble_leaseweb_host(provider_name: HostProvider::LEASEWEB_EU_PROVIDER_NAME)
+      described_class.create(cidr: "0.0.0.0/30", vm_host:).populate_ipv4_addresses
+      expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq %w[0.0.0.1 0.0.0.2]
     end
 
     it "populates ipv4_address table with addresses in cidr without first and last" do

--- a/spec/model/host_provider_spec.rb
+++ b/spec/model/host_provider_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe HostProvider do
       expect(provider.api).to be_a Hosting::HetznerApis
     end
 
+    it "maps every leaseweb org onto the shared leaseweb api" do
+      provider.provider_name = HostProvider::LEASEWEB_EU_PROVIDER_NAME
+      expect(provider.api).to be_a Hosting::LeasewebApis
+    end
+
     it "raises for an unknown provider" do
       provider.provider_name = "unknown"
       expect { provider.api }.to raise_error RuntimeError, "unknown provider unknown"

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -226,6 +226,35 @@ RSpec.describe VmHost do
     end
   end
 
+  describe "#leaseweb?" do
+    def make_provider(name)
+      HostProvider.create do
+        it.id = vm_host.id
+        it.server_identifier = "123"
+        it.provider_name = name
+      end
+    end
+
+    it "is false without a provider" do
+      expect(vm_host.leaseweb?).to be false
+    end
+
+    it "is false for hetzner" do
+      make_provider(HostProvider::HETZNER_PROVIDER_NAME)
+      expect(vm_host.leaseweb?).to be false
+    end
+
+    it "is true for the base org" do
+      make_provider(HostProvider::LEASEWEB_PROVIDER_NAME)
+      expect(vm_host.leaseweb?).to be true
+    end
+
+    it "is true for the eu org" do
+      make_provider(HostProvider::LEASEWEB_EU_PROVIDER_NAME)
+      expect(vm_host.leaseweb?).to be true
+    end
+  end
+
   describe "#create_addresses" do
     let(:hetzner_ips) {
       [

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -87,6 +87,27 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(DB[:ipv4_address].select_order_map(:ip).map(&:to_s)).to eq((65..126).map { "216.22.15.#{it}" })
     end
 
+    it "creates addresses from the leaseweb-eu org with its own key" do
+      allow(Config).to receive_messages(
+        leaseweb_connection_string: "https://api.leaseweb.com",
+        leaseweb_eu_api_key: "eu-key",
+      )
+      rows = [
+        {ip: "212.95.60.214/26", prefixLength: 26, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: true, gateway: "212.95.60.254"},
+      ]
+      eu = {headers: {"X-Lsw-Auth" => "eu-key"}}
+      Excon.stub(eu.merge(path: "/bareMetals/v2/servers/456/ips", query: {limit: 50, offset: 0}),
+        {status: 200, body: JSON.generate(ips: rows, _metadata: {totalCount: rows.length})})
+      Excon.stub(eu.merge(path: "/bareMetals/v2/servers/456", method: :get),
+        {status: 200, body: JSON.generate(location: {site: "FRA-10", suite: "2", rack: "11"})})
+      Excon.stub(eu.merge(path: "/bareMetals/v2/servers/456", method: :put), {status: 204})
+
+      st = described_class.assemble("212.95.60.214", provider_name: HostProvider::LEASEWEB_EU_PROVIDER_NAME, server_identifier: "456")
+      expect(st.subject.provider_name).to eq(HostProvider::LEASEWEB_EU_PROVIDER_NAME)
+      expect(st.subject.data_center).to eq("FRA-10-2-11")
+      expect(st.subject.assigned_host_addresses.map { it.ip.to_s }).to eq ["212.95.60.214/32"]
+    end
+
     it "does not set the server name in development" do
       expect(Config).to receive(:development?).and_return(true)
       api = instance_double(Hosting::HetznerApis)


### PR DESCRIPTION
The new EU account shares Leaseweb's API endpoint and server id space but
authenticates with its own key. The org a host belongs to is the
host_provider row's name: leaseweb-eu resolves through its dash prefix to
the shared LeasewebApis class, which picks the API key for its org; the
endpoint stays the shared leaseweb_connection_string. VmHost#leaseweb?
answers for every leaseweb org so callers stop enumerating names;
assemble, LearnNetwork, and the routed-block network/broadcast trim all
key on it.

Stacked on #5867 (leaseweb-netplan-automation is the base branch); only
the two commits here are new. Specs pin the key selection at the wire:
the Excon stubs match the X-Lsw-Auth header, so the wrong org's key
cannot pass. Both commits hold 100% line and branch coverage in
isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3NEyzcGaxDCTdWBKsQ29X