### PR TITLE
Replace rsyslog with a capped journal on existing Postgres servers

### DIFF
--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -18,6 +18,7 @@ configure_hash = JSON.parse($stdin.read)
 pgsetup = PostgresSetup.new(v)
 pgsetup.configure_memory_overcommit(strict: configure_hash["strict_overcommit"])
 pgsetup.configure_service_slice
+pgsetup.configure_journald
 
 # Update /etc/hosts
 hosts = <<-HOSTS

--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../../common/lib/util"
+require "fileutils"
 require "logger"
 
 class PostgresSetup
@@ -45,6 +46,40 @@ class PostgresSetup
       net.ipv4.tcp_keepalive_intvl=10
     SYSCTL
     r "sudo sysctl --system"
+  end
+
+  JOURNALD_CONF_PATH = "/etc/systemd/journald.conf.d/50-persistent.conf"
+
+  JOURNALD_CONF = <<~JOURNALD
+    [Journal]
+    Storage=persistent
+    SystemMaxUse=4G
+    Compress=yes
+    ForwardToSyslog=no
+  JOURNALD
+
+  # Every file the stock rsyslog config writes, with its rotated and compressed
+  # generations. Once rsyslog is gone nothing writes, rotates or reads them.
+  RSYSLOG_LOGS_GLOB = "/var/log/{syslog,auth.log,kern.log,daemon.log,user.log,lpr.log,cron.log,debug,messages,mail.log,mail.info,mail.warn,mail.err}*"
+
+  # rsyslog duplicates the journal into /var/log with no size ceiling, so the
+  # root filesystem fills. The current image drops it for a capped persistent
+  # journal at build time; servers built before that image need the same end
+  # state applied in place, including reclaiming what rsyslog already wrote.
+  def configure_journald
+    unless File.exist?(JOURNALD_CONF_PATH) && File.read(JOURNALD_CONF_PATH) == JOURNALD_CONF
+      r "mkdir", "-p", File.dirname(JOURNALD_CONF_PATH)
+      safe_write_to_file(JOURNALD_CONF_PATH, JOURNALD_CONF)
+      r "systemctl", "restart", "systemd-journald"
+    end
+
+    return unless File.exist?("/usr/sbin/rsyslogd")
+
+    # postrm takes /etc/logrotate.d/rsyslog with it, so the stale weekly config
+    # does not outlive the daemon.
+    r "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "purge", "-y", "rsyslog"
+
+    FileUtils.rm_f(Dir.glob(RSYSLOG_LOGS_GLOB))
   end
 
   def configure_service_slice

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -113,6 +113,76 @@ RSpec.describe PostgresSetup do
     end
   end
 
+  describe "#configure_journald" do
+    it "writes the drop-in, restarts journald, purges rsyslog and reclaims what it wrote" do
+      expect(File).to receive(:exist?).with(PostgresSetup::JOURNALD_CONF_PATH).and_return(false)
+      expect(pg_setup).to receive(:_run_command).with("mkdir", "-p", "/etc/systemd/journald.conf.d")
+      expect(pg_setup).to receive(:safe_write_to_file).with(PostgresSetup::JOURNALD_CONF_PATH, <<~JOURNALD)
+        [Journal]
+        Storage=persistent
+        SystemMaxUse=4G
+        Compress=yes
+        ForwardToSyslog=no
+      JOURNALD
+      expect(pg_setup).to receive(:_run_command).with("systemctl", "restart", "systemd-journald")
+      expect(File).to receive(:exist?).with("/usr/sbin/rsyslogd").and_return(true)
+      expect(pg_setup).to receive(:_run_command).with("env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "purge", "-y", "rsyslog")
+      expect(Dir).to receive(:glob).with(PostgresSetup::RSYSLOG_LOGS_GLOB).and_return(["/var/log/syslog", "/var/log/syslog.1", "/var/log/auth.log.2.gz"])
+      expect(FileUtils).to receive(:rm_f).with(["/var/log/syslog", "/var/log/syslog.1", "/var/log/auth.log.2.gz"])
+
+      pg_setup.configure_journald
+    end
+
+    it "skips the write and the journald restart when the drop-in already matches" do
+      expect(File).to receive(:exist?).with(PostgresSetup::JOURNALD_CONF_PATH).and_return(true)
+      expect(File).to receive(:read).with(PostgresSetup::JOURNALD_CONF_PATH).and_return(PostgresSetup::JOURNALD_CONF)
+      expect(pg_setup).not_to receive(:safe_write_to_file)
+      expect(File).to receive(:exist?).with("/usr/sbin/rsyslogd").and_return(false)
+
+      pg_setup.configure_journald
+    end
+
+    it "rewrites the drop-in when the content differs" do
+      expect(File).to receive(:exist?).with(PostgresSetup::JOURNALD_CONF_PATH).and_return(true)
+      expect(File).to receive(:read).with(PostgresSetup::JOURNALD_CONF_PATH).and_return("[Journal]\nSystemMaxUse=1G\n")
+      expect(pg_setup).to receive(:_run_command).with("mkdir", "-p", "/etc/systemd/journald.conf.d")
+      expect(pg_setup).to receive(:safe_write_to_file).with(PostgresSetup::JOURNALD_CONF_PATH, PostgresSetup::JOURNALD_CONF)
+      expect(pg_setup).to receive(:_run_command).with("systemctl", "restart", "systemd-journald")
+      expect(File).to receive(:exist?).with("/usr/sbin/rsyslogd").and_return(false)
+
+      pg_setup.configure_journald
+    end
+
+    it "leaves rsyslog alone on a server built from an image that has none" do
+      expect(File).to receive(:exist?).with(PostgresSetup::JOURNALD_CONF_PATH).and_return(true)
+      expect(File).to receive(:read).with(PostgresSetup::JOURNALD_CONF_PATH).and_return(PostgresSetup::JOURNALD_CONF)
+      expect(File).to receive(:exist?).with("/usr/sbin/rsyslogd").and_return(false)
+      expect(Dir).not_to receive(:glob)
+      expect(FileUtils).not_to receive(:rm_f)
+
+      pg_setup.configure_journald
+    end
+
+    it "covers every file the stock rsyslog config writes" do
+      stock_paths = [
+        "/var/log/syslog", "/var/log/mail.info", "/var/log/mail.warn", "/var/log/mail.err",
+        "/var/log/mail.log", "/var/log/daemon.log", "/var/log/kern.log", "/var/log/auth.log",
+        "/var/log/user.log", "/var/log/lpr.log", "/var/log/cron.log", "/var/log/debug",
+        "/var/log/messages",
+      ]
+      stock_paths.each do |path|
+        expect(File.fnmatch?(PostgresSetup::RSYSLOG_LOGS_GLOB, path, File::FNM_EXTGLOB)).to be(true), "#{path} not covered"
+        expect(File.fnmatch?(PostgresSetup::RSYSLOG_LOGS_GLOB, "#{path}.2.gz", File::FNM_EXTGLOB)).to be(true), "#{path}.2.gz not covered"
+      end
+    end
+
+    it "does not match unrelated files under /var/log" do
+      ["/var/log/postgresql.log", "/var/log/journal", "/var/log/wtmp", "/var/log/dpkg.log"].each do |path|
+        expect(File.fnmatch?(PostgresSetup::RSYSLOG_LOGS_GLOB, path, File::FNM_EXTGLOB)).to be(false), "#{path} matched"
+      end
+    end
+  end
+
   describe "#configure_service_slice" do
     it "writes slice + drop-ins, reloads, sets slice property, restarts only services not yet in the slice" do
       expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/system-go_services.slice", <<~SLICE)


### PR DESCRIPTION
Replaces #6085, which bounded rsyslog's output instead of removing the writer.

rsyslog duplicates the journal into `/var/log` under a weekly rotate-4 config
with no size ceiling, so one generation accumulates a week of output. A live
server measured 888 MB in a single `/var/log/syslog` generation, about
52 MB/day, on a 16 GiB root filesystem. `disk-full-check` does not catch this:
it watches the `/dat` data disk.

The image stopped shipping rsyslog in favour of a capped persistent journal, so
servers built since then already have the end state we want and the problem is
confined to older servers. `PostgresSetup#configure_journald` applies that same
end state in place: write the journald drop-in, purge rsyslog, and delete what
it already wrote — after the purge nothing rotates or reads those files, and
the reclaimed space is the point.

## Why this instead of #6085

#6085 kept rsyslog and bounded it with `maxsize`. That helps only the servers
that still run rsyslog, a set that shrinks to zero as the fleet rolls over,
while newly provisioned servers took its hourly `logrotate.timer` and gained
nothing. This converges the old fleet onto the same configuration as the new
one, so there is one end state rather than two.

It also runs from `bin/configure` rather than `configure-logs`. `configure-logs`
fires only on provisioning, a log-destination edit, or failover, which the
affected servers may never see; every other host-level knob already lives in
`bin/configure`.

## Safety checks

Verified on a live pre-image server before choosing to purge:

- `apt-get -s purge rsyslog` removes **only** rsyslog. `ufw` and
  `ubuntu-minimal` reverse-depend through Recommends, not Depends, which the
  simulation confirms by removing neither.
- `systemctl list-dependencies --reverse rsyslog.service` lists only
  `multi-user.target`, i.e. the unit is enabled, not depended upon.
- ufw is never installed or enabled on Postgres servers; only
  `rhizome/host/bin/setup-grafana` uses it.
- `/dev/log` is a symlink to `/run/systemd/journal/dev-log`, so journald already
  owns the syslog socket. Callers of `syslog(3)` keep working; their messages
  land in the journal rather than `/var/log/syslog`.
- The collector reads the journal through a `journald` receiver over
  `system-postgresql.slice` and `system-pgbouncer.slice`, so customer log
  destinations are untouched.
- The deletion glob was exercised against a real directory: it matched all 16
  rsyslog files including rotated and compressed generations, and matched
  none of `/var/log/journal`, `wtmp`, `btmp`, `dpkg.log`, `postgresql.log`.

## Consequences worth naming

- `SystemMaxUse=4G` matches the image but sits above journald's
  10%-of-filesystem default, so the journal ceiling on a 16 GiB root disk rises
  from about 1.6 GB to 4 GB — traded against removing an unbounded writer.
- Deleting the old files removes local history, `auth.log` included. The journal
  holds the same records.
- `libestr0` and `libfastjson4` are left orphaned. No `apt autoremove` runs: it
  can take more than expected on a live database server.
- `ubuntu-minimal` recommends rsyslog, so an upgrade of that metapackage can
  reinstall it. The check is on every `bin/configure` run, so the next one
  purges it again — the fix repairs itself.

730 rhizome examples pass at 100% line and branch coverage; the main suite
passes with 7823 examples; rubocop is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)