### PR TITLE
Add VM Host COGS page to admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -191,16 +191,23 @@ class CloverAdmin < Roda
 
   COGS_LOCATION_IDS = [Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID, Location::LEASEWEB_WDC02_ID, Location::GITHUB_RUNNERS_ID].freeze
   COGS_RUNNER_LOCATION_IDS = (COGS_LOCATION_IDS - [Location::LEASEWEB_WDC02_ID]).freeze
+  BIGDECIMAL_ZERO = BigDecimal(0)
 
   def format_usd(value)
     value ? format("$%.2f", value) : "-"
   end
 
   def cogs_summary(hosts)
-    monthly_usd = hosts.sum(BigDecimal(0)) { it[:monthly_usd] || 0 }
+    monthly_usd = hosts.sum(BIGDECIMAL_ZERO) { it[:monthly_usd] || 0 }
     sellable_vcpus = hosts.sum { it[:sellable_vcpus] }
-    per_2vcpu_usd = (monthly_usd / sellable_vcpus * 2 if sellable_vcpus.positive?)
+    per_2vcpu_usd = monthly_usd / sellable_vcpus * 2 if sellable_vcpus.positive?
     [hosts.size, monthly_usd, sellable_vcpus, per_2vcpu_usd]
+  end
+
+  def cogs_row(group, labels)
+    count, monthly_usd, sellable_vcpus, per_2vcpu_usd = cogs_summary(group)
+    labels.merge("Host Count" => count, "Monthly Cost" => format_usd(monthly_usd),
+      "Sellable vCPUs" => sellable_vcpus, "Per 2 vCPU Cost" => format_usd(per_2vcpu_usd))
   end
 
   def _classes
@@ -1563,11 +1570,10 @@ class CloverAdmin < Roda
       minio_host_ids = Vm.where(id: MinioServer.select(:vm_id)).exclude(vm_host_id: nil).select(:vm_host_id)
       nonrunner_vcpus = DB[:vm]
         .where(vm_host_id: DB[:vm_host].where(location_id: COGS_LOCATION_IDS).select(:id))
-        .left_join(:github_runner, vm_id: Sequel[:vm][:id])
+        .left_join(:github_runner, vm_id: :id)
         .where(Sequel[:github_runner][:id] => nil)
-        .group(Sequel[:vm][:vm_host_id])
-        .select(
-          Sequel[:vm][:vm_host_id].as(:id),
+        .select_group(Sequel[:vm][:vm_host_id].as(:id))
+        .select_append(
           Sequel.function(:sum, Sequel.case({{family: "burstable"} => Sequel[:vcpus] * 0.5}, :vcpus)).as(:nonrunner_vcpus),
         )
 
@@ -1581,7 +1587,7 @@ class CloverAdmin < Roda
       server_type = Sequel.function(:coalesce, Sequel.function(:split_part, Sequel[:vm_host_inventory][:server_model], "-", 1), "unknown")
 
       hosts = DB[:vm_host]
-        .join(:location, id: Sequel[:vm_host][:location_id])
+        .join(:location, id: :location_id)
         .join(:vm_host_inventory, id: Sequel[:vm_host][:id])
         .left_join(nonrunner_vcpus.as(:nrv), id: Sequel[:vm_host][:id])
         .exclude(Sequel[:vm_host][:id] => minio_host_ids)
@@ -1601,20 +1607,16 @@ class CloverAdmin < Roda
 
       inventory_hosts = hosts.select { it[:arch] == "x64" }
       @by_location = inventory_hosts.group_by { [it[:location_id], it[:location], it[:family]] }.sort_by { |(location_id, _, family), _| [COGS_LOCATION_IDS.index(location_id), family] }.map do |(_, location, family), group|
-        count, monthly_usd, sellable_vcpus, per_2vcpu_usd = cogs_summary(group)
-        {"Location" => location, "Family" => family, "Host Count" => count, "Monthly Cost" => format_usd(monthly_usd),
-         "Sellable vCPUs" => sellable_vcpus, "Per 2 vCPU Cost" => format_usd(per_2vcpu_usd)}
+        cogs_row(group, {"Location" => location, "Family" => family})
       end
       @by_type = inventory_hosts.group_by { it[:server_type] }.sort_by(&:first).map do |type, group|
-        count, monthly_usd, sellable_vcpus, per_2vcpu_usd = cogs_summary(group)
-        {"Type" => type, "Host Count" => count, "Monthly Cost" => format_usd(monthly_usd),
-         "Sellable vCPUs" => sellable_vcpus, "Per 2 vCPU Cost" => format_usd(per_2vcpu_usd)}
+        cogs_row(group, {"Type" => type})
       end
 
       @github_runners = hosts.select { COGS_RUNNER_LOCATION_IDS.include?(it[:location_id]) }.group_by { it[:server_type] }.sort_by(&:first).map do |type, group|
         count, _, _, per_2vcpu_usd = cogs_summary(group)
-        usable_vcpus = group.sum(BigDecimal(0)) { it[:sellable_vcpus] - (it[:nonrunner_vcpus] || 0) }
-        weekly_usd = (usable_vcpus * per_2vcpu_usd / 2 / 30 * 7 if per_2vcpu_usd)
+        usable_vcpus = group.sum(BIGDECIMAL_ZERO) { it[:sellable_vcpus] - (it[:nonrunner_vcpus] || 0) }
+        weekly_usd = usable_vcpus * per_2vcpu_usd / 2 / 30 * 7 if per_2vcpu_usd
         {"Type" => type, "Host Count" => count, "Runner Usable vCPUs" => usable_vcpus.to_i,
          "Per 2 vCPU Cost" => format_usd(per_2vcpu_usd), "Weekly Cost" => format_usd(weekly_usd)}
       end

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -189,6 +189,20 @@ class CloverAdmin < Roda
     "%02d:%02d:%02d" % [h, m, s]
   end
 
+  COGS_LOCATION_IDS = [Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID, Location::LEASEWEB_WDC02_ID, Location::GITHUB_RUNNERS_ID].freeze
+  COGS_RUNNER_LOCATION_IDS = (COGS_LOCATION_IDS - [Location::LEASEWEB_WDC02_ID]).freeze
+
+  def format_usd(value)
+    value ? format("$%.2f", value) : "-"
+  end
+
+  def cogs_summary(hosts)
+    monthly_usd = hosts.sum(BigDecimal(0)) { it[:monthly_usd] || 0 }
+    sellable_vcpus = hosts.sum { it[:sellable_vcpus] }
+    per_2vcpu_usd = (monthly_usd / sellable_vcpus * 2 if sellable_vcpus.positive?)
+    [hosts.size, monthly_usd, sellable_vcpus, per_2vcpu_usd]
+  end
+
   def _classes
     classes = []
     Sequel::Model.subclasses.each do |c|
@@ -1540,6 +1554,72 @@ class CloverAdmin < Roda
       @spilled_vcpus = Vm.where(arch: @arch, boot_image: Prog::Github::GithubRunnerNexus::AWS_AMI_VERSIONS).sum(:vcpus) || 0
 
       view("github_runner_usage")
+    end
+
+    r.get "cogs" do
+      @rate = BigDecimal(typecast_params.nonempty_str("rate") || "1.14", exception: false)
+      fail CloverError.new(400, "InvalidRequest", "invalid conversion rate") unless @rate&.positive?
+
+      minio_host_ids = Vm.where(id: MinioServer.select(:vm_id)).exclude(vm_host_id: nil).select(:vm_host_id)
+      nonrunner_vcpus = DB[:vm]
+        .where(vm_host_id: DB[:vm_host].where(location_id: COGS_LOCATION_IDS).select(:id))
+        .left_join(:github_runner, vm_id: Sequel[:vm][:id])
+        .where(Sequel[:github_runner][:id] => nil)
+        .group(Sequel[:vm][:vm_host_id])
+        .select(
+          Sequel[:vm][:vm_host_id].as(:id),
+          Sequel.function(:sum, Sequel.case({{family: "burstable"} => Sequel[:vcpus] * 0.5}, :vcpus)).as(:nonrunner_vcpus),
+        )
+
+      memory_per_vcpu = Sequel.case({"arm64" => 3.2}, 4, Sequel[:vm_host][:arch])
+      sellable_vcpus = Sequel.function(:greatest,
+        Sequel.function(:least,
+          Sequel.function(:coalesce, Sequel[:vm_host][:total_cpus], 0) - 1,
+          Sequel.function(:floor, Sequel[:vm_host][:total_hugepages_1g] / memory_per_vcpu)), 0).cast(:integer)
+      monthly_price = Sequel[:vm_host_inventory][:monthly_price]
+      monthly_usd = Sequel.case({"EUR" => monthly_price * @rate}, monthly_price, Sequel[:vm_host_inventory][:currency])
+      server_type = Sequel.function(:coalesce, Sequel.function(:split_part, Sequel[:vm_host_inventory][:server_model], "-", 1), "unknown")
+
+      hosts = DB[:vm_host]
+        .join(:location, id: Sequel[:vm_host][:location_id])
+        .join(:vm_host_inventory, id: Sequel[:vm_host][:id])
+        .left_join(nonrunner_vcpus.as(:nrv), id: Sequel[:vm_host][:id])
+        .exclude(Sequel[:vm_host][:id] => minio_host_ids)
+        .exclude(Sequel[:vm_host][:allocation_state] => "unprepared")
+        .where(Sequel[:vm_host][:location_id] => COGS_LOCATION_IDS)
+        .select(
+          Sequel[:location][:name].as(:location),
+          Sequel[:vm_host][:location_id],
+          Sequel[:vm_host][:family],
+          Sequel[:vm_host][:arch],
+          sellable_vcpus.as(:sellable_vcpus),
+          monthly_usd.as(:monthly_usd),
+          server_type.as(:server_type),
+          Sequel[:nrv][:nonrunner_vcpus],
+        )
+        .all
+
+      inventory_hosts = hosts.select { it[:arch] == "x64" }
+      @by_location = inventory_hosts.group_by { [it[:location_id], it[:location], it[:family]] }.sort_by { |(location_id, _, family), _| [COGS_LOCATION_IDS.index(location_id), family] }.map do |(_, location, family), group|
+        count, monthly_usd, sellable_vcpus, per_2vcpu_usd = cogs_summary(group)
+        {"Location" => location, "Family" => family, "Host Count" => count, "Monthly Cost" => format_usd(monthly_usd),
+         "Sellable vCPUs" => sellable_vcpus, "Per 2 vCPU Cost" => format_usd(per_2vcpu_usd)}
+      end
+      @by_type = inventory_hosts.group_by { it[:server_type] }.sort_by(&:first).map do |type, group|
+        count, monthly_usd, sellable_vcpus, per_2vcpu_usd = cogs_summary(group)
+        {"Type" => type, "Host Count" => count, "Monthly Cost" => format_usd(monthly_usd),
+         "Sellable vCPUs" => sellable_vcpus, "Per 2 vCPU Cost" => format_usd(per_2vcpu_usd)}
+      end
+
+      @github_runners = hosts.select { COGS_RUNNER_LOCATION_IDS.include?(it[:location_id]) }.group_by { it[:server_type] }.sort_by(&:first).map do |type, group|
+        count, _, _, per_2vcpu_usd = cogs_summary(group)
+        usable_vcpus = group.sum(BigDecimal(0)) { it[:sellable_vcpus] - (it[:nonrunner_vcpus] || 0) }
+        weekly_usd = (usable_vcpus * per_2vcpu_usd / 2 / 30 * 7 if per_2vcpu_usd)
+        {"Type" => type, "Host Count" => count, "Runner Usable vCPUs" => usable_vcpus.to_i,
+         "Per 2 vCPU Cost" => format_usd(per_2vcpu_usd), "Weekly Cost" => format_usd(weekly_usd)}
+      end
+
+      view("cogs")
     end
 
     r.get "vm-host-usage" do

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -195,6 +195,17 @@ h1 { font-size: 1.5em; }
 h2 { font-size: 1.3em; }
 h3 { font-size: 1.1em; }
 
+.cogs-page {
+  display: flex;
+  flex-direction: column;
+  gap: 3em;
+}
+
+#cogs-rate-form {
+  display: flex;
+  gap: 5px;
+}
+
 label {
   display: inline-block;
   margin-right: 5px;

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -3204,6 +3204,96 @@ RSpec.describe CloverAdmin do
     end
   end
 
+  describe "cogs" do
+    def create_cogs_host(server_model: nil, monthly_price: nil, currency: nil, **args)
+      host = create_vm_host(**args)
+      if server_model || monthly_price
+        VmHostInventory.create(server_model:, monthly_price:, currency:) { it.id = host.id }
+      end
+      host
+    end
+
+    def create_minio_server(vm_host)
+      cluster = MinioCluster.create(
+        location_id: Location::HETZNER_FSN1_ID,
+        name: "minio-cluster-name",
+        admin_user: "minio-admin",
+        admin_password: "dummy-password",
+        root_cert_1: "dummy-root-cert-1",
+        root_cert_2: "dummy-root-cert-2",
+        project_id: Project.create(name: "minio-project").id,
+      )
+      pool = MinioPool.create(cluster_id: cluster.id, start_index: 0, server_count: 1, drive_count: 1, storage_size_gib: 100, vm_size: "standard-2")
+      MinioServer.create(minio_pool_id: pool.id, vm_id: create_vm(vm_host_id: vm_host.id).id, index: 0)
+    end
+
+    it "shows inventory and runner tables with the default conversion rate" do
+      create_cogs_host(total_cpus: 16, total_hugepages_1g: 52, server_model: "AX102", monthly_price: 100, currency: "EUR")
+      hel1_host = create_cogs_host(location_id: Location::HETZNER_HEL1_ID, total_cpus: 96, total_hugepages_1g: 368, server_model: "AX162-R", monthly_price: 400, currency: "EUR")
+      # Draining hosts still cost money, so they stay included.
+      create_cogs_host(location_id: Location::LEASEWEB_WDC02_ID, allocation_state: "draining", total_cpus: 128, total_hugepages_1g: 500, server_model: "HPE RL300", monthly_price: 500, currency: "USD")
+      create_cogs_host(location_id: Location::GITHUB_RUNNERS_ID, family: "premium", total_cpus: 16, total_hugepages_1g: 52, server_model: "AX102-U", monthly_price: 50, currency: "EUR")
+      create_cogs_host(location_id: Location::GITHUB_RUNNERS_ID, arch: "arm64", total_cpus: 80, total_hugepages_1g: 320, server_model: "RX220", monthly_price: 220, currency: "EUR")
+      # A host with an empty inventory row and no learned cpus contributes
+      # zero cost and zero sellable vCPUs.
+      empty_inventory_host = create_cogs_host
+      VmHostInventory.create { it.id = empty_inventory_host.id }
+      # Excluded: a host without an inventory row, a host running a Minio
+      # server, a host outside the listed locations, and an unprepared host.
+      create_cogs_host(total_cpus: 16, total_hugepages_1g: 52)
+      create_minio_server(create_cogs_host(total_cpus: 16, total_hugepages_1g: 52, server_model: "AX102", monthly_price: 999, currency: "EUR"))
+      create_cogs_host(location_id: Location[name: "hetzner-ai"].id, total_cpus: 16, total_hugepages_1g: 52, server_model: "AX102", monthly_price: 999, currency: "EUR")
+      create_cogs_host(allocation_state: "unprepared", total_cpus: 16, total_hugepages_1g: 52, server_model: "AX102", monthly_price: 999, currency: "EUR")
+
+      create_vm(vm_host_id: hel1_host.id, vcpus: 4)
+      create_vm(vm_host_id: hel1_host.id, family: "burstable", vcpus: 1)
+      runner_vm = create_vm(vm_host_id: hel1_host.id, vcpus: 8)
+      GithubRunner.create(label: "ubicloud", repository_name: "my-repo", vm_id: runner_vm.id)
+
+      click_link "VM Host COGS"
+      expect(page.title).to eq "Ubicloud Admin - VM Host COGS"
+      expect(find_by_id("rate").value).to eq "1.14"
+
+      expect(page.all(".cogs-by-location-table td").map(&:text)).to eq [
+        "hetzner-fsn1", "standard", "2", "$114.00", "13", "$17.54",
+        "hetzner-hel1", "standard", "1", "$456.00", "92", "$9.91",
+        "leaseweb-wdc02", "standard", "1", "$500.00", "125", "$8.00",
+        "github-runners", "premium", "1", "$57.00", "13", "$8.77",
+      ]
+
+      expect(page.all(".cogs-by-type-table td").map(&:text)).to eq [
+        "AX102", "2", "$171.00", "26", "$13.15",
+        "AX162", "1", "$456.00", "92", "$9.91",
+        "HPE RL300", "1", "$500.00", "125", "$8.00",
+        "unknown", "1", "$0.00", "0", "-",
+      ]
+
+      expect(page.all(".cogs-github-runners-table td").map(&:text)).to eq [
+        "AX102", "2", "26", "$13.15", "$39.90",
+        "AX162", "1", "87", "$9.91", "$101.20",
+        "RX220", "1", "79", "$6.35", "$58.52",
+        "unknown", "1", "0", "-", "-",
+      ]
+    end
+
+    it "recalculates with a submitted conversion rate" do
+      create_cogs_host(total_cpus: 16, total_hugepages_1g: 52, server_model: "AX102", monthly_price: 100, currency: "EUR")
+
+      click_link "VM Host COGS"
+      fill_in "EUR/USD Rate", with: "2"
+      click_button "Recalculate"
+      expect(find_by_id("rate").value).to eq "2.0"
+      expect(page.all(".cogs-by-location-table td").map(&:text)).to eq [
+        "hetzner-fsn1", "standard", "1", "$200.00", "13", "$30.77",
+      ]
+    end
+
+    it "raises for an invalid conversion rate" do
+      expect { visit "/cogs?rate=abc" }.to raise_error(CloverError, "invalid conversion rate")
+      expect { visit "/cogs?rate=0" }.to raise_error(CloverError, "invalid conversion rate")
+    end
+  end
+
   it "shows VM Host Usage filtered by location" do
     vm_host = create_vm_host(data_center: "FSN1-DC1", total_cores: 48, used_cores: 4, total_hugepages_1g: 375, used_hugepages_1g: 32)
     HostProvider.create do

--- a/views/admin/cogs.erb
+++ b/views/admin/cogs.erb
@@ -1,0 +1,20 @@
+<% @page_title = "VM Host COGS" %>
+
+<div class="cogs-page">
+  <div>
+    <h2>VM Host Inventory</h2>
+    <%== part("components/table", title: "By Location", table_class: "cogs-by-location-table", data: @by_location, use_admin_label: false) %>
+    <%== part("components/table", title: "By Type", table_class: "cogs-by-type-table", data: @by_type, use_admin_label: false) %>
+  </div>
+
+  <div>
+    <h2>GitHub Runners Inventory</h2>
+    <p>GitHub runners can be allocated to any of the hetzner-fsn1, hetzner-hel1, and github-runners locations, so all hosts there are listed.</p>
+    <%== part("components/table", title: "GitHub Runners", table_class: "cogs-github-runners-table", data: @github_runners, use_admin_label: false) %>
+  </div>
+
+  <% form({id: "cogs-rate-form"}, wrapper: :div) do |f| %>
+    <%== f.input(:text, key: "rate", label: "EUR/USD Rate", value: @rate.to_s("F")) %>
+    <%== f.button("Recalculate") %>
+  <% end %>
+</div>

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -51,6 +51,7 @@
     <li><a href="/vm-by-ipv4">Find VM by IPv4 Address</a></li>
     <li><a href="/github-runner-usage">GitHub Runner VM Usage</a></li>
     <li><a href="/vm-host-usage">VM Host Usage</a></li>
+    <li><a href="/cogs">VM Host COGS</a></li>
     <li><a href="/setup-vm-host">Setup VM Host</a></li>
     <li><a href="/customer-usage">Customer Usage</a></li>
     <li>


### PR DESCRIPTION
Now that vm_host_inventory records per-host hardware and monthly prices, expose the cost side in the admin panel. The /cogs page aggregates cost of goods sold for x64 hosts by location and by server type, and estimates the vCPU capacity and weekly cost available to GitHub runners across the locations they can allocate in, deducting vCPUs already used by other services (burstable VMs count at 50%).

Sellable vCPUs per host are min(total_cpus - 1, hugepages / memory per vCPU), using 4 GiB per vCPU on x64 and 3.2 GiB on arm64. Mixed EUR/USD inventory prices are shown in USD, converted with an adjustable rate defaulting to 1.14. Hosts are excluded when they run Minio servers, have no inventory row, or are unprepared. A host without an inventory row must not deflate the per-vCPU cost with free sellable vCPUs.