### PR TITLE
Convert admin object action definition to use DSL

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1373,7 +1373,7 @@ class CloverAdmin < Roda
             action = actions[key]
             action_type = action.type
             @label = action.label
-            @params = action.params.is_a?(Proc) ? action.params.call(@obj) : action.params
+            @params = action.params
 
             r.get(action_type != :form) do
               if action_type == :direct

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -431,12 +431,6 @@ class CloverAdmin < Roda
     end
   end
 
-  require_vm_host_provider = lambda do |obj|
-    fail CloverError.new(400, "InvalidRequest", "VmHost has no provider") unless obj.provider
-  end
-
-  github_page_run = ->(obj) { "http://github.com/#{obj.name}" }
-
   OBJECT_ACTIONS = {}
 
   Object.new.instance_exec do
@@ -500,6 +494,8 @@ class CloverAdmin < Roda
         end
       end
     end
+
+    github_page_run = ->(obj) { "http://github.com/#{obj.name}" }
 
     model GithubInstallation do
       action "github_page", "GitHub Page" do
@@ -777,6 +773,10 @@ class CloverAdmin < Roda
       action "reboot", "Reboot" do
         flash "Reboot scheduled for VmHost"
         run(&:incr_reboot)
+      end
+
+      require_vm_host_provider = lambda do |obj|
+        fail CloverError.new(400, "InvalidRequest", "VmHost has no provider") unless obj.provider
       end
 
       action "power_on", "Power On" do

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -395,6 +395,46 @@ class CloverAdmin < Roda
     ObjectAction.define(...)
   end
 
+  class ObjectModelDSL
+    def initialize(model, &)
+      @model = model
+      instance_exec(&)
+    end
+
+    def action(action, label, &)
+      ObjectActionDSL.new(@model.name, action, label, &)
+    end
+  end
+
+  class ObjectActionDSL
+    def initialize(class_name, action, label, &)
+      @opts = {params: {}}
+      @block = nil
+      instance_exec(&)
+      (OBJECT_ACTIONS[class_name] ||= {})[action] = ObjectAction.define(label, **@opts, &@block)
+    end
+
+    def run(&block)
+      @block = block
+    end
+
+    def flash(notice)
+      @opts[:flash] = notice
+    end
+
+    def param(name, **opts)
+      @opts[:params][name] = opts
+    end
+
+    def type(type)
+      @opts[:type] = type
+    end
+
+    def pass_request!
+      @opts[:pass_request] = true
+    end
+  end
+
   require_vm_host_provider = lambda do |obj|
     fail CloverError.new(400, "InvalidRequest", "VmHost has no provider") unless obj.provider
   end
@@ -605,30 +645,67 @@ class CloverAdmin < Roda
         request.redirect("/model/Vm/#{obj.ubid}")
       end,
     },
-    "VmHost" => {
-      "accept" => object_action("Move to Accepting", flash: "Host allocation state changed to accepting") do |obj|
-        obj.update(allocation_state: "accepting")
-      end,
-      "drain" => object_action("Move to Draining", flash: "Host allocation state changed to draining") do |obj|
-        obj.update(allocation_state: "draining")
-      end,
-      "reset" => object_action("Hardware Reset", flash: "Hardware reset scheduled for VmHost", &:incr_hardware_reset),
-      "reboot" => object_action("Reboot", flash: "Reboot scheduled for VmHost", &:incr_reboot),
-      "power_on" => object_action("Power On", flash: "Power on requested for VmHost") do |obj|
-        require_vm_host_provider.call(obj)
-        obj.power_on
-      end,
-      "power_status" => object_action("Power Status", type: :content) do |obj|
-        require_vm_host_provider.call(obj)
-        "Power status: #{Erubi.h(obj.power_status)}"
-      end,
-      "provision_spare_runners" => object_action("Provision Spare Runners", flash: "Spare runners provisioned for GitHub runners on this host", type: :form) do |obj|
-        DB.ignore_duplicate_queries do
-          GithubRunner.where(vm_id: obj.vms_dataset.select(:id)).eager(:semaphores, :installation).all(&:provision_spare_runner)
+  }
+
+  Object.new.instance_exec do
+    def model(...)
+      ObjectModelDSL.new(...)
+    end
+
+    model VmHost do
+      action "accept", "Move to Accepting" do
+        flash "Host allocation state changed to accepting"
+        run do |obj|
+          obj.update(allocation_state: "accepting")
         end
-      end,
-      "move_location" => object_action("Move to Location", flash: "Location updated and missing boot image downloads started", params: {
-        location: {
+      end
+
+      action "drain", "Move to Draining" do
+        flash "Host allocation state changed to draining"
+        run do |obj|
+          obj.update(allocation_state: "draining")
+        end
+      end
+
+      action "reset", "Hardware Reset" do
+        flash "Hardware reset scheduled for VmHost"
+        run(&:incr_hardware_reset)
+      end
+
+      action "reboot", "Reboot" do
+        flash "Reboot scheduled for VmHost"
+        run(&:incr_reboot)
+      end
+
+      action "power_on", "Power On" do
+        flash "Power on requested for VmHost"
+        run do |obj|
+          require_vm_host_provider.call(obj)
+          obj.power_on
+        end
+      end
+
+      action "power_status", "Power Status" do
+        type :content
+        run do |obj|
+          require_vm_host_provider.call(obj)
+          "Power status: #{Erubi.h(obj.power_status)}"
+        end
+      end
+
+      action "provision_spare_runners", "Provision Spare Runners" do
+        type :form
+        flash "Spare runners provisioned for GitHub runners on this host"
+        run do |obj|
+          DB.ignore_duplicate_queries do
+            GithubRunner.where(vm_id: obj.vms_dataset.select(:id)).eager(:semaphores, :installation).all(&:provision_spare_runner)
+          end
+        end
+      end
+
+      action "move_location", "Move to Location" do
+        flash "Location updated and missing boot image downloads started"
+        param :location,
           typecast: :ubid_uuid!,
           type: "select",
           add_blank: true,
@@ -637,36 +714,39 @@ class CloverAdmin < Roda
             .where(project_id: nil, provider: %w[hetzner leaseweb].freeze)
             .or(id: Location::GITHUB_RUNNERS_ID)
             .select_order_map([:display_name, :id])
-            .each { it[1] = UBID.to_ubid(it[1]) },
-        },
-      }) do |obj, target_location_id|
-        obj.move_to_location(target_location_id)
-      end,
-      "force_create_vm" => object_action("Force Create VM", flash: "VM creation scheduled", params: ->(obj) {
-        {
-          project_id: {typecast: :ubid_uuid!, required: true, placeholder: "Project UBID"},
-          public_key: {typecast: :nonempty_str!, required: true},
-          name: {typecast: :nonempty_str, required: nil, placeholder: "auto-generated if blank"},
-          size: {
-            typecast: :nonempty_str!,
-            type: "select",
-            required: true,
-            options: Option::VmSizes.select { it.arch == obj.arch && (it.family == obj.family || (it.family == "burstable" && obj.accepts_slices)) }.map(&:name),
-          },
-          boot_image: {
-            typecast: :nonempty_str!,
-            type: "select",
-            required: true,
-            options: obj.boot_images_dataset.exclude(activated_at: nil).distinct.select_order_map(:name),
-          },
-        }
-      }) do |obj, project_id, public_key, name, size, boot_image|
-        Prog::Vm::Nexus.assemble(public_key, project_id, name:, size:, boot_image:,
-          location_id: obj.location_id, arch: obj.arch, force_host_id: obj.id, enable_ip4: true)
-      end,
-    },
-  }.freeze
-  OBJECT_ACTIONS.each_value(&:freeze)
+            .each { it[1] = UBID.to_ubid(it[1]) }
+        run do |obj, target_location_id|
+          obj.move_to_location(target_location_id)
+        end
+      end
+
+      action "force_create_vm", "Force Create VM" do
+        flash "VM creation scheduled"
+        param :project_id, typecast: :ubid_uuid!, required: true, placeholder: "Project UBID"
+        param :public_key, typecast: :nonempty_str!, required: true
+        param :name, typecast: :nonempty_str, required: nil, placeholder: "auto-generated if blank"
+        param :size, typecast: :nonempty_str!,
+          type: "select",
+          required: true,
+          options: ->(obj) do
+            Option::VmSizes.select { it.arch == obj.arch && (it.family == obj.family || (it.family == "burstable" && obj.accepts_slices)) }.map(&:name)
+          end
+        param :boot_image,
+          typecast: :nonempty_str!,
+          type: "select",
+          required: true,
+          options: ->(obj) do
+            obj.boot_images_dataset.exclude(activated_at: nil).distinct.select_order_map(:name)
+          end
+        run do |obj, project_id, public_key, name, size, boot_image|
+          Prog::Vm::Nexus.assemble(public_key, project_id, name:, size:, boot_image:,
+            location_id: obj.location_id, arch: obj.arch, force_host_id: obj.id, enable_ip4: true)
+        end
+      end
+    end
+  end
+
+  OBJECT_ACTIONS.freeze.each_value(&:freeze)
 
   SEARCH_QUERIES = {
     "Account" => [:email, :name],

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -391,10 +391,6 @@ class CloverAdmin < Roda
     end
   end
 
-  def self.object_action(...)
-    ObjectAction.define(...)
-  end
-
   class ObjectModelDSL
     def initialize(model, &)
       @model = model
@@ -439,217 +435,323 @@ class CloverAdmin < Roda
     fail CloverError.new(400, "InvalidRequest", "VmHost has no provider") unless obj.provider
   end
 
-  github_page_action = object_action("GitHub Page", type: :direct) do |obj|
-    "http://github.com/#{obj.name}"
-  end
+  github_page_run = ->(obj) { "http://github.com/#{obj.name}" }
 
-  OBJECT_ACTIONS = {
-    "Account" => {
-      "suspend" => object_action("Suspend", flash: "Account suspended", &:suspend),
-      "unsuspend" => object_action("Unsuspend", flash: "Account unsuspended", &:unsuspend),
-    },
-    "BootImage" => {
-      "remove_boot_image" => object_action("Remove Boot Image", flash: "Boot image removal scheduled", &:remove_boot_image),
-      "activate_boot_image" => object_action("Activate Boot Image", flash: "Boot image activated") do |obj|
-        obj.update(activated_at: Time.now)
-      end,
-      "disable_boot_image" => object_action("Disable Boot Image", flash: "Boot image disabled") do |obj|
-        obj.update(activated_at: nil)
-      end,
-    },
-    "DnsZone" => {
-      "add_record" => object_action("Add DNS Record", flash: "Added DNS Record",
-        params: {
-          name: {typecast: :nonempty_str!, label: "name (without zone)"},
-          type: {typecast: :nonempty_str!},
-          data: {typecast: :nonempty_str!},
-          ttl: {typecast: :pos_int!, type: :number, attr: {min: 60, max: 3600}, value: 600},
-        }) do |obj, record_name, type, data, ttl|
-          record_name += ".#{obj.name}."
-          obj.insert_record(record_name:, type:, ttl:, data:)
-        end,
-    },
-    "DnsRecord" => {
-      "delete" => object_action("Delete DNS Record", flash: "Deleted DNS Record") do |obj|
-        dns_zone = DnsZone.with_pk!(obj.dns_zone_id)
-        dns_zone.delete_record(record_name: obj.name, type: obj.type, data: obj.data)
-      end,
-    },
-    "GithubInstallation" => {
-      "github_page" => github_page_action,
-    },
-    "GithubRepository" => {
-      "github_page" => github_page_action,
-      "show_job_log" => object_action("Show Job Log", params: {job_ids: {typecast: :nonempty_str!, label: "Job IDs (comma-separated)"}}, type: :content) do |obj, job_ids|
-        client = obj.installation.client
-        items = job_ids.split(",").filter_map do |job_id|
-          job_id.strip!
-          next if job_id.empty?
-
-          unless (id = Integer(job_id, exception: false)) && id.between?(1, 2**63 - 1)
-            next "<li>Job #{Erubi.h(job_id)}: invalid job ID</li>"
-          end
-
-          begin
-            url = client.workflow_run_job_logs(obj.name, id)
-            "<li><a href=\"#{Erubi.h(url)}\" target=\"_blank\">Job #{id}: Show Log</a></li>"
-          rescue Octokit::Error => e
-            "<li>Job #{id}: #{e.class}: #{Erubi.h(e.message)}</li>"
-          end
-        end
-        "<ol>#{items.join}</ol>"
-      end,
-    },
-    "GithubRunner" => {
-      "provision" => object_action("Provision Spare Runner", flash: "Spare runner provisioned", type: :form, &:provision_spare_runner),
-    },
-    "Invoice" => {
-      "download_pdf" => object_action("Download PDF", type: :direct) do |obj|
-        obj.generate_download_link
-      end,
-    },
-    "OidcProvider" => {
-      "add_allowed_domain" => object_action("Add Allowed Domain", flash: "Added allowed domain", params: {domain: {typecast: :nonempty_str!}}) do |obj, domain|
-        obj.add_allowed_domain(domain)
-      end,
-      "remove_allowed_domain" => object_action("Remove Allowed Domain", flash: "Removed allowed domain",
-        params: ->(obj) {
-          {domain: {typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options: obj.allowed_domains}}
-        }) do |obj, domain|
-          obj.remove_allowed_domain(domain)
-        end,
-    },
-    "Page" => {
-      "resolve" => object_action("Resolve", flash: "Resolve scheduled for Page", &:incr_resolve),
-      "retrigger" => object_action("Retrigger", flash: "Retrigger scheduled for Page", &:incr_retrigger),
-    },
-    "PostgresResource" => {
-      "restart" => object_action("Restart", flash: "Restart scheduled for PostgresResource") do |obj|
-        obj.server_incr("restart")
-      end,
-    },
-    "PostgresServer" => {
-      "recycle" => object_action("Recycle", flash: "Recycle scheduled for PostgresServer", &:incr_recycle),
-    },
-    "Project" => {
-      "add_credit" => object_action("Add credit", flash: "Added credit", params: {credit: {typecast: :float!, type: "number", attr: {min: -10**6, max: 10**6}}}) do |obj, credit|
-        obj.this.update(credit: Sequel[:credit] + credit)
-      end,
-      "set_feature_flag" => object_action("Set Feature Flag", flash: "Set feature flag", params: {
-        name: {
-          typecast: :str!,
-          type: "select",
-          add_blank: true,
-          options: Project.instance_methods.grep(/\Aset_ff_/).map! { it[7...] }.sort!,
-        },
-        value: {
-          typecast: :nonempty_str,
-          placeholder: "JSON",
-          required: nil,
-        },
-      }) do |obj, name, value|
-        begin
-          value = JSON.parse(value) if value
-        rescue JSON::ParserError
-          fail CloverError.new(400, "InvalidRequest", "invalid JSON for feature flag value")
-        end
-        obj.send("set_ff_#{name}", value)
-      end,
-      "set_quota" => object_action("Set Quota", flash: "Set quota", params: {
-        resource_type: {
-          typecast: :str!,
-          type: "select",
-          add_blank: true,
-          options: ProjectQuota.default_quotas.keys,
-        },
-        value: {
-          typecast: :int,
-          type: "number",
-          placeholder: "blank to reset to default",
-          required: nil,
-        },
-      }) do |obj, resource_type, value|
-        quota_id = ProjectQuota.default_quotas[resource_type]["id"]
-        if (existing_quota = obj.quotas_dataset.first(quota_id:))
-          if value
-            existing_quota.update(value:)
-          else
-            existing_quota.destroy
-          end
-        elsif value
-          obj.add_quota(quota_id:, value:)
-        end
-      end,
-    },
-    "Strand" => {
-      "subject" => object_action("Subject", type: :direct) do |obj|
-        "/model/#{obj.subject.class}/#{obj.subject.ubid}"
-      end,
-      "schedule" => object_action("Schedule Strand to Run Immediately", flash: "Scheduled strand to run immediately", type: :form) do |obj|
-        obj.this.update(schedule: Sequel::CURRENT_TIMESTAMP)
-      end,
-      "extend" => object_action("Extend Schedule", flash: "Extended schedule", params: {minutes: {typecast: :pos_int!, type: "number", attr: {min: 1, max: 1440}}}) do |obj, minutes|
-        obj.this.update(schedule: Sequel.date_add(:schedule, minutes:))
-      end,
-      "incr_semaphore" => object_action("Increment Semaphore", flash: "Incremented semaphore", params: ->(obj) {
-        subject_class = obj.subject.class
-        options = subject_class.respond_to?(:semaphore_names) ? subject_class.semaphore_names.map(&:name).sort! : [].freeze
-        {
-          name: {typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options:},
-          name_confirmation: {typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options:},
-        }
-      }) do |obj, name, name_confirmation|
-        fail CloverError.new(400, "InvalidRequest", "Semaphore name confirmation does not match") unless name == name_confirmation
-        Semaphore.incr(obj.id, name)
-      end,
-      "decr_semaphore" => object_action("Decrement Semaphore", flash: "Decremented semaphore", params: ->(obj) {
-        options = obj.semaphores_dataset.distinct.select_order_map(:name)
-        {
-          name: {typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options:},
-          name_confirmation: {typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options:},
-        }
-      }) do |obj, name, name_confirmation|
-        fail CloverError.new(400, "InvalidRequest", "Semaphore name confirmation does not match") unless name == name_confirmation
-        Semaphore.where(strand_id: obj.id, name:).destroy
-      end,
-    },
-    "Vm" => {
-      "restart" => object_action("Restart", flash: "Restart scheduled for Vm", &:incr_restart),
-      "stop" => object_action("Stop", flash: "Stop scheduled for Vm") do |obj|
-        DB.transaction do
-          obj.incr_admin_stop
-          obj.incr_stop
-        end
-      end,
-      "prepare_to_move" => object_action("Prepare to Move", flash: "Prepare to move scheduled for Vm") do |obj|
-        fail CloverError.new(400, "InvalidRequest", "Prepare to move is only supported for metal Vms") unless obj.location.metal?
-        DB.transaction do
-          obj.incr_prepare_to_move
-          obj.incr_stop
-        end
-      end,
-      "move" => object_action("Move to Host", flash: "Vm move scheduled", pass_request: true, params: ->(obj) {
-        {
-          vm_host_id: {
-            typecast: :ubid_uuid!,
-            type: "select",
-            add_blank: true,
-            required: true,
-            options: VmHost.where(location_id: obj.location_id).select_order_map(:id).map { UBID.to_ubid(it) },
-          },
-        }
-      }) do |obj, vm_host_id, request:|
-        Prog::Vm::Metal::MoveVm.assemble(obj, VmHost.with_pk!(vm_host_id))
-      rescue RuntimeError => e
-        request.scope.flash["error"] = e.message
-        request.redirect("/model/Vm/#{obj.ubid}")
-      end,
-    },
-  }
+  OBJECT_ACTIONS = {}
 
   Object.new.instance_exec do
     def model(...)
       ObjectModelDSL.new(...)
+    end
+
+    model Account do
+      action "suspend", "Suspend" do
+        flash "Account suspended"
+        run(&:suspend)
+      end
+
+      action "unsuspend", "Unsuspend" do
+        flash "Account unsuspended"
+        run(&:unsuspend)
+      end
+    end
+
+    model BootImage do
+      action "remove_boot_image", "Remove Boot Image" do
+        flash "Boot image removal scheduled"
+        run(&:remove_boot_image)
+      end
+
+      action "activate_boot_image", "Activate Boot Image" do
+        flash "Boot image activated"
+        run do |obj|
+          obj.update(activated_at: Time.now)
+        end
+      end
+
+      action "disable_boot_image", "Disable Boot Image" do
+        flash "Boot image disabled"
+        run do |obj|
+          obj.update(activated_at: nil)
+        end
+      end
+    end
+
+    model DnsZone do
+      action "add_record", "Add DNS Record" do
+        flash "Added DNS Record"
+        param :name, typecast: :nonempty_str!, label: "name (without zone)"
+        param :type, typecast: :nonempty_str!
+        param :data, typecast: :nonempty_str!
+        param :ttl, typecast: :pos_int!, type: :number, attr: {min: 60, max: 3600}, value: 600
+        run do |obj, record_name, type, data, ttl|
+          record_name += ".#{obj.name}."
+          obj.insert_record(record_name:, type:, ttl:, data:)
+        end
+      end
+    end
+
+    model DnsRecord do
+      action "delete", "Delete DNS Record" do
+        flash "Deleted DNS Record"
+        run do |obj|
+          dns_zone = DnsZone.with_pk!(obj.dns_zone_id)
+          dns_zone.delete_record(record_name: obj.name, type: obj.type, data: obj.data)
+        end
+      end
+    end
+
+    model GithubInstallation do
+      action "github_page", "GitHub Page" do
+        type :direct
+        run(&github_page_run)
+      end
+    end
+
+    model GithubRepository do
+      action "github_page", "GitHub Page" do
+        type :direct
+        run(&github_page_run)
+      end
+
+      action "show_job_log", "Show Job Log" do
+        type :content
+        param :job_ids, typecast: :nonempty_str!, label: "Job IDs (comma-separated)"
+        run do |obj, job_ids|
+          client = obj.installation.client
+          items = job_ids.split(",").filter_map do |job_id|
+            job_id.strip!
+            next if job_id.empty?
+
+            unless (id = Integer(job_id, exception: false)) && id.between?(1, 2**63 - 1)
+              next "<li>Job #{Erubi.h(job_id)}: invalid job ID</li>"
+            end
+
+            begin
+              url = client.workflow_run_job_logs(obj.name, id)
+              "<li><a href=\"#{Erubi.h(url)}\" target=\"_blank\">Job #{id}: Show Log</a></li>"
+            rescue Octokit::Error => e
+              "<li>Job #{id}: #{e.class}: #{Erubi.h(e.message)}</li>"
+            end
+          end
+          "<ol>#{items.join}</ol>"
+        end
+      end
+    end
+
+    model GithubRunner do
+      action "provision", "Provision Spare Runner" do
+        flash "Spare runner provisioned"
+        type :form
+        run(&:provision_spare_runner)
+      end
+    end
+
+    model Invoice do
+      action "download_pdf", "Download PDF" do
+        type :direct
+        run do |obj|
+          obj.generate_download_link
+        end
+      end
+    end
+
+    model OidcProvider do
+      action "add_allowed_domain", "Add Allowed Domain" do
+        flash "Added allowed domain"
+        param :domain, typecast: :nonempty_str!
+        run do |obj, domain|
+          obj.add_allowed_domain(domain)
+        end
+      end
+
+      action "remove_allowed_domain", "Remove Allowed Domain" do
+        flash "Removed allowed domain"
+        param :domain, typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options: ->(obj) { obj.allowed_domains }
+        run do |obj, domain|
+          obj.remove_allowed_domain(domain)
+        end
+      end
+    end
+
+    model Page do
+      action "resolve", "Resolve" do
+        flash "Resolve scheduled for Page"
+        run(&:incr_resolve)
+      end
+
+      action "retrigger", "Retrigger" do
+        flash "Retrigger scheduled for Page"
+        run(&:incr_retrigger)
+      end
+    end
+
+    model PostgresResource do
+      action "restart", "Restart" do
+        flash "Restart scheduled for PostgresResource"
+        run do |obj|
+          obj.server_incr("restart")
+        end
+      end
+    end
+
+    model PostgresServer do
+      action "recycle", "Recycle" do
+        flash "Recycle scheduled for PostgresServer"
+        run(&:incr_recycle)
+      end
+    end
+
+    model Project do
+      action "add_credit", "Add credit" do
+        flash "Added credit"
+        param :credit, typecast: :float!, type: "number", attr: {min: -10**6, max: 10**6}
+        run do |obj, credit|
+          obj.this.update(credit: Sequel[:credit] + credit)
+        end
+      end
+
+      action "set_feature_flag", "Set Feature Flag" do
+        flash "Set feature flag"
+        param :name,
+          typecast: :str!,
+          type: "select",
+          add_blank: true,
+          options: Project.instance_methods.grep(/\Aset_ff_/).map! { it[7...] }.sort!
+        param :value,
+          typecast: :nonempty_str,
+          placeholder: "JSON",
+          required: nil
+        run do |obj, name, value|
+          begin
+            value = JSON.parse(value) if value
+          rescue JSON::ParserError
+            fail CloverError.new(400, "InvalidRequest", "invalid JSON for feature flag value")
+          end
+          obj.send("set_ff_#{name}", value)
+        end
+      end
+
+      action "set_quota", "Set Quota" do
+        flash "Set quota"
+        param :resource_type,
+          typecast: :str!,
+          type: "select",
+          add_blank: true,
+          options: ProjectQuota.default_quotas.keys
+        param :value,
+          typecast: :int,
+          type: "number",
+          placeholder: "blank to reset to default",
+          required: nil
+        run do |obj, resource_type, value|
+          quota_id = ProjectQuota.default_quotas[resource_type]["id"]
+          if (existing_quota = obj.quotas_dataset.first(quota_id:))
+            if value
+              existing_quota.update(value:)
+            else
+              existing_quota.destroy
+            end
+          elsif value
+            obj.add_quota(quota_id:, value:)
+          end
+        end
+      end
+    end
+
+    model Strand do
+      action "subject", "Subject" do
+        type :direct
+        run do |obj|
+          "/model/#{obj.subject.class}/#{obj.subject.ubid}"
+        end
+      end
+
+      action "schedule", "Schedule Strand to Run Immediately" do
+        flash "Scheduled strand to run immediately"
+        type :form
+        run do |obj|
+          obj.this.update(schedule: Sequel::CURRENT_TIMESTAMP)
+        end
+      end
+
+      action "extend", "Extend Schedule" do
+        flash "Extended schedule"
+        param :minutes, typecast: :pos_int!, type: "number", attr: {min: 1, max: 1440}
+        run do |obj, minutes|
+          obj.this.update(schedule: Sequel.date_add(:schedule, minutes:))
+        end
+      end
+
+      action "incr_semaphore", "Increment Semaphore" do
+        flash "Incremented semaphore"
+        options = ->(obj) do
+          subject_class = obj.subject.class
+          subject_class.respond_to?(:semaphore_names) ? subject_class.semaphore_names.map(&:name).sort! : [].freeze
+        end
+        param(:name, typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options:)
+        param(:name_confirmation, typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options:)
+        run do |obj, name, name_confirmation|
+          fail CloverError.new(400, "InvalidRequest", "Semaphore name confirmation does not match") unless name == name_confirmation
+          Semaphore.incr(obj.id, name)
+        end
+      end
+
+      action "decr_semaphore", "Decrement Semaphore" do
+        flash "Decremented semaphore"
+        options = ->(obj) { DB.ignore_duplicate_queries { obj.semaphores_dataset.distinct.select_order_map(:name) } }
+        param(:name, typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options:)
+        param(:name_confirmation, typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options:)
+        run do |obj, name, name_confirmation|
+          fail CloverError.new(400, "InvalidRequest", "Semaphore name confirmation does not match") unless name == name_confirmation
+          Semaphore.where(strand_id: obj.id, name:).destroy
+        end
+      end
+    end
+
+    model Vm do
+      action "restart", "Restart" do
+        flash "Restart scheduled for Vm"
+        run(&:incr_restart)
+      end
+
+      action "stop", "Stop" do
+        flash "Stop scheduled for Vm"
+        run do |obj|
+          DB.transaction do
+            obj.incr_admin_stop
+            obj.incr_stop
+          end
+        end
+      end
+
+      action "prepare_to_move", "Prepare to Move" do
+        flash "Prepare to move scheduled for Vm"
+        run do |obj|
+          fail CloverError.new(400, "InvalidRequest", "Prepare to move is only supported for metal Vms") unless obj.location.metal?
+          DB.transaction do
+            obj.incr_prepare_to_move
+            obj.incr_stop
+          end
+        end
+      end
+
+      action "move", "Move to Host" do
+        flash "Vm move scheduled"
+        pass_request!
+        param :vm_host_id,
+          typecast: :ubid_uuid!,
+          type: "select",
+          add_blank: true,
+          required: true,
+          options: ->(obj) { VmHost.where(location_id: obj.location_id).select_order_map(:id).map { UBID.to_ubid(it) } }
+        run do |obj, vm_host_id, request:|
+          Prog::Vm::Metal::MoveVm.assemble(obj, VmHost.with_pk!(vm_host_id))
+        rescue RuntimeError => e
+          request.scope.flash["error"] = e.message
+          request.redirect("/model/Vm/#{obj.ubid}")
+        end
+      end
     end
 
     model VmHost do

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -699,7 +699,7 @@ class CloverAdmin < Roda
 
       action "decr_semaphore", "Decrement Semaphore" do
         flash "Decremented semaphore"
-        options = ->(obj) { DB.ignore_duplicate_queries { obj.semaphores_dataset.distinct.select_order_map(:name) } }
+        options = ->(obj) { obj.semaphores.map(&:name).sort!.uniq }
         param(:name, typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options:)
         param(:name_confirmation, typecast: :nonempty_str!, type: "select", add_blank: true, required: true, options:)
         run do |obj, name, name_confirmation|

--- a/views/admin/object_action.erb
+++ b/views/admin/object_action.erb
@@ -2,7 +2,8 @@
 
 <% form(method: :post, id: "action-form", class: "form-vertical") do |f| %>
   <% @params.each do |name, value| %>
-    <%== f.input(value.fetch(:type, "text"), key: name, label: name, required: true, **value) %>
+    <% options = {options: value[:options].call(@obj)} if value[:options].is_a?(Proc) %>
+    <%== f.input(value.fetch(:type, "text"), key: name, label: name, required: true, **value, **options) %>
   <% end %>
   <%== f.button(@label) %>
 <% end %>


### PR DESCRIPTION
The nested hashes approach used before is a bit ugly, and will get
uglier as object actions get more complex. This adds an alternative DSL
that can be used to define object actions, and switch the VmHost object
actions to use it.

The DSL definition of an action is generally longer in terms of lines,
but is generally simpler and requires less punctuation. Most keyword
arguments in the object_action method become separate method calls,
and parameters are defined individually instead of all at once. This
adds support for using a lambda around only the options for a single
parameter, instead of using a lambda for all parameters, which is
necessary now that parameters are defined individually instead of all
at once.