### PR TITLE
Restore Excon stubs after each example

### DIFF
--- a/spec/excon_stub_isolation_spec.rb
+++ b/spec/excon_stub_isolation_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Excon stubs are global and shadow the catch-all stub webmock uses to
+# serve stub_request; spec_helper restores them after each example.
+# Whichever twin runs second fails if the first one's stub leaked.
+RSpec.describe Excon, "stub isolation" do
+  2.times do |i|
+    it "does not see Excon stubs from other examples (#{i + 1})" do
+      stub_request(:get, "https://excon-leak.test/").to_return(status: 400)
+      expect { described_class.new("https://excon-leak.test").get(expects: 200) }.to raise_error Excon::Error::BadRequest
+      described_class.stub({host: "excon-leak.test"}, {status: 200, body: ""})
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,8 +52,18 @@ def Object.method_added(method)
 end
 
 RSpec.configure do |config|
+  # Excon stubs are process-global and Excon serves the newest match, so
+  # a stub registered in one example shadows the catch-all stub webmock
+  # uses to route Excon requests to stub_request, for every later
+  # example in the process. Snapshot the stub list once webmock has
+  # installed its catch-all (webmock/rspec's before(:suite) hook runs
+  # first, as it was registered first), and restore the snapshot after
+  # each example.
+  excon_stubs = nil
+
   config.before(:suite) do
     clover_freeze
+    excon_stubs = Excon.stubs.dup
   end
 
   leaked_threads = ObjectSpace::WeakMap.new
@@ -71,6 +81,7 @@ RSpec.configure do |config|
         example.run
       end
     end
+    Excon.stubs.replace(excon_stubs)
     Thread.current[:clover_ssh_cache] = nil
     Mail::TestMailer.deliveries.clear if defined?(Mail)
 


### PR DESCRIPTION
Excon keeps stubs in a process-global list, prepends new ones, and serves the first match. webmock's Excon adapter installs a catch-all stub when it is enabled that routes anything unmatched to stub_request, and WebMock.reset! does not touch Excon's list, so the catch-all stays at the bottom for the life of the process. Nothing cleared the list, so every Excon.stub call leaked into all later examples in the same process and shadowed the catch-all for matching requests.

The visible symptom was an order-dependent flake in spec/lib/hosting/hetzner_apis_spec.rb. stub_hetzner_api in spec/routes/web/admin/admin_spec.rb stubs GET /ip, /subnet, and /failover with no host constraint. When turbo_tests placed the two files in the same process and random ordering ran a setup-vm-host example first, the leaked stubs answered the pull_ips requests before webmock was consulted: the examples expecting Excon::Error::BadRequest saw 200s, and the data examples got [] because the leaked /ip body carries a server_ip that does not match the host the spec creates. The remaining example in the describe block expects no error, so it kept passing.

Reproduce the original flake on the parent commit with:

    bundle exec rspec --order defined -e setup-vm-host \
      -e hetzner_pull_ips spec/routes/web/admin/admin_spec.rb \
      spec/lib/hosting/hetzner_apis_spec.rb

Snapshot the stub list in a before(:suite) hook, which runs after webmock/rspec's own hook has installed the catch-all, and restore the snapshot after each example next to the other per-example cleanup. Excon stubs are registered in examples and per-example before hooks throughout the suite, so nothing relies on the leak; the one before(:all) in the suite boots a Puma server and registers no stubs.

The new spec fails without the restore under either ordering: each of the twin examples first checks that a stub_request is honored, then registers the Excon stub that would shadow its twin.