### PR TITLE
Use 400 response instead of 500 for an uploaded file

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -249,7 +249,7 @@ class Clover < Roda
     end
 
     case e
-    when Sequel::ValidationFailed, Roda::RodaPlugins::InvalidRequestBody::Error, Roda::RodaPlugins::TypecastParams::Error
+    when Sequel::ValidationFailed, Roda::RodaPlugins::InvalidRequestBody::Error, Roda::RodaPlugins::TypecastParams::Error, Roda::RodaPlugins::DisallowFileUploads::Error
       code = 400
       type = "InvalidRequest"
       message = e.to_s


### PR DESCRIPTION
Avoids a production exception.