### PR TITLE
Clear Excon stubs registered during each example

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,8 @@ RSpec.configure do |config|
   leaked_threads[Thread.current] = true
 
   config.around do |example|
+    excon_stub_count = Excon.stubs.length
+
     if example.metadata[:no_db_transaction]
       # Real concurrency specs check out multiple connections and commit
       # on their own. They must opt out of the wrapping rollback-only
@@ -71,6 +73,7 @@ RSpec.configure do |config|
         example.run
       end
     end
+    Excon.stubs.shift(Excon.stubs.length - excon_stub_count)
     Thread.current[:clover_ssh_cache] = nil
     Mail::TestMailer.deliveries.clear if defined?(Mail)
 


### PR DESCRIPTION
Excon.stubs is a process-global, newest-first list, and WebMock's catch-all stub (which serves stub_request stubs) sits at its tail. Stubs registered with Excon.stub during an example were never removed, so they persisted for the rest of the worker process and shadowed WebMock stubs in later examples.

This made hetzner_pull_ips specs flaky under turbo_tests: whenever the admin panel's setup-vm-host specs (which stub /ip, /subnet, and /failover globally with 200 responses) ran earlier in the same worker, the WebMock stubs in hetzner_apis_spec were never consulted, so pull_ips returned no matching IPs and the expected-error cases raised nothing.

Drop any stubs added during an example in the around hook, keeping the pre-existing tail (WebMock's catch-all) intact.