### PR TITLE
Allow configure_logs rollouts for Postgres servers

### DIFF
--- a/prog/rollout_semaphore.rb
+++ b/prog/rollout_semaphore.rb
@@ -10,7 +10,7 @@ class Prog::RolloutSemaphore < Prog::Base
     LoadBalancer => [:rewrite_dns_records, :refresh_cert, :update_load_balancer],
     Page => [:resolve, :retrigger],
     PostgresResource => [:refresh_dns_record, :refresh_certificates],
-    PostgresServer => [:install_rhizome, :configure, :configure_metrics, :refresh_walg_credentials],
+    PostgresServer => [:install_rhizome, :configure, :configure_logs, :configure_metrics, :refresh_walg_credentials],
     Vm => [:update_firewall_rules, :restart],
     VmHost => [:patch],
   }.freeze.each_value(&:freeze)


### PR DESCRIPTION
The fleet rollout for the collector auth stream (#6108) increments `configure_logs` on every AWS server after `install_rhizome` completes, but the admin panel's rollout prog did not allow-list that semaphore for `PostgresServer`, so the second step could not be started from it.

One line: `:configure_logs` joins the allowlist; the admin panel options build from the same constant. For the rollout itself, `wait: "wait"` gives the per-server ordering #6108 requires: each server's `configure_logs` fires only after the previous one is consumed and its strand is back at `wait`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)