### PR TITLE
Export Kubernetes node metrics from bin/monitor

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -69,6 +69,7 @@ else
     PostgresServer.exclude(id: Semaphore.where(name: "initial_provisioning").where(strand_id: PostgresServer.select(:id)).select(:strand_id)),
     VmHost.exclude(allocation_state: "unprepared"),
     ParseableServer.exclude(id: Semaphore.where(name: "initial_provisioning").where(strand_id: ParseableServer.select(:id)).select(:strand_id)),
+    KubernetesNode.eager(:vm, :kubernetes_cluster, :kubernetes_nodepool),
   ]
 end
 


### PR DESCRIPTION
Adds KubernetesNode to metric_export_models so the metrics buffered by the collector on each node are drained into VictoriaMetrics. The cluster and nodepool associations are eager loaded because metrics_config reads labels from both.