### PR TITLE
Fix firewall E2E test failure

### DIFF
--- a/prog/test/firewall_rules.rb
+++ b/prog/test/firewall_rules.rb
@@ -5,6 +5,7 @@ require "uri"
 
 class Prog::Test::FirewallRules < Prog::Test::Base
   subject_is :firewall
+  frame_reader :subnet_id_outside
   frame_accessor :vm_to_be_connected_id, :firewalls
 
   label def start
@@ -164,7 +165,7 @@ ExecStart=nc -l 8080 -6
   end
 
   def vm_outside
-    @vm_outside ||= PrivateSubnet.find { |ps| ps.id != vm1.private_subnets.first.id }.vms.first
+    @vm_outside ||= PrivateSubnet[subnet_id_outside].vms.first
   end
 
   def test_connection(to_connect_ip, connecting, should_fail: false, ipv4: true, hop_method_symbol: nil)

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -102,7 +102,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
       hop_verify_connected_subnets
     end
 
-    push Prog::Test::FirewallRules, {"subject_id" => PrivateSubnet[subnets.first].firewalls.first.id}
+    push Prog::Test::FirewallRules, {"subject_id" => PrivateSubnet[subnets.first].firewalls.first.id, "subnet_id_outside" => subnets.last}
   end
 
   label def verify_connected_subnets

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -102,7 +102,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
       hop_verify_connected_subnets
     end
 
-    push Prog::Test::FirewallRules, {subject_id: PrivateSubnet[subnets.first].firewalls.first.id}
+    push Prog::Test::FirewallRules, {"subject_id" => PrivateSubnet[subnets.first].firewalls.first.id}
   end
 
   label def verify_connected_subnets
@@ -115,7 +115,7 @@ class Prog::Test::VmGroup < Prog::Test::Base
     end
 
     ps1, ps2 = subnets.map { PrivateSubnet[it] }
-    push Prog::Test::ConnectedSubnets, {subnet_id_multiple: ((ps1.vms.count > 1) ? ps1.id : ps2.id), subnet_id_single: ((ps1.vms.count > 1) ? ps2.id : ps1.id)}
+    push Prog::Test::ConnectedSubnets, {"subnet_id_multiple" => ((ps1.vms.count > 1) ? ps1.id : ps2.id), "subnet_id_single" => ((ps1.vms.count > 1) ? ps2.id : ps1.id)}
   end
 
   label def test_reboot

--- a/spec/prog/test/firewall_rules_spec.rb
+++ b/spec/prog/test/firewall_rules_spec.rb
@@ -508,11 +508,11 @@ ExecStart=nc -l 8080 -6
   end
 
   describe ".vm_outside" do
-    it "returns the vm outside" do
-      expect(firewall_test.vm1).to receive(:private_subnets).and_return([instance_double(PrivateSubnet, id: "ps1", vms: [instance_double(Vm, inhost_name: "vm1")])])
+    it "returns the first vm of the outside subnet from the frame" do
       prj = Project.create(name: "project1")
       ps = Prog::Vnet::SubnetNexus.assemble(prj.id, name: "ps2", location_id: Location::HETZNER_FSN1_ID)
-      Prog::Vm::Nexus.assemble("a a", prj.id, name: "vm-outside", location_id: Location::HETZNER_FSN1_ID, private_subnet_id: ps.id).subject
+      Prog::Vm::Nexus.assemble("a a", prj.id, name: "vm-outside", location_id: Location::HETZNER_FSN1_ID, private_subnet_id: ps.id)
+      expect(firewall_test).to receive(:frame).and_return({"subnet_id_outside" => ps.id})
       expect(firewall_test.vm_outside.name).to eq("vm-outside")
     end
   end

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -195,7 +195,9 @@ RSpec.describe Prog::Test::VmGroup do
 
     it "runs tests for the first firewall" do
       refresh_frame(vg_test, new_values: {"subnets" => [ps1.id]})
-      expect { vg_test.verify_firewall_rules }.to hop("start", "Test::FirewallRules")
+      expect { vg_test.verify_firewall_rules }.to hop("start", "Test::FirewallRules") { |hop|
+        expect(hop.strand_update_args[:stack].first["subject_id"]).to eq ps1.firewalls.first.id
+      }
     end
   end
 
@@ -207,7 +209,9 @@ RSpec.describe Prog::Test::VmGroup do
 
     it "runs tests for the first connected subnet" do
       refresh_frame(vg_test, new_values: {"subnets" => [ps1.id, ps2.id]})
-      expect { vg_test.verify_connected_subnets }.to hop("start", "Test::ConnectedSubnets")
+      expect { vg_test.verify_connected_subnets }.to hop("start", "Test::ConnectedSubnets") { |hop|
+        expect(hop.strand_update_args[:stack].first.values_at("subnet_id_multiple", "subnet_id_single")).to eq [ps2.id, ps1.id]
+      }
     end
 
     it "runs tests for the second connected subnet" do

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -193,10 +193,10 @@ RSpec.describe Prog::Test::VmGroup do
       expect { vg_test.verify_firewall_rules }.to hop("verify_connected_subnets")
     end
 
-    it "runs tests for the first firewall" do
-      refresh_frame(vg_test, new_values: {"subnets" => [ps1.id]})
+    it "runs tests for the first firewall with the other subnet as the outside subnet" do
+      refresh_frame(vg_test, new_values: {"subnets" => [ps1.id, ps2.id]})
       expect { vg_test.verify_firewall_rules }.to hop("start", "Test::FirewallRules") { |hop|
-        expect(hop.strand_update_args[:stack].first["subject_id"]).to eq ps1.firewalls.first.id
+        expect(hop.strand_update_args[:stack].first.values_at("subject_id", "subnet_id_outside")).to eq [ps1.firewalls.first.id, ps2.id]
       }
     end
   end


### PR DESCRIPTION
**Use string frame keys when pushing test progs**
Prog::Base#push merges the caller frame over {"subject_id" => ...}, so a symbol key adds a second entry instead of replacing it. The first run of the pushed prog reads frame["subject_id"] as nil and raises; it only recovers because the JSON round-trip emits a duplicate key and the last one wins on parse.

**Pass the outside subnet to the firewall rules test**
Sequel treats Model.find's block as a virtual row block, so PrivateSubnet.find { |ps| ps.id != ... } compares an SQL identifier with Object#!=, always yields true, and runs SELECT * FROM private_subnet WHERE 't' LIMIT 1. vm_outside was therefore an arbitrary subnet from any project, and picked up a VM-less one once the rest of the e2e suite began running in parallel with the post-reboot pass, leaving the strand to raise NoMethodError on nil.boot_image until the run timed out.

VmGroup already knows both subnets, so hand the other one to the test.