### PR TITLE
Add an admin page for presigned certs

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1864,6 +1864,22 @@ class CloverAdmin < Roda
       r.redirect "/admin-list"
     end
 
+    r.get "presigned-certs" do
+      @rows = %i[presigned_postgres_cert presigned_load_balancer_cert].freeze.map do |table|
+        row = DB[table].select do
+          [
+            count.function.*.as(:count),
+            min(:created_at).as(:min_created_at),
+            max(:created_at).as(:max_created_at),
+          ]
+        end.single_record
+
+        {table:, **row}
+      end
+
+      view("presigned_certs")
+    end
+
     r.get "search" do
       @query = typecast_params.str!("q")
       prefix, term = @query.split(":", 2)

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1523,6 +1523,42 @@ RSpec.describe CloverAdmin do
     expect(downloaded_names).to eq %w[github-ubuntu-2204 github-ubuntu-2404].freeze
   end
 
+  it "shows information on presigned certs" do
+    click_link "Presigned Certs Info"
+    expect(page.title).to eq "Ubicloud Admin - Presigned Certs"
+
+    expect(page.all("table.presigned-certs tbody td").map(&:text)).to eq [
+      "presigned_postgres_cert", "0", "", "",
+      "presigned_load_balancer_cert", "0", "", "",
+    ]
+
+    t1 = Time.local(2026, 8, 13, 12)
+    DB[:presigned_postgres_cert].insert(
+      postgres_resource_id: PostgresResource.generate_uuid,
+      cert_id: Cert.create(hostname: "test.example.com").id,
+      created_at: t1,
+    )
+
+    page.refresh
+    expect(page.all("table.presigned-certs tbody td").map(&:text)).to eq [
+      "presigned_postgres_cert", "1", t1.to_s, t1.to_s,
+      "presigned_load_balancer_cert", "0", "", "",
+    ]
+
+    t2 = Time.local(2026, 8, 14, 12)
+    DB[:presigned_postgres_cert].insert(
+      postgres_resource_id: PostgresResource.generate_uuid,
+      cert_id: Cert.create(hostname: "test.example.com").id,
+      created_at: t2,
+    )
+
+    page.refresh
+    expect(page.all("table.presigned-certs tbody td").map(&:text)).to eq [
+      "presigned_postgres_cert", "2", t1.to_s, t2.to_s,
+      "presigned_load_balancer_cert", "0", "", "",
+    ]
+  end
+
   it "supports force creating a VM on a VmHost" do
     vmh = create_vm_host
     BootImage.create(vm_host_id: vmh.id, name: "ubuntu-jammy", version: "1", size_gib: 14, activated_at: Time.now)

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -59,6 +59,7 @@
       <a href="/authentication-audit-log">View Authentication Audit Logs</a> |
       <a href="/authentication-audit-log/admin">View Admin Authentication Audit Logs</a>
     </li>
+    <li><a href="/presigned-certs">Presigned Certs Info</a></li>
     <li><a href="/rollouts">Manage Rollouts</a></li>
     <li><a href="/remove-boot-images">Remove Boot Images</a></li>
     <li><a href="/kubernetes-node-image">Build Kubernetes Node Image</a></li>

--- a/views/admin/presigned_certs.erb
+++ b/views/admin/presigned_certs.erb
@@ -1,0 +1,3 @@
+<% @page_title = "Presigned Certs" %>
+
+<%== part("components/table", title: "Presigned Certs", table_class: "presigned-certs", data: @rows) %>


### PR DESCRIPTION
This allows viewing count and created at min/max information. This can give a decent indication for whether the pool size is rightly sized.