### PR TITLE
Reduce admin table header size

### DIFF
--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -218,9 +218,10 @@ tbody tr {
   td[rowspan] { background-color: var(--bg); }
 }
 caption, .collapsible-table summary {
-  font-size: 1.3em;
+  font-size: 1.1em;
   font-weight: bold;
   text-align: left;
+  margin-bottom: 2px;
 }
 
 .collapsible-table {


### PR DESCRIPTION
The table captions and collapsible table summaries used 1.3em, the same size as h2, which made them louder than the section headings around them. Use the h3 size instead and add a small bottom margin so the header does not touch the table.