### PR TITLE
Show host inventory on the admin VmHost page

### DIFF
--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -3566,19 +3566,49 @@ RSpec.describe CloverAdmin do
     expect(page).to have_no_content("vm-in-another-host")
   end
 
-  it "shows host provider details on VmHost page" do
+  it "shows inventory and host provider details on VmHost page" do
     vm_host = create_vm_host
 
     visit "/model/VmHost/#{vm_host.ubid}"
-    expect(page).to have_no_content("Host Provider")
+    expect(page).to have_css("summary", text: "Inventory")
+    expect(page).to have_no_css(".vm-host-inventory-table")
+    page.all("summary").each(&:click)
+    expect(page).to have_content("No data available for Inventory table")
 
+    inventory = VmHostInventory.create do
+      it.id = vm_host.id
+      it.server_model = "AX102"
+      it.cpu = "AMD Ryzen 9 7950X3D"
+      it.memory = "128GB"
+      it.storage = "2x 1.92TB NVMe SSD"
+      it.uplink = "1Gbps"
+      it.monthly_price = 109.9
+      it.currency = "EUR"
+    end
+    page.refresh
+    page.all("summary").each(&:click)
+    expect(page.all(".vm-host-inventory-table thead th").map(&:text)).to eq(["Column", "Value"])
+    expect(page.all(".vm-host-inventory-table tbody tr").map { it.all("td").map(&:text) }.to_h).to eq({
+      "updated_at" => inventory.updated_at.to_s,
+      "server_model" => "AX102",
+      "cpu" => "AMD Ryzen 9 7950X3D",
+      "memory" => "128GB",
+      "storage" => "2x 1.92TB NVMe SSD",
+      "uplink" => "1Gbps",
+      "gpu" => "",
+      "monthly_price" => "109.90",
+      "currency" => "EUR",
+    })
+
+    # With a provider, the table is titled after it.
     HostProvider.create do
       it.id = vm_host.id
       it.server_identifier = "123"
       it.provider_name = HostProvider::HETZNER_PROVIDER_NAME
     end
     page.refresh
-    expect(page).to have_css("h2", text: "Host Provider: hetzner (server identifier: 123)")
+    expect(page).to have_css("summary", text: "Provider hetzner #123")
+    expect(page).to have_no_css("summary", text: "Inventory")
   end
 
   it "renders the customer summary when customers have equal resource totals" do

--- a/views/admin/extras/VmHost.erb
+++ b/views/admin/extras/VmHost.erb
@@ -1,13 +1,19 @@
 <%# locals: (obj:) %>
 
-<% if provider = obj.provider %>
-  <h2>Host Provider:
-    <%= provider.provider_name %>
-    (server identifier:
-    <%= provider.server_identifier %>)</h2>
-<% end %>
+<% inventory_title = if (provider = obj.provider)
+  "Provider #{provider.provider_name} ##{provider.server_identifier}"
+ else
+  "Inventory"
+end
 
-<% rows = customer_vm_dataset
+inventory_data = if (inv = obj.inventory)
+  inventory_data = inv.to_hash.except(:id)&.map do |k, v|
+    v = "%.2f" % v if k == :monthly_price && v
+    {"Column" => k, "Value" => v}
+  end
+end
+
+rows = customer_vm_dataset
   .where(Sequel[:cvm][:vm_host_id] => obj.id)
   .left_join(Sequel[:project].as(:proj), id: Sequel[:cvm][:project_id])
   .left_join(customer_email_dataset.as(:ce), project_id: Sequel[:proj][:id])
@@ -51,6 +57,8 @@ summary_data = summary
     }
   end
   .sort_by { [it["Total"], it["Customer"].value] } %>
+
+<%== part("components/collapsible_table", title: inventory_title, table_class: "vm-host-inventory-table", data: inventory_data) %>
 
 <% if resource_data.empty? %>
   <p>No customer resources are hosted on this host.</p>


### PR DESCRIPTION
Show them as a collapsible table, folding the former provider heading into its title, since the provider names the same physical machine the inventory describes. Hosts without an inventory row stay common until the data is backfilled, so they fall back to the table component's empty state.
<img width="1232" height="592" alt="CleanShot 2026-08-06 at 19 20 39@2x" src="https://github.com/user-attachments/assets/07d9a74f-0193-4c91-bec7-211a40ac6bc4" />

