### PR TITLE
Read the health pulse LSN from ubi_admin, not postgres

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -458,7 +458,7 @@ class PostgresServer < Sequel::Model
 
   def check_pulse(session:, previous_pulse:)
     reading = begin
-      session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, port: 5432, database: "postgres", user: "ubi_monitoring", connect_timeout: 4, keep_reference: false)
+      session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, port: 5432, database: "ubi_admin", user: "ubi_monitoring", connect_timeout: 4, keep_reference: false)
       last_known_lsn = session[:db_connection].get(last_lsn_expression.as(:lsn))
       "up"
     rescue

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -902,7 +902,7 @@ RSpec.describe PostgresServer do
   it "passes hardcoded port and database to Sequel.connect when opening a fresh db_connection" do
     db = instance_double(Sequel::Postgres::Database)
     expect(Sequel).to receive(:connect).with(
-      hash_including(host: postgres_server.health_monitor_socket_path, port: 5432, database: "postgres", user: "ubi_monitoring"),
+      hash_including(host: postgres_server.health_monitor_socket_path, port: 5432, database: "ubi_admin", user: "ubi_monitoring"),
     ).and_return(db)
     expect(db).to receive(:get).and_raise(Sequel::DatabaseConnectionError)
 


### PR DESCRIPTION
Fixes a failure that ddfebb4d8 introduced on main.

That commit moved `PostgresServer#check_pulse` from the `postgres` superuser to `ubi_monitoring`, but it left the connection on the `postgres` database. A superuser skips every privilege check, so the old connection always reached that database. `ubi_monitoring` cannot reach it after a customer revokes CONNECT from PUBLIC. One customer already revoked it, and the pulse on that server fails on each check:

```
FATAL:  permission denied for database "postgres"
DETAIL:  User does not have CONNECT privilege.
```

The `datacl` value of that server shows the revoke. PUBLIC keeps TEMPORARY, but it no longer holds CONNECT:

```
postgres|{=T/postgres,postgres=CTc/postgres}
```

## Why this matters

The failure gives no signal. `check_pulse` turns every error into a "down" reading. The checkup then calls `available?`, which asks the server over SSH as `postgres` and succeeds, so no page occurs. The failure stops `last_known_lsn` instead. The async HA guard then refuses each failover, because it treats an old LSN as an unsafe target.

## The change

Read the LSN from `ubi_admin`. No customer reaches that database, because pg_hba rejects each TCP connection to it. `collect-pg-metrics` already reads these same LSN functions there as `ubi_monitoring`. The WAL LSN belongs to the whole cluster, so the source database does not change the value.

## Verification

I reproduced the failure on a throwaway cluster. I gave that cluster the same `datacl` value that the affected server has, and I ran the real `Sequel.connect` call from `check_pulse`:

| Scenario | Pulse reading |
|---|---|
| main today, database `postgres` | down, `permission denied for database "postgres"` |
| this change, database `ubi_admin` | up, `0/191B8E8` |

On the affected production server, the pulse query returns an LSN:

```console
$ sudo -u ubi psql -h /var/run/postgresql -U ubi_monitoring -d ubi_admin \
    -c "SELECT CASE WHEN pg_is_in_recovery() THEN pg_last_wal_receive_lsn() ELSE pg_current_wal_lsn() END"
 pg_current_wal_lsn
--------------------
 193/F773BD28
```

Tests: 217 model examples pass. Rubocop reports no offense.

## Rollout

This change works on every server at once, and it needs no sweep.

To find the other affected servers, run this command:

```sh
sudo -u postgres psql -d postgres -tAc "SELECT has_database_privilege('ubi_monitoring','postgres','CONNECT')"
```

The command returns `f` on an affected server.
