### PR TITLE
Restore load balancer rules after the network namespace is rebuilt

### DIFF
--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -637,7 +637,17 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     decr_start_after_host_reboot
 
     vm.incr_update_firewall_rules
+    hop_restore_load_balancer if vm.load_balancer
     hop_wait
+  end
+
+  # Recreating the network namespace resets its nat table, which drops the load
+  # balancer rules the namespace was serving, so they have to be reinstalled.
+  label def restore_load_balancer
+    load_balancer = vm.load_balancer
+    hop_wait if retval || load_balancer.nil?
+
+    push Prog::Vnet::UpdateLoadBalancerNode, {"load_balancer_id" => load_balancer.id}, :update_load_balancer
   end
 
   def available?

--- a/prog/vm/update_ipv6.rb
+++ b/prog/vm/update_ipv6.rb
@@ -36,6 +36,14 @@ class Prog::Vm::UpdateIpv6 < Prog::Base
     vm_host.sshable.cmd("sudo ip -n :inhost_name addr replace :addr dev :tap_name", inhost_name:, addr:, tap_name: nic.ubid_to_tap_name)
     vm_host.sshable.cmd("sudo systemctl start :inhost_name-metadata-endpoint.service", inhost_name:) if vm.load_balancer&.cert_enabled
     vm.incr_update_firewall_rules
+
+    # Deleting the network namespace drops the load balancer rules it was
+    # serving, and the new address invalidates the DNS records advertising it.
+    if (load_balancer = vm.load_balancer)
+      load_balancer.incr_update_load_balancer
+      load_balancer.incr_rewrite_dns_records
+    end
+
     vm.private_subnets.first.incr_refresh_keys
     pop "VM #{vm.name} updated"
   end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       state: "active")
   }
 
+  def create_load_balancer
+    lb = LoadBalancer.create(name: "test-lb", private_subnet_id: private_subnet.id, project_id: project.id, health_check_endpoint: "/up")
+    LoadBalancerVm.create(load_balancer_id: lb.id, vm_id: vm.id)
+    lb
+  end
+
   describe ".assemble" do
     it "fails if there is no project" do
       expect {
@@ -1606,6 +1612,29 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect { nx.start_after_host_reboot }.to hop("wait")
         .and change { vm.reload.update_firewall_rules_set? }.from(false).to(true)
       expect(vm.reload.display_state).to eq("running")
+    end
+
+    it "hops to restore_load_balancer if the vm is part of a load balancer" do
+      create_load_balancer
+      expect(sshable).to receive(:_cmd).with(/sudo host\/bin\/setup-vm recreate-unpersisted #{nx.vm_name}/, {stdin: '{"storage":{}}'})
+      expect { nx.start_after_host_reboot }.to hop("restore_load_balancer")
+    end
+  end
+
+  describe "#restore_load_balancer" do
+    it "reinstalls the load balancer rules in the recreated network namespace" do
+      lb = create_load_balancer
+      expect { nx.restore_load_balancer }.to hop(:update_load_balancer, "Vnet::UpdateLoadBalancerNode") { it.strand_update_args[:stack].first["load_balancer_id"] == lb.id }
+    end
+
+    it "hops to wait after the rules are reinstalled" do
+      create_load_balancer
+      st.update(retval: {"msg" => "load balancer is updated"})
+      expect { nx.restore_load_balancer }.to hop("wait")
+    end
+
+    it "hops to wait if the vm is no longer part of a load balancer" do
+      expect { nx.restore_load_balancer }.to hop("wait")
     end
   end
 

--- a/spec/prog/vm/update_ipv6_spec.rb
+++ b/spec/prog/vm/update_ipv6_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Prog::Vm::UpdateIpv6 do
       name: "test-lb", private_subnet_id: private_subnet.id, project_id: project.id,
       health_check_endpoint: "/health", cert_enabled:,
     )
+    Strand.create_with_id(lb, prog: "Vnet::LoadBalancerNexus", label: "wait")
     LoadBalancerVm.create(load_balancer_id: lb.id, vm_id: vm.id)
     lb
   end
@@ -111,7 +112,7 @@ RSpec.describe Prog::Vm::UpdateIpv6 do
   end
 
   it "starts vm" do
-    create_load_balancer(cert_enabled: true)
+    lb = create_load_balancer(cert_enabled: true)
     inhost_name = vm.inhost_name
     nic = vm.nics.first
     addr = nic.private_subnet.net4.nth(1).to_s + nic.private_subnet.net4.netmask.to_s
@@ -120,6 +121,8 @@ RSpec.describe Prog::Vm::UpdateIpv6 do
     expect { pr.start_vm }.to exit({"msg" => "VM test updated"})
     expect(vm.reload.update_firewall_rules_set?).to be true
     expect(private_subnet.reload.refresh_keys_set?).to be true
+    expect(lb.update_load_balancer_set?).to be true
+    expect(lb.rewrite_dns_records_set?).to be true
   end
 
   it "does not start metadata endpoint service if not load balancer" do


### PR DESCRIPTION
Load balancing on metal is implemented as nftables NAT rules inside each member VM's network namespace, written by `Vnet::UpdateLoadBalancerNode`. Anything that rebuilds a namespace silently drops those rules, because the rebuild reinstalls the plain one-to-one NAT rules from `VmSetup#generate_nat4_rules`, which have no port mapping and no member map. Traffic to the load balancer address then lands on the single VM at the source port instead of being mapped to the destination port and balanced.

Two progs rebuild namespaces and neither put the rules back.

### Restore load balancer rules after a host reboot

Namespaces do not survive a host reboot, and `Vm::Metal::Nexus#start_after_host_reboot` runs `setup-vm recreate-unpersisted`. The label only incremented `update_firewall_rules`, which writes a different table (`inet fw_table`), so operators had to run `incr_update_load_balancer` by hand after every host reboot to make their load balancers work again.

The rules are now reinstalled from the VM's own strand, right after its namespace is known to be rebuilt. Incrementing `update_load_balancer` on the load balancer instead would fan out `UpdateLoadBalancerNode` to every member, including siblings on the same host whose namespaces have not been recreated yet, and those `ip netns exec` calls would fail and churn through strand retries. Neighbors need no update anyway, since this VM's private address is unchanged.

The cert server needs no equivalent treatment: it is installed with `systemctl enable --now`, so it comes back on its own.

### Restore load balancer state after changing a VM's IPv6

`Vm::UpdateIpv6` deletes the namespace and rebuilds it with `setup-vm reassign-ip6`, losing the rules the same way. Unlike a reboot, it also assigns the VM a new `ephemeral_net6`. That address appears in the load balancer's own rules for this VM and in the AAAA records published for the load balancer hostname, so both are stale afterwards and the load balancer keeps directing IPv6 traffic at an address the VM no longer holds.

Both semaphores are incremented on the load balancer, following the convention in `LoadBalancer#add_port` and `#evacuate_vm`. This prog has no in-tree callers today and is run by hand, so this has been latent.

### Not addressed

The reboot fix restores the rules but does not close the window during which they are wrong. Between the host coming up and each VM's strand reaching `restore_load_balancer`, that VM answers on the load balancer address with unbalanced, unmapped NAT. Narrowing that would mean teaching `recreate-unpersisted` not to write the plain NAT table for load balancer members, which reaches into rhizome and seemed worth separating from the recovery fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)