### PR TITLE
Render the k8s creation form on an empty cluster list

### DIFF
--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -82,7 +82,11 @@ class Clover
       paginated_result(dataset, Serializers::KubernetesCluster)
     else
       @kcs = dataset.all
-      view "kubernetes-cluster/index"
+      if @kcs.empty? && has_project_permission("KubernetesCluster:create")
+        view "kubernetes-cluster/create"
+      else
+        view "kubernetes-cluster/index"
+      end
     end
   end
 

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -83,14 +83,12 @@ RSpec.describe Clover, "Kubernetes" do
     end
 
     describe "list" do
-      it "works with 0 kubernetes clusters" do
+      it "shows the creation form with 0 kubernetes clusters" do
         visit "#{project.path}/kubernetes-cluster"
-        expect(page.title).to eq("Ubicloud - Kubernetes Clusters")
-        expect(page).to have_content "No Kubernetes Clusters"
-        expect(page).to have_content "Create Kubernetes Cluster"
 
-        click_link "Create Kubernetes Cluster"
         expect(page.title).to eq("Ubicloud - Create Kubernetes Cluster")
+        expect(page).to have_field "Cluster Name"
+        expect(page).to have_button "Create"
       end
 
       it "lists existing permissible clusters" do

--- a/views/kubernetes-cluster/create.erb
+++ b/views/kubernetes-cluster/create.erb
@@ -9,9 +9,10 @@
   breadcrumbs: [
     %w[Projects /project].freeze,
     [@project.name, @project.path],
-    ["Kubernetes Clusters", "#{@project.path}/kubernetes-cluster"],
+    # @kcs is only set when the empty cluster list renders this form in place
+    (["Kubernetes Clusters", "#{@project.path}/kubernetes-cluster"] unless @kcs),
     %w[Create #].freeze
-  ]
+  ].compact
 ) %>
 
 <%


### PR DESCRIPTION
A project with no Kubernetes clusters showed a list page whose only content was a button to the creation form. Render the form directly from the list route instead, when the user has KubernetesCluster:create.