### PR TITLE
Pin SPDK->ubiblk migration to ubiblk v0.2.x

### DIFF
--- a/prog/storage/migrate_spdk_vm_to_ubiblk.rb
+++ b/prog/storage/migrate_spdk_vm_to_ubiblk.rb
@@ -3,6 +3,11 @@
 class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
   subject_is :vm
 
+  # Pinned to ubiblk v0.2.x rather than Config.vhost_block_backend_version (the
+  # current default): this prog now exists only to reproduce a legacy v0.2.x VM
+  # for testing MoveVm. See the commit that introduced this constant.
+  TARGET_VHOST_BLOCK_BACKEND_VERSION = "v0.2.2"
+
   def self.assemble(vm_id)
     unless (vm = Vm[vm_id])
       fail "Vm does not exist"
@@ -26,7 +31,7 @@ class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
       fail "Vm storage volume is not encrypted"
     end
 
-    unless vm.vm_host.vhost_block_backends.find { |b| b.version == Config.vhost_block_backend_version }
+    unless vm.vm_host.vhost_block_backends.find { |b| b.version == TARGET_VHOST_BLOCK_BACKEND_VERSION }
       fail "VmHost does not have the right vhost block backend installed"
     end
 
@@ -158,7 +163,7 @@ class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
 
   label def update_vm_configurations
     prep_json = vm.vm_host.sshable.cmd_json("sudo cat /vm/:inhost_name/prep.json", inhost_name:)
-    prep_json["storage_volumes"][0]["vhost_block_backend_version"] = Config.vhost_block_backend_version
+    prep_json["storage_volumes"][0]["vhost_block_backend_version"] = TARGET_VHOST_BLOCK_BACKEND_VERSION
     prep_json["storage_volumes"][0]["spdk_version"] = nil
     vm.vm_host.sshable.write_file("/vm/#{inhost_name}/prep.json", JSON.pretty_generate(prep_json))
 
@@ -183,7 +188,7 @@ class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
       "vm_name" => vm.inhost_name,
       "encrypted" => true,
       "disk_index" => 0,
-      "vhost_block_backend_version" => Config.vhost_block_backend_version,
+      "vhost_block_backend_version" => TARGET_VHOST_BLOCK_BACKEND_VERSION,
       "max_read_mbytes_per_sec" => vm_storage_volume.max_read_mbytes_per_sec,
       "max_write_mbytes_per_sec" => vm_storage_volume.max_write_mbytes_per_sec,
       "spdk_version" => vm_storage_volume.spdk_installation.version,
@@ -226,7 +231,7 @@ class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
   end
 
   def vm_host_vhost_block_backend
-    vm.vm_host.vhost_block_backends.find { |b| b.version == Config.vhost_block_backend_version }
+    vm.vm_host.vhost_block_backends.find { |b| b.version == TARGET_VHOST_BLOCK_BACKEND_VERSION }
   end
 
   def inhost_name

--- a/rhizome/host/bin/convert-encrypted-dek-to-vhost-backend-conf
+++ b/rhizome/host/bin/convert-encrypted-dek-to-vhost-backend-conf
@@ -85,7 +85,11 @@ def wrap_key_b64(key_bytes, kek_data)
 end
 
 def generate_vhost_conf(plain_keys, kek_data, vm_name, device)
-  write_through = StorageVolume.new(vm_name, {"storage_device" => device, "disk_index" => 0}).write_through_device?
+  # This StorageVolume is a throwaway used only to read write_through_device?.
+  # The volume being converted is always encrypted (a migration precondition), so
+  # mark it as such to satisfy the "unencrypted non-read-only volumes are not
+  # supported" guard in StorageVolume#initialize.
+  write_through = StorageVolume.new(vm_name, {"storage_device" => device, "disk_index" => 0, "encrypted" => true}).write_through_device?
   root_storage_dir = (device == "DEFAULT") ? "/var/storage/#{vm_name}" : "/var/storage/devices/#{device}/#{vm_name}"
   config = {
     "socket" => "#{root_storage_dir}/0/vhost.sock",

--- a/spec/prog/storage/migrate_spdk_vm_to_ubiblk_spec.rb
+++ b/spec/prog/storage/migrate_spdk_vm_to_ubiblk_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Prog::Storage::MigrateSpdkVmToUbiblk do
   let(:st) { Strand.new }
   let(:vm_host) {
     vm_host = create_vm_host
-    vbb = create_vhost_block_backend(version: Config.vhost_block_backend_version, allocation_weight: 0, vm_host_id: vm_host.id)
+    vbb = create_vhost_block_backend(version: described_class::TARGET_VHOST_BLOCK_BACKEND_VERSION, allocation_weight: 0, vm_host_id: vm_host.id)
     vm_host.add_vhost_block_backend(vbb)
     si = SpdkInstallation.create(version: "v1", allocation_weight: 100, vm_host_id: vm_host.id)
     vm_host.add_spdk_installation(si)
@@ -236,7 +236,7 @@ RSpec.describe Prog::Storage::MigrateSpdkVmToUbiblk do
       storage_unit = vm.vm_storage_volumes.first.vhost_backend_systemd_unit_name
       vm_unit_path = "/etc/systemd/system/#{vm.inhost_name}.service"
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo cat /vm/#{vm.inhost_name}/prep.json").and_return({"storage_volumes" => [{"vhost_block_backend_version" => nil, "spdk_version" => "v.0.1.2"}]}.to_json)
-      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo tee /vm/#{vm.inhost_name}/prep.json > /dev/null", stdin: JSON.pretty_generate({"storage_volumes" => [{"vhost_block_backend_version" => Config.vhost_block_backend_version, "spdk_version" => nil}]}))
+      expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo tee /vm/#{vm.inhost_name}/prep.json > /dev/null", stdin: JSON.pretty_generate({"storage_volumes" => [{"vhost_block_backend_version" => described_class::TARGET_VHOST_BLOCK_BACKEND_VERSION, "spdk_version" => nil}]}))
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo sed -i 's/After=spdk-.*\\.service/After='#{storage_unit}'/' #{vm_unit_path}")
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo sed -i 's/Requires=spdk-.*\\.service/Requires='#{storage_unit}'/' #{vm_unit_path}")
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
@@ -261,7 +261,7 @@ RSpec.describe Prog::Storage::MigrateSpdkVmToUbiblk do
         "encrypted" => true,
         "spdk_version" => "v1",
         "disk_index" => 0,
-        "vhost_block_backend_version" => Config.vhost_block_backend_version,
+        "vhost_block_backend_version" => described_class::TARGET_VHOST_BLOCK_BACKEND_VERSION,
         "max_read_mbytes_per_sec" => nil,
         "max_write_mbytes_per_sec" => nil,
       })


### PR DESCRIPTION
### Pin SPDK->ubiblk migration to ubiblk v0.2.x 

This prog was used to migrate customer VMs off SPDK onto ubiblk v0.2.x. All regular customer VMs were migrated several months ago, and we no longer plan to use this prog in production. It now exists purely so we can reproduce a legacy v0.2.x VM and exercise the recent MoveVm prog against such VMs.

Because of that, it makes sense to pin the migration target to v0.2.x instead of following Config.vhost_block_backend_version (which tracks the current default), so the prog reproduces a state similar to the customer VMs that were migrated back then. Introduce a TARGET_VHOST_BLOCK_BACKEND_VERSION = "v0.2.2" constant and use it everywhere the prog previously read Config.vhost_block_backend_version; update the spec to match.

### Fix SPDK->ubiblk migration: mark the probe volume encrypted 

generate_vhost_conf builds a throwaway StorageVolume only to read write_through_device?, but passes no encrypted/read_only flag. A later guard in StorageVolume#initialize ("unencrypted non-read-only volumes are not supported") rejects that, so the migration prog fails at generate_vhost_backend_conf. The volume being migrated is always encrypted (a precondition of the prog), so pass encrypted: true for the probe.