### PR TITLE
Improve node exporter & parsable installation

### DIFF
--- a/prog/setup_node_exporter.rb
+++ b/prog/setup_node_exporter.rb
@@ -4,7 +4,7 @@ class Prog::SetupNodeExporter < Prog::Base
   subject_is :sshable
 
   label def start
-    sshable.cmd("sudo host/bin/setup-node-exporter 1.9.1")
+    sshable.cmd("sudo host/bin/setup-node-exporter")
     pop "node exporter was setup"
   end
 end

--- a/rhizome/common/lib/node_exporter_setup.rb
+++ b/rhizome/common/lib/node_exporter_setup.rb
@@ -46,7 +46,7 @@ class NodeExporterSetup
 
     fail "Invalid SHA-256 digest" unless curl_file(url, tarball) == CHECKSUM
 
-    r "sudo", "tar", "xfz", tarball, "-C", "/usr/local/bin", "--strip-components=1", "#{file_name}/node_exporter"
+    r "sudo", "tar", "xfz", tarball, "-C", "/usr/local/bin", "--no-same-owner", "--strip-components=1", "#{file_name}/node_exporter"
     r "rm", tarball
 
     safe_write_to_file("/etc/systemd/system/node_exporter.service", service)

--- a/rhizome/common/lib/node_exporter_setup.rb
+++ b/rhizome/common/lib/node_exporter_setup.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative "util"
+require_relative "arch"
+
+class NodeExporterSetup
+  VERSION = "1.12.1"
+  CHECKSUM = Arch.render(
+    x64: "b51d8a76aa2a9156a55d501aca6276fae09e262259a5e4e831d2c2222f084e63",
+    arm64: "ad35b605f9954b9f1ffddf5ba054bdc5a98d790b9eae5291e1eeb83f1ecbd0e7",
+  )
+
+  def service
+    <<~SERVICE
+      [Unit]
+      Description=Prometheus Node Exporter
+      Wants=network-online.target
+      After=network-online.target
+
+      [Service]
+      NoNewPrivileges=yes
+      PrivateTmp=yes
+      ProtectSystem=strict
+      ProtectHome=read-only
+      ProtectKernelModules=yes
+      ProtectKernelTunables=yes
+      RestrictRealtime=yes
+      RestrictSUIDSGID=yes
+      MemoryDenyWriteExecute=yes
+      LockPersonality=yes
+      Type=simple
+      ExecStart=/usr/local/bin/node_exporter --web.listen-address=127.0.0.1:9100
+      Restart=always
+      User=nobody
+      Group=nogroup
+
+      [Install]
+      WantedBy=multi-user.target
+    SERVICE
+  end
+
+  def run
+    file_name = "node_exporter-#{VERSION}.linux-#{Arch.render(x64: "amd64", arm64: "arm64")}"
+    tarball = "#{file_name}.tar.gz"
+    url = "https://github.com/prometheus/node_exporter/releases/download/v#{VERSION}/#{tarball}"
+
+    fail "Invalid SHA-256 digest" unless curl_file(url, tarball) == CHECKSUM
+
+    r "sudo", "tar", "xfz", tarball, "-C", "/usr/local/bin", "--strip-components=1", "#{file_name}/node_exporter"
+    r "rm", tarball
+
+    safe_write_to_file("/etc/systemd/system/node_exporter.service", service)
+
+    r "sudo systemctl daemon-reload"
+    r "sudo systemctl enable node_exporter"
+    r "sudo systemctl start node_exporter"
+  end
+end

--- a/rhizome/common/spec/node_exporter_setup_spec.rb
+++ b/rhizome/common/spec/node_exporter_setup_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe NodeExporterSetup do
       setup.run
 
       expect(commands).to eq [
-        "sudo tar xfz #{tarball} -C /usr/local/bin --strip-components=1 #{file_name}/node_exporter",
+        "sudo tar xfz #{tarball} -C /usr/local/bin --no-same-owner --strip-components=1 #{file_name}/node_exporter",
         "rm #{tarball}",
         "sudo systemctl daemon-reload",
         "sudo systemctl enable node_exporter",

--- a/rhizome/common/spec/node_exporter_setup_spec.rb
+++ b/rhizome/common/spec/node_exporter_setup_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative "../lib/node_exporter_setup"
+
+RSpec.describe NodeExporterSetup do
+  subject(:setup) { described_class.new }
+
+  let(:file_name) { "node_exporter-1.12.1.linux-#{Arch.render(x64: "amd64", arm64: "arm64")}" }
+  let(:tarball) { "#{file_name}.tar.gz" }
+  let(:url) { "https://github.com/prometheus/node_exporter/releases/download/v1.12.1/#{tarball}" }
+
+  describe "#run" do
+    it "installs the binary and starts the service" do
+      commands = []
+      allow(setup).to receive(:_run_command) { |*command| commands << command.join(" ") }
+      written = {}
+      allow(setup).to receive(:safe_write_to_file) { |path, content| written[path] = content }
+      expect(setup).to receive(:curl_file).with(url, tarball).and_return(described_class::CHECKSUM)
+
+      setup.run
+
+      expect(commands).to eq [
+        "sudo tar xfz #{tarball} -C /usr/local/bin --strip-components=1 #{file_name}/node_exporter",
+        "rm #{tarball}",
+        "sudo systemctl daemon-reload",
+        "sudo systemctl enable node_exporter",
+        "sudo systemctl start node_exporter",
+      ]
+      expect(written).to eq("/etc/systemd/system/node_exporter.service" => setup.service)
+    end
+
+    it "fails when the download does not match the pinned checksum" do
+      expect(setup).to receive(:curl_file).with(url, tarball).and_return("wrongsha256")
+
+      expect { setup.run }.to raise_error RuntimeError, "Invalid SHA-256 digest"
+    end
+  end
+end

--- a/rhizome/host/bin/setup-node-exporter
+++ b/rhizome/host/bin/setup-node-exporter
@@ -1,49 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../../common/lib/util"
-require_relative "../../common/lib/arch"
-require "fileutils"
+require_relative "../../common/lib/node_exporter_setup"
 
-unless (version = ARGV.shift)
-  fail "No version provided"
-end
+fail "expected no arguments, got #{ARGV.length}" unless ARGV.empty?
 
-file_name = "node_exporter-#{version}.linux-#{Arch.render(x64: "amd64", arm64: "arm64")}"
-url = "https://github.com/prometheus/node_exporter/releases/download/v#{version}/#{file_name}.tar.gz"
-
-r "curl", "-fsSLO", url
-r "tar", "xvfz", "#{file_name}.tar.gz"
-r "sudo", "mv", "#{file_name}/node_exporter", "/usr/local/bin/"
-r "sudo rm -rf :prefix*", prefix: file_name
-
-safe_write_to_file("/etc/systemd/system/node_exporter.service", <<NODEEXPORTERCONFIG)
-[Unit]
-Description=Prometheus Node Exporter
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-NoNewPrivileges=yes
-PrivateTmp=yes
-ProtectSystem=strict
-ProtectHome=read-only
-ProtectKernelModules=yes
-ProtectKernelTunables=yes
-RestrictRealtime=yes
-RestrictSUIDSGID=yes
-MemoryDenyWriteExecute=yes
-LockPersonality=yes
-Type=simple
-ExecStart=/usr/local/bin/node_exporter --web.listen-address=127.0.0.1:9100
-Restart=always
-User=nobody
-Group=nogroup
-
-[Install]
-WantedBy=multi-user.target
-NODEEXPORTERCONFIG
-
-r "sudo systemctl daemon-reload"
-r "sudo systemctl enable node_exporter"
-r "sudo systemctl start node_exporter"
+NodeExporterSetup.new.run

--- a/rhizome/parseable/bin/install
+++ b/rhizome/parseable/bin/install
@@ -1,14 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../../common/lib/util"
+require_relative "../lib/parseable_setup"
 require_relative "../../common/lib/node_exporter_setup"
 
-unless (ver = ARGV.shift)
-  fail "No version provided"
-end
-
-r "curl", "-fsSL", "-o", "/usr/local/bin/parseable", "https://github.com/parseablehq/parseable/releases/download/#{ver}/Parseable_OSS_x86_64-unknown-linux-gnu"
-r "chmod", "+x", "/usr/local/bin/parseable"
-
+ParseableSetup.new(ARGV).run
 NodeExporterSetup.new.run

--- a/rhizome/parseable/bin/install
+++ b/rhizome/parseable/bin/install
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require_relative "../../common/lib/util"
-require_relative "../../common/lib/arch"
+require_relative "../../common/lib/node_exporter_setup"
 
 unless (ver = ARGV.shift)
   fail "No version provided"
@@ -11,40 +11,4 @@ end
 r "curl", "-fsSL", "-o", "/usr/local/bin/parseable", "https://github.com/parseablehq/parseable/releases/download/#{ver}/Parseable_OSS_x86_64-unknown-linux-gnu"
 r "chmod", "+x", "/usr/local/bin/parseable"
 
-node_exporter_version = "1.9.1"
-node_exporter_dir = "node_exporter-#{node_exporter_version}.linux-#{Arch.render(x64: "amd64", arm64: "arm64")}"
-r "curl", "-fsSLO", "https://github.com/prometheus/node_exporter/releases/download/v#{node_exporter_version}/#{node_exporter_dir}.tar.gz"
-r "tar", "xvfz", "#{node_exporter_dir}.tar.gz"
-r "sudo", "mv", "#{node_exporter_dir}/node_exporter", "/usr/local/bin/"
-r "sudo rm -rf :prefix*", prefix: node_exporter_dir
-
-safe_write_to_file("/etc/systemd/system/node_exporter.service", <<NODEEXPORTERCONFIG)
-[Unit]
-Description=Prometheus Node Exporter
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-NoNewPrivileges=yes
-PrivateTmp=yes
-ProtectSystem=strict
-ProtectHome=read-only
-ProtectKernelModules=yes
-ProtectKernelTunables=yes
-RestrictRealtime=yes
-RestrictSUIDSGID=yes
-MemoryDenyWriteExecute=yes
-LockPersonality=yes
-Type=simple
-ExecStart=/usr/local/bin/node_exporter --web.listen-address=127.0.0.1:9100
-Restart=always
-User=nobody
-Group=nogroup
-
-[Install]
-WantedBy=multi-user.target
-NODEEXPORTERCONFIG
-
-r "sudo systemctl daemon-reload"
-r "sudo systemctl enable node_exporter"
-r "sudo systemctl start node_exporter"
+NodeExporterSetup.new.run

--- a/rhizome/parseable/lib/parseable_setup.rb
+++ b/rhizome/parseable/lib/parseable_setup.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "fileutils"
+
+class ParseableSetup
+  BIN_PATH = "/usr/local/bin/parseable"
+
+  # Upstream publishes only a SHA-1 in checksum.txt, so these are the SHA-256
+  # digests of the artifacts that SHA-1 matched.
+  CHECKSUMS = {
+    "v2.6.5" => "4beeca018f3d60e8fb1b8eccb8d2d493f6676dd9567b489d8923f952fa5fa9ef",
+  }.freeze
+
+  def initialize(argv)
+    fail "expected a single argument, a parseable version like v2.6.5, got #{argv.length}" unless argv.length == 1
+
+    @version = argv[0]
+    fail "no parseable checksum for version #{@version.inspect}" unless CHECKSUMS.key?(@version)
+  end
+
+  def run
+    url = "https://github.com/parseablehq/parseable/releases/download/#{@version}/Parseable_OSS_x86_64-unknown-linux-gnu"
+
+    safe_write_to_file(BIN_PATH) do |f|
+      fail "Invalid SHA-256 digest" unless curl_file(url, f.path) == CHECKSUMS.fetch(@version)
+    end
+    FileUtils.chmod "a+x", BIN_PATH
+  end
+end

--- a/rhizome/parseable/spec/parseable_setup_spec.rb
+++ b/rhizome/parseable/spec/parseable_setup_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative "../lib/parseable_setup"
+
+RSpec.describe ParseableSetup do
+  subject(:setup) { described_class.new(["v2.6.5"]) }
+
+  let(:url) { "https://github.com/parseablehq/parseable/releases/download/v2.6.5/Parseable_OSS_x86_64-unknown-linux-gnu" }
+  let(:tmp_file) { instance_double(File, path: "#{described_class::BIN_PATH}.tmp") }
+
+  describe "#initialize" do
+    it "rejects a missing version" do
+      expect { described_class.new([]) }.to raise_error RuntimeError, "expected a single argument, a parseable version like v2.6.5, got 0"
+    end
+
+    it "rejects extra arguments" do
+      expect { described_class.new(["v2.6.5", "x64"]) }.to raise_error RuntimeError, "expected a single argument, a parseable version like v2.6.5, got 2"
+    end
+
+    it "rejects a version there is no checksum for" do
+      expect { described_class.new(["v2.6.4"]) }.to raise_error RuntimeError, "no parseable checksum for version \"v2.6.4\""
+    end
+  end
+
+  describe "#run" do
+    it "downloads the binary to a temporary path and makes it executable" do
+      expect(setup).to receive(:safe_write_to_file).with(described_class::BIN_PATH).and_yield(tmp_file)
+      expect(setup).to receive(:curl_file).with(url, tmp_file.path).and_return(described_class::CHECKSUMS.fetch("v2.6.5"))
+      expect(FileUtils).to receive(:chmod).with("a+x", described_class::BIN_PATH)
+
+      setup.run
+    end
+
+    it "fails without making anything executable when the digest does not match" do
+      expect(setup).to receive(:safe_write_to_file).with(described_class::BIN_PATH).and_yield(tmp_file)
+      expect(setup).to receive(:curl_file).with(url, tmp_file.path).and_return("wrongsha256")
+      expect(FileUtils).not_to receive(:chmod)
+
+      expect { setup.run }.to raise_error RuntimeError, "Invalid SHA-256 digest"
+    end
+  end
+end

--- a/spec/prog/setup_node_exporter_spec.rb
+++ b/spec/prog/setup_node_exporter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Prog::SetupNodeExporter do
 
   describe "#start" do
     it "Sets it up and pops" do
-      expect(sn.sshable).to receive(:_cmd).with("sudo host/bin/setup-node-exporter 1.9.1")
+      expect(sn.sshable).to receive(:_cmd).with("sudo host/bin/setup-node-exporter")
       expect { sn.start }.to exit({"msg" => "node exporter was setup"})
     end
   end


### PR DESCRIPTION
**Verify the node_exporter download against a pinned checksum**
setup-node-exporter fetched a release tarball from GitHub and installed the binary without checking it, so a tampered or corrupted download would have been installed unnoticed. The expected SHA-256 for each supported version is now pinned in the source and compared with curl_file, the same way cloud_hypervisor and vhost_block_backend already verify their downloads.

The logic moves into a NodeExporterSetup class so it can be tested, and lives in rhizome/common because parseable installs node_exporter the same way and can reuse it.

Extracting only the binary from the tarball with --strip-components leaves no directory behind, so the cleanup no longer needs a glob or sudo.

**Reuse the shared node_exporter setup in the parseable installer**
The parseable installer carried its own copy of the node_exporter download, systemd unit and enablement. The unit was byte identical to the one in NodeExporterSetup and the steps matched, so the copy is replaced with a call to the shared class.

This also brings the checksum verification to parseable, which was installing the tarball without checking it.

**Verify the parseable download against a pinned checksum**
The installer wrote the release binary straight to /usr/local/bin without checking it, so a tampered or corrupted download would have been made executable and run. The binary now downloads to a temporary path, is compared against a pinned SHA-256, and is only moved into place when it matches.

Upstream publishes only a SHA-1, so the pinned SHA-256 is the digest of the artifact whose SHA-1 matched theirs.

The logic moves into a ParseableSetup class so it can be tested, leaving bin/install to call it alongside NodeExporterSetup.

**Extract node_exporter as root rather than the archive's owner**
tar preserves the uid and gid recorded in the tarball when it runs as root, so the installed binary ended up owned by uid 1002 instead of root. Nothing owns that uid today, but an account created at it later would own an executable in /usr/local/bin. Extracting with
--no-same-owner leaves the binary owned by root.