### PR TITLE
Show ubid links in a monospace font

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -163,7 +163,7 @@ class CloverAdmin < Roda
       uuid = id if id.include?("-")
       ubid = uuid ? UBID.to_ubid(uuid) : id
       if (klass = UBID.class_for_ubid(ubid))
-        link = "<a href=\"/model/#{klass}/#{ubid}\">#{ubid}</a>"
+        link = "<a class=\"ubid\" href=\"/model/#{klass}/#{ubid}\">#{ubid}</a>"
         uuid ? "#{uuid} [#{link}]" : link
       else
         id

--- a/public/admin/app.css
+++ b/public/admin/app.css
@@ -66,6 +66,8 @@ a {
   &:hover { text-decoration: underline; }
 }
 
+.ubid { font-family: monospace; }
+
 input, select, textarea {
   padding: 5px;
   font-size: 1em;


### PR DESCRIPTION
All ubids have the same character count, so a monospace font gives them the same width. This aligns the ubid columns of the admin tables and makes them easier to scan.