### PR TITLE
Stub HTTP in specs with WebMock, not Excon.stub

### DIFF
--- a/spec/lib/cloudflare_client_spec.rb
+++ b/spec/lib/cloudflare_client_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe CloudflareClient do
   let(:client) { described_class.new("api_key") }
 
   it "create_token" do
-    Excon.stub({path: "/client/v4/user/tokens", method: :post}, {status: 200, body: {result: {id: "123", value: "secret"}}.to_json})
+    stub_request(:post, "https://api.cloudflare.com/client/v4/user/tokens").to_return(status: 200, body: {result: {id: "123", value: "secret"}}.to_json)
     expect(client.create_token("test-token", [{id: "test-policy"}])).to eq(["123", "secret"])
   end
 
   it "delete_token" do
     token_id = "123"
-    Excon.stub({path: "/client/v4/user/tokens/#{token_id}", method: :delete}, {status: 200})
+    stub_request(:delete, "https://api.cloudflare.com/client/v4/user/tokens/#{token_id}").to_return(status: 200)
     expect(client.delete_token(token_id)).to eq(200)
   end
 
@@ -18,73 +18,67 @@ RSpec.describe CloudflareClient do
     let(:zone_id) { "abc123" }
 
     it "zone_id_by_name returns the zone id" do
-      Excon.stub({path: "/client/v4/zones", method: :get, query: {name: "tahcloud.com"}}, {status: 200, body: {result: [{id: zone_id, name: "tahcloud.com"}]}.to_json})
+      stub_request(:get, "https://api.cloudflare.com/client/v4/zones").with(query: {name: "tahcloud.com"}).to_return(status: 200, body: {result: [{id: zone_id, name: "tahcloud.com"}]}.to_json)
       expect(client.zone_id_by_name("tahcloud.com")).to eq(zone_id)
     end
 
     it "zone_id_by_name raises when no zone is found" do
-      Excon.stub({path: "/client/v4/zones", method: :get, query: {name: "missing.com"}}, {status: 200, body: {result: []}.to_json})
+      stub_request(:get, "https://api.cloudflare.com/client/v4/zones").with(query: {name: "missing.com"}).to_return(status: 200, body: {result: []}.to_json)
       expect { client.zone_id_by_name("missing.com") }.to raise_error(RuntimeError, /Cloudflare zone not found: missing.com/)
     end
 
     describe "#ensure_dns_record" do
       let(:name) { "ns-e2e.example.com" }
-      let(:list_path) { "/client/v4/zones/#{zone_id}/dns_records" }
+      let(:list_url) { "https://api.cloudflare.com/client/v4/zones/#{zone_id}/dns_records" }
       let(:create_body) { {type: "A", name:, content: "1.2.3.4", ttl: 60, proxied: false}.to_json }
 
       it "returns the existing record id when an exact match is found" do
-        Excon.stub(
-          {path: list_path, method: :get, query: {name:, type: "A"}},
-          {status: 200, body: {result: [{id: "rec1", content: "1.2.3.4", ttl: 60, proxied: false}]}.to_json},
-        )
+        stub_request(:get, list_url).with(query: {name:, type: "A"})
+          .to_return(status: 200, body: {result: [{id: "rec1", content: "1.2.3.4", ttl: 60, proxied: false}]}.to_json)
         expect(client.ensure_dns_record(zone_id, type: "A", name:, content: "1.2.3.4")).to eq("rec1")
       end
 
       it "creates a new record when none exist" do
-        Excon.stub({path: list_path, method: :get, query: {name:, type: "A"}}, {status: 200, body: {result: []}.to_json})
-        Excon.stub({path: list_path, method: :post, body: create_body}, {status: 200, body: {result: {id: "new-rec"}}.to_json})
+        stub_request(:get, list_url).with(query: {name:, type: "A"}).to_return(status: 200, body: {result: []}.to_json)
+        stub_request(:post, list_url).with(body: create_body).to_return(status: 200, body: {result: {id: "new-rec"}}.to_json)
         expect(client.ensure_dns_record(zone_id, type: "A", name:, content: "1.2.3.4")).to eq("new-rec")
       end
 
       it "deletes a record that differs and creates a fresh one" do
-        Excon.stub(
-          {path: list_path, method: :get, query: {name:, type: "A"}},
-          {status: 200, body: {result: [{id: "stale", content: "9.9.9.9", ttl: 60, proxied: false}]}.to_json},
-        )
-        Excon.stub({path: "#{list_path}/stale", method: :delete}, {status: 200})
-        Excon.stub({path: list_path, method: :post, body: create_body}, {status: 200, body: {result: {id: "new-rec"}}.to_json})
+        stub_request(:get, list_url).with(query: {name:, type: "A"})
+          .to_return(status: 200, body: {result: [{id: "stale", content: "9.9.9.9", ttl: 60, proxied: false}]}.to_json)
+        stub_request(:delete, "#{list_url}/stale").to_return(status: 200)
+        stub_request(:post, list_url).with(body: create_body).to_return(status: 200, body: {result: {id: "new-rec"}}.to_json)
         expect(client.ensure_dns_record(zone_id, type: "A", name:, content: "1.2.3.4")).to eq("new-rec")
       end
 
       it "deletes every non-matching record but keeps and returns the matching one" do
-        Excon.stub(
-          {path: list_path, method: :get, query: {name:, type: "A"}},
-          {status: 200, body: {result: [
+        stub_request(:get, list_url).with(query: {name:, type: "A"})
+          .to_return(status: 200, body: {result: [
             {id: "stale-1", content: "9.9.9.9", ttl: 60, proxied: false},
             {id: "keep", content: "1.2.3.4", ttl: 60, proxied: false},
             {id: "stale-2", content: "8.8.8.8", ttl: 60, proxied: false},
-          ]}.to_json},
-        )
-        Excon.stub({path: "#{list_path}/stale-1", method: :delete}, {status: 200})
-        Excon.stub({path: "#{list_path}/stale-2", method: :delete}, {status: 200})
+          ]}.to_json)
+        stub_request(:delete, "#{list_url}/stale-1").to_return(status: 200)
+        stub_request(:delete, "#{list_url}/stale-2").to_return(status: 200)
         expect(client.ensure_dns_record(zone_id, type: "A", name:, content: "1.2.3.4")).to eq("keep")
       end
     end
 
     it "delete_dns_record returns the response status" do
-      Excon.stub({path: "/client/v4/zones/#{zone_id}/dns_records/rec1", method: :delete}, {status: 200})
+      stub_request(:delete, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/dns_records/rec1").to_return(status: 200)
       expect(client.delete_dns_record(zone_id, "rec1")).to eq(200)
     end
 
     it "delete_dns_record tolerates 404 for already-removed records" do
-      Excon.stub({path: "/client/v4/zones/#{zone_id}/dns_records/gone", method: :delete}, {status: 404})
+      stub_request(:delete, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/dns_records/gone").to_return(status: 404)
       expect(client.delete_dns_record(zone_id, "gone")).to eq(404)
     end
 
     it "delete_dns_records deletes each id in turn" do
-      Excon.stub({path: "/client/v4/zones/#{zone_id}/dns_records/a", method: :delete}, {status: 200})
-      Excon.stub({path: "/client/v4/zones/#{zone_id}/dns_records/b", method: :delete}, {status: 200})
-      Excon.stub({path: "/client/v4/zones/#{zone_id}/dns_records/c", method: :delete}, {status: 200})
+      stub_request(:delete, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/dns_records/a").to_return(status: 200)
+      stub_request(:delete, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/dns_records/b").to_return(status: 200)
+      stub_request(:delete, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/dns_records/c").to_return(status: 200)
       expect { client.delete_dns_records(zone_id, ["a", "b", "c"]) }.not_to raise_error
     end
   end
@@ -96,13 +90,13 @@ RSpec.describe CloudflareClient do
     end
 
     it "create_token" do
-      Excon.stub({path: "/client/v4/accounts/XYZ/tokens", method: :post}, {status: 200, body: {result: {id: "123", value: "secret"}}.to_json})
+      stub_request(:post, "https://api.cloudflare.com/client/v4/accounts/XYZ/tokens").to_return(status: 200, body: {result: {id: "123", value: "secret"}}.to_json)
       expect(client.create_token("test-token", [{id: "test-policy"}])).to eq(["123", "secret"])
     end
 
     it "delete_token" do
       token_id = "123"
-      Excon.stub({path: "/client/v4/accounts/XYZ/tokens/#{token_id}", method: :delete}, {status: 200})
+      stub_request(:delete, "https://api.cloudflare.com/client/v4/accounts/XYZ/tokens/#{token_id}").to_return(status: 200)
       expect(client.delete_token(token_id)).to eq(200)
     end
   end

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe Hosting::HetznerApis do
 
   describe "reimage" do
     it "can reimage a server" do
-      Excon.stub({path: "/boot/123/linux", method: :post}, {status: 200, body: ""})
-      Excon.stub({path: "/reset/123", method: :post, body: "type=hw"}, {status: 200, body: ""})
+      stub_request(:post, "https://robot-ws.your-server.de/boot/123/linux").to_return(status: 200, body: "")
+      stub_request(:post, "https://robot-ws.your-server.de/reset/123").with(body: "type=hw").to_return(status: 200, body: "")
       expect(hetzner_apis.reimage).to be_nil
     end
 
     it "raises an error if the reimage fails" do
-      Excon.stub({path: "/boot/123/linux", method: :post}, {status: 200, body: ""})
-      Excon.stub({path: "/reset/123", method: :post, body: "type=hw"}, {status: 400, body: ""})
+      stub_request(:post, "https://robot-ws.your-server.de/boot/123/linux").to_return(status: 200, body: "")
+      stub_request(:post, "https://robot-ws.your-server.de/reset/123").with(body: "type=hw").to_return(status: 400, body: "")
       expect { hetzner_apis.reimage }.to raise_error Excon::Error::BadRequest
     end
 
@@ -42,14 +42,14 @@ RSpec.describe Hosting::HetznerApis do
     end
 
     it "raises an error if the boot fails" do
-      Excon.stub({path: "/boot/123/linux", method: :post}, {status: 400, body: ""})
+      stub_request(:post, "https://robot-ws.your-server.de/boot/123/linux").to_return(status: 400, body: "")
       expect { hetzner_apis.reimage }.to raise_error Excon::Error::BadRequest
     end
   end
 
   describe "enable_rescue" do
     it "can enable the rescue system" do
-      Excon.stub({path: "/boot/123/rescue", method: :post}, {status: 200, body: ""})
+      stub_request(:post, "https://robot-ws.your-server.de/boot/123/rescue").to_return(status: 200, body: "")
       expect(hetzner_apis.enable_rescue).to be_nil
     end
 
@@ -59,74 +59,74 @@ RSpec.describe Hosting::HetznerApis do
     end
 
     it "raises an error if enabling rescue fails" do
-      Excon.stub({path: "/boot/123/rescue", method: :post}, {status: 400, body: ""})
+      stub_request(:post, "https://robot-ws.your-server.de/boot/123/rescue").to_return(status: 400, body: "")
       expect { hetzner_apis.enable_rescue }.to raise_error Excon::Error::BadRequest
     end
   end
 
   describe "hardware_reset" do
     it "can reset a server" do
-      Excon.stub({path: "/reset/123", method: :post, body: "type=hw"}, {status: 200, body: ""})
+      stub_request(:post, "https://robot-ws.your-server.de/reset/123").with(body: "type=hw").to_return(status: 200, body: "")
       expect(hetzner_apis.hardware_reset).to be_nil
     end
 
     it "raises an error if the reset fails" do
-      Excon.stub({path: "/reset/123", method: :post, body: "type=hw"}, {status: 400, body: ""})
+      stub_request(:post, "https://robot-ws.your-server.de/reset/123").with(body: "type=hw").to_return(status: 400, body: "")
       expect { hetzner_apis.hardware_reset }.to raise_error Excon::Error::BadRequest
     end
   end
 
   describe "power_on" do
     it "presses the power button if the server is shut off" do
-      Excon.stub({path: "/reset/123", method: :get}, {status: 200, body: JSON.generate(reset: {operating_status: "shut off"})})
-      Excon.stub({path: "/reset/123", method: :post, body: "type=power"}, {status: 200, body: ""})
+      stub_request(:get, "https://robot-ws.your-server.de/reset/123").to_return(status: 200, body: JSON.generate(reset: {operating_status: "shut off"}))
+      stub_request(:post, "https://robot-ws.your-server.de/reset/123").with(body: "type=power").to_return(status: 200, body: "")
       expect(hetzner_apis.power_on).to be_nil
     end
 
     it "does nothing if the server is already running" do
-      Excon.stub({path: "/reset/123", method: :get}, {status: 200, body: JSON.generate(reset: {operating_status: "running"})})
+      stub_request(:get, "https://robot-ws.your-server.de/reset/123").to_return(status: 200, body: JSON.generate(reset: {operating_status: "running"}))
       expect(hetzner_apis.power_on).to be_nil
     end
 
     it "raises an error if pressing the power button fails" do
-      Excon.stub({path: "/reset/123", method: :get}, {status: 200, body: JSON.generate(reset: {operating_status: "shut off"})})
-      Excon.stub({path: "/reset/123", method: :post, body: "type=power"}, {status: 400, body: ""})
+      stub_request(:get, "https://robot-ws.your-server.de/reset/123").to_return(status: 200, body: JSON.generate(reset: {operating_status: "shut off"}))
+      stub_request(:post, "https://robot-ws.your-server.de/reset/123").with(body: "type=power").to_return(status: 400, body: "")
       expect { hetzner_apis.power_on }.to raise_error Excon::Error::BadRequest
     end
   end
 
   describe "power_status" do
     it "returns the operating status of a server" do
-      Excon.stub({path: "/reset/123", method: :get}, {status: 200, body: JSON.generate(reset: {operating_status: "running"})})
+      stub_request(:get, "https://robot-ws.your-server.de/reset/123").to_return(status: 200, body: JSON.generate(reset: {operating_status: "running"}))
       expect(hetzner_apis.power_status).to eq "running"
     end
 
     it "raises an error if getting the power status fails" do
-      Excon.stub({path: "/reset/123", method: :get}, {status: 404, body: ""})
+      stub_request(:get, "https://robot-ws.your-server.de/reset/123").to_return(status: 404, body: "")
       expect { hetzner_apis.power_status }.to raise_error Excon::Error::NotFound
     end
   end
 
   describe "get_main_ip4" do
     it "can get the main ip4" do
-      Excon.stub({path: "/server/123", method: :get}, {status: 200, body: "{\"server\": {\"server_ip\": \"1.2.3.4\"}}"})
+      stub_request(:get, "https://robot-ws.your-server.de/server/123").to_return(status: 200, body: "{\"server\": {\"server_ip\": \"1.2.3.4\"}}")
       expect(hetzner_apis.get_main_ip4).to eq "1.2.3.4"
     end
 
     it "raises an error if getting the main ip4 fails" do
-      Excon.stub({path: "/server/123", method: :get}, {status: 404, body: ""})
+      stub_request(:get, "https://robot-ws.your-server.de/server/123").to_return(status: 404, body: "")
       expect { hetzner_apis.get_main_ip4 }.to raise_error Excon::Error::NotFound
     end
   end
 
   describe "pull_data_center" do
     it "can get the dc info" do
-      Excon.stub({path: "/server/123", method: :get}, {status: 200, body: "{\"server\": {\"dc\": \"fsn1-dc8\"}}"})
+      stub_request(:get, "https://robot-ws.your-server.de/server/123").to_return(status: 200, body: "{\"server\": {\"dc\": \"fsn1-dc8\"}}")
       expect(hetzner_apis.pull_data_center).to eq "fsn1-dc8"
     end
 
     it "raises an error if getting the dc info fails" do
-      Excon.stub({path: "/server/123", method: :get}, {status: 400, body: ""})
+      stub_request(:get, "https://robot-ws.your-server.de/server/123").to_return(status: 400, body: "")
       expect { hetzner_apis.pull_data_center }.to raise_error Excon::Error::BadRequest
     end
   end
@@ -323,17 +323,17 @@ RSpec.describe Hosting::HetznerApis do
 
   describe "set_server_name" do
     it "can set the server name" do
-      Excon.stub({path: "/server/123", method: :post, body: "server_name=84fe406c-42af-8771-bcde-4a29adc23bb0"}, {status: 200, body: "{}"})
+      stub_request(:post, "https://robot-ws.your-server.de/server/123").with(body: "server_name=84fe406c-42af-8771-bcde-4a29adc23bb0").to_return(status: 200, body: "{}")
       expect { hetzner_apis.set_server_name("84fe406c-42af-8771-bcde-4a29adc23bb0") }.not_to raise_error
     end
 
     it "raises an error if setting the server name fails due to invalid input" do
-      Excon.stub({path: "/server/123", method: :post, body: "server_name=84fe406c-42af-8771-bcde-4a29adc23bb0"}, {status: 400, body: ""})
+      stub_request(:post, "https://robot-ws.your-server.de/server/123").with(body: "server_name=84fe406c-42af-8771-bcde-4a29adc23bb0").to_return(status: 400, body: "")
       expect { hetzner_apis.set_server_name("84fe406c-42af-8771-bcde-4a29adc23bb0") }.to raise_error Excon::Error::BadRequest
     end
 
     it "raises an error if setting the server name fails due to not found" do
-      Excon.stub({path: "/server/123", method: :post, body: "server_name=84fe406c-42af-8771-bcde-4a29adc23bb0"}, {status: 404, body: ""})
+      stub_request(:post, "https://robot-ws.your-server.de/server/123").with(body: "server_name=84fe406c-42af-8771-bcde-4a29adc23bb0").to_return(status: 404, body: "")
       expect { hetzner_apis.set_server_name("84fe406c-42af-8771-bcde-4a29adc23bb0") }.to raise_error Excon::Error::NotFound
     end
   end

--- a/spec/lib/hosting/leaseweb_apis_spec.rb
+++ b/spec/lib/hosting/leaseweb_apis_spec.rb
@@ -31,15 +31,15 @@ RSpec.describe Hosting::LeasewebApis do
     end
 
     it "sends the base org's key" do
-      Excon.stub({path: "/bareMetals/v2/servers/123", method: :get, headers: {"X-Lsw-Auth" => "key123"}},
-        {status: 200, body: JSON.generate(location: {site: "WDC-01", suite: "8", rack: "9"})})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123").with(headers: {"X-Lsw-Auth" => "key123"})
+        .to_return(status: 200, body: JSON.generate(location: {site: "WDC-01", suite: "8", rack: "9"}))
       expect(leaseweb_apis.pull_data_center).to eq("WDC-01-8-9")
     end
 
     it "sends the eu org's key" do
       allow(Config).to receive(:leaseweb_eu_api_key).and_return("eu-key")
-      Excon.stub({path: "/bareMetals/v2/servers/123", method: :get, headers: {"X-Lsw-Auth" => "eu-key"}},
-        {status: 200, body: JSON.generate(location: {site: "FRA-10", suite: "2", rack: "11"})})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123").with(headers: {"X-Lsw-Auth" => "eu-key"})
+        .to_return(status: 200, body: JSON.generate(location: {site: "FRA-10", suite: "2", rack: "11"}))
       expect(leaseweb_eu_apis.pull_data_center).to eq("FRA-10-2-11")
     end
 
@@ -61,8 +61,8 @@ RSpec.describe Hosting::LeasewebApis do
     total = pages.sum(&:length)
     offset = 0
     pages.each do |page|
-      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset:}},
-        {status: 200, body: JSON.generate(ips: page, _metadata: {totalCount: total})})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123/ips").with(query: {limit: 50, offset:})
+        .to_return(status: 200, body: JSON.generate(ips: page, _metadata: {totalCount: total}))
       offset += page.length
     end
   end
@@ -106,42 +106,42 @@ RSpec.describe Hosting::LeasewebApis do
 
   describe "hardware_reset" do
     it "can power cycle a server" do
-      Excon.stub({path: "/bareMetals/v2/servers/123/powerCycle", method: :post}, {status: 204, body: ""})
+      stub_request(:post, "https://api.leaseweb.com/bareMetals/v2/servers/123/powerCycle").to_return(status: 204, body: "")
       expect(leaseweb_apis.hardware_reset).to be_nil
     end
   end
 
   describe "power_on" do
     it "can power on a server" do
-      Excon.stub({path: "/bareMetals/v2/servers/123/powerOn", method: :post}, {status: 204, body: ""})
+      stub_request(:post, "https://api.leaseweb.com/bareMetals/v2/servers/123/powerOn").to_return(status: 204, body: "")
       expect(leaseweb_apis.power_on).to be_nil
     end
   end
 
   describe "power_status" do
     it "returns the ipmi and pdu power status of a server" do
-      Excon.stub({path: "/bareMetals/v2/servers/123/powerInfo", method: :get}, {status: 200, body: JSON.generate(ipmi: {status: "off"}, pdu: {status: "on"})})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123/powerInfo").to_return(status: 200, body: JSON.generate(ipmi: {status: "off"}, pdu: {status: "on"}))
       expect(leaseweb_apis.power_status).to eq "ipmi: off, pdu: on"
     end
   end
 
   describe "set_server_name" do
     it "updates the server reference" do
-      Excon.stub({path: "/bareMetals/v2/servers/123", method: :put, body: JSON.generate(reference: "vh123")}, {status: 204, body: ""})
+      stub_request(:put, "https://api.leaseweb.com/bareMetals/v2/servers/123").with(body: JSON.generate(reference: "vh123")).to_return(status: 204, body: "")
       expect(leaseweb_apis.set_server_name("vh123")).to be_nil
     end
   end
 
   describe "pull_data_center" do
     it "returns the site and suite" do
-      Excon.stub({path: "/bareMetals/v2/servers/123", method: :get}, {status: 200, body: JSON.generate(location: {site: "WDC-02", suite: "SC03.03A", rack: "F10"})})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123").to_return(status: 200, body: JSON.generate(location: {site: "WDC-02", suite: "SC03.03A", rack: "F10"}))
       expect(leaseweb_apis.pull_data_center).to eq "WDC-02-SC03.03A-F10"
     end
   end
 
   describe "pull_network_interfaces" do
     def stub_server(**body)
-      Excon.stub({path: "/bareMetals/v2/servers/123", method: :get}, {status: 200, body: JSON.generate(body)})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123").to_return(status: 200, body: JSON.generate(body))
     end
 
     # Server 91478's private network, as the API reports it.
@@ -262,8 +262,8 @@ RSpec.describe Hosting::LeasewebApis do
     # Reconciling it would prune Address rows and stop routing blocks Leaseweb
     # still carries, so the pull fails instead of handing prune_addresses less.
     it "fails on a truncated page rather than returning a partial ip list" do
-      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
-        {status: 200, body: JSON.generate(ips: [ip_row("216.22.50.197/26", prefix_length: 26, main_ip: true, gateway: "216.22.50.254")], _metadata: {totalCount: 9})})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123/ips").with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.generate(ips: [ip_row("216.22.50.197/26", prefix_length: 26, main_ip: true, gateway: "216.22.50.254")], _metadata: {totalCount: 9}))
 
       expect { leaseweb_apis.pull_ips }.to raise_error RuntimeError, "leaseweb server 123 returned 1 of 9 ips"
     end
@@ -274,8 +274,8 @@ RSpec.describe Hosting::LeasewebApis do
     # prune_addresses delete the ips it silently dropped.
     it "fails when a page repeats a row even where dedup would match the count" do
       main = ip_row("216.22.50.197/26", prefix_length: 26, main_ip: true, gateway: "216.22.50.254")
-      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
-        {status: 200, body: JSON.generate(ips: [main, main], _metadata: {totalCount: 1})})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123/ips").with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.generate(ips: [main, main], _metadata: {totalCount: 1}))
 
       expect { leaseweb_apis.pull_ips }.to raise_error RuntimeError, "leaseweb server 123 repeated an ip in its ip list"
     end
@@ -285,10 +285,10 @@ RSpec.describe Hosting::LeasewebApis do
     # loops forever concatenating the same rows.
     it "fails when a later page repeats an ip from an earlier full page" do
       page = (1..50).map { ip_row("23.0.0.#{it}/32", prefix_length: 32, gateway: "23.0.0.254") }
-      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
-        {status: 200, body: JSON.generate(ips: page, _metadata: {totalCount: 100})})
-      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 50}},
-        {status: 200, body: JSON.generate(ips: page, _metadata: {totalCount: 100})})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123/ips").with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.generate(ips: page, _metadata: {totalCount: 100}))
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123/ips").with(query: {limit: 50, offset: 50})
+        .to_return(status: 200, body: JSON.generate(ips: page, _metadata: {totalCount: 100}))
 
       expect { leaseweb_apis.pull_ips }.to raise_error RuntimeError, "leaseweb server 123 repeated an ip in its ip list"
     end
@@ -299,10 +299,10 @@ RSpec.describe Hosting::LeasewebApis do
     it "pages past a full page whose totalCount already matches it" do
       main = ip_row("216.22.50.197/26", prefix_length: 26, main_ip: true, gateway: "216.22.50.254")
       filler = (1..49).map { ip_row("23.0.0.#{it}/32", prefix_length: 32, gateway: "23.0.0.254") }
-      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
-        {status: 200, body: JSON.generate(ips: [main] + filler, _metadata: {totalCount: 50})})
-      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 50}},
-        {status: 200, body: JSON.generate(ips: [ip_row("216.22.15.64/26", prefix_length: 26)], _metadata: {totalCount: 51})})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123/ips").with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.generate(ips: [main] + filler, _metadata: {totalCount: 50}))
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123/ips").with(query: {limit: 50, offset: 50})
+        .to_return(status: 200, body: JSON.generate(ips: [ip_row("216.22.15.64/26", prefix_length: 26)], _metadata: {totalCount: 51}))
 
       expect(leaseweb_apis.pull_ips.map(&:ip_address)).to include("216.22.15.64/26")
     end

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -298,13 +298,13 @@ RSpec.describe Validation do
 
       it "valid cloudflare response" do
         expect(Config).to receive(:cloudflare_turnstile_site_key).and_return("cf_site_key")
-        Excon.stub({url: "https://challenges.cloudflare.com/turnstile/v0/siteverify", method: :post}, {status: 200, body: {"success" => true}.to_json})
+        stub_request(:post, "https://challenges.cloudflare.com/turnstile/v0/siteverify").to_return(status: 200, body: {"success" => true}.to_json)
         expect(described_class.validate_cloudflare_turnstile("cf_response")).to be_nil
       end
 
       it "invalid cloudflare response" do
         expect(Config).to receive(:cloudflare_turnstile_site_key).and_return("cf_site_key")
-        Excon.stub({url: "https://challenges.cloudflare.com/turnstile/v0/siteverify", method: :post}, {status: 200, body: {"success" => false, "error-codes" => "123"}.to_json})
+        stub_request(:post, "https://challenges.cloudflare.com/turnstile/v0/siteverify").to_return(status: 200, body: {"success" => false, "error-codes" => "123"}.to_json)
         expect { described_class.validate_cloudflare_turnstile("cf_response") }.to raise_error described_class::ValidationFailed
       end
     end

--- a/spec/model/address_spec.rb
+++ b/spec/model/address_spec.rb
@@ -43,14 +43,14 @@ RSpec.describe Address do
         leaseweb_api_key: "key123",
         leaseweb_eu_api_key: "eu-key",
       )
-      Excon.stub({path: "/bareMetals/v2/servers/1/ips", query: {limit: 50, offset: 0}},
-        {status: 200, body: JSON.generate(
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/1/ips").with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.generate(
           ips: [{ip: "1.2.3.4/24", prefixLength: 24, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: true, gateway: "1.2.3.254"}],
           _metadata: {totalCount: 1},
-        )})
-      Excon.stub({path: "/bareMetals/v2/servers/1", method: :get},
-        {status: 200, body: JSON.generate(location: {site: "AMS-01", suite: "8", rack: "9200"})})
-      Excon.stub({path: "/bareMetals/v2/servers/1", method: :put}, {status: 204})
+        ))
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/1")
+        .to_return(status: 200, body: JSON.generate(location: {site: "AMS-01", suite: "8", rack: "9200"}))
+      stub_request(:put, "https://api.leaseweb.com/bareMetals/v2/servers/1").to_return(status: 204)
       Prog::Vm::HostNexus.assemble("1.2.3.4", provider_name:, server_identifier: "1").subject
     end
 

--- a/spec/model/oidc_provider_spec.rb
+++ b/spec/model/oidc_provider_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe OidcProvider do
 
   [true, false].each do |with_group_prefix|
     it ".register registers a new provider#{" with group prefix" if with_group_prefix}" do
-      Excon.stub({path: "/.well-known/openid-configuration", method: :get}, {status: 200, body: registration_body})
+      stub_request(:get, "https://example.com/.well-known/openid-configuration").to_return(status: 200, body: registration_body)
       scopes = "openid email"
       if with_group_prefix
         scopes += " groups"
@@ -49,7 +49,7 @@ RSpec.describe OidcProvider do
         registration_client_uri: "https://host/rc",
         registration_access_token: "789",
       }.to_json
-      Excon.stub({path: "/register", method: :post, body: request_body}, {status: 201, body: response_body})
+      stub_request(:post, "https://example.com/register").with(body: request_body).to_return(status: 201, body: response_body)
 
       expect(described_class).to receive(:generate_uuid).and_return("9a2d00a7-7d70-8816-82db-4c9e34e1d008")
       oidc_provider = described_class.register("Test", "https://example.com", group_prefix:)
@@ -72,7 +72,7 @@ RSpec.describe OidcProvider do
   end
 
   it ".register registers a new provider with given client_id and client_secret" do
-    Excon.stub({path: "/.well-known/openid-configuration", method: :get}, {status: 200, body: registration_body})
+    stub_request(:get, "https://example.com/.well-known/openid-configuration").to_return(status: 200, body: registration_body)
     expect(described_class).to receive(:generate_uuid).and_return("9a2d00a7-7d70-8816-82db-4c9e34e1d008")
     oidc_provider = described_class.register("Test", "https://example.com/.well-known/openid-configuration", client_id: "123", client_secret: "456")
     expect(described_class.all).to eq [oidc_provider]
@@ -88,14 +88,14 @@ RSpec.describe OidcProvider do
   end
 
   it ".register handles errors registering a new provider" do
-    Excon.stub({path: "/.well-known/openid-configuration", method: :get}, {status: 200, body: registration_body})
+    stub_request(:get, "https://example.com/.well-known/openid-configuration").to_return(status: 200, body: registration_body)
 
     body = {
       client_name: "Ubicloud",
       redirect_uris: ["#{Config.base_url}/auth/0pk8pg19vxe24gbdms7hmw780h/callback"],
       scopes: "openid email",
     }.to_json
-    Excon.stub({path: "/register", method: :post, body:}, {status: 403, body: {error: "bad"}.to_json})
+    stub_request(:post, "https://example.com/register").with(body:).to_return(status: 403, body: {error: "bad"}.to_json)
 
     expect(described_class).to receive(:generate_uuid).and_return("9a2d00a7-7d70-8816-82db-4c9e34e1d008")
     expect { described_class.register("Test", "https://example.com") }.to raise_error(RuntimeError, 'Unable to register with oidc provider: 403 {"error" => "bad"}')

--- a/spec/model/page_spec.rb
+++ b/spec/model/page_spec.rb
@@ -107,9 +107,7 @@ RSpec.describe Page do
 
     describe "#trigger" do
       it "triggers a page if key is present" do
-        Excon.stub({
-          url: "https://api.incident.io/v2/alert_events/http/source-id",
-          method: "post",
+        stub_request(:post, "https://api.incident.io/v2/alert_events/http/source-id").with(
           body: {
             deduplication_key: p.client.send(:deduplication_key, p.tag),
             status: "firing",
@@ -121,14 +119,12 @@ RSpec.describe Page do
             "Authorization" => "Bearer dummy-key",
             "Content-Type" => "application/json",
           },
-        }, {status: 202})
+        ).to_return(status: 202)
         expect(p.trigger.status).to eq(202)
       end
 
       it "triggers a page with extra links" do
-        Excon.stub({
-          url: "https://api.incident.io/v2/alert_events/http/source-id",
-          method: "post",
+        stub_request(:post, "https://api.incident.io/v2/alert_events/http/source-id").with(
           body: {
             deduplication_key: p.client.send(:deduplication_key, p.tag),
             status: "firing",
@@ -143,16 +139,14 @@ RSpec.describe Page do
             "Authorization" => "Bearer dummy-key",
             "Content-Type" => "application/json",
           },
-        }, {status: 202})
+        ).to_return(status: 202)
         expect(p.client.trigger(p.tag, summary: "title", severity: "low", details: {}, links: [nil, "https://example.com"]).status).to eq(202)
       end
     end
 
     describe "#resolve" do
       it "resolves the page if key is present" do
-        Excon.stub({
-          url: "https://api.incident.io/v2/alert_events/http/source-id",
-          method: "post",
+        stub_request(:post, "https://api.incident.io/v2/alert_events/http/source-id").with(
           body: {
             deduplication_key: p.client.send(:deduplication_key, p.tag),
             status: "resolved",
@@ -162,7 +156,7 @@ RSpec.describe Page do
             "Authorization" => "Bearer dummy-key",
             "Content-Type" => "application/json",
           },
-        }, {status: 202})
+        ).to_return(status: 202)
         expect(p.resolve.status).to eq(202)
       end
     end

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -377,10 +377,10 @@ RSpec.describe VmHost do
       end
       vm_host.sshable.update(host: "23.105.171.112")
       rows = leaseweb_91478_ip_rows
-      Excon.stub({path: "/bareMetals/v2/servers/91478/ips", query: {limit: 50, offset: 0}},
-        {status: 200, body: JSON.generate(ips: rows.take(50), _metadata: {totalCount: rows.length})})
-      Excon.stub({path: "/bareMetals/v2/servers/91478/ips", query: {limit: 50, offset: 50}},
-        {status: 200, body: JSON.generate(ips: rows.drop(50), _metadata: {totalCount: rows.length})})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/91478/ips").with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.generate(ips: rows.take(50), _metadata: {totalCount: rows.length}))
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/91478/ips").with(query: {limit: 50, offset: 50})
+        .to_return(status: 200, body: JSON.generate(ips: rows.drop(50), _metadata: {totalCount: rows.length}))
 
       ip_records = vm_host.provider.api.pull_ips
       vm_host.create_addresses(ip_records:)

--- a/spec/prog/leaseweb/setup_networking_spec.rb
+++ b/spec/prog/leaseweb/setup_networking_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
       leaseweb_api_key: "key123",
     )
 
-    Excon.stub({path: "/bareMetals/v2/servers/123", method: :get},
-      {status: 200, body: JSON.generate(networkInterfaces: {public: {mac: "8C:84:74:54:EA:D0"}, internal: internal_nic},
-        isPrivateNetworkEnabled: private_networks.any?, privateNetworks: private_networks)})
+    stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123")
+      .to_return(status: 200, body: JSON.generate(networkInterfaces: {public: {mac: "8C:84:74:54:EA:D0"}, internal: internal_nic},
+        isPrivateNetworkEnabled: private_networks.any?, privateNetworks: private_networks))
 
     block = (64..127).map do
       {ip: "216.22.15.#{it}/26", prefixLength: 26, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: false, gateway: ""}
@@ -74,10 +74,10 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
       {ip: "2604:9a00:2100:a020:4::_112/64", prefixLength: 64, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: false, gateway: "2604:9a00:2100:a020::1"},
       {ip: "2607:f5b7:3:104::_64/64", prefixLength: 64, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: false, gateway: ""},
     ]
-    Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
-      {status: 200, body: JSON.generate(ips: rows.take(50), _metadata: {totalCount: rows.length})})
-    Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 50}},
-      {status: 200, body: JSON.generate(ips: rows.drop(50), _metadata: {totalCount: rows.length})})
+    stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123/ips").with(query: {limit: 50, offset: 0})
+      .to_return(status: 200, body: JSON.generate(ips: rows.take(50), _metadata: {totalCount: rows.length}))
+    stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123/ips").with(query: {limit: 50, offset: 50})
+      .to_return(status: 200, body: JSON.generate(ips: rows.drop(50), _metadata: {totalCount: rows.length}))
   end
 
   describe "#start" do

--- a/spec/prog/test/dns_zone_spec.rb
+++ b/spec/prog/test/dns_zone_spec.rb
@@ -110,26 +110,20 @@ RSpec.describe Prog::Test::DnsZone do
     it "registers NS, A, and AAAA records at the minimum TTL and stores their ids" do
       ttl = described_class::CLOUDFLARE_RECORD_TTL
       ns = "ns-e2e-#{zone_label}.#{parent_zone_name}"
-      records_path = "/client/v4/zones/parent-zone-id/dns_records"
-      Excon.stub({path: "/client/v4/zones", method: :get, query: {name: parent_zone_name}}, {status: 200, body: {result: [{id: "parent-zone-id"}]}.to_json})
+      records_url = "https://api.cloudflare.com/client/v4/zones/parent-zone-id/dns_records"
+      stub_request(:get, "https://api.cloudflare.com/client/v4/zones").with(query: {name: parent_zone_name}).to_return(status: 200, body: {result: [{id: "parent-zone-id"}]}.to_json)
 
-      Excon.stub({path: records_path, method: :get, query: {name: ns, type: "A"}}, {status: 200, body: {result: []}.to_json})
-      Excon.stub(
-        {path: records_path, method: :post, body: {type: "A", name: ns, content: vm.ip4.to_s, ttl:, proxied: false}.to_json},
-        {status: 200, body: {result: {id: "rec-a"}}.to_json},
-      )
+      stub_request(:get, records_url).with(query: {name: ns, type: "A"}).to_return(status: 200, body: {result: []}.to_json)
+      stub_request(:post, records_url).with(body: {type: "A", name: ns, content: vm.ip4.to_s, ttl:, proxied: false}.to_json)
+        .to_return(status: 200, body: {result: {id: "rec-a"}}.to_json)
 
-      Excon.stub({path: records_path, method: :get, query: {name: ns, type: "AAAA"}}, {status: 200, body: {result: []}.to_json})
-      Excon.stub(
-        {path: records_path, method: :post, body: {type: "AAAA", name: ns, content: vm.ip6.to_s, ttl:, proxied: false}.to_json},
-        {status: 200, body: {result: {id: "rec-aaaa"}}.to_json},
-      )
+      stub_request(:get, records_url).with(query: {name: ns, type: "AAAA"}).to_return(status: 200, body: {result: []}.to_json)
+      stub_request(:post, records_url).with(body: {type: "AAAA", name: ns, content: vm.ip6.to_s, ttl:, proxied: false}.to_json)
+        .to_return(status: 200, body: {result: {id: "rec-aaaa"}}.to_json)
 
-      Excon.stub({path: records_path, method: :get, query: {name: zone_name, type: "NS"}}, {status: 200, body: {result: []}.to_json})
-      Excon.stub(
-        {path: records_path, method: :post, body: {type: "NS", name: zone_name, content: ns, ttl:, proxied: false}.to_json},
-        {status: 200, body: {result: {id: "rec-ns"}}.to_json},
-      )
+      stub_request(:get, records_url).with(query: {name: zone_name, type: "NS"}).to_return(status: 200, body: {result: []}.to_json)
+      stub_request(:post, records_url).with(body: {type: "NS", name: zone_name, content: ns, ttl:, proxied: false}.to_json)
+        .to_return(status: 200, body: {result: {id: "rec-ns"}}.to_json)
 
       expect { dns_zone_test.register_cloudflare_records }.to hop("insert_sentinel_records")
       expect(dns_zone_test.strand.stack[0]["cloudflare_zone_id"]).to eq("parent-zone-id")
@@ -224,7 +218,7 @@ RSpec.describe Prog::Test::DnsZone do
       })
 
       ["rec-a", "rec-aaaa", "rec-ns"].each do |rid|
-        Excon.stub({path: "/client/v4/zones/parent-zone-id/dns_records/#{rid}", method: :delete}, {status: 200})
+        stub_request(:delete, "https://api.cloudflare.com/client/v4/zones/parent-zone-id/dns_records/#{rid}").to_return(status: 200)
       end
 
       expect { dns_zone_test.trigger_destroy }

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -71,11 +71,11 @@ RSpec.describe Prog::Vm::HostNexus do
         {ip: "216.22.15.65/26", prefixLength: 26, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: false, gateway: ""},
         {ip: "2607:f5b7:3:104::_64/64", prefixLength: 64, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: false, gateway: ""},
       ]
-      Excon.stub({path: "/bareMetals/v2/servers/123/ips", query: {limit: 50, offset: 0}},
-        {status: 200, body: JSON.generate(ips: rows, _metadata: {totalCount: rows.length})})
-      Excon.stub({path: "/bareMetals/v2/servers/123", method: :get},
-        {status: 200, body: JSON.generate(location: {site: "AMS-01", suite: "8", rack: "9200"})})
-      Excon.stub({path: "/bareMetals/v2/servers/123", method: :put}, {status: 204})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123/ips").with(query: {limit: 50, offset: 0})
+        .to_return(status: 200, body: JSON.generate(ips: rows, _metadata: {totalCount: rows.length}))
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/123")
+        .to_return(status: 200, body: JSON.generate(location: {site: "AMS-01", suite: "8", rack: "9200"}))
+      stub_request(:put, "https://api.leaseweb.com/bareMetals/v2/servers/123").to_return(status: 204)
 
       st = described_class.assemble("216.22.50.197", provider_name: HostProvider::LEASEWEB_PROVIDER_NAME, server_identifier: "123")
       expect(st.subject.provider_name).to eq(HostProvider::LEASEWEB_PROVIDER_NAME)
@@ -96,11 +96,11 @@ RSpec.describe Prog::Vm::HostNexus do
         {ip: "212.95.60.214/26", prefixLength: 26, type: "NORMAL_IP", networkType: "PUBLIC", mainIp: true, gateway: "212.95.60.254"},
       ]
       eu = {headers: {"X-Lsw-Auth" => "eu-key"}}
-      Excon.stub(eu.merge(path: "/bareMetals/v2/servers/456/ips", query: {limit: 50, offset: 0}),
-        {status: 200, body: JSON.generate(ips: rows, _metadata: {totalCount: rows.length})})
-      Excon.stub(eu.merge(path: "/bareMetals/v2/servers/456", method: :get),
-        {status: 200, body: JSON.generate(location: {site: "FRA-10", suite: "2", rack: "11"})})
-      Excon.stub(eu.merge(path: "/bareMetals/v2/servers/456", method: :put), {status: 204})
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/456/ips").with(query: {limit: 50, offset: 0}, **eu)
+        .to_return(status: 200, body: JSON.generate(ips: rows, _metadata: {totalCount: rows.length}))
+      stub_request(:get, "https://api.leaseweb.com/bareMetals/v2/servers/456").with(**eu)
+        .to_return(status: 200, body: JSON.generate(location: {site: "FRA-10", suite: "2", rack: "11"}))
+      stub_request(:put, "https://api.leaseweb.com/bareMetals/v2/servers/456").with(**eu).to_return(status: 204)
 
       st = described_class.assemble("212.95.60.214", provider_name: HostProvider::LEASEWEB_EU_PROVIDER_NAME, server_identifier: "456")
       expect(st.subject.provider_name).to eq(HostProvider::LEASEWEB_EU_PROVIDER_NAME)

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1382,8 +1382,8 @@ RSpec.describe CloverAdmin do
       hetzner_user: "user1",
       hetzner_password: "pass",
     )
-    Excon.stub({path: "/reset/123", method: :get}, {status: 200, body: JSON.generate(reset: {operating_status: "shut off"})})
-    Excon.stub({path: "/reset/123", method: :post, body: "type=power"}, {status: 200, body: ""})
+    stub_request(:get, "https://robot-ws.your-server.de/reset/123").to_return(status: 200, body: JSON.generate(reset: {operating_status: "shut off"}))
+    stub_request(:post, "https://robot-ws.your-server.de/reset/123").with(body: "type=power").to_return(status: 200, body: "")
 
     fill_in "UBID, UUID, or prefix:term", with: vmh.ubid
     click_button "Show Object"
@@ -1415,7 +1415,7 @@ RSpec.describe CloverAdmin do
       hetzner_user: "user1",
       hetzner_password: "pass",
     )
-    Excon.stub({path: "/reset/123", method: :get}, {status: 200, body: JSON.generate(reset: {operating_status: "shut off"})})
+    stub_request(:get, "https://robot-ws.your-server.de/reset/123").to_return(status: 200, body: JSON.generate(reset: {operating_status: "shut off"}))
 
     fill_in "UBID, UUID, or prefix:term", with: vmh.ubid
     click_button "Show Object"
@@ -2474,11 +2474,11 @@ RSpec.describe CloverAdmin do
     end
 
     def stub_hetzner_api(host, server_identifier)
-      Excon.stub({path: "/ip", method: :get}, {status: 200, body: JSON.dump([{"ip" => {"ip" => host, "server_ip" => host}}])})
-      Excon.stub({path: "/subnet", method: :get}, {status: 200, body: JSON.dump([])})
-      Excon.stub({path: "/failover", method: :get}, {status: 200, body: JSON.dump([])})
-      Excon.stub({path: "/server/#{server_identifier}", method: :get}, {status: 200, body: JSON.generate(server: {dc: "fsn1-dc14"})})
-      Excon.stub({path: "/server/#{server_identifier}", method: :post}, {status: 200, body: "{}"})
+      stub_request(:get, "https://robot-ws.your-server.de/ip").to_return(status: 200, body: JSON.dump([{"ip" => {"ip" => host, "server_ip" => host}}]))
+      stub_request(:get, "https://robot-ws.your-server.de/subnet").to_return(status: 200, body: JSON.dump([]))
+      stub_request(:get, "https://robot-ws.your-server.de/failover").to_return(status: 200, body: JSON.dump([]))
+      stub_request(:get, "https://robot-ws.your-server.de/server/#{server_identifier}").to_return(status: 200, body: JSON.generate(server: {dc: "fsn1-dc14"}))
+      stub_request(:post, "https://robot-ws.your-server.de/server/#{server_identifier}").to_return(status: 200, body: "{}")
     end
 
     it "shows unprepared hosts" do


### PR DESCRIPTION
The suite stubbed HTTP two ways, and the Excon one only worked by accident. Nothing here ever set `mock: true`: Excon stubs were consulted solely because WebMock's Excon adapter sets `Excon.defaults[:mock]` and registers a catch-all stub, and because `Excon.stub` unshifts, so a spec's own stub landed ahead of WebMock's.

That accident had teeth. `Excon.defaults[:stubs]` is `:global`, so `Excon.stubs` is one process-wide array, and nothing cleared it between examples. A stub outlived its example and shadowed a later `stub_request` for the same URL, in whichever random order put them in that sequence. The shadowed request never reached WebMock, so it went unrecorded for `have_been_made` and invisible to `disable_net_connect!` — a stubbed response arriving from an unrelated example two files away, with nothing to indicate it.

Converting the 98 remaining call sites leaves WebMock as the only mechanism, which also covers the Net::HTTP and Faraday traffic that gem dependencies generate. Stubs that matched on `path` alone matched any host; they now name the host they mean.