### PR TITLE
Show matching VM host count on admin VM Host Usage

### DIFF
--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -3331,11 +3331,13 @@ RSpec.describe CloverAdmin do
     headers = page.all(".vm-host-usage-table thead th").map(&:text)
     expect(headers).to include("location", "provider")
     expect(page.all(".vm-host-usage-table tbody tr").size).to eq 2
+    expect(page.find(".vm-host-usage-table caption").text).to eq "VM Hosts (2)"
 
     select "hetzner-fsn1", from: "Location"
     click_button "Search"
     row = page.all(".vm-host-usage-table tbody tr").map { it.all("td").map(&:text) }
     expect(row.size).to eq 1
+    expect(page.find(".vm-host-usage-table caption").text).to eq "VM Hosts (1)"
     expect(row.first).to include(vm_host.ubid, "accepting", "FSN1-DC1", "hetzner", "standard", "2", "4 / 48", "32 / 375", "800 / 1500", "0 / 0", "2")
   end
 

--- a/views/admin/vm_host_usage.erb
+++ b/views/admin/vm_host_usage.erb
@@ -10,5 +10,5 @@
 <% end %>
 
 <% if @data %>
-  <%== part("components/table", title: nil, table_class: "vm-host-usage-table", data: @data, use_admin_label: false) %>
+  <%== part("components/table", title: "VM Hosts (#{@data.count})", table_class: "vm-host-usage-table", data: @data, use_admin_label: false) %>
 <% end %>


### PR DESCRIPTION
The usage table had no title and no indication of how many hosts matched the current filters, so counting rows was the only way to tell. Use the table caption to show the number of matching hosts.