### PR TITLE
Disable storage sizes that cannot hold the data in use

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -8,6 +8,8 @@
         @apply flex items-center justify-center rounded-md sm:flex-1 cursor-pointer focus:outline-none;
         @apply ring-1 ring-gray-300 bg-white text-gray-900 hover:bg-gray-50 peer-focus-visible:ring-2 peer-focus-visible:ring-orange-600;
         @apply peer-focus-visible:ring-offset-2 peer-checked:bg-orange-600 peer-checked:text-white peer-checked:hover:bg-orange-700;
+        @apply peer-disabled:cursor-not-allowed peer-disabled:bg-gray-50 peer-disabled:text-gray-400;
+        @apply peer-disabled:ring-gray-200 peer-disabled:hover:bg-gray-50;
     }
 
     .checkbox-chip {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -230,19 +230,27 @@ function redrawChildOptions(name) {
       }
 
       let elements2select = [];
+      // Options the server marked as unavailable stay disabled and
+      // unselectable, whichever parent option is chosen.
+      let available = ":not(.option-unavailable)";
+
       switch (child_type) {
         case "input_radio":
           $("input[name=" + child_name + "]").parent().hide()
           $("input[name=" + child_name + "]").prop('disabled', true).prop('checked', false).prop('selected', false);
           $("input[name=" + child_name + "]").parent(classes).show()
-          $("input[name=" + child_name + "]").parent(classes).children("input[name=" + child_name + "]").prop('disabled', false);
+          $("input[name=" + child_name + "]").parent(classes + available).children("input[name=" + child_name + "]").prop('disabled', false);
 
           if (option_dirty[child_name]) {
-            elements2select = $("input[name=" + child_name + "][value=" + option_dirty[child_name] + "]").parent(classes);
+            elements2select = $("input[name=" + child_name + "][value=" + option_dirty[child_name] + "]").parent(classes + available);
           }
 
           if (elements2select.length == 0) {
             option_dirty[child_name] = null;
+            elements2select = $("input[name=" + child_name + "]").parent(classes + available);
+          }
+
+          if (elements2select.length == 0) {
             elements2select = $("input[name=" + child_name + "]").parent(classes);
           }
 

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -231,6 +231,25 @@ class PostgresResource < Sequel::Model
     effective_timeline.latest_backup_size_in_gib > target_storage_size_gib
   end
 
+  # A scale down is only allowed if the current disk usage stays below this
+  # fraction of the requested storage size.
+  STORAGE_SCALE_DOWN_MAX_USAGE_RATIO = 0.8
+
+  # Current disk usage of the representative server in GiB, or nil if there
+  # are no recent metrics. A scale down is refused while this is nil, because
+  # there is no way to tell whether the data fits.
+  def observed_disk_usage_gib
+    return unless (percent = representative_server.observed_disk_usage_percent)
+    percent * representative_server.storage_size_gib / 100.0
+  end
+
+  # Whether usage_gib fits in target_storage_size_gib with the headroom a
+  # scale down requires. Callers pass usage_gib in, so that checking many
+  # sizes queries the metrics only once.
+  def storage_size_fits_usage?(target_storage_size_gib, usage_gib)
+    target_storage_size_gib * STORAGE_SCALE_DOWN_MAX_USAGE_RATIO >= usage_gib
+  end
+
   def in_maintenance_window?
     return true if maintenance_window_start_at.nil?
     now = Time.now.utc

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -75,13 +75,11 @@ class Clover
         validate_postgres_input(pg.name, postgres_params)
 
         if target_storage_size_gib < pg.representative_server.storage_size_gib
-          disk_usage_percent = pg.representative_server.observed_disk_usage_percent
+          usage_gib = pg.observed_disk_usage_gib
 
-          fail CloverError.new(400, "InvalidRequest", "Metrics unavailable right now to verify scale down safety", {}) unless disk_usage_percent
+          fail CloverError.new(400, "InvalidRequest", "Metrics unavailable right now to verify scale down safety", {}) unless usage_gib
 
-          current_disk_usage = disk_usage_percent * pg.representative_server.storage_size_gib / 100.0
-
-          if target_storage_size_gib * 0.8 < current_disk_usage
+          unless pg.storage_size_fits_usage?(target_storage_size_gib, usage_gib)
             fail Validation::ValidationFailed.new({storage_size: "Insufficient storage size is requested. It is only possible to reduce the storage size if the current usage is less than 80% of the requested size."})
           end
         end

--- a/spec/model/postgres/postgres_resource_spec.rb
+++ b/spec/model/postgres/postgres_resource_spec.rb
@@ -884,6 +884,12 @@ RSpec.describe PostgresResource do
     expect { described_class.maintenance_window_days_mask(["funday"]) }.to raise_error(Validation::ValidationFailed, /maintenance_window_days/)
   end
 
+  it "checks whether a storage size fits the observed disk usage" do
+    # A scale down needs the usage to stay below 80% of the requested size.
+    expect(postgres_resource.storage_size_fits_usage?(128, 102.4)).to be(true)
+    expect(postgres_resource.storage_size_fits_usage?(128, 102.5)).to be(false)
+  end
+
   it "labels the maintenance window" do
     expect(postgres_resource.maintenance_window_label).to be_nil
 

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -609,8 +609,9 @@ RSpec.describe Clover, "postgres" do
         visit "#{project.path}#{pg.path}/resize"
 
         expect(page).to have_content "Current disk usage is unavailable"
-        expect(page).to have_content "Disk usage unknown"
         expect(page).to have_css("label.form_size_standard-2.option-unavailable input[value='64'][disabled]")
+        # The reason is the same for every size, so it is not repeated per card.
+        expect(page).to have_no_content "Too small for"
       end
 
       it "shows the maintenance window in the resize failover steps" do

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -573,6 +573,9 @@ RSpec.describe Clover, "postgres" do
       end
 
       it "can update PostgreSQL instance size configuration" do
+        # Low disk usage, so that no storage option is disabled for not
+        # holding the data in use.
+        POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].insert(postgres_server_id: pg.representative_server.id, data_disk_usage_percent: 5, observed_at: Time.now)
         visit "#{project.path}#{pg.path}/resize"
 
         choose option: "standard-8"
@@ -586,6 +589,28 @@ RSpec.describe Clover, "postgres" do
         pg.reload
         expect(pg.target_vm_size).to eq("standard-8")
         expect(pg.target_storage_size_gib).to eq(256)
+      ensure
+        POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].where(postgres_server_id: pg.representative_server.id).delete
+      end
+
+      it "disables the storage sizes that cannot hold the data in use" do
+        POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].insert(postgres_server_id: pg.representative_server.id, data_disk_usage_percent: 60, observed_at: Time.now)
+        visit "#{project.path}#{pg.path}/resize"
+
+        expect(page).to have_content "76.8 GB of 128 GB is used"
+        expect(page).to have_content "Too small for 76.8 GB used"
+        expect(page).to have_css("label.form_size_standard-2.option-unavailable input[value='64'][disabled]")
+        expect(page).to have_no_css("label.form_size_standard-2.option-unavailable input[value='128']")
+      ensure
+        POSTGRES_MONITOR_DB[:postgres_disk_usage_monitor].where(postgres_server_id: pg.representative_server.id).delete
+      end
+
+      it "disables the smaller storage sizes when the disk usage is unknown" do
+        visit "#{project.path}#{pg.path}/resize"
+
+        expect(page).to have_content "Current disk usage is unavailable"
+        expect(page).to have_content "Disk usage unknown"
+        expect(page).to have_css("label.form_size_standard-2.option-unavailable input[value='64'][disabled]")
       end
 
       it "shows the maintenance window in the resize failover steps" do

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -41,7 +41,8 @@ let option_dirty = <%== allow_unescaped(JSON.generate(form_elements.map { it[:na
 
         # Options the resource cannot accept right now are shown, but disabled,
         # with the reason in place of the subtitle. option_disabler returns that
-        # reason, or nil when the option is available.
+        # reason, an empty string to disable without one, or nil when the option
+        # is available.
         unavailable_reason = element[:option_disabler]&.call(opt_val)
         opt_text = [opt_text[0], unavailable_reason, *opt_text[2..]] if unavailable_reason
 

--- a/views/components/form/resource_creation_form.erb
+++ b/views/components/form/resource_creation_form.erb
@@ -39,6 +39,12 @@ let option_dirty = <%== allow_unescaped(JSON.generate(form_elements.map { it[:na
 
         opt_text = content_generator.call(*option.values)
 
+        # Options the resource cannot accept right now are shown, but disabled,
+        # with the reason in place of the subtitle. option_disabler returns that
+        # reason, or nil when the option is available.
+        unavailable_reason = element[:option_disabler]&.call(opt_val)
+        opt_text = [opt_text[0], unavailable_reason, *opt_text[2..]] if unavailable_reason
+
         parents = option.reject { |k, v| k == name }.transform_values { |v| v.is_a?(Sequel::Model) ? v.ubid : v.to_s }
 
         parents_selected = parents.all? { |k, v| selected_options[k] == v }
@@ -47,15 +53,16 @@ let option_dirty = <%== allow_unescaped(JSON.generate(form_elements.map { it[:na
         selected_in_pre_selection = submitted_value.nil? && selected_options[name] == opt_val
         first_of_its_kind = submitted_value.nil? && selected_options[name].nil? unless type == "checkbox" && !request.get?
         default_unchecked = request.get? && element[:default_unchecked]
-        checked = !default_unchecked && parents_selected && (selected_in_form_submission || selected_in_pre_selection || first_of_its_kind)
+        checked = !default_unchecked && !unavailable_reason && parents_selected && (selected_in_form_submission || selected_in_pre_selection || first_of_its_kind)
         selected_options[name] = opt_val if checked
 
         opt_classes = parents.map { |k, v| "form_#{k} form_#{k}_#{v.tr(".", "-")}" }
         opt_classes << "hidden" unless parents_selected
+        opt_classes << "option-unavailable" if unavailable_reason
         opt_classes = opt_classes.join(" ")
 
         opt_attrs = {}
-        opt_attrs[:disabled] = "disabled" unless parents_selected
+        opt_attrs[:disabled] = "disabled" if unavailable_reason || !parents_selected
         opt_attrs[:checked] = checked
 
         [opt_val, opt_text, opt_classes, opt_attrs]

--- a/views/postgres/resize.erb
+++ b/views/postgres/resize.erb
@@ -45,7 +45,9 @@ end
 
 storage_option_disabler = lambda do |storage_size|
   next if storage_size.to_i >= server.storage_size_gib
-  next "Disk usage unknown" unless usage_gib
+  # No per option reason when the usage is unknown, because the reason is the
+  # same for every size and the description below the options already gives it.
+  next "" unless usage_gib
   "Too small for #{usage_gib.round(1)} GB used" unless @pg.storage_size_fits_usage?(storage_size.to_i, usage_gib)
 end
 

--- a/views/postgres/resize.erb
+++ b/views/postgres/resize.erb
@@ -34,10 +34,25 @@ end %>
   ["hero-refresh", "Failover", "Typically under a minute of downtime"]
 ]
 
+# A smaller disk is only accepted if the data still fits with room to spare,
+# so disable the sizes the update would reject, and say why on each of them.
+usage_gib = @pg.observed_disk_usage_gib
+storage_description = if usage_gib
+  "#{usage_gib.round(1)} GB of #{server.storage_size_gib} GB is used. A smaller size must keep usage below 80%, so the sizes that cannot hold your data are disabled."
+else
+  "Current disk usage is unavailable, so the storage size cannot be reduced right now."
+end
+
+storage_option_disabler = lambda do |storage_size|
+  next if storage_size.to_i >= server.storage_size_gib
+  next "Disk usage unknown" unless usage_gib
+  "Too small for #{usage_gib.round(1)} GB used" unless @pg.storage_size_fits_usage?(storage_size.to_i, usage_gib)
+end
+
 form_elements = [
   {name: "family", type: "radio_small_cards", label: "Server family", required: "required"},
   {name: "size", type: "radio_small_cards", label: "Server size", required: "required"},
-  {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required"},
+  {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required", option_disabler: storage_option_disabler, description_html: "<p class=\"mt-2 text-sm text-gray-600\">#{h(storage_description)}</p>"},
   {name: "failover_time_notice", type: "section", label: "What happens after you update", content_html: part("components/step_timeline", steps: failover_steps, note: "Your database stays online until the failover."), separator: false}
 ]
 


### PR DESCRIPTION
Stacked on #6147. Review that one first; this PR targets
`postgres-failover-steps` and its diff is the last two commits.

A customer asked to see the used disk space on the resize page, so that
they could tell whether the data fits on a smaller box. The number was
already on the page, in the current configuration block, but too far
from the decision: the customer still had to divide it by hand, and the
sizes that the update would reject looked selectable until the error
came back.

Storage sizes that cannot hold the data in use are now disabled, with
the reason on each card, in the subtitle slot that storage cards leave
empty:

```
┌──────────────────────┐  ┌──────────────────────┐
│ 64GB        $12/mo   │  │ 128GB       $25/mo   │
│ Too small for        │  │                      │
│ 76.8 GB used         │  │                      │
└─────── greyed ───────┘  └────── selected ──────┘
```

The threshold is the one the patch route enforces — usage must stay
below 80% of the requested size — now shared through
`PostgresResource#storage_size_fits_usage?`, so the page and the API
cannot disagree. When the disk usage metrics are stale, every smaller
size is disabled with "Disk usage unknown", which is what the API does
too.

Sizes are disabled rather than hidden: a missing option reads as a
missing feature and teaches the customer nothing about their own disk.

The form gains an `option_disabler` hook. Options it disables carry an
`option-unavailable` class, so the option tree JavaScript leaves them
alone when it redraws children after a server size change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2372" height="1480" alt="CleanShot 2026-08-14 at 16 10 13@2x" src="https://github.com/user-attachments/assets/61b21b01-493d-4ada-a9d1-5515e5ed7adc" />
