### PR TITLE
Start collecting metrics

### DIFF
--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -20,7 +20,7 @@ class KubernetesCluster < Sequel::Model
   dataset_module Pagination
 
   plugin ResourceMethods, encrypted_columns: :kubeconfig
-  plugin SemaphoreMethods, :destroy, :sync_kubernetes_services, :upgrade, :upgrade_nodepools, :install_metrics_server, :sync_worker_mesh, :install_csi, :update_billing_records, :sync_internal_dns_config, :sync_kubeconfig
+  plugin SemaphoreMethods, :destroy, :sync_kubernetes_services, :upgrade, :upgrade_nodepools, :install_metrics_server, :sync_worker_mesh, :install_csi, :update_billing_records, :sync_internal_dns_config, :sync_kubeconfig, :install_prometheus_rbac
   include HealthMonitorMethods
 
   def validate

--- a/model/kubernetes/kubernetes_node.rb
+++ b/model/kubernetes/kubernetes_node.rb
@@ -11,6 +11,7 @@ class KubernetesNode < Sequel::Model
   plugin ResourceMethods
   plugin SemaphoreMethods, :destroy, :retire, :checkup, :renew_certs
   include HealthMonitorMethods
+  include MetricsTargetMethods
 
   MESH_STATUS_FILE_PATH = "/var/lib/ubicsi/mesh_status.json"
 
@@ -18,9 +19,36 @@ class KubernetesNode < Sequel::Model
     vm.sshable
   end
 
+  def control_plane?
+    kubernetes_nodepool_id.nil?
+  end
+
   def init_health_monitor_session
     {
       ssh_session: sshable.start_fresh_session,
+    }
+  end
+
+  def init_metrics_export_session
+    {
+      ssh_session: sshable.start_fresh_session,
+    }
+  end
+
+  def metrics_config
+    {
+      endpoints: ["http://localhost:9100/metrics"],
+      max_file_retention: 120,
+      interval: "15s",
+      additional_labels: {
+        ubicloud_resource_id: kubernetes_cluster.ubid,
+        ubicloud_resource_role: control_plane? ? "control-plane" : "worker",
+        instance: name,
+        nodepool: kubernetes_nodepool&.name,
+      }.compact,
+      exclude_metrics: ["^(# (HELP|TYPE) )?node_scrape_collector_"],
+      metrics_dir: "/home/ubi/kubernetes/metrics",
+      project_id: Config.kubernetes_service_project_id,
     }
   end
 

--- a/model/kubernetes/kubernetes_node.rb
+++ b/model/kubernetes/kubernetes_node.rb
@@ -35,9 +35,22 @@ class KubernetesNode < Sequel::Model
     }
   end
 
+  FEDERATE_MATCHES = [
+    "{__name__=~\"ubicloud:.*\"}",
+    "apiserver_current_inflight_requests",
+    "apiserver_storage_size_bytes",
+    "scheduler_pending_pods",
+  ].freeze
+
   def metrics_config
+    endpoints = ["http://localhost:9100/metrics"]
+    if control_plane?
+      query = URI.encode_www_form(FEDERATE_MATCHES.map { ["match[]", it] })
+      endpoints << "http://localhost:9090/federate?#{query}"
+    end
+
     {
-      endpoints: ["http://localhost:9100/metrics"],
+      endpoints:,
       max_file_retention: 120,
       interval: "15s",
       additional_labels: {

--- a/model/kubernetes/kubernetes_node.rb
+++ b/model/kubernetes/kubernetes_node.rb
@@ -9,7 +9,7 @@ class KubernetesNode < Sequel::Model
   many_to_one :kubernetes_nodepool, read_only: true
 
   plugin ResourceMethods
-  plugin SemaphoreMethods, :destroy, :retire, :checkup, :renew_certs
+  plugin SemaphoreMethods, :destroy, :retire, :checkup, :renew_certs, :configure_metrics
   include HealthMonitorMethods
   include MetricsTargetMethods
 

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -87,6 +87,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     register_deadline("wait", 120 * 60)
     Prog::Kubernetes::EtcdBackupNexus.assemble(kubernetes_cluster.id)
     incr_install_metrics_server
+    incr_install_prometheus_rbac
     incr_sync_worker_mesh
     incr_install_csi
     incr_sync_internal_dns_config
@@ -241,6 +242,10 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
       hop_install_csi
     end
 
+    when_install_prometheus_rbac_set? do
+      hop_install_prometheus_rbac
+    end
+
     when_update_billing_records_set? do
       hop_update_billing_records
     end
@@ -310,6 +315,15 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
 
   label def wait_upgrade
     reap(:upgrade)
+  end
+
+  label def install_prometheus_rbac
+    decr_install_prometheus_rbac
+
+    kubernetes_cluster.client.kubectl("apply -f /home/ubi/kubernetes/lib/prometheus-rbac.yaml")
+    KubernetesNode.incr_configure_metrics(kubernetes_cluster.nodes_dataset.select(:id))
+
+    hop_wait
   end
 
   label def install_metrics_server

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -57,7 +57,61 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
       hop_renew_certs
     end
 
+    when_configure_metrics_set? do
+      hop_configure_metrics
+    end
+
     nap 6 * 60 * 60
+  end
+
+  label def configure_metrics
+    register_deadline("wait", 2 * 60)
+    decr_configure_metrics
+
+    sshable = kubernetes_node.sshable
+    metrics_dir = metrics_config[:metrics_dir]
+    sshable.cmd("mkdir -p :metrics_dir", metrics_dir:)
+    sshable.write_file("#{metrics_dir}/config.json", metrics_config.to_json, user: :current)
+    sshable.write_file("/etc/systemd/system/kubernetes-metrics.service", metrics_service)
+    sshable.write_file("/etc/systemd/system/kubernetes-metrics.timer", metrics_timer)
+
+    sshable.cmd("sudo systemctl daemon-reload")
+    sshable.cmd("sudo systemctl enable --now kubernetes-metrics.timer")
+
+    hop_wait
+  end
+
+  def metrics_config
+    @metrics_config ||= kubernetes_node.metrics_config
+  end
+
+  def metrics_service
+    <<SERVICE
+[Unit]
+Description=Kubernetes Node Metrics Collection
+
+[Service]
+Type=oneshot
+User=ubi
+ExecStart=/home/ubi/common/bin/metrics-collector #{metrics_config[:metrics_dir]}
+StandardOutput=journal
+StandardError=journal
+SERVICE
+  end
+
+  def metrics_timer
+    <<TIMER
+[Unit]
+Description=Run Kubernetes Node Metrics Collection Periodically
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=#{metrics_config[:interval]}
+AccuracySec=1s
+
+[Install]
+WantedBy=timers.target
+TIMER
   end
 
   label def renew_certs

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -65,7 +65,7 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
   end
 
   label def configure_metrics
-    register_deadline("wait", 2 * 60)
+    register_deadline("wait", 30 * 60)
     decr_configure_metrics
 
     sshable = kubernetes_node.sshable
@@ -78,7 +78,67 @@ class Prog::Kubernetes::KubernetesNodeNexus < Prog::Base
     sshable.cmd("sudo systemctl daemon-reload")
     sshable.cmd("sudo systemctl enable --now kubernetes-metrics.timer")
 
+    hop_wait unless kubernetes_node.control_plane?
+    hop_configure_prometheus
+  end
+
+  label def configure_prometheus
+    encoded_token = cluster.client.kubectl("-n kube-system get secret prometheus-metrics -o jsonpath='{.data.token}' --ignore-not-found")
+    nap 10 if encoded_token.empty?
+
+    sshable = kubernetes_node.sshable
+    sshable.write_file("/etc/prometheus/token", Base64.decode64(encoded_token))
+    sshable.cmd("sudo chown prometheus:prometheus /etc/prometheus/token")
+    sshable.cmd("sudo chmod 600 /etc/prometheus/token")
+    sshable.write_file("/etc/prometheus/prometheus.yml", prometheus_config)
+    sshable.write_file("/etc/prometheus/rules.yml", prometheus_rules)
+    sshable.cmd("sudo systemctl enable --now prometheus")
+    sshable.cmd("sudo systemctl reload prometheus")
+
     hop_wait
+  end
+
+  def prometheus_config
+    <<CONFIG
+global:
+  scrape_interval: #{metrics_config[:interval]}
+
+rule_files:
+  - /etc/prometheus/rules.yml
+
+scrape_configs:
+- job_name: apiserver
+  scheme: https
+  tls_config:
+    insecure_skip_verify: true
+  bearer_token_file: /etc/prometheus/token
+  static_configs:
+  - targets: ['localhost:6443']
+- job_name: scheduler
+  scheme: https
+  tls_config:
+    insecure_skip_verify: true
+  bearer_token_file: /etc/prometheus/token
+  static_configs:
+  - targets: ['localhost:10259']
+CONFIG
+  end
+
+  def prometheus_rules
+    <<RULES
+groups:
+- name: ubicloud
+  interval: #{metrics_config[:interval]}
+  rules:
+  - record: ubicloud:apiserver_request:rate5m
+    expr: sum by (code) (rate(apiserver_request_total[5m]))
+  - record: ubicloud:apiserver_latency_seconds:p99
+    expr: histogram_quantile(0.99, sum by (verb, le) (rate(apiserver_request_duration_seconds_bucket[5m])))
+  - record: ubicloud:apiserver_latency_seconds:p50
+    expr: histogram_quantile(0.50, sum by (verb, le) (rate(apiserver_request_duration_seconds_bucket[5m])))
+  - record: ubicloud:apiserver_storage_objects:total
+    expr: sum(apiserver_storage_objects)
+RULES
   end
 
   def metrics_config

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -283,6 +283,7 @@ CONFIG
     kubernetes_cluster.incr_sync_internal_dns_config
     kubernetes_cluster.incr_sync_worker_mesh
     kubernetes_cluster.incr_update_billing_records
+    node.incr_configure_metrics
     pop({node_id: node.id})
   end
 

--- a/rhizome/kubernetes/lib/kubernetes_install_prometheus.rb
+++ b/rhizome/kubernetes/lib/kubernetes_install_prometheus.rb
@@ -29,7 +29,7 @@ class KubernetesInstallPrometheus
     LockPersonality=yes
     MemoryMax=1G
     Type=simple
-    ExecStart=/usr/local/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/var/lib/prometheus --storage.tsdb.retention.time=2h --web.listen-address=127.0.0.1:9090
+    ExecStart=/usr/local/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/var/lib/prometheus --storage.tsdb.retention.time=2h --storage.tsdb.wal-compression --web.listen-address=127.0.0.1:9090
     ExecReload=/bin/kill -HUP $MAINPID
     Restart=always
     User=prometheus
@@ -50,7 +50,7 @@ class KubernetesInstallPrometheus
     r "rm", tarball
 
     r "groupadd -f --system prometheus"
-    r "useradd --no-create-home --system -g prometheus prometheus"
+    r "useradd --no-create-home --system -g prometheus prometheus", expect: [0, 9] # 9 is "already exists"
     r "mkdir -p /etc/prometheus /var/lib/prometheus"
     r "chown prometheus:prometheus /var/lib/prometheus"
 

--- a/rhizome/kubernetes/lib/prometheus-rbac.yaml
+++ b/rhizome/kubernetes/lib/prometheus-rbac.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-metrics
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-metrics
+rules:
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-metrics
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-metrics
+    namespace: kube-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prometheus-metrics
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: prometheus-metrics
+type: kubernetes.io/service-account-token

--- a/rhizome/kubernetes/spec/kubernetes_install_prometheus_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_install_prometheus_spec.rb
@@ -11,7 +11,11 @@ RSpec.describe KubernetesInstallPrometheus do
   describe "#run" do
     it "installs the binary and the unit without enabling it" do
       commands = []
-      allow(installer).to receive(:_run_command) { |*command| commands << command.join(" ") }
+      accepted_exit_codes = {}
+      allow(installer).to receive(:_run_command) do |*command, **kw|
+        commands << command.join(" ")
+        accepted_exit_codes[command.join(" ")] = kw[:expect] if kw[:expect]
+      end
       written = {}
       allow(installer).to receive(:safe_write_to_file) { |path, content| written[path] = content }
       expect(installer).to receive(:curl_file).with(url, tarball).and_return(described_class::CHECKSUM)
@@ -28,6 +32,7 @@ RSpec.describe KubernetesInstallPrometheus do
         "systemctl daemon-reload",
       ]
       expect(written).to eq("/etc/systemd/system/prometheus.service" => described_class::SERVICE)
+      expect(accepted_exit_codes).to eq("useradd --no-create-home --system -g prometheus prometheus" => [0, 9])
     end
 
     it "fails when the download does not match the pinned checksum" do

--- a/spec/model/kubernetes/kubernetes_node_spec.rb
+++ b/spec/model/kubernetes/kubernetes_node_spec.rb
@@ -14,21 +14,7 @@ RSpec.describe KubernetesNode do
   }
 
   let(:project) { Project.create(name: "test") }
-  let(:subnet) { Prog::Vnet::SubnetNexus.assemble(Config.kubernetes_service_project_id, name: "test-subnet", ipv4_range: "172.19.0.0/16", ipv6_range: "fd40:1a0a:8d48:182a::/64").subject }
-  let(:kc) {
-    kc = KubernetesCluster.create(
-      name: "kc-name",
-      version: Option.selectable_kubernetes_versions.first,
-      location_id: Location::HETZNER_FSN1_ID,
-      cp_node_count: 1,
-      project_id: project.id,
-      private_subnet_id: subnet.id,
-      target_node_size: "standard-2",
-    )
-    Firewall.create(name: "#{kc.ubid}-cp-vm-firewall", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id)
-    Firewall.create(name: "#{kc.ubid}-worker-vm-firewall", location_id: Location::HETZNER_FSN1_ID, project_id: Config.kubernetes_service_project_id)
-    kc
-  }
+  let(:kc) { Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "kc-name", version: Option.selectable_kubernetes_versions.first, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 1, project_id: project.id, target_node_size: "standard-2").subject }
   let(:session) { {ssh_session: Net::SSH::Connection::Session.allocate} }
   let(:ssh_session) { session[:ssh_session] }
 
@@ -41,6 +27,44 @@ RSpec.describe KubernetesNode do
       expect(kn.sshable).to receive(:start_fresh_session).and_return("mock_session")
       session = kn.init_health_monitor_session
       expect(session).to eq({ssh_session: "mock_session"})
+    end
+  end
+
+  describe "#init_metrics_export_session" do
+    it "initiates a new metrics export session" do
+      expect(kn.sshable).to receive(:start_fresh_session).and_return("mock_session")
+      session = kn.init_metrics_export_session
+      expect(session).to eq({ssh_session: "mock_session"})
+    end
+  end
+
+  describe "#metrics_config" do
+    it "labels a control plane node with its cluster and role" do
+      expect(kn.metrics_config).to eq({
+        endpoints: ["http://localhost:9100/metrics"],
+        max_file_retention: 120,
+        interval: "15s",
+        additional_labels: {
+          ubicloud_resource_id: kc.ubid,
+          ubicloud_resource_role: "control-plane",
+          instance: kn.name,
+        },
+        exclude_metrics: ["^(# (HELP|TYPE) )?node_scrape_collector_"],
+        metrics_dir: "/home/ubi/kubernetes/metrics",
+        project_id: Config.kubernetes_service_project_id,
+      })
+    end
+
+    it "labels a worker node with its nodepool" do
+      nodepool = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np", node_count: 1, kubernetes_cluster_id: kc.id).subject
+      kn.update(kubernetes_nodepool_id: nodepool.id)
+
+      expect(kn.reload.metrics_config[:additional_labels]).to eq({
+        ubicloud_resource_id: kc.ubid,
+        ubicloud_resource_role: "worker",
+        instance: kn.name,
+        nodepool: "np",
+      })
     end
   end
 

--- a/spec/model/kubernetes/kubernetes_node_spec.rb
+++ b/spec/model/kubernetes/kubernetes_node_spec.rb
@@ -41,7 +41,10 @@ RSpec.describe KubernetesNode do
   describe "#metrics_config" do
     it "labels a control plane node with its cluster and role" do
       expect(kn.metrics_config).to eq({
-        endpoints: ["http://localhost:9100/metrics"],
+        endpoints: [
+          "http://localhost:9100/metrics",
+          "http://localhost:9090/federate?match%5B%5D=%7B__name__%3D%7E%22ubicloud%3A.*%22%7D&match%5B%5D=apiserver_current_inflight_requests&match%5B%5D=apiserver_storage_size_bytes&match%5B%5D=scheduler_pending_pods",
+        ],
         max_file_retention: 120,
         interval: "15s",
         additional_labels: {
@@ -55,11 +58,12 @@ RSpec.describe KubernetesNode do
       })
     end
 
-    it "labels a worker node with its nodepool" do
+    it "scrapes only node_exporter on a worker node and labels it with its nodepool" do
       nodepool = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np", node_count: 1, kubernetes_cluster_id: kc.id).subject
       kn.update(kubernetes_nodepool_id: nodepool.id)
 
-      expect(kn.reload.metrics_config[:additional_labels]).to eq({
+      expect(kn.reload.metrics_config[:endpoints]).to eq ["http://localhost:9100/metrics"]
+      expect(kn.metrics_config[:additional_labels]).to eq({
         ubicloud_resource_id: kc.ubid,
         ubicloud_resource_role: "worker",
         instance: kn.name,

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(nx.strand.stack.first["deadline_target"]).to eq "wait"
       expect(Time.new(nx.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 120 * 60)
       expect(nx.install_metrics_server_set?).to be true
+      expect(nx.install_prometheus_rbac_set?).to be true
       expect(nx.sync_worker_mesh_set?).to be true
       expect(nx.sync_internal_dns_config_set?).to be true
       expect(nx.install_csi_set?).to be true
@@ -515,6 +516,11 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect { nx.wait }.to hop("sync_kubeconfig")
     end
 
+    it "hops to install_prometheus_rbac when its semaphore is set" do
+      nx.incr_install_prometheus_rbac
+      expect { nx.wait }.to hop("install_prometheus_rbac")
+    end
+
     it "hops to update_billing_records" do
       nx.incr_update_billing_records
       expect { nx.wait }.to hop("update_billing_records")
@@ -677,6 +683,20 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       st.update(label: "destroy")
       Strand.create(parent_id: st.id, prog: "Kubernetes::ProvisionKubernetesNode", label: "start", stack: [{}], lease: Time.now + 10)
       expect { nx.wait_upgrade }.to nap(120)
+    end
+  end
+
+  describe "#install_prometheus_rbac" do
+    it "applies the rbac manifest and reconfigures metrics on the control plane nodes" do
+      nx.incr_install_prometheus_rbac
+      ssh_session = Net::SSH::Connection::Session.allocate
+      expect(nx.kubernetes_cluster).to receive(:client).and_return(Kubernetes::Client.new(kubernetes_cluster, ssh_session))
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s apply -f /home/ubi/kubernetes/lib/prometheus-rbac.yaml").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))
+
+      expect { nx.install_prometheus_rbac }.to hop("wait")
+
+      expect(kubernetes_cluster.install_prometheus_rbac_set?).to be false
+      expect(kubernetes_cluster.reload.nodes.map { it.configure_metrics_set? }).to eq [true, true]
     end
   end
 

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -119,22 +119,60 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
   end
 
   describe "#configure_metrics" do
-    it "writes the collector config and unit files, enables the timer and registers a wait deadline" do
-      nx.incr_configure_metrics
-      sshable = nx.kubernetes_node.sshable
+    def expect_collector_setup(sshable)
       expect(sshable).to receive(:_cmd).with("mkdir -p /home/ubi/kubernetes/metrics")
       expect(sshable).to receive(:_cmd).with("tee /home/ubi/kubernetes/metrics/config.json > /dev/null", stdin: nx.metrics_config.to_json)
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/kubernetes-metrics.service > /dev/null", stdin: nx.metrics_service)
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/kubernetes-metrics.timer > /dev/null", stdin: nx.metrics_timer)
       expect(sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now kubernetes-metrics.timer")
+    end
 
-      expect { nx.configure_metrics }.to hop("wait")
+    it "hops to configure_prometheus on a control plane node and registers a wait deadline" do
+      nx.incr_configure_metrics
+      expect_collector_setup(nx.kubernetes_node.sshable)
+
+      expect { nx.configure_metrics }.to hop("configure_prometheus")
 
       expect(kd.configure_metrics_set?).to be false
       frame = nx.strand.stack.first
       expect(frame["deadline_target"]).to eq "wait"
-      expect(Time.new(frame["deadline_at"].to_s)).to be_within(3).of(Time.now + 2 * 60)
+      expect(Time.new(frame["deadline_at"].to_s)).to be_within(3).of(Time.now + 30 * 60)
+    end
+
+    it "skips prometheus on a worker node" do
+      kd.update(kubernetes_nodepool_id: Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np", node_count: 1, kubernetes_cluster_id: kc.id).subject.id)
+      expect_collector_setup(nx.kubernetes_node.sshable)
+
+      expect { nx.configure_metrics }.to hop("wait")
+    end
+  end
+
+  describe "#configure_prometheus" do
+    def expect_token_read(encoded)
+      ssh_session = Net::SSH::Connection::Session.allocate
+      expect(nx.cluster).to receive(:client).and_return(Kubernetes::Client.new(kc, ssh_session))
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s -n kube-system get secret prometheus-metrics -o jsonpath='{.data.token}' --ignore-not-found").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(encoded, 0))
+    end
+
+    it "writes the token and config, then starts prometheus" do
+      sshable = nx.kubernetes_node.sshable
+      expect_token_read(Base64.strict_encode64("sa-token"))
+      expect(sshable).to receive(:_cmd).with("sudo tee /etc/prometheus/token > /dev/null", stdin: "sa-token")
+      expect(sshable).to receive(:_cmd).with("sudo chown prometheus:prometheus /etc/prometheus/token")
+      expect(sshable).to receive(:_cmd).with("sudo chmod 600 /etc/prometheus/token")
+      expect(sshable).to receive(:_cmd).with("sudo tee /etc/prometheus/prometheus.yml > /dev/null", stdin: nx.prometheus_config)
+      expect(sshable).to receive(:_cmd).with("sudo tee /etc/prometheus/rules.yml > /dev/null", stdin: nx.prometheus_rules)
+      expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now prometheus")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl reload prometheus")
+
+      expect { nx.configure_prometheus }.to hop("wait")
+    end
+
+    it "naps without redoing any work until the service account token exists" do
+      expect_token_read("")
+
+      expect { nx.configure_prometheus }.to nap(10)
     end
   end
 

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -111,6 +111,31 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       nx.incr_renew_certs
       expect { nx.wait }.to hop("renew_certs")
     end
+
+    it "hops to configure_metrics when configure_metrics semaphore is set" do
+      nx.incr_configure_metrics
+      expect { nx.wait }.to hop("configure_metrics")
+    end
+  end
+
+  describe "#configure_metrics" do
+    it "writes the collector config and unit files, enables the timer and registers a wait deadline" do
+      nx.incr_configure_metrics
+      sshable = nx.kubernetes_node.sshable
+      expect(sshable).to receive(:_cmd).with("mkdir -p /home/ubi/kubernetes/metrics")
+      expect(sshable).to receive(:_cmd).with("tee /home/ubi/kubernetes/metrics/config.json > /dev/null", stdin: nx.metrics_config.to_json)
+      expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/kubernetes-metrics.service > /dev/null", stdin: nx.metrics_service)
+      expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/kubernetes-metrics.timer > /dev/null", stdin: nx.metrics_timer)
+      expect(sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
+      expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now kubernetes-metrics.timer")
+
+      expect { nx.configure_metrics }.to hop("wait")
+
+      expect(kd.configure_metrics_set?).to be false
+      frame = nx.strand.stack.first
+      expect(frame["deadline_target"]).to eq "wait"
+      expect(Time.new(frame["deadline_at"].to_s)).to be_within(3).of(Time.now + 2 * 60)
+    end
   end
 
   describe "#renew_certs" do


### PR DESCRIPTION
**Collect Kubernetes cluster metrics**

Sets up the collection side of Kubernetes metrics, from the node up to VictoriaMetrics. Nothing is exposed to customers yet.

**Node metrics**. KubernetesNode implements the MetricsTargetMethods contract, and configure_metrics writes the metrics-collector config and its systemd timer so node_exporter samples buffer on disk. bin/monitor drains that buffer into VictoriaMetrics. Series carry the cluster ubid, the node name, and whether the node is control plane or a worker in a named nodepool.

**Control plane metrics**. Each control plane node runs a local Prometheus scraping its own apiserver and scheduler, authenticated with a service account scoped to /metrics. Recording rules collapse apiserver_request_total and apiserver_request_duration_seconds before anything leaves the node, since those two are high cardinality; only the aggregates and a few small gauges are federated out.

**Cardinality**. Two exclusions keep a node's series count from growing with its pod count, and one drops scrape bookkeeping. A control plane node emits about 430 series.

Newly provisioned nodes configure themselves once they join. Existing nodes need configure_metrics set.