### PR TITLE
Keep leaseweb connectivity prefixes out of the address registry

### DIFF
--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -82,6 +82,8 @@ class Hosting::HetznerApis < Hosting::ProviderApis
     # Hetzner routes every extra address to the host's main IP, so the host
     # claims only the main IP itself and every extra stays VM-allocatable.
     def host_only? = ip_address == "#{source_host_ip}/32"
+
+    def host_connectivity? = false
   end
 
   # Finds IP addresses that match with the host's IP address. An important

--- a/lib/hosting/leaseweb_apis.rb
+++ b/lib/hosting/leaseweb_apis.rb
@@ -6,6 +6,10 @@ class Hosting::LeasewebApis < Hosting::ProviderApis
     # A gatewayed IPv4 sits on a switched segment the host must claim (no VM may
     # take it); a gateway-less IPv4 is a block routed here that VMs draw from.
     def host_only? = !gateway.nil? && !ip_address.include?(":")
+
+    # A gatewayed IPv6 prefix exists so the host can reach its router; VMs
+    # never draw from it and the control plane does not track it.
+    def host_connectivity? = !gateway.nil? && ip_address.include?(":")
   end
 
   NetworkInterfaces = Data.define(:public_mac, :internal_mac, :internal_ip)

--- a/migrate/20260803_delete_leaseweb_connectivity_addresses.rb
+++ b/migrate/20260803_delete_leaseweb_connectivity_addresses.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# create_addresses recorded the gatewayed IPv6 prefixes leaseweb hands out
+# for host connectivity as Address rows, presenting them in assigned_subnets
+# as if VMs could draw from them. Nothing allocates from them; drop the rows.
+Sequel.migration do
+  up do
+    run <<~SQL
+      DELETE FROM address AS a
+      USING host_provider AS hp
+      WHERE hp.id = a.routed_to_host_id
+        AND hp.provider_name LIKE 'leaseweb%'
+        AND family(a.cidr) = 6
+        AND masklen(a.cidr) = 112
+    SQL
+  end
+end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -185,6 +185,9 @@ class VmHost < Sequel::Model
 
     DB.transaction do
       ip_records.each do |ip_record|
+        # Connectivity space reaches the netplan but never the address registry.
+        next if ip_record.host_connectivity?
+
         ip_addr = ip_record.ip_address
 
         next if assigned_subnets.any? { |a| a.cidr.to_s == ip_addr }

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -383,6 +383,15 @@ RSpec.describe VmHost do
           "2607:f5b7:1:30:9::2/112",
         ],
       )
+      # The gatewayed /112 never enters the registry: hosts and VMs strictly
+      # never share a prefix, and nothing may present it as allocatable.
+      expect(vm_host.assigned_subnets_dataset.select_order_map(:cidr).map(&:to_s)).to eq [
+        "23.105.171.112/32",
+        "23.105.176.1/32",
+        "23.105.176.2/32",
+        "23.105.176.3/32",
+        "216.22.15.64/26",
+      ]
       # The claim set is exactly the main IP and the segment members; the
       # routed block and the delegated prefix belong to VMs, not the host.
       expect(vm_host.assigned_host_addresses_dataset.select_order_map(:ip).map(&:to_s)).to eq [

--- a/spec/prog/leaseweb/setup_networking_spec.rb
+++ b/spec/prog/leaseweb/setup_networking_spec.rb
@@ -88,7 +88,12 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
 
       expect {
         expect { ln.start }.to hop("verify")
-      }.to change { vm_host.assigned_subnets_dataset.count }.from(0).to(4)
+      }.to change { vm_host.assigned_subnets_dataset.count }.from(0).to(3)
+
+      # The gatewayed /112 is host connectivity: in the netplan, not the registry.
+      expect(vm_host.assigned_subnets.map { it.cidr.to_s }.sort).to eq(
+        ["216.22.15.64/26", "216.22.50.197/32", "2607:f5b7:3:104::/64"],
+      )
 
       expect(ln.expected_addresses).to eq("ens3f0np0" => expected_addresses)
       expect(ln.expected_gateways).to eq expected_gateways
@@ -104,7 +109,7 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
 
       expect {
         expect { ln.start }.to hop("verify")
-      }.not_to change { vm_host.assigned_subnets_dataset.count }.from(4)
+      }.not_to change { vm_host.assigned_subnets_dataset.count }.from(3)
     end
 
     it "sends the netplan the generator produced" do


### PR DESCRIPTION
A gatewayed leaseweb IPv6 prefix (the /112 the host takes ::2 from) exists
so the host can reach its router. Hosts and VMs strictly never share a
prefix, but create_addresses recorded it as an Address row, presenting
host connectivity space as allocatable in assigned_subnets. Nothing
allocates from those rows today -- VM IPv6 comes from net6, which
LearnNetwork pins to the routed /64 -- but the registry lied about the
prefix's role.

IpInfo now answers host_connectivity? and create_addresses skips such
records entirely. The netplan is unchanged: it builds from the same
snapshot, so the host still claims ::2 and routes via the prefix's
gateway. The first commit carries a data migration deleting the rows the
already-deployed code created in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)