### PR TITLE
Hardcode SHA-256 for GitHub webhook signature check

### DIFF
--- a/routes/webhook/github.rb
+++ b/routes/webhook/github.rb
@@ -5,9 +5,8 @@ class Clover
     r.post true do
       body = r.body.read
       next 401 unless (signature = r.headers["x-hub-signature-256"])
-      method, actual_digest = signature.split("=")
-      expected_digest = OpenSSL::HMAC.hexdigest(method, Config.github_app_webhook_secret, body)
-      next 401 unless Rack::Utils.secure_compare(actual_digest, expected_digest)
+      expected_signature = "sha256=#{OpenSSL::HMAC.hexdigest("SHA256", Config.github_app_webhook_secret, body)}"
+      next 401 unless Rack::Utils.secure_compare(signature, expected_signature)
 
       response.content_type = :json
 

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -25,6 +25,21 @@ RSpec.describe Clover, "github" do
     expect(page.status_code).to eq(401)
   end
 
+  it "fails if signature does not use sha256" do
+    page.driver.post("/webhook/github", {}, {"HTTP_X_HUB_SIGNATURE_256" => "md5=#{OpenSSL::HMAC.hexdigest("md5", "secret", "")}"})
+    expect(page.status_code).to eq(401)
+  end
+
+  it "fails if signature algorithm is not supported by OpenSSL" do
+    page.driver.post("/webhook/github", {}, {"HTTP_X_HUB_SIGNATURE_256" => "unsupported_hashing_method=abc123digest"})
+    expect(page.status_code).to eq(401)
+  end
+
+  it "fails if signature has no algorithm prefix" do
+    page.driver.post("/webhook/github", {}, {"HTTP_X_HUB_SIGNATURE_256" => "sha256"})
+    expect(page.status_code).to eq(401)
+  end
+
   it "fails if unexpected event" do
     send_webhook("repository", {})
 


### PR DESCRIPTION
The webhook route took the HMAC algorithm from the X-Hub-Signature-256 request header and passed it straight to OpenSSL::HMAC.hexdigest. This is not a signature bypass: forging a digest under any algorithm still requires the webhook secret, and HMAC-MD5 and HMAC-SHA-1 stay forgery resistant even though their hashes are broken for collisions.

It does let an unauthenticated caller crash the route, though. An unknown algorithm name raises OpenSSL::Digest::DigestError, and a header with no "=" leaves the digest nil, which makes Rack::Utils.secure_compare raise NoMethodError. Both become 500 responses with an exception log entry, so anyone can fill the log with noise and hide real errors.

GitHub documents that the signature always starts with a lowercase "sha256=" prefix, so build the whole expected header value and compare it against the header as a whole. The prefix check then falls out of the constant-time comparison, and dropping the split saves two object allocations per request.

https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries

Reported by an external security researcher.