### PR TITLE
Add admin action to provision spare runners per host

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -585,6 +585,11 @@ class CloverAdmin < Roda
         require_vm_host_provider.call(obj)
         "Power status: #{Erubi.h(obj.power_status)}"
       end,
+      "provision_spare_runners" => object_action("Provision Spare Runners", flash: "Spare runners provisioned for GitHub runners on this host", type: :form) do |obj|
+        DB.ignore_duplicate_queries do
+          GithubRunner.where(vm_id: obj.vms_dataset.select(:id)).eager(:semaphores, :installation).all(&:provision_spare_runner)
+        end
+      end,
       "move_location" => object_action("Move to Location", flash: "Location updated and missing boot image downloads started", params: {
         location: {
           typecast: :ubid_uuid!,

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1397,6 +1397,26 @@ RSpec.describe CloverAdmin do
     expect(page).to have_content("Power status: shut off")
   end
 
+  it "supports provisioning spare GitHubRunners for all runners on a VmHost" do
+    vmh = create_vm_host
+    ins = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User")
+    create_vm(vm_host_id: vmh.id, name: "customer-vm")
+    2.times do |i|
+      runner_vm = create_vm(vm_host_id: vmh.id, name: "runner-vm-#{i}")
+      GithubRunner.create(repository_name: "test-repo-#{i}", label: "ubicloud", installation_id: ins.id, vm_id: runner_vm.id)
+    end
+
+    fill_in "UBID, UUID, or prefix:term", with: vmh.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+
+    click_button "Provision Spare Runners"
+    expect(page).to have_flash_notice("Spare runners provisioned for GitHub runners on this host")
+    expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+    expect(GithubRunner.where(vm_id: nil).select_order_map([:repository_name, :label]))
+      .to eq [["test-repo-0", "ubicloud"], ["test-repo-1", "ubicloud"]]
+  end
+
   it "supports moving VmHost to a non-github location and downloading boot images" do
     vmh = Prog::Vm::HostNexus.assemble("127.0.0.2").subject
     target_location = Location[Location::HETZNER_HEL1_ID]


### PR DESCRIPTION
When a host misbehaves, its GitHub runner VMs are often unusable, and the queued jobs they were meant to serve stall until a replacement runner is provisioned. Recovering meant opening each runner's admin page and clicking "Provision Spare Runner" one at a time, or running the equivalent loop from a console.

Add a "Provision Spare Runners" button to the VmHost page that calls provision_spare_runner on every GithubRunner whose VM is on the host. Runners already carrying the spare_runner_provisioned semaphore are skipped by provision_spare_runner itself, so the button is safe to press more than once.

The runners are found through GithubRunner.vm_id rather than by matching VM names against the "gr" ubid prefix, since vm_id is the actual foreign key and carries a unique constraint. Semaphores and installations are eager loaded because provision_spare_runner reads both, and the per-runner queries would otherwise be an N+1.