### PR TITLE
Drop the unix_device_list name-to-id migration

### DIFF
--- a/model/storage_device.rb
+++ b/model/storage_device.rb
@@ -7,10 +7,6 @@ class StorageDevice < Sequel::Model
 
   plugin ResourceMethods, etc_type: true
 
-  def migrate_device_name_to_device_id
-    update(unix_device_list: unix_device_list.map { |device_name| StorageDevice.convert_device_name_to_device_id(vm_host.sshable, device_name) })
-  end
-
   # We have both raided and non-raided servers, in non-raided servers, we can call blkid to get the uuid
   # but in the case of raided servers, all the underlying disk devices will be shown with the same uuid of the raid device
   # (/dev/md) so we end up with duplicate uuids for different ssd or nvme disks. so we won't use /dev/disk/by-uuid

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -395,11 +395,6 @@ class VmHost < Sequel::Model
   end
 
   def disk_device_ids
-    # we use this next line to migrate data from the old formatting (storing device names) to the new (storing id) so we trigger the convert
-    # whenever an element inside unix_device_list is not a SSD or NVMe id.
-    # SSD and NVMe ids start with wwn or nvme-eui respectively.
-    # YYY: This next line can be removed in the future after the first run of the code.
-    storage_devices.each { |sd| sd.migrate_device_name_to_device_id if sd.unix_device_list.any? { |device_name| device_name !~ /\A(wwn|nvme-eui)/i } }
     storage_devices.flat_map { |sd| sd.unix_device_list }
   end
 

--- a/spec/model/storage_device_spec.rb
+++ b/spec/model/storage_device_spec.rb
@@ -3,34 +3,22 @@
 require_relative "spec_helper"
 
 RSpec.describe StorageDevice do
-  describe "#migrate_device_name_to_device_id" do
-    context "when finding the disk id from device_name for SSD disks" do
-      it "changes the unix_device_list to the device id and saves changes" do
-        storage_device = described_class.create(vm_host_id: create_vm_host.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["sda"])
-
-        expect(storage_device.vm_host.sshable).to receive(:_cmd).with("ls -l /dev/disk/by-id/ | grep sda\\$ | grep 'wwn-' | sed -E 's/.*(wwn[^ ]*).*/\\1/'").and_return("wwn-random-id")
-        expect(storage_device).to receive(:save_changes)
-        storage_device.migrate_device_name_to_device_id
-        expect(storage_device.unix_device_list).to(eq(["wwn-random-id"]))
-      end
+  describe ".convert_device_name_to_device_id" do
+    it "returns the wwn id for SSD disks" do
+      sshable = Sshable.create(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
+      expect(sshable).to receive(:_cmd).with("ls -l /dev/disk/by-id/ | grep sda\\$ | grep 'wwn-' | sed -E 's/.*(wwn[^ ]*).*/\\1/'").and_return("wwn-random-id")
+      expect(described_class.convert_device_name_to_device_id(sshable, "sda")).to eq("wwn-random-id")
     end
 
-    context "when finding the disk id from device_name for NVMe disks" do
-      it "changes the unix_device_list to the device id and saves changes" do
-        storage_device = described_class.create(vm_host_id: create_vm_host.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["nvme0n1"])
-
-        expect(storage_device.vm_host.sshable).to receive(:_cmd).with("ls -l /dev/disk/by-id/ | grep nvme0n1\\$ | grep 'nvme-eui' | sed -E 's/.*(nvme-eui[^ ]*).*/\\1/'").and_return("nvme-eui.random-id")
-        expect(storage_device).to receive(:save_changes)
-        storage_device.migrate_device_name_to_device_id
-        expect(storage_device.unix_device_list).to(eq(["nvme-eui.random-id"]))
-      end
+    it "returns the nvme-eui id for NVMe disks" do
+      sshable = Sshable.create(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
+      expect(sshable).to receive(:_cmd).with("ls -l /dev/disk/by-id/ | grep nvme0n1\\$ | grep 'nvme-eui' | sed -E 's/.*(nvme-eui[^ ]*).*/\\1/'").and_return("nvme-eui.random-id")
+      expect(described_class.convert_device_name_to_device_id(sshable, "nvme0n1")).to eq("nvme-eui.random-id")
     end
 
-    context "when converting device name to device id on non ssd or nvme disks" do
-      it "returns the device_name unchanged" do
-        sshable = Sshable.create(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
-        expect(described_class.convert_device_name_to_device_id(sshable, "qwer")).to equal("qwer")
-      end
+    it "returns the device_name unchanged for other disks" do
+      sshable = Sshable.create(host: "test.localhost", raw_private_key_1: SshKey.generate.keypair)
+      expect(described_class.convert_device_name_to_device_id(sshable, "qwer")).to eq("qwer")
     end
   end
 

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -456,18 +456,6 @@ RSpec.describe VmHost do
       StorageDevice.create(vm_host_id: vm_host.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["wwn-random-id1", "wwn-random-id2"])
       expect(vm_host.disk_device_ids).to eq(["wwn-random-id1", "wwn-random-id2"])
     end
-
-    it "converts disk devices when StorageDevice has unix_device_list with the old formatting for SSD disks" do
-      StorageDevice.create(vm_host_id: vm_host.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["sda"])
-      expect(vm_host.sshable).to receive(:_cmd).with("ls -l /dev/disk/by-id/ | grep sda\\$ | grep 'wwn-' | sed -E 's/.*(wwn[^ ]*).*/\\1/'").and_return("wwn-random-id1")
-      expect(vm_host.disk_device_ids).to eq(["wwn-random-id1"])
-    end
-
-    it "converts disk devices when StorageDevice has unix_device_list with the old formatting for NVMe disks" do
-      StorageDevice.create(vm_host_id: vm_host.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["nvme0n1"])
-      expect(vm_host.sshable).to receive(:_cmd).with("ls -l /dev/disk/by-id/ | grep nvme0n1\\$ | grep 'nvme-eui' | sed -E 's/.*(nvme-eui[^ ]*).*/\\1/'").and_return("nvme-eui.random-id")
-      expect(vm_host.disk_device_ids).to eq(["nvme-eui.random-id"])
-    end
   end
 
   describe "#disk_device_names" do


### PR DESCRIPTION
The migration ran on every vm_host long ago; all storage_device rows already store wwn or nvme-eui ids, so disk_device_ids no longer needs to convert on read. StorageDevice#migrate_device_name_to_device_id had no other caller and goes with it, while convert_device_name_to_device_id stays for LearnStorage.