### PR TITLE
Make default rake task only run coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       run: ruby bin/production_check
 
     - name: Run controlplane tests
-      run: bundle exec rake
+      run: bundle exec rake default frozen_spec
 
     - name: Run dataplane tests
       run: bundle exec rake rhizome_spec

--- a/Rakefile
+++ b/Rakefile
@@ -124,7 +124,7 @@ end
 # Specs
 
 desc "Run specs in with coverage in unfrozen mode, and without coverage in frozen mode"
-task default: [:coverage, :frozen_spec]
+task default: :coverage
 
 rspec = lambda do |env|
   sh(env.merge("RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1", "EAGER_EC2_CLIENT" => "1"), "bundle", "exec", "rspec", "spec")


### PR DESCRIPTION
Still run both coverage and frozen specs in CI.

When we originally made the default task run both, the test suite was much smaller and ran much faster. The vast majority of problems are going to be caught by the coverage tests. The frozen specs are still important to run before deployment, but can be run as part of CI.