### PR TITLE
Update GitHub runner AWS AMI versions to 20260801.1.1

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -225,12 +225,12 @@ module Config
   optional :ubicloud_images_r2_access_key, string, clear: true
   optional :ubicloud_images_r2_secret_key, string, clear: true
 
-  override :github_ubuntu_2204_x64_aws_ami_version, "ami-027521b1fcdfb2d1d", string
-  override :github_ubuntu_2404_x64_aws_ami_version, "ami-00053ab2c8f2e7a3f", string
-  override :github_ubuntu_2604_x64_aws_ami_version, "ami-05a5aaba660346f42", string
-  override :github_ubuntu_2204_arm64_aws_ami_version, "ami-057b1610e577ebfa5", string
-  override :github_ubuntu_2404_arm64_aws_ami_version, "ami-005e84aaf5eab2384", string
-  override :github_ubuntu_2604_arm64_aws_ami_version, "ami-0695161c7269e474e", string
+  override :github_ubuntu_2204_x64_aws_ami_version, "ami-06278f3369923ea6d", string
+  override :github_ubuntu_2404_x64_aws_ami_version, "ami-0c43c7772150382e4", string
+  override :github_ubuntu_2604_x64_aws_ami_version, "ami-050a11359633cef1e", string
+  override :github_ubuntu_2204_arm64_aws_ami_version, "ami-075a811d824904134", string
+  override :github_ubuntu_2404_arm64_aws_ami_version, "ami-0037a28ce39645ec3", string
+  override :github_ubuntu_2604_arm64_aws_ami_version, "ami-05821fff80af45eca", string
   override :postgres_gce_image_gcp_project_id, "ubicloud-images", string
 
   # Allocator


### PR DESCRIPTION
Bump all six GitHub runner AMI IDs to the latest builds:
- https://github.com/ubicloud/runner-images/actions/runs/30715559703