### PR TITLE
Show host provider info in admin VmHost pages

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1023,13 +1023,14 @@ class CloverAdmin < Roda
     model VmHost do
       order Sequel[:vm_host][:id]
       eager [:location]
-      eager_graph [:sshable]
+      eager_graph [:sshable, :provider]
       columns do |type_symbol, request|
-        cs = [:sshable_host, :allocation_state, :arch, :location, :data_center, :family, :total_cores, :total_hugepages_1g]
+        cs = [:sshable_host, :allocation_state, :arch, :location, :data_center, :provider_name, :family, :total_cores, :total_hugepages_1g]
         cs.prepend(:ubid) unless type_symbol == :search_form
         cs
       end
       column_options sshable_host: {label: "Sshable", type: :text, value: ""},
+        provider_name: {label: "Provider", type: :text, value: ""},
         allocation_state: {type: "select", options: ["accepting", "draining", "unprepared"], add_blank: true},
         arch: {type: "select", options: ["x64", "arm64"], add_blank: true},
         family: {type: "select", options: Option::VmFamilies.map(&:name), add_blank: true},
@@ -1037,8 +1038,11 @@ class CloverAdmin < Roda
         total_hugepages_1g: {type: "number"}
 
       column_search_filter do |ds, column, value|
-        if column == :sshable_host
+        case column
+        when :sshable_host
           column_grep.call(ds, Sequel[:sshable][:host], value)
+        when :provider_name
+          column_grep.call(ds, Sequel[:provider][:provider_name], value)
         end
       end
     end
@@ -1512,11 +1516,13 @@ class CloverAdmin < Roda
       @archs = %w[x64 arm64].freeze
       @core_counts = VmHost.exclude(total_cores: nil).distinct.select_order_map(:total_cores)
       @states = %w[unprepared accepting draining].freeze
+      @providers = HostProvider.distinct.select_order_map(:provider_name)
 
       @location_id = typecast_params.ubid("location_id")
       @arch = typecast_params.nonempty_str("arch")
       @cores = typecast_params.pos_int("cores")
       @state = typecast_params.nonempty_str("state")
+      @provider = typecast_params.nonempty_str("provider")
 
       unless r.query_string.empty?
         storage_agg = DB[:storage_device]
@@ -1552,11 +1558,13 @@ class CloverAdmin < Roda
           .left_join(boot_agg.as(:bi), vm_host_id:)
           .left_join(ip4_agg.as(:ip), routed_to_host_id: vmh[:id])
           .left_join(vm_agg.as(:vm), vm_host_id:)
+          .left_join(Sequel[:host_provider].as(:hp), id: vmh[:id])
           .select(
             vmh[:id],
             Sequel[:location][:name].as(:location),
             vmh[:allocation_state],
             vmh[:data_center],
+            Sequel[:hp][:provider_name],
             vmh[:family],
             Sequel.function(:coalesce, Sequel[:vm][:vm_count], 0).as(:vm_count),
             vmh[:used_cores],
@@ -1575,6 +1583,7 @@ class CloverAdmin < Roda
         ds = ds.where(vmh[:arch] => @arch) if @arch
         ds = ds.where(vmh[:total_cores] => @cores) if @cores
         ds = ds.where(vmh[:allocation_state] => @state) if @state
+        ds = ds.where(Sequel[:hp][:provider_name] => @provider) if @provider
 
         @data = ds.map do |row|
           used_storage = row[:total_storage] - row[:available_storage]
@@ -1584,6 +1593,7 @@ class CloverAdmin < Roda
             location: row[:location],
             state: row[:allocation_state],
             datacenter: row[:data_center],
+            provider: row[:provider_name],
             family: row[:family],
             vms: row[:vm_count],
             cores: "#{row[:used_cores]} / #{row[:total_cores]}",

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -308,14 +308,20 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - Location #{Location::HETZNER_FSN1_UBID}"
 
     vmh = Prog::Vm::HostNexus.assemble("1.1.0.0", location_id: Location::HETZNER_FSN1_ID, family: "standard").subject
+    HostProvider.create do
+      it.id = vmh.id
+      it.server_identifier = "123"
+      it.provider_name = HostProvider::HETZNER_PROVIDER_NAME
+    end
     click_link "Ubicloud Admin"
     click_link "VmHost"
     click_link "Search"
 
     select "standard", from: "Family"
+    fill_in "Provider", with: "hetz"
     fill_in "Sshable", with: "1.0"
     click_button "Search"
-    expect(page.all("#autoforme_content td").map(&:text)).to eq [vmh.ubid, "1.1.0.0", "unprepared", "", "hetzner-fsn1", "", "standard", "", "0"]
+    expect(page.all("#autoforme_content td").map(&:text)).to eq [vmh.ubid, "1.1.0.0", "unprepared", "", "hetzner-fsn1", "", "hetzner", "standard", "", "0"]
 
     vm = Prog::Vm::Nexus.assemble("k y", project.id, unix_user: "ubi", name: "vm1", location_id: Location::HETZNER_FSN1_ID, boot_image: "github-ubuntu-2204", size: "standard-2", arch: "x64").subject
     click_link "Ubicloud Admin"
@@ -3085,6 +3091,11 @@ RSpec.describe CloverAdmin do
 
   it "shows VM Host Usage filtered by location" do
     vm_host = create_vm_host(data_center: "FSN1-DC1", total_cores: 48, used_cores: 4, total_hugepages_1g: 375, used_hugepages_1g: 32)
+    HostProvider.create do
+      it.id = vm_host.id
+      it.server_identifier = "123"
+      it.provider_name = HostProvider::HETZNER_PROVIDER_NAME
+    end
     StorageDevice.create(name: "nvme0", total_storage_gib: 1000, available_storage_gib: 600, vm_host_id: vm_host.id)
     StorageDevice.create(name: "nvme1", total_storage_gib: 500, available_storage_gib: 100, vm_host_id: vm_host.id)
     BootImage.create(name: "ubuntu-jammy", version: "1", vm_host_id: vm_host.id, size_gib: 14)
@@ -3104,20 +3115,25 @@ RSpec.describe CloverAdmin do
 
     click_button "Search"
     headers = page.all(".vm-host-usage-table thead th").map(&:text)
-    expect(headers).to include("location")
+    expect(headers).to include("location", "provider")
     expect(page.all(".vm-host-usage-table tbody tr").size).to eq 2
 
     select "hetzner-fsn1", from: "Location"
     click_button "Search"
     row = page.all(".vm-host-usage-table tbody tr").map { it.all("td").map(&:text) }
     expect(row.size).to eq 1
-    expect(row.first).to include(vm_host.ubid, "accepting", "FSN1-DC1", "standard", "2", "4 / 48", "32 / 375", "800 / 1500", "0 / 0", "2")
+    expect(row.first).to include(vm_host.ubid, "accepting", "FSN1-DC1", "hetzner", "standard", "2", "4 / 48", "32 / 375", "800 / 1500", "0 / 0", "2")
   end
 
-  it "filters VM Host Usage by arch, total_cores and state, composing filters" do
+  it "filters VM Host Usage by arch, total_cores, state and provider, composing filters" do
     x64_48 = create_vm_host(arch: "x64", total_cores: 48, allocation_state: "accepting")
     x64_96 = create_vm_host(arch: "x64", total_cores: 96, allocation_state: "draining")
     arm_48 = create_vm_host(arch: "arm64", total_cores: 48, allocation_state: "accepting")
+    HostProvider.create do
+      it.id = x64_96.id
+      it.server_identifier = "123"
+      it.provider_name = HostProvider::LEASEWEB_PROVIDER_NAME
+    end
     ubids = lambda { page.all(".vm-host-usage-table tbody tr").map { it.all("td").map(&:text).first } }
 
     click_link "VM Host Usage"
@@ -3132,6 +3148,11 @@ RSpec.describe CloverAdmin do
 
     visit "/vm-host-usage"
     select "draining", from: "State"
+    click_button "Search"
+    expect(ubids.call).to eq([x64_96.ubid])
+
+    visit "/vm-host-usage"
+    select "leaseweb", from: "Provider"
     click_button "Search"
     expect(ubids.call).to eq([x64_96.ubid])
 
@@ -3329,6 +3350,21 @@ RSpec.describe CloverAdmin do
 
     expect(page).to have_no_content("internal-service")
     expect(page).to have_no_content("vm-in-another-host")
+  end
+
+  it "shows host provider details on VmHost page" do
+    vm_host = create_vm_host
+
+    visit "/model/VmHost/#{vm_host.ubid}"
+    expect(page).to have_no_content("Host Provider")
+
+    HostProvider.create do
+      it.id = vm_host.id
+      it.server_identifier = "123"
+      it.provider_name = HostProvider::HETZNER_PROVIDER_NAME
+    end
+    page.refresh
+    expect(page).to have_css("h2", text: "Host Provider: hetzner (server identifier: 123)")
   end
 
   it "renders the customer summary when customers have equal resource totals" do

--- a/views/admin/extras/VmHost.erb
+++ b/views/admin/extras/VmHost.erb
@@ -1,5 +1,12 @@
 <%# locals: (obj:) %>
 
+<% if provider = obj.provider %>
+  <h2>Host Provider:
+    <%= provider.provider_name %>
+    (server identifier:
+    <%= provider.server_identifier %>)</h2>
+<% end %>
+
 <% rows = customer_vm_dataset
   .where(Sequel[:cvm][:vm_host_id] => obj.id)
   .left_join(Sequel[:project].as(:proj), id: Sequel[:cvm][:project_id])

--- a/views/admin/vm_host_usage.erb
+++ b/views/admin/vm_host_usage.erb
@@ -5,6 +5,7 @@
   <%== f.input(:select, key: "arch", label: "Arch", options: @archs, add_blank: "all", value: @arch) %>
   <%== f.input(:select, key: "cores", label: "Cores", options: @core_counts, add_blank: "all", value: @cores) %>
   <%== f.input(:select, key: "state", label: "State", options: @states, add_blank: "all", value: @state) %>
+  <%== f.input(:select, key: "provider", label: "Provider", options: @providers, add_blank: "all", value: @provider) %>
   <%== f.button("Search") %>
 <% end %>
 


### PR DESCRIPTION
Admins currently have no way to see which provider a host belongs
to without querying the database, since host_provider has no admin
page of its own.

Show the provider name and server identifier as a section header on
the VmHost detail page, and add a provider column to the VmHost
autoforme table and to the VM host usage table.

Both tables also gain a provider filter. The autoforme filter is a
text input that greps the provider association joined via
eager_graph, like the sshable host filter, so a single search such
as leaseweb covers both leaseweb and leaseweb-eu hosts. The usage
page select is populated from the distinct provider names actually
present in host_provider, like the cores filter.
