### PR TITLE
Prevent removal of last admin from project

### DIFF
--- a/model/account.rb
+++ b/model/account.rb
@@ -51,11 +51,8 @@ class Account < Sequel::Model(:accounts)
   end
 
   def first_sole_project_with_resources
-    Project
-      .where(id: DB[:access_tag]
-        .select_group(:project_id)
-        .where(project_id: projects_dataset.select(Sequel[:project][:id]))
-        .having(Sequel.function(:count).* => 1))
+    projects_dataset
+      .where_sole_admin_is(self)
       .first_project_with_resources
   end
 

--- a/model/project.rb
+++ b/model/project.rb
@@ -99,6 +99,15 @@ class Project < Sequel::Model
     "/project/#{ubid}"
   end
 
+  def sole_admin?(account)
+    DB[:applied_subject_tag]
+      .where(
+        tag_id: subject_tags_dataset.where(name: "Admin").select(:id),
+        subject_id: DB[:access_tag].where(project_id: id).select(:hyper_tag_id),
+      )
+      .select_map(:subject_id) == [account.id]
+  end
+
   # Returns the MachineImageStore to use for the given location, falling
   # back to the platform default store if the project has none of its own.
   def machine_image_store_for(location_id)

--- a/model/project.rb
+++ b/model/project.rb
@@ -53,6 +53,19 @@ class Project < Sequel::Model
 
       nil
     end
+
+    def where_sole_admin_is(account)
+      account_array = Sequel.pg_array([account.id], :uuid)
+      project_id = Sequel[:project][:id]
+      ds = select(project_id)
+        .from_self(alias: :project)
+        .join(:subject_tag, project_id: :id, name: "Admin")
+        .join(:applied_subject_tag, tag_id: :id)
+        .join(:access_tag, hyper_tag_id: :subject_id, project_id:)
+        .select_group(project_id)
+        .having { {array_agg(:hyper_tag_id) => account_array} }
+      where(project_id => ds)
+    end
   end
 
   plugin :association_dependencies,
@@ -100,12 +113,7 @@ class Project < Sequel::Model
   end
 
   def sole_admin?(account)
-    DB[:applied_subject_tag]
-      .where(
-        tag_id: subject_tags_dataset.where(name: "Admin").select(:id),
-        subject_id: DB[:access_tag].where(project_id: id).select(:hyper_tag_id),
-      )
-      .select_map(:subject_id) == [account.id]
+    !this.where_sole_admin_is(account).empty?
   end
 
   # Returns the MachineImageStore to use for the given location, falling

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -375,6 +375,9 @@ class Clover
           unless @project.accounts_dataset.count > 1
             raise_web_error("You can't remove the last user from '#{@project.name}' project. Delete project instead.")
           end
+          if @project.sole_admin?(user)
+            raise_web_error("You can't remove the last admin from '#{@project.name}' project.")
+          end
 
           @project.disassociate_subject(user.id)
           # ProjectInvitation doesn't use ResourceMethods

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -122,7 +122,7 @@ class Clover
           additions.transform_keys!(&:name)
           removals.transform_keys!(&:name)
 
-          if @project.subject_tags_dataset.first(name: "Admin").member_ids.empty?
+          unless @project.subject_tags_dataset.first(name: "Admin").member_ids.any? { UBID.uuid_class_match?(it, Account) }
             raise_web_error("The project must have at least one admin.")
           end
 

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -251,6 +251,39 @@ RSpec.describe Project do
     expect(project.quota_available?("VmVCpu", 20)).to be false
   end
 
+  it "#sole_admin? returns whether the given admin is the sole admin on the project" do
+    st = SubjectTag.create(project_id: project.id, name: "Admin")
+    account = Account.create(email: "test@example.com")
+    expect(project.sole_admin?(account)).to be false
+
+    project.add_account(account)
+    expect(project.sole_admin?(account)).to be false
+
+    st.add_member(account.id)
+    expect(project.sole_admin?(account)).to be true
+
+    account2 = Account.create(email: "test2@example.com")
+    expect(project.sole_admin?(account)).to be true
+    expect(project.sole_admin?(account2)).to be false
+
+    project.add_account(account2)
+    expect(project.sole_admin?(account)).to be true
+    expect(project.sole_admin?(account2)).to be false
+
+    st.add_member(account2.id)
+    expect(project.sole_admin?(account)).to be false
+    expect(project.sole_admin?(account2)).to be false
+
+    st.remove_members([account.id])
+    expect(project.sole_admin?(account)).to be false
+    expect(project.sole_admin?(account2)).to be true
+
+    mst = SubjectTag.create(project_id: project.id, name: "Member")
+    st.add_member(mst.id)
+    expect(project.sole_admin?(account)).to be false
+    expect(project.sole_admin?(account2)).to be true
+  end
+
   it "defaults gcp_dedicated_subnet_vpcs to false for new projects" do
     expect(project.gcp_dedicated_subnet_vpcs).to be false
   end

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -627,6 +627,30 @@ RSpec.describe Clover, "auth" do
       expect(audit_log_hash).to eq({})
     end
 
+    it "can close account if the project with resources has another admin" do
+      vm = create_vm
+      account = Account[email: TEST_USER_EMAIL]
+      project = account.projects.first
+      vm.update(project_id: project.id)
+
+      account2 = Account.create(email: "test2@example.com")
+      project.add_account(account2)
+
+      visit "/account/close-account"
+      click_button "Close Account"
+      expect(page.title).to eq("Ubicloud - Close Account")
+      expect(page).to have_flash_error("'Default' project has some resources. Delete all related resources first.")
+
+      project.subject_tags_dataset.first(name: "Admin").add_member(account2.id)
+
+      click_button "Close Account"
+      expect(page.title).to eq("Ubicloud - Login")
+      expect(page).to have_flash_notice("Your account has been closed")
+      expect(Account[email: TEST_USER_EMAIL]).to be_nil
+      expect(DB[:access_tag].where(hyper_tag_id: account.id).count).to eq 0
+      expect(audit_log_hash).to eq({"close_account" => ip_hash})
+    end
+
     it "show password change page" do
       visit "/account/change-password"
 

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -147,8 +147,9 @@ RSpec.describe Clover, "project" do
         expect(page).to have_no_content new_project.name
       end
 
-      it "can remove self from any project with multiple users" do
+      it "can remove self from any project with multiple admins" do
         project.add_account(user2)
+        project.subject_tags_dataset[name: "Admin"].add_member(user2.id)
 
         visit "/project"
         within("#project-#{project.ubid}") { click_button "Remove Access" }
@@ -156,8 +157,9 @@ RSpec.describe Clover, "project" do
         expect(page).to have_no_content "project-1"
       end
 
-      it "can remove self from any project with multiple users, even without authorization" do
+      it "can remove self from any project with multiple admins, even without authorization" do
         project.add_account(user2)
+        project.subject_tags_dataset[name: "Admin"].add_member(user2.id)
         AccessControlEntry.dataset.destroy
 
         visit "/project"
@@ -175,8 +177,18 @@ RSpec.describe Clover, "project" do
         expect(page.title).to eq "Ubicloud - project-1 Dashboard"
       end
 
+      it "cannot remove self from project where you are the only admin" do
+        project.add_account(user2)
+        visit "/project"
+        within("#project-#{project.ubid}") { click_button "Remove Access" }
+        expect(page).to have_flash_error("You can't remove the last admin from 'project-1' project.")
+        within("#project-#{project.ubid}") { click_link project.name }
+        expect(page.title).to eq "Ubicloud - project-1 Dashboard"
+      end
+
       it "removes invitations for project sent by user when removing user from project" do
         project.add_account(user2)
+        project.subject_tags_dataset[name: "Admin"].add_member(user2.id)
         invitation1 = project.add_invitation(email: "user3@example.com", inviter_id: user.id, expires_at: Time.now + 1000)
         invitation2 = project.add_invitation(email: user2.email, inviter_id: user.id, expires_at: Time.now + 1000)
 

--- a/spec/routes/web/project_spec.rb
+++ b/spec/routes/web/project_spec.rb
@@ -906,6 +906,14 @@ RSpec.describe Clover, "project" do
           click_button "Update"
         end
         expect(page).to have_flash_error("The project must have at least one admin.")
+
+        mst = SubjectTag.create(project_id: project.id, name: "Empty")
+        admin_tag.add_member(mst.id)
+        within "form#managed-policy" do
+          select "No access", from: "user_policies[#{user.ubid}]"
+          click_button "Update"
+        end
+        expect(page).to have_flash_error("The project must have at least one admin.")
       end
 
       it "can not have more than 50 pending invitations" do


### PR DESCRIPTION
We previously prevented removal of last user from project, but if there is one admin and one non-admin, if the admin removed themselves or closed their account, they could leave the project with no admin. If the project had resources, that would be problematic as it would require operator assistance to remove the resources.

While here, I found a condition where the user permissions page could be used to remove the last admin from the project if there was an empty subject tag in the Admin subject tag. This includes a fix for that issue.