### PR TITLE
Sample down high-frequency, low-value log lines

### DIFF
--- a/bin/respirate
+++ b/bin/respirate
@@ -71,7 +71,6 @@ d.handle_disconnects("unexpected respirate scan thread error") do
       # but that is an accept tradeoff, because we do not want to busy loop the
       # database (potentially, LISTEN/NOTIFY could be used to reduce this latency)
       sleep sleep_duration_sec
-      Clog.emit("respirate finished sleep", {sleep_duration_sec:})
     end
   end
 end

--- a/lib/metrics_target_resource.rb
+++ b/lib/metrics_target_resource.rb
@@ -9,6 +9,7 @@ class MetricsTargetResource
     @session = nil
     @last_export_success = false
     @export_started_at = Time.now
+    @export_success_streak = 0
     @deleted = false
     @tsdb_client = VictoriaMetricsResource.client_for_project(resource.metrics_config[:project_id])
   end
@@ -29,9 +30,13 @@ class MetricsTargetResource
     @export_started_at = Time.now
     begin
       count = @resource.export_metrics(session: @session, tsdb_client: @tsdb_client)
-      Clog.emit("Metrics export has finished.", {metrics_export_success: {ubid: @resource.ubid, count:}})
+      @export_success_streak += 1
+      if @export_success_streak % 20 == 1
+        Clog.emit("Metrics export has finished.", {metrics_export_success: {ubid: @resource.ubid, count:, streak: @export_success_streak}})
+      end
       @last_export_success = true
     rescue => ex
+      @export_success_streak = 0
       @last_export_success = false
       close_resource_session
       Clog.emit("Metrics export has failed.", {metrics_export_failure: Util.exception_to_hash(ex, into: {ubid: @resource.ubid})})

--- a/lib/monitorable_resource.rb
+++ b/lib/monitorable_resource.rb
@@ -76,7 +76,7 @@ class MonitorableResource
     begin
       @pulse = @resource.check_pulse(session: @session, previous_pulse: @pulse)
       @session[:last_pulse] = Time.now
-      Clog.emit("Got new pulse.", {got_pulse: {ubid: @resource.ubid, pulse: @pulse}}) if (rpt = @pulse[:reading_rpt]) && (rpt < 6 || rpt % 5 == 1) || @pulse[:reading] != "up"
+      Clog.emit("Got new pulse.", {got_pulse: {ubid: @resource.ubid, pulse: @pulse}}) if (rpt = @pulse[:reading_rpt]) && (rpt < 6 || rpt % 20 == 1) || @pulse[:reading] != "up"
     rescue => ex
       if !stale_retry &&
           (

--- a/spec/lib/metrics_target_resource_spec.rb
+++ b/spec/lib/metrics_target_resource_spec.rb
@@ -146,6 +146,14 @@ RSpec.describe MetricsTargetResource do
       expect { resource.export_metrics }.to change { resource.instance_variable_get(:@last_export_success) }.from(false).to(true)
     end
 
+    it "only logs a sampled subset of consecutive successful exports" do
+      resource.instance_variable_set(:@session, "session")
+      expect(postgres_server).to receive(:export_metrics).with(session: "session", tsdb_client: "tsdb_client").twice
+      expect(Clog).to receive(:emit).with("Metrics export has finished.", instance_of(Hash)).once.and_call_original
+      resource.export_metrics
+      resource.export_metrics
+    end
+
     it "swallows exceptions and logs them" do
       expect(postgres_server).to receive(:export_metrics).and_raise(StandardError.new("Export failed"))
       expect(Clog).to receive(:emit).and_call_original

--- a/spec/lib/monitorable_resource_spec.rb
+++ b/spec/lib/monitorable_resource_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe MonitorableResource do
       expect { r_w_event_loop.check_pulse }.not_to raise_error
     end
 
-    it "does not log the pulse if reading is up and reading_rpt is not every 5th and reading_rpt is large enough" do
+    it "does not log the pulse if reading is up and reading_rpt is not every 20th and reading_rpt is large enough" do
       expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 13})
       expect(Clog).not_to receive(:emit).and_call_original
       r_w_event_loop.check_pulse
@@ -287,8 +287,8 @@ RSpec.describe MonitorableResource do
       r_w_event_loop.check_pulse
     end
 
-    it "logs the pulse if reading is up and reading_rpt is every 5th reading" do
-      expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 6})
+    it "logs the pulse if reading is up and reading_rpt is every 20th reading" do
+      expect(postgres_server).to receive(:check_pulse).and_return({reading: "up", reading_rpt: 21})
       expect(Clog).to receive(:emit).and_call_original
       r_w_event_loop.check_pulse
     end

--- a/spec/monitor_smoke_test.rb
+++ b/spec/monitor_smoke_test.rb
@@ -105,7 +105,7 @@ lines.each_value(&:uniq!).each_value { it.sort_by!(&:inspect) }
   expected_lines = Array.new(lines[r].size - 1) do
     {"got_pulse" => {"ubid" => r, "pulse" => {"reading" => reading, "reading_rpt" => it + 1}}, "message" => "Got new pulse."}
   end
-  expected_lines << {"metrics_export_success" => {"ubid" => r, "count" => count}, "message" => "Metrics export has finished."}
+  expected_lines << {"metrics_export_success" => {"ubid" => r, "count" => count, "streak" => 1}, "message" => "Metrics export has finished."}
   unless lines[r] == expected_lines
     warn "unexpected lines for #{r}: #{lines[r]}"
     exit 1


### PR DESCRIPTION
- **Remove the "respirate finished sleep" log**
 This log is too noisy for the value it provides.

- **Sample metrics export logs to 1-in-20 on success**
  Logging every successful export is pretty noisy. Track a per-resource
  success streak and only log every 20th, resetting to 0 on failure so
  the next success afterward logs again at streak 1. The streak is
  included in the payload so a sampled line still shows how long the
  run has been healthy.
  

- **Widen pulse steady-state sampling from 1-in-5 to 1-in-20**
  Once a reading has been stable for a while, logging occurrences
  is mostly repetition. Any change in reading is still logged immediately
  regardless of sampling.
  