### PR TITLE
Make web process SSH disabling reload-safe

### DIFF
--- a/lib/net_ssh.rb
+++ b/lib/net_ssh.rb
@@ -62,8 +62,10 @@ module NetSsh
       end
 
       if WEB_SSH_DISABLED
-        ::Net::SSH.send(:remove_const, :Connection)
-        ::Net::SSH.singleton_class.send(:undef_method, :start)
+        if ::Net::SSH.const_defined?(:Connection, false)
+          ::Net::SSH.send(:remove_const, :Connection)
+          ::Net::SSH.singleton_class.send(:undef_method, :start)
+        end
       # simplecov:enable
       else
         ::Net::SSH::Connection::Session.prepend self


### PR DESCRIPTION
Removing Net::SSH::Connection modifies the net-ssh gem itself, which Unreloader does not undo when it reloads lib/net_ssh.rb. Switching branches in development changes the file's mtime, so the reload re-ran remove_const on an already removed constant and every request failed with "constant Net::SSH::Connection not defined". Skip the removal if a previous load already applied it.