### PR TITLE
Bound the monitor-driven sync_kubernetes_services increments

### DIFF
--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -165,7 +165,7 @@ class KubernetesCluster < Sequel::Model
   def check_pulse(session:, previous_pulse:)
     reading = begin
       k8s_client = client(session: session[:ssh_session])
-      incr_sync_kubernetes_services if k8s_client.any_lb_services_modified?
+      incr_sync_kubernetes_services if !sync_kubernetes_services_set?(cached: false) && k8s_client.any_lb_services_modified?
 
       pvs = JSON.parse(k8s_client.kubectl("get pv -ojson"))["items"]
       stuck_pvs = pvs.select { Integer(it.dig("metadata", "annotations", "csi.ubicloud.com/migration-retry-count") || "0", 10) >= 3 }

--- a/model/kubernetes/kubernetes_node.rb
+++ b/model/kubernetes/kubernetes_node.rb
@@ -82,7 +82,7 @@ class KubernetesNode < Sequel::Model
     end
     pulse = aggregate_readings(previous_pulse:, reading:)
 
-    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !checkup_set?
+    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !checkup_set?(cached: false)
       incr_checkup
     end
 

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -229,6 +229,16 @@ RSpec.describe KubernetesCluster do
       expect(kc.sync_kubernetes_services_set?(cached: false)).to be true
     end
 
+    it "keeps a single sync_kubernetes_services semaphore across pulses" do
+      LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 80, dst_port: 30000)
+      kc.incr_sync_kubernetes_services
+      pv_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate({"items" => []}), 0)
+      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(pv_response)
+
+      expect(kc.check_pulse(session:, previous_pulse: up_pulse)[:reading]).to eq("up")
+      expect(Semaphore.where(strand_id: kc.id, name: "sync_kubernetes_services").count).to eq 1
+    end
+
     it "checks pulse on with no changes to the internal services" do
       lb_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate({"items" => []}), 0)
       pv_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate({"items" => []}), 0)

--- a/spec/model/kubernetes/kubernetes_node_spec.rb
+++ b/spec/model/kubernetes/kubernetes_node_spec.rb
@@ -177,6 +177,19 @@ RSpec.describe KubernetesNode do
       expect(kn.checkup_set?(cached: false)).to be true
     end
 
+    it "keeps a single checkup semaphore when one was set after the node was loaded" do
+      status_json = JSON.generate({
+        "node_id" => "node-1",
+        "pods" => {"ubicsi-nodeplugin-abc" => {"ip" => "10.0.0.2", "reachable" => false}},
+      })
+      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(kn.checkup_set?).to be false
+      described_class[kn.id].incr_checkup
+
+      kn.check_pulse(session:, previous_pulse: {reading: "down", reading_rpt: 6, reading_chg: Time.now - 31})
+      expect(Semaphore.where(strand_id: kn.id, name: "checkup").count).to eq 1
+    end
+
     it "does not increment checkup when reading_rpt is too low" do
       status_json = JSON.generate({
         "node_id" => "node-1",


### PR DESCRIPTION
KubernetesCluster#check_pulse incremented sync_kubernetes_services on every pulse, roughly every five seconds, while any_lb_services_modified? stayed true. During bootstrap that condition holds from the moment the first control plane node goes active, because vm_diff_for_lb reports every worker VM as missing from services_lb until sync_kubernetes_services attaches them, and that only runs once the cluster strand reaches wait. The result was hundreds of rows on one strand.

Guard the increment on the semaphore not already being set. The check reloads the cluster first: the monitor keeps a single model object alive across pulses to reuse its SSH session, and Semaphore.incr does not update the cached semaphores association.

Apply the same reload to the KubernetesNode checkup guard, which was the only pulse guard in the codebase reading a possibly cached association.