### PR TITLE
Add Ubuntu 26.04 to GitHub Actions runner E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ on:
       test_cases:
         description: 'Comma-separated list of test cases (vm)'
         required: true
-        default: 'vm,github_runner_ubuntu_2404,github_runner_ubuntu_2204,postgres_standard,postgres_ha,postgres_upgrade,postgres_upgrade16,postgres_firewall,kubernetes,kubernetes_upgrade,machine_image_vm_capture,move_vm'
+        default: 'vm,github_runner_ubuntu_2604,github_runner_ubuntu_2404,github_runner_ubuntu_2204,postgres_standard,postgres_ha,postgres_upgrade,postgres_upgrade16,postgres_firewall,kubernetes,kubernetes_upgrade,machine_image_vm_capture,move_vm'
         type: string
       providers:
         description: 'Comma-separated list of providers (metal,aws,gcp)'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ on:
       test_cases:
         description: 'Comma-separated list of test cases (vm)'
         required: true
-        default: 'vm,github_runner_ubuntu_2404,github_runner_ubuntu_2204,postgres_standard,postgres_ha,postgres_upgrade,postgres_upgrade16,postgres_firewall,kubernetes,kubernetes_upgrade,machine_image_vm_capture'
+        default: 'vm,github_runner_ubuntu_2604,github_runner_ubuntu_2404,github_runner_ubuntu_2204,postgres_standard,postgres_ha,postgres_upgrade,postgres_upgrade16,postgres_firewall,kubernetes,kubernetes_upgrade,machine_image_vm_capture'
         type: string
       providers:
         description: 'Comma-separated list of providers (metal,aws,gcp)'

--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -1,4 +1,5 @@
 - { name: vm,                        images: ["ubuntu-resolute", "ubuntu-noble", "debian-12", "almalinux-9"] }
+- { name: github_runner_ubuntu_2604, images: ["github-ubuntu-2604"] }
 - { name: github_runner_ubuntu_2404, images: ["github-ubuntu-2404"] }
 - { name: github_runner_ubuntu_2204, images: ["github-ubuntu-2204"] }
 - { name: postgres_standard,         images: ["postgres-ubuntu-2204"] }


### PR DESCRIPTION
The control plane supports ubuntu-26.04 runners. Add github_runner_ubuntu_2604 to the scheduled test-case list and the workflow_dispatch default so 26.04 runners get covered alongside 22.04 and 24.04.