### PR TITLE
Split GitHub runner AWS spillover quota from metal, cap it per customer

### DIFF
--- a/config/default_quotas.yml
+++ b/config/default_quotas.yml
@@ -1,6 +1,8 @@
 - { id: c088f732-0a30-454b-aa6b-542ce1d67bfb, resource_type: VmVCpu,                   limited_value: 16,  new_value: 32,   verified_value: 256 }
 - { id: 14fa6820-bf63-41d2-b35e-4a4dcefd1b15, resource_type: GithubRunnerVCpu,         limited_value: 128, new_value: 300,  verified_value: 300 }
 - { id: 452f14c5-4858-457e-9fb8-d5e81452c804, resource_type: GithubRunnerVCpuArm,      limited_value: 50,  new_value: 100,  verified_value: 100 }
+- { id: c4c06b31-a416-4cac-8721-6f15ea3b21d7, resource_type: GithubRunnerVCpuAws,      limited_value: 0,   new_value: 100,  verified_value: 100 }
+- { id: c8d83548-c804-40f5-b7d9-3de142325df9, resource_type: GithubRunnerVCpuArmAws,   limited_value: 0,   new_value: 50,   verified_value: 50  }
 - { id: 0ac764de-48c5-4432-876d-389878da0885, resource_type: GithubRunnerCacheStorage, limited_value: 30,  new_value: 30,   verified_value: 30  }
 - { id: 91d616ea-a15b-4d54-90b7-aaa1e1bd2f19, resource_type: PostgresVCpu,             limited_value: 16,  new_value: 128,  verified_value: 256 }
 - { id: 3acfffdb-37d6-42ff-8d1f-78a1915c7912, resource_type: KubernetesVCpu,           limited_value: 16,  new_value: 32,   verified_value: 256 }

--- a/model/github/github_runner.rb
+++ b/model/github/github_runner.rb
@@ -17,10 +17,25 @@ class GithubRunner < Sequel::Model
 
   dataset_module do
     def total_active_runner_vcpus
-      left_join(:strand, id: :id)
+      left_join(:strand, id: Sequel[:github_runner][:id])
         .exclude(Sequel[:strand][:label] => NOT_VM_ALLOCATED_RUNNER_LABELS)
         .select_map(Sequel[:github_runner][:label])
         .sum { Github.runner_labels[it]["vcpus"] }
+    end
+
+    def metal_active_runner_vcpus
+      ds = join(:vm, id: Sequel[:github_runner][:vm_id])
+      if (aws_location_id = Config.github_runner_aws_location_id)
+        ds = ds.exclude(Sequel[:vm][:location_id] => aws_location_id)
+      end
+      ds.total_active_runner_vcpus
+    end
+
+    def aws_active_runner_vcpus
+      return 0 unless (aws_location_id = Config.github_runner_aws_location_id)
+      join(:vm, id: Sequel[:github_runner][:vm_id])
+        .where(Sequel[:vm][:location_id] => aws_location_id)
+        .total_active_runner_vcpus
     end
   end
 

--- a/model/project.rb
+++ b/model/project.rb
@@ -165,8 +165,10 @@ class Project < Sequel::Model
   def current_resource_usage(resource_type)
     case resource_type
     when "VmVCpu" then vms_dataset.sum(:vcpus) || 0
-    when "GithubRunnerVCpu" then GithubRunner.where(installation_id: github_installations_dataset.select(:id)).exclude(Sequel.like(Sequel[:github_runner][:label], "%-arm%")).total_active_runner_vcpus
-    when "GithubRunnerVCpuArm" then GithubRunner.where(installation_id: github_installations_dataset.select(:id)).where(Sequel.like(Sequel[:github_runner][:label], "%-arm%")).total_active_runner_vcpus
+    when "GithubRunnerVCpu" then GithubRunner.where(installation_id: github_installations_dataset.select(:id)).exclude(Sequel.like(Sequel[:github_runner][:label], "%-arm%")).metal_active_runner_vcpus
+    when "GithubRunnerVCpuArm" then GithubRunner.where(installation_id: github_installations_dataset.select(:id)).where(Sequel.like(Sequel[:github_runner][:label], "%-arm%")).metal_active_runner_vcpus
+    when "GithubRunnerVCpuAws" then GithubRunner.where(installation_id: github_installations_dataset.select(:id)).exclude(Sequel.like(Sequel[:github_runner][:label], "%-arm%")).aws_active_runner_vcpus
+    when "GithubRunnerVCpuArmAws" then GithubRunner.where(installation_id: github_installations_dataset.select(:id)).where(Sequel.like(Sequel[:github_runner][:label], "%-arm%")).aws_active_runner_vcpus
     when "PostgresVCpu" then postgres_resources_dataset.association_join(servers: :vm).sum(:vcpus) || 0
     when "KubernetesVCpu" then kubernetes_clusters_dataset.select(Sequel[:kubernetes_cluster][:cp_node_count].as(:node_count), Sequel[:kubernetes_cluster][:target_node_size])
       .union(kubernetes_clusters_dataset.association_join(:nodepools).select(:node_count, Sequel[:nodepools][:target_node_size]), all: true)

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -347,6 +347,11 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     project.quota_available?(resource_type, 0)
   end
 
+  def aws_quota_available?
+    resource_type = x64? ? "GithubRunnerVCpuAws" : "GithubRunnerVCpuArmAws"
+    project.quota_available?(resource_type, 0)
+  end
+
   label def wait_concurrency_limit
     if quota_available?
       hop_apply_custom_label_quota if github_runner.custom_label
@@ -376,7 +381,8 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     if is_high_util
       should_spill_over = support_alien? &&
         project.get_ff_spill_to_alien_runners &&
-        Time.now - github_runner.created_at > Config.github_runner_aws_spill_threshold_seconds
+        Time.now - github_runner.created_at > Config.github_runner_aws_spill_threshold_seconds &&
+        aws_quota_available?
 
       if should_spill_over
         spilled_vcpus = Vm.where(boot_image: AWS_AMI_VERSIONS).sum(:vcpus) || 0

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -186,9 +186,11 @@ RSpec.describe Project do
     grst = Strand.new(id: gr.id, label: "start", prog: "Prog::Github::GithubRunnerNexus")
     expect { grst.update(label: "wait_vm") }.to change { project.current_resource_usage("GithubRunnerVCpu") }.from(0).to(2)
     gr2 = gi.add_runner(label: "ubicloud-standard-16-arm", repository_name: "a/a")
+    gr2.update(vm_id: create_vm(project_id: project.id, name: "test-vm-2").id)
     grst2 = Strand.new(id: gr2.id, label: "wait_concurrency_limit", prog: "Prog::Github::GithubRunnerNexus")
     expect { grst2.update(label: "wait_vm") }.to change { project.current_resource_usage("GithubRunnerVCpuArm") }.from(0).to(16)
     gr3 = gi.add_runner(label: "ubicloud-standard-60", repository_name: "a/a")
+    gr3.update(vm_id: create_vm(project_id: project.id, name: "test-vm-3").id)
     grst3 = Strand.new(id: gr3.id, label: "wait_concurrency_limit", prog: "Prog::Github::GithubRunnerNexus")
     expect { grst3.update(label: "wait_vm") }.to change { project.current_resource_usage("GithubRunnerVCpu") }.from(2).to(62)
 
@@ -218,6 +220,45 @@ RSpec.describe Project do
     }.to change { project.current_resource_usage("MachineImageVersion") }.from(0).to(2)
 
     expect { project.current_resource_usage("UnknownResource") }.to raise_error(RuntimeError)
+  end
+
+  it "calculates github runner vcpu usage separately for metal and alien (aws) placements" do
+    expect(Config).to receive(:github_runner_aws_location_id).and_return(Location::HETZNER_HEL1_ID).at_least(:once)
+    gi = GithubInstallation.create(installation_id: 2, name: "b", project_id: project.id, type: "a")
+
+    metal_vm = create_vm(location_id: Location::HETZNER_FSN1_ID, vcpus: 2, project_id: project.id)
+    gr_metal = gi.add_runner(label: "ubicloud", repository_name: "a/a")
+    gr_metal.update(vm_id: metal_vm.id)
+    Strand.create(id: gr_metal.id, label: "wait_vm", prog: "Prog::Github::GithubRunnerNexus")
+
+    expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 2
+    expect(project.current_resource_usage("GithubRunnerVCpuAws")).to eq 0
+
+    alien_vm = create_vm(location_id: Location::HETZNER_HEL1_ID, vcpus: 4, project_id: project.id, name: "alien-vm")
+    gr_alien = gi.add_runner(label: "ubicloud-standard-4", repository_name: "a/a")
+    gr_alien.update(vm_id: alien_vm.id)
+    Strand.create(id: gr_alien.id, label: "wait_vm", prog: "Prog::Github::GithubRunnerNexus")
+
+    expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 2
+    expect(project.current_resource_usage("GithubRunnerVCpuAws")).to eq 4
+
+    alien_arm_vm = create_vm(location_id: Location::HETZNER_HEL1_ID, vcpus: 16, project_id: project.id, name: "alien-arm-vm")
+    gr_alien_arm = gi.add_runner(label: "ubicloud-standard-16-arm", repository_name: "a/a")
+    gr_alien_arm.update(vm_id: alien_arm_vm.id)
+    Strand.create(id: gr_alien_arm.id, label: "wait_vm", prog: "Prog::Github::GithubRunnerNexus")
+
+    expect(project.current_resource_usage("GithubRunnerVCpuArmAws")).to eq 16
+  end
+
+  it "counts no alien vcpu usage when the aws alien location isn't configured" do
+    gi = GithubInstallation.create(installation_id: 3, name: "c", project_id: project.id, type: "a")
+    vm = create_vm(project_id: project.id, name: "no-alien-vm", vcpus: 2)
+    gr = gi.add_runner(label: "ubicloud", repository_name: "a/a")
+    gr.update(vm_id: vm.id)
+    Strand.create(id: gr.id, label: "wait_vm", prog: "Prog::Github::GithubRunnerNexus")
+
+    expect(project.current_resource_usage("GithubRunnerVCpu")).to eq 2
+    expect(project.current_resource_usage("GithubRunnerVCpuAws")).to eq 0
   end
 
   it "calculates effective quota value" do

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -239,7 +239,13 @@ RSpec.describe Project do
     expect(project.effective_quota_value("VmVCpu")).to eq 16
     expect(project.effective_quota_value("GithubRunnerVCpu")).to eq 128
     expect(project.effective_quota_value("GithubRunnerVCpuArm")).to eq 50
+    expect(project.effective_quota_value("GithubRunnerVCpuAws")).to eq 0
+    expect(project.effective_quota_value("GithubRunnerVCpuArmAws")).to eq 0
     expect(project.effective_quota_value("PostgresVCpu")).to eq 16
+
+    project.reputation = "verified"
+    expect(project.effective_quota_value("GithubRunnerVCpuAws")).to eq 100
+    expect(project.effective_quota_value("GithubRunnerVCpuArmAws")).to eq 50
   end
 
   it "checks if quota is available" do

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -421,6 +421,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
       it "waits if utilization is high, spill over enabled, and waited enough but spill vcpus limit exceeded" do
         expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpuAws", 0).and_return(true)
         project.set_ff_spill_to_alien_runners(true)
         runner.update(created_at: now - 40)
         expect(Config).to receive(:github_runner_aws_spill_vcpu_capacity).and_return(10)
@@ -430,8 +431,19 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
         expect(runner.spill_over_set?).to be(false)
       end
 
+      it "waits if utilization is high, spill over enabled, and waited enough but customer's own alien quota is exceeded" do
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpuAws", 0).and_return(false)
+        project.set_ff_spill_to_alien_runners(true)
+        runner.update(created_at: now - 40)
+
+        expect { nx.wait_concurrency_limit }.to nap
+        expect(runner.spill_over_set?).to be(false)
+      end
+
       it "allocates if utilization is high but spill over enabled and waited enough" do
         expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpuAws", 0).and_return(true)
         project.set_ff_spill_to_alien_runners(true)
         runner.update(created_at: now - 40)
 
@@ -481,6 +493,16 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
         runner.update(label: "ubicloud-standard-4-arm")
         VmHost[arch: "arm64"].update(used_cores: 8)
         expect { nx.wait_concurrency_limit }.to hop("allocate_vm")
+      end
+
+      it "checks the arm alien quota when spilling over an arm64 runner" do
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpuArm", 0).and_return(false)
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpuArmAws", 0).and_return(true)
+        runner.update(label: "ubicloud-standard-16-arm", created_at: now - 40)
+        project.set_ff_spill_to_alien_runners(true)
+
+        expect { nx.wait_concurrency_limit }.to hop("allocate_vm")
+        expect(runner.spill_over_set?).to be(true)
       end
     end
 

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -357,10 +357,11 @@ RSpec.describe Clover, "github" do
 
     it "shows concurrency warning for limited access accounts" do
       installation.project.update(reputation: "limited")
-      Array.new(3).each {
-        runner = GithubRunner.create(installation_id: installation.id, repository_name: repository.name, label: "ubicloud-standard-60")
+      3.times do |i|
+        vm = create_vm(project_id: project.id, name: "test-vm-#{i}", vcpus: 60)
+        runner = GithubRunner.create(installation_id: installation.id, repository_name: repository.name, label: "ubicloud-standard-60", vm_id: vm.id)
         Strand.create_with_id(runner, prog: "Github::GithubRunnerNexus", label: "wait")
-      }
+      end
       visit "#{project.path}/github/#{installation.ubid}/runner"
       expect(page.status_code).to eq(200)
       expect(page).to have_content "You've reached your vCPU concurrency limit"


### PR DESCRIPTION
## Summary

`GithubRunnerVCpu`/`Arm` count metal and AWS-spilled vCPUs together. This causes two bugs:

1. **Sticky spillover** — AWS runners are long-lived, so combined usage stays ≥quota as long as any spilled runner is alive, even after metal usage frees up. Every new request re-checks the same stale combined number and spills again.
2. **Unfair shared cap** — `github_runner_aws_spill_vcpu_capacity` is global across all customers, so whoever spills first can block everyone else.

## Fix 

1. Add `GithubRunnerVCpuAlien`/`ArmAlien` quota types — no behavior change yet.
2. Split usage counting by provider (`metal_active_runner_vcpus`/`alien_active_runner_vcpus`). `GithubRunnerVCpu`/`Arm` now count metal only, so `#start`'s existing quota check naturally with no changes to `#start` itself.
3. Gate spillover on the new alien quota too (`alien_quota_available?`). Global cap stays as an outer safety valve.

## Notes

- New quota default values are placeholders — open to adjusting.
- `bundle exec rspec spec/model spec/prog`: 4942 examples, 0 failures.
