### PR TITLE
Fix moving VMs which were migrated from SPDK

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -248,7 +248,7 @@ jobs:
         SMTP_TLS: false
         STRIPE_PUBLIC_KEY: ${{ secrets.STRIPE_PUBLIC_KEY }}
         STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-        VHOST_BLOCK_BACKEND_VERSION: v0.5.0
+        VHOST_BLOCK_BACKEND_VERSION: v0.5.1
         OPERATOR_SSH_PUBLIC_KEYS: ${{ secrets.OPERATOR_SSH_PUBLIC_KEYS }}
       run: |
         set -o pipefail

--- a/model/metal/vm.rb
+++ b/model/metal/vm.rb
@@ -168,6 +168,9 @@ class Vm < Sequel::Model
         "psk_identity" => server.psk_identity,
         "encrypted_psk" => sv.key_encryption_key_1.encrypt(Base64.decode64(server.psk), "remote-psk"),
         "autofetch" => true,
+        # Size the target's disk.raw from the source's actual byte size so an
+        # oversized source (e.g. an SPDK-migrated disk.raw) is carried forward.
+        "disk_size_bytes" => server.source_disk_file_size,
       }
     end
 

--- a/model/remote_storage_server.rb
+++ b/model/remote_storage_server.rb
@@ -23,6 +23,13 @@ class RemoteStorageServer < Sequel::Model
   def address
     "#{vm_host.sshable.host}:#{port}"
   end
+
+  # Byte size of the source volume's disk.raw, read live over SSH, so a MoveVm
+  # target can size its own disk.raw to hold a (possibly oversized) source.
+  def source_disk_file_size
+    disk_file = File.join(source_vm_storage_volume.path, "disk.raw")
+    Integer(vm_host.sshable.cmd("sudo stat -c %s :disk_file", disk_file:).strip, 10)
+  end
 end
 
 # Table: remote_storage_server

--- a/prog/storage/remote_storage_server/nexus.rb
+++ b/prog/storage/remote_storage_server/nexus.rb
@@ -12,7 +12,7 @@ class Prog::Storage::RemoteStorageServer::Nexus < Prog::Base
 
   # The server always runs the remote-stripe-server binary, which can
   # serve volumes created by older backends.
-  SERVER_VERSION_CODE = 500
+  SERVER_VERSION_CODE = 501
 
   # Given the volume to serve, figure out its host, pick a free port on that
   # host, create a PSK, and start the server.
@@ -23,7 +23,7 @@ class Prog::Storage::RemoteStorageServer::Nexus < Prog::Base
     vm = source_volume.vm
     vm_host = vm.vm_host
     fail "VM isn't in stopped_by_admin state" unless vm.strand.label == "stopped_by_admin"
-    fail "Host doesn't have ubiblk v0.5.0+" if vm_host.vhost_block_backends_dataset.where { version_code >= SERVER_VERSION_CODE }.empty?
+    fail "Host doesn't have ubiblk v0.5.1+" if vm_host.vhost_block_backends_dataset.where { version_code >= SERVER_VERSION_CODE }.empty?
 
     DB.transaction do
       port = free_port(vm_host.id)

--- a/prog/storage/setup_vhost_block_backend.rb
+++ b/prog/storage/setup_vhost_block_backend.rb
@@ -6,8 +6,8 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
   frame_accessor :vhost_block_backend_id
 
   SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS = [
-    ["v0.5.0", "x64"],
-    ["v0.5.0", "arm64"],
+    ["v0.5.1", "x64"],
+    ["v0.5.1", "arm64"],
     ["v0.4.2", "x64"],
     ["v0.4.2", "arm64"],
     ["v0.3.1", "x64"],

--- a/prog/test/move_vm.rb
+++ b/prog/test/move_vm.rb
@@ -13,7 +13,7 @@ class Prog::Test::MoveVm < Prog::Test::Base
       project_id ||= Project.create(name: "move-vm-test").id
 
       if vm_host.vhost_block_backends_dataset.where { version_code >= 500 }.empty?
-        Prog::Storage::SetupVhostBlockBackend.assemble(VmHost.first.id, "v0.5.0", allocation_weight: 100)
+        Prog::Storage::SetupVhostBlockBackend.assemble(VmHost.first.id, "v0.5.1", allocation_weight: 100)
       end
 
       vm_st = Prog::Vm::Nexus.assemble_with_sshable(

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -229,13 +229,13 @@ class Prog::Vm::Metal::Nexus < Prog::Base
         amount: vm.vcpus,
       )
 
-      vm.storage_volumes.each do |vol|
+      vm.vm_storage_volumes.each do |vol|
         BillingRecord.create(
           project_id: project.id,
           resource_id: vm.id,
-          resource_name: "Disk ##{vol["disk_index"]} of #{vm.name}",
+          resource_name: "Disk ##{vol.disk_index} of #{vm.name}",
           billing_rate_id: BillingRate.from_resource_properties("VmStorage", vm.family, vm.location.name)["id"],
-          amount: vol["size_gib"],
+          amount: vol.size_gib,
         )
       end
 

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -80,7 +80,7 @@ class StorageVolume
     encryption_key = generate_data_encryption_key
 
     if @vhost_backend_version
-      create_empty_disk_file
+      create_empty_disk_file(disk_size_mib: vhost_backend_disk_size_mib)
       prep_vhost_backend(encryption_key, key_wrapping_secrets)
       return
     end
@@ -652,6 +652,19 @@ class StorageVolume
     create_empty_disk_file(disk_size_mib: @disk_size_gib * 1024 + 16)
     # just clear the metadata section, i.e. first 8MB
     encrypted_image_copy(encryption_key, "/dev/zero", block_size: 2097152, count: 4)
+  end
+
+  # Size (MiB) of a vhost-backend disk.raw: the requested size_gib, or the source
+  # volume's actual disk.raw size when moving (remote_source["disk_size_bytes"]),
+  # whichever is larger.
+  def vhost_backend_disk_size_mib
+    nominal_mib = @disk_size_gib * 1024
+    source_bytes = @remote_source && @remote_source["disk_size_bytes"]
+    return nominal_mib unless source_bytes
+
+    mib = 1024 * 1024
+    source_mib = (source_bytes + mib - 1) / mib # round up to whole MiB
+    [nominal_mib, source_mib].max
   end
 
   def create_empty_disk_file(disk_size_mib: @disk_size_gib * 1024)

--- a/rhizome/host/lib/vhost_block_backend.rb
+++ b/rhizome/host/lib/vhost_block_backend.rb
@@ -6,8 +6,8 @@ require_relative "../../common/lib/util"
 
 class VhostBlockBackend
   SHA256_BY_VERSION_AND_ARCH = {
-    ["v0.5.0", :x64] => "66de621c2eaf31577232b69438ec05d2c0a29225f7027ceff48c4d5548cd7d1f",
-    ["v0.5.0", :arm64] => "c201909408b634a271313af85238d04ad9f5e5f249817b7c08bbd807ab2524dd",
+    ["v0.5.1", :x64] => "7b82f4769a7ee52b1fa71d17f12dbe02a4795e4bdb5e8fe4cea98bb3a7913972",
+    ["v0.5.1", :arm64] => "f538c4ee0618274a738d5cb3695c720004a46d3edef89bce6c17a0a0df12b719",
     ["v0.4.2", :x64] => "e7e430f2e722a2d5d7c18a4f609360e003798d481e26da6db380e698ccb079eb",
     ["v0.4.2", :arm64] => "ada92fe076e49f731f5d343d445b1e80d7685b811c33cde7fe88918e93649093",
     ["v0.3.1", :x64] => "3b4a6d3387a8da7c914d85203955c0a879168518aed76679a334070403630262",

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -346,6 +346,50 @@ RSpec.describe StorageVolume do
     end
   end
 
+  describe "#vhost_backend_disk_size_mib" do
+    def remote_source_sv(remote_source)
+      described_class.new("test", {
+        "disk_index" => 2,
+        "device_id" => "xyz01",
+        "encrypted" => true,
+        "size_gib" => 40,
+        "vhost_block_backend_version" => "v0.4.2",
+        "remote_source" => {
+          "address" => "10.0.0.5:4600", "psk_identity" => "id", "encrypted_psk" => "p",
+        }.merge(remote_source),
+      })
+    end
+
+    it "uses the requested size for a locally-sourced vhost volume" do
+      expect(encrypted_vhost_sv.vhost_backend_disk_size_mib).to eq(12 * 1024)
+    end
+
+    it "sizes the target to an oversized (e.g. SPDK-migrated) source's disk.raw" do
+      # A 40 GiB SPDK-migrated source keeps 8 MiB of former bdev_ubi metadata.
+      bytes = (40 * 1024 + 8) * 1024 * 1024
+      expect(remote_source_sv("disk_size_bytes" => bytes).vhost_backend_disk_size_mib).to eq(40 * 1024 + 8)
+    end
+
+    it "uses the requested size when the source disk.raw matches size_gib" do
+      bytes = 40 * 1024 * 1024 * 1024
+      expect(remote_source_sv("disk_size_bytes" => bytes).vhost_backend_disk_size_mib).to eq(40 * 1024)
+    end
+
+    it "never shrinks below the requested size" do
+      bytes = 10 * 1024 * 1024 * 1024
+      expect(remote_source_sv("disk_size_bytes" => bytes).vhost_backend_disk_size_mib).to eq(40 * 1024)
+    end
+
+    it "rounds a non-MiB-aligned source size up to whole MiB" do
+      bytes = (40 * 1024 + 1) * 1024 * 1024 + 1
+      expect(remote_source_sv("disk_size_bytes" => bytes).vhost_backend_disk_size_mib).to eq(40 * 1024 + 2)
+    end
+
+    it "falls back to the requested size when the source size is unknown" do
+      expect(remote_source_sv({}).vhost_backend_disk_size_mib).to eq(40 * 1024)
+    end
+  end
+
   describe "#set_disk_file_permissions" do
     it "can set disk file permissions" do
       expect(FileUtils).to receive(:chown).with("test", "test", disk_file)

--- a/spec/model/remote_storage_server_spec.rb
+++ b/spec/model/remote_storage_server_spec.rb
@@ -31,4 +31,10 @@ RSpec.describe RemoteStorageServer do
   it "builds the client-facing address from the host and port" do
     expect(rss.address).to end_with(":5500")
   end
+
+  it "reads the source volume's disk.raw byte size over ssh" do
+    expected_disk_file = File.join(source_volume.path, "disk.raw")
+    expect(rss.vm_host.sshable).to receive(:_cmd).with("sudo stat -c %s #{expected_disk_file}").and_return("42949672960\n")
+    expect(rss.source_disk_file_size).to eq(42949672960)
+  end
 end

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -461,6 +461,9 @@ RSpec.describe Vm do
         psk_identity: "ubiblk-rss", port: 4600,
       )
       VmStorageVolume.where(vm_id: vm.id, disk_index: 0).update(remote_storage_server_id: rss.id, boot_image_id: nil)
+      source_disk_size = 40 * 1024 * 1024 * 1024 + 8 * 1024 * 1024
+      source_sshable = vm.vm_storage_volumes.find { |s| s.disk_index == 0 }.remote_storage_server.vm_host.sshable
+      expect(source_sshable).to receive(:_cmd).with("sudo stat -c %s #{File.join(source_volume.path, "disk.raw")}").and_return("#{source_disk_size}\n")
 
       volumes = vm.storage_volumes
 
@@ -470,6 +473,7 @@ RSpec.describe Vm do
       expect(src["psk_identity"]).to eq("ubiblk-rss")
       expect(src).to have_key("encrypted_psk")
       expect(src["autofetch"]).to be(true)
+      expect(src["disk_size_bytes"]).to eq(source_disk_size)
 
       expect(volumes[1]).not_to have_key("remote_source")
     end

--- a/spec/prog/storage/remote_storage_server/nexus_spec.rb
+++ b/spec/prog/storage/remote_storage_server/nexus_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Prog::Storage::RemoteStorageServer::Nexus do
   let(:source_vm) do
     vm = create_archive_ready_vm
     vm.strand.update(label: "stopped_by_admin")
-    VhostBlockBackend.create(version: "0.5.0", allocation_weight: 100, vm_host_id: vm.vm_host_id)
+    VhostBlockBackend.create(version: "0.5.1", allocation_weight: 100, vm_host_id: vm.vm_host_id)
     vm
   end
   let(:source_volume) { VmStorageVolume.first(vm_id: source_vm.id) }

--- a/spec/prog/test/move_vm_spec.rb
+++ b/spec/prog/test/move_vm_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Prog::Test::MoveVm do
 
     it "allows using an existing project, and not starting vhost_block_backend strand if host already has suitable one" do
       project_id = Project.create(name: "move-vm-test").id
-      VhostBlockBackend.create(version: "0.5.0", allocation_weight: 100, vm_host_id: vm_host.id)
+      VhostBlockBackend.create(version: "0.5.1", allocation_weight: 100, vm_host_id: vm_host.id)
 
       st = described_class.assemble(vm_host, project_id:)
       expect(st.prog).to eq("Test::MoveVm")
@@ -90,7 +90,7 @@ RSpec.describe Prog::Test::MoveVm do
       vm.incr_prepare_to_move
       vm.strand.update(label: "stopped_by_admin")
       vm.vm_host.update(total_cpus: 24)
-      VhostBlockBackend.create(version: "0.5.0", allocation_weight: 100, vm_host_id: vm.vm_host_id)
+      VhostBlockBackend.create(version: "0.5.1", allocation_weight: 100, vm_host_id: vm.vm_host_id)
       private_subnet = PrivateSubnet.create(name: "ps", location_id: Location::HETZNER_FSN1_ID, net6: "fd10:9b0b:6b4b:8fbb::/64",
         net4: "1.1.1.0/26", state: "waiting", project_id: vm.project_id)
       Nic.create(private_subnet_id: private_subnet.id, private_ipv6: "fd10:9b0b:6b4b:8fbb:abc::", private_ipv4: "10.0.0.1",

--- a/spec/prog/vm/metal/move_vm_spec.rb
+++ b/spec/prog/vm/metal/move_vm_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Prog::Vm::Metal::MoveVm do
 
     let(:source_host) {
       vm_host = create_vm_host(location_id: Location::HETZNER_FSN1_ID)
-      VhostBlockBackend.create(version: "0.5.0", allocation_weight: 100, vm_host_id: vm_host.id)
+      VhostBlockBackend.create(version: "0.5.1", allocation_weight: 100, vm_host_id: vm_host.id)
       vm_host
     }
 
@@ -172,7 +172,7 @@ RSpec.describe Prog::Vm::Metal::MoveVm do
 
     let(:target_host) {
       vm_host = create_vm_host(location_id: Location::HETZNER_FSN1_ID)
-      VhostBlockBackend.create(version: "0.5.0", allocation_weight: 100, vm_host_id: vm_host.id)
+      VhostBlockBackend.create(version: "0.5.1", allocation_weight: 100, vm_host_id: vm_host.id)
       vm_host
     }
 

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -1005,7 +1005,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       sv.update(machine_image_version_id: miv.id)
       rvm = create_vm(vm_host_id: vm.vm_host_id)
       Strand.create_with_id(rvm.id, prog: "Vm::Metal::Nexus", label: "stopped_by_admin")
-      VhostBlockBackend.create(version: "0.5.0", allocation_weight: 100, vm_host_id: vm.vm_host_id)
+      VhostBlockBackend.create(version: "0.5.1", allocation_weight: 100, vm_host_id: vm.vm_host_id)
       rsv = VmStorageVolume.create(vm_id: rvm.id, boot: false, size_gib: 15, disk_index: 0, use_bdev_ubi: false, storage_device_id: sv.storage_device_id, key_encryption_key_1_id: StorageKeyEncryptionKey.create_random(auth_data: "abcdef1234567890").id)
       rss = Prog::Storage::RemoteStorageServer::Nexus.assemble(rsv.id).subject
       VmStorageVolume.create(vm_id: vm.id, boot: false, size_gib: 15, disk_index: 2, use_bdev_ubi: false, storage_device_id: sv.storage_device_id, remote_storage_server_id: rss.id)
@@ -1137,7 +1137,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       rss_source_vm = create_vm(vm_host_id: target_host.id, name: "rss-source-vm")
       sd = StorageDevice.create(vm_host_id: target_host.id, name: "rss-sd", total_storage_gib: 10, available_storage_gib: 10)
       Strand.create_with_id(rss_source_vm.id, prog: "Vm::Metal::Nexus", label: "stopped_by_admin")
-      VhostBlockBackend.create(version: "0.5.0", allocation_weight: 100, vm_host_id: target_host.id)
+      VhostBlockBackend.create(version: "0.5.1", allocation_weight: 100, vm_host_id: target_host.id)
       rss_source_volume = VmStorageVolume.create(vm_id: rss_source_vm.id, boot: true, size_gib: 5, disk_index: 0, storage_device_id: sd.id,
         key_encryption_key_1_id: StorageKeyEncryptionKey.create_random(auth_data: "rss-src").id)
       rss = Prog::Storage::RemoteStorageServer::Nexus.assemble(rss_source_volume.id).subject

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1302,7 +1302,7 @@ RSpec.describe CloverAdmin do
       mac: "00:00:00:00:00:00", encryption_key: "0x736f6d655f656e6372797074696f6e5f6b6579", name: "old-vm-nic",
       vm_id: vm.id, state: "active")
     create_vm_host(location_id: Location::HETZNER_HEL1_ID)
-    VhostBlockBackend.create(version: "0.5.0", allocation_weight: 100, vm_host_id: vm.vm_host_id)
+    VhostBlockBackend.create(version: "0.5.1", allocation_weight: 100, vm_host_id: vm.vm_host_id)
 
     fill_in "UBID, UUID, or prefix:term", with: vm.ubid
     click_button "Show Object"

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -1051,11 +1051,11 @@ RSpec.describe Scheduling::Allocator do
     end
 
     it "allocates without boot image filter when using remote_storage_server_id" do
-      create_vhost_block_backend(vm_host_id: VmHost.first.id, version: "v0.5.0", allocation_weight: 100)
+      create_vhost_block_backend(vm_host_id: VmHost.first.id, version: "v0.5.1", allocation_weight: 100)
       vm = create_vm
       source_vm = create_archive_ready_vm(project_id: vm.project_id, name: "source-vm")
       source_vm.strand.update(label: "stopped_by_admin")
-      create_vhost_block_backend(vm_host_id: source_vm.vm_host_id, version: "v0.5.0", allocation_weight: 100)
+      create_vhost_block_backend(vm_host_id: source_vm.vm_host_id, version: "v0.5.1", allocation_weight: 100)
       VmHost.dataset.update(total_cpus: 96, total_cores: 96, used_cores: 2)
       rss = Prog::Storage::RemoteStorageServer::Nexus.assemble(source_vm.vm_storage_volumes.first.id).subject
       vol = [{


### PR DESCRIPTION
Summary:

1. SPDK VMs were 8M larger than the allocated size. When they were migrated to ubiblk, they retained the additional size. Before this error, moving such ubiblk VMs errored out because we tried to move 40G+8M to 40G. First commit fixes this by matching the target size to the source size.
2. Upgrade to ubiblk v0.5.1 for better performance & error handling. In one of the tests, boot time of moving from untracked source went from > 4min down to ~30s.

| # | Source | track_written | Target | Boot (s) | Catch-up (s) | Stripes fetched | 
|---|---------------------|---|--------|----------|--------------|--------------------------|
| 1 | v0.2.2, migrated from spdk | false | v0.5.0 | 261.8 | 267.5 | 40968 |
| 2 | v0.2.2, migrated from spdk | false | v0.5.1 | 31.7 | 70.2 | 40968 |
| 3 | v0.4.2 | true | v0.5.0 | 36.5 | 43.5 | 2586 |
| 4 | v0.4.2 | true | v0.5.1 | 29.1 | 34.7 | 2704 |

### Size MoveVm target from the source volume's actual disk size 

MoveVm sizes the fresh target's disk.raw at the nominal size_gib and streams the source into it. If the source disk.raw is larger than size_gib, the target's ubiblk backend rejects it at startup and the moved VM never boots:

>  Invalid parameter: Source stripe count 40968 exceeds metadata stripe
>  count 40960 (metadata_flusher.rs)

SPDK-migrated volumes trigger this. SPDK allocated disk.raw at size_gib + 16 MiB, of which bdev_ubi used only 8 MiB for metadata, so the volume's logical size ran 8 MiB (16 - 8) over the requested size_gib. Migrating to ubiblk preserves that, leaving 8 extra 1 MiB stripes (a 40 GiB volume is 40968 stripes, not 40960).

Fix: size the target's disk.raw to the source's actual disk.raw byte size. The control plane reads it over SSH (stat -c %s) and passes it as remote_source["disk_size_bytes"]; the host sizes the target to at least that, never below size_gib. This is version-independent and stays correct across repeated moves.

### Bill storage from vm_storage_volumes, not the prep descriptor 

create_billing_record only needs each volume's disk_index and size_gib, but it iterated Vm#storage_volumes, which builds the full prep descriptor. That descriptor's remote_source entry reads the source volume's disk.raw size live over SSH (for MoveVm target sizing).That SSH is avoided by iterating over the vm_storage_volumes records directly and reading the two fields off the model.

### Support ubiblk v0.5.1, drop v0.5.0, use it in E2E 

Add the v0.5.1 release (x64/arm64 SHA256 from the GitHub release) to VhostBlockBackend and the setup prog's supported versions, and drop v0.5.0 as an installable version. Make v0.5.1 the E2E version in e2e.yml and Prog::Test::MoveVm.

Highlights since v0.5.0:
- Remote stripe fetch performance: pull stripes over a pool of parallel  connections (new "connections" config option).
- Remote stripe fetch robustness: reconnect a worker on connection loss, reject  a reconnect if the server's metadata changed, terminate the session on any  error, and survive worker panics.
- Safety: make the vhost backend thread Send without unsafe, and replace  hand-rolled libc calls with nix safe wrappers (thread name, umask, core-dump  disable, eventfd pair).
- Dependencies: bump rust-vmm (vhost 0.17, vhost-user-backend 0.23,  vm-memory 0.18, virtio-queue 0.18, vmm-sys-util 0.15) and RustCrypto   (aes-gcm 0.11, sha2 0.11, hmac 0.13), plus assorted cargo-audit cleanups.