### PR TITLE
Use MachineImages in kubernetes e2e tests

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -13,6 +13,11 @@ def main(options)
 end
 
 def test_metal(options, test_cases)
+  run_kubernetes_tests = options[:test_cases].any? { it.start_with?("kubernetes") }
+  if run_kubernetes_tests && !Config.machine_images_service_project_id
+    fail "kubernetes test cases build their node images as machine images, set MACHINE_IMAGES_SERVICE_PROJECT_ID"
+  end
+
   base_machine_image_names = if Config.machine_images_service_project_id
     %w[ubuntu-noble ubuntu-resolute].freeze
   else
@@ -45,7 +50,7 @@ def test_metal(options, test_cases)
     wait_until(minio_cluster_st, "wait")
   end
 
-  if options[:test_cases].include?("kubernetes") || options[:test_cases].include?("kubernetes_upgrade") || options[:test_cases].include?("kubernetes_firewall")
+  if run_kubernetes_tests
     Project[Config.kubernetes_service_project_id] ||
       Project.create_with_id(Config.kubernetes_service_project_id, name: "Ubicloud-Kubernetes-Resources")
     Project[Config.load_balancer_service_project_id] ||
@@ -65,6 +70,12 @@ def test_metal(options, test_cases)
     # and VmGroup starts re-verifying its VMs, the rest runs in parallel.
     wait_until(encrypted_vms_st, "verify_vms_after_reboot")
     tests_to_wait << encrypted_vms_st
+  end
+
+  if run_kubernetes_tests
+    kubernetes_versions = [Option.selectable_kubernetes_versions[1]]
+    kubernetes_versions << Option.selectable_kubernetes_versions[0] if options[:test_cases].include?("kubernetes_upgrade")
+    kubernetes_node_images_st = Prog::Test::KubernetesNodeImages.assemble(location_id: vm_host.location_id, kubernetes_versions:)
   end
 
   if Config.machine_images_service_project_id && options[:test_cases].include?("machine_image_vm_capture")
@@ -102,9 +113,10 @@ def test_metal(options, test_cases)
   # exercise the assertion against deny-by-default cloud firewalls
   # where it has teeth.
 
-  if k8s_dns_zone_st
+  if run_kubernetes_tests
     wait_until(k8s_dns_zone_st, "wait")
     wait_until(lb_dns_zone_st, "wait")
+    wait_until(kubernetes_node_images_st, "wait")
     tests_to_wait << Prog::Test::Kubernetes.assemble if options[:test_cases].include?("kubernetes")
     tests_to_wait << Prog::Test::KubernetesUpgrade.assemble if options[:test_cases].include?("kubernetes_upgrade")
     tests_to_wait << Prog::Test::KubernetesFirewall.assemble if options[:test_cases].include?("kubernetes_firewall")
@@ -115,22 +127,23 @@ def test_metal(options, test_cases)
   # No need to make it parallel.
   tests_to_wait.each { |st| wait_until(st) }
 
+  Semaphore.incr(base_machine_images_st.id, "destroy_base_machine_images") if base_machine_images_st
+
   if minio_cluster_st
     Semaphore.incr(minio_cluster_st.id, "destroy_and_verify")
     wait_until(minio_cluster_st)
   end
 
-  if k8s_dns_zone_st
+  if run_kubernetes_tests
     Semaphore.incr(k8s_dns_zone_st.id, "destroy_and_verify")
     Semaphore.incr(lb_dns_zone_st.id, "destroy_and_verify")
+    Semaphore.incr(kubernetes_node_images_st.id, "destroy_kubernetes_node_images")
     wait_until(k8s_dns_zone_st)
     wait_until(lb_dns_zone_st)
+    wait_until(kubernetes_node_images_st)
   end
 
-  if base_machine_images_st
-    Semaphore.incr(base_machine_images_st.id, "destroy_base_machine_images")
-    wait_until(base_machine_images_st)
-  end
+  wait_until(base_machine_images_st) if base_machine_images_st
 
   Semaphore.incr(hetzner_server_st.id, "verify_cleanup_and_destroy")
   wait_until(hetzner_server_st)

--- a/bin/e2e
+++ b/bin/e2e
@@ -57,6 +57,10 @@ def test_metal(options, test_cases)
       Project.create_with_id(Config.load_balancer_service_project_id, name: "Load-Balancer-Service-Project")
     k8s_dns_zone_st = Prog::Test::DnsZone.assemble(Config.kubernetes_service_hostname, Config.kubernetes_service_project_id)
     lb_dns_zone_st = Prog::Test::DnsZone.assemble(Config.load_balancer_service_hostname, Config.load_balancer_service_project_id)
+
+    kubernetes_versions = [Option.selectable_kubernetes_versions[1]]
+    kubernetes_versions << Option.selectable_kubernetes_versions[0] if options[:test_cases].include?("kubernetes_upgrade")
+    kubernetes_node_images_st = Prog::Test::KubernetesNodeImages.assemble(location_id: vm_host.location_id, kubernetes_versions:)
   end
 
   tests_to_wait = []
@@ -65,17 +69,15 @@ def test_metal(options, test_cases)
     # burstable VMs. The test will also test host reboot.
     encrypted_vms_st = Prog::Test::VmGroup.assemble(boot_images: test_case["images"], base_machine_image_names:, test_reboot: true)
     log(encrypted_vms_st, "storage_encrypted: true")
+    # The reboot would kill the node image builders, so let it happen only once
+    # the images are captured.
+    wait_until(kubernetes_node_images_st, "wait") if run_kubernetes_tests
+    Semaphore.incr(encrypted_vms_st.id, "allow_reboot")
     # Block only until the in-test host reboot completes; rebooting the shared
     # host while other tests run would disrupt their VMs. Once the host is back
     # and VmGroup starts re-verifying its VMs, the rest runs in parallel.
     wait_until(encrypted_vms_st, "verify_vms_after_reboot")
     tests_to_wait << encrypted_vms_st
-  end
-
-  if run_kubernetes_tests
-    kubernetes_versions = [Option.selectable_kubernetes_versions[1]]
-    kubernetes_versions << Option.selectable_kubernetes_versions[0] if options[:test_cases].include?("kubernetes_upgrade")
-    kubernetes_node_images_st = Prog::Test::KubernetesNodeImages.assemble(location_id: vm_host.location_id, kubernetes_versions:)
   end
 
   if Config.machine_images_service_project_id && options[:test_cases].include?("machine_image_vm_capture")

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -7,7 +7,7 @@
 - { name: postgres_upgrade16,        images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_firewall,         images: ["postgres-ubuntu-2204"] }
 - { name: postgres_unarchive,        images: ["postgres-ubuntu-2204"] }
-- { name: kubernetes,                images: ["ubuntu-noble", "kubernetes-v1_35"] }
-- { name: kubernetes_upgrade,        images: ["ubuntu-noble", "kubernetes-v1_35", "kubernetes-v1_36"] }
-- { name: kubernetes_firewall,       images: ["ubuntu-noble", "kubernetes-v1_35"] }
+- { name: kubernetes,                images: ["ubuntu-noble"] }
+- { name: kubernetes_upgrade,        images: ["ubuntu-noble"] }
+- { name: kubernetes_firewall,       images: ["ubuntu-noble"] }
 - { name: machine_image_vm_capture,  images: ["ubuntu-noble"] }

--- a/prog/kubernetes/build_node_image.rb
+++ b/prog/kubernetes/build_node_image.rb
@@ -56,9 +56,9 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
       hop_sanitize
     when "NotStarted"
       vm.sshable.d_run(BUILD_UNIT, "kubernetes/bin/build-node-image", kubernetes_version)
-      nap 180
+      nap 10
     when "InProgress"
-      nap 180
+      nap 10
     else
       trigger_page("build #{state}")
       hop_failed

--- a/prog/kubernetes/build_node_image.rb
+++ b/prog/kubernetes/build_node_image.rb
@@ -3,12 +3,12 @@
 class Prog::Kubernetes::BuildNodeImage < Prog::Base
   semaphore :destroy
 
-  frame_reader :kubernetes_version, :location_id, :image_version, :machine_image_id, :vm_id
+  frame_reader :kubernetes_version, :location_id, :image_version, :machine_image_id, :vm_id, :skip_verification
   frame_accessor :machine_image_version_id, :verify_cluster_id
 
   BUILD_UNIT = "build_node_image"
 
-  def self.assemble(kubernetes_version:, location_id:, image_version:)
+  def self.assemble(kubernetes_version:, location_id:, image_version:, skip_verification: false)
     fail "invalid kubernetes version: #{kubernetes_version}" unless Option.kubernetes_versions.include?(kubernetes_version)
     fail "invalid location for kubernetes: #{location_id}" if Option.kubernetes_locations.none? { it.id == location_id }
     fail "invalid image version: #{image_version}" unless Validation::ALLOWED_MACHINE_IMAGE_VERSION_LABEL_PATTERN.match?(image_version)
@@ -28,6 +28,7 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
         "image_version" => image_version,
         "machine_image_id" => machine_image.id,
         "vm_id" => vm_id,
+        "skip_verification" => skip_verification,
       }])
     end
   end
@@ -83,7 +84,7 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
   label def wait_capture
     case MachineImageVersionMetal[machine_image_version_id].status
     when "ready"
-      hop_verify
+      skip_verification ? hop_promote : hop_verify
     when "failed"
       trigger_page("capture failed")
       hop_failed
@@ -109,7 +110,7 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
   end
 
   label def promote
-    verify_cluster.incr_destroy
+    verify_cluster&.incr_destroy
     machine_image.update(latest_version_id: machine_image_version_id)
     pop "Kubernetes node image built"
   end

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -4,7 +4,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
   subject_is :kubernetes_cluster
 
   frame_reader :nodepool_id, :machine_image_version_id
-  frame_accessor :node_id
+  frame_accessor :node_id, :no_bundler_install
 
   def node
     @node ||= KubernetesNode[node_id]
@@ -83,6 +83,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     vm = node.vm
 
     self.node_id = node.id
+    self.no_bundler_install = true if vm.vm_storage_volumes_dataset.first(boot: true).machine_image_version_id
 
     unless kubernetes_nodepool
       kubernetes_cluster.api_server_lb.add_vm(vm)
@@ -131,7 +132,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
       vm.sshable.write_file("/home/ubi/.ssh/authorized_keys", all_keys_str, user: :current)
     end
 
-    bud Prog::BootstrapRhizome, {"target_folder" => "kubernetes", "subject_id" => vm.id, "user" => "ubi"}
+    bud Prog::BootstrapRhizome, {"target_folder" => "kubernetes", "subject_id" => vm.id, "user" => "ubi", "no_bundler_install" => no_bundler_install}.compact
 
     hop_wait_bootstrap_rhizome
   end

--- a/prog/test/kubernetes_node_images.rb
+++ b/prog/test/kubernetes_node_images.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class Prog::Test::KubernetesNodeImages < Prog::Test::Base
+  semaphore :destroy_kubernetes_node_images
+  frame_reader :location_id, :kubernetes_versions
+  frame_accessor :build_strand_ids, :machine_image_version_ids
+
+  def self.assemble(location_id:, kubernetes_versions:)
+    Strand.create(
+      prog: "Test::KubernetesNodeImages",
+      label: "build_node_images",
+      stack: [{
+        "location_id" => location_id,
+        "kubernetes_versions" => kubernetes_versions,
+      }],
+    )
+  end
+
+  label def build_node_images
+    self.build_strand_ids = kubernetes_versions.map {
+      Prog::Kubernetes::BuildNodeImage.assemble(kubernetes_version: it, location_id:, image_version: "e2e", skip_verification: true).id
+    }
+    hop_wait_node_images
+  end
+
+  label def wait_node_images
+    build_strand_ids.each do |build_strand_id|
+      # A build that popped leaves no strand behind, so a missing row is success
+      next unless (st = Strand[build_strand_id])
+      fail_test "Kubernetes node image build for #{st.stack.first["kubernetes_version"]} failed" if st.label == "failed"
+      nap 30
+    end
+
+    self.machine_image_version_ids = kubernetes_versions.map { machine_image(it).latest_version_id }
+    hop_wait
+  end
+
+  label def wait
+    when_destroy_kubernetes_node_images_set? do
+      MachineImageVersionMetal.incr_destroy(machine_image_version_ids)
+      hop_wait_destroy
+    end
+
+    nap 60 * 60
+  end
+
+  label def wait_destroy
+    nap 15 unless MachineImageVersionMetal.where(id: machine_image_version_ids).empty?
+    pop "Kubernetes node images destroyed!"
+  end
+
+  label def failed
+    nap 15
+  end
+
+  def machine_image(kubernetes_version)
+    MachineImage.first(
+      project_id: Config.machine_images_service_project_id,
+      location_id:,
+      name: "kubernetes-#{kubernetes_version.tr(".", "_")}",
+    )
+  end
+end

--- a/prog/test/kubernetes_node_images.rb
+++ b/prog/test/kubernetes_node_images.rb
@@ -28,7 +28,7 @@ class Prog::Test::KubernetesNodeImages < Prog::Test::Base
       # A build that popped leaves no strand behind, so a missing row is success
       next unless (st = Strand[build_strand_id])
       fail_test "Kubernetes node image build for #{st.stack.first["kubernetes_version"]} failed" if st.label == "failed"
-      nap 30
+      nap 10
     end
 
     self.machine_image_version_ids = kubernetes_versions.map { machine_image(it).latest_version_id }

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Prog::Test::VmGroup < Prog::Test::Base
+  semaphore :allow_reboot
+
   frame_reader :test_reboot?, :boot_images, :base_machine_image_names, :verify_host_capacity?
   frame_accessor :first_boot, :vms, :subnets, :project_id
 
@@ -117,8 +119,13 @@ class Prog::Test::VmGroup < Prog::Test::Base
   end
 
   label def test_reboot
-    vm_host.incr_reboot
-    hop_wait_reboot
+    when_allow_reboot_set? do
+      decr_allow_reboot
+      vm_host.incr_reboot
+      hop_wait_reboot
+    end
+
+    nap 10
   end
 
   label def wait_reboot

--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -96,7 +96,7 @@ puts r("sudo", "kubeadm", "init", "--config", config_path, "--node-name", node_n
 r("sudo /home/ubi/kubernetes/bin/setup-cni")
 
 api_server_up = false
-12.times do
+20.times do
   r("kubectl --kubeconfig=/etc/kubernetes/admin.conf get --raw='/healthz'")
   api_server_up = true
   break

--- a/spec/prog/kubernetes/build_node_image_spec.rb
+++ b/spec/prog/kubernetes/build_node_image_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
       expect(vm.boot_image).to eq "ubuntu-noble"
       expect(vm.unix_user).to eq "ubi"
       expect(vm.storage_size_gib).to eq 10
+      expect(strand.stack.first["skip_verification"]).to be false
     end
 
     it "reuses the machine image when building another version" do
@@ -256,6 +257,13 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
       expect { prog.wait_capture }.to hop("verify")
     end
 
+    it "hops straight to promote when verification is skipped" do
+      metal = create_machine_image_version_metal
+      refresh_frame(prog, new_values: {"machine_image_version_id" => metal.id, "skip_verification" => true})
+
+      expect { prog.wait_capture }.to hop("promote")
+    end
+
     it "pages and hops to failed when the archive failed" do
       metal = create_machine_image_version_metal
       metal.update(status: "failed")
@@ -315,6 +323,14 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
       expect { prog.promote }.to exit({"msg" => "Kubernetes node image built"})
       expect(MachineImage[strand.stack.first["machine_image_id"]].latest_version_id).to eq metal.id
       expect(cluster.destroy_set?).to be true
+    end
+
+    it "tags the version as latest when verification was skipped" do
+      metal = create_machine_image_version_metal
+      refresh_frame(prog, new_values: {"machine_image_version_id" => metal.id})
+
+      expect { prog.promote }.to exit({"msg" => "Kubernetes node image built"})
+      expect(MachineImage[strand.stack.first["machine_image_id"]].latest_version_id).to eq metal.id
     end
   end
 

--- a/spec/prog/kubernetes/build_node_image_spec.rb
+++ b/spec/prog/kubernetes/build_node_image_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check build_node_image").and_return("NotStarted")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run build_node_image kubernetes/bin/build-node-image v1.35", {log: true, stdin: nil})
 
-      expect { prog.build }.to nap(180)
+      expect { prog.build }.to nap(10)
       expect(prog.strand.stack.first["deadline_target"]).to eq "sanitize"
       expect(Time.new(prog.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 15 * 60)
     end
@@ -122,7 +122,7 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
     it "naps while the build is in progress" do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check build_node_image").and_return("InProgress")
 
-      expect { prog.build }.to nap(180)
+      expect { prog.build }.to nap(10)
     end
 
     it "cleans the unit and hops to sanitize when the build succeeds" do

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -138,6 +138,15 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(new_vm.boot_image).to eq("kubernetes-#{Option.kubernetes_versions[1].tr(".", "_")}")
     end
 
+    it "records that the bundler install can be skipped when the node boots from a machine image" do
+      metal = create_machine_image_version_metal(name: "kubernetes-#{Option.selectable_kubernetes_versions.first.tr(".", "_")}", set_latest_version: true)
+      allow(Config).to receive(:machine_images_service_project_id).and_return(metal.machine_image_version.machine_image.project_id)
+
+      expect { prog.create_node }.to hop("bootstrap_rhizome")
+
+      expect(prog.strand.stack.first["no_bundler_install"]).to be true
+    end
+
     it "fails if the given nodepool does not belong to the cluster" do
       other_cluster = Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "other-cluster", version: Option.selectable_kubernetes_versions.first, cp_node_count: 1, location_id: Location::HETZNER_FSN1_ID, project_id: project.id, target_node_size: "standard-4").subject
       other_nodepool = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "other-np", node_count: 1, kubernetes_cluster_id: other_cluster.id, target_node_size: "standard-2").subject
@@ -216,6 +225,19 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(br_frame["target_folder"]).to eq "kubernetes"
       expect(br_frame["subject_id"]).to eq prog.node.vm.id
       expect(br_frame["user"]).to eq "ubi"
+      expect(br_frame).not_to have_key "no_bundler_install"
+    end
+
+    it "skips the bundler install when the node booted from a machine image" do
+      prog.node.vm.strand.update(label: "wait")
+      refresh_frame(prog, new_values: {"no_bundler_install" => true})
+      sshable = prog.vm.sshable
+      expect(sshable).to receive(:_cmd).with("sudo tee /etc/nftables.conf > /dev/null", stdin: expected_nft_rules).ordered
+      expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now nftables").ordered
+      expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now kubelet").ordered
+
+      expect { prog.bootstrap_rhizome }.to hop("wait_bootstrap_rhizome")
+      expect(Strand.where(prog: "BootstrapRhizome").get(:stack)[0]["no_bundler_install"]).to be true
     end
 
     it "does not grant operator access to control plane nodes when operator keys are not configured" do

--- a/spec/prog/test/kubernetes_node_images_spec.rb
+++ b/spec/prog/test/kubernetes_node_images_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Prog::Test::KubernetesNodeImages do
       build = Strand.create(prog: "Kubernetes::BuildNodeImage", label: "build", stack: [{"kubernetes_version" => kubernetes_versions.first}])
       refresh_frame(prog, new_values: {"build_strand_ids" => [build.id]})
 
-      expect { prog.wait_node_images }.to nap(30)
+      expect { prog.wait_node_images }.to nap(10)
     end
 
     it "fails the test when a build failed" do

--- a/spec/prog/test/kubernetes_node_images_spec.rb
+++ b/spec/prog/test/kubernetes_node_images_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::Test::KubernetesNodeImages do
+  let(:location_id) { Location::HETZNER_FSN1_ID }
+  let(:kubernetes_versions) { Option.selectable_kubernetes_versions }
+  let(:prog) { described_class.new(described_class.assemble(location_id:, kubernetes_versions:)) }
+  let(:image_project) { Project.create(name: "machine-images-service") }
+  let(:metals) { kubernetes_versions.map { create_machine_image_version_metal(name: "kubernetes-#{it.tr(".", "_")}") } }
+
+  describe ".assemble" do
+    it "creates a strand with the versions to build" do
+      strand = described_class.assemble(location_id:, kubernetes_versions:)
+      expect(strand.stack.first.values_at("location_id", "kubernetes_versions")).to eq [location_id, kubernetes_versions]
+    end
+  end
+
+  describe "#build_node_images" do
+    it "starts a build for each version" do
+      kubernetes_project = Project.create(name: "kubernetes-service")
+      MachineImageStore.create(project_id: image_project.id, location_id:, provider: "r2", region: "auto", endpoint: "https://r2.cloudflare.com/", bucket: "test-bucket", access_key: "ak", secret_key: "sk")
+      allow(Config).to receive_messages(kubernetes_service_project_id: kubernetes_project.id, machine_images_service_project_id: image_project.id)
+
+      expect { prog.build_node_images }.to hop("wait_node_images")
+
+      builds = prog.build_strand_ids.map { Strand[it] }
+      expect(builds.map { it.stack.first.values_at("kubernetes_version", "image_version", "skip_verification") })
+        .to eq(kubernetes_versions.map { [it, "e2e", true] })
+    end
+  end
+
+  describe "#wait_node_images" do
+    it "naps while a build is still running" do
+      build = Strand.create(prog: "Kubernetes::BuildNodeImage", label: "build", stack: [{"kubernetes_version" => kubernetes_versions.first}])
+      refresh_frame(prog, new_values: {"build_strand_ids" => [build.id]})
+
+      expect { prog.wait_node_images }.to nap(30)
+    end
+
+    it "fails the test when a build failed" do
+      build = Strand.create(prog: "Kubernetes::BuildNodeImage", label: "failed", stack: [{"kubernetes_version" => kubernetes_versions.first}])
+      refresh_frame(prog, new_values: {"build_strand_ids" => [build.id]})
+
+      expect { prog.wait_node_images }.to hop("failed")
+      expect(prog.strand.exitval).to eq({msg: "Kubernetes node image build for #{kubernetes_versions.first} failed"})
+    end
+
+    it "records the built versions once every build has popped" do
+      allow(Config).to receive(:machine_images_service_project_id).and_return(image_project.id)
+      metals.each { it.machine_image_version.machine_image.update(project_id: image_project.id, location_id:, latest_version_id: it.id) }
+      refresh_frame(prog, new_values: {"build_strand_ids" => [Strand.generate_uuid]})
+
+      expect { prog.wait_node_images }.to hop("wait")
+      expect(prog.machine_image_version_ids).to eq metals.map(&:id)
+    end
+  end
+
+  describe "#wait" do
+    before { refresh_frame(prog, new_values: {"machine_image_version_ids" => metals.map(&:id)}) }
+
+    it "hops to wait_destroy when destroy_kubernetes_node_images is set" do
+      prog.incr_destroy_kubernetes_node_images
+
+      expect { prog.wait }.to hop("wait_destroy")
+      expect(metals.map { it.refresh.destroy_set? }).to all(be true)
+    end
+
+    it "naps for an hour otherwise" do
+      expect { prog.wait }.to nap(60 * 60)
+    end
+  end
+
+  describe "#wait_destroy" do
+    before { refresh_frame(prog, new_values: {"machine_image_version_ids" => metals.map(&:id)}) }
+
+    it "naps until the versions are destroyed" do
+      expect { prog.wait_destroy }.to nap(15)
+    end
+
+    it "pops once the versions are destroyed" do
+      metals.each(&:destroy)
+
+      expect { prog.wait_destroy }.to exit({"msg" => "Kubernetes node images destroyed!"})
+    end
+  end
+
+  describe "#failed" do
+    it "naps" do
+      expect { prog.failed }.to nap(15)
+    end
+  end
+end

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -227,11 +227,21 @@ RSpec.describe Prog::Test::VmGroup do
   end
 
   describe "#test_reboot" do
-    it "hops to wait_reboot" do
+    it "hops to wait_reboot once the reboot is allowed" do
       vm_host = create_vm_host
       vm = create_vm(vm_host_id: vm_host.id)
       refresh_frame(vg_test, new_values: {"vms" => [vm.id]})
+      vg_test.incr_allow_reboot
+
       expect { vg_test.test_reboot }.to hop("wait_reboot")
+    end
+
+    it "naps until the reboot is allowed" do
+      vm_host = create_vm_host
+      vm = create_vm(vm_host_id: vm_host.id)
+      refresh_frame(vg_test, new_values: {"vms" => [vm.id]})
+
+      expect { vg_test.test_reboot }.to nap(10)
     end
   end
 


### PR DESCRIPTION
**Allow skipping node image verification**
Verification bootstraps a full cluster, which is more than a timing experiment or an environment with separate cluster coverage needs. When skipped, a ready capture promotes to latest directly.

**Add an e2e prog to build Kubernetes node images**
Assembles a BuildNodeImage strand per requested version and pops once they all finish, so the kubernetes suites wait on a single strand.

Verification is skipped, as the kubernetes test cases bootstrap clusters from these images themselves. The captured versions are left in place, since the workflow empties the e2e bucket after every run.

**Build Kubernetes node images in e2e instead of downloading them**
The kubernetes test cases no longer list kubernetes-* boot images, so the host does not download them during bootstrap. Node images are built in-cloud instead, alongside the github runner and postgres cases, and only the kubernetes suites wait for them.

The builds start after the VmGroup host reboot, which would otherwise kill the builder VMs mid-build.

Only the versions the selected cases need are built: the version the clusters start on, plus the upgrade target for kubernetes_upgrade.

**Poll the node image build every 10 seconds**
The build label napped 180 seconds between daemonizer checks, so a build that finished early still waited out the full interval. In the last e2e run the label took 182 seconds for both versions, one nap cycle, meaning the work itself finished somewhere inside the first interval.