### PR TITLE
Make linter:cmd_exec rake task check for Excon.stub

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -523,7 +523,7 @@ namespace :linter do
       File.foreach(file) do |line|
         number += 1
         cmds = Regexp.union(%w[cmd exec! kubectl rootish_ssh run_query].freeze)
-        if /\(:#{cmds}|instance_double\(.*#{cmds}: /.match?(line)
+        if /\(:#{cmds}|instance_double\(.*#{cmds}: |Excon\.stub/.match?(line)
           failure = true
           warn "Potentially insecure method override: #{file}:#{number}: #{line}"
         end


### PR DESCRIPTION
We should be using Webmock's stub_request instead of Excon.stub. No current code uses Excon.stub, but we want to be sure that future code does not reintroduce usage.

Failure message isn't accurate, but I don't think it's worth complicating the code for an accurate one.