### PR TITLE
Add support for creating PostgreSQL databases without firewall rules to the web UI

### DIFF
--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -132,6 +132,10 @@ module ContentGenerator
       ]
     end
 
+    def self.restrict_by_default(value)
+      "Restrict access by default (no firewall rules will be created)"
+    end
+
     def self.partnership_notice(flavor)
       notice = {
         PostgresResource::Flavor::LANTERN => [[

--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -132,8 +132,8 @@ module ContentGenerator
       ]
     end
 
-    def self.restrict_by_default(value)
-      "Restrict access by default (no firewall rules will be created)"
+    def self.restrict_by_default(_)
+      "Restrict access by default"
     end
 
     def self.partnership_notice(flavor)

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -672,6 +672,8 @@ class PostgresResource < Sequel::Model
 
     options.add_option(name: "ha_type", values: Option::POSTGRES_HA_OPTIONS.keys, parent: "storage_size")
 
+    options.add_option(name: "restrict_by_default", values: ["1"])
+
     if project.get_ff_postgres_init_script
       options.add_option(name: "init_script")
     end

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -171,6 +171,27 @@ RSpec.describe Clover, "postgres" do
         expect(PostgresResource.first.init_script.init_script).to eq("sudo whoami")
       end
 
+      it "can create new PostgreSQL database without firewall rules" do
+        visit "#{project.path}/postgres/create?flavor=#{PostgresResource::Flavor::STANDARD}"
+
+        expect(page.title).to eq("Ubicloud - Create PostgreSQL Database")
+        name = "new-pg-db"
+        fill_in "Name", with: name
+        choose option: Location::HETZNER_FSN1_UBID
+        choose option: "standard-2"
+        choose option: PostgresResource::HaType::NONE
+        check "Restrict access by default (no firewall rules will be created)"
+
+        click_button "Create"
+
+        expect(page.title).to eq("Ubicloud - #{name}")
+        expect(page).to have_flash_notice("'#{name}' will be ready in a few minutes")
+        expect(PostgresResource.count).to eq(1)
+        pg = PostgresResource.first
+        expect(pg.project_id).to eq(project.id)
+        expect(pg.pg_firewall_rules_dataset.count).to eq(0)
+      end
+
       it "handles errors when creating new PostgreSQL database" do
         visit "#{project.path}/postgres/create?flavor=#{PostgresResource::Flavor::STANDARD}"
 

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Clover, "postgres" do
         choose option: Location::HETZNER_FSN1_UBID
         choose option: "standard-2"
         choose option: PostgresResource::HaType::NONE
-        check "Restrict access by default (no firewall rules will be created)"
+        check "Restrict access by default"
 
         click_button "Create"
 

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -48,7 +48,7 @@
     {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required", content_generator: ContentGenerator::Postgres.method(:storage_size)},
     {name: "version", type: "radio_small_cards", label: "Version", required: "required", content_generator: ContentGenerator::Postgres.method(:version)},
     {name: "ha_type", type: "radio_small_cards", label: "High Availability", required: "required", content_generator: ContentGenerator::Postgres.method(:ha_type)},
-    {name: "restrict_by_default", type: "checkbox", label: "Firewall Rules", description: "By default, Ubicloud creates firewall rules that allow access to the database from any location. Check this box to create the database without any firewall rules; you can add specific firewall rules afterward.", content_generator: ContentGenerator::Postgres.method(:restrict_by_default), default_unchecked: true},
+    {name: "restrict_by_default", type: "checkbox", label: "Firewall Rules", description: "By default, the subnet for the database will have firewall rules that allow access to the database from any location. Check this box to skip adding firewall rules. You can add specific firewall rules afterward.", content_generator: ContentGenerator::Postgres.method(:restrict_by_default), default_unchecked: true},
   ]
 
   if PostgresResource.partner_notification_flavors.include?(@flavor)

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -48,6 +48,7 @@
     {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required", content_generator: ContentGenerator::Postgres.method(:storage_size)},
     {name: "version", type: "radio_small_cards", label: "Version", required: "required", content_generator: ContentGenerator::Postgres.method(:version)},
     {name: "ha_type", type: "radio_small_cards", label: "High Availability", required: "required", content_generator: ContentGenerator::Postgres.method(:ha_type)},
+    {name: "restrict_by_default", type: "checkbox", label: "Firewall Rules", description: "By default, Ubicloud creates firewall rules that allow access to the database from any location. Check this box to create the database without any firewall rules; you can add specific firewall rules afterward.", content_generator: ContentGenerator::Postgres.method(:restrict_by_default), default_unchecked: true},
   ]
 
   if PostgresResource.partner_notification_flavors.include?(@flavor)


### PR DESCRIPTION
This is already supported in the API and CLI, but it is useful to support on the web as well.