### PR TITLE
Verify binary downloads

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -161,7 +161,7 @@ module Config
   # VictoriaMetrics
   optional :victoria_metrics_service_project_id, uuid
   override :victoria_metrics_host_name, "metrics.ubicloud.com", string
-  override :victoria_metrics_version, "v1.148.0", string
+  override :victoria_metrics_version, "v1.149.0", string
   optional :victoria_metrics_endpoint_override, string
 
   # Spdk

--- a/rhizome/common/lib/node_exporter_setup.rb
+++ b/rhizome/common/lib/node_exporter_setup.rb
@@ -64,13 +64,13 @@ class NodeExporterSetup
 
     fail "Invalid SHA-256 digest" unless curl_file(url, tarball) == CHECKSUM
 
-    r "sudo", "tar", "xfz", tarball, "-C", "/usr/local/bin", "--no-same-owner", "--strip-components=1", "#{file_name}/node_exporter"
+    r "tar", "xfz", tarball, "-C", "/usr/local/bin", "--no-same-owner", "--strip-components=1", "#{file_name}/node_exporter"
     r "rm", tarball
 
     safe_write_to_file("/etc/systemd/system/node_exporter.service", service)
 
-    r "sudo systemctl daemon-reload"
-    r "sudo systemctl enable node_exporter"
-    r "sudo systemctl start node_exporter"
+    r "systemctl daemon-reload"
+    r "systemctl enable node_exporter"
+    r "systemctl start node_exporter"
   end
 end

--- a/rhizome/common/spec/node_exporter_setup_spec.rb
+++ b/rhizome/common/spec/node_exporter_setup_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe NodeExporterSetup do
       setup.run
 
       expect(commands).to eq [
-        "sudo tar xfz #{tarball} -C /usr/local/bin --no-same-owner --strip-components=1 #{file_name}/node_exporter",
+        "tar xfz #{tarball} -C /usr/local/bin --no-same-owner --strip-components=1 #{file_name}/node_exporter",
         "rm #{tarball}",
-        "sudo systemctl daemon-reload",
-        "sudo systemctl enable node_exporter",
-        "sudo systemctl start node_exporter",
+        "systemctl daemon-reload",
+        "systemctl enable node_exporter",
+        "systemctl start node_exporter",
       ]
       expect(written).to eq("/etc/systemd/system/node_exporter.service" => setup.service)
     end

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -1,10 +1,10 @@
 #!/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../../common/lib/arch"
 require_relative "../../common/lib/util"
 require_relative "../lib/cloud_hypervisor"
 require_relative "../lib/crypt_swap_setup"
+require_relative "../lib/htcat_setup"
 require_relative "../lib/spdk_setup"
 require "fileutils"
 require "socket"
@@ -103,9 +103,7 @@ r "apt-get -y install nvme-cli systemd-coredump" if is_prod_env
 # We need smartmontools, nvme-cli and jq in order to probe the disk status of VmHosts
 r "apt-get -y install smartmontools nvme-cli jq"
 
-# htcat is able to download a file from signed URLs concurrently
-r "curl", "-fsSL", "-o", "htcat.tar.gz", "https://github.com/ubicloud/htcat/releases/download/v2.0.0-ubi1/htcat_2.0.0-ubi1_linux_#{Arch.render(x64: "amd64", arm64: "arm64")}.tar.gz"
-r "tar xvf htcat.tar.gz -C /usr/local/bin/"
+HtcatSetup.new.run
 
 SpdkSetup.prep
 

--- a/rhizome/host/lib/cert_server_setup.rb
+++ b/rhizome/host/lib/cert_server_setup.rb
@@ -7,6 +7,13 @@ require "fileutils"
 require "json"
 
 class CertServerSetup
+  # Upstream publishes a checksums.txt next to each tarball; these are the
+  # digests it lists for server_version.
+  CHECKSUMS = {
+    "x86_64" => "be92e125f3dc753a7b0c3a365768fe4e2506e367f7feadbca56a69099566efbd",
+    "arm64" => "8a628c54d4508cdbfb6bd52757ab942fb17a34558f98ab7d498fa17e3cc06b2f",
+  }.freeze
+
   def initialize(vm_name)
     @vm_name = vm_name
   end
@@ -47,9 +54,12 @@ class CertServerSetup
     File.join(cert_folder, "metadata-endpoint-#{server_version}")
   end
 
+  def package_arch
+    @package_arch ||= Arch.render(x64: "x86_64", arm64: "arm64")
+  end
+
   def package_url
-    arch = Arch.render(x64: "x86_64", arm64: "arm64")
-    "https://github.com/ubicloud/metadata-endpoint/releases/download/v#{server_version}/metadata-endpoint_Linux_#{arch}.tar.gz"
+    "https://github.com/ubicloud/metadata-endpoint/releases/download/v#{server_version}/metadata-endpoint_Linux_#{package_arch}.tar.gz"
   end
 
   def setup
@@ -75,11 +85,11 @@ class CertServerSetup
 
   def download_server
     temp_tarball = "/tmp/metadata-endpoint-#{server_version}.tar.gz"
-    r "curl", "-L3", "-o", temp_tarball, package_url
+    fail "Invalid SHA-256 digest" unless curl_file(package_url, temp_tarball) == CHECKSUMS.fetch(package_arch)
 
     FileUtils.mkdir_p(server_main_path)
     FileUtils.cd server_main_path do
-      r "tar", "-xzf", temp_tarball
+      r "tar", "-xzf", temp_tarball, "--no-same-owner"
     end
 
     FileUtils.rm_f(temp_tarball)

--- a/rhizome/host/lib/htcat_setup.rb
+++ b/rhizome/host/lib/htcat_setup.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require_relative "../../common/lib/arch"
+
+# htcat is able to download a file from signed URLs concurrently.
+class HtcatSetup
+  VERSION = "2.0.0-ubi1"
+  CHECKSUM = Arch.render(
+    x64: "81876d39ed892e07705114e8ebc48eea112f6f514a9c296d286461d22a0f24d3",
+    arm64: "d43bfc8693d2e833b81110f6f392d2c1486716d667e844140fc5d91f0b34f744",
+  )
+
+  def run
+    tarball = "htcat_#{VERSION}_linux_#{Arch.render(x64: "amd64", arm64: "arm64")}.tar.gz"
+    url = "https://github.com/ubicloud/htcat/releases/download/v#{VERSION}/#{tarball}"
+
+    fail "Invalid SHA-256 digest" unless curl_file(url, tarball) == CHECKSUM
+
+    r "tar", "xfz", tarball, "-C", "/usr/local/bin", "--no-same-owner", "htcat"
+    r "rm", tarball
+  end
+end

--- a/rhizome/host/spec/cert_server_setup_spec.rb
+++ b/rhizome/host/spec/cert_server_setup_spec.rb
@@ -58,22 +58,30 @@ RSpec.describe CertServerSetup do
   describe "#download_server" do
     it "downloads the server, extracts it, and removes the tarball" do
       expect(Arch).to receive(:render).with(x64: "x86_64", arm64: "arm64").and_return("arm64")
-      expect(cert_server_setup).to receive(:_run_command).with("curl", "-L3", "-o", "/tmp/metadata-endpoint-0.1.6.tar.gz", "https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_arm64.tar.gz")
+      expect(cert_server_setup).to receive(:curl_file).with("https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_arm64.tar.gz", "/tmp/metadata-endpoint-0.1.6.tar.gz").and_return(described_class::CHECKSUMS.fetch("arm64"))
       expect(FileUtils).to receive(:mkdir_p).with("/opt/metadata-endpoint-0.1.6")
       expect(FileUtils).to receive(:cd).with("/opt/metadata-endpoint-0.1.6").and_yield
-      expect(cert_server_setup).to receive(:_run_command).with("tar", "-xzf", "/tmp/metadata-endpoint-0.1.6.tar.gz")
+      expect(cert_server_setup).to receive(:_run_command).with("tar", "-xzf", "/tmp/metadata-endpoint-0.1.6.tar.gz", "--no-same-owner")
       expect(FileUtils).to receive(:rm_f).with("/tmp/metadata-endpoint-0.1.6.tar.gz")
       expect { cert_server_setup.download_server }.not_to raise_error
     end
 
     it "downloads the server for x64" do
       expect(Arch).to receive(:render).with(x64: "x86_64", arm64: "arm64").and_return("x86_64")
-      expect(cert_server_setup).to receive(:_run_command).with("curl", "-L3", "-o", "/tmp/metadata-endpoint-0.1.6.tar.gz", "https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_x86_64.tar.gz")
+      expect(cert_server_setup).to receive(:curl_file).with("https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_x86_64.tar.gz", "/tmp/metadata-endpoint-0.1.6.tar.gz").and_return(described_class::CHECKSUMS.fetch("x86_64"))
       expect(FileUtils).to receive(:mkdir_p).with("/opt/metadata-endpoint-0.1.6")
       expect(FileUtils).to receive(:cd).with("/opt/metadata-endpoint-0.1.6").and_yield
-      expect(cert_server_setup).to receive(:_run_command).with("tar", "-xzf", "/tmp/metadata-endpoint-0.1.6.tar.gz")
+      expect(cert_server_setup).to receive(:_run_command).with("tar", "-xzf", "/tmp/metadata-endpoint-0.1.6.tar.gz", "--no-same-owner")
       expect(FileUtils).to receive(:rm_f).with("/tmp/metadata-endpoint-0.1.6.tar.gz")
       expect { cert_server_setup.download_server }.not_to raise_error
+    end
+
+    it "fails without extracting anything when the digest does not match" do
+      expect(Arch).to receive(:render).with(x64: "x86_64", arm64: "arm64").and_return("x86_64")
+      expect(cert_server_setup).to receive(:curl_file).with("https://github.com/ubicloud/metadata-endpoint/releases/download/v0.1.6/metadata-endpoint_Linux_x86_64.tar.gz", "/tmp/metadata-endpoint-0.1.6.tar.gz").and_return("wrongsha256")
+      expect(FileUtils).not_to receive(:mkdir_p)
+
+      expect { cert_server_setup.download_server }.to raise_error RuntimeError, "Invalid SHA-256 digest"
     end
   end
 

--- a/rhizome/host/spec/htcat_setup_spec.rb
+++ b/rhizome/host/spec/htcat_setup_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "../lib/htcat_setup"
+
+RSpec.describe HtcatSetup do
+  subject(:setup) { described_class.new }
+
+  let(:tarball) { "htcat_2.0.0-ubi1_linux_#{Arch.render(x64: "amd64", arm64: "arm64")}.tar.gz" }
+  let(:url) { "https://github.com/ubicloud/htcat/releases/download/v2.0.0-ubi1/#{tarball}" }
+
+  describe "#run" do
+    it "installs the binary and removes the tarball" do
+      commands = []
+      allow(setup).to receive(:_run_command) { |*command| commands << command.join(" ") }
+      expect(setup).to receive(:curl_file).with(url, tarball).and_return(described_class::CHECKSUM)
+
+      setup.run
+
+      expect(commands).to eq [
+        "tar xfz #{tarball} -C /usr/local/bin --no-same-owner htcat",
+        "rm #{tarball}",
+      ]
+    end
+
+    it "fails when the download does not match the pinned checksum" do
+      expect(setup).to receive(:curl_file).with(url, tarball).and_return("wrongsha256")
+
+      expect { setup.run }.to raise_error RuntimeError, "Invalid SHA-256 digest"
+    end
+  end
+end

--- a/rhizome/kubernetes/lib/kubernetes_install_prometheus.rb
+++ b/rhizome/kubernetes/lib/kubernetes_install_prometheus.rb
@@ -46,16 +46,16 @@ class KubernetesInstallPrometheus
 
     fail "Invalid SHA-256 digest" unless curl_file(url, tarball) == CHECKSUM
 
-    r "sudo", "tar", "xfz", tarball, "-C", "/usr/local/bin", "--no-same-owner", "--strip-components=1", "#{file_name}/prometheus"
+    r "tar", "xfz", tarball, "-C", "/usr/local/bin", "--no-same-owner", "--strip-components=1", "#{file_name}/prometheus"
     r "rm", tarball
 
-    r "sudo groupadd -f --system prometheus"
-    r "sudo useradd --no-create-home --system -g prometheus prometheus"
-    r "sudo mkdir -p /etc/prometheus /var/lib/prometheus"
-    r "sudo chown prometheus:prometheus /var/lib/prometheus"
+    r "groupadd -f --system prometheus"
+    r "useradd --no-create-home --system -g prometheus prometheus"
+    r "mkdir -p /etc/prometheus /var/lib/prometheus"
+    r "chown prometheus:prometheus /var/lib/prometheus"
 
     safe_write_to_file("/etc/systemd/system/prometheus.service", SERVICE)
 
-    r "sudo systemctl daemon-reload"
+    r "systemctl daemon-reload"
   end
 end

--- a/rhizome/kubernetes/spec/kubernetes_install_prometheus_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_install_prometheus_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe KubernetesInstallPrometheus do
       installer.run
 
       expect(commands).to eq [
-        "sudo tar xfz #{tarball} -C /usr/local/bin --no-same-owner --strip-components=1 prometheus-3.13.2.linux-amd64/prometheus",
+        "tar xfz #{tarball} -C /usr/local/bin --no-same-owner --strip-components=1 prometheus-3.13.2.linux-amd64/prometheus",
         "rm #{tarball}",
-        "sudo groupadd -f --system prometheus",
-        "sudo useradd --no-create-home --system -g prometheus prometheus",
-        "sudo mkdir -p /etc/prometheus /var/lib/prometheus",
-        "sudo chown prometheus:prometheus /var/lib/prometheus",
-        "sudo systemctl daemon-reload",
+        "groupadd -f --system prometheus",
+        "useradd --no-create-home --system -g prometheus prometheus",
+        "mkdir -p /etc/prometheus /var/lib/prometheus",
+        "chown prometheus:prometheus /var/lib/prometheus",
+        "systemctl daemon-reload",
       ]
       expect(written).to eq("/etc/systemd/system/prometheus.service" => described_class::SERVICE)
     end

--- a/rhizome/minio/bin/install_minio
+++ b/rhizome/minio/bin/install_minio
@@ -1,12 +1,6 @@
 #!/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../../common/lib/util"
+require_relative "../lib/minio_setup"
 
-unless (ver = ARGV.shift)
-  fail "No version provided"
-end
-
-r "curl", "-fsSL", "-o", "minio.deb", "https://dl.min.io/server/minio/release/linux-amd64/archive/#{ver}.deb"
-r "sudo dpkg -i minio.deb"
-r "systemctl enable minio.service"
+MinioSetup.new(ARGV).run

--- a/rhizome/minio/lib/minio_setup.rb
+++ b/rhizome/minio/lib/minio_setup.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+class MinioSetup
+  # Upstream publishes a .sha256sum next to each package; these are the digests
+  # it lists for the linux-amd64 builds.
+  CHECKSUMS = {
+    "minio_20250723155402.0.0_amd64" => "a6ff2d7424206c3d8be43bd5eac159e49ea57780ef1d7fb3afbe47227650a62d",
+  }.freeze
+
+  def initialize(argv)
+    fail "expected a single argument, a minio version like minio_20250723155402.0.0_amd64, got #{argv.length}" unless argv.length == 1
+
+    @version = argv[0]
+    fail "no minio checksum for version #{@version.inspect}" unless CHECKSUMS.key?(@version)
+  end
+
+  def run
+    package = "#{@version}.deb"
+    url = "https://dl.min.io/server/minio/release/linux-amd64/archive/#{package}"
+
+    fail "Invalid SHA-256 digest" unless curl_file(url, package) == CHECKSUMS.fetch(@version)
+
+    r "dpkg", "-i", package
+    r "rm", package
+    r "systemctl enable minio.service"
+  end
+end

--- a/rhizome/minio/spec/minio_setup_spec.rb
+++ b/rhizome/minio/spec/minio_setup_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "../lib/minio_setup"
+
+RSpec.describe MinioSetup do
+  subject(:setup) { described_class.new(["minio_20250723155402.0.0_amd64"]) }
+
+  let(:package) { "minio_20250723155402.0.0_amd64.deb" }
+  let(:url) { "https://dl.min.io/server/minio/release/linux-amd64/archive/#{package}" }
+
+  describe "#initialize" do
+    it "rejects a missing version" do
+      expect { described_class.new([]) }.to raise_error RuntimeError, "expected a single argument, a minio version like minio_20250723155402.0.0_amd64, got 0"
+    end
+
+    it "rejects extra arguments" do
+      expect { described_class.new(["minio_20250723155402.0.0_amd64", "amd64"]) }.to raise_error RuntimeError, "expected a single argument, a minio version like minio_20250723155402.0.0_amd64, got 2"
+    end
+
+    it "rejects a version there is no checksum for" do
+      expect { described_class.new(["minio_20240101000000.0.0_amd64"]) }.to raise_error RuntimeError, "no minio checksum for version \"minio_20240101000000.0.0_amd64\""
+    end
+  end
+
+  describe "#run" do
+    it "installs the package and enables the service" do
+      commands = []
+      allow(setup).to receive(:_run_command) { |*command| commands << command.join(" ") }
+      expect(setup).to receive(:curl_file).with(url, package).and_return(described_class::CHECKSUMS.fetch("minio_20250723155402.0.0_amd64"))
+
+      setup.run
+
+      expect(commands).to eq [
+        "dpkg -i #{package}",
+        "rm #{package}",
+        "systemctl enable minio.service",
+      ]
+    end
+
+    it "fails without installing anything when the digest does not match" do
+      commands = []
+      allow(setup).to receive(:_run_command) { |*command| commands << command.join(" ") }
+      expect(setup).to receive(:curl_file).with(url, package).and_return("wrongsha256")
+
+      expect { setup.run }.to raise_error RuntimeError, "Invalid SHA-256 digest"
+      expect(commands).to eq []
+    end
+  end
+end

--- a/rhizome/victoria_metrics/bin/install
+++ b/rhizome/victoria_metrics/bin/install
@@ -1,14 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../../common/lib/util"
+require_relative "../lib/victoria_metrics_setup"
 
-unless (ver = ARGV.shift)
-  fail "No version provided"
-end
-
-r "curl", "-fsSL", "-o", "victoria-metrics.tar.gz", "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/#{ver}/victoria-metrics-linux-amd64-#{ver}.tar.gz"
-r "tar", "xvf", "victoria-metrics.tar.gz", "-C", "/usr/local/bin/"
-
-r "curl", "-fsSL", "-o", "vmutils.tar.gz", "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/#{ver}/vmutils-linux-amd64-#{ver}.tar.gz"
-r "tar", "xvf", "vmutils.tar.gz", "-C", "/usr/local/bin/"
+VictoriaMetricsSetup.new(ARGV).run

--- a/rhizome/victoria_metrics/lib/victoria_metrics_setup.rb
+++ b/rhizome/victoria_metrics/lib/victoria_metrics_setup.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+class VictoriaMetricsSetup
+  # Upstream publishes a checksums.txt next to each tarball; these are the
+  # digests it lists for the linux-amd64 builds.
+  CHECKSUMS = {
+    "v1.149.0" => {
+      "victoria-metrics" => "6695fbee54bca58b78162ddf785c387b24641e57dfe4f3f743fb241f41dc3697",
+      "vmutils" => "1ccaa92acf4f2fcba03d8c197f1b1da7194cc4777ecf45ab5b212bd6ed52be58",
+    },
+  }.freeze
+
+  def initialize(argv)
+    fail "expected a single argument, a VictoriaMetrics version like v1.149.0, got #{argv.length}" unless argv.length == 1
+
+    @version = argv[0]
+    fail "no VictoriaMetrics checksums for version #{@version.inspect}" unless CHECKSUMS.key?(@version)
+  end
+
+  def run
+    install("victoria-metrics")
+    install("vmutils")
+  end
+
+  def install(component)
+    tarball = "#{component}-linux-amd64-#{@version}.tar.gz"
+    url = "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/#{@version}/#{tarball}"
+
+    fail "Invalid SHA-256 digest" unless curl_file(url, tarball) == CHECKSUMS.fetch(@version).fetch(component)
+
+    r "tar", "xfz", tarball, "-C", "/usr/local/bin", "--no-same-owner"
+    r "rm", tarball
+  end
+end

--- a/rhizome/victoria_metrics/spec/victoria_metrics_setup_spec.rb
+++ b/rhizome/victoria_metrics/spec/victoria_metrics_setup_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative "../lib/victoria_metrics_setup"
+
+RSpec.describe VictoriaMetricsSetup do
+  subject(:setup) { described_class.new(["v1.149.0"]) }
+
+  let(:base_url) { "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v1.149.0" }
+
+  describe "#initialize" do
+    it "rejects a missing version" do
+      expect { described_class.new([]) }.to raise_error RuntimeError, "expected a single argument, a VictoriaMetrics version like v1.149.0, got 0"
+    end
+
+    it "rejects extra arguments" do
+      expect { described_class.new(["v1.149.0", "amd64"]) }.to raise_error RuntimeError, "expected a single argument, a VictoriaMetrics version like v1.149.0, got 2"
+    end
+
+    it "rejects a version there is no checksum for" do
+      expect { described_class.new(["v1.148.0"]) }.to raise_error RuntimeError, "no VictoriaMetrics checksums for version \"v1.148.0\""
+    end
+  end
+
+  describe "#run" do
+    it "installs both tarballs and removes them" do
+      commands = []
+      allow(setup).to receive(:_run_command) { |*command| commands << command.join(" ") }
+      checksums = described_class::CHECKSUMS.fetch("v1.149.0")
+      expect(setup).to receive(:curl_file).with("#{base_url}/victoria-metrics-linux-amd64-v1.149.0.tar.gz", "victoria-metrics-linux-amd64-v1.149.0.tar.gz").and_return(checksums.fetch("victoria-metrics"))
+      expect(setup).to receive(:curl_file).with("#{base_url}/vmutils-linux-amd64-v1.149.0.tar.gz", "vmutils-linux-amd64-v1.149.0.tar.gz").and_return(checksums.fetch("vmutils"))
+
+      setup.run
+
+      expect(commands).to eq [
+        "tar xfz victoria-metrics-linux-amd64-v1.149.0.tar.gz -C /usr/local/bin --no-same-owner",
+        "rm victoria-metrics-linux-amd64-v1.149.0.tar.gz",
+        "tar xfz vmutils-linux-amd64-v1.149.0.tar.gz -C /usr/local/bin --no-same-owner",
+        "rm vmutils-linux-amd64-v1.149.0.tar.gz",
+      ]
+    end
+
+    it "fails when the download does not match the pinned checksum" do
+      expect(setup).to receive(:curl_file).with("#{base_url}/victoria-metrics-linux-amd64-v1.149.0.tar.gz", "victoria-metrics-linux-amd64-v1.149.0.tar.gz").and_return("wrongsha256")
+
+      expect { setup.run }.to raise_error RuntimeError, "Invalid SHA-256 digest"
+    end
+  end
+end


### PR DESCRIPTION
Every binary rhizome downloads (htcat, victoria-metrics, vmutils, the minio .deb, and metadata-endpoint) is now checked against a SHA-256 pinned in the source before it is installed, so a tampered or corrupted download fails loudly instead of being executed. Each installer moves out of its bin script into a lib class with specs covering the happy path and the digest mismatch, and VictoriaMetrics moves to v1.149.0 since only pinned versions can be installed. A final commit drops the redundant sudo from the node_exporter and Prometheus installers, which already run as root, so all the installers read the same way.