### PR TITLE
Metrics backlog high page for kubernetes

### DIFF
--- a/lib/metrics_target_methods.rb
+++ b/lib/metrics_target_methods.rb
@@ -3,6 +3,7 @@
 module MetricsTargetMethods
   MAX_SCRAPE_FETCH_COUNT = 4
   FILENAME_FORMAT = "%Y-%m-%dT%H-%M-%S-%N"
+  METRICS_BACKLOG_THRESHOLD_SECONDS = 300
 
   def metrics_config
     {
@@ -47,6 +48,28 @@ module MetricsTargetMethods
 
     mark_pending_scrapes_as_done(session, scrape_results[-1].time)
     scrape_results.count
+  end
+
+  def observe_metrics_backlog(session)
+    metrics_done_dir = "#{metrics_dir}/done"
+    metrics_backlog = begin
+      result = session[:ssh_session].exec!("find :metrics_done_dir -name '*.txt' | wc -l", metrics_done_dir:)
+      Integer(result.strip, 10)
+    rescue ArgumentError => ex
+      Clog.emit("Failed to observe metrics backlog", {metrics_backlog_failure: Util.exception_to_hash(ex, into: {ubid:})})
+      return
+    end
+
+    metrics_interval = metrics_config[:interval].to_i
+    tag = metrics_backlog_page_tag
+
+    if metrics_backlog * metrics_interval > METRICS_BACKLOG_THRESHOLD_SECONDS
+      Prog::PageNexus.assemble("#{ubid} metrics backlog high",
+        [tag, id], ubid,
+        severity: "warning", extra_data: {metrics_backlog:})
+    elsif metrics_backlog * metrics_interval < METRICS_BACKLOG_THRESHOLD_SECONDS * 0.8
+      Page.from_tag_parts(tag, id)&.incr_resolve
+    end
   end
 
   def scrape_endpoints(session)

--- a/lib/metrics_target_methods.rb
+++ b/lib/metrics_target_methods.rb
@@ -51,17 +51,18 @@ module MetricsTargetMethods
   end
 
   def observe_metrics_backlog(session)
+    tag = metrics_backlog_page_tag
     metrics_done_dir = "#{metrics_dir}/done"
-    metrics_backlog = begin
-      result = session[:ssh_session].exec!("find :metrics_done_dir -name '*.txt' | wc -l", metrics_done_dir:)
-      Integer(result.strip, 10)
-    rescue ArgumentError => ex
-      Clog.emit("Failed to observe metrics backlog", {metrics_backlog_failure: Util.exception_to_hash(ex, into: {ubid:})})
+    fields = session[:ssh_session].exec!("test -d :metrics_done_dir && echo $(date +%s) $(stat -c %Y :metrics_done_dir) $(ls :metrics_done_dir | wc -l) || echo missing", metrics_done_dir:).split
+    now, touched_at, metrics_backlog = fields.map { Integer(it, 10) } unless fields == ["missing"]
+
+    if fields == ["missing"] || now - touched_at > METRICS_BACKLOG_THRESHOLD_SECONDS
+      Prog::PageNexus.assemble("#{ubid} is not collecting metrics",
+        [tag, id], ubid, severity: "warning")
       return
     end
 
     metrics_interval = metrics_config[:interval].to_i
-    tag = metrics_backlog_page_tag
 
     if metrics_backlog * metrics_interval > METRICS_BACKLOG_THRESHOLD_SECONDS
       Prog::PageNexus.assemble("#{ubid} metrics backlog high",

--- a/model/kubernetes/kubernetes_node.rb
+++ b/model/kubernetes/kubernetes_node.rb
@@ -65,6 +65,19 @@ class KubernetesNode < Sequel::Model
     }
   end
 
+  def metrics_backlog_page_tag
+    "KubernetesMetricsBacklogHigh"
+  end
+
+  def export_metrics(session:, tsdb_client:)
+    session[:export_count] ||= 0
+    session[:export_count] += 1
+
+    observe_metrics_backlog(session) if session[:export_count] % 12 == 1
+
+    super
+  end
+
   def check_pulse(session:, previous_pulse:)
     reading = begin
       available_result = check_mesh_availability(session[:ssh_session])

--- a/model/page.rb
+++ b/model/page.rb
@@ -82,7 +82,8 @@ class Page < Sequel::Model
     PostgresServer
     InferenceEndpointReplica
     InferenceRouterReplica
-    GithubRunner].freeze.each do |name|
+    GithubRunner
+    KubernetesNode].freeze.each do |name|
       EAGER_ROOT_RESOURCES[name] = :vm
     end
   EAGER_ROOT_RESOURCES["PostgresTimeline"] = :leader

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -735,24 +735,8 @@ class PostgresServer < Sequel::Model
     [(storage_size_gib * 1024 / (16 * 100)) * archival_backlog_threshold_percent, archival_backlog_threshold_count].min
   end
 
-  def observe_metrics_backlog(session)
-    metrics_done_dir = "#{metrics_config[:metrics_dir]}/done"
-    result = session[:ssh_session].exec!(
-      "find :metrics_done_dir -name '*.txt' | wc -l",
-      metrics_done_dir:,
-    )
-    metrics_backlog = Integer(result.strip, 10)
-    metrics_interval = metrics_config[:interval].to_i
-
-    if metrics_backlog * metrics_interval > METRICS_BACKLOG_THRESHOLD_SECONDS
-      Prog::PageNexus.assemble("#{ubid} metrics backlog high",
-        ["PGMetricsBacklogHigh", id], ubid,
-        severity: "warning", extra_data: {metrics_backlog:})
-    elsif metrics_backlog * metrics_interval < METRICS_BACKLOG_THRESHOLD_SECONDS * 0.8
-      Page.from_tag_parts("PGMetricsBacklogHigh", id)&.incr_resolve
-    end
-  rescue => ex
-    Clog.emit("Failed to observe metrics backlog", Util.exception_to_hash(ex, into: {postgres_server_id: id}))
+  def metrics_backlog_page_tag
+    "PGMetricsBacklogHigh"
   end
 
   def observe_io_throttle(session)
@@ -840,7 +824,6 @@ class PostgresServer < Sequel::Model
     Clog.emit("Failed to observe replica lag", Util.exception_to_hash(ex, into: {postgres_server_id: id}))
   end
 
-  METRICS_BACKLOG_THRESHOLD_SECONDS = 300
   REPLICA_LAG_SOFT_THRESHOLD_BYTES = 1024 * 1024 * 1024
   REPLICA_LAG_HARD_THRESHOLD_BYTES = 10 * 1024 * 1024 * 1024
   REPLICA_LAG_THRESHOLD_SECONDS = 15 * 60

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -294,6 +294,7 @@ TIMER
   end
 
   label def destroy
+    Page.from_tag_parts("KubernetesMetricsBacklogHigh", kubernetes_node.id)&.incr_resolve
     kubernetes_node.vm.incr_destroy
     kubernetes_node.destroy
     cluster.incr_sync_internal_dns_config

--- a/spec/model/kubernetes/kubernetes_node_spec.rb
+++ b/spec/model/kubernetes/kubernetes_node_spec.rb
@@ -103,10 +103,12 @@ RSpec.describe KubernetesNode do
   end
 
   describe "#observe_metrics_backlog" do
-    let(:find_command) { "find /home/ubi/kubernetes/metrics/done -name '*.txt' | wc -l" }
+    let(:find_command) { "test -d /home/ubi/kubernetes/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/kubernetes/metrics/done) $(ls /home/ubi/kubernetes/metrics/done | wc -l) || echo missing" }
+    let(:now) { Time.now.utc.to_i }
+    let(:reading) { ->(count, touched_secs_ago: 0) { "#{now} #{now - touched_secs_ago} #{count}\n" } }
 
     it "does nothing when the backlog is within limits" do
-      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("10\n")
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return(reading.call(10))
 
       kn.observe_metrics_backlog(session)
 
@@ -114,7 +116,7 @@ RSpec.describe KubernetesNode do
     end
 
     it "creates a page when the backlog exceeds the threshold" do
-      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("30\n")
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return(reading.call(30))
 
       kn.observe_metrics_backlog(session)
 
@@ -129,7 +131,7 @@ RSpec.describe KubernetesNode do
     it "resolves the page when the backlog is back within limits" do
       Prog::PageNexus.assemble("#{kn.ubid} metrics backlog high", ["KubernetesMetricsBacklogHigh", kn.id], kn.ubid, severity: "warning", extra_data: {metrics_backlog: 30})
       page = Page.from_tag_parts("KubernetesMetricsBacklogHigh", kn.id)
-      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("10\n")
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return(reading.call(10))
 
       kn.observe_metrics_backlog(session)
 
@@ -139,15 +141,33 @@ RSpec.describe KubernetesNode do
     it "keeps the page when the backlog is still above the resolve threshold" do
       Prog::PageNexus.assemble("#{kn.ubid} metrics backlog high", ["KubernetesMetricsBacklogHigh", kn.id], kn.ubid, severity: "warning", extra_data: {metrics_backlog: 30})
       page = Page.from_tag_parts("KubernetesMetricsBacklogHigh", kn.id)
-      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("18\n")
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return(reading.call(18))
 
       kn.observe_metrics_backlog(session)
 
       expect(page.semaphores_dataset.all).to eq []
     end
 
-    it "does not page when the backlog count cannot be parsed" do
-      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("find: '/home/ubi/kubernetes/metrics/done': No such file or directory\n")
+    it "pages when the metrics directory is missing" do
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("missing\n")
+
+      kn.observe_metrics_backlog(session)
+
+      page = Page.from_tag_parts("KubernetesMetricsBacklogHigh", kn.id)
+      expect(page.summary).to eq "#{kn.ubid} is not collecting metrics"
+      expect(page.severity).to eq "warning"
+    end
+
+    it "pages when the directory has not been written to or drained recently" do
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return(reading.call(0, touched_secs_ago: 20 * 60))
+
+      kn.observe_metrics_backlog(session)
+
+      expect(Page.from_tag_parts("KubernetesMetricsBacklogHigh", kn.id).summary).to eq "#{kn.ubid} is not collecting metrics"
+    end
+
+    it "does nothing when the exporter has just drained the directory" do
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return(reading.call(0))
 
       kn.observe_metrics_backlog(session)
 

--- a/spec/model/kubernetes/kubernetes_node_spec.rb
+++ b/spec/model/kubernetes/kubernetes_node_spec.rb
@@ -72,6 +72,89 @@ RSpec.describe KubernetesNode do
     end
   end
 
+  describe "#export_metrics" do
+    let(:tsdb_client) { instance_double(VictoriaMetrics::Client) }
+
+    it "observes the metrics backlog at export counts where count % 12 == 1" do
+      session[:export_count] = 12
+      allow(kn).to receive(:scrape_endpoints).and_return([])
+      expect(kn).to receive(:observe_metrics_backlog).with(session)
+
+      kn.export_metrics(session:, tsdb_client:)
+    end
+
+    it "does not observe the metrics backlog when count % 12 != 1" do
+      session[:export_count] = 2
+      allow(kn).to receive(:scrape_endpoints).and_return([])
+      expect(kn).not_to receive(:observe_metrics_backlog)
+
+      kn.export_metrics(session:, tsdb_client:)
+    end
+
+    it "increments export_count in session" do
+      allow(kn).to receive_messages(observe_metrics_backlog: nil, scrape_endpoints: [])
+
+      kn.export_metrics(session:, tsdb_client:)
+      expect(session[:export_count]).to eq 1
+
+      kn.export_metrics(session:, tsdb_client:)
+      expect(session[:export_count]).to eq 2
+    end
+  end
+
+  describe "#observe_metrics_backlog" do
+    let(:find_command) { "find /home/ubi/kubernetes/metrics/done -name '*.txt' | wc -l" }
+
+    it "does nothing when the backlog is within limits" do
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("10\n")
+
+      kn.observe_metrics_backlog(session)
+
+      expect(Page.from_tag_parts("KubernetesMetricsBacklogHigh", kn.id)).to be_nil
+    end
+
+    it "creates a page when the backlog exceeds the threshold" do
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("30\n")
+
+      kn.observe_metrics_backlog(session)
+
+      page = Page.from_tag_parts("KubernetesMetricsBacklogHigh", kn.id)
+      expect(page.summary).to eq "#{kn.ubid} metrics backlog high"
+      expect(page.severity).to eq "warning"
+      expect(page.details["metrics_backlog"]).to eq 30
+      expect(page.details["related_resources"]).to eq [kn.ubid]
+      expect(DB[:page_root_resource].where(page_id: page.id).select_map(:root_resource_id)).to eq [kn.kubernetes_cluster_id]
+    end
+
+    it "resolves the page when the backlog is back within limits" do
+      Prog::PageNexus.assemble("#{kn.ubid} metrics backlog high", ["KubernetesMetricsBacklogHigh", kn.id], kn.ubid, severity: "warning", extra_data: {metrics_backlog: 30})
+      page = Page.from_tag_parts("KubernetesMetricsBacklogHigh", kn.id)
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("10\n")
+
+      kn.observe_metrics_backlog(session)
+
+      expect(page.semaphores_dataset.map(:name)).to eq ["resolve"]
+    end
+
+    it "keeps the page when the backlog is still above the resolve threshold" do
+      Prog::PageNexus.assemble("#{kn.ubid} metrics backlog high", ["KubernetesMetricsBacklogHigh", kn.id], kn.ubid, severity: "warning", extra_data: {metrics_backlog: 30})
+      page = Page.from_tag_parts("KubernetesMetricsBacklogHigh", kn.id)
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("18\n")
+
+      kn.observe_metrics_backlog(session)
+
+      expect(page.semaphores_dataset.all).to eq []
+    end
+
+    it "does not page when the backlog count cannot be parsed" do
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("find: '/home/ubi/kubernetes/metrics/done': No such file or directory\n")
+
+      kn.observe_metrics_backlog(session)
+
+      expect(Page.from_tag_parts("KubernetesMetricsBacklogHigh", kn.id)).to be_nil
+    end
+  end
+
   describe "#check_pulse" do
     let(:pulse) {
       {

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -1504,13 +1504,14 @@ RSpec.describe PostgresServer do
       expect(existing_page.reload.semaphores.map(&:name)).to include("resolve")
     end
 
-    it "logs errors when checking metrics backlog fails" do
+    it "does not page when the backlog count cannot be parsed" do
       expect(session[:ssh_session]).to receive(:_exec!).with(
         "find /home/ubi/postgres/metrics/done -name '*.txt' | wc -l",
-      ).and_raise(Net::SSH::Exception.new("SSH error"))
-      expect(Clog).to receive(:emit).with("Failed to observe metrics backlog", instance_of(Hash)).and_call_original
+      ).and_return("find: '/home/ubi/postgres/metrics/done': No such file or directory\n")
 
       postgres_server.observe_metrics_backlog(session)
+
+      expect(Page.from_tag_parts("PGMetricsBacklogHigh", postgres_server.id)).to be_nil
     end
 
     it "does not resolve page if it is still high" do

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -1451,6 +1451,8 @@ RSpec.describe PostgresServer do
     let(:session) {
       {ssh_session: Net::SSH::Connection::Session.allocate}
     }
+    let(:now) { Time.now.utc.to_i }
+    let(:reading) { ->(count, touched_secs_ago: 0) { "#{now} #{now - touched_secs_ago} #{count}\n" } }
 
     before do
       allow(postgres_server).to receive(:metrics_config).and_return({
@@ -1461,8 +1463,8 @@ RSpec.describe PostgresServer do
 
     it "checks metrics backlog and does nothing if it is within limits" do
       expect(session[:ssh_session]).to receive(:_exec!).with(
-        "find /home/ubi/postgres/metrics/done -name '*.txt' | wc -l",
-      ).and_return("10\n")
+        "test -d /home/ubi/postgres/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/done) $(ls /home/ubi/postgres/metrics/done | wc -l) || echo missing",
+      ).and_return(reading.call(10))
 
       postgres_server.observe_metrics_backlog(session)
 
@@ -1472,8 +1474,8 @@ RSpec.describe PostgresServer do
     it "checks metrics backlog and creates a page if it exceeds threshold" do
       # 30 files * 15 seconds = 450 > 300 threshold
       expect(session[:ssh_session]).to receive(:_exec!).with(
-        "find /home/ubi/postgres/metrics/done -name '*.txt' | wc -l",
-      ).and_return("30\n")
+        "test -d /home/ubi/postgres/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/done) $(ls /home/ubi/postgres/metrics/done | wc -l) || echo missing",
+      ).and_return(reading.call(30))
 
       postgres_server.observe_metrics_backlog(session)
 
@@ -1496,22 +1498,34 @@ RSpec.describe PostgresServer do
       existing_page = Page.from_tag_parts("PGMetricsBacklogHigh", postgres_server.id)
       # 10 files * 15 seconds = 150 < 300 threshold
       expect(session[:ssh_session]).to receive(:_exec!).with(
-        "find /home/ubi/postgres/metrics/done -name '*.txt' | wc -l",
-      ).and_return("10\n")
+        "test -d /home/ubi/postgres/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/done) $(ls /home/ubi/postgres/metrics/done | wc -l) || echo missing",
+      ).and_return(reading.call(10))
 
       postgres_server.observe_metrics_backlog(session)
 
       expect(existing_page.reload.semaphores.map(&:name)).to include("resolve")
     end
 
-    it "does not page when the backlog count cannot be parsed" do
+    it "pages when the metrics directory is missing" do
       expect(session[:ssh_session]).to receive(:_exec!).with(
-        "find /home/ubi/postgres/metrics/done -name '*.txt' | wc -l",
-      ).and_return("find: '/home/ubi/postgres/metrics/done': No such file or directory\n")
+        "test -d /home/ubi/postgres/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/done) $(ls /home/ubi/postgres/metrics/done | wc -l) || echo missing",
+      ).and_return("missing\n")
 
       postgres_server.observe_metrics_backlog(session)
 
-      expect(Page.from_tag_parts("PGMetricsBacklogHigh", postgres_server.id)).to be_nil
+      page = Page.from_tag_parts("PGMetricsBacklogHigh", postgres_server.id)
+      expect(page.summary).to eq "#{postgres_server.ubid} is not collecting metrics"
+    end
+
+    it "pages when the directory has not been written to or drained recently" do
+      expect(session[:ssh_session]).to receive(:_exec!).with(
+        "test -d /home/ubi/postgres/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/done) $(ls /home/ubi/postgres/metrics/done | wc -l) || echo missing",
+      ).and_return(reading.call(0, touched_secs_ago: 20 * 60))
+
+      postgres_server.observe_metrics_backlog(session)
+
+      page = Page.from_tag_parts("PGMetricsBacklogHigh", postgres_server.id)
+      expect(page.summary).to eq "#{postgres_server.ubid} is not collecting metrics"
     end
 
     it "does not resolve page if it is still high" do
@@ -1524,8 +1538,8 @@ RSpec.describe PostgresServer do
       )
       existing_page = Page.from_tag_parts("PGMetricsBacklogHigh", postgres_server.id)
       expect(session[:ssh_session]).to receive(:_exec!).with(
-        "find /home/ubi/postgres/metrics/done -name '*.txt' | wc -l",
-      ).and_return("19\n")
+        "test -d /home/ubi/postgres/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/done) $(ls /home/ubi/postgres/metrics/done | wc -l) || echo missing",
+      ).and_return(reading.call(19))
 
       postgres_server.observe_metrics_backlog(session)
 

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -511,5 +511,14 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       expect(Semaphore.where(strand_id: kc.id, name: "sync_worker_mesh").count).to eq(1)
       expect(Semaphore.where(strand_id: kc.id, name: "update_billing_records").count).to eq(1)
     end
+
+    it "resolves the metrics backlog page so it does not orphan" do
+      Prog::PageNexus.assemble("#{kd.ubid} metrics backlog high", ["KubernetesMetricsBacklogHigh", kd.id], kd.ubid, severity: "warning", extra_data: {metrics_backlog: 30})
+      page = Page.from_tag_parts("KubernetesMetricsBacklogHigh", kd.id)
+
+      expect { nx.destroy }.to exit({"msg" => "kubernetes node is deleted"})
+
+      expect(page.semaphores_dataset.map(:name)).to eq ["resolve"]
+    end
   end
 end


### PR DESCRIPTION
Moves the Postgres metrics backlog check into MetricsTargetMethods and gives Kubernetes nodes the same page.

A node that keeps scraping but stops exporting fills metrics/done until the collector starts dropping the oldest scrapes, and the gap only shows up later as missing data. The check runs on every twelfth export and pages KubernetesMetricsBacklogHigh above five minutes of backlog, resolving below four.

A node with no metrics directory at all pages under the same tag, since not collecting is worse than lagging and previously looked identical to healthy from the control plane.

The page is keyed on the node, which Page.root_resources maps to the cluster, so a stalled cluster groups under one root resource and triggers once. KubernetesNode#destroy resolves it, matching PostgresServer.

PGMetricsBacklogHigh keeps its tag, threshold, and hysteresis.