### PR TITLE
Add deployment routing stamp to generated ubids

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -121,6 +121,7 @@ module Config
   override :control_plane_outbound_cidrs, "0.0.0.0/0,::/0", array(string)
   optional :git_commit_hash, string
   optional :ip_from_header, string
+  optional :ubid_routing_stamp, match?(/\A[0-9a-hj-km-np-tv-z]{2}\z/)
 
   # GitHub Runner App
   optional :github_app_name, string

--- a/lib/casting_config_helpers.rb
+++ b/lib/casting_config_helpers.rb
@@ -56,6 +56,16 @@ module CastingConfigHelpers
     end
   end
 
+  def match?(regexp)
+    ->(v) do
+      if v.nil? || regexp.match?(v)
+        v
+      else
+        raise "invalid value #{v.inspect}, must match #{regexp}"
+      end
+    end
+  end
+
   def base64
     ->(v) { v && Base64.decode64(v) }
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -42,6 +42,25 @@ RSpec.describe Config do
     }.to raise_error("invalid uuid invalid")
   end
 
+  it "match? accepts nil and matching values" do
+    described_class.class_eval do
+      override :test_match, "g1", match?(/\A[0-9a-hj-km-np-tv-z]{2}\z/)
+      optional :test_nil_match, match?(/\A[0-9a-hj-km-np-tv-z]{2}\z/)
+    end
+    expect(described_class.test_match).to eq("g1")
+    expect(described_class.test_nil_match).to be_nil
+  end
+
+  it "match? rejects non-matching values" do
+    ["g", "g1x", "gu", "G1", "o1", "1l"].each do |value|
+      expect {
+        described_class.class_eval do
+          override :test_match, value, match?(/\A[0-9a-hj-km-np-tv-z]{2}\z/)
+        end
+      }.to raise_error(RuntimeError, /invalid value #{Regexp.escape(value.inspect)}, must match/)
+    end
+  end
+
   it "ignores LoadError when .env.rb is not present" do
     main = TOPLEVEL_BINDING.eval("self")
     expect(main).to receive(:require_relative).with("lib/casting_config_helpers")

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -100,6 +100,43 @@ RSpec.describe UBID do
     expect(ubid2.to_i).to eq(ubid1.to_i)
   end
 
+  context "when a routing stamp is configured", if: Config.unfrozen_test? || Config.ubid_routing_stamp do
+    subject(:stamped_class) do
+      Class.new(described_class) { UBID::RoutingStamp.apply(self) }
+    end
+
+    before do
+      allow(Config).to receive(:ubid_routing_stamp).and_return("g1")
+    end
+
+    it "stamps variant, routing version, and stamp into chars 13-16" do
+      [
+        stamped_class.generate(UBID::TYPE_POSTGRES_RESOURCE),
+        stamped_class.generate(UBID::TYPE_SEMAPHORE),
+        stamped_class.generate_from_time("et", Time.now),
+      ].each do |ubid|
+        expect(ubid.to_s[13, 4]).to eq "r1g1"
+        expect(ubid.to_uuid[19]).to eq "c"
+        expect(ubid.variant).to eq 0b11
+        expect(ubid.routing_version).to eq UBID::RoutingStamp::VERSION
+        expect(ubid.routing_stamp).to eq "g1"
+        expect(described_class.parse(ubid.to_s).to_i).to eq ubid.to_i
+        expect(described_class.from_uuidish(ubid.to_uuid).to_s).to eq ubid.to_s
+      end
+    end
+
+    it "does not stamp vanity ubids" do
+      expect(stamped_class.generate_vanity_action_type("Project:view").to_s).to eq "ttzzzzzzzz021gzzz0pj0v1ew0"
+    end
+  end
+
+  it "does not stamp ubids when routing stamp is not configured", if: !Config.ubid_routing_stamp do
+    ubid = described_class.generate(UBID::TYPE_VM)
+    expect(ubid.to_s[13]).to be_between("g", "q")
+    expect(ubid.variant).to eq 0b10
+    expect(ubid).not_to respond_to(:routing_version)
+  end
+
   it "can convert to and from uuid" do
     ubid1 = described_class.generate(UBID::TYPE_VM)
     ubid2 = described_class.from_uuidish(ubid1.to_uuid)

--- a/spec/ubid_spec.rb
+++ b/spec/ubid_spec.rb
@@ -100,6 +100,31 @@ RSpec.describe UBID do
     expect(ubid2.to_i).to eq(ubid1.to_i)
   end
 
+  it "stamps routing version and stamp into chars 14-16 when configured" do
+    allow(Config).to receive(:ubid_routing_stamp).and_return("g1")
+    [
+      described_class.generate(UBID::TYPE_POSTGRES_RESOURCE),
+      described_class.generate(UBID::TYPE_SEMAPHORE),
+      described_class.generate_from_time("et", Time.now),
+    ].each do |ubid|
+      expect(ubid.to_s[13, 4]).to eq "g1g1"
+      expect(ubid.routing_version).to eq described_class::ROUTING_VERSION
+      expect(ubid.routing_stamp).to eq "g1"
+      expect(described_class.parse(ubid.to_s).to_i).to eq ubid.to_i
+      expect(described_class.from_uuidish(ubid.to_uuid).to_s).to eq ubid.to_s
+    end
+  end
+
+  it "does not alter rand_b when routing stamp is not configured" do
+    expect(Config.ubid_routing_stamp).to be_nil
+    expect(described_class.stamp_routing(123)).to eq 123
+  end
+
+  it "does not stamp vanity ubids" do
+    allow(Config).to receive(:ubid_routing_stamp).and_return("g1")
+    expect(described_class.generate_vanity_action_type("Project:view").to_s).to eq "ttzzzzzzzz021gzzz0pj0v1ew0"
+  end
+
   it "can convert to and from uuid" do
     ubid1 = described_class.generate(UBID::TYPE_VM)
     ubid2 = described_class.from_uuidish(ubid1.to_uuid)

--- a/ubid.rb
+++ b/ubid.rb
@@ -30,6 +30,16 @@ class UBID
   # timestamp is 48 bits, so 2^48 - 1
   MAX_TIMESTAMP = 281474976710655
 
+  # When Config.ubid_routing_stamp is set, the top 18 bits of rand_b are
+  # reserved: 3 zero bits, a 5-bit scheme version, and a 10-bit routing
+  # stamp identifying the deployment (string chars 14-16).
+  ROUTING_VERSION = 1
+  ROUTING_VERSION_BIT_COUNT = 5
+  ROUTING_STAMP_BIT_COUNT = 10
+  ROUTING_SHIFT = 44
+  ROUTING_VERSION_SHIFT = ROUTING_SHIFT + ROUTING_STAMP_BIT_COUNT
+  ROUTING_RANDOM_MASK = (1 << ROUTING_SHIFT) - 1
+
   # types
   TYPE_VM = "vm"
   TYPE_VM_STORAGE_VOLUME = "v1"
@@ -130,17 +140,27 @@ class UBID
   def self.generate_random(type)
     timestamp = SecureRandom.random_number(MAX_TIMESTAMP)
     random_value = SecureRandom.random_number(MAX_ENTROPY)
-    from_parts(timestamp, type, random_value & 0b11, random_value >> 2)
+    from_parts(timestamp, type, random_value & 0b11, stamp_routing(random_value >> 2))
   end
 
   def self.generate_from_current_ts(type)
     random_value = SecureRandom.random_number(MAX_ENTROPY)
-    from_parts(current_milliseconds, type, random_value & 0b11, random_value >> 2)
+    from_parts(current_milliseconds, type, random_value & 0b11, stamp_routing(random_value >> 2))
   end
 
   def self.generate_from_time(type, time)
     random_value = SecureRandom.random_number(MAX_ENTROPY)
-    from_parts((time.to_f * 1000).round, type, random_value & 0b11, random_value >> 2)
+    from_parts((time.to_f * 1000).round, type, random_value & 0b11, stamp_routing(random_value >> 2))
+  end
+
+  def self.routing_code
+    return unless (stamp = Config.ubid_routing_stamp)
+    (ROUTING_VERSION << ROUTING_STAMP_BIT_COUNT) | to_base32_n(stamp)
+  end
+
+  def self.stamp_routing(rand_b)
+    return rand_b unless (code = routing_code)
+    (code << ROUTING_SHIFT) | (rand_b & ROUTING_RANDOM_MASK)
   end
 
   # InferenceApiKey does not have a type, and using et (TYPE_ETC) seems like a bad idea
@@ -339,6 +359,15 @@ class UBID
 
   def to_i
     @value
+  end
+
+  def routing_version
+    UBID.get_bits(@value, ROUTING_VERSION_SHIFT, ROUTING_VERSION_SHIFT + ROUTING_VERSION_BIT_COUNT - 1)
+  end
+
+  # Only meaningful when routing_version == ROUTING_VERSION.
+  def routing_stamp
+    UBID.from_base32_n(UBID.get_bits(@value, ROUTING_SHIFT, ROUTING_VERSION_SHIFT - 1), 2)
   end
 
   def inspect

--- a/ubid.rb
+++ b/ubid.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require("securerandom")
+require_relative("config")
 
 class UBIDParseError < RuntimeError
 end
@@ -129,18 +130,64 @@ class UBID
 
   def self.generate_random(type)
     timestamp = SecureRandom.random_number(MAX_TIMESTAMP)
-    random_value = SecureRandom.random_number(MAX_ENTROPY)
-    from_parts(timestamp, type, random_value & 0b11, random_value >> 2)
+    from_random_value(timestamp, type, SecureRandom.random_number(MAX_ENTROPY))
   end
 
   def self.generate_from_current_ts(type)
-    random_value = SecureRandom.random_number(MAX_ENTROPY)
-    from_parts(current_milliseconds, type, random_value & 0b11, random_value >> 2)
+    from_random_value(current_milliseconds, type, SecureRandom.random_number(MAX_ENTROPY))
   end
 
   def self.generate_from_time(type, time)
-    random_value = SecureRandom.random_number(MAX_ENTROPY)
-    from_parts((time.to_f * 1000).round, type, random_value & 0b11, random_value >> 2)
+    from_random_value((time.to_f * 1000).round, type, SecureRandom.random_number(MAX_ENTROPY))
+  end
+
+  def self.from_random_value(unix_ts_ms, type, random_value)
+    from_parts(unix_ts_ms, type, random_value & 0b11, random_value >> 2)
+  end
+
+  # Prepended to UBID.singleton_class and UBID when Config.ubid_routing_stamp
+  # is set, reserving the top 18 bits of rand_b (3 zero bits, 5-bit scheme
+  # version, 10-bit routing stamp) and setting variant 0b11, so string chars
+  # 13-16 become "r" + version + stamp.
+  # simplecov:disable
+  if Config.unfrozen_test? || Config.ubid_routing_stamp
+    # simplecov:enable
+    module RoutingStamp
+      VARIANT = 0b11
+      VERSION = 1
+      VERSION_BIT_COUNT = 5
+      STAMP_BIT_COUNT = 10
+      SHIFT = 44
+      VERSION_SHIFT = SHIFT + STAMP_BIT_COUNT
+      RANDOM_MASK = (1 << SHIFT) - 1
+
+      module SingletonMethods
+        def from_random_value(unix_ts_ms, type, random_value)
+          code = (VERSION << STAMP_BIT_COUNT) | to_base32_n(Config.ubid_routing_stamp)
+          rand_b = (code << SHIFT) | ((random_value >> 2) & RANDOM_MASK)
+          from_parts(unix_ts_ms, type, random_value & 0b11, rand_b, variant: VARIANT)
+        end
+      end
+
+      module InstanceMethods
+        def routing_version
+          UBID.get_bits(@value, VERSION_SHIFT, VERSION_SHIFT + VERSION_BIT_COUNT - 1)
+        end
+
+        # Only meaningful when routing_version == VERSION.
+        def routing_stamp
+          UBID.from_base32_n(UBID.get_bits(@value, SHIFT, VERSION_SHIFT - 1), 2)
+        end
+      end
+
+      def self.apply(klass)
+        klass.singleton_class.prepend(SingletonMethods)
+        klass.prepend(InstanceMethods)
+      end
+      # simplecov:disable
+      apply(UBID) if Config.ubid_routing_stamp
+      # simplecov:enable
+    end
   end
 
   # InferenceApiKey does not have a type, and using et (TYPE_ETC) seems like a bad idea
@@ -339,6 +386,10 @@ class UBID
 
   def to_i
     @value
+  end
+
+  def variant
+    UBID.get_bits(@value, 62, 63)
   end
 
   def inspect


### PR DESCRIPTION
Operators running more than one ubicloud deployment (for example split by cloud provider or region) have no way to tell from an id which deployment created it, which is needed to route API calls and connection strings that only carry the id.

When the new UBID_ROUTING_STAMP config is set, reserve the top 18 bits of rand_b in every generated ubid: 3 zero bits, a 5-bit scheme version owned by the code, and a 10-bit routing stamp taken verbatim from the config (two canonical base32 characters, validated at config load via a new generic match? caster). Stamped ids also flip the variant bits from 0b10 to 0b11, which together with the zeroed top rand_b bit reads as UUID Variant 2, so stamped ids are recognizable at the uuid level too. The reserved bits land on whole base32 characters, so the stamp is readable directly from the id string: char 13 becomes a constant "r" (unstamped generated ids keep variant 0b10 and always fall in "g".."q" there, so "r" cannot occur without stamping), char 14 the scheme version, and chars 15-16 the stamp -- a deployment configured with "g1" mints ids like pg6nfqe2stv62r1g16z0kee188. Ids from outside ubicloud carry arbitrary bits, so readers should still check the variant and version chars together and only route on ids of types an operator actually federates.

The remaining 44 bits of rand_b stay random and contiguous, leaving 94 random bits per id (48 timestamp + 2 rand_a + 44); collision probability within a deployment stays negligible, and ids from differently-stamped deployments can no longer collide at all. When the config is unset, generation is unchanged.

The support is zero cost when not enabled: UBID::RoutingStamp is only defined in unfrozen test mode or when the config is set, and its modules are prepended to UBID.singleton_class and UBID at load time only when the config is set, overriding a single extracted seam (from_random_value) shared by the three generators. The default generation path has no config check, and the routing_version and routing_stamp readers only exist on stamped deployments. A variant reader on UBID itself exposes the variant bits on any deployment, giving unstamped deployments the first-level check for stamped ids minted elsewhere. Specs exercise both stamped and unstamped behavior by prepending the modules to UBID subclasses via RoutingStamp.apply. Since the definition and activation read Config at load time, ubid.rb now requires config.rb directly, keeping bare requires of ubid.rb working (the monitor smoke test is one).

Vanity ubids are exempt since they hand-craft rand_b. The database functions gen_random_ubid_uuid and gen_timestamp_ubid_uuid are left unstamped: their only callers are the audit log column defaults and Semaphore.incr, which mint internal ids that never leave the deployment, and stamping them later is a purely additive follow-up.
