### PR TITLE
Add ff for the IAM sweep in AWS timeline destroy

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -197,6 +197,7 @@ module Config
   optional :postgres_lantern_notification_email, string
   optional :postgres_notification_email, string
   override :aws_postgres_iam_access, false, bool
+  override :aws_postgres_blob_storage_iam_sweep, true, bool
   override :postgres_internal_firewall_cidrs, "", array(string)
 
   # Logging

--- a/model/postgres/aws/postgres_timeline.rb
+++ b/model/postgres/aws/postgres_timeline.rb
@@ -128,6 +128,21 @@ PGDATA=/dat/#{version}/data
 
       iam_client = location.location_credential_aws.iam_client
 
+      sweep_iam_leftovers(iam_client) if Config.aws_postgres_blob_storage_iam_sweep
+      ignore_missing_entity { iam_client.delete_policy(policy_arn: aws_s3_policy_arn) }
+    end
+
+    # A deployment that stays in iam-access mode has none of this. Setup creates
+    # no user and no access key, and the policy it attaches to each server role
+    # is detached by VM destroy before the role goes away.
+    #
+    # That detach in prog/vm/aws/nexus is gated on aws_postgres_iam_access as
+    # well, so flipping to access-key mode leaves roles still holding the policy
+    # and delete_role failing on them. The reverse flip leaves the user and key
+    # of every timeline created before it. Either way the leftovers outlive the
+    # mode that made them and only get cleared here, so the sweep defaults on
+    # and only a deployment that has never left iam-access mode should skip it.
+    def sweep_iam_leftovers(iam_client)
       (ignore_missing_entity { iam_client.list_access_keys(user_name: ubid).access_key_metadata } || []).each do |key|
         ignore_missing_entity { iam_client.delete_access_key(user_name: ubid, access_key_id: key.access_key_id) }
       end
@@ -136,15 +151,14 @@ PGDATA=/dat/#{version}/data
       end
       ignore_missing_entity { iam_client.delete_user(user_name: ubid) }
 
-      # The policy goes last, whichever mode created it. A policy will not
-      # delete while attached, and in iam-access mode it is attached to server
-      # roles rather than a user, so detach every holder that remains first.
+      # A policy will not delete while attached, and in iam-access mode it is
+      # attached to server roles rather than a user, so detach every holder
+      # that remains before the caller deletes it.
       if (entities = ignore_missing_entity { iam_client.list_entities_for_policy(policy_arn: aws_s3_policy_arn) })
         entities.policy_users.each { |user| ignore_missing_entity { iam_client.detach_user_policy(user_name: user.user_name, policy_arn: aws_s3_policy_arn) } }
         entities.policy_roles.each { |role| ignore_missing_entity { iam_client.detach_role_policy(role_name: role.role_name, policy_arn: aws_s3_policy_arn) } }
         entities.policy_groups.each { |group| ignore_missing_entity { iam_client.detach_group_policy(group_name: group.group_name, policy_arn: aws_s3_policy_arn) } }
       end
-      ignore_missing_entity { iam_client.delete_policy(policy_arn: aws_s3_policy_arn) }
     end
 
     # Tolerate an IAM entity already being gone. Wrapping each call separately,

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -522,6 +522,22 @@ PGDATA=/dat/17/data
 
         expect { postgres_timeline.destroy_blob_storage }.to raise_error(Aws::S3::Errors::BucketNotEmpty)
       end
+
+      it "deletes only the bucket and the policy when the IAM sweep is disabled" do
+        # A deployment that has only ever run in iam-access mode has no user,
+        # no access key and no surviving role attachment, so it can drop the
+        # IAM permissions the sweep needs.
+        expect(Config).to receive(:aws_postgres_blob_storage_iam_sweep).and_return(false)
+
+        expect(s3_client).to receive(:delete_bucket).with(bucket: postgres_timeline.ubid)
+        expect(iam_client).not_to receive(:list_access_keys)
+        expect(iam_client).not_to receive(:list_attached_user_policies)
+        expect(iam_client).not_to receive(:delete_user)
+        expect(iam_client).not_to receive(:list_entities_for_policy)
+        expect(iam_client).to receive(:delete_policy).with(policy_arn:)
+
+        postgres_timeline.destroy_blob_storage
+      end
     end
   end
 


### PR DESCRIPTION
Timeline destroy tears down the IAM user, its access keys and any remaining policy attachment whether or not the deployment ever made them. A deployment that only ever runs in iam-access mode makes none of that state, so it has to grant a pile of IAM permissions purely to call things that find nothing.

Put that half behind `ws_postgres_blob_storage_iam_sweep`, on by default. With it off the destroy empties and deletes the bucket and deletes the policy, and wants nothing else. Only turn it off where no access-key-mode timeline ever existed, since those leave behind a user and key that nothing else cleans up.