### PR TITLE
Remove support for OIDC client registration

### DIFF
--- a/model/oidc_provider.rb
+++ b/model/oidc_provider.rb
@@ -22,10 +22,7 @@ class OidcProvider < Sequel::Model
   # a new client. If the OIDC provider does not provide OIDC discovery
   # information, you'll need to be provided all OIDC information and
   # create the instance manually using OidcProvider.create.
-  def self.register(display_name, url, client_id: nil, client_secret: nil, group_prefix: nil)
-    # new_with_id needed for callback_url before saving
-    oidc_provider = new_with_id(display_name:)
-
+  def self.register(display_name, url, client_id:, client_secret:, group_prefix: nil)
     uri = URI(url)
     unless url.end_with?("/.well-known/openid-configuration")
       uri.path += "/.well-known/openid-configuration"
@@ -38,27 +35,8 @@ class OidcProvider < Sequel::Model
     userinfo_endpoint = URI(config_info.fetch("userinfo_endpoint")).path
     jwks_uri = config_info.fetch("jwks_uri")
 
-    unless client_id && client_secret
-      scopes = "openid email"
-      scopes += " groups" if group_prefix
-      response = Excon.post(config_info["registration_endpoint"],
-        headers: {"Accept" => "application/json", "Content-Type" => "application/json"},
-        body: {
-          client_name: "Ubicloud",
-          redirect_uris: [oidc_provider.callback_url],
-          scopes:,
-        }.to_json)
-
-      registration_info = JSON.parse(response.body)
-      raise "Unable to register with oidc provider: #{response.status} #{registration_info.inspect}" unless response.status == 201
-
-      client_id = registration_info.fetch("client_id")
-      client_secret = registration_info.fetch("client_secret")
-      registration_client_uri = registration_info["registration_client_uri"]
-      registration_access_token = registration_info["registration_access_token"]
-    end
-
-    oidc_provider.update(
+    create(
+      display_name:,
       url:,
       client_id:,
       client_secret:,
@@ -67,8 +45,6 @@ class OidcProvider < Sequel::Model
       userinfo_endpoint:,
       jwks_uri:,
       group_prefix:,
-      registration_client_uri:,
-      registration_access_token:,
     )
   end
 

--- a/spec/model/oidc_provider_spec.rb
+++ b/spec/model/oidc_provider_spec.rb
@@ -5,7 +5,6 @@ require_relative "spec_helper"
 RSpec.describe OidcProvider do
   let(:registration_body) do
     {
-      registration_endpoint: "https://example.com/register",
       issuer: "https://host/issuer",
       authorization_endpoint: "https://host/auth",
       token_endpoint: "https://host/tok",
@@ -29,31 +28,10 @@ RSpec.describe OidcProvider do
     expect(described_class.name_for_ubid(provider.ubid)).to eq "TestOIDC"
   end
 
-  [true, false].each do |with_group_prefix|
-    it ".register registers a new provider#{" with group prefix" if with_group_prefix}" do
-      stub_request(:get, "https://example.com/.well-known/openid-configuration").to_return(status: 200, body: registration_body)
-      scopes = "openid email"
-      if with_group_prefix
-        scopes += " groups"
-        group_prefix = "foo-"
-      end
-
-      request_body = {
-        client_name: "Ubicloud",
-        redirect_uris: ["#{Config.base_url}/auth/0pk8pg19vxe24gbdms7hmw780h/callback"],
-        scopes:,
-      }.to_json
-      response_body = {
-        client_id: "123",
-        client_secret: "456",
-        registration_client_uri: "https://host/rc",
-        registration_access_token: "789",
-      }.to_json
-      stub_request(:post, "https://example.com/register").with(body: request_body).to_return(status: 201, body: response_body)
-
-      expect(described_class).to receive(:generate_uuid).and_return("9a2d00a7-7d70-8816-82db-4c9e34e1d008")
-      oidc_provider = described_class.register("Test", "https://example.com", group_prefix:)
-      expect(described_class.all).to eq [oidc_provider]
+  it ".register registers a new provider with given client_id and client_secret" do
+    stub_request(:get, "https://example.com/.well-known/openid-configuration").to_return(status: 200, body: registration_body)
+    %w[https://example.com/.well-known/openid-configuration https://example.com].each do |url|
+      oidc_provider = described_class.register("Test", url, client_id: "123", client_secret: "456")
       expect(oidc_provider.url).to eq "https://host/issuer"
       expect(oidc_provider.client_id).to eq "123"
       expect(oidc_provider.client_secret).to eq "456"
@@ -61,43 +39,9 @@ RSpec.describe OidcProvider do
       expect(oidc_provider.token_endpoint).to eq "/tok"
       expect(oidc_provider.userinfo_endpoint).to eq "/ui"
       expect(oidc_provider.jwks_uri).to eq "https://host/jw"
-      expect(oidc_provider.registration_client_uri).to eq "https://host/rc"
-      expect(oidc_provider.registration_access_token).to eq "789"
-      if group_prefix
-        expect(oidc_provider.group_prefix).to eq "foo-"
-      else
-        expect(oidc_provider.group_prefix).to be_nil
-      end
+      expect(oidc_provider.registration_client_uri).to be_nil
+      expect(oidc_provider.registration_access_token).to be_nil
     end
-  end
-
-  it ".register registers a new provider with given client_id and client_secret" do
-    stub_request(:get, "https://example.com/.well-known/openid-configuration").to_return(status: 200, body: registration_body)
-    expect(described_class).to receive(:generate_uuid).and_return("9a2d00a7-7d70-8816-82db-4c9e34e1d008")
-    oidc_provider = described_class.register("Test", "https://example.com/.well-known/openid-configuration", client_id: "123", client_secret: "456")
-    expect(described_class.all).to eq [oidc_provider]
-    expect(oidc_provider.url).to eq "https://host/issuer"
-    expect(oidc_provider.client_id).to eq "123"
-    expect(oidc_provider.client_secret).to eq "456"
-    expect(oidc_provider.authorization_endpoint).to eq "/auth"
-    expect(oidc_provider.token_endpoint).to eq "/tok"
-    expect(oidc_provider.userinfo_endpoint).to eq "/ui"
-    expect(oidc_provider.jwks_uri).to eq "https://host/jw"
-    expect(oidc_provider.registration_client_uri).to be_nil
-    expect(oidc_provider.registration_access_token).to be_nil
-  end
-
-  it ".register handles errors registering a new provider" do
-    stub_request(:get, "https://example.com/.well-known/openid-configuration").to_return(status: 200, body: registration_body)
-
-    body = {
-      client_name: "Ubicloud",
-      redirect_uris: ["#{Config.base_url}/auth/0pk8pg19vxe24gbdms7hmw780h/callback"],
-      scopes: "openid email",
-    }.to_json
-    stub_request(:post, "https://example.com/register").with(body:).to_return(status: 403, body: {error: "bad"}.to_json)
-
-    expect(described_class).to receive(:generate_uuid).and_return("9a2d00a7-7d70-8816-82db-4c9e34e1d008")
-    expect { described_class.register("Test", "https://example.com") }.to raise_error(RuntimeError, 'Unable to register with oidc provider: 403 {"error" => "bad"}')
+    expect(described_class.count).to eq 2
   end
 end


### PR DESCRIPTION
When I originally designed the OIDC support, I was not aware that OIDC client registration is uncommon. For good reasons, most OIDC providers do not allow automatic client registration, and instead expect that the user will create the client account, and provide the client id and secret to the client (Ubicloud is the client in this case). This is better because it allows the user of the provider control over which clients are allowed to authenticate.

Make the OidcProvider.register client_id and client_secret arguments required, remove the client registration support, and simplify the related code and specs.