### PR TITLE
Bound the rsyslog log files under /var/log on Postgres servers

### DIFF
--- a/rhizome/postgres/bin/configure-logs
+++ b/rhizome/postgres/bin/configure-logs
@@ -4,6 +4,7 @@
 require "json"
 require_relative "../../common/lib/util"
 require_relative "../lib/otel_log_config"
+require_relative "../lib/syslog_rotate_config"
 
 config = JSON.parse($stdin.read)
 instance = config["instance"]
@@ -14,6 +15,10 @@ resource_name = config["resource_name"]
 log_destinations = config["log_destinations"] || []
 
 log_dir = "/dat/#{version}/data/pg_log"
+
+# Bound the rsyslog copies under /var/log. Independent of log_destinations:
+# these files are never shipped anywhere, they just fill the root filesystem.
+SyslogRotateConfig.new.setup
 
 r "mkdir", "-p", "/etc/otelcol-contrib", "/var/lib/otelcol-contrib/state", "/tmp/otelcol"
 otelcol_user = "otelcol-contrib"

--- a/rhizome/postgres/lib/syslog_rotate_config.rb
+++ b/rhizome/postgres/lib/syslog_rotate_config.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+# Bounds the size of the rsyslog-written files under /var/log.
+#
+# These files are a duplicate of the systemd journal: rsyslog reads the journal
+# and writes /var/log/syslog, /var/log/auth.log and friends. Nothing in the
+# product consumes them -- OtelLogConfig ships postgres and pgbouncer logs to
+# customer destinations from the journald receiver, not from /var/log -- so they
+# exist purely for on-box debugging and can be rotated aggressively.
+#
+# The stock Ubuntu config (/etc/logrotate.d/rsyslog, an rsyslog conffile) is
+# `weekly` with `rotate 4` and no size ceiling, so a single generation
+# accumulates an entire week. On a busy server pgbouncer alone logs a line per
+# client connect and disconnect, which is enough to reach multiple GB in one
+# generation and fill the root filesystem. disk-full-check does not help here:
+# it watches the /dat data disk, not the root filesystem.
+#
+# Two pieces are needed, and the timer is not optional:
+#
+#   1. MAXSIZE caps a single generation, so growth is bounded by volume rather
+#      than by the calendar.
+#   2. logrotate.timer runs daily out of the box, and `maxsize` is only
+#      evaluated when logrotate actually runs -- a daily timer cannot enforce a
+#      sub-daily cap. The drop-in moves it to hourly. This is safe for every
+#      other logrotate config on the host: time-based configs still honor their
+#      own daily/weekly interval regardless of how often logrotate is invoked,
+#      so only maxsize configs rotate more frequently.
+#
+# We overwrite the rsyslog conffile in place rather than shipping our own file.
+# logrotate aborts with "duplicate log entry" if two configs cover the same
+# path, so a drop-in alongside the stock file is not an option. Package
+# upgrades can drift the file, but unattended-upgrades runs --force-confold so
+# the local version survives, and re-running this installer repairs drift.
+class SyslogRotateConfig
+  RSYSLOG_LOGROTATE_PATH = "/etc/logrotate.d/rsyslog"
+  TIMER_OVERRIDE_DIR = "/etc/systemd/system/logrotate.timer.d"
+  TIMER_OVERRIDE_PATH = File.join(TIMER_OVERRIDE_DIR, "10-ubicloud-hourly.conf")
+
+  # Cap for a single generation. Two generations are uncompressed at any moment
+  # -- the live file and, under delaycompress, the one behind it -- so this term
+  # dominates the disk budget. Aged generations compress roughly 35x and are
+  # nearly free by comparison.
+  MAXSIZE = "500M"
+
+  # Retention is bounded by count, not time: with maxsize doing the rotating, a
+  # noisy server keeps fewer days than a quiet one. That is the intended
+  # tradeoff -- these files are a journal duplicate, and bounding disk matters
+  # more than a fixed retention window.
+  #
+  # Both constants are sized against a ~2 GB budget for the whole set. The
+  # busiest server we have measured logs 31 MiB/h -- pgbouncer logs a line per
+  # client connect and disconnect, which is what drives the busy case -- and at
+  # these values keeps about a month of history for ~1.6 GB. The headroom is
+  # deliberate: at 25x compression rather than the ~43x we actually see, the set
+  # is still under budget. A quiet server never reaches maxsize, falls through
+  # to `daily`, and keeps 45 days.
+  ROTATE = 45
+
+  # Paths from the stock Ubuntu rsyslog logrotate config. Kept verbatim so the
+  # non-syslog files (notably auth.log, which also grows large) stay covered.
+  LOG_PATHS = [
+    "/var/log/syslog",
+    "/var/log/mail.info",
+    "/var/log/mail.warn",
+    "/var/log/mail.err",
+    "/var/log/mail.log",
+    "/var/log/daemon.log",
+    "/var/log/kern.log",
+    "/var/log/auth.log",
+    "/var/log/user.log",
+    "/var/log/lpr.log",
+    "/var/log/cron.log",
+    "/var/log/debug",
+    "/var/log/messages",
+  ].freeze
+
+  def logrotate_content
+    <<~LOGROTATE
+      # Managed by Ubicloud. Local edits are overwritten by configure-logs.
+      #{LOG_PATHS.join("\n")}
+      {
+          rotate #{ROTATE}
+          daily
+          maxsize #{MAXSIZE}
+          missingok
+          notifempty
+          compress
+          delaycompress
+          sharedscripts
+          postrotate
+              /usr/lib/rsyslog/rsyslog-rotate
+          endscript
+      }
+    LOGROTATE
+  end
+
+  def timer_override_content
+    <<~TIMER
+      # Managed by Ubicloud. Local edits are overwritten by configure-logs.
+      # maxsize in #{RSYSLOG_LOGROTATE_PATH} is only evaluated when logrotate
+      # runs; the stock timer is daily, which is too coarse to enforce it.
+      [Timer]
+      OnCalendar=
+      OnCalendar=hourly
+      RandomizedDelaySec=5m
+    TIMER
+  end
+
+  def setup
+    # logrotate skips configs that are group- or world-writable, so the mode is
+    # load-bearing rather than cosmetic. perm applies it before the rename, so
+    # the file is never published at a mode logrotate would reject.
+    safe_write_to_file(RSYSLOG_LOGROTATE_PATH, logrotate_content, perm: 0o644)
+
+    r "mkdir", "-p", TIMER_OVERRIDE_DIR
+    safe_write_to_file(TIMER_OVERRIDE_PATH, timer_override_content, perm: 0o644)
+
+    r "systemctl", "daemon-reload"
+    r "systemctl", "restart", "logrotate.timer"
+  end
+end

--- a/rhizome/postgres/spec/syslog_rotate_config_spec.rb
+++ b/rhizome/postgres/spec/syslog_rotate_config_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative "../lib/syslog_rotate_config"
+
+RSpec.describe SyslogRotateConfig do
+  let(:syslog_rotate) { described_class.new }
+
+  describe "#logrotate_content" do
+    let(:content) { syslog_rotate.logrotate_content }
+
+    it "caps a single generation by size" do
+      expect(content).to include("maxsize 500M")
+    end
+
+    it "rotates daily rather than weekly" do
+      expect(content).to include("daily")
+      expect(content).not_to include("weekly")
+    end
+
+    it "bounds retention by generation count" do
+      expect(content).to include("rotate 45")
+    end
+
+    it "compresses aged generations" do
+      expect(content).to include("compress")
+      expect(content).to include("delaycompress")
+    end
+
+    it "covers syslog and auth.log" do
+      expect(content).to include("/var/log/syslog\n")
+      expect(content).to include("/var/log/auth.log\n")
+    end
+
+    it "keeps the stock postrotate hook so rsyslog reopens its files" do
+      expect(content).to include("postrotate")
+      expect(content).to include("/usr/lib/rsyslog/rsyslog-rotate")
+      expect(content).to include("endscript")
+    end
+
+    it "uses sharedscripts so postrotate runs once for all paths" do
+      expect(content).to include("sharedscripts")
+    end
+
+    it "tolerates paths removed by hand" do
+      expect(content).to include("missingok")
+    end
+
+    it "marks the file as managed" do
+      expect(content).to include("Managed by Ubicloud")
+    end
+  end
+
+  describe "#timer_override_content" do
+    let(:content) { syslog_rotate.timer_override_content }
+
+    it "resets the stock OnCalendar before setting its own" do
+      # Without the empty assignment systemd appends, leaving the daily
+      # trigger in place alongside the hourly one.
+      expect(content).to match(/OnCalendar=\nOnCalendar=hourly/)
+    end
+
+    it "is a Timer section override" do
+      expect(content).to include("[Timer]")
+    end
+  end
+
+  describe "#setup" do
+    before do
+      allow(syslog_rotate).to receive_messages(safe_write_to_file: nil, _run_command: nil)
+    end
+
+    it "writes the logrotate config at a mode logrotate accepts" do
+      expect(syslog_rotate).to receive(:safe_write_to_file).with("/etc/logrotate.d/rsyslog", syslog_rotate.logrotate_content, perm: 0o644)
+      syslog_rotate.setup
+    end
+
+    it "writes the timer override at a mode logrotate accepts, into a drop-in dir it creates" do
+      expect(syslog_rotate).to receive(:_run_command).with("mkdir", "-p", "/etc/systemd/system/logrotate.timer.d")
+      expect(syslog_rotate).to receive(:safe_write_to_file).with("/etc/systemd/system/logrotate.timer.d/10-ubicloud-hourly.conf", syslog_rotate.timer_override_content, perm: 0o644)
+      syslog_rotate.setup
+    end
+
+    it "reloads systemd and restarts the timer so the override takes effect" do
+      expect(syslog_rotate).to receive(:_run_command).with("systemctl", "daemon-reload")
+      expect(syslog_rotate).to receive(:_run_command).with("systemctl", "restart", "logrotate.timer")
+      syslog_rotate.setup
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The stock Ubuntu rsyslog logrotate config (`/etc/logrotate.d/rsyslog`) is `weekly` with `rotate 4` and no size ceiling, so a single generation accumulates an entire week. pgbouncer logs a line per client connect and disconnect, which is enough to fill the root filesystem on a busy server. `disk-full-check` does not catch this — it watches the `/dat` data disk, not `/`.

Two production servers measured a week apart:

| | `vmlq1e35gi` (Aug 3) | `vm79dwvw` (Aug 8) |
|---|---|---|
| largest syslog file | 4.37 GB (`syslog.1`) | 4.85 GiB (live `syslog`) |
| share from pgbouncer | ~95% | ~94% |

On `vm79dwvw`, `/var/log/syslog` covered Aug 2 00:00:02 → Aug 8 14:07:33 — a full weekly cycle at a steady **31.4 MiB/h**, so this is normal operation rather than a burst.

## Fix

Rewrite the rsyslog logrotate config with a `maxsize` cap so growth is bounded by volume rather than by the calendar, and move `logrotate.timer` to hourly.

The timer change is not optional: `maxsize` is only evaluated when logrotate actually runs, and the stock timer is daily, which is too coarse to enforce a sub-daily cap. It is safe for every other logrotate config on the host — time-based configs still honor their own daily/weekly interval regardless of how often logrotate is invoked, so only `maxsize` configs rotate more frequently.

The config is overwritten in place rather than shipped as a drop-in alongside the stock file: logrotate aborts with `duplicate log entry` if two configs cover the same path.

`maxsize 500M` with `rotate 45` is sized against a ~2 GB budget for the whole set. Two generations are uncompressed at any moment (the live file and, under `delaycompress`, the one behind it), so that term dominates; aged generations compress ~43x in practice and are nearly free. The headroom is deliberate — at a pessimistic 25x the set is still under budget.

At the measured 31.4 MiB/h:

| | before | after |
|---|---|---|
| rotation trigger | weekly | every ~16 h (size) |
| live file peak | unbounded — 4.85 GiB | ≤ 500 MiB |
| total on disk | unbounded | ~1.6 GB |
| history kept | 4 weeks | ~30 days |

A quiet server never reaches the size cap, falls through to `daily`, and keeps 45 days.

One qualifier on those numbers: `maxsize` and `rotate` are per log path, not per server. `syslog` dominates and is what the ~1.6 GB describes. The other paths in the config are typically empty, and `notifempty` keeps empty files from rotating at all — but `auth.log` was 83 MB on `vmlq1e35gi`, so a server with a chatty `auth.log` carries a second, smaller set on top of it. A hard per-server ceiling would need a different mechanism (journald's `SystemMaxUse`) and is out of scope here.

## Notes

These files are a duplicate of the systemd journal and nothing in the product consumes them: `OtelLogConfig` ships postgres and pgbouncer logs to customer destinations from the journald receiver, not from `/var/log`. They exist for on-box debugging, which is why this bounds them rather than disabling the rsyslog duplication outright.

pgbouncer's `log_connections`/`log_disconnections` both default to `1` and we never override them, which is the ~94%. Turning them off would cut the volume at the source, but it costs the per-connection forensics used to debug customer connection problems, and it would not bound the disk against anything else getting noisy. Left as a separate decision.

Existing servers pick this up via `resource.server_incr("configure_logs")`.

Reclaiming space on an already-full server needs `truncate -s 0`, not `rm` — rsyslog holds the fd on the live file, so `rm` frees nothing.

## Testing

`rhizome/postgres/spec/syslog_rotate_config_spec.rb`, 14 examples. Rubocop and `rake linter:cmd_exec` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
