### PR TITLE
Do not page when a customer fills their runner group

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -256,6 +256,21 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       nap 0
     end
 
+    if e.message.match?(/has reached max limit of \d+ runners/)
+      # GitHub rejects new registrations once the runner group holds
+      # 10,000 runners. While clover's just-in-time runners are
+      # deregistered on job completion and reaped by GitHub within a
+      # day otherwise, some repositories have multiple sources of
+      # runners registered, and some of those may be non-ephemeral and
+      # subject to resource leaks; GitHub reaps such leaked runners
+      # only after fourteen days. It is this case that compels
+      # ignoring this kind of exception, rather than assuming clover
+      # caused it.
+      Clog.emit("The runner group is full", {runner_group_full: {label: github_runner.label, repository_name: github_runner.repository_name}})
+      github_runner.incr_destroy
+      nap 0
+    end
+
     if e.message.include?("API rate limit exceeded")
       rate_limit = client.rate_limit
       Prog::PageNexus.assemble(

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -912,6 +912,14 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(runner.destroy_set?).to be(true)
     end
 
+    it "destroys the runner without a page or email if the runner group is full" do
+      expect(client).not_to receive(:get)
+      expect { nx.rescue_common_github_api_errors { raise Octokit::UnprocessableEntity.new({body: "Runner group 1 has reached max limit of 10000 runners."}) } }.to nap(0)
+        .and not_change { Page.count }
+        .and not_change { Mail::TestMailer.deliveries.length }
+      expect(runner.destroy_set?).to be(true)
+    end
+
     it "destroys the runner if TooManyRequests is raised with a self-hosted runners disabled message" do
       expect(client).not_to receive(:rate_limit)
       expect { nx.rescue_common_github_api_errors { raise Octokit::TooManyRequests.new({body: "Repository level self-hosted runners are disabled"}) } }.to nap(0)


### PR DESCRIPTION
A runner group holds at most 10,000 registered runners [1]. Once a repository's group is full, generate-jitconfig fails with 422 "Runner group 1 has reached max limit of 10000 runners" via `Octokit::UnprocessableEntity` until slots free up, chiefly as GitHub garbage collects runners that stopped connecting: after one day for ephemeral runners, fourteen days otherwise [2].

I encountered a page from this. A census of the runner group showed it full of the customer's own runners, 9,986 of them offline, next to a single registration of ours.

Destroy the runner and log instead of paging: only the customer can remove their runners, and the queued job survives because the poller in Prog::Github::GithubRepositoryNexus keeps provisioning replacements, which succeed once the group has room.

[1] https://docs.github.com/en/actions/reference/limits
[2] https://github.com/github/docs/blob/main/data/reusables/actions/self-hosted-runner-removal-policy.md