### PR TITLE
Install node exporter prometheus on k8s images

### DIFF
--- a/rhizome/common/lib/node_exporter_setup.rb
+++ b/rhizome/common/lib/node_exporter_setup.rb
@@ -10,7 +10,25 @@ class NodeExporterSetup
     arm64: "ad35b605f9954b9f1ffddf5ba054bdc5a98d790b9eae5291e1eeb83f1ecbd0e7",
   )
 
+  # ubicni names the host side of each pod veth pair veth_<id>, and containerd
+  # and kubelet mount a sandbox and a token volume per pod. Without excluding
+  # them, every pod on the node adds network and filesystem series. The
+  # mountpoint list is node_exporter's default plus those two paths.
+  KUBERNETES_FLAGS = [
+    "--collector.netdev.device-exclude=^veth_",
+    "--collector.netclass.ignored-devices=^veth_",
+    "--collector.arp.device-exclude=^veth_",
+    "--collector.filesystem.mount-points-exclude=^/(dev|proc|run/credentials/.+|run/containerd/.+|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)",
+  ].freeze
+
+  def initialize(kubernetes: false)
+    @kubernetes = kubernetes
+  end
+
   def service
+    flags = ["--web.listen-address=127.0.0.1:9100"]
+    flags.concat(KUBERNETES_FLAGS) if @kubernetes
+
     <<~SERVICE
       [Unit]
       Description=Prometheus Node Exporter
@@ -29,7 +47,7 @@ class NodeExporterSetup
       MemoryDenyWriteExecute=yes
       LockPersonality=yes
       Type=simple
-      ExecStart=/usr/local/bin/node_exporter --web.listen-address=127.0.0.1:9100
+      ExecStart=/usr/local/bin/node_exporter #{flags.join(" ")}
       Restart=always
       User=nobody
       Group=nogroup

--- a/rhizome/common/spec/node_exporter_setup_spec.rb
+++ b/rhizome/common/spec/node_exporter_setup_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe NodeExporterSetup do
   let(:tarball) { "#{file_name}.tar.gz" }
   let(:url) { "https://github.com/prometheus/node_exporter/releases/download/v1.12.1/#{tarball}" }
 
+  describe "#service" do
+    it "listens on localhost only" do
+      expect(setup.service).to include "ExecStart=/usr/local/bin/node_exporter --web.listen-address=127.0.0.1:9100\n"
+    end
+
+    it "excludes the per pod collectors on a kubernetes node" do
+      setup = described_class.new(kubernetes: true)
+
+      expect(setup.service).to include "ExecStart=/usr/local/bin/node_exporter --web.listen-address=127.0.0.1:9100 #{described_class::KUBERNETES_FLAGS.join(" ")}\n"
+    end
+  end
+
   describe "#run" do
     it "installs the binary and starts the service" do
       commands = []

--- a/rhizome/kubernetes/bin/install-node-exporter
+++ b/rhizome/kubernetes/bin/install-node-exporter
@@ -1,0 +1,6 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/node_exporter_setup"
+
+NodeExporterSetup.new(kubernetes: true).run

--- a/rhizome/kubernetes/bin/install-prometheus
+++ b/rhizome/kubernetes/bin/install-prometheus
@@ -1,0 +1,8 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/kubernetes_install_prometheus"
+
+fail "expected no arguments, got #{ARGV.length}" unless ARGV.empty?
+
+KubernetesInstallPrometheus.new.run

--- a/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
+++ b/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
@@ -47,6 +47,7 @@ class KubernetesBuildNodeImage
     r "sudo tee /etc/containerd/config.toml > /dev/null", stdin: r("containerd config default").gsub("SystemdCgroup = false", "SystemdCgroup = true")
 
     r "kubernetes/bin/install-node-exporter"
+    r "kubernetes/bin/install-prometheus"
 
     r "sudo apt-mark hold kubelet kubeadm kubectl"
     r "sudo systemctl disable unattended-upgrades"

--- a/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
+++ b/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
@@ -46,6 +46,8 @@ class KubernetesBuildNodeImage
     r "sudo mkdir -p /etc/containerd"
     r "sudo tee /etc/containerd/config.toml > /dev/null", stdin: r("containerd config default").gsub("SystemdCgroup = false", "SystemdCgroup = true")
 
+    r "kubernetes/bin/install-node-exporter"
+
     r "sudo apt-mark hold kubelet kubeadm kubectl"
     r "sudo systemctl disable unattended-upgrades"
 

--- a/rhizome/kubernetes/lib/kubernetes_install_prometheus.rb
+++ b/rhizome/kubernetes/lib/kubernetes_install_prometheus.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+class KubernetesInstallPrometheus
+  VERSION = "3.13.2"
+  CHECKSUM = "0e8c4d46101bd025ea8265e377d2caabc57f488fc1be1c367f37db69ea41be6f"
+
+  # metrics-collector federates every scrape out to VictoriaMetrics, so the
+  # local blocks only need to cover collector downtime. MemoryMax keeps a
+  # scrape of the apiserver from squeezing etcd on a control plane node.
+  SERVICE = <<~SERVICE
+    [Unit]
+    Description=Prometheus
+    Wants=network-online.target
+    After=network-online.target
+
+    [Service]
+    NoNewPrivileges=yes
+    PrivateTmp=yes
+    ProtectSystem=strict
+    ProtectHome=read-only
+    ReadWritePaths=/var/lib/prometheus
+    ProtectKernelModules=yes
+    ProtectKernelTunables=yes
+    RestrictRealtime=yes
+    RestrictSUIDSGID=yes
+    MemoryDenyWriteExecute=yes
+    LockPersonality=yes
+    MemoryMax=1G
+    Type=simple
+    ExecStart=/usr/local/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/var/lib/prometheus --storage.tsdb.retention.time=2h --web.listen-address=127.0.0.1:9090
+    ExecReload=/bin/kill -HUP $MAINPID
+    Restart=always
+    User=prometheus
+    Group=prometheus
+
+    [Install]
+    WantedBy=multi-user.target
+  SERVICE
+
+  def run
+    file_name = "prometheus-#{VERSION}.linux-amd64"
+    tarball = "#{file_name}.tar.gz"
+    url = "https://github.com/prometheus/prometheus/releases/download/v#{VERSION}/#{tarball}"
+
+    fail "Invalid SHA-256 digest" unless curl_file(url, tarball) == CHECKSUM
+
+    r "sudo", "tar", "xfz", tarball, "-C", "/usr/local/bin", "--no-same-owner", "--strip-components=1", "#{file_name}/prometheus"
+    r "rm", tarball
+
+    r "sudo groupadd -f --system prometheus"
+    r "sudo useradd --no-create-home --system -g prometheus prometheus"
+    r "sudo mkdir -p /etc/prometheus /var/lib/prometheus"
+    r "sudo chown prometheus:prometheus /var/lib/prometheus"
+
+    safe_write_to_file("/etc/systemd/system/prometheus.service", SERVICE)
+
+    r "sudo systemctl daemon-reload"
+  end
+end

--- a/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe KubernetesBuildNodeImage do
         "sudo mkdir -p /etc/containerd",
         "containerd config default",
         "sudo tee /etc/containerd/config.toml > /dev/null",
+        "kubernetes/bin/install-node-exporter",
         "sudo apt-mark hold kubelet kubeadm kubectl",
         "sudo systemctl disable unattended-upgrades",
         "sudo -E apt-get autoremove -y",

--- a/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe KubernetesBuildNodeImage do
         "containerd config default",
         "sudo tee /etc/containerd/config.toml > /dev/null",
         "kubernetes/bin/install-node-exporter",
+        "kubernetes/bin/install-prometheus",
         "sudo apt-mark hold kubelet kubeadm kubectl",
         "sudo systemctl disable unattended-upgrades",
         "sudo -E apt-get autoremove -y",

--- a/rhizome/kubernetes/spec/kubernetes_install_prometheus_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_install_prometheus_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "../lib/kubernetes_install_prometheus"
+
+RSpec.describe KubernetesInstallPrometheus do
+  subject(:installer) { described_class.new }
+
+  let(:tarball) { "prometheus-3.13.2.linux-amd64.tar.gz" }
+  let(:url) { "https://github.com/prometheus/prometheus/releases/download/v3.13.2/#{tarball}" }
+
+  describe "#run" do
+    it "installs the binary and the unit without enabling it" do
+      commands = []
+      allow(installer).to receive(:_run_command) { |*command| commands << command.join(" ") }
+      written = {}
+      allow(installer).to receive(:safe_write_to_file) { |path, content| written[path] = content }
+      expect(installer).to receive(:curl_file).with(url, tarball).and_return(described_class::CHECKSUM)
+
+      installer.run
+
+      expect(commands).to eq [
+        "sudo tar xfz #{tarball} -C /usr/local/bin --no-same-owner --strip-components=1 prometheus-3.13.2.linux-amd64/prometheus",
+        "rm #{tarball}",
+        "sudo groupadd -f --system prometheus",
+        "sudo useradd --no-create-home --system -g prometheus prometheus",
+        "sudo mkdir -p /etc/prometheus /var/lib/prometheus",
+        "sudo chown prometheus:prometheus /var/lib/prometheus",
+        "sudo systemctl daemon-reload",
+      ]
+      expect(written).to eq("/etc/systemd/system/prometheus.service" => described_class::SERVICE)
+    end
+
+    it "fails when the download does not match the pinned checksum" do
+      expect(installer).to receive(:curl_file).with(url, tarball).and_return("deadbeef")
+
+      expect { installer.run }.to raise_error RuntimeError, "Invalid SHA-256 digest"
+    end
+  end
+end


### PR DESCRIPTION
**Install node_exporter in the Kubernetes node image**
Bakes the node_exporter binary and its systemd unit into the node image so metrics collection does not depend on reaching GitHub releases during node provisioning. The image build reuses NodeExporterSetup rather than a Kubernetes copy of it, so it also gets the pinned checksum verification.

A Kubernetes node needs collector exclusions the other callers do not, for the per-pod resources that would otherwise make a node's series count grow with its pod count: ubicni names the host side of each pod veth pair veth_<id>, containerd mounts a sandbox per pod under /run/containerd, and kubelet mounts a projected token volume under /var/lib/kubelet. The mountpoint list is node_exporter's default plus those two paths, since the default only covers pods/.../volume/ and these mounts use the plural volumes/.

The unit is enabled and started during the build. node_exporter keeps no state, so it running inside the builder VM does not affect the captured image.

**Install Prometheus in the Kubernetes node image**
Each control plane node will run a local Prometheus that scrapes its own apiserver and pre-aggregates the high cardinality histograms into recording rules, so metrics-collector can federate a small fixed set of series instead of the raw ones.