### PR TITLE
Use UMIs for Kubernetes images

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1407,6 +1407,38 @@ class CloverAdmin < Roda
       end
     end
 
+    r.on "kubernetes-node-image" do
+      r.is do
+        r.get do
+          @strands = Strand.where(prog: "Kubernetes::BuildNodeImage").order(:id).all
+          @location_names = Location.where(id: @strands.map { it.stack[0]["location_id"] }).select_hash(:id, :display_name)
+          view("kubernetes_node_image")
+        end
+
+        r.post do
+          kubernetes_version, image_version = typecast_params.nonempty_str!(%w[kubernetes_version image_version].freeze)
+          location_id = typecast_params.ubid_uuid!("location_id")
+
+          error = if !Option.kubernetes_versions.include?(kubernetes_version)
+            "invalid kubernetes version"
+          elsif Option.kubernetes_locations.none? { it.id == location_id }
+            "invalid location for kubernetes"
+          elsif !Validation::ALLOWED_MACHINE_IMAGE_VERSION_LABEL_PATTERN.match?(image_version)
+            "invalid image version"
+          end
+
+          if error
+            flash["error"] = error
+            r.redirect
+          end
+
+          st = Prog::Kubernetes::BuildNodeImage.assemble(kubernetes_version:, location_id:, image_version:)
+          flash["notice"] = "Started kubernetes node image build strand: #{st.ubid}"
+          r.redirect
+        end
+      end
+    end
+
     r.on "local-e2e" do
       strand_ds = Strand.where(Sequel.like(:prog, "Test::%"))
 

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1408,9 +1408,11 @@ class CloverAdmin < Roda
     end
 
     r.on "kubernetes-node-image" do
+      strand_ds = Strand.where(prog: "Kubernetes::BuildNodeImage")
+
       r.is do
         r.get do
-          @strands = Strand.where(prog: "Kubernetes::BuildNodeImage").order(:id).all
+          @strands = strand_ds.order(:id).all
           @location_names = Location.where(id: @strands.map { it.stack[0]["location_id"] }).select_hash(:id, :display_name)
           view("kubernetes_node_image")
         end
@@ -1436,6 +1438,17 @@ class CloverAdmin < Roda
           flash["notice"] = "Started kubernetes node image build strand: #{st.ubid}"
           r.redirect
         end
+      end
+
+      r.post :ubid_uuid, "destroy" do |strand_id|
+        unless (strand = strand_ds.with_pk(strand_id))
+          flash["error"] = "Strand not found, it was probably already deleted"
+          r.redirect "/kubernetes-node-image"
+        end
+
+        Semaphore.incr(strand.id, "destroy")
+        flash["notice"] = "Destroying node image build strand: #{strand.ubid}"
+        r.redirect "/kubernetes-node-image"
       end
     end
 

--- a/prog/kubernetes/build_node_image.rb
+++ b/prog/kubernetes/build_node_image.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Prog::Kubernetes::BuildNodeImage < Prog::Base
+  semaphore :destroy
+
   frame_reader :kubernetes_version, :location_id, :image_version, :machine_image_id, :vm_id
   frame_accessor :machine_image_version_id
 
@@ -92,6 +94,15 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
 
   label def failed
     nap 60 * 60
+  end
+
+  label def destroy
+    reap do
+      vm&.incr_destroy
+      MachineImageVersionMetal.where(id: machine_image_version_id).first&.incr_destroy
+      Page.from_tag_parts("KubernetesNodeImageBuild", machine_image_id, image_version)&.incr_resolve
+      pop "Kubernetes node image build destroyed"
+    end
   end
 
   def trigger_page(reason)

--- a/prog/kubernetes/build_node_image.rb
+++ b/prog/kubernetes/build_node_image.rb
@@ -45,6 +45,8 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
   end
 
   label def build
+    register_deadline("sanitize", 15 * 60)
+
     case (state = vm.sshable.d_check(BUILD_UNIT))
     when "Succeeded"
       vm.sshable.d_clean(BUILD_UNIT)

--- a/prog/kubernetes/build_node_image.rb
+++ b/prog/kubernetes/build_node_image.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+class Prog::Kubernetes::BuildNodeImage < Prog::Base
+  frame_reader :kubernetes_version, :location_id, :image_version, :machine_image_id, :vm_id
+  frame_accessor :machine_image_version_id
+
+  BUILD_UNIT = "build_node_image"
+
+  def self.assemble(kubernetes_version:, location_id:, image_version:)
+    fail "invalid kubernetes version: #{kubernetes_version}" unless Option.kubernetes_versions.include?(kubernetes_version)
+    fail "invalid location for kubernetes: #{location_id}" if Option.kubernetes_locations.none? { it.id == location_id }
+    fail "invalid image version: #{image_version}" unless Validation::ALLOWED_MACHINE_IMAGE_VERSION_LABEL_PATTERN.match?(image_version)
+    fail "no kubernetes service project" unless Project[Config.kubernetes_service_project_id]
+    fail "no machine images service project" unless (image_project = Project[Config.machine_images_service_project_id])
+    fail "no machine image store for #{location_id}" unless image_project.machine_image_store_for(location_id)
+
+    DB.transaction do
+      name = "kubernetes-#{kubernetes_version.tr(".", "_")}"
+      machine_image = MachineImage.first(project_id: image_project.id, location_id:, name:) ||
+        MachineImage.create(project_id: image_project.id, location_id:, name:, arch: "x64")
+      vm_id = Prog::Vm::Nexus.assemble_with_sshable(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", location_id:, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 10}], boot_image: "ubuntu-noble", enable_ip4: true).id
+
+      Strand.create(prog: "Kubernetes::BuildNodeImage", label: "wait_vm", stack: [{
+        "kubernetes_version" => kubernetes_version,
+        "location_id" => location_id,
+        "image_version" => image_version,
+        "machine_image_id" => machine_image.id,
+        "vm_id" => vm_id,
+      }])
+    end
+  end
+
+  label def wait_vm
+    nap 10 unless vm.display_state == "running"
+    hop_bootstrap_rhizome
+  end
+
+  label def bootstrap_rhizome
+    bud Prog::BootstrapRhizome, {"target_folder" => "kubernetes", "subject_id" => vm_id, "user" => "ubi"}
+    hop_wait_bootstrap_rhizome
+  end
+
+  label def wait_bootstrap_rhizome
+    reap(:build)
+  end
+
+  label def build
+    case (state = vm.sshable.d_check(BUILD_UNIT))
+    when "Succeeded"
+      vm.sshable.d_clean(BUILD_UNIT)
+      hop_sanitize
+    when "NotStarted"
+      vm.sshable.d_run(BUILD_UNIT, "kubernetes/bin/build-node-image", kubernetes_version)
+      nap 180
+    when "InProgress"
+      nap 180
+    else
+      trigger_page("build #{state}")
+      hop_failed
+    end
+  end
+
+  label def sanitize
+    vm.sshable.cmd("kubernetes/bin/sanitize-node-image")
+    vm.incr_stop
+    hop_wait_stopped
+  end
+
+  label def wait_stopped
+    nap 10 unless vm.display_state == "stopped"
+    hop_capture
+  end
+
+  label def capture
+    self.machine_image_version_id = Prog::MachineImage::VersionMetalNexus.assemble_from_vm(machine_image, image_version, vm, machine_image_store, destroy_source_after: true).id
+    hop_wait_capture
+  end
+
+  label def wait_capture
+    case MachineImageVersionMetal[machine_image_version_id].status
+    when "ready"
+      pop "Kubernetes node image built"
+    when "failed"
+      trigger_page("capture failed")
+      hop_failed
+    else
+      nap 15
+    end
+  end
+
+  label def failed
+    nap 60 * 60
+  end
+
+  def trigger_page(reason)
+    Prog::PageNexus.assemble(
+      "Kubernetes node image #{machine_image.name}@#{image_version} #{reason}",
+      ["KubernetesNodeImageBuild", machine_image_id, image_version],
+      machine_image.ubid,
+      severity: "info",
+      extra_data: {kubernetes_version:, image_version:, builder_vm_id: vm_id, reason:},
+    )
+  end
+
+  def vm
+    @vm ||= Vm[vm_id]
+  end
+
+  def machine_image
+    @machine_image ||= MachineImage[machine_image_id]
+  end
+
+  def machine_image_store
+    @machine_image_store ||= Project[Config.machine_images_service_project_id].machine_image_store_for(location_id)
+  end
+end

--- a/prog/kubernetes/build_node_image.rb
+++ b/prog/kubernetes/build_node_image.rb
@@ -4,7 +4,7 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
   semaphore :destroy
 
   frame_reader :kubernetes_version, :location_id, :image_version, :machine_image_id, :vm_id
-  frame_accessor :machine_image_version_id
+  frame_accessor :machine_image_version_id, :verify_cluster_id
 
   BUILD_UNIT = "build_node_image"
 
@@ -76,20 +76,42 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
   end
 
   label def capture
-    self.machine_image_version_id = Prog::MachineImage::VersionMetalNexus.assemble_from_vm(machine_image, image_version, vm, machine_image_store, destroy_source_after: true).id
+    self.machine_image_version_id = Prog::MachineImage::VersionMetalNexus.assemble_from_vm(machine_image, image_version, vm, machine_image_store, destroy_source_after: true, set_as_latest: false).id
     hop_wait_capture
   end
 
   label def wait_capture
     case MachineImageVersionMetal[machine_image_version_id].status
     when "ready"
-      pop "Kubernetes node image built"
+      hop_verify
     when "failed"
       trigger_page("capture failed")
       hop_failed
     else
       nap 15
     end
+  end
+
+  label def verify
+    register_deadline("promote", 30 * 60)
+
+    cluster_name = "verify-#{MachineImageVersion[machine_image_version_id].ubid}"
+    cluster = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: cluster_name, project_id: Config.kubernetes_service_project_id, location_id:, version: kubernetes_version, cp_node_count: 3, machine_image_version_id:).subject
+    Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "#{cluster_name}-np", node_count: 1, kubernetes_cluster_id: cluster.id, machine_image_version_id:)
+
+    self.verify_cluster_id = cluster.id
+    hop_wait_verify
+  end
+
+  label def wait_verify
+    nap 30 unless verify_cluster.strand.label == "wait" && verify_cluster.nodepools.all? { it.strand.label == "wait" }
+    hop_promote
+  end
+
+  label def promote
+    verify_cluster.incr_destroy
+    machine_image.update(latest_version_id: machine_image_version_id)
+    pop "Kubernetes node image built"
   end
 
   label def failed
@@ -99,6 +121,7 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
   label def destroy
     reap do
       vm&.incr_destroy
+      verify_cluster&.incr_destroy
       MachineImageVersionMetal.where(id: machine_image_version_id).first&.incr_destroy
       Page.from_tag_parts("KubernetesNodeImageBuild", machine_image_id, image_version)&.incr_resolve
       pop "Kubernetes node image build destroyed"
@@ -121,6 +144,10 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
 
   def machine_image
     @machine_image ||= MachineImage[machine_image_id]
+  end
+
+  def verify_cluster
+    @verify_cluster ||= KubernetesCluster.where(id: verify_cluster_id).first
   end
 
   def machine_image_store

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -3,7 +3,9 @@
 class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   subject_is :kubernetes_cluster
 
-  def self.assemble(name:, project_id:, location_id:, version: Option.selectable_kubernetes_versions.first, cp_node_count: 3, target_node_size: "standard-2", target_node_storage_size_gib: nil)
+  frame_reader :machine_image_version_id
+
+  def self.assemble(name:, project_id:, location_id:, version: Option.selectable_kubernetes_versions.first, cp_node_count: 3, target_node_size: "standard-2", target_node_storage_size_gib: nil, machine_image_version_id: nil)
     DB.transaction do
       unless (project = Project[project_id])
         fail "No existing project"
@@ -50,7 +52,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       id = ubid.to_uuid
       KubernetesCluster.create_with_id(id, name:, version:, cp_node_count:, location_id:, target_node_size:, target_node_storage_size_gib:, project_id: project.id, private_subnet_id: subnet.id)
 
-      Strand.create_with_id(id, prog: "Kubernetes::KubernetesClusterNexus", label: "start")
+      Strand.create_with_id(id, prog: "Kubernetes::KubernetesClusterNexus", label: "start", stack: [{"machine_image_version_id" => machine_image_version_id}])
     end
   end
 
@@ -139,7 +141,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
 
     hop_wait_nodes if kubernetes_cluster.nodes.count >= kubernetes_cluster.cp_node_count
 
-    bud Prog::Kubernetes::ProvisionKubernetesNode, {"subject_id" => kubernetes_cluster.id}
+    bud Prog::Kubernetes::ProvisionKubernetesNode, {"subject_id" => kubernetes_cluster.id, "machine_image_version_id" => machine_image_version_id}
 
     hop_wait_control_plane_node
   end

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -3,7 +3,9 @@
 class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
   subject_is :kubernetes_nodepool
 
-  def self.assemble(name:, node_count:, kubernetes_cluster_id:, target_node_size: "standard-2", target_node_storage_size_gib: nil)
+  frame_reader :machine_image_version_id
+
+  def self.assemble(name:, node_count:, kubernetes_cluster_id:, target_node_size: "standard-2", target_node_storage_size_gib: nil, machine_image_version_id: nil)
     DB.transaction do
       unless (cluster = KubernetesCluster[kubernetes_cluster_id])
         fail "No existing cluster"
@@ -14,7 +16,7 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
 
       kn = KubernetesNodepool.create(name:, node_count:, kubernetes_cluster_id:, target_node_size:, target_node_storage_size_gib:, version: cluster.version)
 
-      strand = Strand.create_with_id(kn, prog: "Kubernetes::KubernetesNodepoolNexus", label: "start")
+      strand = Strand.create_with_id(kn, prog: "Kubernetes::KubernetesNodepoolNexus", label: "start", stack: [{"machine_image_version_id" => machine_image_version_id}])
       kn.incr_start_bootstrapping if cluster.strand.label == "wait"
       strand
     end
@@ -36,7 +38,7 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
 
     if current_node_count < desired_node_count
       (desired_node_count - current_node_count).times do
-        bud Prog::Kubernetes::ProvisionKubernetesNode, {"nodepool_id" => kubernetes_nodepool.id, "subject_id" => kubernetes_nodepool.kubernetes_cluster_id}
+        bud Prog::Kubernetes::ProvisionKubernetesNode, {"nodepool_id" => kubernetes_nodepool.id, "subject_id" => kubernetes_nodepool.kubernetes_cluster_id, "machine_image_version_id" => machine_image_version_id}
       end
     elsif current_node_count > desired_node_count
       excess_nodes = kubernetes_nodepool.functional_nodes.first(current_node_count - desired_node_count)

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -3,7 +3,7 @@
 class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
   subject_is :kubernetes_cluster
 
-  frame_reader :nodepool_id
+  frame_reader :nodepool_id, :machine_image_version_id
   frame_accessor :node_id
 
   def node
@@ -62,7 +62,9 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
         kubernetes_cluster.target_node_storage_size_gib]
     end
 
-    storage_volumes = [{encrypted: true, size_gib: storage_size_gib}] if storage_size_gib
+    if storage_size_gib || machine_image_version_id
+      storage_volumes = [{encrypted: true, size_gib: storage_size_gib, machine_image_version_id:}.compact]
+    end
 
     boot_image = "kubernetes-#{(kubernetes_nodepool || kubernetes_cluster).version.tr(".", "_")}"
 

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -55,7 +55,12 @@ class Prog::Vm::Nexus < Prog::Base
     metal_vm = location.provider_dispatcher_group_name == "metal"
     boot_volume = storage_volumes[boot_disk_index]
 
-    if boot_image.include?("@")
+    if boot_volume[:machine_image_version_id]
+      # The caller already resolved the version, so no lookup by name is done.
+      # This is only reachable internally, as storage volumes are built by the
+      # routes rather than accepted from the request.
+      fail "Machine images are only supported for metal locations" unless metal_vm
+    elsif boot_image.include?("@")
       fail "Machine images are only supported for metal locations" unless metal_vm
       image_name, image_version = boot_image.split("@", 2)
       machine_image_version = lookup_machine_image_version(project_id, location_id, image_name, image_version, boot_volume[:size_gib], false)

--- a/rhizome/kubernetes/bin/build-node-image
+++ b/rhizome/kubernetes/bin/build-node-image
@@ -1,0 +1,6 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/kubernetes_build_node_image"
+
+KubernetesBuildNodeImage.new(ARGV).run

--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -92,7 +92,7 @@ File.open(config_path, "w") do |file|
   file.write(kubelet_config.to_yaml)
 end
 
-r("sudo", "kubeadm", "init", "--config", config_path, "--node-name", node_name)
+puts r("sudo", "kubeadm", "init", "--config", config_path, "--node-name", node_name)
 r("sudo /home/ubi/kubernetes/bin/setup-cni")
 
 api_server_up = false

--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -96,7 +96,7 @@ r("sudo", "kubeadm", "init", "--config", config_path, "--node-name", node_name)
 r("sudo /home/ubi/kubernetes/bin/setup-cni")
 
 api_server_up = false
-5.times do
+12.times do
   r("kubectl --kubeconfig=/etc/kubernetes/admin.conf get --raw='/healthz'")
   api_server_up = true
   break

--- a/rhizome/kubernetes/bin/sanitize-node-image
+++ b/rhizome/kubernetes/bin/sanitize-node-image
@@ -1,0 +1,16 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+r("bash", "-s", stdin: <<~SH)
+  set -ueo pipefail
+
+  sudo rm -rf /var/lib/cloud
+  sudo cloud-init clean --logs
+  sudo journalctl --rotate
+  sudo journalctl --vacuum-time=1s
+  sudo rm -f /etc/ssh/ssh_host_*
+  sudo truncate -s 0 /etc/machine-id
+  sudo truncate -s 0 /home/ubi/.ssh/authorized_keys
+SH

--- a/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
+++ b/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
@@ -41,7 +41,7 @@ class KubernetesBuildNodeImage
     r "echo :line | sudo tee /etc/apt/sources.list.d/kubernetes.list > /dev/null", line: "deb [signed-by=#{KEYRING}] #{repo_url} /"
 
     r "sudo -E apt-get update"
-    r "sudo -E apt-get install -y containerd cri-tools kubelet kubeadm kubectl"
+    r "sudo -E apt-get install -y containerd cri-tools kubelet kubeadm kubectl ruby-bundler"
 
     r "sudo mkdir -p /etc/containerd"
     r "sudo tee /etc/containerd/config.toml > /dev/null", stdin: r("containerd config default").gsub("SystemdCgroup = false", "SystemdCgroup = true")

--- a/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
+++ b/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+class KubernetesBuildNodeImage
+  VERSION_PATTERN = /\Av\d+\.\d+\z/
+  KEYRING = "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
+  KEY_PATH = "/tmp/kubernetes-release.key"
+
+  SYSCTL_CONF = <<~CONF
+    net.ipv6.conf.all.forwarding=1
+    net.ipv6.conf.all.proxy_ndp=1
+    net.ipv4.conf.all.forwarding=1
+    net.ipv4.ip_forward=1
+  CONF
+
+  def initialize(argv)
+    fail "expected a single argument, a kubernetes version like v1.35, got #{argv.length}" unless argv.length == 1
+    fail "expected a kubernetes version like v1.35, got #{argv[0].inspect}" unless VERSION_PATTERN.match?(argv[0])
+
+    @kubernetes_version = argv[0]
+  end
+
+  def repo_url
+    "https://pkgs.k8s.io/core:/stable:/#{@kubernetes_version}/deb/"
+  end
+
+  def run
+    ENV["DEBIAN_FRONTEND"] = "noninteractive"
+
+    r "sudo tee /etc/sysctl.d/72-clover-forward-packets.conf > /dev/null", stdin: SYSCTL_CONF
+
+    r "sudo -E apt-get update"
+    r "sudo -E apt-get upgrade -y"
+    r "sudo -E apt-get install -y ca-certificates curl gpg"
+
+    r "sudo install -m 0755 -d /etc/apt/keyrings"
+    r "curl -fsSL :url -o :path", url: "#{repo_url}Release.key", path: KEY_PATH
+    r "sudo gpg --batch --yes --dearmor -o :keyring :path", keyring: KEYRING, path: KEY_PATH
+    r "rm -f :path", path: KEY_PATH
+    r "echo :line | sudo tee /etc/apt/sources.list.d/kubernetes.list > /dev/null", line: "deb [signed-by=#{KEYRING}] #{repo_url} /"
+
+    r "sudo -E apt-get update"
+    r "sudo -E apt-get install -y containerd cri-tools kubelet kubeadm kubectl"
+
+    r "sudo mkdir -p /etc/containerd"
+    r "sudo tee /etc/containerd/config.toml > /dev/null", stdin: r("containerd config default").gsub("SystemdCgroup = false", "SystemdCgroup = true")
+
+    r "sudo apt-mark hold kubelet kubeadm kubectl"
+    r "sudo systemctl disable unattended-upgrades"
+
+    r "sudo -E apt-get autoremove -y"
+    r "sudo -E apt-get clean"
+    r "sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*"
+  end
+end

--- a/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe KubernetesBuildNodeImage do
         "rm -f /tmp/kubernetes-release.key",
         "echo deb\\ \\[signed-by\\=/etc/apt/keyrings/kubernetes-apt-keyring.gpg\\]\\ https://pkgs.k8s.io/core:/stable:/v1.35/deb/\\ / | sudo tee /etc/apt/sources.list.d/kubernetes.list > /dev/null",
         "sudo -E apt-get update",
-        "sudo -E apt-get install -y containerd cri-tools kubelet kubeadm kubectl",
+        "sudo -E apt-get install -y containerd cri-tools kubelet kubeadm kubectl ruby-bundler",
         "sudo mkdir -p /etc/containerd",
         "containerd config default",
         "sudo tee /etc/containerd/config.toml > /dev/null",

--- a/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative "../lib/kubernetes_build_node_image"
+
+RSpec.describe KubernetesBuildNodeImage do
+  subject(:builder) { described_class.new(["v1.35"]) }
+
+  describe "#initialize" do
+    it "rejects a missing version" do
+      expect { described_class.new([]) }.to raise_error RuntimeError, "expected a single argument, a kubernetes version like v1.35, got 0"
+    end
+
+    it "rejects extra arguments" do
+      expect { described_class.new(["v1.35", "x64"]) }.to raise_error RuntimeError, "expected a single argument, a kubernetes version like v1.35, got 2"
+    end
+
+    it "rejects a version that is not a kubernetes minor version" do
+      expect { described_class.new(["1.35"]) }.to raise_error RuntimeError, "expected a kubernetes version like v1.35, got \"1.35\""
+    end
+  end
+
+  describe "#run" do
+    it "installs kubernetes and containerd for the requested version" do
+      commands = []
+      stdins = {}
+      allow(builder).to receive(:_run_command) do |command, **kw|
+        commands << command
+        stdins[command] = kw[:stdin] if kw[:stdin]
+        (command == "containerd config default") ? "  SystemdCgroup = false\n" : ""
+      end
+
+      builder.run
+
+      expect(commands).to eq [
+        "sudo tee /etc/sysctl.d/72-clover-forward-packets.conf > /dev/null",
+        "sudo -E apt-get update",
+        "sudo -E apt-get upgrade -y",
+        "sudo -E apt-get install -y ca-certificates curl gpg",
+        "sudo install -m 0755 -d /etc/apt/keyrings",
+        "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.35/deb/Release.key -o /tmp/kubernetes-release.key",
+        "sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg /tmp/kubernetes-release.key",
+        "rm -f /tmp/kubernetes-release.key",
+        "echo deb\\ \\[signed-by\\=/etc/apt/keyrings/kubernetes-apt-keyring.gpg\\]\\ https://pkgs.k8s.io/core:/stable:/v1.35/deb/\\ / | sudo tee /etc/apt/sources.list.d/kubernetes.list > /dev/null",
+        "sudo -E apt-get update",
+        "sudo -E apt-get install -y containerd cri-tools kubelet kubeadm kubectl",
+        "sudo mkdir -p /etc/containerd",
+        "containerd config default",
+        "sudo tee /etc/containerd/config.toml > /dev/null",
+        "sudo apt-mark hold kubelet kubeadm kubectl",
+        "sudo systemctl disable unattended-upgrades",
+        "sudo -E apt-get autoremove -y",
+        "sudo -E apt-get clean",
+        "sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*",
+      ]
+      expect(stdins).to eq(
+        "sudo tee /etc/sysctl.d/72-clover-forward-packets.conf > /dev/null" => described_class::SYSCTL_CONF,
+        "sudo tee /etc/containerd/config.toml > /dev/null" => "  SystemdCgroup = true\n",
+      )
+      expect(ENV["DEBIAN_FRONTEND"]).to eq "noninteractive"
+    end
+  end
+end

--- a/spec/prog/kubernetes/build_node_image_spec.rb
+++ b/spec/prog/kubernetes/build_node_image_spec.rb
@@ -109,11 +109,13 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
   end
 
   describe "#build" do
-    it "starts the build when it has not started" do
+    it "registers a deadline and starts the build when it has not started" do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check build_node_image").and_return("NotStarted")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run build_node_image kubernetes/bin/build-node-image v1.35", {log: true, stdin: nil})
 
       expect { prog.build }.to nap(180)
+      expect(prog.strand.stack.first["deadline_target"]).to eq "sanitize"
+      expect(Time.new(prog.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 15 * 60)
     end
 
     it "naps while the build is in progress" do

--- a/spec/prog/kubernetes/build_node_image_spec.rb
+++ b/spec/prog/kubernetes/build_node_image_spec.rb
@@ -158,6 +158,45 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
     end
   end
 
+  describe "#destroy" do
+    it "hops to destroy from any label when the destroy semaphore is set" do
+      Semaphore.incr(strand.id, "destroy")
+
+      expect { described_class.new(strand.reload).before_run }.to hop("destroy")
+    end
+
+    it "destroys the builder vm and resolves the page" do
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check build_node_image").and_return("Failed")
+      expect { prog.build }.to hop("failed")
+
+      expect { prog.destroy }.to exit({"msg" => "Kubernetes node image build destroyed"})
+      expect(vm.destroy_set?).to be true
+      expect(Page.first.semaphores.map(&:name)).to eq ["resolve"]
+    end
+
+    it "destroys the captured version when there is one" do
+      metal = create_machine_image_version_metal
+      refresh_frame(prog, new_values: {"machine_image_version_id" => metal.id})
+
+      expect { prog.destroy }.to exit({"msg" => "Kubernetes node image build destroyed"})
+      expect(metal.destroy_set?).to be true
+      expect(vm.destroy_set?).to be true
+    end
+
+    it "succeeds when the builder vm is already destroyed" do
+      refresh_frame(prog, new_values: {"vm_id" => Vm.generate_uuid})
+
+      expect { prog.destroy }.to exit({"msg" => "Kubernetes node image build destroyed"})
+    end
+
+    it "waits for the rhizome install before tearing anything down" do
+      Strand.create(parent_id: strand.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
+
+      expect { prog.destroy }.to nap(120)
+      expect(vm.destroy_set?).to be false
+    end
+  end
+
   describe "#sanitize" do
     it "sanitizes the builder vm and stops it" do
       expect(sshable).to receive(:_cmd).with("kubernetes/bin/sanitize-node-image")

--- a/spec/prog/kubernetes/build_node_image_spec.rb
+++ b/spec/prog/kubernetes/build_node_image_spec.rb
@@ -183,6 +183,13 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
       expect(vm.destroy_set?).to be true
     end
 
+    it "destroys the verification cluster when there is one" do
+      cluster = assemble_verify_cluster
+
+      expect { prog.destroy }.to exit({"msg" => "Kubernetes node image build destroyed"})
+      expect(cluster.destroy_set?).to be true
+    end
+
     it "succeeds when the builder vm is already destroyed" do
       refresh_frame(prog, new_values: {"vm_id" => Vm.generate_uuid})
 
@@ -229,6 +236,7 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
       expect(miv_metal.status).to eq "creating"
       expect(miv_metal.machine_image_version.version).to eq "20260730.1.0"
       expect(miv_metal.pinned_source_vm_id).to eq source.id
+      expect(Strand[miv_metal.id].stack.first["set_as_latest"]).to be false
     end
   end
 
@@ -241,11 +249,11 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
       expect { prog.wait_capture }.to nap(15)
     end
 
-    it "pops once the version is ready" do
+    it "hops to verify once the version is ready" do
       metal = create_machine_image_version_metal
       refresh_frame(prog, new_values: {"machine_image_version_id" => metal.id})
 
-      expect { prog.wait_capture }.to exit({"msg" => "Kubernetes node image built"})
+      expect { prog.wait_capture }.to hop("verify")
     end
 
     it "pages and hops to failed when the archive failed" do
@@ -259,5 +267,61 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
       expect(page.summary).to eq "Kubernetes node image kubernetes-v1_35@20260730.1.0 capture failed"
       expect(page.severity).to eq "info"
     end
+  end
+
+  describe "#verify" do
+    it "creates a cluster and a nodepool pinned to the captured version" do
+      metal = create_machine_image_version_metal
+      refresh_frame(prog, new_values: {"machine_image_version_id" => metal.id})
+
+      expect { prog.verify }.to hop("wait_verify")
+      expect(Time.new(prog.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 30 * 60)
+
+      name = "verify-#{metal.machine_image_version.ubid}"
+      cluster = KubernetesCluster[prog.strand.stack.first["verify_cluster_id"]]
+      expect(cluster.name).to eq name
+      expect(cluster.version).to eq "v1.35"
+      expect(cluster.cp_node_count).to eq 3
+      expect(cluster.project_id).to eq project.id
+      expect(cluster.strand.stack.first["machine_image_version_id"]).to eq metal.id
+      expect(cluster.nodepools.map { [it.name, it.node_count, it.strand.stack.first["machine_image_version_id"]] })
+        .to eq [["#{name}-np", 1, metal.id]]
+    end
+  end
+
+  describe "#wait_verify" do
+    it "naps until the cluster and its nodepools are ready" do
+      cluster = assemble_verify_cluster
+      cluster.strand.update(label: "wait")
+
+      expect { prog.wait_verify }.to nap(30)
+    end
+
+    it "hops to promote once the cluster and its nodepools are ready" do
+      cluster = assemble_verify_cluster
+      cluster.strand.update(label: "wait")
+      cluster.nodepools.each { it.strand.update(label: "wait") }
+
+      expect { prog.wait_verify }.to hop("promote")
+    end
+  end
+
+  describe "#promote" do
+    it "tags the version as latest and destroys the verification cluster" do
+      metal = create_machine_image_version_metal
+      cluster = assemble_verify_cluster
+      refresh_frame(prog, new_values: {"machine_image_version_id" => metal.id, "verify_cluster_id" => cluster.id})
+
+      expect { prog.promote }.to exit({"msg" => "Kubernetes node image built"})
+      expect(MachineImage[strand.stack.first["machine_image_id"]].latest_version_id).to eq metal.id
+      expect(cluster.destroy_set?).to be true
+    end
+  end
+
+  def assemble_verify_cluster
+    cluster = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "verify-cluster", project_id: project.id, location_id:, version: Option.selectable_kubernetes_versions.first, cp_node_count: 3).subject
+    Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "verify-cluster-np", node_count: 1, kubernetes_cluster_id: cluster.id)
+    refresh_frame(prog, new_values: {"verify_cluster_id" => cluster.id})
+    cluster
   end
 end

--- a/spec/prog/kubernetes/build_node_image_spec.rb
+++ b/spec/prog/kubernetes/build_node_image_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
     it "hops to destroy from any label when the destroy semaphore is set" do
       Semaphore.incr(strand.id, "destroy")
 
-      expect { described_class.new(strand.reload).before_run }.to hop("destroy")
+      expect { prog.before_run }.to hop("destroy")
     end
 
     it "destroys the builder vm and resolves the page" do

--- a/spec/prog/kubernetes/build_node_image_spec.rb
+++ b/spec/prog/kubernetes/build_node_image_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Kubernetes::BuildNodeImage do
+  let(:project) { Project.create(name: "kubernetes-service") }
+  let(:image_project) { Project.create(name: "machine-images-service") }
+  let(:location_id) { Location::HETZNER_FSN1_ID }
+  let(:strand) { described_class.assemble(kubernetes_version: "v1.35", location_id:, image_version: "20260730.1.0") }
+  let(:prog) { described_class.new(strand) }
+  let(:vm) { prog.vm }
+  let(:sshable) { vm.sshable }
+
+  before do
+    allow(Config).to receive_messages(kubernetes_service_project_id: project.id, machine_images_service_project_id: image_project.id)
+    MachineImageStore.create(project_id: image_project.id, location_id:, provider: "r2", region: "auto", endpoint: "https://r2.cloudflare.com/", bucket: "test-bucket", access_key: "ak", secret_key: "sk")
+  end
+
+  describe ".assemble" do
+    it "creates the machine image and a builder vm" do
+      expect(strand.label).to eq "wait_vm"
+
+      machine_image = MachineImage[strand.stack.first["machine_image_id"]]
+      expect(machine_image.name).to eq "kubernetes-v1_35"
+      expect(machine_image.arch).to eq "x64"
+      expect(machine_image.location_id).to eq location_id
+      expect(machine_image.project_id).to eq image_project.id
+
+      expect(vm.boot_image).to eq "ubuntu-noble"
+      expect(vm.unix_user).to eq "ubi"
+      expect(vm.storage_size_gib).to eq 10
+    end
+
+    it "reuses the machine image when building another version" do
+      first = strand
+      second = described_class.assemble(kubernetes_version: "v1.35", location_id:, image_version: "20260731.1.0")
+
+      expect(second.stack.first["machine_image_id"]).to eq first.stack.first["machine_image_id"]
+      expect(MachineImage.where(project_id: image_project.id, name: "kubernetes-v1_35").count).to eq 1
+    end
+
+    it "rejects an unsupported kubernetes version" do
+      expect { described_class.assemble(kubernetes_version: "v0.1", location_id:, image_version: "20260730.1.0") }
+        .to raise_error RuntimeError, "invalid kubernetes version: v0.1"
+    end
+
+    it "rejects a location that does not run kubernetes" do
+      expect { described_class.assemble(kubernetes_version: "v1.35", location_id: Location::HETZNER_HEL1_ID, image_version: "20260730.1.0") }
+        .to raise_error RuntimeError, "invalid location for kubernetes: #{Location::HETZNER_HEL1_ID}"
+    end
+
+    it "rejects an invalid image version" do
+      expect { described_class.assemble(kubernetes_version: "v1.35", location_id:, image_version: "not a version") }
+        .to raise_error RuntimeError, "invalid image version: not a version"
+    end
+
+    it "rejects a missing kubernetes service project" do
+      allow(Config).to receive(:kubernetes_service_project_id).and_return(nil)
+
+      expect { described_class.assemble(kubernetes_version: "v1.35", location_id:, image_version: "20260730.1.0") }
+        .to raise_error RuntimeError, "no kubernetes service project"
+    end
+
+    it "rejects a missing machine images service project" do
+      allow(Config).to receive(:machine_images_service_project_id).and_return(nil)
+
+      expect { described_class.assemble(kubernetes_version: "v1.35", location_id:, image_version: "20260730.1.0") }
+        .to raise_error RuntimeError, "no machine images service project"
+    end
+
+    it "rejects a location without a machine image store" do
+      expect { described_class.assemble(kubernetes_version: "v1.35", location_id: Location::LEASEWEB_WDC02_ID, image_version: "20260730.1.0") }
+        .to raise_error RuntimeError, "no machine image store for #{Location::LEASEWEB_WDC02_ID}"
+    end
+  end
+
+  describe "#wait_vm" do
+    it "naps until the builder vm is running" do
+      expect { prog.wait_vm }.to nap(10)
+    end
+
+    it "hops to bootstrap_rhizome once the vm is running" do
+      vm.update(display_state: "running")
+
+      expect { prog.wait_vm }.to hop("bootstrap_rhizome")
+    end
+  end
+
+  describe "#bootstrap_rhizome" do
+    it "installs the kubernetes rhizome on the builder vm" do
+      strands = Strand.where(prog: "BootstrapRhizome")
+
+      expect { prog.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")
+        .and change { strands.count }.from(0).to(1)
+      expect(strands.get(:stack)[0].values_at("target_folder", "subject_id", "user")).to eq ["kubernetes", vm.id, "ubi"]
+    end
+  end
+
+  describe "#wait_bootstrap_rhizome" do
+    it "hops to build if there are no sub-programs running" do
+      expect { prog.wait_bootstrap_rhizome }.to hop("build")
+    end
+
+    it "naps while the rhizome install is still leased by another thread" do
+      Strand.create(parent_id: strand.id, prog: "BootstrapRhizome", label: "start", stack: [{}], lease: Time.now + 10)
+
+      expect { prog.wait_bootstrap_rhizome }.to nap(120)
+    end
+  end
+
+  describe "#build" do
+    it "starts the build when it has not started" do
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check build_node_image").and_return("NotStarted")
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run build_node_image kubernetes/bin/build-node-image v1.35", {log: true, stdin: nil})
+
+      expect { prog.build }.to nap(180)
+    end
+
+    it "naps while the build is in progress" do
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check build_node_image").and_return("InProgress")
+
+      expect { prog.build }.to nap(180)
+    end
+
+    it "cleans the unit and hops to sanitize when the build succeeds" do
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check build_node_image").and_return("Succeeded")
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 clean build_node_image")
+
+      expect { prog.build }.to hop("sanitize")
+    end
+
+    it "pages and hops to failed when the build fails" do
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check build_node_image").and_return("Failed")
+
+      expect { prog.build }.to hop("failed")
+
+      page = Page.first
+      expect(page.summary).to eq "Kubernetes node image kubernetes-v1_35@20260730.1.0 build Failed"
+      expect(page.severity).to eq "info"
+      expect(page.details["reason"]).to eq "build Failed"
+      expect(page.details["builder_vm_id"]).to eq vm.id
+    end
+
+    it "pages when the daemonizer reports an unexpected state" do
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check build_node_image").and_return("Unknown")
+
+      expect { prog.build }.to hop("failed")
+
+      expect(Page.first.summary).to eq "Kubernetes node image kubernetes-v1_35@20260730.1.0 build Unknown"
+    end
+  end
+
+  describe "#failed" do
+    it "naps" do
+      expect { prog.failed }.to nap(60 * 60)
+    end
+  end
+
+  describe "#sanitize" do
+    it "sanitizes the builder vm and stops it" do
+      expect(sshable).to receive(:_cmd).with("kubernetes/bin/sanitize-node-image")
+
+      expect { prog.sanitize }.to hop("wait_stopped")
+      expect(vm.stop_set?).to be true
+    end
+  end
+
+  describe "#wait_stopped" do
+    it "naps until the builder vm is stopped" do
+      expect { prog.wait_stopped }.to nap(10)
+    end
+
+    it "hops to capture once the vm is stopped" do
+      vm.strand.update(label: "stopped")
+
+      expect { prog.wait_stopped }.to hop("capture")
+    end
+  end
+
+  describe "#capture" do
+    it "captures the builder vm as a machine image version" do
+      source = create_archive_ready_vm(project_id: project.id, location_id:)
+      refresh_frame(prog, new_values: {"vm_id" => source.id})
+
+      expect { prog.capture }.to hop("wait_capture")
+
+      miv_metal = MachineImageVersionMetal[strand.stack.first["machine_image_version_id"]]
+      expect(miv_metal.status).to eq "creating"
+      expect(miv_metal.machine_image_version.version).to eq "20260730.1.0"
+      expect(miv_metal.pinned_source_vm_id).to eq source.id
+    end
+  end
+
+  describe "#wait_capture" do
+    it "naps while the version is still being archived" do
+      metal = create_machine_image_version_metal
+      metal.update(status: "creating")
+      refresh_frame(prog, new_values: {"machine_image_version_id" => metal.id})
+
+      expect { prog.wait_capture }.to nap(15)
+    end
+
+    it "pops once the version is ready" do
+      metal = create_machine_image_version_metal
+      refresh_frame(prog, new_values: {"machine_image_version_id" => metal.id})
+
+      expect { prog.wait_capture }.to exit({"msg" => "Kubernetes node image built"})
+    end
+
+    it "pages and hops to failed when the archive failed" do
+      metal = create_machine_image_version_metal
+      metal.update(status: "failed")
+      refresh_frame(prog, new_values: {"machine_image_version_id" => metal.id})
+
+      expect { prog.wait_capture }.to hop("failed")
+
+      page = Page.first
+      expect(page.summary).to eq "Kubernetes node image kubernetes-v1_35@20260730.1.0 capture failed"
+      expect(page.severity).to eq "info"
+    end
+  end
+end

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
     it "buds enough number of times ProvisionKubernetesNode progs when we need to provision more nodes" do
       kn.update(node_count: 4)
       (kn.node_count - kn.functional_nodes.count).times do
-        expect(nx).to receive(:bud).with(Prog::Kubernetes::ProvisionKubernetesNode, {"nodepool_id" => kn.id, "subject_id" => kn.cluster.id})
+        expect(nx).to receive(:bud).with(Prog::Kubernetes::ProvisionKubernetesNode, {"nodepool_id" => kn.id, "subject_id" => kn.cluster.id, "machine_image_version_id" => nil})
       end
       expect { nx.bootstrap_worker_nodes }.to hop("wait_worker_node")
     end

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -114,6 +114,12 @@ usermod -L ubuntu
       }.to raise_error("Machine images are only supported for metal locations")
     end
 
+    it "fails if a machine image version id is provided for non-metal location" do
+      expect {
+        Prog::Vm::Nexus.assemble("some_ssh key", project.id, location_id: assemble_loc.id, storage_volumes: [{size_gib: 20, machine_image_version_id: MachineImageVersion.generate_uuid}])
+      }.to raise_error("Machine images are only supported for metal locations")
+    end
+
     it "creates a management NIC when use_separate_management_nic is set" do
       vm = Prog::Vm::Nexus.assemble("some_ssh key", project.id, location_id: assemble_loc.id, use_separate_management_nic: true).subject
       expect(vm.nics.count).to eq(2)

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -126,6 +126,12 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(vols[1]).not_to have_key("machine_image_version_id")
     end
 
+    it "uses a machine image version supplied by the caller without looking it up by name" do
+      miv = create_machine_image_version_metal.machine_image_version
+      st = Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "ubuntu-noble", storage_volumes: [{size_gib: 20, machine_image_version_id: miv.id}])
+      expect(st.stack.first["storage_volumes"].first["machine_image_version_id"]).to eq(miv.id)
+    end
+
     it "fails if machine image name does not exist in project/location" do
       expect {
         Prog::Vm::Nexus.assemble("some_ssh key", project.id, boot_image: "missing-mi@v1")

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2219,7 +2219,27 @@ RSpec.describe CloverAdmin do
       expect(st.stack.first.values_at("kubernetes_version", "location_id", "image_version"))
         .to eq [kubernetes_version, location.id, "20260730.1.0"]
       expect(page.all(".kubernetes-node-image-table td").map(&:text))
-        .to eq ["wait_vm", "0", st.ubid, kubernetes_version, location.display_name, "20260730.1.0"]
+        .to eq ["wait_vm", "0", st.ubid, kubernetes_version, location.display_name, "20260730.1.0", ""]
+    end
+
+    it "destroys a build" do
+      st = Prog::Kubernetes::BuildNodeImage.assemble(kubernetes_version: Option.kubernetes_versions.first, location_id: Option.kubernetes_locations.first.id, image_version: "20260730.1.0")
+      page.refresh
+
+      click_button "Destroy"
+
+      expect(page).to have_flash_notice("Destroying node image build strand: #{st.ubid}")
+      expect(st.semaphores.map(&:name)).to eq ["destroy"]
+    end
+
+    it "shows error when destroying a build that is already gone" do
+      st = Prog::Kubernetes::BuildNodeImage.assemble(kubernetes_version: Option.kubernetes_versions.first, location_id: Option.kubernetes_locations.first.id, image_version: "20260730.1.0")
+      page.refresh
+      st.destroy
+
+      click_button "Destroy"
+
+      expect(page).to have_flash_error("Strand not found, it was probably already deleted")
     end
 
     it "shows error for an unsupported kubernetes version" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2193,6 +2193,65 @@ RSpec.describe CloverAdmin do
     end
   end
 
+  describe "kubernetes node image" do
+    before do
+      kubernetes_project = Project.create(name: "Kubernetes-Service")
+      image_project = Project.create(name: "Machine-Images-Service")
+      allow(Config).to receive_messages(kubernetes_service_project_id: kubernetes_project.id, machine_images_service_project_id: image_project.id)
+      MachineImageStore.create(project_id: image_project.id, location_id: Option.kubernetes_locations.first.id, provider: "r2", region: "auto", endpoint: "https://r2.cloudflare.com/", bucket: "test-bucket", access_key: "ak", secret_key: "sk")
+      click_link "Build Kubernetes Node Image"
+    end
+
+    it "starts a build and lists it" do
+      kubernetes_version = Option.kubernetes_versions.first
+      location = Option.kubernetes_locations.first
+
+      expect(page.title).to eq "Ubicloud Admin - Build Kubernetes Node Image"
+      expect(page).to have_content("No data available for Active Node Image Builds")
+
+      select kubernetes_version, from: "Kubernetes Version"
+      select location.display_name, from: "Location"
+      fill_in "Image Version", with: "20260730.1.0"
+      click_button "Start Node Image Build"
+
+      st = Strand.first(prog: "Kubernetes::BuildNodeImage")
+      expect(page).to have_flash_notice("Started kubernetes node image build strand: #{st.ubid}")
+      expect(st.stack.first.values_at("kubernetes_version", "location_id", "image_version"))
+        .to eq [kubernetes_version, location.id, "20260730.1.0"]
+      expect(page.all(".kubernetes-node-image-table td").map(&:text))
+        .to eq ["wait_vm", "0", st.ubid, kubernetes_version, location.display_name, "20260730.1.0"]
+    end
+
+    it "shows error for an unsupported kubernetes version" do
+      # The select only offers valid options, so submit a tampered request directly.
+      csrf = find("#start-kubernetes-node-image input[name=_csrf]", visible: false).value
+      page.driver.submit :post, "/kubernetes-node-image", _csrf: csrf,
+        kubernetes_version: "v0.1", location_id: Option.kubernetes_locations.first.ubid, image_version: "20260730.1.0"
+
+      expect(page).to have_flash_error("invalid kubernetes version")
+      expect(Strand.first(prog: "Kubernetes::BuildNodeImage")).to be_nil
+    end
+
+    it "shows error for a location without kubernetes" do
+      csrf = find("#start-kubernetes-node-image input[name=_csrf]", visible: false).value
+      page.driver.submit :post, "/kubernetes-node-image", _csrf: csrf,
+        kubernetes_version: Option.kubernetes_versions.first, location_id: Location[Location::HETZNER_HEL1_ID].ubid, image_version: "20260730.1.0"
+
+      expect(page).to have_flash_error("invalid location for kubernetes")
+      expect(Strand.first(prog: "Kubernetes::BuildNodeImage")).to be_nil
+    end
+
+    it "shows error for an invalid image version" do
+      select Option.kubernetes_versions.first, from: "Kubernetes Version"
+      select Option.kubernetes_locations.first.display_name, from: "Location"
+      fill_in "Image Version", with: "not a version"
+      click_button "Start Node Image Build"
+
+      expect(page).to have_flash_error("invalid image version")
+      expect(Strand.first(prog: "Kubernetes::BuildNodeImage")).to be_nil
+    end
+  end
+
   describe "remove boot images" do
     before do
       click_link "Remove Boot Images"

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -60,6 +60,7 @@
     </li>
     <li><a href="/rollouts">Manage Rollouts</a></li>
     <li><a href="/remove-boot-images">Remove Boot Images</a></li>
+    <li><a href="/kubernetes-node-image">Build Kubernetes Node Image</a></li>
     <li><a href="/local-e2e">Manage Local E2E</a></li>
     <li><a href="/admin-list">View Admin List</a></li>
     <li><a href="/autoforme/Strand/search/1?try=10">Strands with try &gt;= 10</a></li>

--- a/views/admin/kubernetes_node_image.erb
+++ b/views/admin/kubernetes_node_image.erb
@@ -7,6 +7,7 @@
   h[:kubernetes_version] = frame["kubernetes_version"]
   h[:location] = @location_names[frame["location_id"]]
   h[:image_version] = frame["image_version"]
+  h[:destroy] = table_form_button("Destroy", action: "/kubernetes-node-image/#{strand.ubid}/destroy", method: "post")
   h
 end %>
 

--- a/views/admin/kubernetes_node_image.erb
+++ b/views/admin/kubernetes_node_image.erb
@@ -1,0 +1,21 @@
+<% @page_title = "Build Kubernetes Node Image" %>
+
+<% data = @strands.map do |strand|
+  frame = strand.stack[0]
+  h = strand.values.slice(:label, :try)
+  h[:id] = strand.ubid
+  h[:kubernetes_version] = frame["kubernetes_version"]
+  h[:location] = @location_names[frame["location_id"]]
+  h[:image_version] = frame["image_version"]
+  h
+end %>
+
+<%== part("components/table", title: "Active Node Image Builds", table_class: "kubernetes-node-image-table", data:) %>
+
+<h2>Start Node Image Build</h2>
+
+<% form({method: "post", id: "start-kubernetes-node-image"}, button: "Start Node Image Build", wrapper: :div) do |f| %>
+  <%== f.input(:select, key: :kubernetes_version, label: "Kubernetes Version", required: true, add_blank: true, options: Option.kubernetes_versions) %>
+  <%== f.input(:select, key: :location_id, label: "Location", required: true, add_blank: true, options: Option.kubernetes_locations.map { [it.display_name, it.ubid] }) %>
+  <%== f.input(:text, key: :image_version, label: "Image Version", required: true) %>
+<% end %>


### PR DESCRIPTION
Replaces the external kubernetes-images build with an in-cloud pipeline that captures a builder VM as a machine image, and boots Kubernetes nodes from it.

**Motivation**

Node images were built in a separate repo via loop-device + chroot, uploaded by hand, and registered by hand-editing BOOT_IMAGE_SHA256. Name reuse silently broke production, the base image URL was pinned to a dated path that upstream garbage-collects, and every image needed a fleet-wide RolloutBootImage before use.

**What's here**

- Build: rhizome/kubernetes/bin/build-node-image runs the old setup.sh against a live VM. Prog::Kubernetes::BuildNodeImage boots an ubuntu-noble builder, installs, sanitizes, stops, captures.
- Operability: 15-minute deadline that pages on a wedged build, a cleanup semaphore that tears down the builder VM and captured version from any label, and an admin Tools page to start and clean up builds.
- Consumption: ProvisionKubernetesNode uses kubernetes-vX_YY@latest when the Kubernetes service project has a ready version in the node's location, else the boot image of the same name. It also waits for the boot disk to finish fetching before bootstrapping.
