### PR TITLE
Keep the monitoring role's database privileges

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -454,12 +454,19 @@ class PostgresServer < Sequel::Model
     }
   end
 
+  # A revoked privilege reads as "down" like any outage, but available? still
+  # answers over SSH as postgres, so the checkup clears and nothing else ever
+  # reports it. Match it here to tell the two apart.
+  MONITORING_ACCESS_DENIED = /permission denied for database|CONNECT privilege|authentication failed for user "ubi_monitoring"|role "ubi_monitoring" does not exist/
+
   def check_pulse(session:, previous_pulse:)
+    access_denied = false
     reading = begin
       session[:db_connection] ||= Sequel.connect(adapter: "postgres", host: health_monitor_socket_path, port: 5432, database: "ubi_admin", user: "ubi_monitoring", connect_timeout: 4, keep_reference: false)
       last_known_lsn = session[:db_connection].get(last_lsn_expression.as(:lsn))
       "up"
-    rescue
+    rescue => ex
+      access_denied = MONITORING_ACCESS_DENIED.match?(ex.message)
       "down"
     end
     pulse = aggregate_readings(previous_pulse:, reading:, data: {last_known_lsn:})
@@ -471,6 +478,14 @@ class PostgresServer < Sequel::Model
         rescue Sequel::Error => ex
           Clog.emit("Failed to update last known lsn", {lsn_update_error: Util.exception_to_hash(ex, into: {ubid:, last_known_lsn:})})
         end
+      end
+
+      # Paged rather than logged: this freezes last_known_lsn, which blocks the
+      # async-HA failover guard, and it persists until someone re-grants.
+      if access_denied && pulse[:reading_rpt] > 5
+        Prog::PageNexus.assemble("Postgres monitoring lost its database privileges", ["PGMonitoringAccessDenied", id], ubid, severity: primary? ? "error" : "warning")
+      elsif pulse[:reading] == "up"
+        Page.from_tag_parts("PGMonitoringAccessDenied", id)&.incr_resolve
       end
 
       if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !reload.checkup_set?

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -187,6 +187,25 @@ r "systemctl", "enable", "--now", "io-throttle@#{v}-main.timer"
 # Reload the postmaster to apply changes
 r "pg_ctlcluster :v main reload || pg_ctlcluster :v main restart", v: v
 
+# Re-assert the privileges the control plane reads through. Both roles hold
+# them by way of PUBLIC, and a customer superuser can revoke that at any time.
+# GRANT is idempotent. A standby refuses writes, so only the primary runs it,
+# and physical replication carries pg_database to the standbys. The first
+# configure of a server precedes post-installation-script, so the database and
+# the roles may not exist yet; the statement then does nothing, and a later
+# configure applies it.
+if r("sudo -u postgres psql -t -c 'SELECT pg_catalog.pg_is_in_recovery();' 2>/dev/null || echo 't'").strip == "f"
+  r "sudo", "-u", "postgres", "psql", "-v", "ON_ERROR_STOP=1", "-c", <<~SQL
+    DO $$ BEGIN
+      IF EXISTS (SELECT FROM pg_database WHERE datname = 'ubi_admin')
+        AND EXISTS (SELECT FROM pg_roles WHERE rolname = 'ubi_monitoring')
+        AND EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgbouncer') THEN
+        EXECUTE 'GRANT CONNECT ON DATABASE ubi_admin TO ubi_monitoring, pgbouncer';
+      END IF;
+    END $$;
+  SQL
+end
+
 if configure_hash["physical_slots"]
   if configure_hash["physical_slots"].size == 0
     r "sudo", "-u", "postgres", "psql", "-c", "select pg_catalog.pg_drop_replication_slot(slot_name) from pg_catalog.pg_replication_slots where slot_name like 'pv%' and LENGTH(slot_name) = 26 and slot_type = 'physical'"

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -943,6 +943,45 @@ RSpec.describe PostgresServer do
     postgres_server.check_pulse(session:, previous_pulse: pulse)
   end
 
+  it "pages when the monitoring role loses its database privileges" do
+    session = {ssh_session: Net::SSH::Connection::Session.allocate, db_connection: instance_double(Sequel::Postgres::Database)}
+    pulse = {reading: "down", reading_rpt: 5, reading_chg: Time.now}
+
+    expect(session[:db_connection]).to receive(:get).and_raise(Sequel::DatabaseConnectionError, 'FATAL:  permission denied for database "ubi_admin"')
+    expect(Prog::PageNexus).to receive(:assemble).with("Postgres monitoring lost its database privileges", ["PGMonitoringAccessDenied", postgres_server.id], postgres_server.ubid, severity: "error")
+
+    postgres_server.check_pulse(session:, previous_pulse: pulse)
+  end
+
+  it "pages at warning severity when the server is not the primary" do
+    session = {ssh_session: Net::SSH::Connection::Session.allocate, db_connection: instance_double(Sequel::Postgres::Database)}
+    pulse = {reading: "down", reading_rpt: 5, reading_chg: Time.now}
+
+    expect(postgres_server).to receive(:primary?).and_return(false)
+    expect(session[:db_connection]).to receive(:get).and_raise(Sequel::DatabaseConnectionError, "FATAL:  role \"ubi_monitoring\" does not exist")
+    expect(Prog::PageNexus).to receive(:assemble).with(anything, anything, anything, severity: "warning")
+
+    postgres_server.check_pulse(session:, previous_pulse: pulse)
+  end
+
+  it "does not page when the pulse is down for an ordinary reason" do
+    session = {ssh_session: Net::SSH::Connection::Session.allocate, db_connection: instance_double(Sequel::Postgres::Database)}
+    pulse = {reading: "down", reading_rpt: 5, reading_chg: Time.now}
+
+    expect(session[:db_connection]).to receive(:get).and_raise(Sequel::DatabaseConnectionError, "could not connect to server")
+    expect(Prog::PageNexus).not_to receive(:assemble)
+
+    postgres_server.check_pulse(session:, previous_pulse: pulse)
+  end
+
+  it "resolves the privilege page once the pulse reads up again" do
+    page = instance_double(Page)
+    expect(Page).to receive(:from_tag_parts).with("PGMonitoringAccessDenied", postgres_server.id).and_return(page)
+    expect(page).to receive(:incr_resolve)
+
+    postgres_server.check_pulse(session: {db_connection: DB}, previous_pulse: {})
+  end
+
   it "increments checkup semaphore if pulse is down for a while and the resource is not upgrading" do
     session = {
       ssh_session: Net::SSH::Connection::Session.allocate,


### PR DESCRIPTION
A customer holds a superuser role, so a customer can revoke the privileges that the control plane reads through. One customer already did so, and 71c9bc6fb then met the same class of failure on a second database. Nobody can prevent this, because a superuser bypasses every permission check. These two commits repair the privilege and report the loss instead.

## Re-apply the grants on each configure run

`configure` now runs one idempotent `GRANT` after it reloads the postmaster:

```sql
GRANT CONNECT ON DATABASE ubi_admin TO ubi_monitoring, pgbouncer;
```

The health pulse reads the WAL LSN from `ubi_admin` as `ubi_monitoring`. pgbouncer connects to the same database as `pgbouncer` for its `auth_query`. Both roles reach it through the privilege of PUBLIC today, so one revoke stops the pulse and stops every customer login.

A migration cannot repair this, because the migration runner applies each file once, and a later revoke defeats it forever. `configure` runs again on each configure semaphore, so it asserts the privilege repeatedly.

Only the primary runs the command, because a standby refuses a write. Physical replication carries `pg_database` to each standby.

## Page when the pulse loses its privileges

`check_pulse` turned every error into a "down" reading. The checkup then called `available?`, which asks the server over SSH as `postgres` and succeeds. A revoked privilege therefore looked the same as a brief outage, and no page fired, while `last_known_lsn` stopped and the async HA guard refused each failover.

The pulse now matches the four errors that mean the monitoring role lost its access, and it raises a page after five repeated readings. A primary raises an `error` page, and any other server raises a `warning`. The page resolves when the pulse reads up again.

## Why no event trigger

PostgreSQL does not fire an event trigger for a command on a shared object, and a database is a shared object. I confirmed this on a throwaway cluster:

```
--- revoke on a DATABASE (shared object) ---
(the trigger did not fire)
--- control: revoke on a SCHEMA (local object) ---
NOTICE:  EVENT TRIGGER FIRED: REVOKE
```

So the server cannot catch the revoke itself, and repair on a cycle is the best available answer.

## Tests

The full suite passes: 7859 examples, 0 failures, with 100% line coverage and 100% branch coverage. Rubocop reports no offense.

## Rollout

The `configure` change needs an `install_rhizome` sweep and a `configure` sweep before it reaches the fleet. The paging change works as soon as the monitor runs the new code.

## Open item

`_run_query` still runs `psql -U postgres` (`model/postgres/postgres_server.rb`). A superuser bypasses CONNECT, which is why the pulse never met this failure before 71c9bc6fb. The pulse is now the only monitoring path that a customer can break. Moving the LSN read onto that same superuser channel would remove the whole class of failure, and it would also reverse the privilege reduction. That trade needs a separate decision.
