### PR TITLE
Add Setup VM Host page to admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -674,6 +674,8 @@ class CloverAdmin < Roda
     metal
   ].freeze
 
+  SETUP_VM_HOST_PROVIDERS = [HostProvider::HETZNER_PROVIDER_NAME, *HostProvider::LEASEWEB_PROVIDER_NAMES].freeze
+
   plugin :autoforme do
     # simplecov:disable
     register_by_name if Config.development?
@@ -1423,6 +1425,35 @@ class CloverAdmin < Roda
       end
 
       strand_semaphore_action(strand_ds, LOCAL_E2E_PROGS + ["LocalE2eLoop"])
+    end
+
+    r.is "setup-vm-host" do
+      r.get do
+        @unprepared_hosts = VmHost.where(allocation_state: "unprepared")
+          .reverse(:created_at, :id)
+          .eager(:sshable, :provider, :strand, :assigned_subnets, :storage_devices)
+          .all
+        view("setup_vm_host")
+      end
+
+      r.post do
+        host, family, provider_name, server_identifier, vhost_block_backend_version =
+          typecast_params.nonempty_str!(%w[host family provider_name server_identifier vhost_block_backend_version].freeze)
+        location_id = typecast_params.ubid_uuid!("location_id")
+        default_boot_images = typecast_params.array(:nonempty_str, "default_boot_images") || []
+        install_os = typecast_params.bool("install_os") || false
+
+        begin
+          NetAddr.parse_ip(host)
+        rescue NetAddr::ValidationError
+          fail CloverError.new(400, "InvalidRequest", "invalid IP address")
+        end
+
+        st = Prog::Vm::HostNexus.assemble(host, location_id:, family:, provider_name:,
+          server_identifier:, vhost_block_backend_version:, default_boot_images:, install_os:)
+        flash["notice"] = "VM host setup started: #{st.ubid} (#{provider_name} #{server_identifier})"
+        r.redirect
+      end
     end
 
     r.get "admin-list" do

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -116,14 +116,20 @@ input[type=submit] {
 }
 /* Checkbox and radio rows: control inline with its label */
 .rollout-form > div:has(> input[type=checkbox]),
-.rollout-form .rollout-radioset {
+.rollout-form .rollout-radioset,
+.rollout-form .rollout-checkboxset {
   display: flex;
   align-items: center;
   gap: 6px;
 }
-.rollout-form .rollout-radioset {
+.rollout-form .rollout-radioset,
+.rollout-form .rollout-checkboxset {
   gap: 4px 12px;
   flex-wrap: wrap;
+}
+.rollout-form .rollout-checkboxset > span.label {
+  flex-basis: 100%;
+  font-weight: 600;
 }
 .rollout-form input[type=submit] {
   margin-top: 16px;

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2341,6 +2341,106 @@ RSpec.describe CloverAdmin do
     end
   end
 
+  describe "setup-vm-host" do
+    before do
+      click_link "Setup VM Host"
+    end
+
+    def stub_hetzner_api(host, server_identifier)
+      Excon.stub({path: "/ip", method: :get}, {status: 200, body: JSON.dump([{"ip" => {"ip" => host, "server_ip" => host}}])})
+      Excon.stub({path: "/subnet", method: :get}, {status: 200, body: JSON.dump([])})
+      Excon.stub({path: "/failover", method: :get}, {status: 200, body: JSON.dump([])})
+      Excon.stub({path: "/server/#{server_identifier}", method: :get}, {status: 200, body: JSON.generate(server: {dc: "fsn1-dc14"})})
+      Excon.stub({path: "/server/#{server_identifier}", method: :post}, {status: 200, body: "{}"})
+    end
+
+    it "shows unprepared hosts" do
+      expect(page.title).to eq "Ubicloud Admin - Setup VM Host"
+      expect(page).to have_content("No data available for Unprepared VM Hosts")
+
+      location_options = find_by_id("location_id").all("option").map(&:text)
+      expect(location_options).to include("hetzner-fsn1", "leaseweb-wdc02")
+      expect(location_options).not_to include("us-east-1")
+      expect(find_by_id("provider_name").all("option").map(&:text)).to eq ["", "hetzner", "leaseweb", "leaseweb-eu"]
+
+      create_vm_host
+      st = Prog::Vm::HostNexus.assemble("127.0.0.1")
+      vmh = VmHost[st.id]
+      vmh.update(total_cores: 48, total_hugepages_1g: 316)
+      StorageDevice.create(name: "nvme0", total_storage_gib: 100, available_storage_gib: 50, vm_host_id: vmh.id)
+
+      page.refresh
+      expect(page.all(".unprepared-vm-hosts-table td").map(&:text)).to eq [
+        vmh.ubid, "127.0.0.1", "", "", "start", "127.0.0.1/32", "100", "316", "48",
+      ]
+      click_link vmh.ubid
+      expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
+    end
+
+    it "allows setting up a vm host" do
+      stub_hetzner_api("1.2.3.4", "12345")
+
+      fill_in "IP Address", with: "1.2.3.4"
+      select "hetzner-fsn1", from: "Location"
+      select "hetzner", from: "Provider"
+      fill_in "Server ID", with: "12345"
+      check "ubuntu-jammy"
+      check "github-ubuntu-2404"
+      check "Install OS"
+      click_button "Setup VM Host"
+
+      st = Strand.first(prog: "Vm::HostNexus")
+      vmh = VmHost[st.id]
+      expect(page).to have_flash_notice("VM host setup started: #{st.ubid} (hetzner 12345)")
+      expect(vmh.sshable.host).to eq "1.2.3.4"
+      expect(vmh.location_id).to eq Location::HETZNER_FSN1_ID
+      expect(vmh.family).to eq "standard"
+      expect(vmh.provider_name).to eq "hetzner"
+      expect(vmh.provider.server_identifier).to eq "12345"
+      expect(vmh.data_center).to eq "fsn1-dc14"
+
+      frame = st.stack.first
+      expect(frame["vhost_block_backend_version"]).to eq Config.vhost_block_backend_version
+      expect(frame["default_boot_images"]).to contain_exactly("ubuntu-jammy", "github-ubuntu-2404")
+      expect(frame["install_os"]).to be true
+
+      expect(page.all(".unprepared-vm-hosts-table td").map(&:text)).to eq [
+        vmh.ubid, "1.2.3.4", "hetzner", "12345", "start", "1.2.3.4/32", "", "0", "",
+      ]
+    end
+
+    it "allows setting up a vm host without boot images or OS install" do
+      stub_hetzner_api("1.2.3.5", "54321")
+
+      fill_in "IP Address", with: "1.2.3.5"
+      select "hetzner-fsn1", from: "Location"
+      select "premium", from: "Family"
+      select "hetzner", from: "Provider"
+      fill_in "Server ID", with: "54321"
+      fill_in "Vhost Block Backend Version", with: "v0.2.2"
+      click_button "Setup VM Host"
+
+      st = Strand.first(prog: "Vm::HostNexus")
+      expect(page).to have_flash_notice("VM host setup started: #{st.ubid} (hetzner 54321)")
+      expect(VmHost[st.id].family).to eq "premium"
+
+      frame = st.stack.first
+      expect(frame["vhost_block_backend_version"]).to eq "v0.2.2"
+      expect(frame["default_boot_images"]).to eq []
+      expect(frame["install_os"]).to be false
+    end
+
+    it "raises error for an unparseable IP address" do
+      fill_in "IP Address", with: "not-an-ip"
+      select "hetzner-fsn1", from: "Location"
+      select "hetzner", from: "Provider"
+      fill_in "Server ID", with: "12345"
+
+      expect { click_button "Setup VM Host" }.to raise_error(CloverError, "invalid IP address")
+      expect(VmHost.count).to eq 0
+    end
+  end
+
   it "shows admin list" do
     click_link "View Admin List"
     expect(page.title).to eq "Ubicloud Admin - Admin List"

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -51,6 +51,7 @@
     <li><a href="/vm-by-ipv4">Find VM by IPv4 Address</a></li>
     <li><a href="/github-runner-usage">GitHub Runner VM Usage</a></li>
     <li><a href="/vm-host-usage">VM Host Usage</a></li>
+    <li><a href="/setup-vm-host">Setup VM Host</a></li>
     <li><a href="/customer-usage">Customer Usage</a></li>
     <li>
       <a href="/audit-log">View Audit Logs</a> |

--- a/views/admin/setup_vm_host.erb
+++ b/views/admin/setup_vm_host.erb
@@ -1,0 +1,38 @@
+<% @page_title = "Setup VM Host" %>
+
+<% data = @unprepared_hosts.map do |vmh|
+  {
+    "UBID" => vmh.ubid,
+    "IP" => vmh.sshable.host,
+    "Provider" => vmh.provider_name,
+    "Server ID" => vmh.provider&.server_identifier,
+    "Label" => vmh.strand.label,
+    "Subnets" => vmh.assigned_subnets.map { it.cidr.to_s }.join(", "),
+    "Disks" => vmh.storage_devices.map(&:total_storage_gib).join(", "),
+    "Hugepage" => vmh.total_hugepages_1g,
+    "Cores" => vmh.total_cores,
+  }
+end %>
+
+<%== part("components/table", title: "Unprepared VM Hosts", table_class: "unprepared-vm-hosts-table", data:) %>
+
+<h2>Setup VM Host</h2>
+
+<div class="rollout-forms">
+  <section class="rollout-card">
+    <h3>New VM Host</h3>
+    <p class="rollout-desc">Create host records and start a HostNexus strand to prepare the server.</p>
+    <% form({method: "post", id: "setup-vm-host", class: "rollout-form"}, button: "Setup VM Host", wrapper: :div) do |f| %>
+      <%== f.input(:text, key: :host, label: "IP Address", required: true) %>
+      <%== f.input(:select, key: :location_id, label: "Location", required: true, add_blank: true, options: Location.exclude(provider: %w[aws gcp]).order(:name).select_map([:name, :id]).each { it[1] = UBID.to_ubid(it[1]) }) %>
+      <%== f.input(:select, key: :family, label: "Family", required: true, options: %w[standard premium], value: "standard") %>
+      <%== f.input(:select, key: :provider_name, label: "Provider", required: true, add_blank: true, options: SETUP_VM_HOST_PROVIDERS) %>
+      <%== f.input(:text, key: :server_identifier, label: "Server ID", required: true) %>
+      <%== f.input(:checkboxset, key: :default_boot_images, label: "Default Boot Images", options: Prog::DownloadBootImage::BOOT_IMAGE_SHA256.keys, wrapper_attr: {class: "rollout-checkboxset"}) %>
+      <%== f.input(:text, key: :vhost_block_backend_version, label: "Vhost Block Backend Version", required: true, value: Config.vhost_block_backend_version) %>
+      <%== f.input(:checkbox, key: :install_os, label: "Install OS") %>
+      <p class="rollout-desc"><strong>Warning:</strong>
+        If Install OS is selected, all disks on the server will be wiped.</p>
+    <% end %>
+  </section>
+</div>


### PR DESCRIPTION
Setting up a new VM host required calling Prog::Vm::HostNexus.assemble from a console. Add an admin page with a form for the host IP, metal location, family, provider (hetzner, leaseweb, leaseweb-eu), server identifier, vhost block backend version, default boot images, and an install OS option that warns about wiping all disks on the server.

Below the form, list unprepared hosts newest first with their provider details, strand label, subnets, disk sizes, hugepages, and cores, so operators can track hosts still being prepared.

<img width="2752" height="2212" alt="CleanShot 2026-08-05 at 21 31 42@2x" src="https://github.com/user-attachments/assets/23968e21-eea9-42d2-8e72-1a4dc4aeba57" />
