### PR TITLE
Create vm host inventory for Leaseweb hosts at assembly

### DIFF
--- a/lib/hosting/leaseweb_apis.rb
+++ b/lib/hosting/leaseweb_apis.rb
@@ -14,6 +14,10 @@ class Hosting::LeasewebApis < Hosting::ProviderApis
 
   NetworkInterfaces = Data.define(:public_mac, :internal_mac, :internal_ip)
 
+  Inventory = Data.define(:server_model, :cpu, :memory, :storage, :uplink, :gpu, :monthly_price, :currency)
+
+  DISK_TYPES = {"NVME" => "NVMe SSD", "SATA" => "SATA SSD"}.freeze
+
   IPS_PAGE_SIZE = 50
 
   def hardware_reset
@@ -102,6 +106,32 @@ class Hosting::LeasewebApis < Hosting::ProviderApis
     end
 
     singles + blocks.uniq.map { IpInfo.new(it, main_ip4, nil) }
+  end
+
+  def pull_inventory
+    server = pull_server
+    specs = server.fetch("specs")
+    contract = server.fetch("contract")
+    unless contract.fetch("billingFrequency") == "MONTH" && contract.fetch("billingCycle") == 1
+      fail "leaseweb server #{@provider.server_identifier} bills per #{contract["billingCycle"]} #{contract["billingFrequency"]}, not monthly"
+    end
+
+    cpu = specs.fetch("cpu")
+    ram = specs.fetch("ram")
+    storage = presence(specs.fetch("hdd").map do |disk|
+      type = disk.fetch("type")
+      "#{disk.fetch("amount")}x #{disk.fetch("size")}#{disk.fetch("unit")} #{DISK_TYPES.fetch(type, type)}"
+    end.join(" + "))
+    Inventory.new(
+      server_model: specs.fetch("chassis"),
+      cpu: (cpu.fetch("quantity") > 1) ? "#{cpu.fetch("quantity")}x #{cpu.fetch("type")}" : cpu.fetch("type"),
+      memory: "#{ram.fetch("size")}#{ram.fetch("unit")}",
+      storage:,
+      uplink: server.fetch("rack").fetch("capacity").sub(/G\z/, "Gbps"),
+      gpu: nil,
+      monthly_price: BigDecimal(contract.fetch("pricePerFrequency")),
+      currency: contract.fetch("currency"),
+    )
   end
 
   private

--- a/lib/hosting/leaseweb_apis.rb
+++ b/lib/hosting/leaseweb_apis.rb
@@ -14,6 +14,8 @@ class Hosting::LeasewebApis < Hosting::ProviderApis
 
   NetworkInterfaces = Data.define(:public_mac, :internal_mac, :internal_ip)
 
+  DISK_TYPES = {"NVME" => "NVMe SSD", "SATA" => "SATA SSD"}.freeze
+
   IPS_PAGE_SIZE = 50
 
   def hardware_reset
@@ -102,6 +104,32 @@ class Hosting::LeasewebApis < Hosting::ProviderApis
     end
 
     singles + blocks.uniq.map { IpInfo.new(it, main_ip4, nil) }
+  end
+
+  def pull_inventory
+    server = pull_server
+    specs = server.fetch("specs")
+    contract = server.fetch("contract")
+    unless contract.fetch("billingFrequency") == "MONTH" && contract.fetch("billingCycle") == 1
+      fail "leaseweb server #{@provider.server_identifier} bills per #{contract["billingCycle"]} #{contract["billingFrequency"]}, not monthly"
+    end
+
+    cpu = specs.fetch("cpu")
+    ram = specs.fetch("ram")
+    storage = presence(specs.fetch("hdd").map do |disk|
+      type = disk.fetch("type")
+      "#{disk.fetch("amount")}x #{disk.fetch("size")}#{disk.fetch("unit")} #{DISK_TYPES.fetch(type, type)}"
+    end.join(" + "))
+    {
+      server_model: specs.fetch("chassis"),
+      cpu: (cpu.fetch("quantity") > 1) ? "#{cpu.fetch("quantity")}x #{cpu.fetch("type")}" : cpu.fetch("type"),
+      memory: "#{ram.fetch("size")}#{ram.fetch("unit")}",
+      storage:,
+      uplink: server.fetch("rack").fetch("capacity").sub(/G\z/, "Gbps"),
+      gpu: nil,
+      monthly_price: BigDecimal(contract.fetch("pricePerFrequency")),
+      currency: contract.fetch("currency"),
+    }
   end
 
   private

--- a/lib/hosting/leaseweb_apis.rb
+++ b/lib/hosting/leaseweb_apis.rb
@@ -110,9 +110,7 @@ class Hosting::LeasewebApis < Hosting::ProviderApis
     server = pull_server
     specs = server.fetch("specs")
     contract = server.fetch("contract")
-    unless contract.fetch("billingFrequency") == "MONTH" && contract.fetch("billingCycle") == 1
-      fail "leaseweb server #{@provider.server_identifier} bills per #{contract["billingCycle"]} #{contract["billingFrequency"]}, not monthly"
-    end
+    monthly = contract.fetch("billingFrequency") == "MONTH" && contract.fetch("billingCycle") == 1
 
     cpu = specs.fetch("cpu")
     ram = specs.fetch("ram")
@@ -127,8 +125,8 @@ class Hosting::LeasewebApis < Hosting::ProviderApis
       storage:,
       uplink: server.fetch("rack").fetch("capacity").sub(/G\z/, "Gbps"),
       gpu: nil,
-      monthly_price: BigDecimal(contract.fetch("pricePerFrequency")),
-      currency: contract.fetch("currency"),
+      monthly_price: (BigDecimal(contract.fetch("pricePerFrequency")) if monthly),
+      currency: (contract.fetch("currency") if monthly),
     }
   end
 

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -249,6 +249,10 @@ class VmHost < Sequel::Model
     update(data_center: provider.api.pull_data_center)
   end
 
+  def create_inventory
+    VmHostInventory.create(provider.api.pull_inventory.to_h) { it.id = id }
+  end
+
   def allow_slices
     update(accepts_slices: true)
   end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -249,6 +249,10 @@ class VmHost < Sequel::Model
     update(data_center: provider.api.pull_data_center)
   end
 
+  def create_inventory
+    VmHostInventory.create(provider.api.pull_inventory) { it.id = id }
+  end
+
   def allow_slices
     update(accepts_slices: true)
   end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -26,6 +26,7 @@ class Prog::Vm::HostNexus < Prog::Base
       if [HostProvider::HETZNER_PROVIDER_NAME, *HostProvider::LEASEWEB_PROVIDER_NAMES].include?(provider_name)
         vmh.create_addresses
         vmh.set_data_center
+        vmh.create_inventory if vmh.leaseweb?
         # Avoid overriding custom server names for development hosts.
         vmh.set_server_name unless Config.development?
       else

--- a/spec/lib/hosting/leaseweb_apis_spec.rb
+++ b/spec/lib/hosting/leaseweb_apis_spec.rb
@@ -139,6 +139,59 @@ RSpec.describe Hosting::LeasewebApis do
     end
   end
 
+  describe "pull_inventory" do
+    # A leaseweb HPE RL300's shape, trimmed to the fields inventory reads.
+    def stub_inventory_server(specs: {}, contract: {})
+      Excon.stub({path: "/bareMetals/v2/servers/123", method: :get},
+        {status: 200, body: JSON.generate(
+          rack: {id: "10101", type: "SHARED_100GE", capacity: "10G"},
+          specs: {
+            brand: "HPE",
+            chassis: "HPE RL300",
+            cpu: {type: "Ampere Altra Max M128-30", quantity: 2},
+            ram: {size: 512, unit: "GB"},
+            hdd: [{id: "U2_3.84TBMU", size: 3.84, unit: "TB", amount: 2, type: "NVME", performanceType: "MIX_USE"}],
+          }.merge(specs),
+          contract: {billingCycle: 1, billingFrequency: "MONTH", pricePerFrequency: "483.62", currency: "EUR"}.merge(contract),
+        )})
+    end
+
+    it "returns the server's hardware and contract details" do
+      stub_inventory_server
+      expect(leaseweb_apis.pull_inventory).to eq described_class::Inventory.new(
+        server_model: "HPE RL300",
+        cpu: "2x Ampere Altra Max M128-30",
+        memory: "512GB",
+        storage: "2x 3.84TB NVMe SSD",
+        uplink: "10Gbps",
+        gpu: nil,
+        monthly_price: BigDecimal("483.62"),
+        currency: "EUR",
+      )
+    end
+
+    it "does not multiply a single cpu" do
+      stub_inventory_server(specs: {cpu: {type: "AMD EPYC 9454P", quantity: 1}})
+      expect(leaseweb_apis.pull_inventory.cpu).to eq "AMD EPYC 9454P"
+    end
+
+    it "stores nil storage when no disks are reported" do
+      stub_inventory_server(specs: {hdd: []})
+      expect(leaseweb_apis.pull_inventory.storage).to be_nil
+    end
+
+    it "keeps an unmapped disk type as reported" do
+      stub_inventory_server(specs: {hdd: [{size: 8, unit: "TB", amount: 4, type: "SAS"}, {size: 1.92, unit: "TB", amount: 2, type: "SATA"}]})
+      expect(leaseweb_apis.pull_inventory.storage).to eq "4x 8TB SAS + 2x 1.92TB SATA SSD"
+    end
+
+    it "fails on a non-monthly contract" do
+      stub_inventory_server(contract: {billingCycle: 3})
+      expect { leaseweb_apis.pull_inventory }.to raise_error RuntimeError,
+        "leaseweb server 123 bills per 3 MONTH, not monthly"
+    end
+  end
+
   describe "pull_network_interfaces" do
     def stub_server(**body)
       Excon.stub({path: "/bareMetals/v2/servers/123", method: :get}, {status: 200, body: JSON.generate(body)})

--- a/spec/lib/hosting/leaseweb_apis_spec.rb
+++ b/spec/lib/hosting/leaseweb_apis_spec.rb
@@ -139,6 +139,59 @@ RSpec.describe Hosting::LeasewebApis do
     end
   end
 
+  describe "pull_inventory" do
+    # A leaseweb HPE RL300's shape, trimmed to the fields inventory reads.
+    def stub_inventory_server(specs: {}, contract: {})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123")
+        .to_return(status: 200, body: JSON.generate(
+          rack: {id: "10101", type: "SHARED_100GE", capacity: "10G"},
+          specs: {
+            brand: "HPE",
+            chassis: "HPE RL300",
+            cpu: {type: "Ampere Altra Max M128-30", quantity: 2},
+            ram: {size: 512, unit: "GB"},
+            hdd: [{id: "U2_3.84TBMU", size: 3.84, unit: "TB", amount: 2, type: "NVME", performanceType: "MIX_USE"}],
+          }.merge(specs),
+          contract: {billingCycle: 1, billingFrequency: "MONTH", pricePerFrequency: "483.62", currency: "EUR"}.merge(contract),
+        ))
+    end
+
+    it "returns the server's hardware and contract details" do
+      stub_inventory_server
+      expect(leaseweb_apis.pull_inventory).to eq(
+        server_model: "HPE RL300",
+        cpu: "2x Ampere Altra Max M128-30",
+        memory: "512GB",
+        storage: "2x 3.84TB NVMe SSD",
+        uplink: "10Gbps",
+        gpu: nil,
+        monthly_price: BigDecimal("483.62"),
+        currency: "EUR",
+      )
+    end
+
+    it "does not multiply a single cpu" do
+      stub_inventory_server(specs: {cpu: {type: "AMD EPYC 9454P", quantity: 1}})
+      expect(leaseweb_apis.pull_inventory[:cpu]).to eq "AMD EPYC 9454P"
+    end
+
+    it "stores nil storage when no disks are reported" do
+      stub_inventory_server(specs: {hdd: []})
+      expect(leaseweb_apis.pull_inventory[:storage]).to be_nil
+    end
+
+    it "keeps an unmapped disk type as reported" do
+      stub_inventory_server(specs: {hdd: [{size: 8, unit: "TB", amount: 4, type: "SAS"}, {size: 1.92, unit: "TB", amount: 2, type: "SATA"}]})
+      expect(leaseweb_apis.pull_inventory[:storage]).to eq "4x 8TB SAS + 2x 1.92TB SATA SSD"
+    end
+
+    it "fails on a non-monthly contract" do
+      stub_inventory_server(contract: {billingCycle: 3})
+      expect { leaseweb_apis.pull_inventory }.to raise_error RuntimeError,
+        "leaseweb server 123 bills per 3 MONTH, not monthly"
+    end
+  end
+
   describe "pull_network_interfaces" do
     def stub_server(**body)
       stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123").to_return(status: 200, body: JSON.generate(body))

--- a/spec/lib/hosting/leaseweb_apis_spec.rb
+++ b/spec/lib/hosting/leaseweb_apis_spec.rb
@@ -185,10 +185,12 @@ RSpec.describe Hosting::LeasewebApis do
       expect(leaseweb_apis.pull_inventory[:storage]).to eq "4x 8TB SAS + 2x 1.92TB SATA SSD"
     end
 
-    it "fails on a non-monthly contract" do
+    it "omits the price for a contract that does not bill monthly" do
       stub_inventory_server(contract: {billingCycle: 3})
-      expect { leaseweb_apis.pull_inventory }.to raise_error RuntimeError,
-        "leaseweb server 123 bills per 3 MONTH, not monthly"
+      inventory = leaseweb_apis.pull_inventory
+      expect(inventory[:server_model]).to eq "HPE RL300"
+      expect(inventory[:monthly_price]).to be_nil
+      expect(inventory[:currency]).to be_nil
     end
   end
 

--- a/spec/model/address_spec.rb
+++ b/spec/model/address_spec.rb
@@ -49,7 +49,17 @@ RSpec.describe Address do
           _metadata: {totalCount: 1},
         )})
       Excon.stub({path: "/bareMetals/v2/servers/1", method: :get},
-        {status: 200, body: JSON.generate(location: {site: "AMS-01", suite: "8", rack: "9200"})})
+        {status: 200, body: JSON.generate(
+          location: {site: "AMS-01", suite: "8", rack: "9200"},
+          rack: {capacity: "10G"},
+          specs: {
+            chassis: "HPE RL300",
+            cpu: {type: "Ampere Altra Max M128-30", quantity: 2},
+            ram: {size: 512, unit: "GB"},
+            hdd: [{size: 3.84, unit: "TB", amount: 2, type: "NVME"}],
+          },
+          contract: {billingCycle: 1, billingFrequency: "MONTH", pricePerFrequency: "483.62", currency: "EUR"},
+        )})
       Excon.stub({path: "/bareMetals/v2/servers/1", method: :put}, {status: 204})
       Prog::Vm::HostNexus.assemble("1.2.3.4", provider_name:, server_identifier: "1").subject
     end

--- a/spec/model/address_spec.rb
+++ b/spec/model/address_spec.rb
@@ -49,7 +49,17 @@ RSpec.describe Address do
           _metadata: {totalCount: 1},
         ))
       stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/1")
-        .to_return(status: 200, body: JSON.generate(location: {site: "AMS-01", suite: "8", rack: "9200"}))
+        .to_return(status: 200, body: JSON.generate(
+          location: {site: "AMS-01", suite: "8", rack: "9200"},
+          rack: {capacity: "10G"},
+          specs: {
+            chassis: "HPE RL300",
+            cpu: {type: "Ampere Altra Max M128-30", quantity: 2},
+            ram: {size: 512, unit: "GB"},
+            hdd: [{size: 3.84, unit: "TB", amount: 2, type: "NVME"}],
+          },
+          contract: {billingCycle: 1, billingFrequency: "MONTH", pricePerFrequency: "483.62", currency: "EUR"},
+        ))
       stub_request(:put, "https://api.leaseweb.com/bareMetals/v2/servers/1").to_return(status: 204)
       Prog::Vm::HostNexus.assemble("1.2.3.4", provider_name:, server_identifier: "1").subject
     end

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -74,12 +74,32 @@ RSpec.describe Prog::Vm::HostNexus do
       stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123/ips").with(query: {limit: 50, offset: 0})
         .to_return(status: 200, body: JSON.generate(ips: rows, _metadata: {totalCount: rows.length}))
       stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123")
-        .to_return(status: 200, body: JSON.generate(location: {site: "AMS-01", suite: "8", rack: "9200"}))
+        .to_return(status: 200, body: JSON.generate(
+          location: {site: "AMS-01", suite: "8", rack: "9200"},
+          rack: {capacity: "10G"},
+          specs: {
+            chassis: "HPE RL300",
+            cpu: {type: "Ampere Altra Max M128-30", quantity: 2},
+            ram: {size: 512, unit: "GB"},
+            hdd: [{size: 3.84, unit: "TB", amount: 2, type: "NVME"}],
+          },
+          contract: {billingCycle: 1, billingFrequency: "MONTH", pricePerFrequency: "512.34", currency: "EUR"},
+        ))
       stub_request(:put, "https://api.leaseweb.com/bareMetals/v2/servers/123").to_return(status: 204)
 
       st = described_class.assemble("216.22.50.197", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "123")
       expect(st.subject.provider_name).to eq(HostProvider::LEASEWEB_PROVIDER_NAME)
       expect(st.subject.data_center).to eq("AMS-01-8-9200")
+      expect(st.subject.inventory).to have_attributes(
+        server_model: "HPE RL300",
+        cpu: "2x Ampere Altra Max M128-30",
+        memory: "512GB",
+        storage: "2x 3.84TB NVMe SSD",
+        uplink: "10Gbps",
+        gpu: nil,
+        monthly_price: BigDecimal("512.34"),
+        currency: "EUR",
+      )
       expect(st.subject.assigned_subnets.map { it.cidr.to_s }.sort).to eq(["216.22.15.64/26", "216.22.50.197/32", "2607:f5b7:3:104::/64"])
       # Only the gatewayed main IP is claimed; the routed block and prefix are VM space.
       expect(st.subject.assigned_host_addresses.map { it.ip.to_s }).to eq ["216.22.50.197/32"]
@@ -99,12 +119,23 @@ RSpec.describe Prog::Vm::HostNexus do
       stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/456/ips").with(query: {limit: 50, offset: 0}, **eu)
         .to_return(status: 200, body: JSON.generate(ips: rows, _metadata: {totalCount: rows.length}))
       stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/456").with(**eu)
-        .to_return(status: 200, body: JSON.generate(location: {site: "FRA-10", suite: "2", rack: "11"}))
+        .to_return(status: 200, body: JSON.generate(
+          location: {site: "FRA-10", suite: "2", rack: "11"},
+          rack: {capacity: "10G"},
+          specs: {
+            chassis: "Dell R6615",
+            cpu: {type: "AMD EPYC 9354P", quantity: 1},
+            ram: {size: 384, unit: "GB"},
+            hdd: [{size: 1.92, unit: "TB", amount: 2, type: "NVME"}],
+          },
+          contract: {billingCycle: 1, billingFrequency: "MONTH", pricePerFrequency: "441.00", currency: "EUR"},
+        ))
       stub_request(:put, "https://api.leaseweb.com/bareMetals/v2/servers/456").with(**eu).to_return(status: 204)
 
       st = described_class.assemble("212.95.60.214", provider_name: HostProvider::LEASEWEB_EU_PROVIDER_NAME, server_identifier: "456")
       expect(st.subject.provider_name).to eq(HostProvider::LEASEWEB_EU_PROVIDER_NAME)
       expect(st.subject.data_center).to eq("FRA-10-2-11")
+      expect(st.subject.inventory.monthly_price).to eq(BigDecimal("441.00"))
       expect(st.subject.assigned_host_addresses.map { it.ip.to_s }).to eq ["212.95.60.214/32"]
     end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -74,12 +74,32 @@ RSpec.describe Prog::Vm::HostNexus do
       Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
         {status: 200, body: JSON.generate(ips: rows, _metadata: {totalCount: rows.length})})
       Excon.stub({path: "/bareMetals/v2/servers/123", method: :get},
-        {status: 200, body: JSON.generate(location: {site: "AMS-01", suite: "8", rack: "9200"})})
+        {status: 200, body: JSON.generate(
+          location: {site: "AMS-01", suite: "8", rack: "9200"},
+          rack: {capacity: "10G"},
+          specs: {
+            chassis: "HPE RL300",
+            cpu: {type: "Ampere Altra Max M128-30", quantity: 2},
+            ram: {size: 512, unit: "GB"},
+            hdd: [{size: 3.84, unit: "TB", amount: 2, type: "NVME"}],
+          },
+          contract: {billingCycle: 1, billingFrequency: "MONTH", pricePerFrequency: "512.34", currency: "EUR"},
+        )})
       Excon.stub({path: "/bareMetals/v2/servers/123", method: :put}, {status: 204})
 
       st = described_class.assemble("216.22.50.197", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "123")
       expect(st.subject.provider_name).to eq(HostProvider::LEASEWEB_PROVIDER_NAME)
       expect(st.subject.data_center).to eq("AMS-01-8-9200")
+      expect(st.subject.inventory).to have_attributes(
+        server_model: "HPE RL300",
+        cpu: "2x Ampere Altra Max M128-30",
+        memory: "512GB",
+        storage: "2x 3.84TB NVMe SSD",
+        uplink: "10Gbps",
+        gpu: nil,
+        monthly_price: BigDecimal("512.34"),
+        currency: "EUR",
+      )
       expect(st.subject.assigned_subnets.map { it.cidr.to_s }.sort).to eq(["216.22.15.64/26", "216.22.50.197/32", "2607:f5b7:3:104::/64"])
       # Only the gatewayed main IP is claimed; the routed block and prefix are VM space.
       expect(st.subject.assigned_host_addresses.map { it.ip.to_s }).to eq ["216.22.50.197/32"]
@@ -99,12 +119,23 @@ RSpec.describe Prog::Vm::HostNexus do
       Excon.stub(eu.merge(path: "/bareMetals/v2/servers/456/ips", query: {limit: 50, offset: 0}),
         {status: 200, body: JSON.generate(ips: rows, _metadata: {totalCount: rows.length})})
       Excon.stub(eu.merge(path: "/bareMetals/v2/servers/456", method: :get),
-        {status: 200, body: JSON.generate(location: {site: "FRA-10", suite: "2", rack: "11"})})
+        {status: 200, body: JSON.generate(
+          location: {site: "FRA-10", suite: "2", rack: "11"},
+          rack: {capacity: "10G"},
+          specs: {
+            chassis: "Dell R6615",
+            cpu: {type: "AMD EPYC 9354P", quantity: 1},
+            ram: {size: 384, unit: "GB"},
+            hdd: [{size: 1.92, unit: "TB", amount: 2, type: "NVME"}],
+          },
+          contract: {billingCycle: 1, billingFrequency: "MONTH", pricePerFrequency: "441.00", currency: "EUR"},
+        )})
       Excon.stub(eu.merge(path: "/bareMetals/v2/servers/456", method: :put), {status: 204})
 
       st = described_class.assemble("212.95.60.214", provider_name: HostProvider::LEASEWEB_EU_PROVIDER_NAME, server_identifier: "456")
       expect(st.subject.provider_name).to eq(HostProvider::LEASEWEB_EU_PROVIDER_NAME)
       expect(st.subject.data_center).to eq("FRA-10-2-11")
+      expect(st.subject.inventory.monthly_price).to eq(BigDecimal("441.00"))
       expect(st.subject.assigned_host_addresses.map { it.ip.to_s }).to eq ["212.95.60.214/32"]
     end
 


### PR DESCRIPTION
Hetzner inventory rows are filled by hand from monthly invoices because Hetzner has no API for hardware or pricing details. Leaseweb reports both on its server endpoint, so pull them instead: a new Hosting::LeasewebApis#pull_inventory maps the server's specs, rack uplink, and contract price into vm_host_inventory's shape, and HostNexus.assemble records it when creating a Leaseweb host.

Contracts that do not bill monthly fail loudly rather than storing a quarterly or yearly amount as a monthly price.