### PR TITLE
Resolve kubernetes pages when their resources are destroyed

### DIFF
--- a/prog/kubernetes/etcd_backup_nexus.rb
+++ b/prog/kubernetes/etcd_backup_nexus.rb
@@ -87,6 +87,8 @@ class Prog::Kubernetes::EtcdBackupNexus < Prog::Base
       admin_client.admin_policy_remove(kubernetes_etcd_backup.ubid)
     end
 
+    Page.from_tag_parts("MissingEtcdBackup", kubernetes_etcd_backup.id)&.incr_resolve
+
     kubernetes_etcd_backup.destroy
     pop "kubernetes etcd backup is deleted"
   end

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -418,9 +418,14 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     reap do
       decr_destroy
 
+      Page.from_tag_parts("K8sExternalConnectivityFailed", kubernetes_cluster.ubid)&.incr_resolve
+
       kubernetes_cluster.kubernetes_etcd_backup&.incr_destroy
 
-      kubernetes_cluster.nodes.each(&:incr_destroy)
+      kubernetes_cluster.nodes.each do |node|
+        Page.from_tag_parts("K8sInvalidVersion", kubernetes_cluster.ubid, node.name)&.incr_resolve
+        node.incr_destroy
+      end
       kubernetes_cluster.nodepools.each(&:incr_destroy)
 
       nap 5 unless kubernetes_cluster.nodepools.empty? &&

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -96,7 +96,10 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
     reap do
       decr_destroy
 
-      kubernetes_nodepool.nodes.each(&:incr_destroy)
+      kubernetes_nodepool.nodes.each do |node|
+        Page.from_tag_parts("K8sInvalidVersion", kubernetes_nodepool.cluster.ubid, node.name)&.incr_resolve
+        node.incr_destroy
+      end
       nap 5 unless kubernetes_nodepool.nodes.empty?
       kubernetes_nodepool.destroy
       pop "kubernetes nodepool is deleted"

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -38,7 +38,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
 
   def before_run
     if kubernetes_cluster.strand.label == "destroy" && strand.label != "destroy"
-      pop "provisioning canceled"
+      hop_destroy
     end
   end
 
@@ -281,5 +281,16 @@ CONFIG
     kubernetes_cluster.incr_sync_worker_mesh
     kubernetes_cluster.incr_update_billing_records
     pop({node_id: node.id})
+  end
+
+  label def destroy
+    if node_id
+      node_ubid = UBID.to_ubid(node_id)
+      %w[KubernetesNodeInitClusterFailed KubernetesNodeJoinControlPlaneFailed KubernetesNodeJoinWorkerFailed].each do
+        Page.from_tag_parts(it, node_ubid)&.incr_resolve
+      end
+    end
+
+    pop "provisioning canceled"
   end
 end

--- a/spec/prog/kubernetes/etcd_backup_nexus_spec.rb
+++ b/spec/prog/kubernetes/etcd_backup_nexus_spec.rb
@@ -244,5 +244,14 @@ RSpec.describe Prog::Kubernetes::EtcdBackupNexus do
         expect { nx.destroy }.to exit({"msg" => "kubernetes etcd backup is deleted"})
       end
     end
+
+    it "resolves the missing backup page" do
+      MinioCluster[name: "minio-cluster"].destroy
+      Prog::PageNexus.assemble("existing", ["MissingEtcdBackup", kubernetes_etcd_backup.id], kubernetes_etcd_backup.ubid)
+
+      expect { nx.destroy }.to exit({"msg" => "kubernetes etcd backup is deleted"})
+
+      expect(Page.from_tag_parts("MissingEtcdBackup", kubernetes_etcd_backup.id).resolve_set?).to be true
+    end
   end
 end

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -1113,5 +1113,17 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
       expect { nx.destroy }.to exit({"msg" => "kubernetes cluster is deleted"})
     end
+
+    it "resolves the cluster and node version pages" do
+      st.update(label: "destroy")
+      node = kubernetes_cluster.nodes.first
+      Prog::PageNexus.assemble("existing", ["K8sExternalConnectivityFailed", kubernetes_cluster.ubid], kubernetes_cluster.ubid)
+      Prog::PageNexus.assemble("existing", ["K8sInvalidVersion", kubernetes_cluster.ubid, node.name], node.ubid)
+
+      expect { nx.destroy }.to nap(5)
+
+      expect(Page.from_tag_parts("K8sExternalConnectivityFailed", kubernetes_cluster.ubid).resolve_set?).to be true
+      expect(Page.from_tag_parts("K8sInvalidVersion", kubernetes_cluster.ubid, node.name).resolve_set?).to be true
+    end
   end
 end

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -270,5 +270,15 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       expect(kn).to receive(:destroy)
       expect { nx.destroy }.to exit({"msg" => "kubernetes nodepool is deleted"})
     end
+
+    it "resolves the node version pages" do
+      kn.strand.update(label: "destroy")
+      node = kn.nodes.first
+      Prog::PageNexus.assemble("existing", ["K8sInvalidVersion", kc.ubid, node.name], node.ubid)
+
+      expect { nx.destroy }.to nap(5)
+
+      expect(Page.from_tag_parts("K8sInvalidVersion", kc.ubid, node.name).resolve_set?).to be true
+    end
   end
 end

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       prog.before_run # Nothing happens
 
       prog.kubernetes_cluster.strand.label = "destroy"
-      expect { prog.before_run }.to exit({"msg" => "provisioning canceled"})
+      expect { prog.before_run }.to hop("destroy")
 
       prog.strand.label = "destroy"
       prog.before_run # Nothing happens
@@ -487,6 +487,29 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(kubernetes_cluster.reload.sync_internal_dns_config_set?).to be true
       expect(kubernetes_cluster.reload.sync_worker_mesh_set?).to be true
       expect(kubernetes_cluster.reload.update_billing_records_set?).to be true
+    end
+  end
+
+  describe "#destroy" do
+    it "resolves the node provisioning pages and exits" do
+      %w[KubernetesNodeInitClusterFailed KubernetesNodeJoinControlPlaneFailed KubernetesNodeJoinWorkerFailed].each do
+        Prog::PageNexus.assemble("existing", [it, node.ubid], node.ubid)
+      end
+
+      expect { prog.destroy }.to exit({"msg" => "provisioning canceled"})
+
+      %w[KubernetesNodeInitClusterFailed KubernetesNodeJoinControlPlaneFailed KubernetesNodeJoinWorkerFailed].each do
+        expect(Page.from_tag_parts(it, node.ubid).resolve_set?).to be true
+      end
+    end
+
+    it "exits when no node provisioning page is open" do
+      expect { prog.destroy }.to exit({"msg" => "provisioning canceled"})
+    end
+
+    it "exits when the node was never created" do
+      refresh_frame(prog, new_values: {"node_id" => nil})
+      expect { prog.destroy }.to exit({"msg" => "provisioning canceled"})
     end
   end
 end


### PR DESCRIPTION
Kubernetes pages were only resolved by the recovery path that created them: a successful daemonizer check, a healthy connectivity report, or a fresh etcd backup. Deleting the resource left the page active forever, with its subject row gone. K8sInvalidVersion had no resolve path at all, since the node it fires on is skipped by the upgrade selector and never replaced.

Resolve each page in the destroy label of the prog that creates it. ProvisionKubernetesNode gains a destroy label for the three node provisioning pages, and derives the node ubid from the frame rather than the row, which KubernetesNodeNexus may have already deleted.