### PR TITLE
Improve k8s init cluster

### DIFF
--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -154,7 +154,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
     case state
     when "Succeeded"
       Page.from_tag_parts("KubernetesNodeInitClusterFailed", node.ubid)&.incr_resolve
-      hop_install_cni
+      hop_wait_api_server_lb
     when "NotStarted"
       params = {
         node_name: vm.name,
@@ -183,6 +183,13 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
       Clog.emit("got unknown state from daemonizer2 check: #{state}")
       nap 30
     end
+  end
+
+  label def wait_api_server_lb
+    kubernetes_cluster.client.kubectl("get --raw=/healthz")
+    hop_install_cni
+  rescue RuntimeError
+    nap 5
   end
 
   label def join_control_plane

--- a/rhizome/kubernetes/bin/init-cluster
+++ b/rhizome/kubernetes/bin/init-cluster
@@ -95,24 +95,11 @@ end
 puts r("sudo", "kubeadm", "init", "--config", config_path, "--node-name", node_name)
 r("sudo /home/ubi/kubernetes/bin/setup-cni")
 
-api_server_up = false
-20.times do
-  r("kubectl --kubeconfig=/etc/kubernetes/admin.conf get --raw='/healthz'")
-  api_server_up = true
-  break
-rescue CommandFail
-  puts "API server is not up yet, retrying in 5 seconds..."
-  sleep 5
-end
+kubectl = ["kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "--server", "https://#{node_ipv4}:6443"]
 
-unless api_server_up
-  puts "API server is not healthy. Could not create customer credentials."
-  exit 1
-end
-
-r "kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "create", "serviceaccount", service_account_name
-r "kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "create", "clusterrolebinding", "#{service_account_name}-binding", "--clusterrole=cluster-admin", "--serviceaccount=kube-system:#{service_account_name}"
-r "kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "apply", "-f", "-", stdin: <<~YAML
+r(*kubectl, "-n", "kube-system", "create", "serviceaccount", service_account_name)
+r(*kubectl, "-n", "kube-system", "create", "clusterrolebinding", "#{service_account_name}-binding", "--clusterrole=cluster-admin", "--serviceaccount=kube-system:#{service_account_name}")
+r(*kubectl, "apply", "-f", "-", stdin: <<~YAML)
   apiVersion: v1
   kind: Secret
   metadata:

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     it "resolves any open page and hops if the init_cluster script is successful" do
       Prog::PageNexus.assemble("existing", ["KubernetesNodeInitClusterFailed", prog.node.ubid], prog.node.ubid)
       expect(prog.vm.sshable).to receive(:d_check).with("init_kubernetes_cluster").and_return("Succeeded")
-      expect { prog.init_cluster }.to hop("install_cni")
+      expect { prog.init_cluster }.to hop("wait_api_server_lb")
       page = Page.from_tag_parts("KubernetesNodeInitClusterFailed", prog.node.ubid)
       expect(page.resolve_set?).to be true
     end
@@ -328,12 +328,30 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     it "hops if the init_cluster script is successful and no page exists" do
       expect(Page.from_tag_parts("KubernetesNodeInitClusterFailed", prog.node.ubid)).to be_nil
       expect(prog.vm.sshable).to receive(:d_check).with("init_kubernetes_cluster").and_return("Succeeded")
-      expect { prog.init_cluster }.to hop("install_cni")
+      expect { prog.init_cluster }.to hop("wait_api_server_lb")
     end
 
     it "naps if the daemonizer check returns something unknown" do
       expect(prog.vm.sshable).to receive(:d_check).with("init_kubernetes_cluster").and_return("Unknown")
       expect { prog.init_cluster }.to nap(30)
+    end
+  end
+
+  describe "#wait_api_server_lb" do
+    let(:session) { Net::SSH::Connection::Session.allocate }
+
+    before do
+      allow(kubernetes_cluster.sshable).to receive(:connect).and_return(session)
+    end
+
+    it "hops once the api server answers through the load balancer" do
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get --raw=/healthz").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("ok", 0))
+      expect { prog.wait_api_server_lb }.to hop("install_cni")
+    end
+
+    it "naps while the load balancer does not serve the api server yet" do
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get --raw=/healthz").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("couldn't get current server API group list: connection refused", 1))
+      expect { prog.wait_api_server_lb }.to nap(5)
     end
   end
 


### PR DESCRIPTION
**Wait for the api server load balancer after cluster init**
kubeadm writes the public control plane endpoint into admin.conf, so every kubectl after the init leaves the node and comes back through the api server load balancer. That load balancer only starts forwarding once the health probe flips the backend port to up, which happens after the init unit already finished, so the first node's csr approval could hit a port that nothing answers on.

Gate the rest of the provisioning on the api server answering through the load balancer.

**Address the local api server while initializing the cluster**
kubeadm writes the control plane endpoint into admin.conf, so the commands that create the customer credentials went out to the api server load balancer, which does not forward yet at that point. The retry loop around them was waiting for the load balancer rather than for the api server, and no retry budget covers that reliably.

kubeadm init only returns after the api server served its own writes, so the credentials can be created right away over the node's own api server address, which kubeadm puts in the serving certificate as the advertise address.