### PR TITLE
Allow resource creation form to accept content_generator_class option

### DIFF
--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -10,11 +10,11 @@ module ContentGenerator
       ssh_public_key.name
     end
 
-    def self.private_subnet(location, private_subnet)
+    def self.private_subnet_id(location, private_subnet)
       private_subnet[:display_name]
     end
 
-    def self.enable_ipv4(location, value)
+    def self.enable_ip4(location, value)
       unit_price = BillingRate.unit_price_from_resource_properties("IPAddress", "IPv4", location.name)
 
       "Enable Public IPv4 ($#{"%.2f" % (unit_price * 60 * 672)}/mo)"

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -1,4 +1,4 @@
-<%# locals: (action:, form_elements:, option_tree:, option_parents:, pre_selected_values: {}, mode: "create", cancel_link: action) %>
+<%# locals: (action:, form_elements:, option_tree:, option_parents:, pre_selected_values: {}, mode: "create", cancel_link: action, content_generator_class: nil) %>
 <% nonce = SecureRandom.hex(32)
 content_security_policy.add_script_src [:nonce, nonce] %>
 
@@ -26,39 +26,41 @@ let option_dirty = <%== allow_unescaped(JSON.generate(form_elements.map { it[:na
 
     name, type, label, required, placeholder, content_generator = element.values_at(:name, :type, :label, :required, :placeholder, :content_generator)
 
-    has_option = ["radio_small_cards", "select", "checkbox"].include?(type)
-    options = OptionTreeGenerator.generate_allowed_options(name, option_tree, option_parents).map do |option|
-      opt_val = if option[name].is_a?(Sequel::Model)
-        option[name].ubid
-      elsif type == "select"
-        option[name][:value].to_s
-      else
-        option[name].to_s
+    if has_option = ["radio_small_cards", "select", "checkbox"].include?(type)
+      content_generator ||= content_generator_class&.method(name)
+      options = OptionTreeGenerator.generate_allowed_options(name, option_tree, option_parents).map do |option|
+        opt_val = if option[name].is_a?(Sequel::Model)
+          option[name].ubid
+        elsif type == "select"
+          option[name][:value].to_s
+        else
+          option[name].to_s
+        end
+
+        opt_text = content_generator.call(*option.values)
+
+        parents = option.reject { |k, v| k == name }.transform_values { |v| v.is_a?(Sequel::Model) ? v.ubid : v.to_s }
+
+        parents_selected = parents.all? { |k, v| selected_options[k] == v }
+        submitted_value = typecast_body_params.str(name)
+        selected_in_form_submission = submitted_value == opt_val
+        selected_in_pre_selection = submitted_value.nil? && selected_options[name] == opt_val
+        first_of_its_kind = submitted_value.nil? && selected_options[name].nil? unless type == "checkbox" && !request.get?
+        default_unchecked = request.get? && element[:default_unchecked]
+        checked = !default_unchecked && parents_selected && (selected_in_form_submission || selected_in_pre_selection || first_of_its_kind)
+        selected_options[name] = opt_val if checked
+
+        opt_classes = parents.map { |k, v| "form_#{k} form_#{k}_#{v.tr(".", "-")}" }
+        opt_classes << "hidden" unless parents_selected
+        opt_classes = opt_classes.join(" ")
+
+        opt_attrs = {}
+        opt_attrs[:disabled] = "disabled" unless parents_selected
+        opt_attrs[:checked] = checked
+
+        [opt_val, opt_text, opt_classes, opt_attrs]
       end
-
-      opt_text = content_generator.call(*option.values)
-
-      parents = option.reject { |k, v| k == name }.transform_values { |v| v.is_a?(Sequel::Model) ? v.ubid : v.to_s }
-
-      parents_selected = parents.all? { |k, v| selected_options[k] == v }
-      submitted_value = typecast_body_params.str(name)
-      selected_in_form_submission = submitted_value == opt_val
-      selected_in_pre_selection = submitted_value.nil? && selected_options[name] == opt_val
-      first_of_its_kind = submitted_value.nil? && selected_options[name].nil? unless type == "checkbox" && !request.get?
-      default_unchecked = request.get? && element[:default_unchecked]
-      checked = !default_unchecked && parents_selected && (selected_in_form_submission || selected_in_pre_selection || first_of_its_kind)
-      selected_options[name] = opt_val if checked
-
-      opt_classes = parents.map { |k, v| "form_#{k} form_#{k}_#{v.tr(".", "-")}" }
-      opt_classes << "hidden" unless parents_selected
-      opt_classes = opt_classes.join(" ")
-
-      opt_attrs = {}
-      opt_attrs[:disabled] = "disabled" unless parents_selected
-      opt_attrs[:checked] = checked
-
-      [opt_val, opt_text, opt_classes, opt_attrs]
-    end if has_option
+    end
 
     attributes = {required:}
 

--- a/views/kubernetes-cluster/create.erb
+++ b/views/kubernetes-cluster/create.erb
@@ -18,14 +18,14 @@
 <%
   form_elements = [
     {name: "name", type: "text", label: "Cluster Name", required: "required", placeholder: "Enter cluster name"},
-    {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:location)},
-    {name: "version", type: "radio_small_cards", label: "Version", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:version)},
-    {name: "cp_nodes", type: "radio_small_cards", label: "Control Plane", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:cp_nodes)},
-    {name: "worker_size", type: "radio_small_cards", label: "Worker size", required: "required", content_generator: ContentGenerator::KubernetesCluster.method(:worker_size)},
-    {name: "worker_nodes", type: "select", label: "Worker Nodes", required: "required", placeholder: "Select number of worker nodes", content_generator: ContentGenerator::KubernetesCluster.method(:worker_nodes), opening_tag: "<div class='sm:col-span-3'>"},
+    {name: "location", type: "radio_small_cards", label: "Location", required: "required"},
+    {name: "version", type: "radio_small_cards", label: "Version", required: "required"},
+    {name: "cp_nodes", type: "radio_small_cards", label: "Control Plane", required: "required"},
+    {name: "worker_size", type: "radio_small_cards", label: "Worker size", required: "required"},
+    {name: "worker_nodes", type: "select", label: "Worker Nodes", required: "required", placeholder: "Select number of worker nodes", opening_tag: "<div class='sm:col-span-3'>"},
   ]
 
   action = "#{@project.path}/kubernetes-cluster"
 %>
 
-<%==part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents)%>
+<%==part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents, content_generator_class: ContentGenerator::KubernetesCluster)%>

--- a/views/networking/firewall/create.erb
+++ b/views/networking/firewall/create.erb
@@ -17,11 +17,11 @@
   form_elements = [
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name", opening_tag: "<div class='sm:col-span-2'>"},
     {name: "description", type: "text", label: "Description", required: "required", placeholder: "Enter description", opening_tag: "<div class='sm:col-span-2'>"},
-    {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::Vm.method(:location)},
-    {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Select private subnet", content_generator: ContentGenerator::Vm.method(:private_subnet), opening_tag: "<div class='sm:col-span-2'>"},
+    {name: "location", type: "radio_small_cards", label: "Location", required: "required"},
+    {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Select private subnet", opening_tag: "<div class='sm:col-span-2'>"},
   ]
 
   action = "#{@project.path}/firewall"
 %>
 
-<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents)%>
+<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents, content_generator_class: ContentGenerator::Vm)%>

--- a/views/networking/load_balancer/create.erb
+++ b/views/networking/load_balancer/create.erb
@@ -12,17 +12,18 @@
 ) %>
 
 <%
+  content_generator = ContentGenerator::LoadBalancer.method(:select_option)
   form_elements = [
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name", opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
-    {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Select private subnet", content_generator: ContentGenerator::LoadBalancer.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
-    {name: "algorithm", type: "select", label: "Load Balancing Algorithm", content_generator: ContentGenerator::LoadBalancer.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
-    {name: "stack", type: "select", label: "Stack", required: "required", content_generator: ContentGenerator::LoadBalancer.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
+    {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Select private subnet", content_generator:, opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
+    {name: "algorithm", type: "select", label: "Load Balancing Algorithm", content_generator:, opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
+    {name: "stack", type: "select", label: "Stack", required: "required", content_generator:, opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
     {name: "forwarding_rule", type: "section", label: "Forwarding Rule", content: "Configures the routing of traffic from the load balancer to your virtual machines.", separator: true},
     {name: "src_port", type: "number", label: "Load Balancer Port", required: "required", placeholder: "80", opening_tag: "<div class='col-span-6 col-start-1 md:col-end-3 xl:col-end-2'>"},
     {name: "dst_port", type: "number", label: "Application Port", required: "required", placeholder: "80", opening_tag: "<div class='col-span-6 col-start-1 md:col-start-3 md:col-end-5 xl:col-start-2 xl:col-end-3'>"},
     {name: "monitoring", type: "section", label: "Monitoring", content: "The health check endpoint is used in combination with the Application Port. Make sure it returns 200.", separator: true},
     {name: "health_check_endpoint", type: "text", label: "HTTP Health Check Endpoint", placeholder: "/up", opening_tag: "<div id='health-check-endpoint-wrapper' class='col-span-6 col-start-1 md:col-end-3'>"},
-    {name: "health_check_protocol", type: "select", label: "Health Check Protocol", required: "required", content_generator: ContentGenerator::LoadBalancer.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-start-3 md:col-end-5'>"},
+    {name: "health_check_protocol", type: "select", label: "Health Check Protocol", required: "required", content_generator:, opening_tag: "<div class='col-span-6 col-start-1 md:col-start-3 md:col-end-5'>"},
     {name: "ssl_certificate_notice", type: "section", label: "SSL Certificate", content: "Ubicloud automatically provides a free SSL certificate for your load balancer. To enable it, check the box.", separator: true},
     {name: "cert_enabled", type: "checkbox", content_generator: ContentGenerator::LoadBalancer.method(:enable_ssl_certificate)}
   ]

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -42,13 +42,13 @@
   form_elements = [
     {name: "flavor", type: "hidden", value: @flavor},
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name", opening_tag: "<div class='sm:col-span-3'>"},
-    {name: "location", type: "radio_small_cards", label: "Location", required: "required", additional_element_html:, description_html: byoc_description_html, content_generator: ContentGenerator::Postgres.method(:location)},
-    {name: "family", type: "radio_small_cards", label: "Server family", required: "required", content_generator: ContentGenerator::Postgres.method(:family)},
-    {name: "size", type: "radio_small_cards", label: "Server size", required: "required", content_generator: ContentGenerator::Postgres.method(:size)},
-    {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required", content_generator: ContentGenerator::Postgres.method(:storage_size)},
-    {name: "version", type: "radio_small_cards", label: "Version", required: "required", content_generator: ContentGenerator::Postgres.method(:version)},
-    {name: "ha_type", type: "radio_small_cards", label: "High Availability", required: "required", content_generator: ContentGenerator::Postgres.method(:ha_type)},
-    {name: "restrict_by_default", type: "checkbox", label: "Firewall Rules", description: "By default, the subnet for the database will have firewall rules that allow access to the database from any location. Check this box to skip adding firewall rules. You can add specific firewall rules afterward.", content_generator: ContentGenerator::Postgres.method(:restrict_by_default), default_unchecked: true},
+    {name: "location", type: "radio_small_cards", label: "Location", required: "required", additional_element_html:, description_html: byoc_description_html},
+    {name: "family", type: "radio_small_cards", label: "Server family", required: "required"},
+    {name: "size", type: "radio_small_cards", label: "Server size", required: "required"},
+    {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required"},
+    {name: "version", type: "radio_small_cards", label: "Version", required: "required"},
+    {name: "ha_type", type: "radio_small_cards", label: "High Availability", required: "required"},
+    {name: "restrict_by_default", type: "checkbox", label: "Firewall Rules", description: "By default, the subnet for the database will have firewall rules that allow access to the database from any location. Check this box to skip adding firewall rules. You can add specific firewall rules afterward.", default_unchecked: true},
   ]
 
   if PostgresResource.partner_notification_flavors.include?(@flavor)
@@ -66,4 +66,4 @@
   pre_selected_values = {"version" => PostgresResource.default_version(@flavor)}
 %>
 
-<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents, pre_selected_values:) %>
+<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents, pre_selected_values:, content_generator_class: ContentGenerator::Postgres) %>

--- a/views/postgres/high_availability.erb
+++ b/views/postgres/high_availability.erb
@@ -13,14 +13,12 @@ pre_selected_values = {
   "ha_type" => @pg.ha_type
 } %>
 
-<%== render(
+<%== part(
   "components/form/resource_creation_form",
-  locals: {
-    action: "#{path(@pg)}/patch",
-    form_elements:,
-    pre_selected_values:,
-    option_tree: @option_tree,
-    option_parents: @option_parents,
-    mode: "update"
-  }
+  action: "#{path(@pg)}/patch",
+  form_elements:,
+  pre_selected_values:,
+  option_tree: @option_tree,
+  option_parents: @option_parents,
+  mode: "update"
 ) %>

--- a/views/postgres/resize.erb
+++ b/views/postgres/resize.erb
@@ -28,9 +28,9 @@ end %>
 </div>
 
 <% form_elements = [
-  {name: "family", type: "radio_small_cards", label: "Server family", required: "required", content_generator: ContentGenerator::Postgres.method(:family)},
-  {name: "size", type: "radio_small_cards", label: "Server size", required: "required", content_generator: ContentGenerator::Postgres.method(:size)},
-  {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required", content_generator: ContentGenerator::Postgres.method(:storage_size)},
+  {name: "family", type: "radio_small_cards", label: "Server family", required: "required"},
+  {name: "size", type: "radio_small_cards", label: "Server size", required: "required"},
+  {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required"},
   {name: "failover_time_notice", type: "section", content: "If a maintenance window is configured, failover to the new server with the desired configuration will occur during the first available maintenance window after the new server is ready. Otherwise, failover will take place as soon as the new server becomes ready. Depending on the size of the data, it may take several hours for the new server to become ready.", separator: false}
 ]
 
@@ -44,14 +44,13 @@ pre_selected_values = {
   "storage_size" => @pg.target_storage_size_gib
 } %>
 
-<%== render(
+<%== part(
   "components/form/resource_creation_form",
-  locals: {
-    action: "#{path(@pg)}/patch",
-    form_elements:,
-    pre_selected_values:,
-    option_tree: @option_tree,
-    option_parents: @option_parents,
-    mode: "update"
-  }
+  action: "#{path(@pg)}/patch",
+  form_elements:,
+  pre_selected_values:,
+  option_tree: @option_tree,
+  option_parents: @option_parents,
+  mode: "update",
+  content_generator_class: ContentGenerator::Postgres
 ) %>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -25,20 +25,20 @@ current_usage = @project.current_resource_usage("VmVCpu")
 
   form_elements = [
     {name: "name", type: "text", label: "Name", placeholder: "Enter name", required: "required", opening_tag: "<div class='sm:col-span-3'>"},
-    {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::Vm.method(:location)},
-    {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Default", description_html: ps_description, content_generator: ContentGenerator::Vm.method(:private_subnet), opening_tag: "<div class='sm:col-span-3'>"},
+    {name: "location", type: "radio_small_cards", label: "Location", required: "required"},
+    {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Default", description_html: ps_description, opening_tag: "<div class='sm:col-span-3'>"},
     {name: "new_private_subnet_name", type: "text", label: "Private Subnet Name", placeholder: "Private Subnet Name", opening_tag: "<div class='sm:col-span-3' id='new-private-subnet-name'>", value: typecast_body_params.str("new_private_subnet_name")},
-    {name: "enable_ip4", type: "checkbox", label: "Public IPv4 Support", description: "Needed for inbound and outbound public IPv4 connections. Websites that do not support IPv6 will be inaccessible without an IPv4 address.", content_generator: ContentGenerator::Vm.method(:enable_ipv4)},
-    {name: "family", type: "radio_small_cards", label: "Server family", required: "required", content_generator: ContentGenerator::Vm.method(:family)}
+    {name: "enable_ip4", type: "checkbox", label: "Public IPv4 Support", description: "Needed for inbound and outbound public IPv4 connections. Websites that do not support IPv6 will be inaccessible without an IPv4 address."},
+    {name: "family", type: "radio_small_cards", label: "Server family", required: "required"}
   ]
 
   elements = [
-    {name: "size", type: "radio_small_cards", label: "Server size", required: "required", content_generator: ContentGenerator::Vm.method(:size)},
-    {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required", content_generator: ContentGenerator::Vm.method(:storage_size)}
+    {name: "size", type: "radio_small_cards", label: "Server size", required: "required"},
+    {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required"}
   ]
 
   if @show_gpu != false
-    gpu = {name: "gpu", type: "radio_small_cards", label: "GPU", required: "required", content_generator: ContentGenerator::Vm.method(:gpu)}
+    gpu = {name: "gpu", type: "radio_small_cards", label: "GPU", required: "required"}
     if @show_gpu
       elements.unshift gpu
     else
@@ -49,13 +49,12 @@ current_usage = @project.current_resource_usage("VmVCpu")
   form_elements.concat(elements)
 
   form_elements.push(
-    {name: "boot_image", type: "radio_small_cards", label: "Boot Image", required: "required", content_generator: ContentGenerator::Vm.method(:boot_image)}
+    {name: "boot_image", type: "radio_small_cards", label: "Boot Image", required: "required"}
   )
 
   if @option_parents.key?("machine_image")
     form_elements.push(
       {name: "machine_image", type: "select", label: "Machine Image", placeholder: "Select a machine image",
-       content_generator: ContentGenerator::Vm.method(:machine_image),
        opening_tag: "<div id='machine-image-block' class='col-span-full sm:col-span-2'>"}
     )
   end
@@ -74,7 +73,7 @@ current_usage = @project.current_resource_usage("VmVCpu")
       public_key_params[:escape_description] = false
     end
   else
-    form_elements.push({name: "ssh_public_key", type: "select", label: "Registered SSH Public Key", placeholder: "New", content_generator: ContentGenerator::Vm.method(:ssh_public_key), opening_tag: "<div class='sm:col-span-3'>"})
+    form_elements.push({name: "ssh_public_key", type: "select", label: "Registered SSH Public Key", placeholder: "New", opening_tag: "<div class='sm:col-span-3'>"})
   end
 
   form_elements.push(public_key_params)
@@ -87,4 +86,4 @@ current_usage = @project.current_resource_usage("VmVCpu")
   action = "#{@project.path}/vm"
 %>
 
-<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>
+<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents, content_generator_class: ContentGenerator::Vm) %>


### PR DESCRIPTION
Use this to DRY up a number of forms using the resource creation form.