### PR TITLE
Align and format cost cells in admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -22,6 +22,16 @@ class CloverAdmin < Roda
     TableFormButton.new(text, attributes)
   end
 
+  TableCost = Data.define(:cost) do
+    def to_s
+      cost ? format("$%.2f", cost).gsub(/(\d)(?=(\d{3})+\.)/, '\1,') : "-"
+    end
+  end
+
+  def table_cost(...)
+    TableCost.new(...)
+  end
+
   Unreloader.record_dependency("lib/audit_log.rb", __FILE__)
 
   MIN_AUDIT_LOG_END_DATE = Date.new(2025, 6)
@@ -193,10 +203,6 @@ class CloverAdmin < Roda
   COGS_RUNNER_LOCATION_IDS = (COGS_LOCATION_IDS - [Location::LEASEWEB_WDC02_ID]).freeze
   BIGDECIMAL_ZERO = BigDecimal(0)
 
-  def format_usd(value)
-    value ? format("$%.2f", value) : "-"
-  end
-
   def cogs_summary(hosts)
     monthly_usd = hosts.sum(BIGDECIMAL_ZERO) { it[:monthly_usd] || 0 }
     sellable_vcpus = hosts.sum { it[:sellable_vcpus] }
@@ -206,8 +212,8 @@ class CloverAdmin < Roda
 
   def cogs_row(group, labels)
     count, monthly_usd, sellable_vcpus, per_2vcpu_usd = cogs_summary(group)
-    labels.merge("Host Count" => count, "Monthly Cost" => format_usd(monthly_usd),
-      "Sellable vCPUs" => sellable_vcpus, "Per 2 vCPU Cost" => format_usd(per_2vcpu_usd))
+    labels.merge("Host Count" => count, "Monthly Cost" => table_cost(monthly_usd),
+      "Sellable vCPUs" => sellable_vcpus, "Per 2 vCPU Cost" => table_cost(per_2vcpu_usd))
   end
 
   def cogs_runner_row(group, labels)
@@ -215,7 +221,7 @@ class CloverAdmin < Roda
     usable_vcpus = group.sum(BIGDECIMAL_ZERO) { it[:sellable_vcpus] - (it[:nonrunner_vcpus] || 0) }
     weekly_usd = usable_vcpus * per_2vcpu_usd / 2 / 30 * 7 if per_2vcpu_usd
     labels.merge("Host Count" => count, "Runner Usable vCPUs" => usable_vcpus.to_i,
-      "Per 2 vCPU Cost" => format_usd(per_2vcpu_usd), "Weekly Cost" => format_usd(weekly_usd))
+      "Per 2 vCPU Cost" => table_cost(per_2vcpu_usd), "Weekly Cost" => table_cost(weekly_usd))
   end
 
   def _classes

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -206,6 +206,8 @@ h3 { font-size: 1.1em; }
   gap: 5px;
 }
 
+td:has(> .cost) { text-align: right; }
+
 label {
   display: inline-block;
   margin-right: 5px;

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -3372,7 +3372,7 @@ RSpec.describe CloverAdmin do
       create_cogs_host(total_cpus: 16, total_hugepages_1g: 52, server_model: "AX102", monthly_price: 100, currency: "EUR")
       hel1_host = create_cogs_host(location_id: Location::HETZNER_HEL1_ID, total_cpus: 96, total_hugepages_1g: 368, server_model: "AX162-R", monthly_price: 400, currency: "EUR")
       # Draining hosts still cost money, so they stay included.
-      create_cogs_host(location_id: Location::LEASEWEB_WDC02_ID, allocation_state: "draining", total_cpus: 128, total_hugepages_1g: 500, server_model: "HPE RL300", monthly_price: 500, currency: "USD")
+      create_cogs_host(location_id: Location::LEASEWEB_WDC02_ID, allocation_state: "draining", total_cpus: 128, total_hugepages_1g: 500, server_model: "HPE RL300", monthly_price: 5000, currency: "USD")
       create_cogs_host(location_id: Location::GITHUB_RUNNERS_ID, family: "premium", total_cpus: 16, total_hugepages_1g: 52, server_model: "AX102-U", monthly_price: 50, currency: "EUR")
       create_cogs_host(location_id: Location::GITHUB_RUNNERS_ID, arch: "arm64", total_cpus: 80, total_hugepages_1g: 320, server_model: "RX220", monthly_price: 220, currency: "EUR")
       # A host with an empty inventory row and no learned cpus contributes
@@ -3398,14 +3398,17 @@ RSpec.describe CloverAdmin do
       expect(page.all(".cogs-by-location-table td").map(&:text)).to eq [
         "hetzner-fsn1", "standard", "2", "$114.00", "13", "$17.54",
         "hetzner-hel1", "standard", "1", "$456.00", "92", "$9.91",
-        "leaseweb-wdc02", "standard", "1", "$500.00", "125", "$8.00",
+        "leaseweb-wdc02", "standard", "1", "$5,000.00", "125", "$80.00",
         "github-runners", "premium", "1", "$57.00", "13", "$8.77",
+      ]
+      expect(page.all(".cogs-by-location-table td .cost").map(&:text)).to eq [
+        "$114.00", "$17.54", "$456.00", "$9.91", "$5,000.00", "$80.00", "$57.00", "$8.77",
       ]
 
       expect(page.all(".cogs-by-type-table td").map(&:text)).to eq [
         "AX102", "2", "$171.00", "26", "$13.15",
         "AX162", "1", "$456.00", "92", "$9.91",
-        "HPE RL300", "1", "$500.00", "125", "$8.00",
+        "HPE RL300", "1", "$5,000.00", "125", "$80.00",
         "unknown", "1", "$0.00", "0", "-",
       ]
 

--- a/views/admin/components/table.erb
+++ b/views/admin/components/table.erb
@@ -29,6 +29,8 @@
                 <a href="<%= v.link %>"><%= v.value %></a>
               <% elsif v.is_a?(CloverAdmin::TableFormButton) %>
                 <%== form(v.attributes, button: v.text) %>
+              <% elsif v.is_a?(CloverAdmin::TableCost) %>
+                <span class="cost"><%= v %></span>
               <% else %>
                 <%== linkify_ubids(v.to_s) %>
               <% end %>


### PR DESCRIPTION
Money values compare more easily when their digits line up. Add a TableCost value object next to TableLink and TableFormButton. The table component renders it with a cost class that aligns the cell right, and its text carries a thousand separator, for example $5,000.00. The COGS tables now build their cost cells with it.