### PR TITLE
Resolve postgres pages on server, resource, and timeline teardown

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -478,6 +478,10 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       PostgresServer.incr_destroy(server_ids_dataset)
       Cert.incr_destroy(current_cert_id) if current_cert_id
       postgres_resource.dns_zone&.delete_record(record_name: postgres_resource.hostname)
+      # Resolve resource-keyed pages so they don't orphan after the resource is gone.
+      %w[PGStorageAutoScaleMaxSize PGStorageAutoScaleQuotaInsufficient PGStorageAutoScaleCanceled PostgresUpgradeFailed].each do |tag|
+        Page.from_tag_parts(tag, postgres_resource.id)&.incr_resolve
+      end
       postgres_resource.destroy
 
       pop "postgres resource is deleted"

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -934,7 +934,6 @@ SQL
 
     case vm.sshable.d_check("promote_postgres")
     when "Succeeded"
-      Page.from_tag_parts("PGPromotionFailed", postgres_server.id)&.incr_resolve
       resource.representative_server.update(is_representative: false)
       resource.representative_server.incr_destroy
       postgres_server.update(timeline_access: "push", is_representative: true, synchronization_status: "ready")
@@ -961,6 +960,10 @@ SQL
 
   label def destroy
     decr_destroy
+    # Resolve server-keyed pages so they don't orphan after the server is gone.
+    %w[PGDiskUsageHigh PGRootDiskUsageHigh PGArchivalBacklogHigh PGMetricsBacklogHigh PGIOThrottleStale PGInitializeDatabaseFromBackupFailed].each do |tag|
+      Page.from_tag_parts(tag, postgres_server.id)&.incr_resolve
+    end
     Semaphore.incr(strand.children_dataset.exclude(prog: "Postgres::PostgresServerNexus").select(:id), "destroy")
     hop_wait_children_destroy
   end

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -100,6 +100,8 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   label def destroy
     decr_destroy
     postgres_timeline.destroy_blob_storage if postgres_timeline.blob_storage
+    # Resolve the timeline-keyed page so it doesn't orphan after the timeline is gone.
+    Page.from_tag_parts("MissingBackup", postgres_timeline.id)&.incr_resolve
     postgres_timeline.destroy
     pop "postgres timeline is deleted"
   end

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -1005,6 +1005,18 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
 
         expect { nx.wait_children_destroyed }.to exit({"msg" => "postgres resource is deleted"})
       end
+
+      it "resolves resource-keyed pages so they do not orphan after the resource is gone" do
+        postgres_server
+        tags = %w[PGStorageAutoScaleMaxSize PGStorageAutoScaleQuotaInsufficient PGStorageAutoScaleCanceled PostgresUpgradeFailed]
+        pages = tags.map { Prog::PageNexus.assemble("#{postgres_resource.ubid} #{it}", [it, postgres_resource.id], postgres_resource.ubid).subject }
+
+        expect { nx.wait_children_destroyed }.to exit({"msg" => "postgres resource is deleted"})
+
+        pages.each do |page|
+          expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
+        end
+      end
     end
   end
 end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1810,39 +1810,6 @@ CMD
       end
     end
 
-    it "resolves existing page, updates the metadata and hops to finalize_taking_over if promote command is succeeded" do
-      postgres_server
-      standby = create_postgres_server(resource: postgres_resource, timeline: postgres_timeline, is_representative: false)
-      standby_nx = described_class.new(standby.strand)
-      standby_sshable = standby_nx.postgres_server.vm.sshable
-
-      page = Prog::PageNexus.assemble(
-        "#{standby.ubid} promotion failed",
-        ["PGPromotionFailed", standby.id],
-        standby.ubid,
-      ).subject
-      expect(standby_sshable).to receive(:d_check).with("promote_postgres").and_return("Succeeded")
-
-      expect { standby_nx.taking_over }.to hop("finalize_taking_over")
-
-      postgres_server.reload
-      expect(Semaphore.where(strand_id: postgres_server.id, name: "destroy").count).to eq(1)
-
-      standby.reload
-      expect(standby.timeline_access).to eq("push")
-      expect(standby.is_representative).to be true
-      expect(standby.synchronization_status).to eq("ready")
-
-      expect(Semaphore.where(strand_id: postgres_resource.id, name: "refresh_dns_record").count).to eq(1)
-
-      [postgres_server, standby].each do |server|
-        expect(Semaphore.where(strand_id: server.id, name: "configure").count).to eq(1)
-        expect(Semaphore.where(strand_id: server.id, name: "configure_metrics").count).to eq(1)
-      end
-
-      expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
-    end
-
     it "naps if script return unknown status" do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check promote_postgres").and_return("Unknown")
       expect { nx.taking_over }.to nap(5)
@@ -1873,6 +1840,17 @@ CMD
 
       expect(Semaphore.where(strand_id: child.id, name: "destroy").count).to eq(1)
       expect(Semaphore.where(strand_id: pg_server_child.id, name: "destroy").count).to eq(0)
+    end
+
+    it "resolves server-keyed pages so they do not orphan after the server is gone" do
+      tags = %w[PGDiskUsageHigh PGRootDiskUsageHigh PGArchivalBacklogHigh PGMetricsBacklogHigh PGIOThrottleStale PGInitializeDatabaseFromBackupFailed]
+      pages = tags.map { Prog::PageNexus.assemble("#{postgres_server.ubid} #{it}", [it, postgres_server.id], postgres_server.ubid).subject }
+
+      expect { nx.destroy }.to hop("wait_children_destroy")
+
+      pages.each do |page|
+        expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
+      end
     end
   end
 

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -535,6 +535,14 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       expect(postgres_timeline).not_to exist
     end
 
+    it "resolves the MissingBackup page so it does not orphan after the timeline is gone" do
+      page = Prog::PageNexus.assemble("Missing backup at #{postgres_timeline}!", ["MissingBackup", postgres_timeline.id], postgres_timeline.ubid).subject
+
+      expect { nx.destroy }.to exit({"msg" => "postgres timeline is deleted"})
+
+      expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
+    end
+
     describe "when blob storage is minio" do
       it "destroys blob storage and postgres timeline" do
         minio_cluster = create_minio_cluster


### PR DESCRIPTION
Server, resource, and timeline keyed pages are only resolved by the entity's own monitor loop, so destroying the entity orphaned any active page. Resolve them in the destroy paths.

Also drop the `PGPromotionFailed` resolve. Its creator was removed in e84ffcc74.