### PR TITLE
Search VmHost by server identifier and host in admin

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -635,8 +635,15 @@ class CloverAdmin < Roda
     "KubernetesCluster" => [:name],
     "PostgresResource" => [:name],
     "Vm" => [:name],
+    "VmHost" => [Sequel[:sshable][:host], Sequel[:host_provider][:server_identifier]],
   }.freeze
   SEARCH_QUERIES.each_value(&:freeze)
+  SEARCH_DATASETS = {
+    "VmHost" => VmHost.dataset
+      .left_join(:sshable, id: :id)
+      .left_join(:host_provider, id: :id)
+      .select_all(:vm_host),
+  }.freeze
   SEARCH_PREFIXES = SEARCH_QUERIES.map { "#{Object.const_get(it[0]).ubid_type} (#{it[0]})" }.join(", ").freeze
 
   OBJECTS_WITH_UI = {
@@ -1685,7 +1692,8 @@ class CloverAdmin < Roda
         next view("search")
       end
       patterns = terms.map { "%#{klass.dataset.escape_like(it)}%" }
-      @search_results = klass.grep(columns, patterns, case_insensitive: true).limit(11).all
+      ds = SEARCH_DATASETS[klass.name] || klass.dataset
+      @search_results = ds.grep(columns, patterns, case_insensitive: true).limit(11).all
       if @search_results.length > 10
         @truncated = @search_results.pop
       end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -106,6 +106,28 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - Vm #{vm.ubid}"
   end
 
+  it "searches by vm host sshable host with prefix and redirects for single result" do
+    vm_host = create_vm_host
+    vm_host.sshable.update(host: "unique-host-search.example.com")
+
+    fill_in "UBID, UUID, or prefix:term", with: "vh:unique-host-search"
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vm_host.ubid}"
+  end
+
+  it "searches by vm host provider server identifier with prefix and redirects for single result" do
+    vm_host = create_vm_host
+    HostProvider.create do
+      it.id = vm_host.id
+      it.server_identifier = "unique-server-id-123"
+      it.provider_name = HostProvider::HETZNER_PROVIDER_NAME
+    end
+
+    fill_in "UBID, UUID, or prefix:term", with: "vh:unique-server-id-123"
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vm_host.ubid}"
+  end
+
   it "searches by postgres resource name with prefix and redirects for single result" do
     project = Project.create(name: "Default")
     expect(Config).to receive(:postgres_service_project_id).and_return(project.id).at_least(:once)


### PR DESCRIPTION
The admin search bar could not find VmHosts, since their searchable values live in associated tables rather than on vm_host itself. Add a vh: prefix that matches against host_provider.server_identifier and sshable.host, so operators can locate a host by the identifier used by the hosting provider or by its IP/hostname.

SEARCH_QUERIES only supported columns on the model's own table, so add a SEARCH_DATASETS override that joins the associated tables. Other search prefixes keep using the plain model dataset.