### PR TITLE
Exec collect-pg-metrics via interpreter, not the script path

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -359,13 +359,13 @@ After=postgresql.service
 [Service]
 Type=oneshot
 User=ubi_monitoring
-# group ubi: traverse /home/ubi (0750) to exec the script; ambient
-# capabilities are not in the effective set at execve time.
-SupplementaryGroups=ubi
-# read the postgres-owned pg_wal/archive_status directory without sudo
+# Exec ruby via env, not the script directly: /home/ubi/postgres/bin is 0700
+# and CAP_DAC_READ_SEARCH is not effective at execve time. ruby then opens the
+# script and the postgres-owned pg_wal/archive_status directory under the
+# capability, which is effective at runtime.
 AmbientCapabilities=CAP_DAC_READ_SEARCH
 NoNewPrivileges=true
-ExecStart=/home/ubi/postgres/bin/collect-pg-metrics #{postgres_server.version}
+ExecStart=/usr/bin/env ruby /home/ubi/postgres/bin/collect-pg-metrics #{postgres_server.version}
 StandardOutput=journal
 StandardError=journal
 SERVICE

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -712,7 +712,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("sudo chown ubi_monitoring:ubi_monitoring /var/lib/node_exporter")
       expect(sshable).to receive(:_cmd).with(
         "sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null",
-        stdin: /User=ubi_monitoring.*SupplementaryGroups=ubi.*AmbientCapabilities=CAP_DAC_READ_SEARCH/m,
+        stdin: %r{User=ubi_monitoring.*AmbientCapabilities=CAP_DAC_READ_SEARCH.*ExecStart=/usr/bin/env ruby}m,
       )
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")


### PR DESCRIPTION
The pg-collect-metrics unit runs as ubi_monitoring and failed at execve with 203/EXEC EACCES. The script lives under /home/ubi/postgres/bin, which the base image creates 0700 ubi:ubi. ubi_monitoring cannot search into it, and CAP_DAC_READ_SEARCH is not in the effective set at execve time, so neither the capability nor SupplementaryGroups=ubi (which only reaches /home/ubi at 0750) lets the exec through.

Exec /usr/bin/env ruby instead of the script directly. The execve target is now a system binary needing no /home traversal; ruby then opens the script and the postgres-owned archive_status directory under the capability, which is effective at runtime. SupplementaryGroups=ubi is no longer needed.