### PR TITLE
Restore the CloudWatch auth stream with the collector

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -581,7 +581,12 @@ class PostgresServer < Sequel::Model
       resource_name: resource.name,
       resource_id: resource.ubid,
       log_destinations: destinations,
+      cloudwatch_auth_region: (vm.location.name if aws_cloudwatch_logs?),
     }
+  end
+
+  def aws_cloudwatch_logs?
+    timeline.aws? && resource.project.get_ff_aws_cloudwatch_logs
   end
 
   def managed_parseable_destination

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -441,12 +441,6 @@ TIMER
             "log_group_name": "/#{postgres_server.ubid}/postgresql",
             "log_stream_name": "#{postgres_server.ubid}/postgresql",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
-          },
-          {
-            "file_path": "/var/log/auth.log",
-            "log_group_name": "/#{postgres_server.ubid}/auth",
-            "log_stream_name": "#{postgres_server.ubid}/auth",
-            "timestamp_format": "%Y-%m-%d %H:%M:%S"
           }
         ]
       }

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -417,7 +417,7 @@ TIMER
     when "Succeeded"
       vm.sshable.d_clean("configure_logs")
       when_initial_provisioning_set? do
-        hop_setup_cloudwatch if postgres_server.timeline.aws? && resource.project.get_ff_aws_cloudwatch_logs
+        hop_setup_cloudwatch if postgres_server.aws_cloudwatch_logs?
         hop_setup_hugepages
       end
       hop_wait

--- a/rhizome/postgres/bin/configure-logs
+++ b/rhizome/postgres/bin/configure-logs
@@ -34,6 +34,34 @@ r "setfacl", "-m", "u:#{otelcol_user}:x", "/dat", "/dat/#{version}", "/dat/#{ver
 # Grant recursive read (+rX) and set the default ACL (+r) for new files in one call
 r "setfacl", "-R", "-m", "u:#{otelcol_user}:rX,d:u:#{otelcol_user}:r", log_dir
 
+# The imds_protection table permits IMDS for root only, and the boot service
+# reloads it from /etc/nftables.conf, so the awscloudwatchlogs exporter needs
+# its user accepted in that file to hold the instance role across reboots.
+if cloudwatch_auth_region
+  safe_write_to_file("/etc/nftables.conf", <<~CONF)
+    #!/usr/sbin/nft -f
+
+    flush ruleset
+
+    table inet imds_protection {
+        chain output {
+            type filter hook output priority 0; policy accept;
+
+            # Allow root and the collector to access IMDS
+            meta skuid 0 ip daddr 169.254.169.254 accept
+            meta skuid 0 ip6 daddr fd00:ec2::254 accept
+            meta skuid "#{otelcol_user}" ip daddr 169.254.169.254 accept
+            meta skuid "#{otelcol_user}" ip6 daddr fd00:ec2::254 accept
+
+            # Block all other users from accessing IMDS
+            ip daddr 169.254.169.254 drop
+            ip6 daddr fd00:ec2::254 drop
+        }
+    }
+  CONF
+  r "nft", "-f", "/etc/nftables.conf"
+end
+
 # Write per-destination TLS CA bundles for any destination that supplies one.
 log_destinations.each_with_index do |dest, i|
   ca_bundle = (dest["options"] || {})["ca_bundle"]

--- a/rhizome/postgres/bin/configure-logs
+++ b/rhizome/postgres/bin/configure-logs
@@ -12,6 +12,7 @@ version = config["version"]
 resource_id = config["resource_id"]
 resource_name = config["resource_name"]
 log_destinations = config["log_destinations"] || []
+cloudwatch_auth_region = config["cloudwatch_auth_region"]
 
 log_dir = "/dat/#{version}/data/pg_log"
 
@@ -49,6 +50,7 @@ log_config = OtelLogConfig.new(
   resource_id: resource_id,
   resource_name: resource_name,
   log_destinations: log_destinations,
+  cloudwatch_auth_region: cloudwatch_auth_region,
 )
 
 safe_write_to_file("/etc/otelcol-contrib/config.yaml", log_config.to_config)

--- a/rhizome/postgres/lib/otel_log_config.rb
+++ b/rhizome/postgres/lib/otel_log_config.rb
@@ -16,6 +16,10 @@ require "uri"
 #   filelog/pglog  — PostgreSQL stderr log files (parsed via log_line_prefix regex) → stream: "postgres"
 #   journald       — systemd journal units   → stream: "postgres" | "pgbouncer" | "upgrade"
 #
+# With cloudwatch_auth_region set, a separate journald/auth receiver ships host
+# authentication records to the CloudWatch log group /{instance}/auth as plain
+# text. That stream carries none of the unified fields below.
+#
 # Unified fields emitted for every log record:
 #   body             Log message text
 #   severity_number  OTel native severity level (set via severity_parser)
@@ -52,13 +56,15 @@ class OtelLogConfig
     "debug" => "7",
   }.freeze.each_value(&:freeze)
 
-  def initialize(instance:, server_role:, log_dir:, resource_name:, resource_id:, log_destinations:)
+  def initialize(instance:, server_role:, log_dir:, resource_name:, resource_id:, log_destinations:,
+    cloudwatch_auth_region: nil)
     @instance = instance
     @server_role = server_role
     @log_dir = log_dir
     @resource_name = resource_name
     @resource_id = resource_id
     @log_destinations = log_destinations
+    @cloudwatch_auth_region = cloudwatch_auth_region
   end
 
   def to_config
@@ -95,10 +101,12 @@ class OtelLogConfig
   end
 
   def receivers_hash
-    {
+    hash = {
       "filelog/pglog" => filelog_receiver_hash,
       "journald" => journald_receiver_hash,
     }
+    hash["journald/auth"] = journald_auth_receiver_hash if @cloudwatch_auth_region
+    hash
   end
 
   def filelog_receiver_hash
@@ -170,14 +178,7 @@ class OtelLogConfig
         "upgrade_postgres.service",
       ],
       "operators" => [
-        {
-          "id" => "parse_journal_timestamp",
-          "type" => "time_parser",
-          "parse_from" => 'body["__REALTIME_TIMESTAMP"]',
-          "layout_type" => "epoch",
-          "layout" => "us",
-          "on_error" => "send_quiet",
-        },
+        journal_timestamp_operator,
         {
           "id" => "filter_units",
           "type" => "router",
@@ -220,6 +221,46 @@ class OtelLogConfig
             "attributes.pid",
           ],
         },
+      ],
+    }
+  end
+
+  def journal_timestamp_operator
+    {
+      "id" => "parse_journal_timestamp",
+      "type" => "time_parser",
+      "parse_from" => 'body["__REALTIME_TIMESTAMP"]',
+      "layout_type" => "epoch",
+      "layout" => "us",
+      "on_error" => "send_quiet",
+    }
+  end
+
+  # The raw_log exporter sends the body alone, so the body must hold the
+  # rebuilt line rather than the journal map. Auth records without _PID or
+  # SYSLOG_IDENTIFIER exist, and a concatenation over a missing field drops
+  # the record. The receiver defaults to priority info; auth needs debug too.
+  def journald_auth_receiver_hash
+    {
+      "storage" => "file_storage/state",
+      "priority" => "debug",
+      "matches" => [
+        {"SYSLOG_FACILITY" => "4"},
+        {"SYSLOG_FACILITY" => "10"},
+      ],
+      "operators" => [
+        journal_timestamp_operator,
+        {"type" => "move", "from" => "body", "to" => "attributes.journald"},
+        {"type" => "add", "field" => 'attributes.journald["SYSLOG_IDENTIFIER"]', "value" => "unknown", "if" => 'attributes.journald["SYSLOG_IDENTIFIER"] == nil'},
+        {"type" => "add", "field" => 'attributes.journald["MESSAGE"]', "value" => "", "if" => 'attributes.journald["MESSAGE"] == nil'},
+        {
+          "type" => "add",
+          "field" => "attributes.auth_line",
+          "value" => 'EXPR(string(attributes.journald["SYSLOG_IDENTIFIER"]) + (attributes.journald["_PID"] == nil ? "" : "[" + string(attributes.journald["_PID"]) + "]") + ": " + string(attributes.journald["MESSAGE"]))',
+          "on_error" => "send_quiet",
+        },
+        {"type" => "move", "from" => "attributes.auth_line", "to" => "body"},
+        {"type" => "remove", "field" => "attributes.journald"},
       ],
     }
   end
@@ -318,8 +359,28 @@ class OtelLogConfig
       end
     end
 
-    hash["nop"] = nil if hash.empty?
+    hash["awscloudwatchlogs/auth"] = cloudwatch_auth_exporter_hash if @cloudwatch_auth_region
+    hash["nop"] = nil if @log_destinations.empty?
     hash
+  end
+
+  def cloudwatch_auth_exporter_hash
+    {
+      "region" => @cloudwatch_auth_region,
+      "log_group_name" => "/#{@instance}/auth",
+      "log_stream_name" => "#{@instance}/auth",
+      "raw_log" => true,
+      "sending_queue" => {
+        "storage" => "file_storage/state",
+        "queue_size" => 1000,
+      },
+      "retry_on_failure" => {
+        "enabled" => true,
+        "initial_interval" => "5s",
+        "max_interval" => "30s",
+        "max_elapsed_time" => "300s",
+      },
+    }
   end
 
   def service_hash
@@ -337,20 +398,24 @@ class OtelLogConfig
   end
 
   def pipelines_hash
+    pipelines = {}
+
     if @log_destinations.empty?
-      return {
-        "logs/pglog/noop" => {"receivers" => ["filelog/pglog"], "processors" => ["memory_limiter", "batch"], "exporters" => ["nop"]},
-        "logs/journal/noop" => {"receivers" => ["journald"], "processors" => ["memory_limiter", "batch"], "exporters" => ["nop"]},
-      }
+      pipelines["logs/pglog/noop"] = {"receivers" => ["filelog/pglog"], "processors" => ["memory_limiter", "batch"], "exporters" => ["nop"]}
+      pipelines["logs/journal/noop"] = {"receivers" => ["journald"], "processors" => ["memory_limiter", "batch"], "exporters" => ["nop"]}
     end
 
-    pipelines = {}
     @log_destinations.each_with_index do |dest, i|
       exporter = (dest["type"] == "otlp") ? "otlp_http/dest#{i}" : "syslog/dest#{i}"
       processors = ["memory_limiter", "transform/timestamp_fallback", "transform/dest#{i}", "batch"]
       pipelines["logs/pglog/dest#{i}"] = {"receivers" => ["filelog/pglog"], "processors" => processors, "exporters" => [exporter]}
       pipelines["logs/journal/dest#{i}"] = {"receivers" => ["journald"], "processors" => processors, "exporters" => [exporter]}
     end
+
+    if @cloudwatch_auth_region
+      pipelines["logs/auth/cloudwatch"] = {"receivers" => ["journald/auth"], "processors" => ["memory_limiter", "batch"], "exporters" => ["awscloudwatchlogs/auth"]}
+    end
+
     pipelines
   end
 

--- a/rhizome/postgres/spec/otel_log_config-golden.yaml
+++ b/rhizome/postgres/spec/otel_log_config-golden.yaml
@@ -1,0 +1,250 @@
+---
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+  file_storage/state:
+    directory: "/var/lib/otelcol-contrib/state"
+    create_directory: true
+    compaction:
+      directory: "/tmp/otelcol"
+      on_start: true
+      on_rebound: true
+      rebound_needed_threshold_mib: 1024
+      rebound_trigger_threshold_mib: 100
+receivers:
+  filelog/pglog:
+    include:
+    - "/dat/17/data/pg_log/postgresql-*.log"
+    start_at: end
+    storage: file_storage/state
+    operators:
+    - type: regex_parser
+      regex: "^(?P<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3} \\w+)
+        \\[(?P<pid>\\d+):\\d+\\] \\([^,]*,[^)]*\\): host=(?P<remote_host_port>[^,]*),db=(?P<dbname>[^,]*),user=(?P<user>[^,]*),app=(?P<app_name>.*?),client=(?P<remote_host>\\S*)
+        (?P<error_severity>[A-Z0-9]+):\\s+(?P<message>.*)"
+      on_error: send_quiet
+      severity:
+        parse_from: attributes.error_severity
+        preset: none
+        mapping:
+          fatal:
+          - FATAL
+          - PANIC
+          error: ERROR
+          warn: WARNING
+          info:
+          - NOTICE
+          - INFO
+          - LOG
+          - DETAIL
+          - HINT
+          - QUERY
+          - CONTEXT
+          - LOCATION
+          - STATEMENT
+          debug:
+          - DEBUG
+          - DEBUG1
+          - DEBUG2
+          - DEBUG3
+          - DEBUG4
+          - DEBUG5
+    - type: time_parser
+      parse_from: attributes.timestamp
+      layout: 2006-01-02 15:04:05.000 MST
+      layout_type: gotime
+      if: attributes.timestamp != nil
+      on_error: send_quiet
+    - type: copy
+      from: body
+      to: attributes.message
+      if: attributes.message == nil
+    - type: copy
+      from: attributes.message
+      to: body
+    - type: remove
+      field: attributes.error_severity
+      if: attributes.error_severity != nil
+    - type: add
+      field: attributes.stream
+      value: postgres
+    - type: add
+      field: attributes.instance
+      value: pg1abc2def3
+    - type: add
+      field: attributes.server_role
+      value: primary
+    - type: add
+      field: attributes.hostname
+      value: pg1abc2def3
+    - type: add
+      field: attributes.resource_name
+      value: my-pg-db
+    - type: add
+      field: attributes.resource_id
+      value: pg9x8y7z6w
+    - type: remove
+      field: attributes.timestamp
+      if: attributes.timestamp != nil
+    - type: add
+      field: attributes.dbname
+      value: ''
+      if: attributes.dbname == nil
+    - type: add
+      field: attributes.user
+      value: ''
+      if: attributes.user == nil
+    - type: add
+      field: attributes.remote_host_port
+      value: ''
+      if: attributes.remote_host_port == nil
+    - type: retain
+      fields:
+      - body
+      - attributes.message
+      - attributes.stream
+      - attributes.instance
+      - attributes.server_role
+      - attributes.hostname
+      - attributes.resource_name
+      - attributes.resource_id
+      - attributes.pid
+      - attributes.dbname
+      - attributes.user
+      - attributes.app_name
+      - attributes.remote_host
+      - attributes.remote_host_port
+  journald:
+    storage: file_storage/state
+    units:
+    - system-postgresql.slice
+    - system-pgbouncer.slice
+    - upgrade_postgres.service
+    operators:
+    - id: parse_journal_timestamp
+      type: time_parser
+      parse_from: body["__REALTIME_TIMESTAMP"]
+      layout_type: epoch
+      layout: us
+      on_error: send_quiet
+    - id: filter_units
+      type: router
+      routes:
+      - output: mark_postgres_stream
+        expr: body["_SYSTEMD_UNIT"] != nil && body["_SYSTEMD_UNIT"] startsWith "postgresql@"
+      - output: mark_pgbouncer_stream
+        expr: body["_SYSTEMD_UNIT"] != nil && body["_SYSTEMD_UNIT"] startsWith "pgbouncer@"
+      - output: mark_upgrade_stream
+        expr: body["_SYSTEMD_UNIT"] != nil && body["_SYSTEMD_UNIT"] startsWith "upgrade_postgres"
+    - id: mark_postgres_stream
+      type: add
+      field: attributes.stream
+      value: postgres
+      output: set_common_fields
+    - id: mark_pgbouncer_stream
+      type: add
+      field: attributes.stream
+      value: pgbouncer
+      output: set_common_fields
+    - id: mark_upgrade_stream
+      type: add
+      field: attributes.stream
+      value: upgrade
+      output: set_common_fields
+    - id: set_common_fields
+      type: add
+      field: attributes.instance
+      value: pg1abc2def3
+    - type: add
+      field: attributes.server_role
+      value: primary
+    - type: add
+      field: attributes.hostname
+      value: pg1abc2def3
+    - type: add
+      field: attributes.resource_name
+      value: my-pg-db
+    - type: add
+      field: attributes.resource_id
+      value: pg9x8y7z6w
+    - type: move
+      from: body
+      to: attributes.journald
+    - type: copy
+      from: attributes.journald["MESSAGE"]
+      to: attributes.message
+    - type: move
+      from: attributes.journald["MESSAGE"]
+      to: body
+    - type: flatten
+      field: attributes.journald
+    - type: move
+      from: attributes["_PID"]
+      to: attributes.pid
+    - type: severity_parser
+      parse_from: attributes["PRIORITY"]
+      preset: none
+      mapping:
+        fatal:
+        - '0'
+        - '1'
+        - '2'
+        error: '3'
+        warn: '4'
+        info:
+        - '5'
+        - '6'
+        debug: '7'
+    - type: retain
+      fields:
+      - body
+      - attributes.message
+      - attributes.stream
+      - attributes.instance
+      - attributes.server_role
+      - attributes.hostname
+      - attributes.resource_name
+      - attributes.resource_id
+      - attributes.pid
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 128
+    spike_limit_mib: 32
+  batch:
+    timeout: 2s
+    send_batch_max_size: 10240
+exporters:
+  nop:
+service:
+  extensions:
+  - health_check
+  - file_storage/state
+  telemetry:
+    logs:
+      level: warn
+    metrics:
+      level: basic
+      readers:
+      - pull:
+          exporter:
+            prometheus:
+              host: 127.0.0.1
+              port: 8888
+  pipelines:
+    logs/pglog/noop:
+      receivers:
+      - filelog/pglog
+      processors:
+      - memory_limiter
+      - batch
+      exporters:
+      - nop
+    logs/journal/noop:
+      receivers:
+      - journald
+      processors:
+      - memory_limiter
+      - batch
+      exporters:
+      - nop

--- a/rhizome/postgres/spec/otel_log_config_spec.rb
+++ b/rhizome/postgres/spec/otel_log_config_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe OtelLogConfig do
   let(:resource_name) { "my-pg-db" }
   let(:resource_id) { "pg9x8y7z6w" }
   let(:log_destinations) { [] }
-  let(:config) { described_class.new(instance: instance, server_role: server_role, log_dir: log_dir, resource_name: resource_name, resource_id: resource_id, log_destinations: log_destinations) }
+  let(:cloudwatch_auth_region) { nil }
+  let(:config) { described_class.new(instance: instance, server_role: server_role, log_dir: log_dir, resource_name: resource_name, resource_id: resource_id, log_destinations: log_destinations, cloudwatch_auth_region: cloudwatch_auth_region) }
   let(:parsed) { YAML.safe_load(config.to_config, aliases: true) }
 
   describe "#to_config" do
@@ -438,6 +439,126 @@ RSpec.describe OtelLogConfig do
         pglog1 = parsed["service"]["pipelines"]["logs/pglog/dest1"]
         expect(pglog1["processors"]).to eq(["memory_limiter", "transform/timestamp_fallback", "transform/dest1", "batch"])
         expect(pglog1["exporters"]).to eq(["syslog/dest1"])
+      end
+    end
+
+    context "with cloudwatch_auth_region unset" do
+      it "adds no auth receiver, exporter or pipeline" do
+        expect(parsed["receivers"]).not_to have_key("journald/auth")
+        expect(parsed["exporters"]).not_to have_key("awscloudwatchlogs/auth")
+        expect(parsed["service"]["pipelines"]).not_to have_key("logs/auth/cloudwatch")
+      end
+
+      # The collector consumes parsed YAML, so compare structure, not bytes.
+      # Regenerate the golden file only for a deliberate collector config change:
+      #   ruby -r./rhizome/postgres/lib/otel_log_config -e 'puts OtelLogConfig.new(
+      #     instance: "pg1abc2def3", server_role: "primary", log_dir: "/dat/17/data/pg_log",
+      #     resource_name: "my-pg-db", resource_id: "pg9x8y7z6w", log_destinations: []).to_config'
+      it "produces the same config as before auth shipping existed" do
+        golden = YAML.safe_load_file(File.expand_path("otel_log_config-golden.yaml", __dir__), aliases: true)
+        expect(YAML.safe_load(config.to_config, aliases: true)).to eq(golden)
+      end
+
+      it "defaults to unset when the control plane sends no key" do
+        older = described_class.new(instance: instance, server_role: server_role, log_dir: log_dir, resource_name: resource_name, resource_id: resource_id, log_destinations: log_destinations)
+        expect(older.to_config).to eq(config.to_config)
+      end
+    end
+
+    context "with cloudwatch_auth_region set" do
+      let(:cloudwatch_auth_region) { "us-west-2" }
+      let(:auth_receiver) { parsed["receivers"]["journald/auth"] }
+      let(:auth_operators) { auth_receiver["operators"] }
+
+      it "matches the auth and authpriv syslog facilities at every priority" do
+        expect(auth_receiver["matches"]).to eq([{"SYSLOG_FACILITY" => "4"}, {"SYSLOG_FACILITY" => "10"}])
+        expect(auth_receiver["priority"]).to eq("debug")
+        expect(auth_receiver["storage"]).to eq("file_storage/state")
+      end
+
+      it "parses the journal realtime timestamp before it rewrites the body" do
+        expect(auth_operators.first).to eq(
+          "id" => "parse_journal_timestamp",
+          "type" => "time_parser",
+          "parse_from" => 'body["__REALTIME_TIMESTAMP"]',
+          "layout_type" => "epoch",
+          "layout" => "us",
+          "on_error" => "send_quiet",
+        )
+      end
+
+      it "defaults the identifier and the message before it concatenates them" do
+        expect(auth_operators[1]).to eq("type" => "move", "from" => "body", "to" => "attributes.journald")
+        expect(auth_operators[2]).to eq("type" => "add", "field" => 'attributes.journald["SYSLOG_IDENTIFIER"]', "value" => "unknown", "if" => 'attributes.journald["SYSLOG_IDENTIFIER"] == nil')
+        expect(auth_operators[3]).to eq("type" => "add", "field" => 'attributes.journald["MESSAGE"]', "value" => "", "if" => 'attributes.journald["MESSAGE"] == nil')
+      end
+
+      it "rebuilds the syslog line in the body and omits the pid when the journal has none" do
+        expect(auth_operators[4]).to eq(
+          "type" => "add",
+          "field" => "attributes.auth_line",
+          "value" => 'EXPR(string(attributes.journald["SYSLOG_IDENTIFIER"]) + (attributes.journald["_PID"] == nil ? "" : "[" + string(attributes.journald["_PID"]) + "]") + ": " + string(attributes.journald["MESSAGE"]))',
+          "on_error" => "send_quiet",
+        )
+        expect(auth_operators[5]).to eq("type" => "move", "from" => "attributes.auth_line", "to" => "body")
+      end
+
+      it "drops the journal map last, so only the rebuilt body ships" do
+        expect(auth_operators.last).to eq("type" => "remove", "field" => "attributes.journald")
+      end
+
+      it "parses no severity and routes nothing, because the exporter ships text" do
+        types = auth_operators.map { |op| op["type"] }
+        expect(types).not_to include("severity_parser")
+        expect(types).not_to include("router")
+      end
+
+      it "exports raw records to the auth log group of the instance" do
+        expect(parsed["exporters"]["awscloudwatchlogs/auth"]).to eq(
+          "region" => "us-west-2",
+          "log_group_name" => "/pg1abc2def3/auth",
+          "log_stream_name" => "pg1abc2def3/auth",
+          "raw_log" => true,
+          "sending_queue" => {"storage" => "file_storage/state", "queue_size" => 1000},
+          "retry_on_failure" => {"enabled" => true, "initial_interval" => "5s", "max_interval" => "30s", "max_elapsed_time" => "300s"},
+        )
+      end
+
+      it "sets no log_retention, which the instance role may not write" do
+        expect(parsed["exporters"]["awscloudwatchlogs/auth"]).not_to have_key("log_retention")
+      end
+
+      it "creates the auth pipeline when there is no customer destination" do
+        expect(parsed["service"]["pipelines"]["logs/auth/cloudwatch"]).to eq(
+          "receivers" => ["journald/auth"],
+          "processors" => ["memory_limiter", "batch"],
+          "exporters" => ["awscloudwatchlogs/auth"],
+        )
+      end
+
+      it "keeps the nop exporter that the noop pipelines name" do
+        expect(parsed["exporters"]).to have_key("nop")
+      end
+
+      context "with a customer destination" do
+        let(:log_destinations) do
+          [{"type" => "syslog", "url" => "tcp://logs.example.com:6514", "options" => nil}]
+        end
+
+        it "creates the auth pipeline alongside the destination pipelines" do
+          pipelines = parsed["service"]["pipelines"]
+          expect(pipelines).to have_key("logs/pglog/dest0")
+          expect(pipelines["logs/auth/cloudwatch"]["exporters"]).to eq(["awscloudwatchlogs/auth"])
+        end
+
+        it "keeps the auth receiver out of the customer pipelines" do
+          pipelines = parsed["service"]["pipelines"].except("logs/auth/cloudwatch")
+          expect(pipelines.values.flat_map { |p| p["receivers"] }).not_to include("journald/auth")
+        end
+
+        it "adds no nop exporter" do
+          expect(parsed["exporters"]).not_to have_key("nop")
+        end
       end
     end
   end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -1948,6 +1948,32 @@ RSpec.describe PostgresServer do
       expect(postgres_server.logs_config[:server_role]).to eq("standby")
     end
 
+    it "ships no auth logs to CloudWatch outside AWS" do
+      expect(postgres_server.logs_config[:cloudwatch_auth_region]).to be_nil
+    end
+
+    context "with an AWS location" do
+      let(:location) {
+        Location.create(
+          name: "us-west-2",
+          project:,
+          display_name: "aws-us-west-2",
+          ui_name: "aws-us-west-2",
+          provider: "aws",
+          visible: true,
+        )
+      }
+
+      it "ships auth logs to the CloudWatch region for a project with the feature flag" do
+        project.set_ff_aws_cloudwatch_logs(true)
+        expect(postgres_server.logs_config[:cloudwatch_auth_region]).to eq("us-west-2")
+      end
+
+      it "ships no auth logs to CloudWatch for a project without the feature flag" do
+        expect(postgres_server.logs_config[:cloudwatch_auth_region]).to be_nil
+      end
+    end
+
     it "includes log destinations" do
       PostgresLogDestination.create(
         postgres_resource_id: resource.id,

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -967,11 +967,20 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
   end
 
   describe "#setup_cloudwatch" do
-    it "hops to setup_hugepages after setting up cloudwatch" do
+    it "collects the postgresql log files only, then hops to setup_hugepages" do
+      written = nil
       expect(sshable).to receive(:_cmd).with("sudo mkdir -p /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d")
-      expect(sshable).to receive(:_cmd).with("sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/001-ubicloud-config.json > /dev/null", stdin: anything)
+      expect(sshable).to receive(:_cmd).with("sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/001-ubicloud-config.json > /dev/null", stdin: anything) { |_, stdin:| written = stdin }
       expect(sshable).to receive(:_cmd).with("sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/001-ubicloud-config.json -s")
       expect { nx.setup_cloudwatch }.to hop("setup_hugepages")
+
+      collect_list = JSON.parse(written).dig("logs", "logs_collected", "files", "collect_list")
+      expect(collect_list).to eq([{
+        "file_path" => "/dat/#{server.version}/data/pg_log/postgresql-*.log",
+        "log_group_name" => "/#{server.ubid}/postgresql",
+        "log_stream_name" => "#{server.ubid}/postgresql",
+        "timestamp_format" => "%Y-%m-%d %H:%M:%S",
+      }])
     end
   end
 


### PR DESCRIPTION
## Problem

AWS Postgres servers must ship host authentication logs to the `/{ubid}/auth` CloudWatch log group. The current image no longer installs rsyslog, nothing writes `/var/log/auth.log`, and the CloudWatch agent tails a file that never appears, so the group is never created. Staging confirms the dead stream.

## Approach

Four commits, each standing alone:

1. **Ship host auth logs to CloudWatch from the journal** — a second journald receiver (syslog facilities 4 and 10, `priority: debug`) rebuilds `identifier[pid]: message` into the body, and an `awscloudwatchlogs` exporter with `raw_log` ships it. Event times come from `__REALTIME_TIMESTAMP`; the old agent entry's timestamp format never matched, so its events fell back to ingestion time.
2. **Allow the collector user to reach the instance role** — the image's `imds_protection` nftables table accepts IMDS for root only; `configure-logs` rewrites `/etc/nftables.conf` with an accept for `otelcol-contrib` when the feature is on, so the rule survives reboots. Companion image PR: ubicloud/postgres-vm-images#47.
3. **Enable collector auth logs on AWS Postgres servers** — the control plane sends one nullable `cloudwatch_auth_region` key, gated by a shared `PostgresServer#aws_cloudwatch_logs?` predicate, so an enabled stream without a region is unrepresentable.
4. **Drop the dead auth.log entry from the CloudWatch agent.**

## Verified live (staging AWS server, us-west-2, PG 18)

- The collector created `/{ubid}/auth` and its stream under the unchanged IAM policy, refuting the stream-scoped-ARN concern two reviews raised.
- 17 auth records shipped with zero errors; event times match login times; the body is plain `sudo[pid]: pam_unix(...)` text; only facility-matched records shipped.
- otelcol-contrib v0.150.1 accepts the persistent `sending_queue.storage` key.
- With the nftables rule, the collector user reads IMDS; the `postgres` user stays blocked.

## Rollout

Existing servers need two ordered steps after deploy — `server_incr("install_rhizome")`, then, once every server strand is back at `wait`, `server_incr("configure_logs")` — and the same two steps on every flag flip for a project with existing servers. Setting both semaphores together is unsafe: `configure_logs` wins first and regenerates with the old rhizome. A tracked follow-up issue covers this.

Known accepted window: servers from rsyslog-era images double-ship each auth record in two formats until #6093 removes rsyslog. Do not merge #6093 before this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)