### PR TITLE
Only show the applicable allocation state action for VmHosts

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -395,13 +395,17 @@ class CloverAdmin < Roda
     end
   end
 
-  ObjectAction = Data.define(:label, :flash, :params, :type, :action, :pass_request) do
-    def self.define(label, flash: nil, params: {}, type: :normal, pass_request: false, &action)
-      new(label, flash, params.dup.freeze, type, action, pass_request)
+  ObjectAction = Data.define(:label, :flash, :params, :type, :action, :pass_request, :allow_if) do
+    def self.define(label, flash: nil, params: {}, type: :normal, pass_request: false, allow_if: nil, &action)
+      new(label, flash, params.dup.freeze, type, action, pass_request, allow_if)
     end
 
     def call(...)
       action.call(...)
+    end
+
+    def allow?(obj)
+      allow_if.nil? || allow_if.call(obj)
     end
   end
 
@@ -442,6 +446,10 @@ class CloverAdmin < Roda
 
     def pass_request!
       @opts[:pass_request] = true
+    end
+
+    def allow_if(&block)
+      @opts[:allow_if] = block
     end
   end
 
@@ -767,6 +775,7 @@ class CloverAdmin < Roda
     model VmHost do
       action "accept", "Move to Accepting" do
         flash "Host allocation state changed to accepting"
+        allow_if { it.allocation_state != "accepting" }
         run do |obj|
           obj.update(allocation_state: "accepting")
         end
@@ -774,6 +783,7 @@ class CloverAdmin < Roda
 
       action "drain", "Move to Draining" do
         flash "Host allocation state changed to draining"
+        allow_if { it.allocation_state != "draining" }
         run do |obj|
           obj.update(allocation_state: "draining")
         end
@@ -1385,6 +1395,8 @@ class CloverAdmin < Roda
         if (actions = OBJECT_ACTIONS[@obj.class.name])
           r.is actions.keys do |key|
             action = actions[key]
+            next unless action.allow?(@obj)
+
             action_type = action.type
             @label = action.label
             @params = action.params

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1367,12 +1367,29 @@ RSpec.describe CloverAdmin do
     expect(page).to have_flash_notice("Host allocation state changed to draining")
     expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
     expect(vmh.reload.allocation_state).to eq "draining"
+    expect(find_by_id("action-list").all("a").map(&:text)).to eq ["Move to Accepting", "Hardware Reset", "Reboot", "Power On", "Power Status", "Move to Location", "Force Create VM"]
 
     click_link "Move to Accepting"
     click_button "Move to Accepting"
     expect(page).to have_flash_notice("Host allocation state changed to accepting")
     expect(page.title).to eq "Ubicloud Admin - VmHost #{vmh.ubid}"
     expect(vmh.reload.allocation_state).to eq "accepting"
+    expect(find_by_id("action-list").all("a").map(&:text)).to eq ["Move to Draining", "Hardware Reset", "Reboot", "Power On", "Power Status", "Move to Location", "Force Create VM"]
+  end
+
+  it "does not allow moving a VmHost to the allocation state it already has" do
+    vmh = Prog::Vm::HostNexus.assemble("127.0.0.2").subject
+    vmh.update(allocation_state: "draining")
+    visit "/model/VmHost/#{vmh.ubid}/accept"
+    vmh.update(allocation_state: "accepting")
+
+    dont_raise_admin_errors do
+      click_button "Move to Accepting"
+      expect(page.title).to eq "Ubicloud Admin - File Not Found"
+
+      visit "/model/VmHost/#{vmh.ubid}/accept"
+      expect(page.title).to eq "Ubicloud Admin - File Not Found"
+    end
   end
 
   it "supports rebooting VmHosts" do

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -27,6 +27,8 @@
   <div id="action-list">
     Actions:
     <% actions.each do |key, action| %>
+      <% next unless action.allow?(@obj) %>
+
       <% if action.type == :form %>
         <%== form({action: "/model/#{@obj.class.name}/#{@obj.ubid}/#{key}", method: :post}, button: action.label) %>
       <% else %>


### PR DESCRIPTION
The VmHost admin panel rendered both "Move to Accepting" and "Move to Draining" regardless of the host's current allocation_state, so one of them was always a no-op.

Add an optional show_if predicate to ObjectAction and have the object view skip actions whose predicate returns false. The accept action is hidden for hosts already accepting, and drain for hosts already draining; unprepared hosts still offer both.