### PR TITLE
Include request information when emitting a route exception message

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -284,11 +284,11 @@ class Clover < Roda
       code = 500
       type = "InternalServerError"
       message = "There was a temporary error attempting to make this change, please try again."
-      Clog.emit("route exception", Util.exception_to_hash(e))
+      Clog.emit("route exception", Util.exception_to_hash(e, into: {request: request.inspect}))
     else
       raise e if Config.test? && e.message != "test error"
 
-      Clog.emit("route exception", Util.exception_to_hash(e))
+      Clog.emit("route exception", Util.exception_to_hash(e, into: {request: request.inspect}))
 
       code = 500
       type = "UnexpectedError"

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -137,7 +137,7 @@ class CloverAdmin < Roda
     @page_title = if e.is_a?(CloverError)
       "#{e.type}: #{e.message}"
     else
-      Clog.emit("admin route exception", Util.exception_to_hash(e))
+      Clog.emit("admin route exception", Util.exception_to_hash(e, into: {request: request.inspect}))
       "Internal Server Error"
     end
     view(content: "")


### PR DESCRIPTION
This makes debugging easier.