### PR TITLE
Default new Postgres databases to version 18

### DIFF
--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -9,7 +9,7 @@ class Clover
     size = typecast_params.nonempty_str!("size").gsub("burstable", "hobby")
     storage_size = typecast_params.pos_int("storage_size")
     ha_type = typecast_params.nonempty_str("ha_type", PostgresResource.ha_type_none)
-    version = typecast_params.nonempty_str("version", PostgresResource.default_version)
+    version = typecast_params.nonempty_str("version", PostgresResource.default_version(flavor))
     user_config = typecast_params.Hash("pg_config", {})
     pgbouncer_user_config = typecast_params.Hash("pgbouncer_config", {})
     tags = typecast_params.array(:Hash, "tags", [])

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -710,11 +710,16 @@ class PostgresResource < Sequel::Model
     self.class.partner_notification_flavors.include?(flavor)
   end
 
-  DEFAULT_VERSION = "17"
+  # Bumped on its own schedule: a version is offered in POSTGRES_VERSION_OPTIONS
+  # for a while before new databases are created with it by default.
+  DEFAULT_VERSION = "18"
   LATEST_VERSION = "18"
 
-  def self.default_version
-    DEFAULT_VERSION
+  def self.default_version(flavor = Flavor::STANDARD)
+    # The flavor is not validated before this runs, so an unknown one falls
+    # back to the standard list.
+    versions = Option::POSTGRES_VERSION_OPTIONS[flavor] || Option::POSTGRES_VERSION_OPTIONS[Flavor::STANDARD]
+    versions.include?(DEFAULT_VERSION) ? DEFAULT_VERSION : versions.max_by(&:to_i)
   end
 
   MAINTENANCE_DURATION_IN_HOURS = 2

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -15,7 +15,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   def_delegators :postgres_resource, :representative_server
 
   def self.assemble(project_id:, location_id:, name:, target_vm_size:, target_storage_size_gib:,
-    target_version: PostgresResource::DEFAULT_VERSION, flavor: PostgresResource::Flavor::STANDARD,
+    target_version: nil, flavor: PostgresResource::Flavor::STANDARD,
     ha_type: PostgresResource::HaType::NONE, parent_id: nil, tags: [], restore_target: nil, with_firewall_rules: true,
     user_config: {}, pgbouncer_user_config: {}, private_subnet_name: nil, init_script: nil,
     hostname_version: Config.postgres_hostname_version_default, restore_from_timeline_id: nil)
@@ -31,6 +31,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
     if restore_from_timeline_id && parent_id
       fail "Cannot specify both parent_id and restore_from_timeline_id"
     end
+
+    target_version ||= PostgresResource.default_version(flavor) if parent_id.nil?
 
     DB.transaction do
       superuser_password, timeline_id, timeline_access, target_version = if restore_from_timeline_id

--- a/spec/common/postgres.rb
+++ b/spec/common/postgres.rb
@@ -14,7 +14,7 @@ module PostgresTestHelpers
       name: "pg-test-#{SecureRandom.hex(4)}",
       target_vm_size: "standard-2",
       target_storage_size_gib: 64,
-      target_version: PostgresResource::DEFAULT_VERSION,
+      target_version: PostgresResource.default_version,
       flavor: "standard",
       ha_type: "none",
       parent_id: nil,
@@ -51,7 +51,7 @@ module PostgresTestHelpers
     s = PostgresServer.create(
       timeline:, resource:, vm_id: vm.id,
       is_representative:, synchronization_status: "ready",
-      timeline_access:, version: PostgresResource::DEFAULT_VERSION,
+      timeline_access:, version: PostgresResource.default_version,
     )
     Strand.create_with_id(s, prog: "Postgres::PostgresServerNexus", label: "start")
     s

--- a/spec/model/page_spec.rb
+++ b/spec/model/page_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Page do
       pg = create_postgres_resource(project:, location_id: Location::HETZNER_FSN1_ID)
       expect(described_class.root_resources(pg)).to eq [pg.id]
 
-      pv = PostgresServer.create(timeline: pt, resource_id: pg.id, is_representative: false, version: PostgresResource::DEFAULT_VERSION)
+      pv = PostgresServer.create(timeline: pt, resource_id: pg.id, is_representative: false, version: PostgresResource.default_version)
       expect(described_class.root_resources(pv)).to eq [pg.id]
 
       pv = create_postgres_server(resource: pg)

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -547,6 +547,22 @@ RSpec.describe PostgresResource do
     end
   end
 
+  describe ".default_version" do
+    it "returns the default version, which the standard flavor must offer" do
+      expect(Option::POSTGRES_VERSION_OPTIONS[PostgresResource::Flavor::STANDARD]).to include(PostgresResource::DEFAULT_VERSION)
+      expect(described_class.default_version).to eq(PostgresResource::DEFAULT_VERSION)
+    end
+
+    it "returns the newest supported version for a flavor without the default" do
+      expect(Option::POSTGRES_VERSION_OPTIONS[PostgresResource::Flavor::LANTERN]).not_to include(PostgresResource::DEFAULT_VERSION)
+      expect(described_class.default_version(PostgresResource::Flavor::LANTERN)).to eq("17")
+    end
+
+    it "falls back to the standard list for a flavor that does not exist" do
+      expect(described_class.default_version("bogus")).to eq(PostgresResource::DEFAULT_VERSION)
+    end
+  end
+
   describe "#boot_image" do
     it "returns the standard metal image for the standard flavor" do
       postgres_resource.update(flavor: PostgresResource::Flavor::STANDARD)

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
         vm_host = create_vm_host(location_id: resource.location_id)
         vm.update(vm_host_id: vm_host.id)
       end
-      boot_image = BootImage.create(vm_host_id: vm.vm_host_id, name: "ubuntu-jammy", version: "20240801", size_gib: 10)
+      boot_image = BootImage.create(vm_host_id: vm.vm_host_id, name: "ubuntu-jammy", version: PostgresResource::UPGRADE_IMAGE_MIN_VERSIONS[resource.target_version], size_gib: 10)
       vm.vm_storage_volumes_dataset.where(disk_index: 0).update(boot_image_id: boot_image.id)
     end
 
@@ -152,7 +152,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       location.update(provider: HostProvider::AWS_PROVIDER_NAME)
       LocationAz.create(location_id: location.id, az: "a", zone_id: "az1")
       LocationAz.create(location_id: location.id, az: "b", zone_id: "az2")
-      PgAwsAmi.create(aws_location_name: location.name, pg_version: "17", arch: "x64", aws_ami_id: "ami-test")
+      PgAwsAmi.create(aws_location_name: location.name, pg_version: pg.target_version, arch: "x64", aws_ami_id: "ami-test")
       server1 = create_server(is_representative: true, subnet_az: "a")
       server2 = create_server(subnet_az: "b")
       server1.incr_recycle
@@ -165,7 +165,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
     it "provisions a new server in a used az for aws if use_different_az_set? is false" do
       location.update(provider: HostProvider::AWS_PROVIDER_NAME)
       LocationAz.create(location_id: location.id, az: "a", zone_id: "az1")
-      PgAwsAmi.create(aws_location_name: location.name, pg_version: "17", arch: "x64", aws_ami_id: "ami-test")
+      PgAwsAmi.create(aws_location_name: location.name, pg_version: pg.target_version, arch: "x64", aws_ami_id: "ami-test")
       server = create_server(is_representative: true, subnet_az: "a")
       server.incr_recycle
       expect(Prog::Postgres::PostgresServerNexus).to receive(:assemble).with(hash_including(availability_zone: "a")).and_call_original
@@ -195,7 +195,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
     it "provisions a new server on AWS even if a server is not assigned to a vm_host" do
       location.update(provider: HostProvider::AWS_PROVIDER_NAME)
       LocationAz.create(location_id: location.id, az: "a", zone_id: "fsn1-az1")
-      PgAwsAmi.create(aws_location_name: location.name, pg_version: "17", arch: "x64", aws_ami_id: "ami-test")
+      PgAwsAmi.create(aws_location_name: location.name, pg_version: pg.target_version, arch: "x64", aws_ami_id: "ami-test")
       server = create_server(is_representative: true, subnet_az: "a")
       server.incr_recycle
       server.vm.update(vm_host_id: nil)
@@ -554,7 +554,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
     it "starts upgrade when not started" do
       expect(candidate.vm.sshable).to receive(:d_check).with("upgrade_postgres").and_return("NotStarted")
       expect(candidate).to receive(:configure_hash).and_return({"user_config" => {"wal_level" => "logical"}})
-      expect(candidate.vm.sshable).to receive(:d_run).with("upgrade_postgres", "sudo", "postgres/bin/upgrade", "17", stdin: JSON.generate({"user_config" => {"wal_level" => "logical"}}))
+      expect(candidate.vm.sshable).to receive(:d_run).with("upgrade_postgres", "sudo", "postgres/bin/upgrade", pg.target_version, stdin: JSON.generate({"user_config" => {"wal_level" => "logical"}}))
       expect { nx.upgrade_standby }.to nap(5)
     end
 
@@ -576,7 +576,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect(candidate).to receive(:switch_to_new_timeline).with(parent_id: nil)
       expect { nx.update_metadata }.to hop("wait_upgrade_candidate")
       expect(candidate.reload).to have_attributes(
-        version: "17",
+        version: pg.target_version,
         configure_set?: true,
         restart_set?: true,
       )

--- a/spec/prog/postgres/postgres_lockout_spec.rb
+++ b/spec/prog/postgres/postgres_lockout_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Prog::Postgres::PostgresLockout do
     it "returns false for failed lockout" do
       refresh_frame(nx, new_frame: {"mechanism" => "pg_stop"})
       expect(sshable).to receive(:_cmd).with(
-        "timeout 10 sudo pg_ctlcluster 17 main stop -m immediate",
+        "timeout 10 sudo pg_ctlcluster 18 main stop -m immediate",
         timeout: 15,
       ).and_raise(Sshable::SshError.new("", "", "", "", ""))
       expect { nx.start }.to exit({"msg" => "lockout_failed"})
@@ -46,7 +46,7 @@ RSpec.describe Prog::Postgres::PostgresLockout do
   describe "#lockout_with_pg_stop" do
     it "stops postgres and returns true on success" do
       expect(sshable).to receive(:_cmd).with(
-        "timeout 10 sudo pg_ctlcluster 17 main stop -m immediate",
+        "timeout 10 sudo pg_ctlcluster 18 main stop -m immediate",
         timeout: 15,
       ).and_return(true)
       expect { nx.lockout_with_pg_stop }.not_to raise_error
@@ -56,7 +56,7 @@ RSpec.describe Prog::Postgres::PostgresLockout do
   describe "#lockout_with_hba" do
     it "applies lockout pg_hba.conf and returns true on success" do
       expect(sshable).to receive(:_cmd).with(
-        "timeout 10 sudo postgres/bin/lockout-hba 17",
+        "timeout 10 sudo postgres/bin/lockout-hba 18",
         timeout: 15,
       ).and_return(true)
       expect { nx.lockout_with_hba }.not_to raise_error

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -479,7 +479,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
   describe "#initialize_empty_database" do
     it "triggers initialize_empty_database if initialize_empty_database command is not sent yet or failed" do
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_empty_database sudo postgres/bin/initialize-empty-database 17 true", {log: true, stdin: nil}).twice
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_empty_database sudo postgres/bin/initialize-empty-database 18 true", {log: true, stdin: nil}).twice
 
       # NotStarted
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_empty_database").and_return("NotStarted")
@@ -503,7 +503,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "passes false for strict overcommit when skip_strict_memory_overcommit semaphore is set" do
       postgres_resource.incr_skip_strict_memory_overcommit
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_empty_database").and_return("NotStarted")
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_empty_database sudo postgres/bin/initialize-empty-database 17 false", {log: true, stdin: nil})
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_empty_database sudo postgres/bin/initialize-empty-database 18 false", {log: true, stdin: nil})
       expect { nx.initialize_empty_database }.to nap(5)
     end
   end
@@ -512,7 +512,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "triggers initialize_database_from_backup if initialize_database_from_backup command is not sent yet or failed" do
       postgres_resource.update(restore_target: Time.now)
       expect(server.timeline).to receive(:latest_backup_label_before_target).and_return("backup-label").twice
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_database_from_backup sudo postgres/bin/initialize-database-from-backup 17 backup-label true recovery", {log: true, stdin: nil}).twice
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_database_from_backup sudo postgres/bin/initialize-database-from-backup 18 backup-label true recovery", {log: true, stdin: nil}).twice
 
       # NotStarted
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_database_from_backup").and_return("NotStarted")
@@ -556,7 +556,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       postgres_resource.incr_skip_strict_memory_overcommit
       expect(server.timeline).to receive(:latest_backup_label_before_target).and_return("backup-label")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_database_from_backup").and_return("NotStarted")
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_database_from_backup sudo postgres/bin/initialize-database-from-backup 17 backup-label false recovery", {log: true, stdin: nil})
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_database_from_backup sudo postgres/bin/initialize-database-from-backup 18 backup-label false recovery", {log: true, stdin: nil})
       expect { nx.initialize_database_from_backup }.to nap(5)
     end
 
@@ -566,7 +566,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       standby_nx = described_class.new(standby.strand)
       standby_sshable = standby_nx.postgres_server.vm.sshable
       expect(standby_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check initialize_database_from_backup").and_return("NotStarted")
-      expect(standby_sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_database_from_backup sudo postgres/bin/initialize-database-from-backup 17 LATEST true standby", {log: true, stdin: nil})
+      expect(standby_sshable).to receive(:_cmd).with("common/bin/daemonizer2 run initialize_database_from_backup sudo postgres/bin/initialize-database-from-backup 18 LATEST true standby", {log: true, stdin: nil})
       expect { standby_nx.initialize_database_from_backup }.to nap(5)
     end
 
@@ -675,7 +675,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("sudo chgrp cert_readers /etc/ssl/certs/server.key && sudo chmod 640 /etc/ssl/certs/server.key")
       expect(sshable).to receive(:_cmd).with("sudo chgrp cert_readers /etc/ssl/certs/client.crt && sudo chmod 640 /etc/ssl/certs/client.crt")
       expect(sshable).to receive(:_cmd).with("sudo chgrp cert_readers /etc/ssl/certs/client.key && sudo chmod 640 /etc/ssl/certs/client.key")
-      expect(sshable).to receive(:_cmd).with("sudo -u postgres pg_ctlcluster 17 main reload")
+      expect(sshable).to receive(:_cmd).with("sudo -u postgres pg_ctlcluster 18 main reload")
       expect(sshable).to receive(:_cmd).with("sudo systemctl reload pgbouncer@*.service")
       expect(server).to receive(:refresh_walg_credentials)
       expect { nx.refresh_certificates }.to hop("wait")
@@ -987,7 +987,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   describe "#configure" do
     it "triggers configure if configure command is not sent yet or failed" do
       expect(server).to receive(:configure_hash).and_return("dummy-configure-hash").twice
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run configure_postgres sudo postgres/bin/configure 17", {log: true, stdin: JSON.generate("dummy-configure-hash")}).twice
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run configure_postgres sudo postgres/bin/configure 18", {log: true, stdin: JSON.generate("dummy-configure-hash")}).twice
 
       # NotStarted
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check configure_postgres").and_return("NotStarted")
@@ -1001,7 +1001,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "handles use_physical_slot semaphore" do
       expect(server).to receive(:configure_hash).and_return("dummy-configure-hash")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check configure_postgres").and_return("NotStarted")
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run configure_postgres sudo postgres/bin/configure 17", {log: true, stdin: JSON.generate("dummy-configure-hash")})
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run configure_postgres sudo postgres/bin/configure 18", {log: true, stdin: JSON.generate("dummy-configure-hash")})
       server.incr_use_physical_slot
       expect { nx.configure }.to nap(5)
       expect(server.use_physical_slot_set?).to be true
@@ -1524,9 +1524,9 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     it "runs checkpoints and perform lockout" do
       expect(nx).to receive(:decr_fence)
       expect(server).to receive(:_run_query).with("CHECKPOINT; CHECKPOINT; CHECKPOINT;")
-      expect(sshable).to receive(:_cmd).with("sudo postgres/bin/lockout 17")
+      expect(sshable).to receive(:_cmd).with("sudo postgres/bin/lockout 18")
       expect(sshable).to receive(:_cmd).with("sudo systemctl stop postgres-metrics.timer")
-      expect(sshable).to receive(:_cmd).with("sudo pg_ctlcluster 17 main stop -m fast")
+      expect(sshable).to receive(:_cmd).with("sudo pg_ctlcluster 18 main stop -m fast")
       expect { nx.fence }.to hop("wait_in_fence")
     end
 
@@ -1684,13 +1684,13 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   describe "#promote_read_replica" do
     it "runs promote command if not started yet" do
       expect(sshable).to receive(:d_check).with("promote_postgres").and_return("NotStarted")
-      expect(sshable).to receive(:d_run).with("promote_postgres", "sudo", "postgres/bin/promote", "17")
+      expect(sshable).to receive(:d_run).with("promote_postgres", "sudo", "postgres/bin/promote", "18")
       expect { nx.promote_read_replica }.to nap(5)
     end
 
     it "retries promote command if previous run failed" do
       expect(sshable).to receive(:d_check).with("promote_postgres").and_return("Failed")
-      expect(sshable).to receive(:d_run).with("promote_postgres", "sudo", "postgres/bin/promote", "17")
+      expect(sshable).to receive(:d_run).with("promote_postgres", "sudo", "postgres/bin/promote", "18")
       expect { nx.promote_read_replica }.to nap(5)
     end
 
@@ -1722,14 +1722,14 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
   describe "#taking_over" do
     it "triggers promote if promote command is not sent yet" do
-      expect(sshable).to receive(:d_run).with("promote_postgres", "sudo", "postgres/bin/promote", "17")
+      expect(sshable).to receive(:d_run).with("promote_postgres", "sudo", "postgres/bin/promote", "18")
 
       expect(sshable).to receive(:d_check).with("promote_postgres").and_return("NotStarted")
       expect { nx.taking_over }.to nap(0)
     end
 
     it "retries if promote command is failed" do
-      expect(sshable).to receive(:d_run).with("promote_postgres", "sudo", "postgres/bin/promote", "17")
+      expect(sshable).to receive(:d_run).with("promote_postgres", "sudo", "postgres/bin/promote", "18")
 
       expect(sshable).to receive(:d_check).with("promote_postgres").and_return("Failed")
       expect { nx.taking_over }.to nap(0)
@@ -1863,7 +1863,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "returns true if the resource is upgrading" do
-      postgres_resource.update(target_version: "18")
+      server.update(version: "17")
       expect(server.resource).to receive(:upgrade_candidate_server).and_return(server)
       expect(nx.available?).to be(true)
     end

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -492,7 +492,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       sshable = nx.postgres_timeline.leader.vm.sshable
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("NotStarted").ordered
       expect(sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return((200 * 1024 * 1024).to_s).ordered
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17 25", {log: true, stdin: nil}).ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 18 25", {log: true, stdin: nil}).ordered
 
       expect { nx.take_backup }.to nap(60)
       expect(postgres_timeline.reload.latest_backup_started_at).not_to be_nil
@@ -504,7 +504,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       allow(nx.postgres_timeline).to receive(:walg_optimized_config_enabled?).and_return(false)
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("NotStarted").ordered
       expect(sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return((200 * 1024 * 1024).to_s).ordered
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17", {log: true, stdin: nil}).ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 18", {log: true, stdin: nil}).ordered
 
       expect { nx.take_backup }.to nap(60)
     end
@@ -513,7 +513,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       sshable = nx.postgres_timeline.leader.vm.sshable
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check take_postgres_backup").and_return("Failed").ordered
       expect(sshable).to receive(:_cmd).with("df --output=used /dat | tail -n 1").and_return("0").ordered
-      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 17 25", {log: true, stdin: nil}).ordered
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 run take_postgres_backup sudo postgres/bin/take-backup 18 25", {log: true, stdin: nil}).ordered
 
       expect { nx.take_backup }.to nap(60)
     end

--- a/spec/prog/test/ha_postgres_resource_spec.rb
+++ b/spec/prog/test/ha_postgres_resource_spec.rb
@@ -208,8 +208,8 @@ RSpec.describe Prog::Test::HaPostgresResource do
       primary = pgr_test.postgres_resource.servers.first
       sshable = Sshable.new
       allow(primary.vm).to receive(:sshable).and_return(sshable)
-      allow(sshable).to receive(:_cmd).with("ps aux | grep -v grep | grep /usr/lib/postgresql/17/bin/postgres | awk '{print $2}' | xargs sudo kill -9").and_return("")
-      allow(sshable).to receive(:_cmd).with("echo -e '\nfoobar = baz' | sudo tee -a /etc/postgresql/17/main/conf.d/999-break.conf").and_return("")
+      allow(sshable).to receive(:_cmd).with("ps aux | grep -v grep | grep /usr/lib/postgresql/18/bin/postgres | awk '{print $2}' | xargs sudo kill -9").and_return("")
+      allow(sshable).to receive(:_cmd).with("echo -e '\nfoobar = baz' | sudo tee -a /etc/postgresql/18/main/conf.d/999-break.conf").and_return("")
       expect { pgr_test.trigger_failover }.to hop("wait_failover")
     end
   end

--- a/spec/routes/api/cli/pg/create-read-replica_spec.rb
+++ b/spec/routes/api/cli/pg/create-read-replica_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Clover, "cli pg create-read-replica" do
     expect(pg.target_vm_size).to eq "standard-2"
     expect(pg.target_storage_size_gib).to eq 64
     expect(pg.ha_type).to eq "none"
-    expect(pg.version).to eq "17"
+    expect(pg.version).to eq "18"
     expect(pg.flavor).to eq "standard"
     expect(pg.user_config).to eq({"max_connections" => "500"})
     expect(pg.pgbouncer_user_config).to eq({"max_client_conn" => "99"})

--- a/spec/routes/api/cli/pg/create_spec.rb
+++ b/spec/routes/api/cli/pg/create_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Clover, "cli pg create" do
     expect(pg.target_vm_size).to eq "standard-2"
     expect(pg.target_storage_size_gib).to eq 64
     expect(pg.ha_type).to eq "none"
-    expect(pg.version).to eq "17"
+    expect(pg.version).to eq "18"
     expect(pg.flavor).to eq "standard"
     expect(pg.pg_firewall_rules_dataset.count).to eq 4
     expect(pg.tags).to eq([])

--- a/spec/routes/api/cli/pg/list_spec.rb
+++ b/spec/routes/api/cli/pg/list_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Clover, "cli pg list" do
   end
 
   it "shows list of PostgreSQL databases" do
-    expect(cli(%w[pg list -N])).to eq "eu-central-h1  test-pg  #{@pg.ubid}  17  standard\n"
+    expect(cli(%w[pg list -N])).to eq "eu-central-h1  test-pg  #{@pg.ubid}  18  standard\n"
   end
 
   it "-f option specifies fields" do
@@ -25,14 +25,14 @@ RSpec.describe Clover, "cli pg list" do
   end
 
   it "-l option filters to specific location" do
-    expect(cli(%w[pg list -Nleu-central-h1])).to eq "eu-central-h1  test-pg  #{@pg.ubid}  17  standard\n"
+    expect(cli(%w[pg list -Nleu-central-h1])).to eq "eu-central-h1  test-pg  #{@pg.ubid}  18  standard\n"
     expect(cli(%w[pg list -Nleu-north-h1])).to eq "\n"
   end
 
   it "headers are shown by default" do
     expect(cli(%w[pg list])).to eq <<~END
       location       name     #{id_headr}  version  flavor  
-      eu-central-h1  test-pg  #{@pg.ubid}  17       standard
+      eu-central-h1  test-pg  #{@pg.ubid}  18       standard
     END
   end
 
@@ -40,7 +40,7 @@ RSpec.describe Clover, "cli pg list" do
     @pg.update(name: "Abc")
     expect(cli(%w[pg list])).to eq <<~END
       location       name  #{id_headr}  version  flavor  
-      eu-central-h1  Abc   #{@pg.ubid}  17       standard
+      eu-central-h1  Abc   #{@pg.ubid}  18       standard
     END
   end
 

--- a/spec/routes/api/cli/pg/show_spec.rb
+++ b/spec/routes/api/cli/pg/show_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Clover, "cli pg show" do
       target-vm-size: standard-2
       storage-size-gib: 64
       target-storage-size-gib: 64
-      version: 17
-      target-version: 17
+      version: 18
+      target-version: 18
       ha-type: none
       flavor: standard
       connection-string: postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com:5432/postgres?sslmode=require&channel_binding=require
@@ -70,8 +70,8 @@ RSpec.describe Clover, "cli pg show" do
       target-vm-size: standard-2
       storage-size-gib: 64
       target-storage-size-gib: 64
-      version: 17
-      target-version: 17
+      version: 18
+      target-version: 18
       ha-type: none
       flavor: standard
       connection-string: postgres://postgres:#{@pg.superuser_password}@test-pg.#{@pg.ubid}.pg.example.com:5432/postgres?sslmode=require&channel_binding=require

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -467,7 +467,7 @@ RSpec.describe CloverAdmin do
     within(".association", text: "postgres_resources") { click_link "(table)" }
     expect(page.title).to eq "Ubicloud Admin - PostgresResource - Search"
     expect(page.all("#autoforme_content td").map(&:text)).to eq [
-      "assoc-table-pg", "assoc-table-test", "hetzner-fsn1", "standard", "standard-2", "64", "none", "17", "", pg.created_at.to_s,
+      "assoc-table-pg", "assoc-table-test", "hetzner-fsn1", "standard", "standard-2", "64", "none", "18", "", pg.created_at.to_s,
     ]
 
     server = pg.servers.first
@@ -475,7 +475,7 @@ RSpec.describe CloverAdmin do
     within(".association", text: "servers") { click_link "(table)" }
     expect(page.title).to eq "Ubicloud Admin - PostgresServer - Search"
     expect(page.all("#autoforme_content td").map(&:text)).to eq [
-      server.ubid, server.vm.ubid, "assoc-table-pg", "push", "ready", "17", "true", server.created_at.to_s,
+      server.ubid, server.vm.ubid, "assoc-table-pg", "push", "ready", "18", "true", server.created_at.to_s,
     ]
 
     vm_host = create_vm_host
@@ -676,7 +676,7 @@ RSpec.describe CloverAdmin do
     click_link "PostgresResource"
     expect(page.title).to eq "Ubicloud Admin - PostgresResource - Browse"
     expect(page.all("#autoforme_content td").map(&:text)).to eq [
-      "test-pg", "PgTest", "hetzner-fsn1", "standard", "standard-2", "64", "none", "17", "", pg.created_at.to_s,
+      "test-pg", "PgTest", "hetzner-fsn1", "standard", "standard-2", "64", "none", "18", "", pg.created_at.to_s,
     ]
 
     click_link pg.name
@@ -690,7 +690,7 @@ RSpec.describe CloverAdmin do
     fill_in "Created at", with: pg.created_at.strftime("%Y-%m")
     click_button "Search"
     expect(page.all("#autoforme_content td").map(&:text)).to eq [
-      "test-pg", "PgTest", "hetzner-fsn1", "standard", "standard-2", "64", "none", "17", "", pg.created_at.to_s,
+      "test-pg", "PgTest", "hetzner-fsn1", "standard", "standard-2", "64", "none", "18", "", pg.created_at.to_s,
     ]
 
     child_pg = Prog::Postgres::PostgresResourceNexus.assemble(
@@ -706,7 +706,7 @@ RSpec.describe CloverAdmin do
     fill_in "Parent", with: pg.ubid
     click_button "Search"
     expect(page.all("#autoforme_content td").map(&:text)).to eq [
-      "test-child-pg", "PgTest", "hetzner-fsn1", "standard", "standard-2", "64", "none", "17", "test-pg", child_pg.created_at.to_s,
+      "test-child-pg", "PgTest", "hetzner-fsn1", "standard", "standard-2", "64", "none", "18", "test-pg", child_pg.created_at.to_s,
     ]
   end
 
@@ -725,7 +725,7 @@ RSpec.describe CloverAdmin do
     click_link "PostgresServer"
     expect(page.title).to eq "Ubicloud Admin - PostgresServer - Browse"
     expect(page.all("#autoforme_content td").map(&:text)).to eq [
-      server.ubid, server.vm.ubid, "test-pg", "push", "ready", "17", "true", server.created_at.to_s,
+      server.ubid, server.vm.ubid, "test-pg", "push", "ready", "18", "true", server.created_at.to_s,
     ]
 
     click_link server.ubid, match: :first
@@ -739,7 +739,7 @@ RSpec.describe CloverAdmin do
     select "push", from: "Timeline access"
     click_button "Search"
     expect(page.all("#autoforme_content td").map(&:text)).to eq [
-      server.ubid, server.vm.ubid, "test-pg", "push", "ready", "17", "true", server.created_at.to_s,
+      server.ubid, server.vm.ubid, "test-pg", "push", "ready", "18", "true", server.created_at.to_s,
     ]
 
     click_link "test-pg"
@@ -751,7 +751,7 @@ RSpec.describe CloverAdmin do
     expect(Config).to receive(:postgres_service_project_id).and_return(project.id).at_least(:once)
 
     resource_id = PostgresResource.generate_uuid
-    server = PostgresServer.create(resource_id:, timeline: create_postgres_timeline(location_id: Location::HETZNER_FSN1_ID), version: PostgresResource::DEFAULT_VERSION)
+    server = PostgresServer.create(resource_id:, timeline: create_postgres_timeline(location_id: Location::HETZNER_FSN1_ID), version: PostgresResource.default_version)
 
     visit "/model/PostgresServer/#{server.ubid}"
     expect(page.title).to eq "Ubicloud Admin - PostgresServer #{server.ubid}"

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -143,6 +143,13 @@ RSpec.describe Clover, "postgres" do
         expect(pg.target_storage_size_gib).to eq(118)
       end
 
+      it "pre-selects the default version rather than the newest one offered" do
+        visit "#{project.path}/postgres/create?flavor=#{PostgresResource::Flavor::STANDARD}"
+
+        checked = all("input[name=version]", visible: false).select(&:checked?).map { |input| input.value }
+        expect(checked).to eq([PostgresResource.default_version])
+      end
+
       it "can specify an init script when creating new PostgreSQL database" do
         project.set_ff_postgres_init_script(true)
         visit "#{project.path}/postgres/create?flavor=#{PostgresResource::Flavor::STANDARD}"

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -59,6 +59,10 @@
   end
 
   action = "#{@project.path}/postgres"
+
+  # Without this the form checks the first version offered, which is the newest
+  # rather than the one new databases default to.
+  pre_selected_values = {"version" => PostgresResource.default_version(@flavor)}
 %>
 
-<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>
+<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents, pre_selected_values:) %>


### PR DESCRIPTION
Stacked on #6076 (ParadeDB removal) — review that one first; this PR's
diff against `main` will shrink once it merges.

The create form pre-selected the first version offered, which is the
newest, while the API, CLI, and `PostgresResourceNexus.assemble`
defaulted to 17, so the version a database got depended on which surface
created it. Give both a single knob: `DEFAULT_VERSION` is what new
databases get, and `POSTGRES_VERSION_OPTIONS` stays the list of what may
be chosen, so a release can be offered for a while before it becomes the
default. A flavor that does not offer `DEFAULT_VERSION` falls back to the
newest it does support, which keeps Lantern on 17 until it supports 18
without naming Lantern anywhere.

That also fixes the parent-version check in `assemble`. `target_version`
defaults to nil now, so "must be the same as the parent" compares what
the caller passed instead of a default the caller never chose; a read
replica of a PG16 database created without an explicit version used to
fail validation.

## Notes for review

- **Adding 19 to the options list will not change the default.** That was
  the flaw in the first cut of this PR, which derived the default from the
  head of the list. It is why the form now gets `pre_selected_values` — the
  form independently defaulted to newest-wins, so fixing only the model
  would have left the UI handing out 19 while the API handed out 18.
- **Version specs assert against `DEFAULT_VERSION`, not a literal**, so
  they begin catching a regression to newest-wins the moment the two
  diverge. Forcing that divergence today via `stub_const` is not possible:
  `CLOVER_FREEZE` freezes `Option`, and the failed stub leaks mock doubles
  into unrelated examples (61 failures in `frozen_pspec`).
- **The `|| STANDARD` fallback is load-bearing.** `postgres_post` resolves
  the default before validation runs, so an unknown flavor would otherwise
  raise `NoMethodError` and turn an existing 400 into a 500.
- **Image availability checked:** PG 18 images exist in all 5 AWS regions
  (both arches) and on GCP, and the metal image carries 16/17/18.
- **Spec churn** is the test factory now provisioning 18. Where a hardcoded
  `17` really meant "whatever the resource is on", it now reads from the
  source (`pg.target_version`,
  `UPGRADE_IMAGE_MIN_VERSIONS[resource.target_version]`) so the next bump
  does not re-break it. `available?` "returns true if the resource is
  upgrading" had gone vacuous with both sides at 18; it now puts the server
  on 17 so an upgrade is genuinely in flight.

`rake coverage_pspec` passes (7759 examples, 100% line and branch),
`frozen_pspec` (7737 examples) and rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)