### PR TITLE
Show current configuration on the Postgres resize page

### DIFF
--- a/views/postgres/resize.erb
+++ b/views/postgres/resize.erb
@@ -1,3 +1,32 @@
+<% server = @pg.representative_server
+vm = server.vm
+
+compute_subtext = h("#{vm.vcpus} vCPUs / #{vm.memory_gib} GB RAM")
+if server.fallback_active?
+  compute_subtext += "<br><span class=\"text-amber-600 text-sm\">Fallback from #{h(@pg.target_vm_size)}</span>"
+elsif @pg.target_vm_size != @pg.vm_size
+  compute_subtext += "<br><span class=\"text-amber-600 text-sm\">Resizing to #{h(@pg.target_vm_size)}</span>"
+end
+
+storage_subtext = if (disk_usage_percent = server.observed_disk_usage_percent)
+  disk_usage_gib = (disk_usage_percent * server.storage_size_gib / 100.0).round(1)
+  subtext = "#{disk_usage_gib} GB is used (#{disk_usage_percent}%)"
+  (disk_usage_percent > 80) ? "<span class=\"text-red-600\">#{subtext}</span>" : subtext
+else
+  ""
+end
+if @pg.target_storage_size_gib != server.storage_size_gib
+  storage_subtext += "<br><span class=\"text-amber-600 text-sm\">Resizing to #{@pg.target_storage_size_gib} GB</span>"
+end %>
+
+<div class="p-6">
+  <h3 class="text-base font-semibold text-gray-900 pb-4">Current configuration</h3>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <%== part("components/icon_with_text", icon: "hero-cpu-chip", text: @pg.vm_size, subtext_html: compute_subtext) %>
+    <%== part("components/icon_with_text", icon: "hero-circle-stack", text: "#{server.storage_size_gib} GB storage", subtext_html: storage_subtext) %>
+  </div>
+</div>
+
 <% form_elements = [
   {name: "family", type: "radio_small_cards", label: "Server family", required: "required", content_generator: ContentGenerator::Postgres.method(:family)},
   {name: "size", type: "radio_small_cards", label: "Server size", required: "required", content_generator: ContentGenerator::Postgres.method(:size)},


### PR DESCRIPTION
The resize form only shows the requested target size and storage, so
users pick new values without seeing what the database currently has.
Add a summary above the form with the current size, vCPU/RAM, storage
size, and disk usage from the monitor DB (the same value the scale-down
validation checks), plus notes when a resize is already in flight or
the instance-type fallback is active.

The summary reuses the `icon_with_text` component and the grid styling
of the overview tab. Disk usage turns red above 80%, matching the
overview page and the scale-down threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2208" height="2307" alt="CleanShot 2026-08-14 at 12 30 39@2x" src="https://github.com/user-attachments/assets/5d5270c0-1fea-4458-9b95-e9a775fbf53c" />


<img width="2264" height="1534" alt="CleanShot 2026-08-14 at 12 31 14@2x" src="https://github.com/user-attachments/assets/21d06a62-e85e-428f-a9d0-4e326df0083b" />
