### PR TITLE
Add log: :on_error mode for Sshable#cmd and use it to quiet noisy SSH command logs

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -145,8 +145,9 @@ class Sshable < Sequel::Model
 
     stdout_str = stdout.string.freeze
     stderr_str = stderr.string.freeze
+    success = exit_code&.zero?
 
-    if log
+    if log == true || (log == :on_error && !success)
       finish = Time.now
       embed = {ubid:, start:, finish:, timeout:, duration: finish - start,
                cmd:, exit_code:, exit_signal:}
@@ -166,7 +167,7 @@ class Sshable < Sequel::Model
       Clog.emit("ssh cmd execution", {ssh: embed})
     end
 
-    fail (exit_code ? SshError : SshTimeout).new(cmd, stdout_str, stderr_str, exit_code, exit_signal) unless exit_code&.zero?
+    fail (exit_code ? SshError : SshTimeout).new(cmd, stdout_str, stderr_str, exit_code, exit_signal) unless success
 
     stdout_str
   end

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -494,7 +494,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
 
     begin
       # Remove comments and empty lines before sending them to the machine
-      vm.sshable.cmd("bash", stdin: NetSsh.combine(*command, joiner: "").gsub(/^(\s*# .*)?\n/, ""))
+      vm.sshable.cmd("bash", stdin: NetSsh.combine(*command, joiner: "").gsub(/^(\s*# .*)?\n/, ""), log: :on_error)
     rescue Net::SSH::AuthenticationFailed
       Clog.emit("ssh authentication failed", {failed_runner_authentication: github_runner})
       nap 1
@@ -511,7 +511,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       client.post(runners_path("generate-jitconfig"), data)
     end
     github_runner.update(runner_id: response[:runner][:id], ready_at: Time.now)
-    vm.sshable.cmd(<<~COMMAND, stdin: response[:encoded_jit_config])
+    vm.sshable.cmd(<<~COMMAND, stdin: response[:encoded_jit_config], log: :on_error)
     sudo -u runner tee /home/runner/actions-runner/.jit_token > /dev/null
     sudo systemctl start runner-script.service
     COMMAND
@@ -598,7 +598,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     if (job = github_runner.workflow_job).nil? || job.fetch("conclusion") != "success"
       if vm_host
         serial_log_path = "/vm/#{vm.inhost_name}/serial.log"
-        vm.vm_host.sshable.cmd("sudo ln :serial_log_path /var/log/ubicloud/serials/:ubid\\_serial.log", serial_log_path:, ubid: github_runner.ubid)
+        vm.vm_host.sshable.cmd("sudo ln :serial_log_path /var/log/ubicloud/serials/:ubid\\_serial.log", serial_log_path:, ubid: github_runner.ubid, log: :on_error)
       end
       # We grep only the lines related to 'run-withenv' and 'systemd'. Other
       # logs include outputs from subprocesses like php, sudo, etc., which

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -146,7 +146,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       sudo usermod -a -G kvm :vm_name
     COMMAND
 
-    host.sshable.cmd(command, vm_name:, vm_home:, uid:)
+    host.sshable.cmd(command, vm_name:, vm_home:, uid:, log: :on_error)
 
     hop_create_billing_record
   end
@@ -164,20 +164,20 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       write_params_json
 
       d_command = NetSsh.command("sudo host/bin/setup-vm prep :vm_name", vm_name:)
-      host.sshable.cmd("common/bin/daemonizer :d_command prep_:vm_name", d_command:, vm_name:, stdin: secrets_json)
+      host.sshable.cmd("common/bin/daemonizer :d_command prep_:vm_name", d_command:, vm_name:, stdin: secrets_json, log: :on_error)
     end
 
     nap 1
   end
 
   label def clean_prep
-    host.sshable.cmd("common/bin/daemonizer --clean prep_:vm_name", vm_name:)
+    host.sshable.cmd("common/bin/daemonizer --clean prep_:vm_name", vm_name:, log: :on_error)
     hop_wait_sshable
   end
 
   def write_params_json
     host.sshable.cmd("sudo -u :vm_name tee :params_path > /dev/null", vm_name:, params_path:,
-      stdin: vm.params_json(**frame.slice("swap_size_bytes", "hugepages", "hypervisor", "ch_version", "firmware_version").transform_keys!(&:to_sym)))
+      stdin: vm.params_json(**frame.slice("swap_size_bytes", "hugepages", "hypervisor", "ch_version", "firmware_version").transform_keys!(&:to_sym)), log: :on_error)
   end
 
   label def wait_sshable
@@ -529,13 +529,13 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       end
 
       begin
-        host.sshable.cmd("sudo systemctl stop :vm_name", vm_name:, timeout: 10)
+        host.sshable.cmd("sudo systemctl stop :vm_name", vm_name:, timeout: 10, log: :on_error)
       rescue Sshable::SshError => ex
         raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.stderr)
       end
 
       begin
-        host.sshable.cmd("sudo systemctl stop :vm_name-dnsmasq", vm_name:)
+        host.sshable.cmd("sudo systemctl stop :vm_name-dnsmasq", vm_name:, log: :on_error)
       rescue Sshable::SshError => ex
         raise unless /Failed to stop .* Unit .* not loaded\./.match?(ex.stderr)
       end
@@ -543,7 +543,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       # If there is a load balancer setup, we want to keep the network setup in
       # tact for a while
       action = vm.load_balancer ? "delete_keep_net" : "delete"
-      host.sshable.cmd("sudo host/bin/setup-vm :action :vm_name", action:, vm_name:)
+      host.sshable.cmd("sudo host/bin/setup-vm :action :vm_name", action:, vm_name:, log: :on_error)
     end
 
     vm.vm_storage_volumes.each do |vol|

--- a/prog/vm/vm_host_slice_nexus.rb
+++ b/prog/vm/vm_host_slice_nexus.rb
@@ -32,11 +32,11 @@ class Prog::Vm::VmHostSliceNexus < Prog::Base
     name = vm_host_slice.name
     case host.sshable.cmd("common/bin/daemonizer --check prep_:name", name:)
     when "Succeeded"
-      host.sshable.cmd("common/bin/daemonizer --clean prep_:name", name:)
+      host.sshable.cmd("common/bin/daemonizer --clean prep_:name", name:, log: :on_error)
       hop_wait
     when "NotStarted", "Failed"
       d_command = NetSsh.command("sudo host/bin/setup-slice prep :inhost_name :allowed_cpus_cgroup", inhost_name:, allowed_cpus_cgroup: vm_host_slice.allowed_cpus_cgroup)
-      host.sshable.cmd("common/bin/daemonizer :d_command prep_:name", name:, d_command:)
+      host.sshable.cmd("common/bin/daemonizer :d_command prep_:name", name:, d_command:, log: :on_error)
     end
 
     nap 1
@@ -78,7 +78,7 @@ class Prog::Vm::VmHostSliceNexus < Prog::Base
   label def destroy
     decr_destroy
 
-    host.sshable.cmd("sudo host/bin/setup-slice delete :inhost_name", inhost_name:)
+    host.sshable.cmd("sudo host/bin/setup-slice delete :inhost_name", inhost_name:, log: :on_error)
 
     VmHost.dataset.where(id: host.id).update(
       used_cores: Sequel[:used_cores] - vm_host_slice.cores,

--- a/prog/vnet/metal/update_firewall_rules.rb
+++ b/prog/vnet/metal/update_firewall_rules.rb
@@ -46,7 +46,7 @@ meta mark 0x00B1C100D ip6 saddr . tcp dport @allowed_ipv6_lb_dest_set ct state e
       ""
     end
 
-    vm.vm_host.sshable.cmd("sudo ip netns exec :inhost_name nft --file -", inhost_name: vm.inhost_name, stdin: <<TEMPLATE)
+    vm.vm_host.sshable.cmd("sudo ip netns exec :inhost_name nft --file -", inhost_name: vm.inhost_name, stdin: <<TEMPLATE, log: :on_error)
 # An nftables idiom for idempotent re-create of a named entity: merge
 # in an empty table (a no-op if the table already exists) and then
 # delete, before creating with a new definition.

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -243,6 +243,18 @@ LOCK
       expect { sa.cmd("exit 1", timeout: nil, _skip_command_checking: true) }.to raise_error Sshable::SshError, "command exited with an error: exit 1"
     end
 
+    it "does not log a successful command when log: :on_error" do
+      expect(Clog).not_to receive(:emit).with("ssh cmd execution", anything)
+      simulate(cmd: "echo hello", exit_status: 0, exit_signal: nil, stdout: "hello", stderr: "world")
+      expect(sa.cmd("echo hello", log: :on_error, timeout: nil, _skip_command_checking: true)).to eq("hello")
+    end
+
+    it "logs a failing command when log: :on_error" do
+      expect(Clog).to receive(:emit).with("ssh cmd execution", instance_of(Hash))
+      simulate(cmd: "exit 1", exit_status: 1, exit_signal: 127, stderr: "", stdout: "")
+      expect { sa.cmd("exit 1", log: :on_error, timeout: nil, _skip_command_checking: true) }.to raise_error Sshable::SshError
+    end
+
     it "raises an SshError with a nil exit status" do
       simulate(cmd: "exit 1", exit_status: nil, exit_signal: nil, stderr: "", stdout: "")
       expect { sa.cmd("exit 1", timeout: nil, _skip_command_checking: true) }.to raise_error Sshable::SshTimeout, "command timed out: exit 1"

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -606,7 +606,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     it "hops to register_runner" do
       expect(vm).to receive(:runtime_token).and_return("my_token")
       installation.update(use_docker_mirror: false, cache_enabled: false)
-      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND)
+      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND, log: :on_error)
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
@@ -622,7 +622,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(vm).to receive(:runtime_token).and_return("my_token")
       installation.update(use_docker_mirror: false, cache_enabled: true)
       expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"), is_management: false)]).at_least(:once)
-      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND)
+      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND, log: :on_error)
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
@@ -639,7 +639,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(vm).to receive(:runtime_token).and_return("my_token")
       installation.update(use_docker_mirror: false, cache_enabled: false)
       project.set_ff_cache_proxy_download_url({"x64" => "https://example.com/cache-proxy-x64.tar.gz", "arm64" => "https://example.com/cache-proxy-arm64.tar.gz"})
-      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND)
+      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND, log: :on_error)
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
@@ -659,7 +659,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(vm).to receive(:runtime_token).and_return("my_token")
       installation.update(use_docker_mirror: false, cache_enabled: false)
       project.set_ff_cache_proxy_download_url({"arm64" => "https://example.com/cache-proxy-arm64.tar.gz"})
-      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND)
+      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND, log: :on_error)
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
@@ -675,7 +675,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(vm).to receive(:runtime_token).and_return("my_token")
       installation.update(use_docker_mirror: false, cache_enabled: false)
       vm.vm_host.update(location_id: Location::LEASEWEB_WDC02_ID)
-      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND)
+      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND, log: :on_error)
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
@@ -696,7 +696,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(vm).to receive(:runtime_token).and_return("my_token")
       installation.update(use_docker_mirror: false, cache_enabled: false)
       vm.update(vm_host_id: nil)
-      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND)
+      expect(vm.sshable).to receive(:_cmd).with("bash", stdin: <<~COMMAND, log: :on_error)
         set -ueo pipefail
         echo "image version: $ImageVersion"
         sudo usermod -a -G sudo,adm runneradmin
@@ -721,7 +721,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
   describe "#register_runner" do
     it "registers runner hops" do
       expect(client).to receive(:post).with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label])).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC$"})
-      expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, stdin: "AABBCC$")
+      expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, stdin: "AABBCC$", log: :on_error)
         sudo -u runner tee /home/runner/actions-runner/.jit_token > /dev/null
         sudo systemctl start runner-script.service
       COMMAND
@@ -774,7 +774,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
     it "fails without a log if the ssh error doesn't match" do
       expect(client).to receive(:post).with(/.*generate-jitconfig/, hash_including(name: runner.ubid.to_s, labels: [runner.label])).and_return({runner: {id: 123}, encoded_jit_config: "AABBCC$"})
-      expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, stdin: "AABBCC$").and_raise Sshable::SshError.new("command", "", "unknown command", 123, nil)
+      expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, stdin: "AABBCC$", log: :on_error).and_raise Sshable::SshError.new("command", "", "unknown command", 123, nil)
         sudo -u runner tee /home/runner/actions-runner/.jit_token > /dev/null
         sudo systemctl start runner-script.service
       COMMAND
@@ -1052,7 +1052,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
     it "Logs journalctl, docker limits, and cache proxy log if workflow_job is not successful" do
       runner.update(workflow_job: {"conclusion" => "failure"})
-      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo ln /vm/#{vm.inhost_name}/serial.log /var/log/ubicloud/serials/#{runner.ubid}\\_serial.log")
+      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo ln /vm/#{vm.inhost_name}/serial.log /var/log/ubicloud/serials/#{runner.ubid}\\_serial.log", log: :on_error)
       expect(vm.sshable).to receive(:_cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
       expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, log: false)
         TOKEN=$(curl -m 10 -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
@@ -1066,7 +1066,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
     it "Logs journalctl, docker limits, and cache proxy log if workflow_job is nil" do
       runner.update(workflow_job: nil)
-      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo ln /vm/#{vm.inhost_name}/serial.log /var/log/ubicloud/serials/#{runner.ubid}\\_serial.log")
+      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo ln /vm/#{vm.inhost_name}/serial.log /var/log/ubicloud/serials/#{runner.ubid}\\_serial.log", log: :on_error)
       expect(vm.sshable).to receive(:_cmd).with("journalctl -u runner-script -t 'run-withenv.sh' -t 'systemd' --no-pager | grep -Fv Started")
       expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, log: false)
         TOKEN=$(curl -m 10 -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
   describe "#create_unix_user" do
     it "runs adduser" do
       expect(nx).to receive(:rand).and_return(1111)
-      expect(sshable).to receive(:_cmd).with(<<~COMMAND)
+      expect(sshable).to receive(:_cmd).with(<<~COMMAND, log: :on_error)
         set -ueo pipefail
         if id #{nx.vm_name} &>/dev/null; then
           procs=$(ps -u #{nx.vm_name} -o pid,comm,args --no-headers) || [ $? -eq 1 ]
@@ -441,7 +441,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
         project.set_ff_ipv6_disabled(true)
 
         expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("NotStarted")
-        expect(sshable).to receive(:_cmd).with(/sudo -u vm[0-9a-z]+ tee/, stdin: String) do |**kwargs|
+        expect(sshable).to receive(:_cmd).with(/sudo -u vm[0-9a-z]+ tee/, stdin: String, log: :on_error) do |**kwargs|
           require "json"
           params = JSON(kwargs.fetch(:stdin))
           expect(params).to include(
@@ -462,7 +462,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
             **frame_update,
           )
         end
-        expect(sshable).to receive(:_cmd).with("common/bin/daemonizer sudo\\ host/bin/setup-vm\\ prep\\ vm4hjdwr prep_vm4hjdwr", {stdin: /{"storage":{"vm.*_0":{"key":"key","init_vector":"iv","algorithm":"aes-256-gcm","auth_data":"somedata"}}}/})
+        expect(sshable).to receive(:_cmd).with("common/bin/daemonizer sudo\\ host/bin/setup-vm\\ prep\\ vm4hjdwr prep_vm4hjdwr", {stdin: /{"storage":{"vm.*_0":{"key":"key","init_vector":"iv","algorithm":"aes-256-gcm","auth_data":"somedata"}}}/, log: :on_error})
 
         expect { nx.prep }.to nap(1)
       end
@@ -476,7 +476,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
 
   describe "#clean_prep" do
     it "cleans and hops" do
-      expect(sshable).to receive(:_cmd).with(/common\/bin\/daemonizer --clean prep_/)
+      expect(sshable).to receive(:_cmd).with(/common\/bin\/daemonizer --clean prep_/, log: :on_error)
       expect { nx.clean_prep }.to hop("wait_sshable")
     end
   end
@@ -1359,35 +1359,35 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     end
 
     it "absorbs an already deleted errors as a success" do
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10).and_raise(
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10, log: :on_error).and_raise(
         Sshable::SshError.new("stop", "", "Failed to stop #{nx.vm_name} Unit .* not loaded.", 1, nil),
       )
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq").and_raise(
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq", log: :on_error).and_raise(
         Sshable::SshError.new("stop", "", "Failed to stop #{nx.vm_name} Unit .* not loaded.", 1, nil),
       )
-      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}")
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}", log: :on_error)
 
       expect { nx.destroy }.to hop("destroy_slice")
     end
 
     it "raises unexpected vm stop errors" do
       ex = Sshable::SshError.new("stop", "", "unknown error", 1, nil)
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10).and_raise(ex)
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10, log: :on_error).and_raise(ex)
 
       expect { nx.destroy }.to raise_error ex
     end
 
     it "raises unexpected dnsmasq stop errors" do
       ex = Sshable::SshError.new("stop", "", "unknown error", 1, nil)
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10)
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq").and_raise(ex)
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10, log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq", log: :on_error).and_raise(ex)
       expect { nx.destroy }.to raise_error ex
     end
 
     it "hops when all commands are succeeded" do
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10)
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq")
-      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10, log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq", log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}", log: :on_error)
 
       expect { nx.destroy }.to hop("destroy_slice")
       expect(vm.display_state).to eq("deleting")
@@ -1400,9 +1400,9 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       dev = StorageDevice.create(name: "DEFAULT", total_storage_gib: 1000, available_storage_gib: 500)
       VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 20, disk_index: 0, use_bdev_ubi: false, storage_device_id: dev.id)
 
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10)
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq")
-      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10, log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq", log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}", log: :on_error)
 
       expect { nx.destroy }.to hop("destroy_slice")
         .and change { dev.reload.available_storage_gib }.from(500).to(520)
@@ -1410,17 +1410,17 @@ RSpec.describe Prog::Vm::Metal::Nexus do
 
     it "hops to remove_vm_from_load_balancer if vm is part of a load balancer" do
       expect(vm).to receive(:load_balancer).and_return(instance_double(LoadBalancer)).at_least(:once)
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10)
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq")
-      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete_keep_net #{nx.vm_name}")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10, log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq", log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete_keep_net #{nx.vm_name}", log: :on_error)
 
       expect { nx.destroy }.to hop("remove_vm_from_load_balancer")
     end
 
     it "detaches from pci devices" do
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10)
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq")
-      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10, log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq", log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}", log: :on_error)
 
       pci = PciDevice.create(vm_id: vm.id, vm_host_id: vm_host.id, slot: "01:00.0", device_class: "dc", vendor: "vd", device: "dv", numa_node: 0, iommu_group: 3)
       expect(pci.vm).to eq(vm)
@@ -1430,9 +1430,9 @@ RSpec.describe Prog::Vm::Metal::Nexus do
 
     it "detaches from gpu partition" do
       expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete_gpu_partition #{nx.vm_name}")
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10)
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq")
-      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10, log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq", log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}", log: :on_error)
 
       pci = PciDevice.create(vm_host_id: vm_host.id, slot: "01:00.0", device_class: "dc", vendor: "vd", device: "dv", numa_node: 0, iommu_group: 3)
       gp = GpuPartition.create(vm_id: vm.id, vm_host_id: vm_host.id, partition_id: 1, gpu_count: 1)
@@ -1443,9 +1443,9 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     end
 
     it "updates slice" do
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10)
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq")
-      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10, log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq", log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}", log: :on_error)
 
       slice = VmHostSlice.create(vm_host_id: vm_host.id, name: "standard", family: "standard", cores: 1, total_cpu_percent: 200, used_cpu_percent: 200, total_memory_gib: 8, used_memory_gib: 8)
       vm.update(vm_host_slice_id: slice.id)
@@ -1455,9 +1455,9 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     end
 
     it "fails if VM cores is 0" do
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10)
-      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq")
-      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}", timeout: 10, log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{nx.vm_name}-dnsmasq", log: :on_error)
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm delete #{nx.vm_name}", log: :on_error)
 
       vm.cores = 0
 

--- a/spec/prog/vm/vm_host_slice_nexus_spec.rb
+++ b/spec/prog/vm/vm_host_slice_nexus_spec.rb
@@ -83,21 +83,21 @@ RSpec.describe Prog::Vm::VmHostSliceNexus do
   describe "#prep" do
     it "starts prep on NotStarted" do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check prep_standard").and_return("NotStarted")
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer sudo\\ host/bin/setup-slice\\ prep\\ standard.slice\\ 2-3 prep_standard")
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer sudo\\ host/bin/setup-slice\\ prep\\ standard.slice\\ 2-3 prep_standard", log: :on_error)
 
       expect { nx.prep }.to nap(1)
     end
 
     it "starts prep on Failed" do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check prep_standard").and_return("Failed")
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer sudo\\ host/bin/setup-slice\\ prep\\ standard.slice\\ 2-3 prep_standard")
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer sudo\\ host/bin/setup-slice\\ prep\\ standard.slice\\ 2-3 prep_standard", log: :on_error)
 
       expect { nx.prep }.to nap(1)
     end
 
     it "hops to wait" do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check prep_standard").and_return("Succeeded")
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --clean prep_standard")
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --clean prep_standard", log: :on_error)
 
       expect { nx.prep }.to hop("wait")
     end
@@ -136,7 +136,7 @@ RSpec.describe Prog::Vm::VmHostSliceNexus do
 
   describe "#destroy" do
     it "deletes resources and exits" do
-      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-slice delete standard.slice")
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-slice delete standard.slice", log: :on_error)
       expect { nx.destroy }.to exit({"msg" => "vm_host_slice destroyed"})
       expect(vm_host_slice.exists?).to be false
     end

--- a/spec/prog/vnet/metal/update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/metal/update_firewall_rules_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Prog::Vnet::Metal::UpdateFirewallRules do
       GloballyBlockedDnsname.create(dns_name: "blockedhost.com", ip_list: ["123.123.123.123", "2a00:1450:400e:811::200e"])
       create_firewall_rules
 
-      expect(sshable).to receive(:_cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<ADD_RULES)
+      expect(sshable).to receive(:_cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<ADD_RULES, log: :on_error)
 # An nftables idiom for idempotent re-create of a named entity: merge
 # in an empty table (a no-op if the table already exists) and then
 # delete, before creating with a new definition.
@@ -271,7 +271,7 @@ ADD_RULES
       LoadBalancerVm.create(load_balancer_id: lb.id, vm_id: vm.id)
       LoadBalancerVm.create(load_balancer_id: lb.id, vm_id: vm2.id)
 
-      expect(sshable).to receive(:_cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<ADD_RULES)
+      expect(sshable).to receive(:_cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<ADD_RULES, log: :on_error)
 # An nftables idiom for idempotent re-create of a named entity: merge
 # in an empty table (a no-op if the table already exists) and then
 # delete, before creating with a new definition.
@@ -429,7 +429,7 @@ ADD_RULES
       LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 443, dst_port: 8443)
       LoadBalancerVm.create(load_balancer_id: lb.id, vm_id: vm.id)
 
-      expect(sshable).to receive(:_cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<ADD_RULES)
+      expect(sshable).to receive(:_cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<ADD_RULES, log: :on_error)
 # An nftables idiom for idempotent re-create of a named entity: merge
 # in an empty table (a no-op if the table already exists) and then
 # delete, before creating with a new definition.
@@ -580,7 +580,7 @@ ADD_RULES
 
       project.set_ff_ipv6_disabled(true)
 
-      expect(sshable).to receive(:_cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<ADD_RULES)
+      expect(sshable).to receive(:_cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<ADD_RULES, log: :on_error)
 # An nftables idiom for idempotent re-create of a named entity: merge
 # in an empty table (a no-op if the table already exists) and then
 # delete, before creating with a new definition.
@@ -723,7 +723,7 @@ ADD_RULES
         {cidr: "::/0", port_range: Sequel.pg_range(53..53), protocol: "udp"},
       ])
 
-      expect(sshable).to receive(:_cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<ADD_RULES)
+      expect(sshable).to receive(:_cmd).with("sudo ip netns exec #{vm.inhost_name} nft --file -", stdin: <<ADD_RULES, log: :on_error)
 # An nftables idiom for idempotent re-create of a named entity: merge
 # in an empty table (a no-op if the table already exists) and then
 # delete, before creating with a new definition.


### PR DESCRIPTION
- **Add Sshable#cmd log: :on_error mode to skip logging on success**
  Every ssh cmd execution is logged by default, which is noisy for
  call sites that only care about failures. log: :on_error keeps
  log: true and log: false behaving as before, but only emits the
  "ssh cmd execution" Clog entry when the command exits non-zero or
  times out.
  

- **Skip logging successful VM host slice prep/destroy commands**
  The daemonizer prep actions and the setup-slice delete call only need
  a log line when they fail, so log: :on_error suppresses the
  "ssh cmd execution" Clog entry on success while still logging
  failures. The --check call is left logging as before since its output
  (Running/Succeeded/NotStarted/Failed) is useful on its own.
  

- **Skip logging successful VM provisioning/deprovisioning ssh commands**
  The unix user setup, daemonizer prep/clean, params-file write, and the
  stop/delete commands in destroy only need a log line when they fail,
  so log: :on_error suppresses the "ssh cmd execution" Clog entry on
  success. Status-reads like the prep check and other non-hot-path
  actions (restart, reinstall-systemd-units, recreate-unpersisted) are
  left logging as before.
  

- **Skip logging successful GitHub runner setup and teardown commands**
  The bootstrap script in setup_environment, the JIT-token write plus
  service start in register_runner, and the serial.log symlink in
  collect_final_telemetry all run for every runner, so log: :on_error
  suppresses the "ssh cmd execution" Clog entry when they succeed while
  still logging failures.
  

- **Skip logging successful firewall rule updates**
  Applying the nftables ruleset runs on every firewall change, so
  log: :on_error suppresses the "ssh cmd execution" Clog entry when it
  succeeds while still logging failures.
  