### PR TITLE
Fix regen-screenshots

### DIFF
--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -543,8 +543,9 @@ class RegenScreenshots
     end
     screenshot "managed-postgresql/settings-screenshot.png"
 
+    # An empty cluster list renders the creation form directly, so clicking
+    # "Kubernetes" already lands on it.
     click_link "Kubernetes"
-    click_link "Create Kubernetes Cluster"
 
     fill_in "Cluster Name", with: "kubernetes-demo"
     find('input[name="cp_nodes"][value="3"]:not([disabled])').trigger("click")

--- a/bin/regen-screenshots
+++ b/bin/regen-screenshots
@@ -276,6 +276,7 @@ class RegenScreenshots
       vm_id: vm_metrics.id,
       cert: "cert-data",
       cert_key: "cert-key-data",
+      is_representative: true,
     )
 
     # Mock the VictoriaMetrics client to return realistic-looking sample data. Each metric


### PR DESCRIPTION
### Mark demo VictoriaMetrics server representative in regen-screenshots

We were getting "undefined method 'query_range' for an instance of VictoriaMetrics::TeeClient" (and a follow-on Capybara "Unable to find link Connection") when running bin/regen-screenshots. This commit fixes it.

The demo VictoriaMetricsServer is created without is_representative. Since cf106297b ("Add dual-write tee client for VictoriaMetrics resources with multiple servers"), client_for_project resolves the primary client from representative_server (which is now nil) and builds a TeeClient wrapping a nil primary, so query_range has nothing to delegate to.

Create the demo server with is_representative: true so client_for_project returns the (mocked) representative client directly, as it would for a normal single-server resource.

### Don't click Create Kubernetes Cluster in regen-screenshots 

We were getting Unable to find link "Create Kubernetes Cluster" (Capybara::ElementNotFound) when running bin/regen-screenshots. This commit fixes it.

Since e7c8afa ("Render the k8s creation form on an empty cluster list"), the kubernetes-cluster list route renders the creation form directly when the project has no clusters and the user can create one. So clicking "Kubernetes" already lands on the form, and there is no "Create Kubernetes Cluster" link to click.

Drop the extra click; the demo project has no clusters at this point, so the creation form is already shown.