### PR TITLE
Verify the local api server after renewing the certs

### DIFF
--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -186,7 +186,7 @@ TIMER
       hop_wait
     when "NotStarted"
       kubernetes_node.update(state: "renewing_certs")
-      kubernetes_node.sshable.d_run("renew_certs", "/home/ubi/kubernetes/bin/renew-certs")
+      kubernetes_node.sshable.d_run("renew_certs", "/home/ubi/kubernetes/bin/renew-certs", stdin: JSON.generate({node_ipv4: kubernetes_node.vm.private_ipv4}))
       nap 30
     when "InProgress"
       nap 30

--- a/rhizome/kubernetes/bin/renew-certs
+++ b/rhizome/kubernetes/bin/renew-certs
@@ -1,7 +1,17 @@
 #!/bin/env ruby
 # frozen_string_literal: true
 
+require "json"
 require_relative "../../common/lib/util"
+
+params = JSON.parse($stdin.read)
+
+begin
+  node_ipv4 = params.fetch("node_ipv4")
+rescue KeyError => e
+  puts "Needed #{e.key} in parameters"
+  exit 1
+end
 
 r("sudo kubeadm certs renew all")
 
@@ -11,7 +21,7 @@ pod_ids = r("sudo crictl pods --namespace kube-system --name 'kube-apiserver-|ku
 r("sudo", "crictl", "stopp", *pod_ids) unless pod_ids.empty?
 
 30.times do
-  r("kubectl --kubeconfig=/etc/kubernetes/admin.conf get --raw='/healthz'")
+  r("kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "--server", "https://#{node_ipv4}:6443", "get", "--raw=/healthz")
   exit 0
 rescue CommandFail
   sleep 5

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
     it "starts the daemonizer, marks the node renewing_certs and naps when not started" do
       nx.incr_renew_certs
       expect(node_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check renew_certs").and_return("NotStarted")
-      expect(node_sshable).to receive(:_cmd).with("common/bin/daemonizer2 run renew_certs /home/ubi/kubernetes/bin/renew-certs", {log: true, stdin: nil})
+      expect(node_sshable).to receive(:_cmd).with("common/bin/daemonizer2 run renew_certs /home/ubi/kubernetes/bin/renew-certs", {log: true, stdin: "{\"node_ipv4\":\"#{kd.vm.private_ipv4}\"}"})
       expect { nx.renew_certs }.to nap(30)
       expect(kd.reload.state).to eq("renewing_certs")
       expect(kd.renew_certs_set?).to be false


### PR DESCRIPTION
The health check after restarting the static pods went through the api server load balancer. On a cluster with several control plane nodes it could be answered by a peer while this node was still down, and on a single node cluster the load balancer drops the backend after two failed probes, so the check kept failing for a while after the api server was back.

Address the api server of the node whose certs were renewed.