### PR TITLE
Build kubernetes node images on ubuntu resolute

### DIFF
--- a/config/e2e_test_cases.yml
+++ b/config/e2e_test_cases.yml
@@ -8,8 +8,8 @@
 - { name: postgres_upgrade16,        images: ["postgres-ubuntu-2204", "ubuntu-jammy"] }
 - { name: postgres_firewall,         images: ["postgres-ubuntu-2204"] }
 - { name: postgres_unarchive,        images: ["postgres-ubuntu-2204"] }
-- { name: kubernetes,                images: ["ubuntu-noble"] }
-- { name: kubernetes_upgrade,        images: ["ubuntu-noble"] }
-- { name: kubernetes_firewall,       images: ["ubuntu-noble"] }
+- { name: kubernetes,                images: ["ubuntu-resolute"] }
+- { name: kubernetes_upgrade,        images: ["ubuntu-resolute"] }
+- { name: kubernetes_firewall,       images: ["ubuntu-resolute", "ubuntu-noble"] }
 - { name: machine_image_vm_capture,  images: ["ubuntu-noble"] }
 - { name: move_vm,                   images: ["ubuntu-noble"] }

--- a/prog/kubernetes/build_node_image.rb
+++ b/prog/kubernetes/build_node_image.rb
@@ -20,7 +20,7 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
       name = "kubernetes-#{kubernetes_version.tr(".", "_")}"
       machine_image = MachineImage.first(project_id: image_project.id, location_id:, name:) ||
         MachineImage.create(project_id: image_project.id, location_id:, name:, arch: "x64")
-      vm_id = Prog::Vm::Nexus.assemble_with_sshable(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", location_id:, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 10}], boot_image: "ubuntu-noble", enable_ip4: true).id
+      vm_id = Prog::Vm::Nexus.assemble_with_sshable(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", location_id:, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 10}], boot_image: "ubuntu-resolute", enable_ip4: true).id
 
       Strand.create(prog: "Kubernetes::BuildNodeImage", label: "wait_vm", stack: [{
         "kubernetes_version" => kubernetes_version,

--- a/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
+++ b/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
@@ -43,8 +43,6 @@ class KubernetesBuildNodeImage
     r "apt-get update"
     r "apt-get install -y containerd cri-tools kubelet kubeadm kubectl ruby-bundler"
 
-    r "apt-get install -y linux-modules-extra-$(linux-version list | linux-version sort | tail -1)"
-
     r "mkdir -p /etc/containerd"
     r "tee /etc/containerd/config.toml > /dev/null", stdin: r("containerd config default").gsub("SystemdCgroup = false", "SystemdCgroup = true")
 

--- a/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe KubernetesBuildNodeImage do
         "echo deb\\ \\[signed-by\\=/etc/apt/keyrings/kubernetes-apt-keyring.gpg\\]\\ https://pkgs.k8s.io/core:/stable:/v1.35/deb/\\ / | tee /etc/apt/sources.list.d/kubernetes.list > /dev/null",
         "apt-get update",
         "apt-get install -y containerd cri-tools kubelet kubeadm kubectl ruby-bundler",
-        "apt-get install -y linux-modules-extra-$(linux-version list | linux-version sort | tail -1)",
         "mkdir -p /etc/containerd",
         "containerd config default",
         "tee /etc/containerd/config.toml > /dev/null",

--- a/spec/prog/kubernetes/build_node_image_spec.rb
+++ b/spec/prog/kubernetes/build_node_image_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
       expect(machine_image.location_id).to eq location_id
       expect(machine_image.project_id).to eq image_project.id
 
-      expect(vm.boot_image).to eq "ubuntu-noble"
+      expect(vm.boot_image).to eq "ubuntu-resolute"
       expect(vm.unix_user).to eq "ubi"
       expect(vm.storage_size_gib).to eq 10
       expect(strand.stack.first["skip_verification"]).to be false


### PR DESCRIPTION
The node image builder VM was the only Ubuntu pin left in the kubernetes path; nodes themselves boot the captured kubernetes-<version> machine image, and the build script keys its apt repo on the kubernetes version rather than the Ubuntu codename.