### PR TITLE
Support cached: false for sempahore *_set? methods 

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -714,7 +714,7 @@ class CloverAdmin < Roda
         param(:name_confirmation, typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options:)
         run do |obj, name, name_confirmation|
           fail CloverError.new(400, "InvalidRequest", "Semaphore name confirmation does not match") unless name == name_confirmation
-          Semaphore.where(strand_id: obj.id, name:).destroy
+          Semaphore.where(strand_id: obj.id, name:).delete
         end
       end
     end
@@ -1317,7 +1317,7 @@ class CloverAdmin < Roda
 
       case action
       when "unpause"
-        Semaphore.where(strand_id: strand.id, name: "pause").destroy
+        Semaphore.where(strand_id: strand.id, name: "pause").delete
         strand.this.update(schedule: Sequel::CURRENT_TIMESTAMP)
       else
         Semaphore.incr(strand.id, action)

--- a/lib/semaphore_methods.rb
+++ b/lib/semaphore_methods.rb
@@ -18,8 +18,12 @@ module SemaphoreMethods
           Semaphore.where(strand_id: id, name:).destroy
         end
 
-        define_method :"#{name}_set?" do
-          semaphores.any? { it.name == name }
+        define_method :"#{name}_set?" do |cached: true|
+          if cached
+            semaphores.any? { it.name == name }
+          else
+            !semaphores_dataset.where(name:).empty?
+          end
         end
 
         define_singleton_method :"incr_#{name}" do

--- a/lib/semaphore_methods.rb
+++ b/lib/semaphore_methods.rb
@@ -15,7 +15,7 @@ module SemaphoreMethods
         end
 
         define_method :"decr_#{name}" do
-          Semaphore.where(strand_id: id, name:).destroy
+          Semaphore.where(strand_id: id, name:).delete
         end
 
         define_method :"#{name}_set?" do |cached: true|

--- a/model/load_balancer_vm_port.rb
+++ b/model/load_balancer_vm_port.rb
@@ -68,12 +68,12 @@ class LoadBalancerVmPort < Sequel::Model
 
     time_passed_health_check_interval = Time.now - pulse[:reading_chg] > load_balancer.health_check_interval
 
-    if state == "up" && pulse[:reading] == "down" && pulse[:reading_rpt] > load_balancer.health_check_down_threshold && time_passed_health_check_interval && !load_balancer.reload.update_load_balancer_set?
+    if state == "up" && pulse[:reading] == "down" && pulse[:reading_rpt] > load_balancer.health_check_down_threshold && time_passed_health_check_interval && !load_balancer.update_load_balancer_set?(cached: false)
       update(state: "down")
       load_balancer.incr_update_load_balancer
     end
 
-    if state == "down" && pulse[:reading] == "up" && pulse[:reading_rpt] > load_balancer.health_check_up_threshold && time_passed_health_check_interval && !load_balancer.reload.update_load_balancer_set?
+    if state == "down" && pulse[:reading] == "up" && pulse[:reading_rpt] > load_balancer.health_check_up_threshold && time_passed_health_check_interval && !load_balancer.update_load_balancer_set?(cached: false)
       update(state: "up")
       load_balancer.incr_update_load_balancer
     end

--- a/model/minio/minio_server.rb
+++ b/model/minio/minio_server.rb
@@ -77,7 +77,7 @@ class MinioServer < Sequel::Model
     end
     pulse = aggregate_readings(previous_pulse:, reading:)
 
-    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !reload.checkup_set?
+    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !checkup_set?(cached: false)
       incr_checkup
     end
 

--- a/model/parseable_server.rb
+++ b/model/parseable_server.rb
@@ -55,7 +55,7 @@ class ParseableServer < Sequel::Model
     end
     pulse = aggregate_readings(previous_pulse:, reading:)
 
-    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !reload.checkup_set?
+    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !checkup_set?(cached: false)
       incr_checkup
     end
 

--- a/model/victoria_metrics_server.rb
+++ b/model/victoria_metrics_server.rb
@@ -48,7 +48,7 @@ class VictoriaMetricsServer < Sequel::Model
     end
     pulse = aggregate_readings(previous_pulse:, reading:)
 
-    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !reload.checkup_set?
+    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !checkup_set?(cached: false)
       incr_checkup
     end
 

--- a/model/vm.rb
+++ b/model/vm.rb
@@ -202,7 +202,7 @@ class Vm < Sequel::Model
     end
     pulse = aggregate_readings(previous_pulse:, reading:)
 
-    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !reload.checkup_set?
+    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !checkup_set?(cached: false)
       incr_checkup
     end
 

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -425,7 +425,7 @@ class VmHost < Sequel::Model
     end
     pulse = aggregate_readings(previous_pulse:, reading:)
 
-    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !reload.checkup_set?
+    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !checkup_set?(cached: false)
       incr_checkup
     end
 

--- a/model/vm_host_slice.rb
+++ b/model/vm_host_slice.rb
@@ -65,7 +65,7 @@ class VmHostSlice < Sequel::Model
     end
     pulse = aggregate_readings(previous_pulse:, reading:)
 
-    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !reload.checkup_set?
+    if pulse[:reading] == "down" && pulse[:reading_rpt] > 5 && Time.now - pulse[:reading_chg] > 30 && !checkup_set?(cached: false)
       incr_checkup
     end
 

--- a/prog/rollout_semaphore.rb
+++ b/prog/rollout_semaphore.rb
@@ -99,7 +99,7 @@ class Prog::RolloutSemaphore < Prog::Base
         hop_wait_current
       end
     else
-      Semaphore.where(strand_id: next_id, name: semaphore).destroy
+      Semaphore.where(strand_id: next_id, name: semaphore).delete
     end
 
     completed << next_id

--- a/spec/model/firewall_spec.rb
+++ b/spec/model/firewall_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Firewall do
     fw.associate_with_private_subnet(ps, apply_firewalls: false)
     expect {
       fw.insert_firewall_rule("0.0.0.0/0", Sequel.pg_range(0..65535))
-    }.to change { ps.reload.update_firewall_rules_set? }.from(false).to(true)
+    }.to change { ps.update_firewall_rules_set?(cached: false) }.from(false).to(true)
   end
 
   it "bulk sets firewall rules" do
@@ -50,7 +50,7 @@ RSpec.describe Firewall do
   it "associates with a private subnet" do
     expect {
       fw.associate_with_private_subnet(ps)
-    }.to change { ps.reload.update_firewall_rules_set? }.from(false).to(true)
+    }.to change { ps.update_firewall_rules_set?(cached: false) }.from(false).to(true)
 
     expect(fw.private_subnets.count).to eq(1)
     expect(fw.private_subnets.first.id).to eq(ps.id)
@@ -62,7 +62,7 @@ RSpec.describe Firewall do
 
     expect {
       fw.disassociate_from_private_subnet(ps)
-    }.to change { ps.reload.update_firewall_rules_set? }.from(false).to(true)
+    }.to change { ps.update_firewall_rules_set?(cached: false) }.from(false).to(true)
 
     expect(fw.reload.private_subnets.count).to eq(0)
     expect(PrivateSubnetFirewall.where(firewall_id: fw.id).count).to eq(0)
@@ -74,7 +74,7 @@ RSpec.describe Firewall do
 
     expect {
       fw.disassociate_from_private_subnet(ps, apply_firewalls: false)
-    }.not_to change { ps.reload.update_firewall_rules_set? }.from(false)
+    }.not_to change { ps.update_firewall_rules_set?(cached: false) }.from(false)
 
     expect(fw.reload.private_subnets.count).to eq(0)
     expect(PrivateSubnetFirewall.where(firewall_id: fw.id).count).to eq(0)

--- a/spec/model/github/github_runner_spec.rb
+++ b/spec/model/github/github_runner_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe GithubRunner do
     expect(spare_runner.installation_id).to eq(github_runner.installation_id)
     expect(spare_runner.repository_name).to eq(github_runner.repository_name)
     expect(spare_runner.label).to eq(github_runner.label)
-    expect(github_runner.reload.spare_runner_provisioned_set?).to be(true)
+    expect(github_runner.spare_runner_provisioned_set?(cached: false)).to be(true)
   end
 
   it "does not provision another spare runner once one has been provisioned" do

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -56,12 +56,12 @@ RSpec.describe KubernetesCluster do
     kc.incr_upgrade
     kc.reload
     expect(kc.display_state).to eq "upgrading"
-    Semaphore.where(strand_id: kc.id, name: "upgrade").destroy
+    Semaphore.where(strand_id: kc.id, name: "upgrade").delete
 
     kc.incr_upgrade_nodepools
     kc.reload
     expect(kc.display_state).to eq "upgrading"
-    Semaphore.where(strand_id: kc.id, name: "upgrade_nodepools").destroy
+    Semaphore.where(strand_id: kc.id, name: "upgrade_nodepools").delete
 
     kc.incr_destroy
     kc.reload
@@ -125,19 +125,19 @@ RSpec.describe KubernetesCluster do
     kc.incr_upgrade
     expect(kc.reload.ready_for_upgrade?).to be false
 
-    Semaphore.where(strand_id: kc.id, name: "upgrade").destroy
+    Semaphore.where(strand_id: kc.id, name: "upgrade").delete
     kc.incr_upgrade_nodepools
     expect(kc.reload.ready_for_upgrade?).to be false
 
-    Semaphore.where(strand_id: kc.id, name: "upgrade_nodepools").destroy
+    Semaphore.where(strand_id: kc.id, name: "upgrade_nodepools").delete
     np2.incr_upgrade_requested
     expect(kc.reload.ready_for_upgrade?).to be false
 
-    Semaphore.where(strand_id: np2.id, name: "upgrade_requested").destroy
+    Semaphore.where(strand_id: np2.id, name: "upgrade_requested").delete
     np2.incr_scale_worker_count
     expect(kc.reload.ready_for_upgrade?).to be false
 
-    Semaphore.where(strand_id: np2.id, name: "scale_worker_count").destroy
+    Semaphore.where(strand_id: np2.id, name: "scale_worker_count").delete
     kc.incr_sync_kubeconfig
     expect(kc.reload.ready_for_upgrade?).to be true
   end

--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe KubernetesCluster do
       expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pv -ojson").and_return(pv_response).ordered
 
       expect(kc.check_pulse(session:, previous_pulse: down_pulse)[:reading]).to eq("up")
-      expect(kc.reload.sync_kubernetes_services_set?).to be true
+      expect(kc.sync_kubernetes_services_set?(cached: false)).to be true
     end
 
     it "checks pulse on with no changes to the internal services" do
@@ -275,7 +275,7 @@ RSpec.describe KubernetesCluster do
 
       expect(kc.check_pulse(session:, previous_pulse: up_pulse)[:reading]).to eq("up")
       page = Page.from_tag_parts("KubernetesClusterPVMigrationStuck", kc.id)
-      expect(page.reload.resolve_set?).to be true
+      expect(page.resolve_set?(cached: false)).to be true
     end
 
     [IOError.new("closed stream"), Errno::ECONNRESET.new("recvfrom(2)")].each do |ex|

--- a/spec/model/kubernetes/kubernetes_node_spec.rb
+++ b/spec/model/kubernetes/kubernetes_node_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe KubernetesNode do
       previous_pulse = {reading: "down", reading_rpt: 6, reading_chg: Time.now - 31}
 
       kn.check_pulse(session:, previous_pulse:)
-      expect(kn.reload.checkup_set?).to be true
+      expect(kn.checkup_set?(cached: false)).to be true
     end
 
     it "does not increment checkup when reading_rpt is too low" do
@@ -187,7 +187,7 @@ RSpec.describe KubernetesNode do
       previous_pulse = {reading: "down", reading_rpt: 4, reading_chg: Time.now - 31}
 
       kn.check_pulse(session:, previous_pulse:)
-      expect(kn.reload.checkup_set?).to be false
+      expect(kn.checkup_set?(cached: false)).to be false
     end
 
     it "does not increment checkup when reading_chg is too recent" do
@@ -200,7 +200,7 @@ RSpec.describe KubernetesNode do
       previous_pulse = {reading: "down", reading_rpt: 6, reading_chg: Time.now - 10}
 
       kn.check_pulse(session:, previous_pulse:)
-      expect(kn.reload.checkup_set?).to be false
+      expect(kn.checkup_set?(cached: false)).to be false
     end
 
     it "does not increment checkup when checkup is already set" do

--- a/spec/model/kubernetes/kubernetes_nodepool_spec.rb
+++ b/spec/model/kubernetes/kubernetes_nodepool_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe KubernetesNodepool do
       expect(kn.reload.request_upgrade).to eq(kc.version)
       expect(kn.reload.version).to eq(kc.version)
       expect(kn.upgrade_requested_set?).to be true
-      expect(kc.reload.upgrade_nodepools_set?).to be true
+      expect(kc.upgrade_nodepools_set?(cached: false)).to be true
     end
 
     it "raises when the nodepool is not ready to be upgraded" do

--- a/spec/model/kubernetes/kubernetes_nodepool_spec.rb
+++ b/spec/model/kubernetes/kubernetes_nodepool_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe KubernetesNodepool do
       kn.incr_destroy
       expect(kn.reload.destroying?).to be true
 
-      Semaphore.where(strand_id: kn.id, name: "destroy").destroy
+      Semaphore.where(strand_id: kn.id, name: "destroy").delete
       kn.strand.update(label: "destroy")
       expect(kn.reload.destroying?).to be true
     end
@@ -54,12 +54,12 @@ RSpec.describe KubernetesNodepool do
 
       kn.strand.update(label: "bootstrap_worker_nodes")
       expect(kn.reload.display_state).to eq "resizing"
-      Semaphore.where(strand_id: kn.id, name: "scale_worker_count").destroy
+      Semaphore.where(strand_id: kn.id, name: "scale_worker_count").delete
       kn.strand.update(label: "wait")
 
       kn.incr_upgrade_requested
       expect(kn.reload.display_state).to eq "upgrading"
-      Semaphore.where(strand_id: kn.id, name: "upgrade_requested").destroy
+      Semaphore.where(strand_id: kn.id, name: "upgrade_requested").delete
 
       kn.strand.update(label: "wait_upgrade")
       expect(kn.reload.display_state).to eq "upgrading"
@@ -90,7 +90,7 @@ RSpec.describe KubernetesNodepool do
     it "is true only when the nodepool is behind the cluster version and the whole cluster is idle" do
       kc.strand.update(label: "wait")
       kn.strand.update(label: "wait")
-      Semaphore.where(strand_id: kn.id, name: "start_bootstrapping").destroy
+      Semaphore.where(strand_id: kn.id, name: "start_bootstrapping").delete
       expect(kn.reload.ready_for_upgrade?).to be false
 
       kn.update(version: Option.kubernetes_versions[1])
@@ -105,7 +105,7 @@ RSpec.describe KubernetesNodepool do
 
       kn.strand.update(label: "wait")
       np2 = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np2", node_count: 1, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
-      Semaphore.where(strand_id: np2.id, name: "start_bootstrapping").destroy
+      Semaphore.where(strand_id: np2.id, name: "start_bootstrapping").delete
       np2.strand.update(label: "upgrade")
       expect(kn.reload.ready_for_upgrade?).to be false
 
@@ -113,11 +113,11 @@ RSpec.describe KubernetesNodepool do
       kn.incr_upgrade
       expect(kn.reload.ready_for_upgrade?).to be false
 
-      Semaphore.where(strand_id: kn.id, name: "upgrade").destroy
+      Semaphore.where(strand_id: kn.id, name: "upgrade").delete
       kn.incr_scale_worker_count
       expect(kn.reload.ready_for_upgrade?).to be false
 
-      Semaphore.where(strand_id: kn.id, name: "scale_worker_count").destroy
+      Semaphore.where(strand_id: kn.id, name: "scale_worker_count").delete
       kc.incr_sync_kubeconfig
       expect(kn.reload.ready_for_upgrade?).to be true
     end
@@ -127,7 +127,7 @@ RSpec.describe KubernetesNodepool do
     before do
       kc.strand.update(label: "wait")
       kn.strand.update(label: "wait")
-      Semaphore.where(strand_id: kn.id, name: "start_bootstrapping").destroy
+      Semaphore.where(strand_id: kn.id, name: "start_bootstrapping").delete
       kn.update(version: Option.kubernetes_versions[1])
     end
 

--- a/spec/model/parseable_server_spec.rb
+++ b/spec/model/parseable_server_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe ParseableServer do
       previous_pulse = {reading: "down", reading_rpt: 5, reading_chg: Time.now - 60}
 
       parseable_server.check_pulse(session:, previous_pulse:)
-      expect(parseable_server.reload.checkup_set?).to be true
+      expect(parseable_server.checkup_set?(cached: false)).to be true
     end
 
     it "does not increment checkup when checkup is already set" do

--- a/spec/model/private_subnet_spec.rb
+++ b/spec/model/private_subnet_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe PrivateSubnet do
         net6: "fd1b:9793:dcef:cd0b::/64", net4: "10.9.40.0/26",
         state: "waiting", project_id: prj.id)
       Strand.create(prog: "Vnet::SubnetNexus", label: "wait", id: ps.id)
-      expect { ps.apply_firewalls }.to change { ps.reload.update_firewall_rules_set? }.from(false).to(true)
+      expect { ps.apply_firewalls }.to change { ps.update_firewall_rules_set?(cached: false) }.from(false).to(true)
     end
   end
 

--- a/spec/model/victoria_metrics/victoria_metrics_server_spec.rb
+++ b/spec/model/victoria_metrics/victoria_metrics_server_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe VictoriaMetricsServer do
       previous_pulse = {reading: "down", reading_rpt: 5, reading_chg: fixed_time - 60}
 
       vms.check_pulse(session:, previous_pulse:)
-      expect(vms.reload.checkup_set?).to be true
+      expect(vms.checkup_set?(cached: false)).to be true
     end
 
     it "does not increment checkup semaphore when already set" do

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Vm do
       vm.update_spdk_version("b")
 
       expect(vm.vm_storage_volumes.first.spdk_installation_id).to eq(spdk_installation.id)
-      expect(vm.reload.update_spdk_dependency_set?).to be true
+      expect(vm.update_spdk_dependency_set?(cached: false)).to be true
     end
 
     it "fails if spdk installation not found" do
@@ -325,14 +325,14 @@ RSpec.describe Vm do
       expect(session[:ssh_session]).to receive(:_exec!).and_return("active\ninactive\n")
       result = pulse_vm.check_pulse(session:, previous_pulse: pulse)
       expect(result[:reading]).to eq("down")
-      expect(pulse_vm.reload.checkup_set?).to be true
+      expect(pulse_vm.checkup_set?(cached: false)).to be true
     end
 
     it "returns down and increments checkup on SSH error" do
       expect(session[:ssh_session]).to receive(:_exec!).and_raise Sshable::SshError
       result = pulse_vm.check_pulse(session:, previous_pulse: pulse)
       expect(result[:reading]).to eq("down")
-      expect(pulse_vm.reload.checkup_set?).to be true
+      expect(pulse_vm.checkup_set?(cached: false)).to be true
     end
   end
 

--- a/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
+++ b/spec/prog/dns_zone/setup_dns_server_vm_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Prog::DnsZone::SetupDnsServerVm do
 
     it "writes knot zone template for each zone" do
       dzs
-      Semaphore.where(name: "refresh_dns_servers").destroy
+      Semaphore.where(name: "refresh_dns_servers").delete
 
       f1 = <<-CONF
 zone1.domain.io.          3600    SOA     ns.zone1.domain.io. zone1.domain.io. 37 86400 7200 1209600 3600

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       Semaphore.where(strand_id: np1.id, name: "upgrade").destroy
       kubernetes_cluster.nodepools(reload: true)
       expect { nx.wait }.to nap(30)
-      expect(np2.reload.upgrade_set?).to be false
+      expect(np2.upgrade_set?(cached: false)).to be false
 
       np1.strand.update(label: "wait")
       kubernetes_cluster.nodepools(reload: true)
@@ -488,7 +488,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       Semaphore.where(strand_id: np2.id, name: "upgrade").destroy
       kubernetes_cluster.nodepools(reload: true)
       expect { nx.wait }.to nap(6 * 60 * 60)
-      expect(kubernetes_cluster.reload.upgrade_nodepools_set?).to be false
+      expect(kubernetes_cluster.upgrade_nodepools_set?(cached: false)).to be false
     end
 
     it "hops to install_metrics_server when semaphore is set" do

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -473,7 +473,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(nps.map(&:upgrade_set?)).to eq([true, false])
 
       np1.strand.update(label: "upgrade")
-      Semaphore.where(strand_id: np1.id, name: "upgrade").destroy
+      Semaphore.where(strand_id: np1.id, name: "upgrade").delete
       kubernetes_cluster.nodepools(reload: true)
       expect { nx.wait }.to nap(30)
       expect(np2.upgrade_set?(cached: false)).to be false
@@ -485,7 +485,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect(np2.upgrade_set?).to be true
 
       np2.strand.update(label: "wait")
-      Semaphore.where(strand_id: np2.id, name: "upgrade").destroy
+      Semaphore.where(strand_id: np2.id, name: "upgrade").delete
       kubernetes_cluster.nodepools(reload: true)
       expect { nx.wait }.to nap(6 * 60 * 60)
       expect(kubernetes_cluster.upgrade_nodepools_set?(cached: false)).to be false

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       status_json = JSON.generate({"pods" => {"pod-1" => {"reachable" => true}}, "external_endpoints" => {}})
       expect(nx.kubernetes_node.sshable).to receive(:_cmd).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
       expect { nx.unavailable }.to hop("wait")
-      expect(kd.reload.checkup_set?).to be false
+      expect(kd.checkup_set?(cached: false)).to be false
     end
 
     it "logs, registers deadline and naps when still unavailable" do

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -496,9 +496,9 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     it "skips approve if the csr is already approved" do
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get csr --sort-by=.metadata.creationTimestamp | awk /Approved/' && /kubelet-serving/ && /'test-vm'/ {print $1}' | tail -1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("csr-abc123\n", 0))
       expect { prog.approve_new_csr }.to exit({node_id: prog.node.id})
-      expect(kubernetes_cluster.reload.sync_internal_dns_config_set?).to be true
-      expect(kubernetes_cluster.reload.sync_worker_mesh_set?).to be true
-      expect(kubernetes_cluster.reload.update_billing_records_set?).to be true
+      expect(kubernetes_cluster.sync_internal_dns_config_set?(cached: false)).to be true
+      expect(kubernetes_cluster.sync_worker_mesh_set?(cached: false)).to be true
+      expect(kubernetes_cluster.update_billing_records_set?(cached: false)).to be true
     end
 
     it "approves the csr when it is pending" do
@@ -506,9 +506,9 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get csr --sort-by=.metadata.creationTimestamp | awk /Pending/' && /kubelet-serving/ && /'test-vm'/ {print $1}' | tail -1").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("csr-abc123\n", 0))
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s certificate approve csr-abc123").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("approved", 0))
       expect { prog.approve_new_csr }.to exit({node_id: prog.node.id})
-      expect(kubernetes_cluster.reload.sync_internal_dns_config_set?).to be true
-      expect(kubernetes_cluster.reload.sync_worker_mesh_set?).to be true
-      expect(kubernetes_cluster.reload.update_billing_records_set?).to be true
+      expect(kubernetes_cluster.sync_internal_dns_config_set?(cached: false)).to be true
+      expect(kubernetes_cluster.sync_worker_mesh_set?(cached: false)).to be true
+      expect(kubernetes_cluster.update_billing_records_set?(cached: false)).to be true
     end
   end
 

--- a/spec/prog/location_nexus_spec.rb
+++ b/spec/prog/location_nexus_spec.rb
@@ -23,22 +23,22 @@ RSpec.describe Prog::LocationNexus do
     it "recycles the server and bypasses the maintenance window when the event is within 24h" do
       stub_events({server.vm_id => Time.now + 10 * 3600})
       expect { nx.wait }.to nap(3600)
-      expect(server.reload.recycle_set?).to be true
-      expect(pg.reload.bypass_maintenance_window_set?).to be true
+      expect(server.recycle_set?(cached: false)).to be true
+      expect(pg.bypass_maintenance_window_set?(cached: false)).to be true
     end
 
     it "recycles but keeps the window when the event is 24h to 48h out" do
       stub_events({server.vm_id => Time.now + 36 * 3600})
       expect { nx.wait }.to nap(3600)
-      expect(server.reload.recycle_set?).to be true
-      expect(pg.reload.bypass_maintenance_window_set?).to be false
+      expect(server.recycle_set?(cached: false)).to be true
+      expect(pg.bypass_maintenance_window_set?(cached: false)).to be false
     end
 
     it "ignores events beyond the 48h lead" do
       stub_events({server.vm_id => Time.now + 72 * 3600})
       expect { nx.wait }.to nap(3600)
-      expect(server.reload.recycle_set?).to be false
-      expect(pg.reload.bypass_maintenance_window_set?).to be false
+      expect(server.recycle_set?(cached: false)).to be false
+      expect(pg.bypass_maintenance_window_set?(cached: false)).to be false
     end
 
     it "does not re-increment recycle when already set" do

--- a/spec/prog/machine_image/version_metal_nexus_spec.rb
+++ b/spec/prog/machine_image/version_metal_nexus_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Prog::MachineImage::VersionMetalNexus do
       refresh_frame(prog, new_values: {"destroy_source_after" => true})
       expect(prog.sshable).to receive(:_cmd).with("sudo rm -f #{stats_path}")
       expect { prog.finish_archive }.to hop("wait")
-        .and change { source_vm.reload.destroy_set? }.from(false).to(true)
+        .and change { source_vm.destroy_set?(cached: false) }.from(false).to(true)
     end
 
     it "skips latest update when set_as_latest is false" do
@@ -244,7 +244,7 @@ RSpec.describe Prog::MachineImage::VersionMetalNexus do
       metal.incr_destroy
       prog = described_class.new(strand)
       expect { prog.destroy }.to hop("wait_vms")
-        .and change { metal.reload.destroy_set? }.from(true).to(false)
+        .and change { metal.destroy_set?(cached: false) }.from(true).to(false)
       expect(metal.reload.status).to eq("destroying")
     end
 

--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
         expect(nx).to receive(:register_deadline).with("wait_for_maintenance_window", 6 * 60 * 60)
 
         expect { nx.start }.to nap(60)
-        expect(timeline.reload.take_backup_for_converge_set?).to be(true)
+        expect(timeline.take_backup_for_converge_set?(cached: false)).to be(true)
       end
 
       it "naps without re-incrementing when the semaphore is still set" do
@@ -421,7 +421,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       representative = nx.postgres_resource.representative_server
       expect(representative.vm.sshable).to receive(:_cmd).and_return("")
       expect { nx.recycle_representative_server }.to nap(60)
-      expect(standby.reload.planned_take_over_set?).to be true
+      expect(standby.planned_take_over_set?(cached: false)).to be true
     end
   end
 
@@ -447,7 +447,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       candidate = create_server(version: "16", upgrade_candidate: true)
       expect(nx.postgres_resource.representative_server).to receive(:unsynced_logical_failover_slots).with(candidate).and_return([])
       expect { nx.wait_for_maintenance_window }.to hop("wait_fence_primary")
-      expect(server.reload.fence_set?).to be true
+      expect(server.fence_set?(cached: false)).to be true
     end
 
     it "naps without fencing when upgrade candidate has unsynced logical failover slots" do
@@ -456,7 +456,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect(nx.postgres_resource.representative_server).to receive(:unsynced_logical_failover_slots).with(candidate).and_return(["slot1"])
       expect(Clog).to receive(:emit).with("Upgrade waiting for logical slot sync", hash_including(missing_slots: ["slot1"]))
       expect { nx.wait_for_maintenance_window }.to nap(30)
-      expect(server.reload.fence_set?).to be false
+      expect(server.fence_set?(cached: false)).to be false
     end
 
     it "hops to recycle_representative_server if in maintenance window and upgrading for read replicas" do
@@ -622,8 +622,8 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       expect(Clog).to receive(:emit).with("Postgres resource upgrade failed", instance_of(Hash)).and_call_original.twice
 
       expect { nx.upgrade_failed }.to nap(6 * 60 * 60).and change(Page, :count).by(1)
-      expect(candidate.reload.destroy_set?).to be false
-      expect(primary.reload.unfence_set?).to be true
+      expect(candidate.destroy_set?(cached: false)).to be false
+      expect(primary.unfence_set?(cached: false)).to be true
     end
 
     it "unfences primary if it is fenced" do
@@ -634,7 +634,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
       expect { nx.upgrade_failed }.to nap(6 * 60 * 60)
 
-      expect(primary.reload.unfence_set?).to be true
+      expect(primary.unfence_set?(cached: false)).to be true
     end
 
     it "does not unfence if primary is not fenced" do
@@ -646,7 +646,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
       expect { nx.upgrade_failed }.to nap(6 * 60 * 60)
 
-      expect(primary.reload.unfence_set?).to be false
+      expect(primary.unfence_set?(cached: false)).to be false
     end
   end
 
@@ -670,11 +670,11 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
       expect { nx.prune_servers }.to hop("wait_prune_servers")
 
-      expect(recycling_server.reload.destroy_set?).to be true
-      expect(unavailable_server.reload.destroy_set?).to be true
-      expect(extra_server.reload.destroy_set?).to be true
-      expect(representative.reload.configure_set?).to be true
-      expect(keep_server.reload.configure_set?).to be true
+      expect(recycling_server.destroy_set?(cached: false)).to be true
+      expect(unavailable_server.destroy_set?(cached: false)).to be true
+      expect(extra_server.destroy_set?(cached: false)).to be true
+      expect(representative.configure_set?(cached: false)).to be true
+      expect(keep_server.configure_set?(cached: false)).to be true
       expect(keep_server.destroy_set?).to be false
 
       servers_to_destroy_ids = strand.stack.first["servers_to_destroy"]
@@ -685,7 +685,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       create_server(is_representative: true)
       pg.incr_bypass_maintenance_window
       expect { nx.prune_servers }.to hop("wait_prune_servers")
-      expect(pg.reload.bypass_maintenance_window_set?).to be false
+      expect(pg.bypass_maintenance_window_set?(cached: false)).to be false
     end
 
     it "prefers servers on intended type when picking which standbys to keep" do
@@ -700,8 +700,8 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
       expect { nx.prune_servers }.to hop("wait_prune_servers")
 
-      expect(fallback.reload.destroy_set?).to be true
-      expect(on_intended.reload.destroy_set?).to be false
+      expect(fallback.destroy_set?(cached: false)).to be true
+      expect(on_intended.destroy_set?(cached: false)).to be false
     end
 
     it "factors fallback_active? into the sort when both standbys survive needs_recycling?" do
@@ -715,8 +715,8 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
       expect { nx.prune_servers }.to hop("wait_prune_servers")
 
-      expect(fallback.reload.destroy_set?).to be true
-      expect(on_intended.reload.destroy_set?).to be false
+      expect(fallback.destroy_set?(cached: false)).to be true
+      expect(on_intended.destroy_set?(cached: false)).to be false
     end
 
     it "destroys servers with older versions" do
@@ -725,8 +725,8 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
 
       expect { nx.prune_servers }.to hop("wait_prune_servers")
 
-      expect(old_server.reload.destroy_set?).to be true
-      expect(new_server.reload.configure_set?).to be true
+      expect(old_server.destroy_set?(cached: false)).to be true
+      expect(new_server.configure_set?(cached: false)).to be true
 
       servers_to_destroy_ids = strand.stack.first["servers_to_destroy"]
       expect(servers_to_destroy_ids).to contain_exactly(old_server.id)

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1097,7 +1097,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 clean configure_postgres").and_return("Succeeded")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check configure_postgres").and_return("Succeeded")
       expect { nx.configure }.to hop("wait")
-      expect(standby_nx.postgres_server.reload.use_physical_slot_set?).to be true
+      expect(standby_nx.postgres_server.use_physical_slot_set?(cached: false)).to be true
       expect(standby_nx.postgres_server.configure_set?).to be true
     end
 
@@ -1108,7 +1108,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check configure_postgres").and_return("Succeeded")
       nx.postgres_server.timeline_access = "fetch"
       expect { nx.configure }.to hop("wait")
-      expect(standby_nx.postgres_server.reload.use_physical_slot_set?).to be false
+      expect(standby_nx.postgres_server.use_physical_slot_set?(cached: false)).to be false
       expect(standby_nx.postgres_server.configure_set?).to be false
     end
 
@@ -1349,7 +1349,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx).to receive(:register_deadline).with("complete_restart", 2 * 60)
       expect(nx).to receive(:daemonized_restart).and_return(false)
       expect { nx.wait }.to nap(1)
-      expect(postgres_server.reload.checkup_set?).to be false
+      expect(postgres_server.checkup_set?(cached: false)).to be false
     end
 
     it "hops to configure_metrics if configure_metrics is set" do
@@ -1506,7 +1506,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx).to receive(:available?).and_return(false)
       expect(nx).to receive(:daemonized_restart)
       expect { nx.unavailable }.to nap(5)
-      expect(postgres_server.reload.recycle_unavailable_server_set?).to be true
+      expect(postgres_server.recycle_unavailable_server_set?(cached: false)).to be true
     end
 
     it "calls daemonized_restart without incrementing recycle when recycle is already set" do
@@ -1523,14 +1523,14 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(nx).to receive(:daemonized_restart)
       expect { nx.unavailable }.to nap(5)
       expect(Strand.where(prog: "Postgres::ConvergePostgresResource", label: "start").count).to eq 1
-      expect(postgres_server.reload.recycle_unavailable_server_set?).to be true
+      expect(postgres_server.recycle_unavailable_server_set?(cached: false)).to be true
     end
 
     it "keeps recycling the server when a dead host makes the restart raise" do
       expect(nx).to receive(:available?).and_return(false)
       expect(sshable).to receive(:d_check).with("postgres_restart").and_raise(Net::SSH::Disconnect)
       expect { nx.unavailable }.to nap(5)
-      expect(postgres_server.reload.recycle_unavailable_server_set?).to be true
+      expect(postgres_server.recycle_unavailable_server_set?(cached: false)).to be true
     end
 
     it "trigger_failover succeeds, naps 0" do

--- a/spec/prog/postgres/postgres_timeline_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_timeline_nexus_spec.rb
@@ -495,7 +495,7 @@ RSpec.describe Prog::Postgres::PostgresTimelineNexus do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 clean take_postgres_backup").ordered
 
       expect { nx.take_backup }.to hop("wait")
-      expect(postgres_timeline.reload.take_backup_for_converge_set?).to be(false)
+      expect(postgres_timeline.take_backup_for_converge_set?(cached: false)).to be(false)
     end
 
     it "naps if a backup is already in progress" do

--- a/spec/prog/rollout_semaphore_spec.rb
+++ b/spec/prog/rollout_semaphore_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Prog::RolloutSemaphore do
     it "increments semaphore on next object and naps if not waiting" do
       refresh_frame(nx, new_values: {"wait_label" => false})
       expect { nx.start }.to nap(295...305)
-        .and change { pages.first.reload.resolve_set? }.from(false).to(true)
+        .and change { pages.first.resolve_set?(cached: false) }.from(false).to(true)
       expect(st.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
       expect(st.stack[0]["completed"]).to eq [page_ids[0]]
       expect(st.stack[0].fetch("current")).to be_nil
@@ -90,7 +90,7 @@ RSpec.describe Prog::RolloutSemaphore do
 
     it "increments semaphore on next object and hops to wait_current" do
       expect { nx.start }.to hop("wait_current")
-        .and change { pages.first.reload.resolve_set? }.from(false).to(true)
+        .and change { pages.first.resolve_set?(cached: false) }.from(false).to(true)
       expect(st.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
       expect(st.stack[0]["completed"]).to eq []
       expect(st.stack[0]["current"]).to eq page_ids[0]
@@ -101,7 +101,7 @@ RSpec.describe Prog::RolloutSemaphore do
       pages.first.incr_resolve
       refresh_frame(nx, new_values: {"increment" => false})
       expect { nx.start }.to nap(295...305)
-        .and change { pages.first.reload.resolve_set? }.from(true).to(false)
+        .and change { pages.first.resolve_set?(cached: false) }.from(true).to(false)
       expect(st.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 300)
       expect(st.stack[0]["completed"]).to eq [page_ids[0]]
       expect(st.stack[0].fetch("current")).to be_nil
@@ -116,7 +116,7 @@ RSpec.describe Prog::RolloutSemaphore do
     it "naps using regular gap after passing the initial number of records" do
       refresh_frame(nx, new_values: {"initial_num" => 0})
       expect { nx.start }.to hop("wait_current")
-        .and change { pages.first.reload.resolve_set? }.from(false).to(true)
+        .and change { pages.first.resolve_set?(cached: false) }.from(false).to(true)
       expect(st.stack[0]["next_increment_time"]).to be_within(5).of(Time.now.to_i + 60)
       expect(st.stack[0]["completed"]).to eq []
       expect(st.stack[0]["current"]).to eq page_ids[0]

--- a/spec/prog/test/kubernetes_firewall_spec.rb
+++ b/spec/prog/test/kubernetes_firewall_spec.rb
@@ -123,8 +123,8 @@ RSpec.describe Prog::Test::KubernetesFirewall do
     it "destroys the probe vm, its firewall, and its subnet, then hops" do
       firewall = probe_subnet.firewalls.first
       expect { kubernetes_test.teardown_probe }.to hop("wait_probe_teardown").and change { Firewall.where(id: firewall.id).count }.from(1).to(0)
-      expect(probe_vm.reload.destroy_set?).to be true
-      expect(probe_subnet.reload.destroy_set?).to be true
+      expect(probe_vm.destroy_set?(cached: false)).to be true
+      expect(probe_subnet.destroy_set?(cached: false)).to be true
     end
   end
 

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Prog::Test::Kubernetes do
     it "records the current cert expiry, triggers renewal on the CP node and wakes its strand" do
       expect(cp_node.sshable).to receive(:_cmd).with("sudo openssl x509 -enddate -noout -in /etc/kubernetes/pki/apiserver.crt").and_return("notAfter=#{(Time.now + 365 * 24 * 60 * 60).utc.strftime("%b %e %H:%M:%S %Y")} GMT\n")
       expect { kubernetes_test.trigger_renew_certs }.to hop("wait_for_renew_certs")
-      expect(cp_node.reload.renew_certs_set?).to be true
+      expect(cp_node.renew_certs_set?(cached: false)).to be true
       expect(kubernetes_test.strand.stack.first["cert_expire_at_before_renew"]).not_to be_nil
     end
   end
@@ -481,7 +481,7 @@ RSpec.describe Prog::Test::Kubernetes do
 
       expect { kubernetes_test.test_node_not_deleted_during_copy }.to hop("verify_node_not_deleted_during_copy")
       expect(kubernetes_test.strand.stack.first["drain_test_node_name"]).to eq("w1-node")
-      expect(pod_node.reload.retire_set?).to be true
+      expect(pod_node.retire_set?(cached: false)).to be true
     end
   end
 

--- a/spec/prog/test/kubernetes_upgrade_spec.rb
+++ b/spec/prog/test/kubernetes_upgrade_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Prog::Test::KubernetesUpgrade do
       expect(kn.reload.version).to eq(kubernetes_cluster.version)
       expect(kn.upgrade_requested_set?).to be true
       expect(kn.upgrade_set?).to be false
-      expect(kubernetes_cluster.reload.upgrade_nodepools_set?).to be true
+      expect(kubernetes_cluster.upgrade_nodepools_set?(cached: false)).to be true
     end
   end
 

--- a/spec/prog/test/move_vm_spec.rb
+++ b/spec/prog/test/move_vm_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe Prog::Test::MoveVm do
       end
 
       expect { prog.start }.to hop("move_vm")
-        .and change { vm.reload.prepare_to_move_set? }.from(false).to(true)
-        .and change { vm.reload.stop_set? }.from(false).to(true)
+        .and change { vm.prepare_to_move_set?(cached: false) }.from(false).to(true)
+        .and change { vm.stop_set?(cached: false) }.from(false).to(true)
 
       expect(prog.markers).to eq(Array.new(described_class::MARKER_COUNT) { |i| ["/opt/markers/marker-#{i}", "sha-#{i}"] })
     end
@@ -160,8 +160,8 @@ RSpec.describe Prog::Test::MoveVm do
 
       expect { prog.destroy }.to hop("wait_resources_destroyed")
 
-      expect(old_vm.reload.destroy_set?).to be true
-      expect(new_vm.reload.destroy_set?).to be true
+      expect(old_vm.destroy_set?(cached: false)).to be true
+      expect(new_vm.destroy_set?(cached: false)).to be true
     end
   end
 

--- a/spec/prog/test/postgres_resource_spec.rb
+++ b/spec/prog/test/postgres_resource_spec.rb
@@ -250,11 +250,11 @@ RSpec.describe Prog::Test::PostgresResource do
       pages = Page.all
       expect(pages.size).to eq 1
       expect(pages[0].severity).to eq "info"
-      expect(pages[0].reload.resolve_set?).to be false
+      expect(pages[0].resolve_set?(cached: false)).to be false
 
       pgr_test.incr_destroy
       expect { pgr_test.destroy }.to hop("destroy_postgres")
-      expect(pages[0].reload.resolve_set?).to be true
+      expect(pages[0].resolve_set?(cached: false)).to be true
     end
   end
 

--- a/spec/prog/test/vm_sourced_machine_images_spec.rb
+++ b/spec/prog/test/vm_sourced_machine_images_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Prog::Test::VmSourcedMachineImages do
         ["/path/to/prev/marker", "sha256-of-prev-marker"],
         *Array.new(5) { |i| ["/opt/markers/round-2-marker-#{i}", "aaaa"] },
       ])
-      expect(vm.reload.stop_set?).to be(true)
+      expect(vm.stop_set?(cached: false)).to be(true)
     end
   end
 
@@ -189,8 +189,8 @@ RSpec.describe Prog::Test::VmSourcedMachineImages do
       expect(prog.sshable).to receive(:_cmd).with("sudo sha256sum /opt/markers/m0").and_return("sha0  x\n")
       expect(prog.sshable).to receive(:_cmd).with("sudo sha256sum /opt/markers/m1").and_return("sha1  x\n")
       expect { prog.verify_markers }.to hop("wait_resources_destroyed")
-      expect(target_vm.reload.destroy_set?).to be(true)
-      expect(miv_metals.map { it.reload.destroy_set? }).to all(be(true))
+      expect(target_vm.destroy_set?(cached: false)).to be(true)
+      expect(miv_metals.map { it.destroy_set?(cached: false) }).to all(be(true))
     end
 
     it "fails when the sha256 doesn't match" do

--- a/spec/prog/victoria_metrics/victoria_metrics_resource_nexus_spec.rb
+++ b/spec/prog/victoria_metrics/victoria_metrics_resource_nexus_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsResourceNexus do
 
       expect { nx.refresh_dns_record }.to hop("wait")
 
-      expect(nx.victoria_metrics_resource.reload.refresh_dns_record_set?).to be false
+      expect(nx.victoria_metrics_resource.refresh_dns_record_set?(cached: false)).to be false
       expect(dns_zone.records_dataset.where(type: "A", data: "1.2.3.4", tombstoned: false).count).to eq(1)
       expect(dns_zone.records_dataset.where(type: "AAAA", data: "2a01::2", tombstoned: false).count).to eq(1)
     end
@@ -148,7 +148,7 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsResourceNexus do
       expect(nx.victoria_metrics_resource.root_cert_key_1).to eq(old_root_cert_key_2)
       expect(nx.victoria_metrics_resource.root_cert_2).not_to eq(old_root_cert_2)
       expect(nx.victoria_metrics_resource.certificate_last_checked_at).to be_within(5).of(Time.now)
-      expect(nx.victoria_metrics_resource.servers.first.reload.reconfigure_set?).to be true
+      expect(nx.victoria_metrics_resource.servers.first.reconfigure_set?(cached: false)).to be true
     end
 
     it "does not rotate certificates if not close to expiration" do
@@ -160,7 +160,7 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsResourceNexus do
       nx.victoria_metrics_resource.reload
       expect(nx.victoria_metrics_resource.root_cert_1).to eq(cert_pem)
       expect(nx.victoria_metrics_resource.certificate_last_checked_at).to be_within(5).of(Time.now)
-      expect(nx.victoria_metrics_resource.servers.first.reload.reconfigure_set?).to be false
+      expect(nx.victoria_metrics_resource.servers.first.reconfigure_set?(cached: false)).to be false
     end
   end
 
@@ -170,7 +170,7 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsResourceNexus do
 
       expect { nx.reconfigure }.to hop("wait")
 
-      expect(nx.victoria_metrics_resource.reload.reconfigure_set?).to be false
+      expect(nx.victoria_metrics_resource.reconfigure_set?(cached: false)).to be false
       server = nx.victoria_metrics_resource.servers.first.reload
       expect(server.reconfigure_set?).to be true
       expect(server.restart_set?).to be true
@@ -188,11 +188,11 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsResourceNexus do
 
       expect { nx.destroy }.to hop("wait_servers_destroyed")
 
-      expect(nx.victoria_metrics_resource.reload.destroy_set?).to be false
+      expect(nx.victoria_metrics_resource.destroy_set?(cached: false)).to be false
       expect(dns_zone.records_dataset.where(type: "A", data: "1.2.3.4", tombstoned: true).count).to eq(1)
       expect(firewall).not_to exist
-      expect(private_subnet.reload.destroy_set?).to be true
-      expect(server.reload.destroy_set?).to be true
+      expect(private_subnet.destroy_set?(cached: false)).to be true
+      expect(server.destroy_set?(cached: false)).to be true
     end
 
     it "skips DNS cleanup when no dns_zone is present" do
@@ -203,10 +203,10 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsResourceNexus do
 
       expect { nx.destroy }.to hop("wait_servers_destroyed")
 
-      expect(nx.victoria_metrics_resource.reload.destroy_set?).to be false
+      expect(nx.victoria_metrics_resource.destroy_set?(cached: false)).to be false
       expect(firewall).not_to exist
-      expect(private_subnet.reload.destroy_set?).to be true
-      expect(server.reload.destroy_set?).to be true
+      expect(private_subnet.destroy_set?(cached: false)).to be true
+      expect(server.destroy_set?(cached: false)).to be true
     end
   end
 

--- a/spec/prog/victoria_metrics/victoria_metrics_server_nexus_spec.rb
+++ b/spec/prog/victoria_metrics/victoria_metrics_server_nexus_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsServerNexus do
     it "handles reconfigure" do
       nx.incr_reconfigure
       expect { nx.wait }.to hop("configure")
-      expect(victoria_metrics_server.reload.reconfigure_set?).to be false
+      expect(victoria_metrics_server.reconfigure_set?(cached: false)).to be false
     end
 
     it "handles restart" do
@@ -219,7 +219,7 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsServerNexus do
       nx.incr_checkup
       expect(nx).to receive(:available?).and_return(true)
       expect { nx.wait }.to nap(60 * 60 * 24 * 30)
-      expect(victoria_metrics_server.reload.checkup_set?).to be false
+      expect(victoria_metrics_server.checkup_set?(cached: false)).to be false
     end
 
     it "naps if no action needed" do
@@ -372,7 +372,7 @@ RSpec.describe Prog::VictoriaMetrics::VictoriaMetricsServerNexus do
       nx.incr_checkup
       expect(nx).to receive(:available?).and_return(true)
       expect { nx.unavailable }.to hop("wait")
-      expect(victoria_metrics_server.reload.checkup_set?).to be false
+      expect(victoria_metrics_server.checkup_set?(cached: false)).to be false
     end
 
     it "buds restart and naps if server remains unavailable" do

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -545,7 +545,7 @@ usermod -L ubuntu
       it "adds failed AZ to exclude_availability_zones on first failure" do
         expect(Clog).to receive(:emit).with("retrying in different az", instance_of(Hash)).and_call_original
         expect { nx.create_instance }.to hop("wait_old_nic_deleted")
-          .and change { nic.reload.destroy_set? }.from(false).to(true)
+          .and change { nic.destroy_set?(cached: false) }.from(false).to(true)
         expect(st.stack.last["exclude_availability_zones"]).to eq(["a"])
         expect(st.stack.last["unsupported_azs"]).to eq([])
       end
@@ -583,7 +583,7 @@ usermod -L ubuntu
       it "adds failed AZ to unsupported_azs on first failure" do
         expect(Clog).to receive(:emit).with("retrying in different az", instance_of(Hash)).and_call_original
         expect { nx.create_instance }.to hop("wait_old_nic_deleted")
-          .and change { nic.reload.destroy_set? }.from(false).to(true)
+          .and change { nic.destroy_set?(cached: false) }.from(false).to(true)
         expect(st.stack.last["unsupported_azs"]).to eq(["a"])
         expect(st.stack.last["exclude_availability_zones"]).to eq([])
       end
@@ -801,7 +801,7 @@ usermod -L ubuntu
       expect(Clog).to receive(:emit).with("aws internal error on launch", instance_of(Hash)).and_call_original
       expect { nx.wait_instance_created }.to nap(60 * 60)
         .and change(GithubRunner, :count).from(1).to(2)
-        .and change { runner.reload.destroy_set? }.from(false).to(true)
+        .and change { runner.destroy_set?(cached: false) }.from(false).to(true)
     end
 
     it "does not provision another spare runner if one was already provisioned" do
@@ -813,7 +813,7 @@ usermod -L ubuntu
       client.stub_responses(:describe_instances, reservations: [{instances: [{state: {name: "terminated"}, state_reason: {code: "Server.InternalError", message: "Server.InternalError: Internal error on launch"}}]}])
       expect { nx.wait_instance_created }.to nap(60 * 60)
         .and not_change(GithubRunner, :count)
-        .and not_change { runner.reload.destroy_set? }
+        .and not_change { runner.destroy_set?(cached: false) }
     end
 
     it "naps without recreating when the instance is terminated due to a non-internal-error reason" do
@@ -936,7 +936,7 @@ usermod -L ubuntu
   describe "#wait_sshable" do
     it "naps 6 seconds if it's the first time we execute wait_sshable" do
       expect { nx.wait_sshable }.to nap(6)
-        .and change { vm.reload.update_firewall_rules_set? }.from(false).to(true)
+        .and change { vm.update_firewall_rules_set?(cached: false) }.from(false).to(true)
     end
 
     it "naps if not sshable" do

--- a/spec/prog/vm/gcp/nexus_spec.rb
+++ b/spec/prog/vm/gcp/nexus_spec.rb
@@ -678,7 +678,7 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       nx.incr_update_firewall_rules
       st.update(retval: Sequel.pg_jsonb({"msg" => "firewall rule is added"}))
       expect { nx.wait_sshable }.to hop("create_billing_record")
-        .and change { vm.reload.update_firewall_rules_set? }.from(true).to(false)
+        .and change { vm.update_firewall_rules_set?(cached: false) }.from(true).to(false)
     end
 
     it "naps if not sshable" do

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -690,7 +690,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect { nx.start_vms }.to hop("configure_metrics")
 
       # The VM was signaled to restart, exactly as on a requested reboot.
-      expect(vm.reload.start_after_host_reboot_set?).to be true
+      expect(vm.start_after_host_reboot_set?(cached: false)).to be true
     end
 
     it "verify_spdk hops to verify_hugepages if spdk started" do

--- a/spec/prog/vm/metal/move_vm_spec.rb
+++ b/spec/prog/vm/metal/move_vm_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe Prog::Vm::Metal::MoveVm do
     describe "#destroy" do
       it "destroys the remote storage server and pops" do
         expect { nx.destroy }.to exit({"msg" => "vm moved"})
-        expect(rss.reload.destroy_set?).to be(true)
+        expect(rss.destroy_set?(cached: false)).to be(true)
       end
     end
   end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -593,7 +593,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       # Second run is able to allocate, but there are still vms in the queue, so we don't resolve the page
       expect(Scheduling::Allocator).to receive(:allocate)
       expect { nx.start }.to hop("create_unix_user")
-        .and change { vm.reload.waiting_for_capacity_set? }.from(true).to(false)
+        .and change { vm.waiting_for_capacity_set?(cached: false) }.from(true).to(false)
       expect(Page.active.count).to eq(1)
       expect(Page.active.first.resolve_set?).to be false
 
@@ -947,7 +947,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
   describe "#wait_sshable" do
     it "naps 6 seconds if it's the first time we execute wait_sshable" do
       expect { nx.wait_sshable }.to nap(6)
-        .and change { vm.reload.update_firewall_rules_set? }.from(false).to(true)
+        .and change { vm.update_firewall_rules_set?(cached: false) }.from(false).to(true)
     end
 
     it "naps if not sshable" do
@@ -1013,7 +1013,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm.inhost_name}/1/rpc.sock -q 2 -w 2 | head -n 1", stdin: payload.to_json).and_return('{"status": {"stripes": {"fetched": 100, "source": 100}}}')
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm.inhost_name}/2/rpc.sock -q 2 -w 2 | head -n 1", stdin: payload.to_json).and_return('{"status": {"stripes": {"fetched": 100, "source": 100}}}')
       expect { nx.wait_storage_catchup }.to hop("wait")
-        .and change { rss.reload.destroy_set? }.from(false).to(true)
+        .and change { rss.destroy_set?(cached: false) }.from(false).to(true)
         .and change { vm.vm_storage_volumes_dataset.where(machine_image_version_id: nil).where(remote_storage_server_id: nil).count }.from(1).to(3)
     end
   end
@@ -1180,7 +1180,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       vm.incr_update_firewall_rules
       expect(nx).to receive(:push).with(Prog::Vnet::Metal::UpdateFirewallRules, {}, :update_firewall_rules)
       expect { nx.update_firewall_rules }
-        .to change { vm.reload.update_firewall_rules_set? }.from(true).to(false)
+        .to change { vm.update_firewall_rules_set?(cached: false) }.from(true).to(false)
     end
 
     it "hops to wait if firewall rules are applied" do
@@ -1195,7 +1195,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(nx).to receive(:write_params_json)
       expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm reinstall-systemd-units #{vm.inhost_name}")
       expect { nx.update_spdk_dependency }.to hop("wait")
-        .and change { vm.reload.update_spdk_dependency_set? }.from(true).to(false)
+        .and change { vm.update_spdk_dependency_set?(cached: false) }.from(true).to(false)
     end
   end
 
@@ -1204,7 +1204,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       vm.incr_restart
       expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm restart #{vm.inhost_name}")
       expect { nx.restart }.to hop("wait")
-        .and change { vm.reload.restart_set? }.from(true).to(false)
+        .and change { vm.restart_set?(cached: false) }.from(true).to(false)
     end
   end
 
@@ -1213,7 +1213,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       vm.incr_start
       expect(sshable).to receive(:_cmd).with("sudo systemctl start #{vm.inhost_name}")
       expect { nx.start_after_stop }.to nap(5)
-        .and change { vm.reload.start_set? }.from(true).to(false)
+        .and change { vm.start_set?(cached: false) }.from(true).to(false)
     end
 
     it "hops to wait if vm is available" do
@@ -1248,24 +1248,24 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       vm.incr_stopping
       expect(sshable).to receive(:_cmd).with("sudo systemctl stop #{vm.inhost_name}")
       expect { nx.stopped }.to hop("stopped_by_admin")
-        .and change { vm.reload.admin_stop_set? }.from(true).to(false)
-        .and change { vm.reload.stop_set? }.from(true).to(false)
-        .and change { vm.reload.stopping_set? }.from(true).to(false)
+        .and change { vm.admin_stop_set?(cached: false) }.from(true).to(false)
+        .and change { vm.stop_set?(cached: false) }.from(true).to(false)
+        .and change { vm.stopping_set?(cached: false) }.from(true).to(false)
     end
 
     it "decrements stop semaphore with stop and stopping semaphores" do
       vm.incr_stop
       vm.incr_stopping
       expect { nx.stopped }.to nap(0)
-        .and change { vm.reload.stop_set? }.from(true).to(false)
-        .and not_change { vm.reload.stopping_set? }
+        .and change { vm.stop_set?(cached: false) }.from(true).to(false)
+        .and not_change { vm.stopping_set?(cached: false) }
     end
 
     it "naps if not running with stop semaphore" do
       vm.incr_stop
       expect(sshable).to receive(:_cmd).with("systemctl is-active #{vm.inhost_name} #{vm.inhost_name}-dnsmasq").and_return("inactive\nactive\n")
       expect { nx.stopped }.to nap(0)
-        .and change { vm.reload.stop_set? }.from(true).to(false)
+        .and change { vm.stop_set?(cached: false) }.from(true).to(false)
     end
 
     it "does a soft stop if running with stop semaphore" do
@@ -1273,15 +1273,15 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(sshable).to receive(:_cmd).with("systemctl is-active #{vm.inhost_name} #{vm.inhost_name}-dnsmasq").and_return("active\nactive\n")
       expect(sshable).to receive(:_cmd).with("sudo host/bin/stop-vm #{vm.inhost_name}")
       expect { nx.stopped }.to nap(10)
-        .and change { vm.reload.stop_set? }.from(true).to(false)
-        .and change { vm.reload.stopping_set? }.from(false).to(true)
+        .and change { vm.stop_set?(cached: false) }.from(true).to(false)
+        .and change { vm.stopping_set?(cached: false) }.from(false).to(true)
     end
 
     it "decrements stopping semaphore when stopping semaphore if vm not running" do
       vm.incr_stopping
       expect(sshable).to receive(:_cmd).with("systemctl is-active #{vm.inhost_name} #{vm.inhost_name}-dnsmasq").and_return("inactive\nactive\n")
       expect { nx.stopped }.to nap(0)
-        .and change { vm.reload.stopping_set? }.from(true).to(false)
+        .and change { vm.stopping_set?(cached: false) }.from(true).to(false)
     end
 
     it "attempts nice shutdown with stopping semaphore and vm is running" do
@@ -1323,7 +1323,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       vm.incr_start
       vm.incr_restart
       expect { nx.stopped }.to hop("stopped_by_admin")
-        .and not_change { vm.reload.prepare_to_move_set? }
+        .and not_change { vm.prepare_to_move_set?(cached: false) }
     end
   end
 
@@ -1331,14 +1331,14 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     it "hops to start_after_host_reboot when needed" do
       vm.incr_start_after_host_reboot
       expect { nx.unavailable }.to hop("start_after_host_reboot")
-        .and change { vm.reload.checkup_set? }.from(false).to(true)
+        .and change { vm.checkup_set?(cached: false) }.from(false).to(true)
     end
 
     it "restarts the VM when needed" do
       vm.incr_restart
       expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm restart #{vm.inhost_name}")
       expect { nx.unavailable }.to nap(0)
-        .and change { vm.reload.restart_set? }.from(true).to(false)
+        .and change { vm.restart_set?(cached: false) }.from(true).to(false)
     end
 
     it "hops to start_after_stop when needed" do
@@ -1436,7 +1436,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       page = Prog::PageNexus.assemble("#{vm.ubid} stopped unexpectedly", ["VmExit", vm.ubid], vm.ubid).subject
       expect(sshable).to receive(:_cmd).with("systemctl is-active #{vm.inhost_name} #{vm.inhost_name}-dnsmasq").and_return("active\nactive\n")
       expect { nx.unavailable }.to hop("wait")
-        .and change { page.reload.resolve_set? }.from(false).to(true)
+        .and change { page.resolve_set?(cached: false) }.from(false).to(true)
     end
   end
 
@@ -1648,7 +1648,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
         {stdin: /{"storage":{"vm.*_0":{"key":"key","init_vector":"iv","algorithm":"aes-256-gcm","auth_data":"somedata"}}}/},
       )
       expect { nx.start_after_host_reboot }.to hop("wait")
-        .and change { vm.reload.update_firewall_rules_set? }.from(false).to(true)
+        .and change { vm.update_firewall_rules_set?(cached: false) }.from(false).to(true)
       expect(vm.reload.display_state).to eq("running")
     end
 

--- a/spec/prog/vm/update_ipv6_spec.rb
+++ b/spec/prog/vm/update_ipv6_spec.rb
@@ -119,8 +119,8 @@ RSpec.describe Prog::Vm::UpdateIpv6 do
     expect(sshable).to receive(:_cmd).with("sudo ip -n #{inhost_name} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
     expect(sshable).to receive(:_cmd).with("sudo systemctl start #{inhost_name}-metadata-endpoint.service")
     expect { pr.start_vm }.to exit({"msg" => "VM test updated"})
-    expect(vm.reload.update_firewall_rules_set?).to be true
-    expect(private_subnet.reload.refresh_keys_set?).to be true
+    expect(vm.update_firewall_rules_set?(cached: false)).to be true
+    expect(private_subnet.refresh_keys_set?(cached: false)).to be true
     expect(lb.update_load_balancer_set?).to be true
     expect(lb.rewrite_dns_records_set?).to be true
   end
@@ -132,8 +132,8 @@ RSpec.describe Prog::Vm::UpdateIpv6 do
     expect(sshable).to receive(:_cmd).with("sudo ip -n #{inhost_name} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
     expect(sshable).not_to receive(:_cmd).with(/metadata-endpoint/)
     expect { pr.start_vm }.to exit({"msg" => "VM test updated"})
-    expect(vm.reload.update_firewall_rules_set?).to be true
-    expect(private_subnet.reload.refresh_keys_set?).to be true
+    expect(vm.update_firewall_rules_set?(cached: false)).to be true
+    expect(private_subnet.refresh_keys_set?(cached: false)).to be true
   end
 
   it "does not start metadata endpoint service if load balancer is not cert enabled" do
@@ -144,8 +144,8 @@ RSpec.describe Prog::Vm::UpdateIpv6 do
     expect(sshable).to receive(:_cmd).with("sudo ip -n #{inhost_name} addr replace #{addr} dev #{nic.ubid_to_tap_name}")
     expect(sshable).not_to receive(:_cmd).with(/metadata-endpoint/)
     expect { pr.start_vm }.to exit({"msg" => "VM test updated"})
-    expect(vm.reload.update_firewall_rules_set?).to be true
-    expect(private_subnet.reload.refresh_keys_set?).to be true
+    expect(vm.update_firewall_rules_set?(cached: false)).to be true
+    expect(private_subnet.refresh_keys_set?(cached: false)).to be true
   end
 
   it "writes params json" do

--- a/spec/prog/vnet/gcp/vpc_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_nexus_spec.rb
@@ -675,8 +675,8 @@ RSpec.describe Prog::Vnet::Gcp::VpcNexus do
       expect(nx.gcp_vpc).to receive(:lock!).with(:no_key_update).and_call_original
 
       expect { nx.destroy }.to hop("wait")
-      expect(gcp_vpc.reload.destroy_set?).to be(false)
-      expect(gcp_vpc.reload.destroying_set?).to be(false)
+      expect(gcp_vpc.destroy_set?(cached: false)).to be(false)
+      expect(gcp_vpc.destroying_set?(cached: false)).to be(false)
       expect(nx.strand.stack.first["deadline_target"]).to be_nil
     end
   end

--- a/spec/prog/vnet/maintain_presigned_load_balancer_certs_spec.rb
+++ b/spec/prog/vnet/maintain_presigned_load_balancer_certs_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Prog::Vnet::MaintainPresignedLoadBalancerCerts do
       expect(Clog).to receive(:emit).with("Strand for presigned cert not finished in time, destroying", {"presigned_cert_strand_destroyed" => UBID.to_ubid(prog.strand.stack[0]["cert_id"])}).and_call_original
       expect { prog.wait_for_signed_cert }.to hop("wait")
         .and not_change { DB[:presigned_load_balancer_cert].count }
-        .and change { cert.reload.destroy_set? }.from(false).to(true)
+        .and change { cert.destroy_set?(cached: false) }.from(false).to(true)
       frame = prog.strand.stack[0]
       expect(frame.fetch("load_balancer_id")).to be_nil
       expect(frame.fetch("cert_id")).to be_nil

--- a/spec/prog/vnet/maintain_presigned_postgres_certs_spec.rb
+++ b/spec/prog/vnet/maintain_presigned_postgres_certs_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Prog::Vnet::MaintainPresignedPostgresCerts do
       expect(Clog).to receive(:emit).with("Strand for presigned cert not finished in time, destroying", {"presigned_cert_strand_destroyed" => UBID.to_ubid(prog.strand.stack[0]["cert_id"])}).and_call_original
       expect { prog.wait_for_signed_cert }.to hop("wait")
         .and not_change { DB[:presigned_postgres_cert].count }
-        .and change { cert.reload.destroy_set? }.from(false).to(true)
+        .and change { cert.destroy_set?(cached: false) }.from(false).to(true)
       frame = prog.strand.stack[0]
       expect(frame.fetch("postgres_resource_id")).to be_nil
       expect(frame.fetch("cert_id")).to be_nil

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       vm = Prog::Vm::Nexus.assemble("pub key", prj.id, name: "test-vm", private_subnet_id: ps.id, nic_id: nic.id).subject
       nx.incr_update_firewall_rules
       expect { nx.wait }.to nap(10 * 60)
-      expect(vm.reload.update_firewall_rules_set?).to be true
+      expect(vm.update_firewall_rules_set?(cached: false)).to be true
     end
 
     it "increments refresh_keys as the leader if it passed more than a day" do
@@ -211,7 +211,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
     it "triggers outbound setup once all nics are inbound" do
       nic.update(rekey_phase: "inbound")
       expect { nx.wait_inbound_setup }.to hop("wait_outbound_setup")
-      expect(nic.reload.trigger_outbound_update_set?).to be true
+      expect(nic.trigger_outbound_update_set?(cached: false)).to be true
     end
 
     it "consumes nic_phase_done and naps while nics are still idle" do
@@ -238,7 +238,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
     it "triggers old state drop once all nics are outbound" do
       nic.update(rekey_phase: "outbound")
       expect { nx.wait_outbound_setup }.to hop("wait_old_state_drop")
-      expect(nic.reload.old_state_drop_trigger_set?).to be true
+      expect(nic.old_state_drop_trigger_set?(cached: false)).to be true
     end
 
     it "consumes nic_phase_done and naps while nics are still inbound" do
@@ -348,7 +348,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       nic
       expect(nx).to receive(:rand).with(5..10).and_return(6)
       expect { nx.destroy }.to nap(6)
-      expect(nic.reload.destroy_set?).to be true
+      expect(nic.destroy_set?(cached: false)).to be true
     end
 
     it "deletes and pops if nics are destroyed" do

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait", id: leader_ps.id)
       nx
       ps.connect_subnet(leader_ps)
-      Semaphore.where(strand_id: [ps.id, leader_ps.id], name: "refresh_keys").destroy
+      Semaphore.where(strand_id: [ps.id, leader_ps.id], name: "refresh_keys").delete
       nx.incr_refresh_keys
       expect { nx.wait }.to nap(0)
       expect(ps.refresh_keys_set?).to be false
@@ -126,7 +126,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait", id: leader_ps.id)
       nx
       ps.connect_subnet(leader_ps)
-      Semaphore.where(strand_id: [ps.id, leader_ps.id], name: "refresh_keys").destroy
+      Semaphore.where(strand_id: [ps.id, leader_ps.id], name: "refresh_keys").delete
       ps.update(last_rekey_at: Time.now - 60 * 60 * 24 - 1)
       expect { nx.wait }.to nap(10 * 60)
       expect(ps.refresh_keys_set?).to be false
@@ -154,7 +154,7 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       Strand.create(prog: "Vnet::Metal::SubnetNexus", label: "wait", id: leader_ps.id)
       nx
       ps.connect_subnet(leader_ps)
-      Semaphore.where(strand_id: [ps.id, leader_ps.id], name: "refresh_keys").destroy
+      Semaphore.where(strand_id: [ps.id, leader_ps.id], name: "refresh_keys").delete
       expect { nx.refresh_keys }.to hop("wait")
       expect(ps.refresh_keys_set?).to be true
     end

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Clover, "firewall" do
 
       expect(firewall.private_subnets.count).to eq(1)
       expect(ps.update_firewall_rules_set?).to be true
-      Semaphore.where(strand_id: ps.id, name: "update_firewall_rules").destroy
+      Semaphore.where(strand_id: ps.id, name: "update_firewall_rules").delete
 
       post "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/#{firewall.ubid}/detach-subnet", {
         private_subnet_id: ps.ubid,

--- a/spec/routes/api/project/private_location_spec.rb
+++ b/spec/routes/api/project/private_location_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Clover, "private-location" do
         delete "/project/#{project.ubid}/private-location/#{reg.ui_name}"
 
         expect(last_response.status).to eq(204)
-        expect(reg.reload.destroy_set?).to be true
+        expect(reg.destroy_set?(cached: false)).to be true
       end
 
       it "success with non-existing region" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1221,7 +1221,7 @@ RSpec.describe CloverAdmin do
     expect(record.ttl).to eq 90
     expect(record.tombstoned).to be false
 
-    Semaphore.where(name: "refresh_dns_servers").destroy
+    Semaphore.where(name: "refresh_dns_servers").delete
     visit "/model/DnsRecord/#{record.ubid}"
     expect(page.title).to eq "Ubicloud Admin - DnsRecord #{record.ubid}"
     click_link "Delete DNS Record"
@@ -2057,7 +2057,7 @@ RSpec.describe CloverAdmin do
       page.refresh
       expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "wait_current", "0", st.ubid, "{}", "", "", "increment resolve"]
 
-      Semaphore.where(strand_id: page_st.id, name: "resolve").destroy
+      Semaphore.where(strand_id: page_st.id, name: "resolve").delete
       st.run
       page.refresh
       expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{\"remaining\" => 0, \"completed\" => 1}", "", "", "increment resolve"]

--- a/spec/routes/web/kubernetes_cluster_spec.rb
+++ b/spec/routes/web/kubernetes_cluster_spec.rb
@@ -618,7 +618,7 @@ RSpec.describe Clover, "Kubernetes" do
 
         expect(page).to have_flash_notice("Node node1 is scheduled to be retired")
         expect(page).to have_current_path("#{project.path}#{kn.path}/nodes")
-        expect(node.reload.retire_set?).to be true
+        expect(node.retire_set?(cached: false)).to be true
         expect(kn.reload.node_count).to eq(1)
       end
 

--- a/spec/routes/web/private_location_spec.rb
+++ b/spec/routes/web/private_location_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Clover, "location-credential" do
         visit "#{project.path}#{private_location.path}"
         click_button "Delete"
         expect(page).to have_flash_notice("Private location deleted")
-        expect(private_location.reload.destroy_set?).to be true
+        expect(private_location.destroy_set?(cached: false)).to be true
       end
 
       it "can not delete aws location credential when does not have permissions" do


### PR DESCRIPTION
This allows for a more efficient approach.

Additionally, switch Semaphore dataset destroy to delete, also for efficiency.