### PR TITLE
Extend deadline while WAL replay advances in wait_recovery_completion

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -617,14 +617,21 @@ SQL
     end
 
     if is_in_recovery
-      is_wal_replay_paused = postgres_server.run_query("SELECT pg_get_wal_replay_pause_state()").chomp == "paused"
-      if is_wal_replay_paused
+      pause_state, current_lsn = postgres_server.run_query("SELECT pg_get_wal_replay_pause_state(), pg_last_wal_replay_lsn()").split(",")
+      if pause_state == "paused"
         postgres_server.run_query("SELECT pg_wal_replay_resume()")
         is_in_recovery = false
+      # Extend the deadline while replay is advancing, so a long but healthy
+      # recovery does not page. Mirrors wait_catch_up. The LSN is NULL until
+      # consistency is reached.
+      elsif !current_lsn.to_s.empty? && (previous_lsn.nil? || postgres_server.lsn_diff(current_lsn, previous_lsn) > 0)
+        self.previous_lsn = current_lsn
+        register_deadline("wait", 10 * 60, allow_extension: 24 * 60 * 60)
       end
     end
 
     if !is_in_recovery
+      delete_from_stack("previous_lsn")
       postgres_server.switch_to_new_timeline
       decr_initial_provisioning
       incr_update_superuser_password

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -639,10 +639,19 @@ SQL
       if is_wal_replay_paused
         postgres_server.run_query("SELECT pg_wal_replay_resume()")
         is_in_recovery = false
+      else
+        # Extend the deadline while replay is advancing, so a long but healthy
+        # recovery does not page. Mirrors wait_catch_up.
+        current_lsn = postgres_server.run_query("SELECT pg_last_wal_replay_lsn()").chomp
+        if !current_lsn.empty? && (previous_lsn.nil? || postgres_server.lsn_diff(current_lsn, previous_lsn) > 0)
+          self.previous_lsn = current_lsn
+          register_deadline("wait", 10 * 60, allow_extension: 24 * 60 * 60)
+        end
       end
     end
 
     if !is_in_recovery
+      delete_from_stack("previous_lsn")
       postgres_server.switch_to_new_timeline
       decr_initial_provisioning
       hop_configure

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1284,9 +1284,21 @@ CMD
   end
 
   describe "#wait_recovery_completion" do
-    it "naps if it is still in recovery and wal replay is not paused" do
+    it "naps and extends the deadline if replay is advancing while still in recovery" do
       expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_return("t")
       expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state()").and_return("not paused")
+      expect(server).to receive(:_run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("0/3000000")
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60, allow_extension: 24 * 60 * 60)
+      expect { nx.wait_recovery_completion }.to nap(5)
+      expect(nx.previous_lsn).to eq("0/3000000")
+    end
+
+    it "naps without extending the deadline if replay is not advancing" do
+      nx.previous_lsn = "0/3000000"
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_return("t")
+      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state()").and_return("not paused")
+      expect(server).to receive(:_run_query).with("SELECT pg_last_wal_replay_lsn()").and_return("0/3000000")
+      expect(nx).not_to receive(:register_deadline)
       expect { nx.wait_recovery_completion }.to nap(5)
     end
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1274,10 +1274,37 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   end
 
   describe "#wait_recovery_completion" do
-    it "naps if it is still in recovery and wal replay is not paused" do
+    it "naps and extends the deadline if replay is advancing while still in recovery" do
       expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres", dbname: "postgres").and_return("t")
-      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state()", user: "postgres", dbname: "postgres").and_return("not paused")
+      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state(), pg_last_wal_replay_lsn()", user: "postgres", dbname: "postgres").and_return("not paused,0/3000000")
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60, allow_extension: 24 * 60 * 60)
       expect { nx.wait_recovery_completion }.to nap(5)
+      expect(nx.previous_lsn).to eq("0/3000000")
+    end
+
+    it "naps and extends the deadline if replay advanced past the previously seen lsn" do
+      refresh_frame(nx, new_values: {"previous_lsn" => "0/2000000"})
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres", dbname: "postgres").and_return("t")
+      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state(), pg_last_wal_replay_lsn()", user: "postgres", dbname: "postgres").and_return("not paused,0/3000000")
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60, allow_extension: 24 * 60 * 60)
+      expect { nx.wait_recovery_completion }.to nap(5)
+      expect(nx.previous_lsn).to eq("0/3000000")
+    end
+
+    it "naps without extending the deadline if replay is not advancing" do
+      refresh_frame(nx, new_values: {"previous_lsn" => "0/3000000"})
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres", dbname: "postgres").and_return("t")
+      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state(), pg_last_wal_replay_lsn()", user: "postgres", dbname: "postgres").and_return("not paused,0/3000000")
+      expect(nx).not_to receive(:register_deadline)
+      expect { nx.wait_recovery_completion }.to nap(5)
+    end
+
+    it "naps without extending the deadline if the replay lsn is not available yet" do
+      expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres", dbname: "postgres").and_return("t")
+      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state(), pg_last_wal_replay_lsn()", user: "postgres", dbname: "postgres").and_return("not paused,")
+      expect(nx).not_to receive(:register_deadline)
+      expect { nx.wait_recovery_completion }.to nap(5)
+      expect(nx.previous_lsn).to be_nil
     end
 
     it "naps if it cannot connect to database due to recovery" do
@@ -1291,12 +1318,14 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "stops wal replay and switches to new timeline if it is still in recovery but wal replay is paused" do
+      refresh_frame(nx, new_values: {"previous_lsn" => "0/3000000"})
       expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()", user: "postgres", dbname: "postgres").and_return("t")
-      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state()", user: "postgres", dbname: "postgres").and_return("paused")
+      expect(server).to receive(:_run_query).with("SELECT pg_get_wal_replay_pause_state(), pg_last_wal_replay_lsn()", user: "postgres", dbname: "postgres").and_return("paused,0/3000000")
       expect(server).to receive(:_run_query).with("SELECT pg_wal_replay_resume()", user: "postgres", dbname: "postgres")
       expect(server).to receive(:switch_to_new_timeline)
 
       expect { nx.wait_recovery_completion }.to hop("configure")
+      expect(nx.previous_lsn).to be_nil
     end
 
     it "switches to new timeline if the recovery is completed" do


### PR DESCRIPTION
`wait_recovery_completion` reused the flat deadline from the backup download and never refreshed it, so a PITR or unarchive restore replaying WAL for over 10 minutes paged even while recovery was healthy.

Push the deadline forward whenever the replay LSN advances, matching `wait_catch_up` and `initialize_database_from_backup`. Query the replay LSN directly since the LSN monitor does not run during initial provisioning.