### PR TITLE
Replace erb_formatter with herb fomatter

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -1,0 +1,96 @@
+# This file configures Herb for your project and team.
+# Settings here take precedence over individual editor preferences.
+#
+# Herb is a suite of tools for HTML+ERB templates including:
+# - Linter: Validates templates and enforces best practices
+# - Formatter: Auto-formats templates with intelligent indentation
+# - Language Server: Provides IDE support (VS Code, Zed, Neovim, etc.)
+#
+# Website: https://herb-tools.dev
+# Configuration: https://herb-tools.dev/configuration
+# GitHub Repo: https://github.com/marcoroth/herb
+#
+
+version: 0.10.3
+
+# # Framework and template engine configuration
+#
+# # Options: ruby | actionview | hanami | sinatra (default: ruby)
+# framework: ruby
+#
+# # Options: erubi | erb | herb (default: erubi)
+# template_engine: erubi
+
+# files:
+#   # Additional patterns beyond the defaults (**.html, **.rhtml, **.html.erb, etc.)
+#   include:
+#     - '**/*.xml.erb'
+#     - 'custom/**/*.html'
+#
+#   # Patterns to exclude (can exclude defaults too)
+#   exclude:
+#     - 'public/**/*'
+#     - 'tmp/**/*'
+
+# engine:
+#   validators:
+#     security: true       # default: true
+#     nesting: true        # default: true
+#     accessibility: true  # default: true
+
+linter:
+  enabled: true
+
+  # # Exit with error code when diagnostics of this severity or higher are present
+  # # Valid values: error (default), warning, info, hint
+  # failLevel: warning
+
+  # # Additional patterns beyond the defaults for linting
+  # include:
+  #   - '**/*.xml.erb'
+  #
+  # # Patterns to exclude from linting
+  # exclude:
+  #   - 'app/views/admin/**/*'
+
+  # rules:
+  #   erb-no-extra-newline:
+  #     enabled: false
+  #
+  #   # Rules can have 'include', 'only', and 'exclude' patterns
+  #   some-rule:
+  #     # Additional patterns to check (additive, ignored when 'only' is present)
+  #     include:
+  #       - 'app/components/**/*'
+  #     # Don't apply this rule to files matching these patterns
+  #     exclude:
+  #       - 'app/views/admin/**/*'
+  #
+  #   another-rule:
+  #     # Only apply this rule to files matching these patterns (overrides all 'include')
+  #     only:
+  #       - 'app/views/**/*'
+  #     # Exclude still applies even with 'only'
+  #     exclude:
+  #       - 'app/views/admin/**/*'
+
+formatter:
+  enabled: false
+  indentWidth: 2
+  maxLineLength: 80
+
+  # # Additional patterns beyond the defaults for formatting
+  # include:
+  #   - '**/*.xml.erb'
+  #
+  # # Patterns to exclude from formatting
+  # exclude:
+  #   - 'app/views/admin/**/*'
+
+  # # Rewriters modify templates during formatting
+  # rewriter:
+  #   # Pre-format rewriters (modify AST before formatting)
+  #   pre:
+  #     - tailwind-class-sorter
+  #   # Post-format rewriters (modify formatted output string)
+  #   post: []

--- a/.herb.yml
+++ b/.herb.yml
@@ -75,9 +75,9 @@ linter:
   #       - 'app/views/admin/**/*'
 
 formatter:
-  enabled: false
+  enabled: true
   indentWidth: 2
-  maxLineLength: 80
+  maxLineLength: 120
 
   # # Additional patterns beyond the defaults for formatting
   # include:

--- a/.herb.yml
+++ b/.herb.yml
@@ -53,7 +53,65 @@ linter:
   # exclude:
   #   - 'app/views/admin/**/*'
 
-  # rules:
+  rules:
+    # These rules only apply to Rails
+    actionview-strict-locals-partial-only:
+      enabled: false
+    erb-strict-locals-comment-syntax:
+      enabled: false
+    erb-prefer-image-tag-helper:
+      enabled: false
+
+    # We use interpolation in erb templates quite a bit, and it's fine
+    erb-prefer-direct-output:
+      enabled: false
+
+    # We don't use autocomplete in all input tags, and that isn't a problem
+    html-input-require-autocomplete:
+      enabled: false
+
+    # We output attributes directly, and the recommendation to avoid it doesn't
+    # make sense in our usage
+    # html_attrs method
+    erb-no-output-in-attribute-position:
+      enabled: false
+    # attributes in button component
+    erb-no-output-in-attribute-name:
+      enabled: false
+    # link_params_html in authentication audit log
+    erb-no-raw-output-in-attribute-value:
+      enabled: false
+
+    # This rule is invalid, you should only need a nonce for a script tag that
+    # doesn't have a src attribute
+    html-require-script-nonce:
+      enabled: false
+
+    # This rule flags methods that are called for side effects, such as
+    # content_security_policy.add_form_action(provider.url)
+    erb-no-unused-expressions:
+      enabled: false
+
+    # We use interpolated class names
+    erb-no-interpolated-class-names:
+      enabled: false
+
+    # This complains about cases where an empty attribute is used, but javascript
+    # handles empty attributes differently from missing attributes.
+    html-no-empty-attributes:
+      enabled: false
+
+    # The Herb parser is currently not able to parse some case/when usage in the
+    # views, and also has issues with opening and closing tags in separate
+    # conditional branches, though these appear fixed in an unreleased version.
+    parser-no-errors:
+      enabled: false
+
+    # Work around an Herb bug that is triggered in views/project/tag-list.rb,
+    # where it thinks an unknown tag is used.
+    html-no-unknown-tag:
+      enabled: false
+
   #   erb-no-extra-newline:
   #     enabled: false
   #

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,10 @@ Style/FrozenStringLiteralComment:
 Style/BlockComments:
   Enabled: false
 
+Layout/ElseAlignment:
+  Exclude:
+    - 'views/**/*.erb'
+
 Layout/HeredocIndentation:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -98,7 +98,6 @@ end
 
 group :lint do
   gem "brakeman"
-  gem "erb-formatter", github: "ubicloud/erb-formatter", ref: "df3174476986706828f7baf3e5e6f5ec8ecd849b"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,13 +16,6 @@ GIT
       roda (>= 2.6.0)
       sequel (>= 4)
 
-GIT
-  remote: https://github.com/ubicloud/erb-formatter.git
-  revision: df3174476986706828f7baf3e5e6f5ec8ecd849b
-  ref: df3174476986706828f7baf3e5e6f5ec8ecd849b
-  specs:
-    erb-formatter (0.7.3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -600,7 +593,6 @@ DEPENDENCIES
   countries
   cuprite
   ed25519
-  erb-formatter!
   erubi (>= 1.5)
   excon
   foreman

--- a/Rakefile
+++ b/Rakefile
@@ -417,9 +417,10 @@ namespace :linter do
     Brakeman.run app_path: ".", quiet: true, force_scan: true, print_report: true, run_all_checks: true
   end
 
-  desc "Run Herb formatter"
+  desc "Run Herb linter and formatter"
   task :erb_formatter do
     sh "npm run format-erb"
+    # sh "npm run lint-erb"
   end
 
   desc "Run golangci-lint"

--- a/Rakefile
+++ b/Rakefile
@@ -417,17 +417,9 @@ namespace :linter do
     Brakeman.run app_path: ".", quiet: true, force_scan: true, print_report: true, run_all_checks: true
   end
 
-  desc "Run ERB::Formatter"
+  desc "Run Herb formatter"
   task :erb_formatter do
-    # "fdr/erb-formatter" can't be required without bundler setup because of custom repository.
-    require "bundler"
-    Bundler.setup(:lint)
-    puts "Running ERB::Formatter..."
-    require "erb/formatter/command_line"
-    files = Dir.glob("views/**/[!icon]*.erb").entries
-    files.delete("views/components/form/select.erb")
-    files.delete("views/github/runner.erb")
-    ERB::Formatter::CommandLine.new(files + ["--write", "--print-width", "120"]).run
+    sh "npm run format-erb"
   end
 
   desc "Run golangci-lint"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,8 @@
   "packages": {
     "": {
       "devDependencies": {
+        "@herb-tools/formatter": "^0.10.3",
+        "@herb-tools/linter": "^0.10.3",
         "@redocly/cli": "^2.43.2",
         "@stoplight/spectral-cli": "^6.16.2",
         "@tailwindcss/forms": "^0.5.11",
@@ -38,6 +40,194 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
+      }
+    },
+    "node_modules/@herb-tools/config": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/config/-/config-0.10.3.tgz",
+      "integrity": "sha512-cSaOwuWnij1wiB4Xh9Zfx/s+lhis7cN/+PXssanT/mXQLSRU2QeYasivyCQ1tRnpIVdGGOC/rqHVJQeNmj4pqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.10.3",
+        "picomatch": "^4.0.5",
+        "tinyglobby": "^0.2.16",
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/@herb-tools/config/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@herb-tools/core": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/core/-/core-0.10.3.tgz",
+      "integrity": "sha512-rtDoh6C/EMYLEtFwYpuY+IlnV7PLsF5hQszq7uMDE/bwEpLVBlPFd2Wlk9E0RB31PVQKV1MwgGqstte87XqF9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ruby/prism": "^1.9.0"
+      }
+    },
+    "node_modules/@herb-tools/formatter": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/formatter/-/formatter-0.10.3.tgz",
+      "integrity": "sha512-3YHtybrrRjXqbBE1+gv4/ksxmbnQbwJHA2IlMYUaLriCKUN02oN6t0Stwoxrude+gE7XICNR9EmBt1kH7QzlqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/config": "0.10.3",
+        "@herb-tools/core": "0.10.3",
+        "@herb-tools/printer": "0.10.3",
+        "@herb-tools/rewriter": "0.10.3",
+        "@ruby/prism": "^1.9.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "herb-format": "bin/herb-format"
+      }
+    },
+    "node_modules/@herb-tools/highlighter": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/highlighter/-/highlighter-0.10.3.tgz",
+      "integrity": "sha512-vyBPl/oWalPcXrhni6RrQzeizzC0i7An3yMAg/Xx+4HDhgU/zOlRqSUYLU7SpzjfK4OU5QhRDdc3OBI8dT5qmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.10.3",
+        "@herb-tools/node-wasm": "0.10.3"
+      },
+      "bin": {
+        "herb-highlight": "bin/herb-highlight"
+      }
+    },
+    "node_modules/@herb-tools/linter": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/linter/-/linter-0.10.3.tgz",
+      "integrity": "sha512-uNwJZkzswJ/IcpsjbuEzOXQQcfc40KGy8Ao1L69na2J6H7b4LFig2OIZ22vJasGdv4jODWJWnMDozRvWuv1vFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/config": "0.10.3",
+        "@herb-tools/core": "0.10.3",
+        "@herb-tools/highlighter": "0.10.3",
+        "@herb-tools/node-wasm": "0.10.3",
+        "@herb-tools/printer": "0.10.3",
+        "@herb-tools/rewriter": "0.10.3",
+        "@ruby/prism": "^1.9.0",
+        "picomatch": "^4.0.5",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "herb-lint": "bin/herb-lint"
+      }
+    },
+    "node_modules/@herb-tools/linter/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@herb-tools/node-wasm": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/node-wasm/-/node-wasm-0.10.3.tgz",
+      "integrity": "sha512-KUwHUMB6kluyvRiW0A9wbTiuO/qlvXLlSAnewmH2za7yePvYRSiThfAZEmXPqEmpmMRcIksFxaNaxUc6nBqyuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.10.3",
+        "@ruby/prism": "^1.9.0"
+      }
+    },
+    "node_modules/@herb-tools/printer": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/printer/-/printer-0.10.3.tgz",
+      "integrity": "sha512-OuuIisERq3TLnms/Wm5N6w/ITYqlBPPLsc1FNHdN3qedPOA/ey1dF2rKewUzQAsAZheRCs5nem7tDYRhPb2D/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.10.3",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "herb-print": "bin/herb-print"
+      }
+    },
+    "node_modules/@herb-tools/rewriter": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/rewriter/-/rewriter-0.10.3.tgz",
+      "integrity": "sha512-UsqWOJVcmB7lptLtjUeFpVvOn44LFae+I44p5ixQ9nDLNnZiN/2+R52tJmVLOWijQORvtMInCWOHrSvXF6Bf/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.10.3",
+        "@herb-tools/tailwind-class-sorter": "0.10.3",
+        "@ruby/prism": "^1.9.0",
+        "tinyglobby": "^0.2.15"
+      }
+    },
+    "node_modules/@herb-tools/tailwind-class-sorter": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@herb-tools/tailwind-class-sorter/-/tailwind-class-sorter-0.10.3.tgz",
+      "integrity": "sha512-KAowwSS6NmcRTQrQ591DR6dGI675KB0o/yxZt113BNDWiBB+bl4xdnd3hT19JV6Jsh3sS/0e90hYGUj/6PBW0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clear-module": "^4.1.3",
+        "escalade": "^3.2.0",
+        "jiti": "^2.7.0",
+        "postcss": "^8.5.18",
+        "postcss-import": "^16.1.1"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.0 || ^4.0"
+      }
+    },
+    "node_modules/@herb-tools/tailwind-class-sorter/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@herb-tools/tailwind-class-sorter/node_modules/postcss-import": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.2.0.tgz",
+      "integrity": "sha512-0mQUGlSp87Zl70K58RNwQAN1WS9plFE6KWGui9nyK6ninduMyjW/Khaoy/BpBoFTBh7ndAvAKrSKVbwy6vd/BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -250,6 +440,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ruby/prism": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@ruby/prism/-/prism-1.9.0.tgz",
+      "integrity": "sha512-/j+JfP1eA0nCjx6c/8L6K/ENErmsqc6RMAba8rKYNz4RadrT7AW20u4WrjpWYWzdlk6k1YWHxoW9OS68w02+Vw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1150,6 +1347,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1213,6 +1420,23 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/clear-module": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.3.tgz",
+      "integrity": "sha512-XdLrg7BnbXKntyrbs2dNjDN9CVoTQ+WV0i7jT5/r9ahzAaSDSzC9e2OVZB/QVwbxBb1/1AeObzjlxsYk5HFvww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^2.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui": {
@@ -2931,22 +3155,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/openapi-format/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
@@ -2964,6 +3172,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
+      "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -3322,6 +3543,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reusify": {
@@ -4303,6 +4534,22 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
     "@redocly/cli": "^2.43.2",
     "@stoplight/spectral-cli": "^6.16.2",
     "openapi-format": "^1.33.5",
+    "@herb-tools/linter": "^0.10.3",
+    "@herb-tools/formatter": "^0.10.3",
     "tailwindcss": "^3.4.19",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/typography": "^0.5.20"
@@ -10,6 +12,8 @@
   "scripts": {
     "dev": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css",
     "prod": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css --minify",
+    "format-erb": "npx @herb-tools/formatter 'views/**/*.erb'",
+    "lint-erb": "npx @herb-tools/linter --no-color --fix --fix-unsafely 'views/**/*.erb'",
     "watch": "npx tailwindcss -o assets/css/app.css -i assets/css/tailwind.css --watch"
   },
   "overrides": {

--- a/views/account/change_login.erb
+++ b/views/account/change_login.erb
@@ -7,22 +7,27 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
+
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Change Email Address</h2>
+
             <% form(action: rodauth.change_login_path, method: :post) do %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== part("components/form/text", label: "Current Email", value: current_account.email, extra_class: "bg-gray-50 text-gray-500 ring-gray-200 ", attributes: {disabled: true}) %>
                 </div>
+
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== part("components/rodauth/login_field", label: "New Email Address") %>
                 </div>
+
                 <% if rodauth.change_login_requires_password? %>
                   <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>
+
                 <div class="col-span-6">
                   <%== part("components/form/submit_button", text: "Change Email") %>
                 </div>

--- a/views/account/change_password.erb
+++ b/views/account/change_password.erb
@@ -8,9 +8,11 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
+
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900"><%= action %> Password</h2>
+
             <% form(action: rodauth.change_password_path, method: :post) do %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.change_password_requires_password? %>
@@ -18,12 +20,15 @@
                     <%== part("components/rodauth/password_field", label: "Current Password") %>
                   </div>
                 <% end %>
+
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== part("components/rodauth/password_field", label: "#{rodauth.new_password_label}#{rodauth.input_field_label_suffix}", name: rodauth.new_password_param, autocomplete: "new-password") %>
                 </div>
+
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== part("components/rodauth/password_field", label: "New Password Confirmation", confirm: true) %>
                 </div>
+
                 <div class="col-span-6">
                   <%== part("components/form/submit_button", text: "#{action} Password") %>
                 </div>

--- a/views/account/close_account.erb
+++ b/views/account/close_account.erb
@@ -7,10 +7,15 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
+
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Close Account</h2>
-            <p class="mt-1 text-sm text-gray-500">This action will permanently delete this account. Deleted data cannot be recovered. Use it carefully.</p>
+
+            <p class="mt-1 text-sm text-gray-500">
+              This action will permanently delete this account. Deleted data cannot be recovered. Use it carefully.
+            </p>
+
             <% form(action: rodauth.close_account_path, method: :post) do %>
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.close_account_requires_password? %>
@@ -18,6 +23,7 @@
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>
+
                 <div class="col-span-6">
                   <%== part("components/form/submit_button", text: "Close Account") %>
                 </div>

--- a/views/account/login_method.erb
+++ b/views/account/login_method.erb
@@ -11,17 +11,16 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
+
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <% omniauth_providers.each do |provider, name| %>
             <div id="login-method-<%= provider %>" class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-4">
-                  <div class="text-lg font-medium leading-6 text-gray-900">Login with
-                    <%= name %></div>
-                  <p class="mt-1 text-sm text-gray-500">Connect your
-                    <%= name %>
-                    to log in to your Ubicloud account</p>
+                  <div class="text-lg font-medium leading-6 text-gray-900">Login with <%= name %></div>
+                  <p class="mt-1 text-sm text-gray-500">Connect your <%= name %> to log in to your Ubicloud account</p>
                 </div>
+
                 <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                   <% if uid = @identities[provider.to_s] %>
                     <% form(action: "/account/login-method/disconnect", method: :post, class: :grow) do %>
@@ -40,15 +39,17 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
 
           <% @oidc_identities.each do |provider, uid| %>
             <% display_name = @oidc_identity_names[UBID.to_uuid(provider)] %>
+
             <div id="login-method-disconnect-oidc-<%= provider %>" class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-4">
-                  <div class="text-lg font-medium leading-6 text-gray-900">Login with
-                    <%= display_name %></div>
-                  <p class="mt-1 text-sm text-gray-500">You currently allow your
-                    <%= display_name %>
-                    account to log in to your Ubicloud account using OIDC</p>
+                  <div class="text-lg font-medium leading-6 text-gray-900">Login with <%= display_name %></div>
+
+                  <p class="mt-1 text-sm text-gray-500">
+                    You currently allow your <%= display_name %> account to log in to your Ubicloud account using OIDC
+                  </p>
                 </div>
+
                 <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                   <% form(action: "/account/login-method/disconnect", method: :post, class: :grow) do %>
                     <%== hidden_inputs(provider:, uid:) %>
@@ -64,9 +65,14 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-4">
                   <div class="text-lg font-medium leading-6 text-gray-900">Login using an OIDC provider</div>
-                  <p class="mt-1 text-sm text-gray-500 mb-2">Allow logging into your Ubicloud account using an OIDC provider</p>
+
+                  <p class="mt-1 text-sm text-gray-500 mb-2">
+                    Allow logging into your Ubicloud account using an OIDC provider
+                  </p>
+
                   <%== part("components/form/text", name: "provider", label: "OIDC Provider ID", attributes: {placeholder: "0p..."}) %>
                 </div>
+
                 <div class="col-span-6 sm:col-span-2 text-right space-y-1 mt-8">
                   <%== part("components/button", text: "Connect") %>
                 </div>
@@ -78,17 +84,19 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
             <div class="mt-6 grid grid-cols-6 gap-6">
               <div class="col-span-6 sm:col-span-4">
                 <div class="text-lg font-medium leading-6 text-gray-900">Login with Password</div>
+
                 <p class="mt-1 text-sm text-gray-500">
                   <% if rodauth.has_password? %>
-                    Change or delete your password. If you delete your password, you can only log in with other
-                    methods.
+                    Change or delete your password. If you delete your password, you can only log in with other methods.
                   <% else %>
                     Create a password to log in to your Ubicloud account
                   <% end %>
                 </p>
               </div>
+
               <div class="col-span-6 sm:col-span-2 text-right space-y-2">
                 <%== part("components/button", text: rodauth.has_password? ? "Change" : "Create", link: "/account/change-password") %>
+
                 <% if rodauth.has_password? %>
                   <% form(action: "/account/login-method/disconnect", method: :post, class: :grow) do %>
                     <%== hidden_inputs(provider: "password") %>
@@ -98,7 +106,6 @@ social_login_providers = omniauth_providers.map { |provider,| provider.to_s }
               </div>
             </div>
           </div>
-
         </div>
       </div>
     </div>

--- a/views/account/multifactor/otp_disable.erb
+++ b/views/account/multifactor/otp_disable.erb
@@ -7,17 +7,21 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
+
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Disable One-Time Password Authentication</h2>
+
             <% form(action: rodauth.otp_disable_path, method: :post) do %>
               <%== rodauth.otp_disable_additional_form_tags %>
+
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.two_factor_modifications_require_password? %>
                   <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>
+
                 <div class="col-span-6">
                   <%== part("components/form/submit_button", text: rodauth.otp_disable_button) %>
                 </div>

--- a/views/account/multifactor/otp_setup.erb
+++ b/views/account/multifactor/otp_setup.erb
@@ -7,26 +7,47 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
+
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Setup One-Time Password Authentication</h2>
+
             <% form(action: rodauth.otp_setup_path, method: :post) do %>
               <%== rodauth.otp_setup_additional_form_tags %>
-              <input type="hidden" id="otp-key" name="<%= rodauth.otp_setup_param %>" value="<%= rodauth.otp_user_key %>"/>
-              <input type="hidden" id="otp-hmac-secretkey" name="<%= rodauth.otp_setup_raw_param %>" value="<%= rodauth.otp_key %>"/>
+
+              <input
+                type="hidden"
+                id="otp-key"
+                name="<%= rodauth.otp_setup_param %>"
+                value="<%= rodauth.otp_user_key %>"
+              />
+
+              <input
+                type="hidden"
+                id="otp-hmac-secretkey"
+                name="<%= rodauth.otp_setup_raw_param %>"
+                value="<%= rodauth.otp_key %>"
+              />
+
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 md:col-span-3">
                   <%== rodauth.otp_qr_code %>
+
                   <p class="mt-2 text-sm text-gray-500 text-center">
-                    If you can't scan the QR code, please enter the following secret in your authenticator app manually: <br>
+                    If you can't scan the QR code, please enter the following secret in your authenticator app
+                    manually:
+                    <br>
                     <span id="otp-secret" class="font-bold break-words"><%= rodauth.otp_user_key %></span>
                   </p>
                 </div>
+
                 <div class="col-span-6 md:col-span-3 space-y-4">
                   <%== render("components/rodauth/otp_auth_code_field") %>
+
                   <% if rodauth.two_factor_modifications_require_password? %>
                     <%== render("components/rodauth/password_field") %>
                   <% end %>
+
                   <%== part("components/form/submit_button", text: rodauth.otp_setup_button) %>
                 </div>
               </div>

--- a/views/account/multifactor/otp_setup.erb
+++ b/views/account/multifactor/otp_setup.erb
@@ -20,14 +20,14 @@
                 id="otp-key"
                 name="<%= rodauth.otp_setup_param %>"
                 value="<%= rodauth.otp_user_key %>"
-              />
+              >
 
               <input
                 type="hidden"
                 id="otp-hmac-secretkey"
                 name="<%= rodauth.otp_setup_raw_param %>"
                 value="<%= rodauth.otp_key %>"
-              />
+              >
 
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 md:col-span-3">

--- a/views/account/multifactor/recovery_codes.erb
+++ b/views/account/multifactor/recovery_codes.erb
@@ -7,15 +7,18 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
+
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <% if rodauth.two_factor_modifications_require_password? %>
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <h2 class="text-lg font-medium leading-6 text-gray-900">Recovery Codes</h2>
+
               <% form(action: rodauth.recovery_codes_path, method: :post) do %>
                 <div class="mt-6 grid grid-cols-6 gap-6">
                   <div class="col-span-6 sm:col-span-2">
                     <%== render("components/rodauth/password_field") %>
                   </div>
+
                   <div class="col-span-6">
                     <%== part("components/form/submit_button", text: rodauth.view_recovery_codes_button) %>
                   </div>
@@ -25,20 +28,21 @@
           <% else %>
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <h2 class="text-lg font-medium leading-6 text-gray-900">Recovery Codes</h2>
+
               <p class="mt-1 text-sm text-gray-500">
                 Copy these recovery codes to a safe location. You can also download them
-                <a
-                  class="font-medium text-orange-500 hover:text-orange-600 underline underline-offset-2"
-                  href="data:text/plain;base64,<%= Base64.encode64(rodauth.recovery_codes.join("\n")) %>"
-                  download="ubicloud-recovery-codes.txt"
-                >here</a>.
+                <a class="font-medium text-orange-500 hover:text-orange-600 underline underline-offset-2" href="data:text/plain;base64,<%= Base64.encode64(rodauth.recovery_codes.join("\n")) %>" download="ubicloud-recovery-codes.txt">here</a>.
               </p>
+
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-6">
                   <% if rodauth.recovery_codes.any? %>
                     <div
                       id="recovery-codes-text"
-                      class="w-fit text-sm xl:text-base whitespace-nowrap border p-3 bg-slate-100 text-rose-500 font-mono rounded"
+                      class="
+                        w-fit text-sm xl:text-base whitespace-nowrap border p-3 bg-slate-100 text-rose-500 font-mono
+                        rounded
+                      "
                     >
                       <% rodauth.recovery_codes.each do |code| %>
                         <div><%= code %></div>
@@ -51,6 +55,7 @@
             <% if rodauth.can_add_recovery_codes? %>
               <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
                 <h2 class="text-lg font-medium leading-6 text-gray-900"><%== rodauth.add_recovery_codes_heading %></h2>
+
                 <% form(action: rodauth.recovery_codes_path, method: :post) do %>
                   <div class="mt-6 grid grid-cols-6 gap-6">
                     <div class="col-span-6">

--- a/views/account/multifactor/webauthn_remove.erb
+++ b/views/account/multifactor/webauthn_remove.erb
@@ -7,17 +7,21 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
+
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Remove Security Key</h2>
+
             <% form(action: rodauth.webauthn_remove_path, method: :post, id: "webauthn-remove-form") do %>
               <%== rodauth.webauthn_remove_additional_form_tags %>
+
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <% if rodauth.two_factor_modifications_require_password? %>
                   <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>
+
                 <div class="col-span-6 sm:col-span-6">
                   <fieldset>
                     <div class="space-y-5">
@@ -36,21 +40,26 @@
                               required
                             >
                           </div>
+
                           <div class="ml-3 text-sm leading-6">
                             <label for="webauthn-remove-<%= id %>" class="font-medium text-gray-900"><%= name %></label>
+
                             <span id="webauthn-remove-<%= id %>-description" class="text-gray-500">
-                              (Last Usage:
-                              <%= last_use.strftime("%F %T") %>)
+                              (Last Usage: <%= last_use.strftime("%F %T") %>)
                             </span>
                           </div>
                         </div>
                       <% end %>
                     </div>
                   </fieldset>
+
                   <% if error = rodauth.field_error(rodauth.webauthn_remove_param) %>
-                    <p class="mt-2 text-sm text-red-600 leading-6" id="<%= rodauth.webauthn_remove_param %>-error"><%= error %></p>
+                    <p class="mt-2 text-sm text-red-600 leading-6" id="<%= rodauth.webauthn_remove_param %>-error">
+                      <%= error %>
+                    </p>
                   <% end %>
                 </div>
+
                 <div class="col-span-6">
                   <%== part("components/form/submit_button", text: rodauth.webauthn_remove_button) %>
                 </div>

--- a/views/account/multifactor/webauthn_setup.erb
+++ b/views/account/multifactor/webauthn_setup.erb
@@ -7,22 +7,35 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
+
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <h2 class="text-lg font-medium leading-6 text-gray-900">Setup Security Key</h2>
+
             <% form(:action => rodauth.webauthn_setup_path, :method => :post, :id => "webauthn-setup-form", "data-credential-options" => (cred = rodauth.new_webauthn_credential).as_json.to_json) do %>
               <%== rodauth.webauthn_setup_additional_form_tags %>
               <%== hidden_inputs(rodauth.webauthn_setup_challenge_param => cred.challenge, rodauth.webauthn_setup_challenge_hmac_param => rodauth.compute_hmac(cred.challenge)) %>
-              <input id="webauthn-setup" class="hidden" type="text" name="<%= rodauth.webauthn_setup_param %>" value="" hidden/>
+
+              <input
+                id="webauthn-setup"
+                class="hidden"
+                type="text"
+                name="<%= rodauth.webauthn_setup_param %>"
+                value=""
+                hidden
+              />
+
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                   <%== part("components/form/text", name: "name", label: "Key Name", attributes: { required: true }) %>
                 </div>
+
                 <% if rodauth.two_factor_modifications_require_password? %>
                   <div class="col-span-6 sm:col-span-3 xl:col-span-2">
                     <%== render("components/rodauth/password_field") %>
                   </div>
                 <% end %>
+
                 <div class="col-span-6">
                   <div id="webauthn-setup-button">
                     <%== part("components/form/submit_button", text: rodauth.webauthn_setup_button) %>
@@ -36,4 +49,5 @@
     </div>
   </div>
 </main>
+
 <script src="<%= "#{rodauth.webauthn_js_host}#{rodauth.webauthn_setup_js_path}" %>"></script>

--- a/views/account/multifactor/webauthn_setup.erb
+++ b/views/account/multifactor/webauthn_setup.erb
@@ -23,7 +23,7 @@
                 name="<%= rodauth.webauthn_setup_param %>"
                 value=""
                 hidden
-              />
+              >
 
               <div class="mt-6 grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-3 xl:col-span-2">

--- a/views/account/submenu.erb
+++ b/views/account/submenu.erb
@@ -10,10 +10,14 @@
         ["Close Account", "/account/close-account", "hero-x-circle"]
       ].each do |label, url, icon, disallowed| %>
       <% next if disallowed %>
+
       <% if request.path == url %>
         <a
           href="<%= url %>"
-          class="border-orange-600 bg-orange-50 text-orange-600 hover:bg-orange-50 hover:text-orange-700 group flex items-center border-l-4 px-3 py-2 text-sm font-medium"
+          class="
+            border-orange-600 bg-orange-50 text-orange-600 hover:bg-orange-50 hover:text-orange-700 group flex
+            items-center border-l-4 px-3 py-2 text-sm font-medium
+          "
           aria-current="page"
         >
           <%== part(
@@ -21,12 +25,16 @@
             name: icon,
             classes: "text-orange-600 group-hover:text-orange-600 -ml-1 mr-3 h-6 w-6 flex-shrink-0"
           ) %>
+
           <span class="truncate"><%= label %></span>
         </a>
       <% else %>
         <a
           href="<%= url %>"
-          class="border-transparent text-gray-900 hover:bg-gray-50 hover:text-gray-900 group flex items-center border-l-4 px-3 py-2 text-sm font-medium"
+          class="
+            border-transparent text-gray-900 hover:bg-gray-50 hover:text-gray-900 group flex items-center border-l-4
+            px-3 py-2 text-sm font-medium
+          "
         >
           <%== part("components/icon", name: icon, classes: "text-gray-400 group-hover:text-gray-500 -ml-1 mr-3 h-6 w-6 flex-shrink-0") %>
           <span class="truncate"><%= label %></span>

--- a/views/account/two_factor_manage.erb
+++ b/views/account/two_factor_manage.erb
@@ -7,13 +7,18 @@
     <div class="overflow-hidden rounded-lg bg-white shadow">
       <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
         <%== render("account/submenu") %>
+
         <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <div class="mt-6 grid grid-cols-6 gap-6">
               <div class="col-span-6 sm:col-span-4">
                 <div class="text-lg font-medium leading-6 text-gray-900">One-Time Password Generator</div>
-                <p class="mt-1 text-sm text-gray-500">Connect an authenticator app that generates verification codes.</p>
+
+                <p class="mt-1 text-sm text-gray-500">
+                  Connect an authenticator app that generates verification codes.
+                </p>
               </div>
+
               <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                 <% if rodauth.otp_exists? %>
                   <%== part("components/button", text: rodauth.otp_disable_link_text, link: rodauth.otp_disable_path, type: "danger") %>
@@ -23,20 +28,24 @@
               </div>
             </div>
           </div>
+
           <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
             <div class="mt-6 grid grid-cols-6 gap-6">
               <div class="col-span-6 sm:col-span-4">
                 <div class="text-lg font-medium leading-6 text-gray-900">Security Keys</div>
                 <p class="mt-1 text-sm text-gray-500">Connect a security key to your account.</p>
               </div>
+
               <div class="col-span-6 sm:col-span-2 text-right space-y-1">
                 <%== part("components/button", text: rodauth.webauthn_setup_link_text, link: rodauth.webauthn_setup_path) %>
+
                 <% if rodauth.webauthn_setup? %>
                   <%== part("components/button", text: rodauth.webauthn_remove_link_text, link: rodauth.webauthn_remove_path, type: "danger") %>
                 <% end %>
               </div>
             </div>
           </div>
+
           <% if rodauth.uses_two_factor_authentication? %>
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <div class="mt-6 grid grid-cols-6 gap-6">
@@ -44,12 +53,14 @@
                   <div class="text-lg font-medium leading-6 text-gray-900">Recovery Codes</div>
                   <p class="mt-1 text-sm text-gray-500">Single-use recovery codes for your account.</p>
                 </div>
+
                 <div class="col-span-6 sm:col-span-2 text-right">
                   <%== part("components/button", text: rodauth.recovery_codes_link_text, link: rodauth.recovery_codes_path) %>
                 </div>
               </div>
             </div>
           <% end %>
+
           <% if rodauth.two_factor_remove_links.length > 1 %>
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <%== part(

--- a/views/admin/admin_list.erb
+++ b/views/admin/admin_list.erb
@@ -7,6 +7,7 @@
 </ul>
 
 <h2>Close Admin Account</h2>
+
 <% form({action: "/close-admin-account", method: "POST"}, button: "Close Admin Account") do |f| %>
   <%== f.input(:select, key: "login", label: "Account", options: @admins, add_blank: "Select Account", required: true) %>
 <% end %>

--- a/views/admin/archived_record_by_id.erb
+++ b/views/admin/archived_record_by_id.erb
@@ -7,8 +7,8 @@
 <% form(id: "archived_record_form", class: "form-vertical") do |f| %>
   <%== f.input("text", key: "id", label: "ID", placeholder: "Enter UBID or UUID", value: @id) %>
   <%== f.input("select", key: "model_name", label: "Model Name", add_blank: "From ID", options: @classes.map(&:name), value: @model_name) %>
-  <%== f.input("number", key: "days", label: "Days", placeholder: "1-15", value: @days, min: 1, max: 15) %>
-  Higher day values will increase query duration significantly. Use the smallest value possible.
+  <%== f.input("number", key: "days", label: "Days", placeholder: "1-15", value: @days, min: 1, max: 15) %> Higher day
+  values will increase query duration significantly. Use the smallest value possible.
   <%== f.button("Find Archived Record") %>
 <% end %>
 

--- a/views/admin/audit_log.erb
+++ b/views/admin/audit_log.erb
@@ -19,6 +19,7 @@
       <th>Object</th>
     </tr>
   </thead>
+
   <tbody>
     <% @audit_logs.each do %>
       <tr>
@@ -29,8 +30,11 @@
         <td><%== linkify_ubids(it[:object_ids].map { |id| UBID.to_ubid(id) }.join(", ")) %></td>
       </tr>
     <% end %>
+
     <% if link_text = audit_log_paginate %>
-      <tr><td colspan="5"><a href="?<%= to_query_string(@next_page_params) %>"><%= link_text %></a></td></tr>
+      <tr>
+        <td colspan="5"><a href="?<%= to_query_string(@next_page_params) %>"><%= link_text %></a></td>
+      </tr>
     <% end %>
   </tbody>
 </table>

--- a/views/admin/authentication_audit_log.erb
+++ b/views/admin/authentication_audit_log.erb
@@ -15,30 +15,38 @@
       <th>Metadata</th>
     </tr>
   </thead>
+
   <tbody>
     <% end_date = @end_date %>
     <% account_name_map = @account_name_map %>
+
     <% @audit_logs.each do %>
       <tr>
         <td><%= it[:at].getutc.strftime("%F %T") %></td>
         <td><a href="?<%= to_query_string("end" => end_date, "action" => it[:message]) %>"><%= it[:message] %></a></td>
+
         <% if account_name_map %>
           <% account_id = it[:account_id] %>
-          <td><a href="?<%= to_query_string("end" => end_date, "account" => UBID.to_ubid(account_id)) %>"><%= account_name_map[account_id] || account_id %></a></td>
+          <td>
+            <a href="?<%= to_query_string("end" => end_date, "account" => UBID.to_ubid(account_id)) %>"><%= account_name_map[account_id] || account_id %></a>
+          </td>
         <% else %>
           <td><%== linkify_ubids(UBID.to_ubid(it[:account_id])) %></td>
         <% end %>
+
         <td>
           <% it[:metadata].map do |k, v| %>
-            <a href="?<%= to_query_string("end" => end_date, "metadata" => "#{k}=#{v}") %>"><%= k %>:
-              <%= v %></a>
+            <a href="?<%= to_query_string("end" => end_date, "metadata" => "#{k}=#{v}") %>"><%= k %>: <%= v %></a>
           <% end %>
         </td>
       </tr>
     <% end %>
+
     <% if link_text = audit_log_paginate %>
       <% link_params_html = @next_page_params.map { |k, v| "#{k}=#{h v}" }.join("&amp;") %>
-      <tr><td colspan="5"><a href="?<%== link_params_html %>"><%= link_text %></a></td></tr>
+      <tr>
+        <td colspan="5"><a href="?<%== link_params_html %>"><%= link_text %></a></td>
+      </tr>
     <% end %>
   </tbody>
 </table>

--- a/views/admin/cogs.erb
+++ b/views/admin/cogs.erb
@@ -9,7 +9,12 @@
 
   <div>
     <h2>GitHub Runners Inventory</h2>
-    <p>GitHub runners can be allocated to any of the hetzner-fsn1, hetzner-hel1, and github-runners locations, so all hosts there are listed.</p>
+
+    <p>
+      GitHub runners can be allocated to any of the hetzner-fsn1, hetzner-hel1, and github-runners locations, so all
+      hosts there are listed.
+    </p>
+
     <%== part("components/table", title: "By Type", table_class: "cogs-runners-by-type-table", data: @runners_by_type, use_admin_label: false) %>
     <%== part("components/table", title: "By Family", table_class: "cogs-runners-by-family-table", data: @runners_by_family, use_admin_label: false) %>
   </div>

--- a/views/admin/components/table.erb
+++ b/views/admin/components/table.erb
@@ -2,13 +2,12 @@
 
 <% if !data || data.empty? %>
   <p>
-    No data available for
-    <strong><%= title %></strong>
-    table
+    No data available for <strong><%= title %></strong> table
   </p>
 <% else %>
   <table class="<%= table_class %>">
     <caption><%= title %></caption>
+
     <thead>
       <tr>
         <% data.first.each_key do |k| %>
@@ -16,6 +15,7 @@
         <% end %>
       </tr>
     </thead>
+
     <tbody>
       <% data.each do |row| %>
         <tr>

--- a/views/admin/customer_usage.erb
+++ b/views/admin/customer_usage.erb
@@ -1,9 +1,8 @@
 <% @page_title = "Customer Usage" %>
 
 <p>
-  Customer projects with attributed resources (VMs, PostgreSQL, Kubernetes,
-  GitHub runners) or invoices, ordered by lifetime spend. Managed-service VMs
-  are attributed to the customer that owns the managing resource.
+  Customer projects with attributed resources (VMs, PostgreSQL, Kubernetes, GitHub runners) or invoices, ordered by
+  lifetime spend. Managed-service VMs are attributed to the customer that owns the managing resource.
 </p>
 
 <%== part("components/table", title: nil, table_class: "customer-usage-table", data: @data, use_admin_label: false) %>

--- a/views/admin/extras/OidcProvider.erb
+++ b/views/admin/extras/OidcProvider.erb
@@ -1,6 +1,7 @@
 <%# locals: (obj:) %>
 
 <h3>Allowed Domains</h3>
+
 <ul id="allowed-domains">
   <% obj.allowed_domains.each do |domain| %>
     <li><%= domain %></li>
@@ -8,6 +9,7 @@
 </ul>
 
 <h3>Locked Domains</h3>
+
 <ul id="locked-domains">
   <% obj.locked_domains.each do |ld| %>
     <li><%= ld.domain %></li>

--- a/views/admin/extras/PostgresServer.erb
+++ b/views/admin/extras/PostgresServer.erb
@@ -26,10 +26,12 @@ content_security_policy.add_img_src [:nonce, nonce] %>
     <h3>Archival Backlog</h3>
     <%== part("components/svg_chart", points: backlog_points, nonce:) %>
   </div>
+
   <div class="chart-cell">
     <h3>WAL Lag</h3>
     <%== part("components/svg_chart", points: lag_points, nonce:) { format_bytes(it) } %>
   </div>
+
   <% if replay_points %>
     <div class="chart-cell">
       <h3>Replay Lag</h3>

--- a/views/admin/extras/Project.erb
+++ b/views/admin/extras/Project.erb
@@ -13,6 +13,7 @@
 ) %>
 
 <% invoice = Serializers::Invoice.serialize(obj.current_invoice) %>
+
 <%== part("components/collapsible_table",
   title: "Current Usage (subtotal: #{invoice.subtotal}, cost: #{invoice.total})",
   table_class: "project-usage-table",

--- a/views/admin/github_runner_usage.erb
+++ b/views/admin/github_runner_usage.erb
@@ -15,15 +15,15 @@ end
 @data.prepend({name: "TOTAL", prem: "", spill: "", **total}) if @data.any? %>
 
 <% other_arch = (@arch == "x64") ? "arm64" : "x64" %>
-<a href="/github-runner-usage?arch=<%= other_arch %>">Show
-  <%= other_arch %></a>
+
+<a href="/github-runner-usage?arch=<%= other_arch %>">Show <%= other_arch %></a>
 
 <p>
   <strong>standard:</strong>
   <%= "vcpu #{@family_utilization.dig("standard", 0) || 0}%, hugepage #{@family_utilization.dig("standard", 1) || 0}%, spilled vcpus #{@spilled_vcpus}" %>
+
   <% if @arch == "x64" %>
-    -
-    <strong>premium:</strong>
+    - <strong>premium:</strong>
     <%= "vcpu #{@family_utilization.dig("premium", 0) || 0}%, hugepage #{@family_utilization.dig("premium", 1) || 0}%" %>
   <% end %>
 </p>
@@ -31,22 +31,26 @@ end
 <%== part("components/table", title: nil, table_class: "github-runner-usage-table", data: @data, use_admin_label: false) %>
 
 <h3>Columns</h3>
-<p><strong>prem:</strong>
-  Whether premium runners are enabled. Even when enabled, runners can still fall back to standard.</p>
-<p><strong>spill:</strong>
-  Whether the spill_to_alien_runners feature flag is enabled for the project.</p>
-<p><strong>quota:</strong>
-  Effective GithubRunnerVCpu quota for the project.</p>
-<p><strong>r*:</strong>
-  Number of requested runners with the specified vCPU count.</p>
-<p><strong>runner_vcpus:</strong>
-  Total allocated vCPUs / total requested vCPUs. Unallocated runners are waiting for the concurrency limit.</p>
-<p><strong>vm_vcpus:</strong>
-  Total allocated vCPUs / total vCPUs. Unallocated VMs have passed the concurrency limit but haven't found an available
-  VM host yet.</p>
-<p><strong>s*:</strong>
-  Number of runners with that standard family, including ones that fell back from premium.</p>
-<p><strong>p*:</strong>
-  Number of runners with that premium family.</p>
-<p><strong>a*:</strong>
-  Number of alien runners.</p>
+
+<p>
+  <strong>prem:</strong> Whether premium runners are enabled. Even when enabled, runners can still fall back to
+  standard.
+</p>
+
+<p><strong>spill:</strong> Whether the spill_to_alien_runners feature flag is enabled for the project.</p>
+<p><strong>quota:</strong> Effective GithubRunnerVCpu quota for the project.</p>
+<p><strong>r*:</strong> Number of requested runners with the specified vCPU count.</p>
+
+<p>
+  <strong>runner_vcpus:</strong> Total allocated vCPUs / total requested vCPUs. Unallocated runners are waiting for the
+  concurrency limit.
+</p>
+
+<p>
+  <strong>vm_vcpus:</strong> Total allocated vCPUs / total vCPUs. Unallocated VMs have passed the concurrency limit but
+  haven't found an available VM host yet.
+</p>
+
+<p><strong>s*:</strong> Number of runners with that standard family, including ones that fell back from premium.</p>
+<p><strong>p*:</strong> Number of runners with that premium family.</p>
+<p><strong>a*:</strong> Number of alien runners.</p>

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -4,6 +4,7 @@
   <% unless @grouped_pages.empty? %>
     <table class="page-table">
       <caption><%= @total_pages %> Active Pages</caption>
+
       <thead>
         <tr>
           <th>Root Resource</th>
@@ -13,19 +14,22 @@
           <th>Details</th>
         </tr>
       </thead>
+
       <tbody>
         <% @grouped_pages.sort_by { |k,| k || "z" }.each do |root_resource_id, pages| %>
           <% pages.each_with_index do |page, index| %>
             <% resources = page.details.delete("related_resources") %>
+
             <tr>
               <% if index == 0 %>
                 <td rowspan="<%= pages.size %>">
                   <% if root_resource_id %>
                     <% root_resource_ubid = UBID.to_ubid(root_resource_id) %>
                     <a href="/model/<%= UBID.class_for_ubid(root_resource_ubid) %>/<%= root_resource_ubid %>"><%= root_resource_ubid %></a>
-                  <% end%>
+                  <% end %>
                 </td>
               <% end %>
+
               <td><%= page.created_at.strftime("%F %T") %></td>
               <td><a href="/model/Page/<%= page.ubid %>"><%= page.summary %></a></td>
               <td><%== linkify_ubids(resources) %></td>
@@ -38,14 +42,19 @@
   <% end %>
 
   <h2>Browse by Model Class</h2>
+
   <ul id="model-class-list">
     <% autoforme_models = self.class.autoforme_framework.models %>
+
     <% @classes.each do |klass| %>
-      <li><a href="<%= autoforme_models[klass.to_s] ? "/autoforme/#{klass}/browse" : "/model/#{klass}" %>"><%= klass %></a></li>
+      <li>
+        <a href="<%= autoforme_models[klass.to_s] ? "/autoforme/#{klass}/browse" : "/model/#{klass}" %>"><%= klass %></a>
+      </li>
     <% end %>
   </ul>
 
   <h2>Tools</h2>
+
   <ul>
     <li><a href="/archived-record-by-id">Find Archived Record by ID</a></li>
     <li><a href="/vm-by-ipv4">Find VM by IPv4 Address</a></li>
@@ -54,11 +63,12 @@
     <li><a href="/cogs">VM Host COGS</a></li>
     <li><a href="/setup-vm-host">Setup VM Host</a></li>
     <li><a href="/customer-usage">Customer Usage</a></li>
+
     <li>
-      <a href="/audit-log">View Audit Logs</a> |
-      <a href="/authentication-audit-log">View Authentication Audit Logs</a> |
-      <a href="/authentication-audit-log/admin">View Admin Authentication Audit Logs</a>
+      <a href="/audit-log">View Audit Logs</a> | <a href="/authentication-audit-log">View Authentication Audit Logs</a>
+      | <a href="/authentication-audit-log/admin">View Admin Authentication Audit Logs</a>
     </li>
+
     <li><a href="/presigned-certs">Presigned Certs Info</a></li>
     <li><a href="/rollouts">Manage Rollouts</a></li>
     <li><a href="/remove-boot-images">Remove Boot Images</a></li>
@@ -66,10 +76,14 @@
     <li><a href="/local-e2e">Manage Local E2E</a></li>
     <li><a href="/admin-list">View Admin List</a></li>
     <li><a href="/autoforme/Strand/search/1?try=10">Strands with try &gt;= 10</a></li>
-    <li><a href="/autoforme/Strand/search/1?<%= to_query_string(prog: "Vm::Metal::Nexus", label: "unavailable") %>">Show Unavailable VMs</a></li>
+
+    <li>
+      <a href="/autoforme/Strand/search/1?<%= to_query_string(prog: "Vm::Metal::Nexus", label: "unavailable") %>">Show Unavailable VMs</a>
+    </li>
   </ul>
 
   <h2>Manage</h2>
+
   <ul>
     <li><a href="/change-password">Change Password</a></li>
     <li><a href="/multifactor-manage">Manage Multifactor Authentication</a></li>
@@ -86,15 +100,18 @@
           <th>Created At</th>
         </tr>
       </thead>
+
       <tbody>
         <% @info_pages.each do |info_page| %>
           <tr>
             <td><a href="/model/Page/<%= info_page.ubid %>"><%= info_page.summary %></a></td>
+
             <% if info_page.details["related_resources"] %>
               <td><%== linkify_ubids(info_page.details["related_resources"].join(" ")) %></td>
             <% else %>
               <td>No related resources</td>
             <% end %>
+
             <td><%= info_page.created_at.strftime("%F %T") %></td>
           </tr>
         <% end %>

--- a/views/admin/layout.erb
+++ b/views/admin/layout.erb
@@ -3,7 +3,7 @@
 <html class="theme-<%= session["theme"] || "system" %>">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
@@ -11,7 +11,7 @@
 
     <title>Ubicloud Admin<%= " - " if @page_title %><%= @page_title %></title>
 
-    <link rel="stylesheet" href="/admin/app.css?m=<%= File.mtime("public/admin/app.css").to_i %>" />
+    <link rel="stylesheet" href="/admin/app.css?m=<%= File.mtime("public/admin/app.css").to_i %>">
   </head>
 
   <body>

--- a/views/admin/layout.erb
+++ b/views/admin/layout.erb
@@ -1,19 +1,24 @@
 <!DOCTYPE html>
+
 <html class="theme-<%= session["theme"] || "system" %>">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <% @page_title ||= @autoforme_action.title if @autoforme_action %>
+
     <title>Ubicloud Admin<%= " - " if @page_title %><%= @page_title %></title>
-    <link rel="stylesheet" href="/admin/app.css?m=<%= File.mtime("public/admin/app.css").to_i %>"/>
+
+    <link rel="stylesheet" href="/admin/app.css?m=<%= File.mtime("public/admin/app.css").to_i %>" />
   </head>
 
   <body>
     <nav class="navbar" role="navigation">
       <div class="container">
         <a class="navbar-brand" href="/">Ubicloud Admin</a>
+
         <% if rodauth.logged_in? %>
           <% form(id: "ubid_form", action: "/") do |f| %>
             <%== f.input("text", key: "id", placeholder: "UBID, UUID, or prefix:term", required: true) %>
@@ -30,12 +35,15 @@
       <% if flash["notice"] %>
         <div class="alert alert-success" role="alert" id="flash-notice"><%= flash["notice"] %></div>
       <% end %>
+
       <% if flash["error"] %>
         <div class="alert alert-danger" role="alert" id="flash-error"><%= flash["error"] %></div>
       <% end %>
+
       <% if @page_title %>
         <h1><%= @page_title %></h1>
       <% end %>
+
       <%== yield %>
     </div>
 
@@ -43,6 +51,7 @@
       <footer>
         <div class="container">
           <span><%= Time.now.utc %></span>
+
           <% if Config.staging %>
             <span>clover-staging</span>
           <% elsif Config.production? %>
@@ -50,15 +59,11 @@
           <% else %>
             <span>clover-<%= Config.rack_env %></span>
           <% end %>
-          <span id="theme-switcher">Theme:
-            <% current_theme = session["theme"] || "system" %>
-            <% %w[light dark system].each do |theme| %>
-              <%== form({action: "/theme/#{theme}", method: :post, class: ("current" if theme == current_theme)}, button: theme.capitalize) %>
-            <% end %>
-          </span>
+
+          <span id="theme-switcher">Theme:<% current_theme = session["theme"] || "system" %> <% %w[light dark system].each do |theme| %><%== form({action: "/theme/#{theme}", method: :post, class: ("current" if theme == current_theme)}, button: theme.capitalize) %><% end %></span>
+
           <% if commit = Config.git_commit_hash %>
-            <span>commit:
-              <a href="https://github.com/ubicloud/ubicloud/commit/<%= commit %>" target="_blank"><%= commit %></a></span>
+            <span>commit: <a href="https://github.com/ubicloud/ubicloud/commit/<%= commit %>" target="_blank"><%= commit %></a></span>
           <% end %>
         </div>
       </footer>

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -6,12 +6,12 @@
 
 <div id="strand-info">
   <% if @klass.associations.include?(:strand) && (strand = @obj.strand) %>
-      <a href="/model/Strand/<%= strand.ubid %>">Strand</a>: <%= strand.prog %>#<%= strand.label %>
-      | schedule: <%= strand.schedule.strftime("%F %T") %>
-      <% if strand.try > 0 %>
-        | try: <%= strand.try %>
-      <% end %>
-      <%== form({action: "/model/Strand/#{strand.ubid}/schedule", method: :post}, button: "Schedule Strand to Run Now") %>
+    <a href="/model/Strand/<%= strand.ubid %>">Strand</a>: <%= strand.prog %>#<%= strand.label %> | schedule:
+    <%= strand.schedule.strftime("%F %T") %>
+    <% if strand.try > 0 %>
+      | try: <%= strand.try %>
+    <% end %>
+    <%== form({action: "/model/Strand/#{strand.ubid}/schedule", method: :post}, button: "Schedule Strand to Run Now") %>
   <% end %>
 </div>
 
@@ -24,7 +24,8 @@
 <% end %>
 
 <% if actions = OBJECT_ACTIONS[@obj.class.name] %>
-  <div id="action-list">Actions:
+  <div id="action-list">
+    Actions:
     <% actions.each do |key, action| %>
       <% if action.type == :form %>
         <%== form({action: "/model/#{@obj.class.name}/#{@obj.ubid}/#{key}", method: :post}, button: action.label) %>
@@ -42,16 +43,16 @@
 ) %>
 
 <% if OBJECTS_WITH_EXTRAS[@klass.name] %>
-<div class="extras">
-  <%== part("extras/#{@klass.name}", obj: @obj) %>
-</div>
+  <div class="extras">
+    <%== part("extras/#{@klass.name}", obj: @obj) %>
+  </div>
 <% end %>
 
 <h2 id="associations-header">Associations</h2>
+
 <div class="associations">
   <% @klass.associations.sort.each do |assoc| %>
-    <%
-    reflection = @klass.association_reflection(assoc)
+    <% reflection = @klass.association_reflection(assoc)
     associated_class = reflection.associated_class
     next unless associated_class.method_defined?(:ubid)
     assoc_objs = if reflection.returns_array?
@@ -60,21 +61,24 @@
       Array(@obj.send(assoc))
     end
     next if assoc_objs.empty?
-    assoc_count = assoc_objs.count
-    %>
+    assoc_count = assoc_objs.count %>
 
     <div class="association">
       <h3>
         <%= assoc %>
         <%= "(#{(assoc_count > 100) ? "100+" : assoc_count})" if assoc_count > 1 %>
+
         <% if table_param = OBJECT_ASSOC_TABLE_PARAMS[[@klass.name, assoc]] %>
           <a href="/autoforme/<%= associated_class %>/search/1?<%= table_param %>=<%= @obj.id %>">(table)</a>
         <% end %>
       </h3>
+
       <ul>
-      <% assoc_objs.each do %>
-        <li><a href="/model/<%= associated_class %>/<%= it.ubid %>" title="<%= it.ubid %>"><%= it.admin_label %></a></li>
-      <% end %>
+        <% assoc_objs.each do %>
+          <li>
+            <a href="/model/<%= associated_class %>/<%= it.ubid %>" title="<%= it.ubid %>"><%= it.admin_label %></a>
+          </li>
+        <% end %>
       </ul>
     </div>
   <% end %>
@@ -82,6 +86,7 @@
 
 <p>
   <a href="/audit-log?<%= AUDIT_LOG_PARAM_MAP[@klass.name] %>=<%= @obj.ubid %>">View Audit Log</a>
+
   <% if @obj.is_a?(Account) %>
     | <a href="/authentication-audit-log?account=<%= @obj.ubid %>">View Authentication Audit Log</a>
   <% end %>

--- a/views/admin/object_action.erb
+++ b/views/admin/object_action.erb
@@ -5,5 +5,6 @@
     <% options = {options: value[:options].call(@obj)} if value[:options].is_a?(Proc) %>
     <%== f.input(value.fetch(:type, "text"), key: name, label: name, required: true, **value, **options) %>
   <% end %>
+
   <%== f.button(@label) %>
 <% end %>

--- a/views/admin/remove_boot_images_confirm.erb
+++ b/views/admin/remove_boot_images_confirm.erb
@@ -1,22 +1,16 @@
 <% @page_title = "Remove Boot Images" %>
 
 <p>
-  You are about to remove boot image
-  <strong><%= @name %>
-    <%= @version %></strong>.
+  You are about to remove boot image <strong><%= @name %> <%= @version %></strong>.
 </p>
+
 <p>
-  This will schedule removal of
-  <strong><%= @removable_count %></strong>
-  of
-  <%= @total_count %>
-  image(s) that have no active storage volumes (i.e. no active VM). Images that still have active storage volumes will
-  be kept.
+  This will schedule removal of <strong><%= @removable_count %></strong> of <%= @total_count %> image(s) that have no
+  active storage volumes (i.e. no active VM). Images that still have active storage volumes will be kept.
 </p>
 
 <% if @removable_count == 0 %>
-  <p>There are no images to remove.
-    <a href="/remove-boot-images">Back</a></p>
+  <p>There are no images to remove. <a href="/remove-boot-images">Back</a></p>
 <% else %>
   <%== form({action: "/remove-boot-images/confirm?#{to_query_string(name: @name, version: @version)}", method: "post", class: "rollout-form"}, button: "Confirm Remove") %>
   <p><a href="/remove-boot-images">Cancel</a></p>

--- a/views/admin/rollouts.erb
+++ b/views/admin/rollouts.erb
@@ -47,7 +47,9 @@ end %>
 <div class="rollout-forms">
   <section class="rollout-card">
     <h3>Boot Image</h3>
+
     <p class="rollout-desc">Download a boot image version to hosts, a few at a time.</p>
+
     <% form({action: "/rollouts/start/RolloutBootImage", method: "post", id: "start-rollout", class: "rollout-form"}, button: "Start Boot Image Rollout", wrapper: :div) do |f| %>
       <%== f.input(:select, key: :image_name, label: "Image Name", required: true, add_blank: true, options: Prog::DownloadBootImage::BOOT_IMAGE_SHA256.keys) %>
       <%== f.input(:text, key: :version, label: "Version", required: true) %>
@@ -61,7 +63,11 @@ end %>
 
   <section class="rollout-card">
     <h3>Semaphore</h3>
-    <p class="rollout-desc">Increment or decrement a semaphore across every instance of a class, spaced out by a gap.</p>
+
+    <p class="rollout-desc">
+      Increment or decrement a semaphore across every instance of a class, spaced out by a gap.
+    </p>
+
     <% form({action: "/rollouts/start/RolloutSemaphore", method: "post", id: "start-semaphore-rollout", class: "rollout-form"}, button: "Start Semaphore Rollout", wrapper: :div) do |f| %>
       <%== f.input(:select, key: :class_semaphore, label: "Class - Semaphore", required: true, add_blank: true, options: ROLLOUT_SEMAPHORE_OPTIONS) %>
       <%== f.input(:select, key: :location_id, label: "Location", add_blank: true, options: Location.where(project_id: nil).order(:name).select_map([:name, :id]).each { it[1] = UBID.to_ubid(it[1]) }) %>
@@ -73,6 +79,7 @@ end %>
 
   <section class="rollout-card">
     <h3>Rhizome</h3>
+
     <p class="rollout-desc">Deploy the latest rhizome code to all hosts.</p>
     <%== form({action: "/rollouts/start/RolloutRhizome", method: "post", class: "rollout-form"}, button: "Start Rhizome Rollout") %>
   </section>

--- a/views/admin/search.erb
+++ b/views/admin/search.erb
@@ -2,14 +2,11 @@
 
 <% if @search_results&.empty? %>
   <p>
-    No results found for
-    <strong><%= @query %></strong>
+    No results found for <strong><%= @query %></strong>
   </p>
 <% elsif @search_results %>
   <p>
-    <%= @search_results.length %>
-    results for
-    <strong><%= @query %></strong>
+    <%= @search_results.length %> results for <strong><%= @query %></strong>
   </p>
   <% if @truncated %>
     <div class="alert alert-danger" role="alert">Results are truncated. Try a more specific search term.</div>

--- a/views/admin/setup_vm_host.erb
+++ b/views/admin/setup_vm_host.erb
@@ -21,7 +21,9 @@ end %>
 <div class="rollout-forms">
   <section class="rollout-card">
     <h3>New VM Host</h3>
+
     <p class="rollout-desc">Create host records and start a HostNexus strand to prepare the server.</p>
+
     <% form({method: "post", id: "setup-vm-host", class: "rollout-form"}, button: "Setup VM Host", wrapper: :div) do |f| %>
       <%== f.input(:text, key: :host, label: "IP Address", required: true) %>
       <%== f.input(:select, key: :location_id, label: "Location", required: true, add_blank: true, options: Location.exclude(provider: %w[aws gcp]).order(:name).select_map([:name, :id]).each { it[1] = UBID.to_ubid(it[1]) }) %>
@@ -31,8 +33,10 @@ end %>
       <%== f.input(:checkboxset, key: :default_boot_images, label: "Default Boot Images", options: Prog::DownloadBootImage::BOOT_IMAGE_SHA256.keys, wrapper_attr: {class: "rollout-checkboxset"}) %>
       <%== f.input(:text, key: :vhost_block_backend_version, label: "Vhost Block Backend Version", required: true, value: Config.vhost_block_backend_version) %>
       <%== f.input(:checkbox, key: :install_os, label: "Install OS") %>
-      <p class="rollout-desc"><strong>Warning:</strong>
-        If Install OS is selected, all disks on the server will be wiped.</p>
+
+      <p class="rollout-desc">
+        <strong>Warning:</strong> If Install OS is selected, all disks on the server will be wiped.
+      </p>
     <% end %>
   </section>
 </div>

--- a/views/admin/vm_by_ipv4.erb
+++ b/views/admin/vm_by_ipv4.erb
@@ -7,8 +7,8 @@
 
 <% form(id: "vm_by_ipv4_form", class: "form-vertical") do |f| %>
   <%== f.input("textarea", key: "ips", placeholder: "Comma seperated IP list", rows: 4, value: @ips_param) %>
-  <%== f.input("number", key: "days", label: "Days", placeholder: "1-15", value: @days, min: 1, max: 15) %>
-  Higher day values will increase query duration significantly. Use the smallest value possible.
+  <%== f.input("number", key: "days", label: "Days", placeholder: "1-15", value: @days, min: 1, max: 15) %> Higher day
+  values will increase query duration significantly. Use the smallest value possible.
   <%== f.button("Show Virtual Machines") %>
 <% end %>
 

--- a/views/auth/create_account.erb
+++ b/views/auth/create_account.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Create a new account" %>
 
 <% form(class: "rodauth space-y-6", method: :post) do %>
-
   <%== part(
     "components/form/text",
     name: "name",

--- a/views/auth/login.erb
+++ b/views/auth/login.erb
@@ -4,8 +4,8 @@
 
 <div class="space-y-6">
   <% form(class: "rodauth space-y-6", method: :post, id: "login-form") do %>
-
     <%== render("components/rodauth/login_field") %>
+
     <% if rodauth.valid_login_entered? %>
       <% if rodauth.has_password? %>
         <%== render("components/rodauth/password_field") %>
@@ -17,8 +17,7 @@
     <% identities = Account[rodauth.account_id].identities %>
     <% unless identities.empty? %>
       <div class="relative flex justify-center text-sm font-medium leading-6">
-        <span class="bg-white px-6 text-gray-900"><%= rodauth.has_password? ? "Or login" : "Login" %>
-          with:</span>
+        <span class="bg-white px-6 text-gray-900"><%= rodauth.has_password? ? "Or login" : "Login" %> with:</span>
       </div>
     <% end %>
 
@@ -28,9 +27,13 @@
         <% provider_name = provider.display_name %>
         <% content_security_policy.add_form_action(provider.url) %>
       <% end %>
+
       <% form(action: rodauth.omniauth_request_path(identity.provider), method: :post, class: "grow") do %>
         <button
-          class="flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+          class="
+            flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm
+            ring-1 ring-inset ring-gray-300 hover:bg-gray-50
+          "
           type="submit"
         >
           <%== part("components/icon", name: identity.provider.to_s) unless provider_name %>
@@ -50,6 +53,7 @@
           class="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
           form="login-form"
         >
+
         <label for="remember-me" class="ml-2 block text-sm text-gray-900">Remember me</label>
       </div>
 
@@ -58,7 +62,9 @@
           <a
             href="/reset-password-request?login=<%= Rack::Utils.escape(rodauth.param("login")) %>"
             class="font-medium text-orange-600 hover:text-orange-700"
-          >Forgot your password?</a>
+          >
+            Forgot your password?
+          </a>
         </div>
       <% end %>
     </div>
@@ -68,6 +74,7 @@
     <% if !rodauth.valid_login_entered? || rodauth.has_password? %>
       <%== part("components/form/submit_button", text: "Sign in", attributes: {form: "login-form"}) %>
     <% end %>
+
     <% unless rodauth.valid_login_entered? %>
       <a href="/create-account" class="mt-2 text-sm font-semibold leading-6 text-gray-900">Create a new account</a>
     <% end %>

--- a/views/auth/oidc_login.erb
+++ b/views/auth/oidc_login.erb
@@ -11,7 +11,10 @@ end %>
 
 <% form(action: form_action, method: :post, class: "rodauth space-y-6") do %>
   <button
-    class="flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+    class="
+      flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1
+      ring-inset ring-gray-300 hover:bg-gray-50
+    "
     type="submit"
   >
     <span class="text-sm font-semibold leading-6"><%= button %></span>

--- a/views/auth/otp_auth.erb
+++ b/views/auth/otp_auth.erb
@@ -3,11 +3,11 @@
 <% @page_message = "Verify your sign in" %>
 
 <% form(action: rodauth.otp_auth_path, method: :post, class: "rodauth space-y-6") do %>
-
   <%== render("components/rodauth/otp_auth_code_field") %>
 
   <div class="flex flex-col text-center">
     <%== part("components/form/submit_button", text: rodauth.otp_auth_button) %>
+
     <p class="mt-10 text-center text-sm text-gray-400">
       Can't access your authentication app?
       <br>

--- a/views/auth/otp_unlock.erb
+++ b/views/auth/otp_unlock.erb
@@ -1,15 +1,18 @@
 <% @page_message = "Your one-time password authentication has been locked out, and must be unlocked to be used." %>
 
 <% form(method: :post, class: "rodauth space-y-6") do %>
-
   <p><%= rodauth.otp_unlock_consecutive_successes_label %>: <%= rodauth.otp_unlock_num_successes %></p>
   <p><%= rodauth.otp_unlock_required_consecutive_successes_label %>: <%= rodauth.otp_unlock_auths_required %></p>
-  <p><%= rodauth.otp_unlock_next_auth_deadline_label %>: <%= (rodauth.otp_unlock_deadline - Time.now).to_i %> seconds</p>
+
+  <p>
+    <%= rodauth.otp_unlock_next_auth_deadline_label %>: <%= (rodauth.otp_unlock_deadline - Time.now).to_i %> seconds
+  </p>
 
   <%== render("components/rodauth/otp_auth_code_field") %>
 
   <div class="flex flex-col text-center">
     <%== part("components/form/submit_button", text: rodauth.otp_unlock_button) %>
+
     <p class="mt-10 text-center text-sm text-gray-400">
       Can't access your authentication app?
       <br>

--- a/views/auth/otp_unlock_not_available.erb
+++ b/views/auth/otp_unlock_not_available.erb
@@ -3,7 +3,13 @@
 <div class="space-y-6">
   <p><%= rodauth.otp_unlock_consecutive_successes_label %>: <%= rodauth.otp_unlock_num_successes %></p>
   <p><%= rodauth.otp_unlock_required_consecutive_successes_label %>: <%= rodauth.otp_unlock_auths_required %></p>
-  <p><%= rodauth.otp_unlock_next_auth_deadline_label %>: <%= (rodauth.otp_unlock_deadline - Time.now).to_i %> seconds</p>
 
-  <p>Page will automatically refresh when authentication is possible (in <%= (rodauth.otp_unlock_next_auth_attempt_after - Time.now).to_i + 1 %> seconds).</p>
+  <p>
+    <%= rodauth.otp_unlock_next_auth_deadline_label %>: <%= (rodauth.otp_unlock_deadline - Time.now).to_i %> seconds
+  </p>
+
+  <p>
+    Page will automatically refresh when authentication is possible (in
+    <%= (rodauth.otp_unlock_next_auth_attempt_after - Time.now).to_i + 1 %> seconds).
+  </p>
 </div>

--- a/views/auth/recovery_auth.erb
+++ b/views/auth/recovery_auth.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Verify your sign in" %>
 
 <% form(action: rodauth.recovery_auth_path, method: :post, class: "rodauth space-y-6") do %>
-
   <%== part(
     "components/form/text",
     name: rodauth.recovery_codes_param,
@@ -16,6 +15,7 @@
 
   <div class="flex flex-col text-center">
     <%== part("components/form/submit_button", text: rodauth.recovery_auth_button) %>
+
     <p class="mt-10 text-center text-sm text-gray-400">
       Can't access your recovery codes?
       <br>

--- a/views/auth/reset_password.erb
+++ b/views/auth/reset_password.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Reset your password" %>
 
 <% form(method: :post, class: "rodauth space-y-6") do %>
-
   <%== render("components/rodauth/password_field") %>
   <%== part("components/rodauth/password_field", confirm: true) %>
 

--- a/views/auth/reset_password_request.erb
+++ b/views/auth/reset_password_request.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Request password reset" %>
 
 <% form(action: rodauth.reset_password_request_path, method: :post, class: "rodauth space-y-6") do %>
-
   <div>
     <p class="leading-6 text-sm"><%== rodauth.reset_password_explanatory_text %></p>
   </div>

--- a/views/auth/social_buttons.erb
+++ b/views/auth/social_buttons.erb
@@ -4,15 +4,20 @@
       <div class="absolute inset-0 flex items-center" aria-hidden="true">
         <div class="w-full border-t border-gray-200"></div>
       </div>
+
       <div class="relative flex justify-center text-sm font-medium leading-6">
         <span class="bg-white px-6 text-gray-900">Or continue with</span>
       </div>
     </div>
+
     <div class="mt-4 grid sm:grid-cols-<%= omniauth_providers.length %> gap-4">
       <% omniauth_providers.each do |provider, name| %>
         <% form(action: rodauth.omniauth_request_path(provider), method: :post, class: :grow) do %>
           <button
-            class="flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+            class="
+              flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm
+              ring-1 ring-inset ring-gray-300 hover:bg-gray-50
+            "
             type="submit"
           >
             <%== part("components/icon", name: provider.to_s) %>

--- a/views/auth/verify_account.erb
+++ b/views/auth/verify_account.erb
@@ -3,7 +3,6 @@
 <% @page_message = "Verify your account" %>
 
 <% form(method: :post, class: "rodauth space-y-6") do %>
-
   <div class="flex flex-col text-center">
     <%== part("components/form/submit_button", text: "Verify Account") %>
     <a href="/login" class="mt-2 text-sm font-semibold leading-6 text-gray-900">Sign in to another account</a>

--- a/views/auth/verify_account_resend.erb
+++ b/views/auth/verify_account_resend.erb
@@ -21,6 +21,7 @@
       text: "Send Verification Again",
       attributes: recently_sent ? { disabled: true } : {}
     ) %>
+
     <a href="/login" class="mt-2 text-sm font-semibold leading-6 text-gray-900">Sign in to another account</a>
   </div>
 <% end %>

--- a/views/auth/verify_login_change.erb
+++ b/views/auth/verify_login_change.erb
@@ -8,9 +8,11 @@
       <div class="overflow-hidden rounded-lg bg-white shadow">
         <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-x lg:divide-y-0">
           <%== render("account/submenu") %>
+
           <div class="divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10">
             <div class="px-4 py-6 sm:p-6 lg:pb-8 space-y-4">
               <h2 class="text-lg font-medium leading-6 text-gray-900">Verify New Email</h2>
+
               <% form(method: :post) do %>
                 <div class="mt-6 grid grid-cols-6 gap-6">
                   <div class="col-span-6">

--- a/views/auth/webauthn_auth.erb
+++ b/views/auth/webauthn_auth.erb
@@ -4,10 +4,20 @@
 
 <% form(:action => rodauth.webauthn_auth_form_path, :method => :post, :class => "rodauth space-y-6", :id => "webauthn-auth-form", "data-credential-options" => (cred = rodauth.webauthn_credential_options_for_get).as_json.to_json) do %>
   <%== hidden_inputs(rodauth.webauthn_auth_challenge_param => cred.challenge, rodauth.webauthn_auth_challenge_hmac_param => rodauth.compute_hmac(cred.challenge)) %>
-  <input id="webauthn-auth" class="hidden" type="text" name="<%= rodauth.webauthn_auth_param %>" value="" hidden/>
+
+  <input
+    id="webauthn-auth"
+    class="hidden"
+    type="text"
+    name="<%= rodauth.webauthn_auth_param %>"
+    value=""
+    hidden
+  />
+
   <div id="webauthn-auth-button" class="flex flex-col text-center">
     <%== part("components/form/submit_button", text: rodauth.webauthn_auth_button) %>
   </div>
+
   <p class="mt-10 text-center text-sm text-gray-400">
     Can't access your authentication app?
     <br>
@@ -16,4 +26,5 @@
     <a href="mailto:support@ubicloud.com" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">contact support</a>
   </p>
 <% end %>
+
 <script src="<%= "#{rodauth.webauthn_js_host}#{rodauth.webauthn_auth_js_path}" %>"></script>

--- a/views/auth/webauthn_auth.erb
+++ b/views/auth/webauthn_auth.erb
@@ -12,7 +12,7 @@
     name="<%= rodauth.webauthn_auth_param %>"
     value=""
     hidden
-  />
+  >
 
   <div id="webauthn-auth-button" class="flex flex-col text-center">
     <%== part("components/form/submit_button", text: rodauth.webauthn_auth_button) %>

--- a/views/cli.erb
+++ b/views/cli.erb
@@ -24,7 +24,8 @@ end %>
       <div class="min-w-0 flex-1">
         <% unless multi %>
           This page provides access to a web version of
-          <a class="font-medium text-orange-600 hover:text-orange-700" href="https://www.ubicloud.com/docs/quick-start/cli">Ubicloud's CLI</a>. You can use it without installing the CLI. All features are available, except ones that execute external
+          <a class="font-medium text-orange-600 hover:text-orange-700" href="https://www.ubicloud.com/docs/quick-start/cli">Ubicloud's CLI</a>.
+          You can use it without installing the CLI. All features are available, except ones that execute external
           programs.
         <% else %>
           This page allows scheduling the execution of multiple commands, one per line. It will run the command on the
@@ -43,19 +44,20 @@ end %>
           <%== part("components/form/text", name: "cli", value: @cli, prefix: "ubi", attributes: {placeholder: "Command. i.e: 'vm list'", autofocus: true, required: true}) %>
         <% end %>
       </div>
+
       <%== part("components/form/submit_button", text: "Run") %>
     </div>
 
-    <div
-      class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200 <%= (multi && !@cli) ? "hidden" : ""%>"
-    >
+    <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200 <%= (multi && !@cli) ? "hidden" : "" %>">
       <div class="px-4 py-5 sm:p-6 space-y-6">
         <% if @clis && !@clis.empty? %>
           <div class="space-y-2">
             <p class="text-xl font-semibold">Remaining commands:</p>
+
             <div class="w-full text-sm border p-3 bg-slate-100 font-mono rounded">
               <% @clis.each do %>
                 <pre class="whitespace-pre-wrap"><code class="next-clis"><%= it %></code></pre>
+
                 <input type="hidden" name="clis[]" value="<%= it %>">
               <% end %>
             </div>
@@ -65,6 +67,7 @@ end %>
         <% if @last_cli %>
           <div class="space-y-2">
             <p class="text-xl font-semibold">Ran command:</p>
+
             <div class="w-full text-sm border p-3 bg-slate-100 font-mono rounded">
               <pre class="whitespace-pre-wrap"><code id="cli-executed"><%= @last_cli %></code></pre>
             </div>
@@ -72,6 +75,7 @@ end %>
 
           <div class="space-y-2">
             <p class="text-xl font-semibold"><%= @ubi_command_execute ? "Would execute" : "Output" %>:</p>
+
             <div class="w-full text-sm border p-3 bg-slate-100 font-mono rounded">
               <pre class="whitespace-pre-wrap"><code id="cli-output"><%== @output_html %></code></pre>
             </div>
@@ -85,6 +89,7 @@ end %>
           <% unless multi %>
             <div class="space-y-2">
               <h2 class="text-xl font-semibold">Examples</h2>
+
               <dl class="w-full text-sm border p-3 bg-slate-100 font-mono rounded">
                 <dt><code>help -ru</code></dt>
                 <dd class="inline-block ml-6 mb-4">Display the syntax for all supported commands</dd>

--- a/views/components/billing_warning.erb
+++ b/views/components/billing_warning.erb
@@ -4,12 +4,13 @@
       <div class="flex-shrink-0">
         <%== part("components/icon", name: "hero-banknotes", classes: "h-9 w-9 text-red-400") %>
       </div>
+
       <div class="ml-3">
         <h3 class="text-sm font-medium text-red-700">
           Project doesn't have valid billing information. You have to create project's billing details first.
           <br>
-          <a href="<%= @project.path %>/billing" class="font-bold text-red-800">Click here</a>
-          to create billing details.
+          <a href="<%= @project.path %>/billing" class="font-bold text-red-800">Click here</a> to create billing
+          details.
         </h3>
       </div>
     </div>

--- a/views/components/button.erb
+++ b/views/components/button.erb
@@ -6,25 +6,28 @@
     href="<%= link %>"
     class="inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 <%= color %> disabled:pointer-events-none disabled:opacity-50 <%= extra_class %>"
     <% attributes.each do |atr_key, atr_value| %>
-    <%= atr_key %>="<%= atr_value %>"
-    <% end%>
+      <%= atr_key %>="<%= atr_value %>"
+    <% end %>
   >
     <% if icon %>
       <%== part("components/icon", name: icon, classes: "h-5 w-5") %>
     <% end %>
+
     <%= text %>
   </a>
 <% else %>
   <button
     class="inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 <%= color %> disabled:pointer-events-none disabled:opacity-50 <%= extra_class %>"
     <% attributes.compact.each do |atr_key, atr_value| %>
-    <%= atr_key %>="<%= atr_value %>"
-    <% end%>
+      <%= atr_key %>="<%= atr_value %>"
+    <% end %>
   >
     <% if icon %>
       <%== part("components/icon", name: icon, classes: "h-5 w-5 #{(text && !text.empty?) ? "ml-0.5 mr-1.5" : "mx-0"}") %>
     <% end %>
+
     <%= text %>
+
     <% if right_icon %>
       <%== part("components/icon", name: right_icon, classes: "ml-1.5 -mr-1 h-5 w-5") %>
     <% end %>

--- a/views/components/config_card.erb
+++ b/views/components/config_card.erb
@@ -11,6 +11,7 @@
     <% config.each_with_index do |(key, value), index| %>
       <% error = errors[name + "." + key] %>
       <% next if key.empty? && value.empty? %>
+
       <div class="px-6 py-2 hover:bg-gray-50 config-group group font-mono" data-config-id="<%= index %>">
         <div class="flex items-center justify-between">
           <div class="flex flex-wrap items-center config-entry">
@@ -21,35 +22,46 @@
               name="<%= name %>_keys[]"
               required
             />
+
             <input
               type="text"
               value="<%= value %>"
               class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500 <%= error ? "border-red-500" : "" %>"
               name="<%= name %>_values[]"
             />
+
             <% if error %>
-              <span class="error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs text-red-600 bg-red-100 rounded" aria-live="polite">
+              <span
+                class="error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs text-red-600 bg-red-100 rounded"
+                aria-live="polite"
+              >
                 <% if error.is_a?(Array) %>
                   <% error.each do |error| %>
-                    <%= error %><br/>
+                    <%= error %><br />
                   <% end %>
                 <% else %>
                   <%= error %>
                 <% end %>
               </span>
             <% end %>
+
             <% if config_validator&.requires_restart?(key) %>
-              <span class="restart-warning ml-1 cursor-help" title="Changes to this parameter take effect after a database restart">
+              <span
+                class="restart-warning ml-1 cursor-help"
+                title="Changes to this parameter take effect after a database restart"
+              >
                 <%== part("components/icon", name: "hero-information-circle", classes: "h-4 w-4 text-orange-600") %>
               </span>
             <% end %>
           </div>
+
           <div class="min-w-16 flex items-center ml-2">
             <%== part("components/button", type: "danger", text: "", icon: "hero-trash", extra_class: "delete-config-btn") if @edit_perm %>
           </div>
         </div>
       </div>
     <% end %>
+
     <!-- Hidden row for generating new entries -->
     <div class="px-6 py-2 hover:bg-gray-50 group config-placeholder-group font-mono hidden" data-config-id="">
       <div class="flex items-center justify-between">
@@ -61,6 +73,7 @@
             name="<%= name %>_keys[]"
             disabled
           />
+
           <input
             type="text"
             value=""
@@ -68,13 +81,19 @@
             name="<%= name %>_values[]"
             disabled
           />
-          <span class="error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs text-red-600 hidden bg-red-100 rounded" aria-live="polite"></span>
+
+          <span
+            class="error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs text-red-600 hidden bg-red-100 rounded"
+            aria-live="polite"
+          ></span>
         </div>
+
         <div class="min-w-16 flex items-center ml-2">
           <%== part("components/button", type: "danger", text: "", icon: "hero-trash", extra_class: "delete-config-btn") %>
         </div>
       </div>
     </div>
+
     <!-- Empty row for new configuration -->
     <% if @edit_perm %>
       <div class="px-6 py-2 hover:bg-gray-50 group new-config font-mono">
@@ -86,14 +105,20 @@
               placeholder="New Key"
               name="<%= name %>_keys[]"
             />
+
             <input
               type="text"
               placeholder="New Value"
               class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500"
               name="<%= name %>_values[]"
             />
-            <span class="error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs text-red-600 hidden bg-red-100 rounded" aria-live="polite"></span>
+
+            <span
+              class="error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs text-red-600 hidden bg-red-100 rounded"
+              aria-live="polite"
+            ></span>
           </div>
+
           <div class="min-w-16 flex items-center ml-2">
             <%== part("components/button", text: "", type: "safe", icon: "hero-plus", extra_class: "add-config-btn") %>
           </div>

--- a/views/components/config_card.erb
+++ b/views/components/config_card.erb
@@ -21,14 +21,14 @@
               value="<%= key %>"
               name="<%= name %>_keys[]"
               required
-            />
+            >
 
             <input
               type="text"
               value="<%= value %>"
               class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500 <%= error ? "border-red-500" : "" %>"
               name="<%= name %>_values[]"
-            />
+            >
 
             <% if error %>
               <span
@@ -37,7 +37,7 @@
               >
                 <% if error.is_a?(Array) %>
                   <% error.each do |error| %>
-                    <%= error %><br />
+                    <%= error %><br>
                   <% end %>
                 <% else %>
                   <%= error %>
@@ -72,7 +72,7 @@
             value=""
             name="<%= name %>_keys[]"
             disabled
-          />
+          >
 
           <input
             type="text"
@@ -80,7 +80,7 @@
             class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500"
             name="<%= name %>_values[]"
             disabled
-          />
+          >
 
           <span
             class="error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs text-red-600 hidden bg-red-100 rounded"
@@ -104,14 +104,14 @@
               class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500 mr-2"
               placeholder="New Key"
               name="<%= name %>_keys[]"
-            />
+            >
 
             <input
               type="text"
               placeholder="New Value"
               class="border rounded py-1 focus:ring-blue-500 focus:border-blue-500"
               name="<%= name %>_values[]"
-            />
+            >
 
             <span
               class="error inline-block h-8 w-54 py-2 px-2 max-w-54 text-xs text-red-600 hidden bg-red-100 rounded"

--- a/views/components/copyable_content.erb
+++ b/views/components/copyable_content.erb
@@ -11,5 +11,10 @@
     <%= content %>
   <% end %>
 
-  <img src="/icons/hero-clipboard-document.svg" width="18px" class="inline-block copy-button cursor-pointer ms1" />
+  <img
+    src="/icons/hero-clipboard-document.svg"
+    width="18px"
+    class="inline-block copy-button cursor-pointer ms1"
+    alt="Copy"
+  />
 </div>

--- a/views/components/copyable_content.erb
+++ b/views/components/copyable_content.erb
@@ -16,5 +16,5 @@
     width="18px"
     class="inline-block copy-button cursor-pointer ms1"
     alt="Copy"
-  />
+  >
 </div>

--- a/views/components/copyable_content.erb
+++ b/views/components/copyable_content.erb
@@ -1,10 +1,15 @@
 <%# locals: (content:, message: "Copied", revealable: false, classes: "") %>
 
-<div class="copyable-content inline-flex items-center gap-1 <%= classes %>" data-content="<%= content %>" data-message="<%= message %>">
+<div
+  class="copyable-content inline-flex items-center gap-1 <%= classes %>"
+  data-content="<%= content %>"
+  data-message="<%= message %>"
+>
   <% if revealable %>
     <%== part("components/revealable_content", content:) %>
   <% else %>
     <%= content %>
   <% end %>
-  <img src="/icons/hero-clipboard-document.svg" width="18px" class="inline-block copy-button cursor-pointer ms1"/>
+
+  <img src="/icons/hero-clipboard-document.svg" width="18px" class="inline-block copy-button cursor-pointer ms1" />
 </div>

--- a/views/components/discount_code.erb
+++ b/views/components/discount_code.erb
@@ -14,6 +14,7 @@
                 }
               ) %>
             </div>
+
             <div class="col-span-2 sm:col-span-3 flex justify-start items-end">
               <%== part("components/form/submit_button", text: "Apply") %>
             </div>

--- a/views/components/empty_state.erb
+++ b/views/components/empty_state.erb
@@ -2,8 +2,11 @@
 
 <div class="text-center empty-state">
   <%== part("components/icon", name: icon, classes: "mx-auto h-12 w-12 text-gray-400") %>
+
   <h3 class="mt-2 text-sm font-semibold text-gray-900"><%= title %></h3>
+
   <p class="mt-1 text-sm text-gray-500"><%= description %></p>
+
   <div class="mt-6">
     <% if buttons %>
       <% buttons.each do |text, link| %>

--- a/views/components/flash_message.erb
+++ b/views/components/flash_message.erb
@@ -4,11 +4,13 @@
     ["error", "hero-x-circle-mini", "bg-red-50", "text-red-800", "text-red-400"]
   ].each do |type, icon, bg_color, text_color, icon_color| %>
     <% next unless flash[type] %>
+
     <div class="rounded-md <%= bg_color %> p-4">
       <div class="flex">
         <div class="flex-shrink-0">
           <%== part("components/icon", name: icon, classes: "h-5 w-5 #{icon_color}") %>
         </div>
+
         <div class="ml-3">
           <h3 id="flash-<%= type %>" class="text-sm font-medium <%= text_color %>"><%= flash[type] %></h3>
         </div>

--- a/views/components/form/checkbox.erb
+++ b/views/components/form/checkbox.erb
@@ -4,11 +4,13 @@
   <% if label %>
     <label class="block text-sm font-medium leading-6"><%= label %></label>
   <% end %>
+
   <fieldset>
     <div class="space-y-5">
       <% options.each_with_index do |(opt_val, opt_text, opt_classes, opt_attrs, opt_options), idx| %>
         <% opt_text = h(opt_text) if opt_text && (!opt_options || opt_options[:escape] != false) %>
         <% id = "#{id_prefix}#{name}-#{opt_val}-#{idx}" %>
+
         <div class="relative flex items-start <%= opt_classes %>">
           <div class="flex h-6 items-center">
             <input
@@ -20,6 +22,7 @@
               <%== html_attrs(opt_attrs || {}) %>
             >
           </div>
+
           <% if opt_text %>
             <div class="ml-3 text-sm leading-6">
               <label for="<%= id %>" class="font-medium text-gray-900"><%== allow_unescaped(opt_text) %></label>
@@ -29,6 +32,7 @@
       <% end %>
     </div>
   </fieldset>
+
   <% if description %>
     <p class="text-sm text-gray-500 leading-6"><%= description %></p>
   <% end %>

--- a/views/components/form/error.erb
+++ b/views/components/form/error.erb
@@ -2,7 +2,7 @@
 <% if error.is_a?(Array) %>
   <p class="text-sm text-red-600 leading-6" id="<%= name %>-error">
     <% error.each do |e| %>
-      <%= e %><br/>
+      <%= e %><br />
     <% end %>
   </p>
 <% else %>

--- a/views/components/form/error.erb
+++ b/views/components/form/error.erb
@@ -2,7 +2,7 @@
 <% if error.is_a?(Array) %>
   <p class="text-sm text-red-600 leading-6" id="<%= name %>-error">
     <% error.each do |e| %>
-      <%= e %><br />
+      <%= e %><br>
     <% end %>
   </p>
 <% else %>

--- a/views/components/form/partnership_notice.erb
+++ b/views/components/form/partnership_notice.erb
@@ -2,11 +2,13 @@
 <div class="col-span-full">
   <div class="space-y-2">
     <label class="text-sm font-medium leading-6 text-gray-900">Partnership Notice</label>
+
     <div class="space-y-1 text-sm leading-6 text-gray-600">
       <% Array(description_html).each do |desc_html| %>
         <p><%== desc_html %></p>
       <% end %>
     </div>
+
     <%== part("components/form/checkbox", options: [["1", tos_text, "", { required: true }, {escape: false}]]) %>
   </div>
 </div>

--- a/views/components/form/radio_small_cards.erb
+++ b/views/components/form/radio_small_cards.erb
@@ -5,8 +5,10 @@ is_content_array = options[0][1].is_a?(Array) %>
 
 <div class="space-y-2">
   <label class="text-sm font-medium leading-6 text-gray-900"><%= label %></label>
+
   <fieldset class="radio-small-cards">
     <legend class="sr-only"><%= label %></legend>
+
     <div class="grid gap-3 grid-cols-[repeat(auto-fill,minmax(285px,1fr))]">
       <% options.each_with_index do |(opt_val, opt_text, opt_classes, opt_attrs), idx| %>
         <label class="<%= opt_classes %>">
@@ -17,12 +19,14 @@ is_content_array = options[0][1].is_a?(Array) %>
             class="peer sr-only"
             <%== html_attrs(**attributes, **opt_attrs) %>
           >
+
           <% if is_content_array %>
             <span class="radio-small-card justify-between p-4">
               <span class="flex flex-col">
                 <span class="text-md font-semibold"><%= opt_text[0] %></span>
                 <span class="text-sm opacity-80"><span class="block sm:inline"><%= opt_text[1] %></span></span>
               </span>
+
               <span class="mt-2 flex text-sm sm:ml-4 sm:mt-0 sm:flex-col sm:text-right">
                 <span class="font-medium"><%= opt_text[2] %></span>
                 <span class="ml-1 opacity-50 sm:ml-0"><%= opt_text[3] %></span>
@@ -33,11 +37,14 @@ is_content_array = options[0][1].is_a?(Array) %>
           <% end %>
         </label>
       <% end %>
+
       <%== additional_element_html %>
     </div>
   </fieldset>
+
   <% if error %>
     <p class="text-sm text-red-600 leading-6" id="<%= name %>-error"><%= error %></p>
   <% end %>
+
   <%== description_html %>
 </div>

--- a/views/components/form/section.erb
+++ b/views/components/form/section.erb
@@ -2,5 +2,7 @@
 <% if separator %>
   <hr class="h-px mb-8 bg-gray-200 border-0 dark:bg-gray-700">
 <% end %>
+
 <h2 class="text-base font-semibold leading-7 text-gray-900"><%= label %></h2>
+
 <p class="mt-1 text-sm leading-6 text-gray-600"><%= content %></p>

--- a/views/components/form/text.erb
+++ b/views/components/form/text.erb
@@ -6,25 +6,34 @@ error = rodauth.field_error(name) || flash.dig("errors", name) %>
   <% if label %>
     <label for="<%= name %>" class="block text-sm font-medium leading-6"><%= label %></label>
   <% end %>
+
   <div class="flex">
     <% if prefix %>
       <div
-        class="flex shrink-0 items-center rounded-l-md bg-gray-50 px-3 text-base text-gray-500 outline outline-1 -outline-offset-1 outline-gray-300 sm:text-sm/6"
-      ><%= prefix %></div>
+        class="
+          flex shrink-0 items-center rounded-l-md bg-gray-50 px-3 text-base text-gray-500 outline outline-1
+          -outline-offset-1 outline-gray-300 sm:text-sm/6
+        "
+      >
+        <%= prefix %>
+      </div>
     <% end %>
+
     <input
       id="<%= id %>"
       type="<%= type %>"
       name="<%= name %>"
       <% if value %>
-      value="<%= value %>"
+        value="<%= value %>"
       <% end %>
-      class="block w-full border-0 py-1.5 pl-3 pr-3 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600"%> <%= prefix ? "rounded-r-md" : "rounded-md" %> <%= extra_class %>"
+      class="block w-full border-0 py-1.5 pl-3 pr-3 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600" %> <%= prefix ? "rounded-r-md" : "rounded-md" %> <%= extra_class %>"
       <%== html_attrs(attributes) %>
     >
+
     <% if button_title %>
       <%== part("components/form/submit_button", text: button_title) %>
     <% end %>
   </div>
+
   <%== part("components/form/error", name:, error:) if error %>
 </div>

--- a/views/components/form/textarea.erb
+++ b/views/components/form/textarea.erb
@@ -7,14 +7,17 @@ error = flash.dig("errors", name) %>
   <% if label %>
     <label for="<%= name %>" class="block text-sm font-medium leading-6 text-gray-900"><%= label %></label>
   <% end %>
+
   <textarea
     id="<%= name %>"
     name="<%= name %>"
     class="block w-full rounded-md border-0 py-1.5 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset text-sm sm:leading-6 <%= error ? "text-red-900 ring-red-300 placeholder:text-red-300 focus:ring-red-500" : "text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-orange-600" %>"
     <%== html_attrs(attributes) %>
   ><%= value %></textarea>
+
   <% if description %>
     <p class="text-sm text-gray-500 leading-6" id="<%= name %>-description"><%== description_html %></p>
   <% end %>
+
   <%== part("components/form/error", name:, error:) if error %>
 </div>

--- a/views/components/form/toggle_form.erb
+++ b/views/components/form/toggle_form.erb
@@ -2,13 +2,21 @@
 
 <% form(action:, method: :post, id: "#{name}_toggle") do %>
   <%== hidden_inputs(name => !active) %>
+
   <div class="group <%= active ? "active" : "" %>">
     <button
       type="submit"
-      class="toggle-parent-to-active relative inline-flex h-8 w-16 shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-200 group-[.active]:bg-orange-600 transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-orange-600 focus:ring-offset-2"
+      class="
+        toggle-parent-to-active relative inline-flex h-8 w-16 shrink-0 cursor-pointer rounded-full border-2
+        border-transparent bg-gray-200 group-[.active]:bg-orange-600 transition-colors duration-200 ease-in-out
+        focus:outline-none focus:ring-2 focus:ring-orange-600 focus:ring-offset-2
+      "
     >
       <span
-        class="pointer-events-none inline-block size-7 translate-x-0 group-[.active]:translate-x-8 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+        class="
+          pointer-events-none inline-block size-7 translate-x-0 group-[.active]:translate-x-8 transform rounded-full
+          bg-white shadow ring-0 transition duration-200 ease-in-out
+        "
       ></span>
     </button>
   </div>

--- a/views/components/free_quota.erb
+++ b/views/components/free_quota.erb
@@ -1,19 +1,18 @@
 <% warning_style = !@has_valid_payment_method %>
 <% bold_text_color = warning_style ? "text-orange-700" : "text-green-900" %>
+
 <div class="mb-2 rounded-md p-4 <%= warning_style ? "bg-orange-50" : "bg-green-50" %>">
   <div class="flex items-center <%= warning_style ? "text-orange-600" : "text-green-800" %>">
     <div class="flex-shrink-0">
       <%== part("components/icon", name: "hero-banknotes", classes: "h-9 w-9") %>
     </div>
+
     <div class="ml-3">
       <h3 class="text-sm font-medium">
-        <span>You have
-          <%= @remaining_free_quota.to_i %>
-          free
-          <%= @free_quota_unit %>
-          available (few-minute delay).</span>
+        <span>You have <%= @remaining_free_quota.to_i %> free <%= @free_quota_unit %> available (few-minute delay).</span>
         <span>Free quota refreshes next month.</span>
         <br>
+
         <% if @has_valid_payment_method %>
           <a href="<%= billing_path %>" class="font-bold <%= bold_text_color %>">Billing</a>
           <span>information is valid. Charges start after the free quota.</span>

--- a/views/components/icon_with_text.erb
+++ b/views/components/icon_with_text.erb
@@ -1,11 +1,12 @@
 <%# locals: (icon:, text:, subtext_html:) %>
 
 <div class="flex gap-3 items-center">
-    <div>
-        <%== part("components/icon", name: icon, classes: "text-orange-600 h-8 w-8") %>
-    </div>
-    <div>
-        <div class="font-bold text-gray-900"><%= text %></div>
-        <div class="text-gray-600"><%== subtext_html %></div>
-    </div>
+  <div>
+    <%== part("components/icon", name: icon, classes: "text-orange-600 h-8 w-8") %>
+  </div>
+
+  <div>
+    <div class="font-bold text-gray-900"><%= text %></div>
+    <div class="text-gray-600"><%== subtext_html %></div>
+  </div>
 </div>

--- a/views/components/kv_data_card.erb
+++ b/views/components/kv_data_card.erb
@@ -5,6 +5,7 @@
       <% data.reject { !it }.each do |name, value, opts| %>
         <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 sm:py-5">
           <dt class="text-sm font-medium text-gray-500"><%= name %></dt>
+
           <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
             <%== part("components/value_content", content: value, opts:) %>
           </dd>

--- a/views/components/page_header.erb
+++ b/views/components/page_header.erb
@@ -11,6 +11,7 @@
           Back
         </a>
       </nav>
+
       <nav class="hidden sm:flex" aria-label="Breadcrumb">
         <ol role="list" class="flex items-center space-x-4">
           <% breadcrumbs.each_with_index do |(name, url), index| %>
@@ -19,6 +20,7 @@
                 <% if index > 0 %>
                   <%== part("components/icon", name: "hero-chevron-right", classes: "w-5 h-5 flex-shrink-0 text-gray-400 mr-4") %>
                 <% end %>
+
                 <a href="<%= url %>" class="text-sm font-medium text-gray-500 hover:text-gray-700"><%= name %></a>
               </div>
             </li>
@@ -32,6 +34,7 @@
     <div class="min-w-0">
       <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:tracking-tight"><%= title %></h2>
     </div>
+
     <% if right_items %>
       <div class="mt-4 flex md:ml-4 md:mt-0">
         <%== allow_unescaped(right_items.join) %>

--- a/views/components/progress_bar.erb
+++ b/views/components/progress_bar.erb
@@ -4,9 +4,9 @@ color = (progress < 60) ? "bg-blue-500" : (progress < 80) ? "bg-yellow-500" : "b
 
 <div class="flex justify-between mb-1">
   <span class="text-base font-medium"><%= title %></span>
-  <span class="text-sm font-medium"><%= numerator %>/<%= denominator %>
-    (<%= progress %>%)</span>
+  <span class="text-sm font-medium"><%= numerator %>/<%= denominator %> (<%= progress %>%)</span>
 </div>
+
 <div class="w-full bg-gray-200 rounded-full h-3">
   <div class="<%= color %> h-3 rounded-full w-[<%= progress %>%]"></div>
 </div>

--- a/views/components/rename_object_input.erb
+++ b/views/components/rename_object_input.erb
@@ -2,13 +2,14 @@
 
 <div class="sm:flex sm:items-center sm:justify-between">
   <div>
-    <h3 class="text-base font-semibold leading-6 text-gray-900">Rename
-      <%= type %></h3>
+    <h3 class="text-base font-semibold leading-6 text-gray-900">Rename <%= type %></h3>
+
     <% if text %>
       <div class="mt-2 text-sm text-gray-500">
         <p><%= text %></p>
       </div>
     <% end %>
+
     <div class="mt-2 text-sm text-gray-500">
       <%== part(
           "components/form/text",
@@ -20,6 +21,7 @@
       ) %>
     </div>
   </div>
+
   <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
     <%== part("components/button", text: "Rename") %>
   </div>

--- a/views/components/revealable_content.erb
+++ b/views/components/revealable_content.erb
@@ -1,13 +1,14 @@
 <%# locals: (content:) %>
 <div class="revealable-content group flex-grow">
   <div class="shadow-content justify-between items-center gap-2 flex group-[.active]:hidden">
-    ●●●●●●
-    <img src="/icons/hero-eye.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1"/>
+    ●●●●●● <img src="/icons/hero-eye.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1" />
   </div>
+
   <div class="revealed-content hidden group-[.active]:block break-all">
     <div class="flex gap-2 items-center justify-between">
       <div class="revealed-content-text whitespace-pre-line"><%= content %></div>
-      <img src="/icons/hero-eye-slash.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1"/>
+
+      <img src="/icons/hero-eye-slash.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1" />
     </div>
   </div>
 </div>

--- a/views/components/revealable_content.erb
+++ b/views/components/revealable_content.erb
@@ -1,7 +1,7 @@
 <%# locals: (content:) %>
 <div class="revealable-content group flex-grow">
   <div class="shadow-content justify-between items-center gap-2 flex group-[.active]:hidden">
-    ●●●●●● <img src="/icons/hero-eye.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1" alt="" />
+    ●●●●●● <img src="/icons/hero-eye.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1" alt="">
   </div>
 
   <div class="revealed-content hidden group-[.active]:block break-all">
@@ -13,7 +13,7 @@
         width="18px"
         class="revealable-button inline-block cursor-pointer ms1"
         alt="Reveal"
-      />
+      >
     </div>
   </div>
 </div>

--- a/views/components/revealable_content.erb
+++ b/views/components/revealable_content.erb
@@ -1,14 +1,19 @@
 <%# locals: (content:) %>
 <div class="revealable-content group flex-grow">
   <div class="shadow-content justify-between items-center gap-2 flex group-[.active]:hidden">
-    ●●●●●● <img src="/icons/hero-eye.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1" />
+    ●●●●●● <img src="/icons/hero-eye.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1" alt="" />
   </div>
 
   <div class="revealed-content hidden group-[.active]:block break-all">
     <div class="flex gap-2 items-center justify-between">
       <div class="revealed-content-text whitespace-pre-line"><%= content %></div>
 
-      <img src="/icons/hero-eye-slash.svg" width="18px" class="revealable-button inline-block cursor-pointer ms1" />
+      <img
+        src="/icons/hero-eye-slash.svg"
+        width="18px"
+        class="revealable-button inline-block cursor-pointer ms1"
+        alt="Reveal"
+      />
     </div>
   </div>
 </div>

--- a/views/components/state_label.erb
+++ b/views/components/state_label.erb
@@ -1,8 +1,6 @@
 <%# locals: (state:, color:, extra_class: nil) %>
 
-<span
-  class="inline-flex items-baseline rounded-full px-2 text-xs font-semibold leading-5 <%= color %> <%= extra_class %>"
->
+<span class="inline-flex items-baseline rounded-full px-2 text-xs font-semibold leading-5 <%= color %> <%= extra_class %>">
   <%== part("components/icon", name: "dot", classes: "mr-1.5 h-2 w-2") %>
   <%= state %>
 </span>

--- a/views/components/structured_data_card.erb
+++ b/views/components/structured_data_card.erb
@@ -2,7 +2,6 @@
 <% input_class = "border border-gray-300 rounded py-1 px-2 text-sm focus:ring-blue-500 focus:border-blue-500 font-mono" %>
 
 <div id="sd-id-groups" class="space-y-2">
-
   <%# Existing SD-ID groups %>
   <% structured_data&.each do |sd_id, params| %>
     <div class="sd-id-group border border-gray-200 rounded-lg overflow-hidden" data-sd-id="<%= sd_id %>">
@@ -10,29 +9,68 @@
         <span class="font-mono text-sm font-semibold text-gray-800 sd-id-label"><%= sd_id %></span>
         <%== part("components/button", type: "danger", text: "Remove", extra_class: "delete-sd-id-btn") if @edit_perm %>
       </div>
+
       <div class="sd-kv-rows divide-y divide-gray-100 font-mono">
         <% params.each do |key, val| %>
           <div class="sd-kv-row flex items-center gap-2 py-2 px-4 hover:bg-gray-50">
             <input type="hidden" name="structured_data_ids[]" value="<%= sd_id %>">
-            <input type="text" name="structured_data_keys[]" value="<%= key %>" class="<%= input_class %>">
+
+            <input
+              type="text"
+              name="structured_data_keys[]"
+              value="<%= key %>"
+              class="<%= input_class %>"
+            >
+
             <span class="text-gray-400 text-sm">=</span>
-            <input type="text" name="structured_data_values[]" value="<%= val %>" class="<%= input_class %>">
+
+            <input
+              type="text"
+              name="structured_data_values[]"
+              value="<%= val %>"
+              class="<%= input_class %>"
+            >
+
             <%== part("components/button", type: "danger", text: "", icon: "hero-trash", extra_class: "delete-sd-kv-btn") if @edit_perm %>
           </div>
         <% end %>
       </div>
+
       <%# Hidden placeholder row for cloning new kv pairs %>
       <div class="sd-kv-placeholder-row hidden flex items-center gap-2 py-2 px-4 hover:bg-gray-50 font-mono">
-        <input type="hidden" name="structured_data_ids[]" value="<%= sd_id %>" disabled>
-        <input type="text" name="structured_data_keys[]" value="" class="<%= input_class %>" disabled>
+        <input
+          type="hidden"
+          name="structured_data_ids[]"
+          value="<%= sd_id %>"
+          disabled
+        >
+
+        <input
+          type="text"
+          name="structured_data_keys[]"
+          value=""
+          class="<%= input_class %>"
+          disabled
+        >
+
         <span class="text-gray-400 text-sm">=</span>
-        <input type="text" name="structured_data_values[]" value="" class="<%= input_class %>" disabled>
+
+        <input
+          type="text"
+          name="structured_data_values[]"
+          value=""
+          class="<%= input_class %>"
+          disabled
+        >
+
         <%== part("components/button", type: "danger", text: "", icon: "hero-trash", extra_class: "delete-sd-kv-btn") if @edit_perm %>
       </div>
+
       <% if @edit_perm %>
         <div class="new-sd-kv-row flex items-center gap-2 py-2 px-4 font-mono">
           <input type="text" class="new-sd-key <%= input_class %>" placeholder="Key">
           <span class="text-gray-400 text-sm">=</span>
+
           <input type="text" class="new-sd-value <%= input_class %>" placeholder="Value">
           <%== part("components/button", type: "safe", text: "", icon: "hero-plus", extra_class: "add-sd-kv-btn") %>
         </div>
@@ -46,18 +84,43 @@
       <span class="font-mono text-sm font-semibold text-gray-800 sd-id-label"></span>
       <%== part("components/button", type: "danger", text: "Remove", extra_class: "delete-sd-id-btn") if @edit_perm %>
     </div>
+
     <div class="sd-kv-rows divide-y divide-gray-100 font-mono"></div>
+
     <div class="sd-kv-placeholder-row hidden flex items-center gap-2 py-2 px-4 hover:bg-gray-50 font-mono">
-      <input type="hidden" name="structured_data_ids[]" value="" disabled>
-      <input type="text" name="structured_data_keys[]" value="" class="<%= input_class %>" disabled>
+      <input
+        type="hidden"
+        name="structured_data_ids[]"
+        value=""
+        disabled
+      >
+
+      <input
+        type="text"
+        name="structured_data_keys[]"
+        value=""
+        class="<%= input_class %>"
+        disabled
+      >
+
       <span class="text-gray-400 text-sm">=</span>
-      <input type="text" name="structured_data_values[]" value="" class="<%= input_class %>" disabled>
+
+      <input
+        type="text"
+        name="structured_data_values[]"
+        value=""
+        class="<%= input_class %>"
+        disabled
+      >
+
       <%== part("components/button", type: "danger", text: "", icon: "hero-trash", extra_class: "delete-sd-kv-btn") if @edit_perm %>
     </div>
+
     <% if @edit_perm %>
       <div class="new-sd-kv-row flex items-center gap-2 py-2 px-4 font-mono">
         <input type="text" class="new-sd-key <%= input_class %>" placeholder="Key">
         <span class="text-gray-400 text-sm">=</span>
+
         <input type="text" class="new-sd-value <%= input_class %>" placeholder="Value">
         <%== part("components/button", type: "safe", text: "", icon: "hero-plus", extra_class: "add-sd-kv-btn") %>
       </div>
@@ -68,11 +131,14 @@
     <div class="new-sd-id-row flex items-center gap-2 py-1">
       <input
         type="text"
-        class="new-sd-id-name w-64 border border-gray-300 rounded text-sm focus:ring-blue-500 focus:border-blue-500 font-mono"
+        class="
+          new-sd-id-name w-64 border border-gray-300 rounded text-sm focus:ring-blue-500 focus:border-blue-500
+          font-mono
+        "
         placeholder="provider@65535"
       >
+
       <%== part("components/button", type: "safe", text: "Add SD-ID", icon: "hero-plus", extra_class: "add-sd-id-btn") %>
     </div>
   <% end %>
-
 </div>

--- a/views/components/tabbar.erb
+++ b/views/components/tabbar.erb
@@ -3,12 +3,17 @@
   <nav class="isolate flex divide-x divide-gray-200 rounded-lg shadow" aria-label="Tabs">
     <% tabs.each_with_index do |(label, url, active), i| %>
       <% active = (request.path == url) if active.nil? %>
+
       <a
         href="<%= url %>"
         class="group flex items-center justify-center relative min-w-0 flex-1 overflow-hidden <%= (i == 0) ? "rounded-l-lg" : ((i == tabs.size - 1) ? "rounded-r-lg" : "") %> px-4 py-4 text-center text-sm bg-white font-medium focus:z-10 <%= active ? "text-orange-600 hover:text-orange-700 hover:bg-orange-50" : "text-gray-500 hover:text-orange-500 hover:bg-orange-50" %>"
       >
         <span><%= label %></span>
-        <span aria-hidden="true" class="absolute inset-x-0 bottom-0 h-0.5 <%= active ? "bg-orange-600" : "bg-transparent" %>"></span>
+
+        <span
+          aria-hidden="true"
+          class="absolute inset-x-0 bottom-0 h-0.5 <%= active ? "bg-orange-600" : "bg-transparent" %>"
+        ></span>
       </a>
     <% end %>
   </nav>

--- a/views/components/table_card.erb
+++ b/views/components/table_card.erb
@@ -8,6 +8,7 @@
           <%= title %>
         </h3>
       </div>
+
       <% if right_items %>
         <div class="mt-4 flex md:ml-4 md:mt-0">
           <%== allow_unescaped(right_items.join) %>
@@ -21,7 +22,7 @@
       <table
         class="min-w-full divide-y divide-gray-300<%= " w-full table-fixed" if allow_wrap %>"
         <% if id %>
-        id="<%= id %>"
+          id="<%= id %>"
         <% end %>
       >
         <% unless headers.empty? || rows.empty? %>
@@ -31,11 +32,11 @@
                 <th
                   scope="col"
                   <% if i == 0 && !consistent_styling %>
-                  class="pl-4 pr-3 sm:pl-6 py-3.5 text-left text-sm font-semibold text-gray-900"
+                    class="pl-4 pr-3 sm:pl-6 py-3.5 text-left text-sm font-semibold text-gray-900"
                   <% elsif i + 1 == headers.length && !consistent_styling %>
-                  class="pl-3 pr-4 sm:pr-6 py-3.5 text-left text-sm font-semibold text-gray-900"
+                    class="pl-3 pr-4 sm:pr-6 py-3.5 text-left text-sm font-semibold text-gray-900"
                   <% else %>
-                  class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                    class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
                   <% end %>
                 >
                   <%= name %>
@@ -44,6 +45,7 @@
             </tr>
           </thead>
         <% end %>
+
         <tbody class="divide-y divide-gray-200 bg-white">
           <% if rows.empty? %>
             <tr>
@@ -58,11 +60,12 @@
           <% else %>
             <% rows.each do |columns, row_opts| %>
               <% row_opts ||= {} %>
+
               <tr id="<%= row_opts[:id] %>">
                 <% columns.each_with_index do |(value, col_opts), i| %>
                   <% col_opts ||= {} %>
-                  <td
-                    <% if i == 0 && !consistent_styling
+
+                  <td <% if i == 0 && !consistent_styling
                       cls="pl-4 pr-3 sm:pl-6 py-4 text-gray-900 font-medium text-sm"
                     elsif i + 1 == columns.length && !consistent_styling
                       cls="pl-3 pr-4 sm:pr-6 py-4 text-gray-500 text-sm"
@@ -74,10 +77,7 @@
                       cls += " break-all"
                     else
                       cls += " whitespace-nowrap"
-                    end
-                  %>
-                    class="<%= cls %> <%= col_opts[:extra_class] %>"
-                  >
+                    end %> class="<%= cls %> <%= col_opts[:extra_class] %>">
                     <% if value.is_a?(Array) %>
                       <% (first_value, first_opts), (second_value, second_opts) = value %>
                       <div class="font-medium text-gray-900">
@@ -99,6 +99,7 @@
         </tbody>
       </table>
     </div>
+
     <%== allow_unescaped(footer) %>
   </div>
 </div>

--- a/views/components/value_content.erb
+++ b/views/components/value_content.erb
@@ -1,11 +1,10 @@
 <%# locals: (content:, opts: nil) %>
 <% opts ||= {} %>
+
 <% if opts[:copyable] && content %>
   <%== part("components/copyable_content", content:, revealable: opts[:revealable]) %>
 <% elsif opts[:link] %>
-  <a href="<%= opts[:link] %>" class="font-medium text-orange-600 hover:text-orange-700">
-    <%= content %>
-  </a>
+  <a href="<%= opts[:link] %>" class="font-medium text-orange-600 hover:text-orange-700"><%= content %></a>
 <% elsif opts[:component] %>
   <%== part("components/#{content}", **opts[:component]) %>
 <% elsif opts[:escape] == false %>

--- a/views/email/button.erb
+++ b/views/email/button.erb
@@ -1,13 +1,41 @@
-<%# locals: (title:, link:) %><table class="action" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+<%# locals: (title:, link:) %>
+<table
+  class="action"
+  align="center"
+  width="100%"
+  cellpadding="0"
+  cellspacing="0"
+  role="presentation"
+>
   <tr>
     <td align="center">
-      <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+      <table
+        width="100%"
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        role="presentation"
+      >
         <tr>
           <td align="center">
-            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+            <table
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+            >
               <tr>
                 <td>
-                  <a href="<%= link %>" class="button button-primary" target="_blank" rel="noopener" style="color: #FFFFFF"><%= title %></a>
+                  <a
+                    href="<%= link %>"
+                    class="button button-primary"
+                    target="_blank"
+                    rel="noopener"
+                    style="color: #FFFFFF"
+                  >
+                    <%= title %>
+                  </a>
                 </td>
               </tr>
             </table>

--- a/views/email/footer.erb
+++ b/views/email/footer.erb
@@ -1,23 +1,30 @@
 <% require "date" %>
+
 <tr>
   <td>
-    <table class="footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
+    <table
+      class="footer"
+      align="center"
+      width="570"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+    >
       <tr>
         <td align="left">
           <p>
-            ©
-            <%= Date.today.year %>
-            Ubicloud. All rights reserved.
+            © <%= Date.today.year %> Ubicloud. All rights reserved.
           </p>
         </td>
+
         <td align="right">
           <a href="https://github.com/ubicloud/ubicloud" class="icon">
             <%== part("components/icon", name: "github", classes: "") %>
           </a>
         </td>
       </tr>
-      <tr>
-      </tr>
+
+      <tr></tr>
     </table>
   </td>
 </tr>

--- a/views/email/layout.erb
+++ b/views/email/layout.erb
@@ -6,8 +6,8 @@
   <head>
     <title><%= subject %></title>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="color-scheme" content="light">
     <meta name="supported-color-schemes" content="light">
 

--- a/views/email/layout.erb
+++ b/views/email/layout.erb
@@ -1,30 +1,58 @@
-<%# locals: (subject:, greeting:, body:, button_title:, button_link:,author_name:) %><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+<%# locals: (subject:, greeting:, body:, button_title:, button_link:,author_name:) %>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title><%= subject %></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="color-scheme" content="light">
     <meta name="supported-color-schemes" content="light">
+
     <% style_html = File.read("views/email/style.html") %>
     <%== style_html %>
   </head>
-  <body>
 
-    <table class="wrapper" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+  <body>
+    <table
+      class="wrapper"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+    >
       <tr>
         <td align="center">
-          <table class="content" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+          <table
+            class="content"
+            width="100%"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+          >
             <%== render("email/header") %>
             <!-- Email Body -->
             <tr>
-              <td class="body" width="100%" cellpadding="0" cellspacing="0" style="border: hidden !important;">
-                <table class="inner-body" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
+              <td
+                class="body"
+                width="100%"
+                cellpadding="0"
+                cellspacing="0"
+                style="border: hidden !important;"
+              >
+                <table
+                  class="inner-body"
+                  align="center"
+                  width="570"
+                  cellpadding="0"
+                  cellspacing="0"
+                  role="presentation"
+                >
                   <!-- Body content -->
                   <tr>
                     <td class="content-cell">
-
                       <h1><%= greeting %></h1>
 
                       <% Array(body).each do |line| %>
@@ -34,18 +62,25 @@
                       <% if button_link %>
                         <%== part("email/button", title: button_title, link: button_link) %>
                       <% end %>
+
                       <p>
                         Regards,<br>
                         <%= author_name %>
                       </p>
 
                       <% if button_link %>
-                        <table class="subcopy" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+                        <table
+                          class="subcopy"
+                          width="100%"
+                          cellpadding="0"
+                          cellspacing="0"
+                          role="presentation"
+                        >
                           <tr>
                             <td>
                               <p>
-                                If you're having trouble clicking the button, copy and paste the URL below into your
-                                web browser:
+                                If you're having trouble clicking the button, copy and paste the URL below into your web
+                                browser:
                                 <span class="break-all"><a href="<%= button_link %>"><%= button_link %></a></span>
                               </p>
                             </td>
@@ -57,6 +92,7 @@
                 </table>
               </td>
             </tr>
+
             <%== render("email/footer") %>
           </table>
         </td>

--- a/views/error.erb
+++ b/views/error.erb
@@ -6,11 +6,18 @@
     <p class="text-base font-semibold text-orange-600"><%= @error[:code] %></p>
     <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl"><%= @error[:type] %></h1>
     <p class="mt-6 text-base leading-7 text-gray-600"><%= @error[:message] %></p>
+
     <div class="mt-10 flex items-center justify-center gap-x-6">
       <button
         type="button"
-        class="back-btn rounded-md bg-orange-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-orange-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600"
-      >Go back</button>
+        class="
+          back-btn rounded-md bg-orange-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm
+          hover:bg-orange-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2
+          focus-visible:outline-orange-600
+        "
+      >
+        Go back
+      </button>
     </div>
   </div>
 </main>

--- a/views/github/cache.erb
+++ b/views/github/cache.erb
@@ -11,26 +11,53 @@
         <% end %>
       </div>
     <% end %>
+
     <div class="overflow-x-auto">
-    <table id="cache-entries" class="min-w-full divide-y divide-gray-300">
-      <tbody class="divide-y divide-gray-200 bg-white">
-        <% if @entries_by_repo.count > 0 %>
-          <% @entries_by_repo.each do |repository_id, entries| %>
-            <tr class="cache-group-row cursor-pointer group" data-repository="<%= repository_id %>">
-              <th scope="colgroup" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 w-full group-[.active]:bg-gray-50" colspan="2">
-                <div class="flex">
-                  <%== part("components/icon", name: "hero-chevron-right", classes: "w-5 h-5 group-[.active]:rotate-90") %>
-                  <%= entries.first.repository.name %>
-                </div>
-              </th>
-              <th scope="colgroup" class="py-3.5 pl-3 pr-3 text-right text-sm font-semibold text-gray-900 whitespace-nowrap group-[.active]:bg-gray-50" colspan="2">
-                <%= entries.count %> cache entries
-              </th>
-              <th scope="colgroup" class="py-3.5 pl-3 pr-3 text-right text-sm font-semibold text-gray-900 whitespace-nowrap group-[.active]:bg-gray-50">
-                <%= humanize_size(entries.sum { it.size.to_i }) %> used of <%= @quota_per_repo %>
-              </th>
-              <th scope="colgroup" class="py-3.5 pl-3 pr-4 text-right text-sm font-normal text-gray-900 whitespace-nowrap group-[.active]:bg-gray-50">
-                <%== part(
+      <table id="cache-entries" class="min-w-full divide-y divide-gray-300">
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <% if @entries_by_repo.count > 0 %>
+            <% @entries_by_repo.each do |repository_id, entries| %>
+              <tr class="cache-group-row cursor-pointer group" data-repository="<%= repository_id %>">
+                <th
+                  scope="colgroup"
+                  class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 w-full group-[.active]:bg-gray-50"
+                  colspan="2"
+                >
+                  <div class="flex">
+                    <%== part("components/icon", name: "hero-chevron-right", classes: "w-5 h-5 group-[.active]:rotate-90") %>
+                    <%= entries.first.repository.name %>
+                  </div>
+                </th>
+
+                <th
+                  scope="colgroup"
+                  class="
+                    py-3.5 pl-3 pr-3 text-right text-sm font-semibold text-gray-900 whitespace-nowrap
+                    group-[.active]:bg-gray-50
+                  "
+                  colspan="2"
+                >
+                  <%= entries.count %> cache entries
+                </th>
+
+                <th
+                  scope="colgroup"
+                  class="
+                    py-3.5 pl-3 pr-3 text-right text-sm font-semibold text-gray-900 whitespace-nowrap
+                    group-[.active]:bg-gray-50
+                  "
+                >
+                  <%= humanize_size(entries.sum { it.size.to_i }) %> used of <%= @quota_per_repo %>
+                </th>
+
+                <th
+                  scope="colgroup"
+                  class="
+                    py-3.5 pl-3 pr-4 text-right text-sm font-normal text-gray-900 whitespace-nowrap
+                    group-[.active]:bg-gray-50
+                  "
+                >
+                  <%== part(
                   "components/delete_button",
                   url: "#{path(@installation)}/repository/#{repository_id}/cache",
                   text: "Delete All",
@@ -38,51 +65,79 @@
                   confirmation: "delete all",
                   confirmation_message: "Are you sure you want to delete all cache entries for this repository?"
                 ) %>
-              </th>
-            </tr>
-            <% entries.each do |entry| %>
-              <tr id="entry-<%= entry.ubid %>" class="hidden cache-group cache-group-<%= repository_id %>">
-                <td class="whitespace-nowrap py-3 pl-3 pr-4 text-sm text-right">
-                  <input type="checkbox" name="ubids[]" value="<%= entry.ubid %>" form="delete-selected-form" class="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600" id="delete-cache-entry-<%= entry.ubid %>">
-                  <label for="delete-cache-entry-<%= entry.ubid %>" class="cache-group-overlay"></label>
-                </td>
-                <td class="py-3 pl-4 pr-3 text-sm sm:pl-6 w-full" scope="row">
-                  <div class="font-medium text-gray-900 break-all"><%= entry.key %></div>
-                  <div class="mt-1 text-gray-500 text-xs ">created <span title="<%= entry.created_at.strftime("%Y-%m-%d %H:%M UTC") %>"><%= humanize_time(entry.created_at) %></span></div>
-                </td>
-                <td class="px-3 py-3 text-sm text-gray-500">
-                  <div><%= entry.scope %></div>
-                </td>
-                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
-                  <div class="inline-flex items-baseline rounded-md px-2 text-xs font-medium leading-5 bg-slate-100 text-slate-800" title="<%= entry.size %> bytes">
-                    <%= humanize_size(entry.size) %>
-                  </div>
-                </td>
-                <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500" colspan="2">
-                  <% if entry.last_accessed_at %>
-                    <div>Last used</div>
-                    <div title="<%= entry.last_accessed_at.strftime("%Y-%m-%d %H:%M UTC") %>"> <%= humanize_time(entry.last_accessed_at) %></div>
-                  <% else %>
-                    <div>Never used</div>
-                  <% end %>
-                </td>
+                </th>
               </tr>
+
+              <% entries.each do |entry| %>
+                <tr id="entry-<%= entry.ubid %>" class="hidden cache-group cache-group-<%= repository_id %>">
+                  <td class="whitespace-nowrap py-3 pl-3 pr-4 text-sm text-right">
+                    <input
+                      type="checkbox"
+                      name="ubids[]"
+                      value="<%= entry.ubid %>"
+                      form="delete-selected-form"
+                      class="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-600"
+                      id="delete-cache-entry-<%= entry.ubid %>"
+                    >
+
+                    <label for="delete-cache-entry-<%= entry.ubid %>" class="cache-group-overlay"></label>
+                  </td>
+
+                  <td class="py-3 pl-4 pr-3 text-sm sm:pl-6 w-full" scope="row">
+                    <div class="font-medium text-gray-900 break-all"><%= entry.key %></div>
+
+                    <div class="mt-1 text-gray-500 text-xs">
+                      created
+                      <span title="<%= entry.created_at.strftime("%Y-%m-%d %H:%M UTC") %>"><%= humanize_time(entry.created_at) %></span>
+                    </div>
+                  </td>
+
+                  <td class="px-3 py-3 text-sm text-gray-500">
+                    <div><%= entry.scope %></div>
+                  </td>
+
+                  <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500">
+                    <div
+                      class="
+                        inline-flex items-baseline rounded-md px-2 text-xs font-medium leading-5 bg-slate-100
+                        text-slate-800
+                      "
+                      title="<%= entry.size %> bytes"
+                    >
+                      <%= humanize_size(entry.size) %>
+                    </div>
+                  </td>
+
+                  <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500" colspan="2">
+                    <% if entry.last_accessed_at %>
+                      <div>Last used</div>
+                      <div title="<%= entry.last_accessed_at.strftime("%Y-%m-%d %H:%M UTC") %>">
+                        <%= humanize_time(entry.last_accessed_at) %>
+                      </div>
+                    <% else %>
+                      <div>Never used</div>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
             <% end %>
+          <% else %>
+            <tr>
+              <td colspan="6">
+                <div class="text-center py-4 px-8 lg:px-32">
+                  <h3 class="text-xl leading-10 font-medium mb-3">No cache entries</h3>
+
+                  <p class="leading-6">
+                    Check out
+                    <a href="https://www.ubicloud.com/docs/github-actions-integration/ubicloud-cache" class="text-orange-500 font-medium">our documentation</a>
+                    to use Ubicloud Cache for faster caching.
+                  </p>
+                </div>
+              </td>
+            </tr>
           <% end %>
-        <% else %>
-          <tr>
-            <td colspan="6">
-              <div class="text-center py-4 px-8 lg:px-32">
-                <h3 class="text-xl leading-10 font-medium mb-3">No cache entries</h3>
-                <p class="leading-6">
-                  Check out <a href="https://www.ubicloud.com/docs/github-actions-integration/ubicloud-cache" class="text-orange-500 font-medium">our documentation</a> to use Ubicloud Cache for faster caching.
-                </p>
-              </div>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
     </div>
   </div>
 </div>

--- a/views/github/runner.erb
+++ b/views/github/runner.erb
@@ -13,6 +13,7 @@
   ].each do |title, value, subtitle| %>
     <div class="overflow-hidden rounded-lg bg-white p-3 shadow sm:p-4">
       <dt class="text-base/6 font-medium text-gray-500"><%= title %></dt>
+
       <dl class="mt-1 flex items-baseline gap-x-2 font-mono">
         <span class="text-3xl font-semibold tracking-tight text-gray-900"><%= value %></span>
         <span class="text-sm text-gray-500"><%= subtitle %></span>
@@ -24,15 +25,16 @@
 <% if @installation.project.reputation == "limited" && !(@installation.project.quota_available?("GithubRunnerVCpu", 0) && @installation.project.quota_available?("GithubRunnerVCpuArm", 0)) %>
   <div class="mb-3 -mt-2 rounded-md bg-red-50 p-4 flex items-center gap-3">
     <%== part("components/icon", name: "hero-squares-plus", classes: "h-5 w-5 text-red-400") %>
+
     <h3 class="text-sm font-medium text-red-800">
-      You've reached your vCPU concurrency limit. If you need higher limits, please contact our support team at support@ubicloud.com
+      You've reached your vCPU concurrency limit. If you need higher limits, please contact our support team at
+      support@ubicloud.com
     </h3>
   </div>
 <% end %>
 
 <div class="grid gap-6">
-  <%
-    free_upgrade_badge = if @installation.free_runner_upgrade?
+  <% free_upgrade_badge = if @installation.free_runner_upgrade?
       <<~CONTENT
         <a href="#{path(@installation)}/setting">
           <span class="rounded-full bg-green-600/10 px-2.5 py-1 text-xs/5 font-medium text-green-600">
@@ -41,8 +43,8 @@
           </span>
         </a>
       CONTENT
-    end
-  %>
+    end %>
+
   <%== part(
     "components/table_card",
     headers: ["Repository", "Runner", "Workflow Job", "", ""],

--- a/views/github/setting.erb
+++ b/views/github/setting.erb
@@ -11,29 +11,32 @@
           <h3 class="text-3xl font-semibold tracking-tight text-gray-900 whitespace-nowrap">
             Premium Runners
           </h3>
+
           <% if @installation.premium_runner_enabled? %>
             <span class="rounded-full bg-orange-600/10 px-2.5 py-1 text-xs/5 font-semibold text-orange-600 ml-2">
               Enabled
             </span>
           <% end %>
         </div>
+
         <% if @installation.free_runner_upgrade? %>
           <span class="rounded-full bg-green-600/10 px-2.5 py-1 text-xs/5 font-medium text-green-600">
-            You’re eligible for an exclusive
-            <span class="font-semibold">50% off</span>
-            premium runners until
+            You’re eligible for an exclusive <span class="font-semibold">50% off</span> premium runners until
             <span class="font-semibold"><%= @installation.free_runner_upgrade_expires_at.strftime("%B %d, %Y") %></span>
           </span>
         <% end %>
+
         <p class="mt-4 text-base/7 text-gray-600">
           Speed up your builds with cutting edge gaming CPUs! We automatically route your jobs to premium machines. If
           capacity's full, you seamlessly fall back to standard runners with no extra wait time. You always get billed
           by the minute and for the runner type you're using.
         </p>
+
         <div class="mt-6 flex items-center gap-x-4">
           <h4 class="flex-none text-sm/6 font-semibold text-orange-600">What’s different</h4>
           <div class="h-px flex-auto bg-gray-100"></div>
         </div>
+
         <ul role="list" class="mt-4 grid grid-cols-1 gap-4 text-sm/6 text-gray-600 sm:grid-cols-2">
           <% [
           "Twice as fast",
@@ -48,15 +51,21 @@
           <% end %>
         </ul>
       </div>
+
       <div class="-mt-2 p-2 lg:mt-0 lg:w-full lg:max-w-sm lg:shrink-0">
         <div
-          class="rounded-lg h-full bg-gray-50 py-10 text-center ring-1 ring-inset ring-gray-900/5 lg:flex lg:flex-col lg:justify-center lg:py-16"
+          class="
+            rounded-lg h-full bg-gray-50 py-10 text-center ring-1 ring-inset ring-gray-900/5 lg:flex lg:flex-col
+            lg:justify-center lg:py-16
+          "
         >
           <div class="mx-auto max-w-sm px-8 space-y-8">
             <p class="flex items-baseline justify-center gap-x-2">
               <span class="text-4xl font-semibold tracking-tight text-gray-900">Boost your builds</span>
             </p>
+
             <%== part("components/form/toggle_form", name: "premium_runner_enabled", action: "#{@project.path}/github/#{@installation.ubid}/set-premium", active: @installation.premium_runner_enabled?) %>
+
             <div class="mt-6 text-sm/5 text-gray-600 italic">
               <p class="font-semibold">1/5th the cost of GitHub runners</p>
               <p>For example, 2 gaming vCPUs, 8GB of RAM, 80GB of NVMe storage comes at $0.0016/min.</p>
@@ -66,6 +75,7 @@
       </div>
     </div>
   <% end %>
+
   <div>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <!-- Transparent Cache Card -->
@@ -74,19 +84,24 @@
           <div>
             <div class="flex items-center">
               <h3 class="text-base font-semibold leading-6 text-gray-900">Ubicloud Transparent Cache</h3>
+
               <% if @installation.cache_enabled %>
                 <span class="rounded-full bg-orange-600/10 px-2.5 py-1 text-xs font-semibold text-orange-600 ml-2">
                   Enabled
                 </span>
               <% end %>
             </div>
+
             <div class="mt-2 text-sm text-gray-500">
-              <p>Transparent cache allows you to use Ubicloud’s cache service without modifying your workflow files.
+              <p>
+                Transparent cache allows you to use Ubicloud’s cache service without modifying your workflow files.
                 Check out
                 <a href="https://www.ubicloud.com/docs/github-actions-integration/ubicloud-cache" class="text-orange-500 font-medium">our documentation</a>
-                for information.</p>
+                for information.
+              </p>
             </div>
           </div>
+
           <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
             <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
               <%== part("components/form/toggle_form", name: "cache_enabled", action: "#{@project.path}/github/#{@installation.ubid}/set-cache", active: @installation.cache_enabled) %>
@@ -94,6 +109,7 @@
           </div>
         </div>
       </div>
+
       <!-- Cache Scope Protection Card -->
       <% if @installation.cache_enabled %>
         <div class="px-4 py-5 sm:p-6">
@@ -101,17 +117,22 @@
             <div>
               <div class="flex items-center">
                 <h3 class="text-base font-semibold leading-6 text-gray-900">Cache branch protection</h3>
+
                 <% if @installation.cache_scope_protected %>
                   <span class="rounded-full bg-orange-600/10 px-2.5 py-1 text-xs font-semibold text-orange-600 ml-2">
                     Enabled
                   </span>
                 <% end %>
               </div>
+
               <div class="mt-2 text-sm text-gray-500">
-                <p>Workflow runs can only access caches created on the current branch/tag or the default branch. This is
-                  the default behavior by GitHub. Disable to share caches across all branches.</p>
+                <p>
+                  Workflow runs can only access caches created on the current branch/tag or the default branch. This is
+                  the default behavior by GitHub. Disable to share caches across all branches.
+                </p>
               </div>
             </div>
+
             <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
               <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                 <%== part("components/form/toggle_form", name: "cache_scope_protected", action: "#{@project.path}/github/#{@installation.ubid}/set-cache-scope", active: @installation.cache_scope_protected) %>
@@ -120,16 +141,22 @@
           </div>
         </div>
       <% end %>
+
       <!-- Configure Repositories -->
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
             <h3 class="text-base font-semibold leading-6 text-gray-900">Repository Access</h3>
+
             <div class="mt-2 text-sm text-gray-500">
               <p>Configure the list of repositories that Ubicloud can access on GitHub's UI.</p>
             </div>
           </div>
-          <div id="configure-<%=@installation.ubid%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+
+          <div
+            id="configure-<%= @installation.ubid %>"
+            class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
+          >
             <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
               <%== part("components/button", text: "Configure", link: "https://github.com/apps/#{Config.github_app_name}/installations/#{@installation.installation_id}") %>
             </div>

--- a/views/github/tabbar.erb
+++ b/views/github/tabbar.erb
@@ -39,6 +39,7 @@
 ) %>
 
 <% installation_path = path(@installation) %>
+
 <%== part(
   "components/tabbar",
   tabs: [

--- a/views/inference/api_key/index.erb
+++ b/views/inference/api_key/index.erb
@@ -39,10 +39,10 @@
   ) %>
 
   <% if has_project_permission("InferenceApiKey:create") && @inference_api_keys.size < 10 %>
-  <div class="flex justify-end space-y-1 mt-6">
-    <% form(action: "#{@project.path}/inference-api-key", method: :post, id: "create-inference-api-key") do %>
-      <%== part("components/form/submit_button", text: "Create API Key") %>
-    <% end %>
-  </div>
+    <div class="flex justify-end space-y-1 mt-6">
+      <% form(action: "#{@project.path}/inference-api-key", method: :post, id: "create-inference-api-key") do %>
+        <%== part("components/form/submit_button", text: "Create API Key") %>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/views/inference/endpoint/playground.erb
+++ b/views/inference/endpoint/playground.erb
@@ -2,6 +2,7 @@
 <%== render("components/free_quota") %>
 <% @enable_marked = true %>
 <%== render("inference/tabbar") %>
+
 <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
   <div class="px-4 py-5 sm:p-6 grid gap-6">
     <div class="grid sm:grid-cols-2 gap-6 text-gray-900">
@@ -19,6 +20,7 @@
         },
         selected: @inference_models.first&.model_name,
       ) %>
+
       <%== part(
         "components/form/select",
         name: "inference_api_key",
@@ -28,11 +30,13 @@
         selected: @inference_api_keys.first&.key
       ) %>
     </div>
+
     <%== part(
       "components/form/checkbox",
       name: "inference_config",
       options: [["show_advanced", "Show advanced settings", nil, nil]]
     ) %>
+
     <div class="hidden grid gap-6" id="inference_config_advanced_settings">
       <div class="grid sm:grid-cols-2 gap-6 text-gray-900">
         <%== part(
@@ -47,6 +51,7 @@
           },
           extra_class: "[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
         ) %>
+
         <%== part(
           "components/form/text",
           name: "inference_top_p",
@@ -60,6 +65,7 @@
           extra_class: "[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
         ) %>
       </div>
+
       <div>
         <%== part(
           "components/form/textarea",
@@ -73,6 +79,7 @@
       </div>
     </div>
   </div>
+
   <div class="px-4 py-5 sm:p-6 grid gap-6">
     <div>
       <%== part(
@@ -84,12 +91,13 @@
         }
       ) %>
     </div>
+
     <div>
       <div class="block text-sm font-medium leading-6 text-gray-900 mb-2">Previous Messages</div>
       <div id="inference_previous_empty" class="text-sm text-gray-500">There are no messages yet.</div>
-      <div id="inference_previous">
-      </div>
+      <div id="inference_previous"></div>
     </div>
+
     <div>
       <%== part(
         "components/form/textarea",
@@ -101,6 +109,7 @@
           "rows" => 3,
         },
       ) %>
+
       <div class="grid grid-cols-2 gap-6 text-gray-900 flex pt-4">
         <div class="flex flex-row items-center">
           <input
@@ -112,6 +121,7 @@
             aria-label="Upload files"
           >
         </div>
+
         <div class="flex flex-row items-center justify-end">
           <%== part(
             "components/button",

--- a/views/kubernetes-cluster/create.erb
+++ b/views/kubernetes-cluster/create.erb
@@ -15,8 +15,7 @@
   ].compact
 ) %>
 
-<%
-  form_elements = [
+<% form_elements = [
     {name: "name", type: "text", label: "Cluster Name", required: "required", placeholder: "Enter cluster name"},
     {name: "location", type: "radio_small_cards", label: "Location", required: "required"},
     {name: "version", type: "radio_small_cards", label: "Version", required: "required"},
@@ -25,7 +24,6 @@
     {name: "worker_nodes", type: "select", label: "Worker Nodes", required: "required", placeholder: "Select number of worker nodes", opening_tag: "<div class='sm:col-span-3'>"},
   ]
 
-  action = "#{@project.path}/kubernetes-cluster"
-%>
+  action = "#{@project.path}/kubernetes-cluster" %>
 
-<%==part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents, content_generator_class: ContentGenerator::KubernetesCluster)%>
+<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents, content_generator_class: ContentGenerator::KubernetesCluster) %>

--- a/views/kubernetes-cluster/networking.erb
+++ b/views/kubernetes-cluster/networking.erb
@@ -75,17 +75,19 @@ pg_ps_fw_edit_ids = dataset_authorize(pg_ps_fw_ds, "Firewall:edit").select_set(:
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
           </tr>
         </thead>
+
         <tbody class="divide-y divide-gray-200 bg-white">
           <% show_connect_info = false %>
+
           <% pg_resources.each do |pg| %>
-            <%
-              pg_ps = pg.private_subnet
-              connected = kc_ps_connected_subnet_ids.include?(pg_ps.id)
-            %>
+            <% pg_ps = pg.private_subnet
+              connected = kc_ps_connected_subnet_ids.include?(pg_ps.id) %>
+
             <tr id="pg-row-<%= pg.ubid %>">
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
                 <%= pg.name %>
               </td>
+
               <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                 <% if connected %>
                   <% if pg_ps_view_ids.include?(pg_ps.id) %>
@@ -97,12 +99,13 @@ pg_ps_fw_edit_ids = dataset_authorize(pg_ps_fw_ds, "Firewall:edit").select_set(:
                   Not connected
                 <% end %>
               </td>
+
               <td class="whitespace-nowrap px-3 py-4 text-sm text-right">
                 <% if connected %>
                   <% pg_ps.firewalls.each do |fw| %>
                     <div class="flex gap-2 justify-end">
                       Firewall:
-                      <% if pg_ps_fw_view_ids.include?(fw.id)  %>
+                      <% if pg_ps_fw_view_ids.include?(fw.id) %>
                         <a href="<%= "#{path(fw)}/networking" %>" class="text-orange-600 hover:text-orange-700"><%= fw.name %></a>
                       <% else %>
                         <%= fw.name %>
@@ -120,19 +123,18 @@ pg_ps_fw_edit_ids = dataset_authorize(pg_ps_fw_ds, "Firewall:edit").select_set(:
           <% end %>
         </tbody>
       </table>
+
       <% if show_connect_info %>
         <div class="px-4 py-5 sm:p-6">
           <p class="text-sm text-gray-700">
-            Connecting this Kubernetes cluster to a PostgreSQL database will set
-            up a connection between the private subnets for the cluster and
-            database, and add firewall rules so the PostgreSQL database will
-            accept connections from the private IP addresses for the cluster.
-            For this to work correctly, you need to have the cluster
+            Connecting this Kubernetes cluster to a PostgreSQL database will set up a connection between the private
+            subnets for the cluster and database, and add firewall rules so the PostgreSQL database will accept
+            connections from the private IP addresses for the cluster. For this to work correctly, you need to have the
+            cluster
             <a class="text-orange-600 hover:text-orange-700" href="https://www.ubicloud.com/docs/managed-postgresql/connection#private-dns">connect to the PostgreSQL database using the private DNS name</a>.
           </p>
         </div>
       <% end %>
-
     </div>
   <% end %>
 </div>

--- a/views/kubernetes-cluster/nodepool/settings.erb
+++ b/views/kubernetes-cluster/nodepool/settings.erb
@@ -28,6 +28,7 @@
                   }
                 ) %>
               </div>
+
               <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
                 <%== part("components/button", text: "Resize") %>
               </div>
@@ -55,21 +56,19 @@
       <div class="px-4 py-5 sm:p-6">
         <% if @kn.display_state == "upgrading" %>
           <p class="text-sm text-gray-700">
-            Upgrade to version
-            <strong><%= @kn.version %></strong>
-            is currently in progress. This may take a few minutes.
+            Upgrade to version <strong><%= @kn.version %></strong> is currently in progress. This may take a few
+            minutes.
           </p>
         <% elsif @kn.ready_for_upgrade? %>
           <% form(action: "#{path(@kn)}/upgrade", method: :post) do %>
             <div class="gap-6 sm:flex sm:items-center sm:justify-between">
               <div class="flex-grow">
                 <p class="text-sm text-gray-700">
-                  This nodepool is currently on version
-                  <strong><%= @kn.version %></strong>
-                  and can be upgraded to version
-                  <strong><%= @kn.available_upgrade_version %></strong>.
+                  This nodepool is currently on version <strong><%= @kn.version %></strong> and can be upgraded to
+                  version <strong><%= @kn.available_upgrade_version %></strong>.
                 </p>
               </div>
+
               <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
                 <%== part("components/button", text: "Upgrade") %>
               </div>
@@ -81,13 +80,12 @@
           </p>
         <% elsif @kc.available_upgrade_version %>
           <p class="text-sm text-gray-700">
-            Your nodepool is on the cluster version
-            <strong><%= @kn.version %></strong>. A newer kubernetes version becomes available for the nodepool once the control plane is upgraded.
+            Your nodepool is on the cluster version <strong><%= @kn.version %></strong>. A newer kubernetes version
+            becomes available for the nodepool once the control plane is upgraded.
           </p>
         <% else %>
           <p class="text-sm text-gray-700">
-            Your nodepool is up to date on version
-            <strong><%= @kn.version %></strong>.
+            Your nodepool is up to date on version <strong><%= @kn.version %></strong>.
           </p>
         <% end %>
       </div>
@@ -103,18 +101,23 @@
           </h3>
         </div>
       </div>
+
       <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
         <!-- Delete Card -->
         <div class="px-4 py-5 sm:p-6">
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
               <h3 class="text-base font-semibold leading-6 text-gray-900">Delete Nodepool</h3>
+
               <div class="mt-2 text-sm text-gray-500">
-                <p>This action will permanently delete this nodepool and its nodes. Deleted data cannot be recovered.
-                  Use it carefully.</p>
+                <p>
+                  This action will permanently delete this nodepool and its nodes. Deleted data cannot be recovered. Use
+                  it carefully.
+                </p>
               </div>
             </div>
-            <div id="kn-delete-<%=@kn.ubid%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+
+            <div id="kn-delete-<%= @kn.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
               <%== part("components/delete_button", url: path(@kn), confirmation: @kn.name) %>
             </div>
           </div>

--- a/views/kubernetes-cluster/settings.erb
+++ b/views/kubernetes-cluster/settings.erb
@@ -16,27 +16,24 @@
       <div class="px-4 py-5 sm:p-6">
         <% if @kc.upgrading? %>
           <p class="text-sm text-gray-700">
-            Upgrade to version
-            <strong><%= @kc.version %></strong>
-            is currently in progress. This may take a few minutes.
+            Upgrade to version <strong><%= @kc.version %></strong> is currently in progress. This may take a few
+            minutes.
           </p>
         <% elsif @kc.available_upgrade_version && !@kc.nodepools_within_version_skew? %>
           <p class="text-sm text-gray-700">
-            An upgrade to version
-            <strong><%= @kc.available_upgrade_version %></strong>
-            is available, but all nodepools must be upgraded to within two minor versions of the cluster first.
+            An upgrade to version <strong><%= @kc.available_upgrade_version %></strong> is available, but all nodepools
+            must be upgraded to within two minor versions of the cluster first.
           </p>
         <% elsif @kc.ready_for_upgrade? %>
           <% form(action: "#{path(@kc)}/upgrade", method: :post) do %>
             <div class="gap-6 sm:flex sm:items-center sm:justify-between">
               <div class="flex-grow">
                 <p class="text-sm text-gray-700">
-                  Your cluster is currently on version
-                  <strong><%= @kc.version %></strong>
-                  and can be upgraded to version
-                  <strong><%= @kc.available_upgrade_version %></strong>.
+                  Your cluster is currently on version <strong><%= @kc.version %></strong> and can be upgraded to
+                  version <strong><%= @kc.available_upgrade_version %></strong>.
                 </p>
               </div>
+
               <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
                 <%== part("components/button", text: "Upgrade") %>
               </div>
@@ -48,8 +45,7 @@
           </p>
         <% else %>
           <p class="text-sm text-gray-700">
-            Your cluster is up to date on version
-            <strong><%= @kc.version %></strong>.
+            Your cluster is up to date on version <strong><%= @kc.version %></strong>.
           </p>
         <% end %>
       </div>
@@ -66,17 +62,22 @@
         </h3>
       </div>
     </div>
+
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <!-- Delete Card -->
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
             <h3 class="text-base font-semibold leading-6 text-gray-900">Delete Kubernetes Cluster</h3>
+
             <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this cluster. Deleted data cannot be recovered. Use it carefully.</p>
+              <p>
+                This action will permanently delete this cluster. Deleted data cannot be recovered. Use it carefully.
+              </p>
             </div>
           </div>
-          <div id="kc-delete-<%=@kc.ubid%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+
+          <div id="kc-delete-<%= @kc.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
             <%== part("components/delete_button", url: path(@kc), confirmation: @kc.name) %>
           </div>
         </div>

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -3,7 +3,7 @@
 <html class="h-full bg-gray-50">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -85,7 +85,7 @@
       <div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
         <div class="sm:mx-auto sm:w-full sm:max-w-md">
           <div class="flex shrink-0 items-center px-10 py-4">
-            <img class="" src="/logo-primary.png" alt="Ubicloud">
+            <img src="/logo-primary.png" alt="Ubicloud">
           </div>
 
           <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900"><%= @page_message %></h2>

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -1,22 +1,28 @@
 <!DOCTYPE html>
+
 <html class="h-full bg-gray-50">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
     <title><%= ["Ubicloud", @page_title].compact.join(" - ") %></title>
     <%== assets(:css) %>
+
     <script
       src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"
       integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
       crossorigin="anonymous"
     ></script>
+
     <script
       src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js"
       integrity="sha256-K99Onu4WoBQeNzYGhT5YstpmQ4pLwPxk6ECP4+/wjNc="
       crossorigin="anonymous"
     ></script>
+
     <% if @enable_datepicker %>
       <link
         rel="stylesheet"
@@ -30,9 +36,11 @@
         crossorigin="anonymous"
       ></script>
     <% end %>
+
     <% if @enable_cloudflare_turnstile %>
       <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
     <% end %>
+
     <% if @enable_marked %>
       <script
         src="https://cdn.jsdelivr.net/npm/marked@15.0.5/marked.min.js"
@@ -40,6 +48,7 @@
         crossorigin="anonymous"
       ></script>
     <% end %>
+
     <% if @enable_echarts %>
       <script
         src="https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js"
@@ -48,7 +57,6 @@
       >
       </script>
     <% end %>
-
   </head>
 
   <body class="h-full">
@@ -56,8 +64,10 @@
       <div>
         <%== render("layouts/sidebar/desktop") %>
         <%== render("layouts/sidebar/mobile") %>
+
         <div class="lg:pl-72 overflow-x-clip">
           <%== render("layouts/topbar") %>
+
           <main class="py-10">
             <div class="px-4 sm:px-6 lg:px-8">
               <div class="px-2 sm:px-3 lg:px-4">
@@ -77,6 +87,7 @@
           <div class="flex shrink-0 items-center px-10 py-4">
             <img class="" src="/logo-primary.png" alt="Ubicloud">
           </div>
+
           <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900"><%= @page_message %></h2>
         </div>
 
@@ -86,38 +97,30 @@
             <%== yield %>
           </div>
         </div>
+
         <div class="mt-10 flex justify-center space-x-5">
           <a href="https://github.com/ubicloud/ubicloud" target="_blank" class="text-gray-400 hover:text-gray-500">
             <span class="sr-only">GitHub</span>
             <%== part("components/icon", name: "github") %>
           </a>
+
           <a href="mailto:support@ubicloud.com" class="text-gray-400 hover:text-gray-500">
             <span class="sr-only">Support</span>
             <%== part("components/icon", name: "hero-envelope") %>
           </a>
         </div>
+
         <% if Config.managed_service %>
           <div class="text-sm text-gray-500 text-center mt-10 w-full">
             By using Ubicloud console you agree to our
-            <a
-              href="https://www.ubicloud.com/docs/about/terms-of-service"
-              class="font-medium text-orange-500 hover:text-orange-600"
-              target="_blank"
-            >
-              terms of service
-            </a>
+            <a href="https://www.ubicloud.com/docs/about/terms-of-service" class="font-medium text-orange-500 hover:text-orange-600" target="_blank"> terms of service </a>
             and
-            <a
-              href="https://www.ubicloud.com/docs/about/privacy-policy"
-              class="font-medium text-orange-500 hover:text-orange-600"
-              target="_blank"
-            >
-              privacy policy
-            </a>
+            <a href="https://www.ubicloud.com/docs/about/privacy-policy" class="font-medium text-orange-500 hover:text-orange-600" target="_blank"> privacy policy </a>
           </div>
         <% end %>
       </div>
     <% end %>
+
     <%== assets(:js) %>
   </body>
 </html>

--- a/views/layouts/notifications.erb
+++ b/views/layouts/notifications.erb
@@ -2,7 +2,11 @@
   <div class="flex w-full flex-col items-center space-y-4 sm:items-end">
     <div
       id="notification-template"
-      class="pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5 transform ease-out duration-300 transition translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2 hidden"
+      class="
+        pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black
+        ring-opacity-5 transform ease-out duration-300 transition translate-y-2 opacity-0 sm:translate-y-0
+        sm:translate-x-2 hidden
+      "
     >
       <div class="p-4">
         <div class="flex items-center">

--- a/views/layouts/sidebar/content.erb
+++ b/views/layouts/sidebar/content.erb
@@ -4,6 +4,7 @@
       <img class="h-6 w-auto" src="/logo-white.png" alt="Ubicloud">
     </a>
   </div>
+
   <nav class="flex flex-1 flex-col">
     <ul role="list" class="flex flex-1 flex-col gap-y-7">
       <li>
@@ -86,9 +87,11 @@
           <% end %>
         </ul>
       </li>
+
       <% if @project_permissions && has_project_permission(["Project:user", "Project:billing", "Project:view", "Project:viewaccess", "Project:token"]) %>
         <li>
           <div class="text-xs font-semibold leading-6 text-orange-200">Project Details</div>
+
           <ul role="list" class="-mx-2 mt-2 space-y-1">
             <% if has_project_permission("Project:user")
                    users_url = "#{@project.path}/user"
@@ -99,14 +102,15 @@
                  end
 
                if users_url %>
-                 <%== part(
+              <%== part(
                     "layouts/sidebar/item",
                     name: users_label,
                     url: users_url,
                     is_active: request.path.start_with?("#{@project.path}/user"),
                     icon: "hero-users",
                   ) %>
-               <% end %>
+            <% end %>
+
             <%== part(
               "layouts/sidebar/item",
               name: "Tokens",
@@ -115,6 +119,7 @@
               icon: "hero-key",
               has_permission: has_project_permission("Project:token")
             ) %>
+
             <% if Config.stripe_secret_key %>
               <%== part(
                 "layouts/sidebar/item",
@@ -126,6 +131,7 @@
                 has_permission: has_project_permission("Project:billing")
               ) %>
             <% end %>
+
             <%== part(
               "layouts/sidebar/item",
               name: "Settings",
@@ -134,6 +140,7 @@
               icon: "hero-cog-6-tooth",
               has_permission: has_project_permission("Project:view")
             ) %>
+
             <% if @project.get_ff_private_locations %>
               <%== part(
                 "layouts/sidebar/item",
@@ -147,9 +154,11 @@
           </ul>
         </li>
       <% end %>
+
       <% if @project_permissions && has_project_permission("Project:github") && Config.github_app_name %>
         <li>
           <div class="text-xs font-semibold leading-6 text-orange-200">Integrations</div>
+
           <ul role="list" class="-mx-2 mt-2 space-y-1">
             <%== part(
               "layouts/sidebar/item",
@@ -161,8 +170,8 @@
             ) %>
           </ul>
         </li>
-
       <% end %>
+
       <li class="-mx-6 mt-auto">
         <%== render("layouts/sidebar/project_switcher") %>
       </li>

--- a/views/layouts/sidebar/group.erb
+++ b/views/layouts/sidebar/group.erb
@@ -2,14 +2,19 @@
   <div class="group <%= items.compact.map { it[2] }.any? ? "active" : "" %>">
     <button
       type="button"
-      class="toggle-parent-to-active w-full text-orange-100 hover:text-white hover:bg-orange-700 flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold"
+      class="
+        toggle-parent-to-active w-full text-orange-100 hover:text-white hover:bg-orange-700 flex gap-x-3 rounded-md
+        p-2 text-sm leading-6 font-semibold
+      "
     >
       <%== part("components/icon", name: icon, classes: "text-white h-6 w-6 shrink-0") %>
       <%= name %>
+
       <div class="ml-auto shrink-0 group-[.active]:rotate-90">
         <%== part("components/icon", name: "hero-chevron-right") %>
       </div>
     </button>
+
     <ul class="mt-1 px-2 hidden group-[.active]:block space-y-1">
       <% items.compact.each do |item_name, item_url, item_is_active| %>
         <li>

--- a/views/layouts/sidebar/mobile.erb
+++ b/views/layouts/sidebar/mobile.erb
@@ -1,19 +1,35 @@
-<div id="mobile-menu" class="relative z-50 hidden group" role="dialog" aria-modal="true">
+<div
+  id="mobile-menu"
+  class="relative z-50 hidden group"
+  role="dialog"
+  aria-modal="true"
+>
   <div
-    class="fixed inset-0 bg-gray-900/80 transition-opacity ease-linear duration-300 opacity-0 group-[.mobile-menu-open]:opacity-100"
+    class="
+      fixed inset-0 bg-gray-900/80 transition-opacity ease-linear duration-300 opacity-0
+      group-[.mobile-menu-open]:opacity-100
+    "
   ></div>
+
   <div class="fixed inset-0 flex">
     <div
-      class="relative mr-16 flex w-full max-w-xs flex-1 transition ease-in-out duration-300 transform -translate-x-full group-[.mobile-menu-open]:translate-x-0"
+      class="
+        relative mr-16 flex w-full max-w-xs flex-1 transition ease-in-out duration-300 transform -translate-x-full
+        group-[.mobile-menu-open]:translate-x-0
+      "
     >
       <div
-        class="absolute left-full top-0 flex w-16 justify-center pt-5 ease-in-out duration-300 opacity-0 group-[.mobile-menu-open]:opacity-100"
+        class="
+          absolute left-full top-0 flex w-16 justify-center pt-5 ease-in-out duration-300 opacity-0
+          group-[.mobile-menu-open]:opacity-100
+        "
       >
         <button type="button" class="toggle-mobile-menu -m-2.5 p-2.5">
           <span class="sr-only">Close sidebar</span>
           <%== part("components/icon", name: "hero-x-mark", classes: "h-6 w-6 text-white") %>
         </button>
       </div>
+
       <%== render("layouts/sidebar/content") %>
     </div>
   </div>

--- a/views/layouts/sidebar/project_switcher.erb
+++ b/views/layouts/sidebar/project_switcher.erb
@@ -2,7 +2,10 @@
   <div>
     <button
       type="button"
-      class="inline-flex w-full items-center gap-x-4 px-6 py-3 text-md font-semibold leading-6 text-white bg-orange-700 hover:bg-orange-800"
+      class="
+        inline-flex w-full items-center gap-x-4 px-6 py-3 text-md font-semibold leading-6 text-white bg-orange-700
+        hover:bg-orange-800
+      "
       id="menu-button"
     >
       <%== part("components/icon", name: "hero-folder-open", classes: "h-8 w-8 rounded-full") %>
@@ -10,8 +13,14 @@
       <%== part("components/icon", name: "hero-chevron-up-down", classes: "h-8 w-8 ml-auto") %>
     </button>
   </div>
+
   <div
-    class="hidden opacity-0 scale-95 group-[.active]:block group-[.active]:opacity-100 group-[.active]:scale-100 transition ease-out duration-100 absolute bottom-12 left-12 z-10 mt-2 w-64 origin-bottom divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none text-gray-800"
+    class="
+      hidden opacity-0 scale-95 group-[.active]:block group-[.active]:opacity-100 group-[.active]:scale-100
+      transition ease-out duration-100 absolute bottom-12 left-12 z-10 mt-2 w-64 origin-bottom divide-y
+      divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none
+      text-gray-800
+    "
     role="menu"
     tabindex="-1"
   >
@@ -22,9 +31,12 @@
           class="block px-4 py-2 hover:bg-gray-100 hover:text-gray-900 <% if p.id == @project&.id %> bg-orange-50 text-orange-600 hover:bg-orange-50 hover:text-orange-700 <% end %>"
           role="menuitem"
           tabindex="-1"
-        ><%= p.name %></a>
+        >
+          <%= p.name %>
+        </a>
       <% end %>
     </div>
+
     <div class="py-1" role="none">
       <a
         href="/project/create"

--- a/views/layouts/topbar.erb
+++ b/views/layouts/topbar.erb
@@ -1,15 +1,21 @@
 <div
-  class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8"
+  class="
+    sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white px-4 shadow-sm
+    sm:gap-x-6 sm:px-6 lg:px-8
+  "
 >
   <button type="button" class="toggle-mobile-menu -m-2.5 p-2.5 text-gray-700 lg:hidden">
     <span class="sr-only">Open sidebar</span>
     <%== part("components/icon", name: "hero-bars-3") %>
   </button>
+
   <!-- Separator -->
   <div class="h-6 w-px bg-gray-900/10 lg:hidden"></div>
+
   <a href="<%= @project_permissions ? "#{@project.path}/dashboard" : "/project" %>">
     <img class="h-5 w-auto lg:hidden" src="/logo-primary.png" alt="Ubicloud">
   </a>
+
   <div class="flex flex-1 gap-x-4 self-stretch justify-end lg:gap-x-6">
     <div class="flex items-center gap-x-4 lg:gap-x-6">
       <div class="flex items-center gap-x-3">
@@ -21,6 +27,7 @@
         >
           <%== part("components/icon", name: "hero-information-circle", classes: "size-6") %>
         </a>
+
         <a
           href="https://www.ubicloud.com/docs/changelog?ref=console"
           target="_blank"
@@ -30,32 +37,64 @@
           <%== part("components/icon", name: "hero-megaphone", classes: "size-6") %>
         </a>
       </div>
+
       <!-- Profile dropdown -->
       <div class="relative group dropdown text-sm leading-6 text-gray-900">
         <button type="button" class="-m-1.5 flex items-center p-1.5" title="<%= current_account.email %>">
           <%== part("components/icon", name: "hero-user-circle", classes: "h-8 w-8 rounded-full bg-gray-50") %>
+
           <span class="hidden lg:flex lg:items-center">
             <span class="ml-3 font-semibold" aria-hidden="true"><%= current_account.name %></span>
             <%== part("components/icon", name: "hero-chevron-down", classes: "h-5 w-5 ml-2 text-gray-400") %>
           </span>
         </button>
+
         <div
-          class="hidden group-[.active]:block absolute right-0 z-10 mt-2.5 w-48 origin-top-right rounded-md bg-white pb-2 shadow-lg ring-1 ring-gray-900/5 focus:outline-none divide-y divide-gray-100"
+          class="
+            hidden group-[.active]:block absolute right-0 z-10 mt-2.5 w-48 origin-top-right rounded-md bg-white pb-2
+            shadow-lg ring-1 ring-gray-900/5 focus:outline-none divide-y divide-gray-100
+          "
           role="menu"
           tabindex="-1"
         >
           <div class="px-3 py-2">
             <p class="text-sm">Signed in as</p>
+
             <p class="truncate text-sm font-medium text-gray-900">
-              <%= current_account.email %></p>
+              <%= current_account.email %>
+            </p>
           </div>
+
           <div>
-            <a href="/account" class="block px-3 py-1 hover:bg-gray-100" role="menuitem" tabindex="-1">My Account</a>
-            <a href="/project" class="block px-3 py-1 hover:bg-gray-100" role="menuitem" tabindex="-1">Projects</a>
+            <a
+              href="/account"
+              class="block px-3 py-1 hover:bg-gray-100"
+              role="menuitem"
+              tabindex="-1"
+            >
+              My Account
+            </a>
+
+            <a
+              href="/project"
+              class="block px-3 py-1 hover:bg-gray-100"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Projects
+            </a>
           </div>
+
           <div>
             <% form(action: "/logout", method: :post) do %>
-              <button type="submit" class="block px-3 py-1 hover:bg-gray-100 w-full text-left" role="menuitem" tabindex="-1">Log out</button>
+              <button
+                type="submit"
+                class="block px-3 py-1 hover:bg-gray-100 w-full text-left"
+                role="menuitem"
+                tabindex="-1"
+              >
+                Log out
+              </button>
             <% end %>
           </div>
         </div>

--- a/views/machine_image/create.erb
+++ b/views/machine_image/create.erb
@@ -11,14 +11,12 @@ option_tree, option_parents = generate_machine_image_options %>
   ]
 ) %>
 
-<%
-  form_elements = [
+<% form_elements = [
     {name: "name", type: "text", label: "Name", placeholder: "Enter name", required: "required", opening_tag: "<div class='sm:col-span-3'>"},
     {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::Vm.method(:location)},
     {name: "vm", type: "select", label: "Source VM (stopped, #{Config.machine_image_max_size_gib}GB or less)", required: "required", placeholder: "Select a stopped VM", content_generator: ->(_location, vm) { vm[:display_name] }},
     {name: "version", type: "text", label: "Version Label", placeholder: "(optional, defaults to timestamp)", opening_tag: "<div class='sm:col-span-3'>"},
     {name: "destroy_source", type: "checkbox", default_unchecked: true, content_generator: ->(_value) { "Destroy source VM after capture" }}
-  ]
-%>
+  ] %>
 
 <%== part("components/form/resource_creation_form", action: "#{@project.path}/machine-image", form_elements:, option_tree:, option_parents:) %>

--- a/views/machine_image/create_version.erb
+++ b/views/machine_image/create_version.erb
@@ -12,12 +12,10 @@ option_tree, option_parents = generate_machine_image_version_options(@machine_im
   ]
 ) %>
 
-<%
-  form_elements = [
+<% form_elements = [
     {name: "version", type: "text", label: "Version Label", placeholder: "(optional, defaults to timestamp)", opening_tag: "<div class='sm:col-span-3'>"},
     {name: "vm", type: "select", label: "Source VM (stopped)", required: "required", placeholder: "Select a stopped VM", content_generator: ->(vm) { vm[:display_name] }},
     {name: "destroy_source", type: "checkbox", default_unchecked: true, content_generator: ->(_value) { "Destroy source VM after capture" }}
-  ]
-%>
+  ] %>
 
 <%== part("components/form/resource_creation_form", action: "#{path(@machine_image)}/version", form_elements:, option_tree:, option_parents:) %>

--- a/views/machine_image/settings.erb
+++ b/views/machine_image/settings.erb
@@ -15,9 +15,11 @@ delete_perm = has_permission?("MachineImage:delete", @machine_image)
         </h3>
       </div>
     </div>
+
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <% ready_versions = @versions.select { |v| v.metal&.display_state == "ready" } %>
+
         <% form(action: "#{path(@machine_image)}/set-latest-version", method: :post, id: "set-latest-version") do %>
           <div class="flex items-center gap-3">
             <%== part(
@@ -27,6 +29,7 @@ delete_perm = has_permission?("MachineImage:delete", @machine_image)
               selected: @machine_image.latest_version&.version,
               classes: "max-w-xs",
             ) %>
+
             <%== part("components/form/submit_button", text: "Save") %>
           </div>
         <% end %>
@@ -44,16 +47,22 @@ delete_perm = has_permission?("MachineImage:delete", @machine_image)
         </h3>
       </div>
     </div>
+
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
             <h3 class="text-base font-semibold leading-6 text-gray-900">Delete machine image</h3>
+
             <div class="mt-2 text-sm text-gray-500">
               <p>This action will permanently delete this machine image. All versions must be deleted first.</p>
             </div>
           </div>
-          <div id="mi-delete-<%= @machine_image.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+
+          <div
+            id="mi-delete-<%= @machine_image.ubid %>"
+            class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
+          >
             <%== part("components/delete_button", text: "Delete Machine Image", url: path(@machine_image), confirmation: @machine_image.name) %>
           </div>
         </div>

--- a/views/networking/firewall/create.erb
+++ b/views/networking/firewall/create.erb
@@ -1,7 +1,6 @@
 <% @page_title = "Create Firewall"
 @option_tree, @option_parents = generate_firewall_options
-@default_location = @project.default_location
-%>
+@default_location = @project.default_location %>
 
 <%== part(
   "components/page_header",
@@ -13,15 +12,13 @@
   ]
 ) %>
 
-<%
-  form_elements = [
+<% form_elements = [
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name", opening_tag: "<div class='sm:col-span-2'>"},
     {name: "description", type: "text", label: "Description", required: "required", placeholder: "Enter description", opening_tag: "<div class='sm:col-span-2'>"},
     {name: "location", type: "radio_small_cards", label: "Location", required: "required"},
     {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Select private subnet", opening_tag: "<div class='sm:col-span-2'>"},
   ]
 
-  action = "#{@project.path}/firewall"
-%>
+  action = "#{@project.path}/firewall" %>
 
-<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents, content_generator_class: ContentGenerator::Vm)%>
+<%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents, content_generator_class: ContentGenerator::Vm) %>

--- a/views/networking/firewall/firewall_rule.erb
+++ b/views/networking/firewall/firewall_rule.erb
@@ -33,6 +33,7 @@
       </h3>
     </div>
   </div>
+
   <div>
     <% form(action:, method: :post, class: "gap-6", id: "firewall-rule-form") do %>
       <div class="mb-2">
@@ -47,6 +48,7 @@
             options: FirewallRule.port_options
           ) %>
         </div>
+
         <div id="custom-ports">
           <%== part("components/form/text", name: "start_port", label: "Start Port", type: "number", attributes: {min: 0, max: 65535}, value: start_port) %>
           <%== part("components/form/text", name: "end_port", label: "End Port (optional)", type: "number", attributes: {min: 0, max: 65535}, value: end_port) %>
@@ -65,6 +67,7 @@
             options: FirewallRule.source_options
           ) %>
         </div>
+
         <div id="subnet-source">
           <%== part(
             "components/form/select",
@@ -79,6 +82,7 @@
               .each { it[0] = UBID.to_ubid(it[0]) }
           ) %>
         </div>
+
         <div id="custom-source">
           <%== part("components/form/text", name: "cidr", label: "Source IP Address Range (CIDR)", attributes: {placeholder: "1.2.3.4 or 1.2.3.0/24"}, value: cidr) %>
         </div>
@@ -98,18 +102,32 @@
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
             <div class="mt-2 text-sm text-gray-500">
-              <p class="mb-2">Firewall rules allow connections to specific IP ports from specific IP address ranges (CIDRs). The
-                default behavior for a new connection without an applicable firewall rule is to disallow access.</p>
-              <p class="mb-2">To allow access, create a firewall rule for the source IP address range that will be connecting and the
-                desination port range that will be connected to.</p>
+              <p class="mb-2">
+                Firewall rules allow connections to specific IP ports from specific IP address ranges (CIDRs). The
+                default behavior for a new connection without an applicable firewall rule is to disallow access.
+              </p>
+
+              <p class="mb-2">
+                To allow access, create a firewall rule for the source IP address range that will be connecting and the
+                desination port range that will be connected to.
+              </p>
+
               <ul class="ml-6 mb-2 list-disc">
-                <li>To allow access from a single IP address, you can omit the netmask (e.g. use "1.2.3.4" instead of
-                  "1.2.3.4/32").</li>
-                <li>You can optionally add a description for the rule, to help you remember why the access has been
-                  allowed.</li>
+                <li>
+                  To allow access from a single IP address, you can omit the netmask (e.g. use "1.2.3.4" instead of
+                  "1.2.3.4/32").
+                </li>
+
+                <li>
+                  You can optionally add a description for the rule, to help you remember why the access has been
+                  allowed.
+                </li>
               </ul>
-              <p class="mb-2">Rules added to this firewall affect access to all resources in all private subnets that the firewall is
-                attached to.</p>
+
+              <p class="mb-2">
+                Rules added to this firewall affect access to all resources in all private subnets that the firewall is
+                attached to.
+              </p>
             </div>
           </div>
         </div>

--- a/views/networking/firewall/networking.erb
+++ b/views/networking/firewall/networking.erb
@@ -29,53 +29,68 @@ edit_perm = has_permission?("Firewall:edit", @firewall) %>
     <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
       Firewall Rules
     </h3>
+
     <% if edit_perm %>
       <div class="mt-4 flex md:ml-4 md:mt-0">
         <%== part("components/button", text: "Add Firewall Rule", link: "#{firewall_path}/firewall-rule") %>
       </div>
     <% end %>
   </div>
+
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <div class="overflow-auto">
-    <table class="min-w-full divide-y divide-gray-300" id="firewall-rules">
-      <thead class="bg-gray-50">
-        <tr>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Source</th>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Destination Ports</th>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Rule Description</th>
-          <% if edit_perm %>
-            <th scope="col" class="p-1 text-center text-sm font-semibold text-gray-900">Edit</th>
-            <th scope="col" class="p-1 pr-2 text-center text-sm font-semibold text-gray-900">Remove</th>
-          <% end %>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-gray-200 bg-white">
-        <% fwrs.each do |fwr| %>
-          <% ubid = fwr.ubid %>
+      <table class="min-w-full divide-y divide-gray-300" id="firewall-rules">
+        <thead class="bg-gray-50">
           <tr>
-            <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 break-all" scope="row"><%= fwr.web_display_cidr(ps_map) %></td>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row"><%= fwr.web_display_port_range %></td>
-            <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 break-all" scope="row"><%= fwr.description %></td>
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Source</th>
+
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+              Destination Ports
+            </th>
+
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+              Rule Description
+            </th>
+
             <% if edit_perm %>
-              <td
-                id="fwr-edit-<%= ubid %>"
-                class="relative whitespace-nowrap p-1 text-center text-sm font-medium"
-              >
-                <%== part("components/button", text: "", icon: "hero-pencil", link: "#{firewall_path}/firewall-rule/#{ubid}", attributes: {id: "edit-#{ubid}"}) %>
-              </td>
-              <td
-                id="fwr-delete-<%= ubid %>"
-                class="relative whitespace-nowrap p-1 text-center text-sm font-medium"
-              >
-                <%== part("components/delete_button", url: "#{firewall_path}/firewall-rule/#{ubid}", text: "") %>
-              </td>
+              <th scope="col" class="p-1 text-center text-sm font-semibold text-gray-900">Edit</th>
+              <th scope="col" class="p-1 pr-2 text-center text-sm font-semibold text-gray-900">Remove</th>
             <% end %>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <% fwrs.each do |fwr| %>
+            <% ubid = fwr.ubid %>
+
+            <tr>
+              <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 break-all" scope="row">
+                <%= fwr.web_display_cidr(ps_map) %>
+              </td>
+
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                <%= fwr.web_display_port_range %>
+              </td>
+
+              <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 break-all" scope="row">
+                <%= fwr.description %>
+              </td>
+
+              <% if edit_perm %>
+                <td id="fwr-edit-<%= ubid %>" class="relative whitespace-nowrap p-1 text-center text-sm font-medium">
+                  <%== part("components/button", text: "", icon: "hero-pencil", link: "#{firewall_path}/firewall-rule/#{ubid}", attributes: {id: "edit-#{ubid}"}) %>
+                </td>
+                <td id="fwr-delete-<%= ubid %>" class="relative whitespace-nowrap p-1 text-center text-sm font-medium">
+                  <%== part("components/delete_button", url: "#{firewall_path}/firewall-rule/#{ubid}", text: "") %>
+                </td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
     </div>
   </div>
+
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
       <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
@@ -83,41 +98,49 @@ edit_perm = has_permission?("Firewall:edit", @firewall) %>
       </h3>
     </div>
   </div>
-  <div id="fw-private-subnets" class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
+
+  <div
+    id="fw-private-subnets"
+    class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200"
+  >
     <div class="overflow-x-auto">
-    <table class="min-w-full divide-y divide-gray-300">
-      <thead class="bg-gray-50">
-        <tr>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
-          <% if edit_perm %>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
-          <% end %>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-gray-200 bg-white">
-        <% @firewall.private_subnets.each do |ps| %>
+      <table class="min-w-full divide-y divide-gray-300">
+        <thead class="bg-gray-50">
           <tr>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-              <% if viewable_subnets.include?(ps.id) %>
-                <a href="<%= path(ps) %>" class="text-orange-600 hover:text-orange-700"><%= ps.name %></a>
-              <% else %>
-                <%= ps.name %>
-              <% end %>
-            </td>
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
+
             <% if edit_perm %>
-              <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                <% form(action: "#{firewall_path}/detach-subnet", method: :post) do %>
-                  <input type="hidden" name="private_subnet_id" value="<%= ps.ubid %>">
-                  <%== part("components/form/submit_button", text: "Detach") %>
-                <% end %>
-              </td>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
             <% end %>
           </tr>
-        <% end %>
-        <% if edit_perm %>
-          <tr>
-            <td class="whitespace-nowrap py-4 pl-2 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
-              <%== part(
+        </thead>
+
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <% @firewall.private_subnets.each do |ps| %>
+            <tr>
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                <% if viewable_subnets.include?(ps.id) %>
+                  <a href="<%= path(ps) %>" class="text-orange-600 hover:text-orange-700"><%= ps.name %></a>
+                <% else %>
+                  <%= ps.name %>
+                <% end %>
+              </td>
+
+              <% if edit_perm %>
+                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                  <% form(action: "#{firewall_path}/detach-subnet", method: :post) do %>
+                    <input type="hidden" name="private_subnet_id" value="<%= ps.ubid %>">
+                    <%== part("components/form/submit_button", text: "Detach") %>
+                  <% end %>
+                </td>
+              <% end %>
+            </tr>
+          <% end %>
+
+          <% if edit_perm %>
+            <tr>
+              <td class="whitespace-nowrap py-4 pl-2 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
+                <%== part(
                 "components/form/select",
                 name: "private_subnet_id",
                 placeholder: "Select a subnet",
@@ -127,16 +150,17 @@ edit_perm = has_permission?("Firewall:edit", @firewall) %>
                   form: "form-fw-attach-#{@firewall.ubid}"
                 }
               ) %>
-            </td>
-            <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-              <% form(action: "#{firewall_path}/attach-subnet", method: :post, id: "form-fw-attach-#{@firewall.ubid}") do %>
-                <%== part("components/form/submit_button", text: "Attach") %>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+              </td>
+
+              <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                <% form(action: "#{firewall_path}/attach-subnet", method: :post, id: "form-fw-attach-#{@firewall.ubid}") do %>
+                  <%== part("components/form/submit_button", text: "Attach") %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
     </div>
   </div>
 </div>

--- a/views/networking/firewall/settings.erb
+++ b/views/networking/firewall/settings.erb
@@ -18,6 +18,7 @@
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
               <h3 class="text-base font-semibold leading-6 text-gray-900">Update firewall description</h3>
+
               <div class="mt-2 text-sm text-gray-500">
                 <%== part(
                     "components/form/text",
@@ -29,6 +30,7 @@
                 ) %>
               </div>
             </div>
+
             <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
               <%== part("components/button", text: "Update Description") %>
             </div>
@@ -54,11 +56,15 @@
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
             <h3 class="text-base font-semibold leading-6 text-gray-900">Delete firewall</h3>
+
             <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this firewall. Deleted firewall cannot be recovered. Use it
-                carefully.</p>
+              <p>
+                This action will permanently delete this firewall. Deleted firewall cannot be recovered. Use it
+                carefully.
+              </p>
             </div>
           </div>
+
           <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
             <%== part("components/delete_button", url: path(@firewall), confirmation: @firewall.name) %>
           </div>

--- a/views/networking/load_balancer/create.erb
+++ b/views/networking/load_balancer/create.erb
@@ -11,8 +11,7 @@
   ]
 ) %>
 
-<%
-  content_generator = ContentGenerator::LoadBalancer.method(:select_option)
+<% content_generator = ContentGenerator::LoadBalancer.method(:select_option)
   form_elements = [
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name", opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
     {name: "private_subnet_id", type: "select", label: "Private Subnet", placeholder: "Select private subnet", content_generator:, opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
@@ -28,7 +27,6 @@
     {name: "cert_enabled", type: "checkbox", content_generator: ContentGenerator::LoadBalancer.method(:enable_ssl_certificate)}
   ]
 
-  action = "#{@project.path}/load-balancer"
-%>
+  action = "#{@project.path}/load-balancer" %>
 
 <%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>

--- a/views/networking/load_balancer/index.erb
+++ b/views/networking/load_balancer/index.erb
@@ -25,7 +25,7 @@
     } : {})
   ) %>
 
-  <% if @lbs.count > 0 && has_project_permission("LoadBalancer:create")%>
+  <% if @lbs.count > 0 && has_project_permission("LoadBalancer:create") %>
     <div class="flex justify-end">
       <%== part("components/button", text: "Create Load Balancer", link: "load-balancer/create") %>
     </div>

--- a/views/networking/load_balancer/overview.erb
+++ b/views/networking/load_balancer/overview.erb
@@ -17,21 +17,32 @@
 unless @lb.health_check_protocol == "tcp"
   data << ["#{@lb.health_check_protocol.upcase} Health Check Endpoint", @lb.health_check_endpoint]
 end
-data << ["SSL Certificate Status", @lb.active_cert&.cert ? "Available" : "Creating"] if @lb.cert_enabled
-%>
+data << ["SSL Certificate Status", @lb.active_cert&.cert ? "Available" : "Creating"] if @lb.cert_enabled %>
 
 <%== part("components/kv_data_card", data:) %>
+
 <% if @lb.cert_enabled %>
-  <div class="p-1 overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200 mt-4 px-4 py-5 sm:flex sm:items-center">
+  <div
+    class="
+      p-1 overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200 mt-4
+      px-4 py-5 sm:flex sm:items-center
+    "
+  >
     <div>
       <h3 class="text-base font-semibold leading-6 text-gray-900">How to fetch the SSL certificate?</h3>
+
       <div class="mt-2 text-sm text-gray-500">
         <p>Run the following commands on your attached virtual machines:</p>
-          <div class="px-4 py-3">
-            <p><code>sudo curl [FD00:0B1C:100D:5AFE:CE::]/load-balancer/cert.pem</code></p>
-            <p><code>sudo curl [FD00:0B1C:100D:5AFE:CE::]/load-balancer/key.pem</code></p>
-          </div>
-        <p>Learn more about Ubicloud SSL certificates in the <a href="https://www.ubicloud.com/docs/networking/load-balancer#ssl-certificates" class="text-orange-600 hover:text-orange-700" target="_blank">documentation</a>.</p>
+
+        <div class="px-4 py-3">
+          <p><code>sudo curl [FD00:0B1C:100D:5AFE:CE::]/load-balancer/cert.pem</code></p>
+          <p><code>sudo curl [FD00:0B1C:100D:5AFE:CE::]/load-balancer/key.pem</code></p>
+        </div>
+
+        <p>
+          Learn more about Ubicloud SSL certificates in the
+          <a href="https://www.ubicloud.com/docs/networking/load-balancer#ssl-certificates" class="text-orange-600 hover:text-orange-700" target="_blank">documentation</a>.
+        </p>
       </div>
     </div>
   </div>

--- a/views/networking/load_balancer/settings.erb
+++ b/views/networking/load_balancer/settings.erb
@@ -10,6 +10,7 @@ delete_perm = has_permission?("LoadBalancer:delete", @lb) %>
         </h3>
       </div>
     </div>
+
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <% if edit_perm %>
         <div class="px-4 py-5 sm:p-6">
@@ -21,33 +22,41 @@ delete_perm = has_permission?("LoadBalancer:delete", @lb) %>
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
               <h3 class="text-base font-semibold leading-6 text-gray-900">SSL Certificate</h3>
+
               <div class="mt-2 text-sm text-gray-500">
-                <p>Ubicloud automatically provides a free SSL certificate for your load balancer. To enable it, toggle
-                  the switch.</p>
-                <p>Learn more about Ubicloud SSL certificates in the
-                  <a
-                    href="https://www.ubicloud.com/docs/networking/load-balancer#ssl-certificates"
-                    class="text-orange-600 hover:text-orange-700"
-                    target="_blank"
-                  >documentation</a>.</p>
+                <p>
+                  Ubicloud automatically provides a free SSL certificate for your load balancer. To enable it, toggle
+                  the switch.
+                </p>
+
+                <p>
+                  Learn more about Ubicloud SSL certificates in the
+                  <a href="https://www.ubicloud.com/docs/networking/load-balancer#ssl-certificates" class="text-orange-600 hover:text-orange-700" target="_blank">documentation</a>.
+                </p>
               </div>
             </div>
+
             <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
               <%== part("components/form/toggle_form", name: "cert_enabled", action: "#{path(@lb)}/toggle-ssl-certificate", active: @lb.cert_enabled) %>
             </div>
           </div>
         </div>
       <% end %>
+
       <% if delete_perm %>
         <div class="px-4 py-5 sm:p-6">
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
               <h3 class="text-base font-semibold leading-6 text-gray-900">Delete load balancer</h3>
+
               <div class="mt-2 text-sm text-gray-500">
-                <p>This action will permanently delete this load balancer. Deleted load balancer cannot be recovered.
-                  Use it carefully.</p>
+                <p>
+                  This action will permanently delete this load balancer. Deleted load balancer cannot be recovered. Use
+                  it carefully.
+                </p>
               </div>
             </div>
+
             <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
               <%== part("components/delete_button", url: path(@lb), confirmation: @lb.name) %>
             </div>

--- a/views/networking/load_balancer/vms.erb
+++ b/views/networking/load_balancer/vms.erb
@@ -16,14 +16,20 @@ edit_perm = has_permission?("LoadBalancer:edit", @lb) %>
       </h3>
     </div>
   </div>
+
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <table class="min-w-full divide-y divide-gray-300">
       <thead class="bg-gray-50">
         <tr>
           <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">VM</th>
+
           <% if @lb.stack == "dual" %>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Application State (IPv4)</th>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Application State (IPv6)</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+              Application State (IPv4)
+            </th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+              Application State (IPv6)
+            </th>
           <% else %>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Application State</th>
           <% end %>
@@ -33,20 +39,24 @@ edit_perm = has_permission?("LoadBalancer:edit", @lb) %>
           <% end %>
         </tr>
       </thead>
+
       <tbody class="divide-y divide-gray-200 bg-white" id="lb-vms">
         <% @lb.vms(eager: :load_balancer_vm_ports).each do |vm| %>
           <tr>
             <td class="whitespace nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
               <a href="<%= path(vm) %>" class="text-orange-600 hover:text-orange-700"><%= vm.name %></a>
             </td>
+
             <td class="px-3 py-3.5 whitespace-nowrap text-sm text-gray-900">
               <%= vm.load_balancer_state.first %>
             </td>
+
             <% if @lb.stack == "dual" %>
               <td class="px-3 py-3.5 whitespace-nowrap text-sm text-gray-900">
                 <%= vm.load_balancer_state.last %>
               </td>
             <% end %>
+
             <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
               <% form(action: "#{load_balancer_path}/detach-vm", method: :post) do %>
                 <input type="hidden" name="vm_id" value="<%= vm.ubid %>">
@@ -55,6 +65,7 @@ edit_perm = has_permission?("LoadBalancer:edit", @lb) %>
             </td>
           </tr>
         <% end %>
+
         <% if edit_perm %>
           <tr>
             <td class="whitespace-nowrap py-4 pl-2 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
@@ -69,8 +80,13 @@ edit_perm = has_permission?("LoadBalancer:edit", @lb) %>
                 }
               ) %>
             </td>
+
             <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"></td>
-            <% if @lb.stack == "dual" %><td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"></td><% end %>
+
+            <% if @lb.stack == "dual" %>
+              <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"></td>
+            <% end %>
+
             <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
               <% form(action: "#{load_balancer_path}/attach-vm", method: :post, id: "form-lb-#{@lb.ubid}") do %>
                 <%== part("components/form/submit_button", text: "Attach") %>

--- a/views/networking/private_subnet/create.erb
+++ b/views/networking/private_subnet/create.erb
@@ -11,13 +11,11 @@
   ]
 ) %>
 
-<%
-  form_elements = [
+<% form_elements = [
     {name: "name", type: "text", label: "Name", required: "required", placeholder: "Enter name", opening_tag: "<div class='sm:col-span-3'>"},
     {name: "location", type: "radio_small_cards", label: "Location", required: "required", content_generator: ContentGenerator::Vm.method(:location)},
   ]
 
-  action = "#{@project.path}/private-subnet"
-%>
+  action = "#{@project.path}/private-subnet" %>
 
 <%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>

--- a/views/networking/private_subnet/index.erb
+++ b/views/networking/private_subnet/index.erb
@@ -25,9 +25,10 @@
       button_title: "Create Private Subnet"
     } : {})
   ) %>
+
   <% if @pss.count > 0 && has_project_permission("PrivateSubnet:create") %>
-  <div class="flex justify-end">
-    <%== part("components/button", text: "Create Private Subnet", link: "private-subnet/create") %>
-  </div>
+    <div class="flex justify-end">
+      <%== part("components/button", text: "Create Private Subnet", link: "private-subnet/create") %>
+    </div>
   <% end %>
 </div>

--- a/views/networking/private_subnet/networking.erb
+++ b/views/networking/private_subnet/networking.erb
@@ -49,6 +49,7 @@ viewable_fws, viewable_subnets, disconnectable_subnets =
         ]
       end
   ) %>
+
   <!-- Connected Private Subnets List -->
   <div class="mt-6 md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
@@ -57,6 +58,7 @@ viewable_fws, viewable_subnets, disconnectable_subnets =
       </h3>
     </div>
   </div>
+
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <table class="min-w-full divide-y divide-gray-300">
       <thead class="bg-gray-50">
@@ -65,12 +67,12 @@ viewable_fws, viewable_subnets, disconnectable_subnets =
           <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
         </tr>
       </thead>
+
       <tbody class="divide-y divide-gray-200 bg-white">
         <% connected_subnets.each do |subnet| %>
-          <%
-            viewable = viewable_subnets.include?(subnet.id)
-            show_delete = disconnectable_subnets.include?(subnet.id)
-          %>
+          <% viewable = viewable_subnets.include?(subnet.id)
+            show_delete = disconnectable_subnets.include?(subnet.id) %>
+
           <tr>
             <td class="whitespace nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
               <% if viewable %>
@@ -79,6 +81,7 @@ viewable_fws, viewable_subnets, disconnectable_subnets =
                 <%= subnet.name %>
               <% end %>
             </td>
+
             <td
               id="cps-delete-<%= subnet.ubid %>"
               class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
@@ -91,10 +94,11 @@ viewable_fws, viewable_subnets, disconnectable_subnets =
                   confirmation_message: "Are you sure to disconnect?",
                   text: "Disconnect"
                 ) %>
-              </td>
-            <% end %>
+              <% end %>
+            </td>
           </tr>
         <% end %>
+
         <% if !connectable_subnets.empty? && has_permission?("PrivateSubnet:connect", @ps.id) %>
           <tr>
             <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
@@ -109,6 +113,7 @@ viewable_fws, viewable_subnets, disconnectable_subnets =
                 }
               ) %>
             </td>
+
             <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
               <% form(action: "#{ps_path}/connect", method: :post, id: "form-connect-subnet") do %>
                 <%== part("components/form/submit_button", text: "Connect") %>

--- a/views/networking/private_subnet/settings.erb
+++ b/views/networking/private_subnet/settings.erb
@@ -13,16 +13,21 @@
         </h3>
       </div>
     </div>
+
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
             <h3 class="text-base font-semibold leading-6 text-gray-900">Delete private subnet</h3>
+
             <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this private subnet. Deleted subnet cannot be recovered. Use it
-                carefully.</p>
+              <p>
+                This action will permanently delete this private subnet. Deleted subnet cannot be recovered. Use it
+                carefully.
+              </p>
             </div>
           </div>
+
           <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
             <%== part("components/delete_button", url: path(@ps), confirmation: @ps.name) %>
           </div>

--- a/views/object/show.erb
+++ b/views/object/show.erb
@@ -24,6 +24,7 @@
                url_class = "border-transparent text-gray-900 hover:bg-gray-50 hover:text-gray-900 group flex items-center border-l-4 px-3 py-2 text-sm font-medium"
                icon_class = "text-gray-400 group-hover:text-gray-500"
             end %>
+
             <a href="<%= "#{path(object)}/#{page}" %>" class="<%= url_class %>">
               <%== part("components/icon", name: icon, classes: icon_class + " -ml-1 mr-3 h-6 w-6 flex-shrink-0") %>
               <span class="truncate"><%= label %></span>
@@ -32,20 +33,22 @@
         </nav>
       </aside>
     </div>
+
     <div class="flex-auto min-w-0 border-t lg:border-t-0 pt-6 lg:pt-0 lg:pl-8">
       <div class="divide-y">
         <div class="pb-6 flex items-center justify-between">
           <div class="min-w-0">
             <span class="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:tracking-tight break-all"><%= object.name %></span>
-            <span class="break-all">(id:
-              <%= object.ubid %>)</span>
+            <span class="break-all">(id: <%= object.ubid %>)</span>
           </div>
+
           <% if right_header %>
             <div>
               <%== allow_unescaped(right_header) %>
             </div>
           <% end %>
         </div>
+
         <%== render("#{prefix}/#{@page.tr("-", "_")}") %>
       </div>
     </div>

--- a/views/postgres/backup_restore.erb
+++ b/views/postgres/backup_restore.erb
@@ -107,7 +107,7 @@ backups = @pg.timeline.backups %>
                 width="18px"
                 class="copy-button invert opacity-70 hover:opacity-100 absolute top-2 right-2 cursor-pointer"
                 alt="Copy command"
-              />
+              >
             </div>
           <% end %>
         </div>

--- a/views/postgres/backup_restore.erb
+++ b/views/postgres/backup_restore.erb
@@ -7,18 +7,24 @@ backups = @pg.timeline.backups %>
     <% form(action: "#{path(@pg)}/restore", method: :post) do %>
       <div class="space-y-4">
         <div>
-          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Fork PostgreSQL database</h3>
+          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+            Fork PostgreSQL database
+          </h3>
+
           <p class="mt-1 text-sm text-gray-500">
             When you fork your existing PostgreSQL database, a new server will be provisioned.
           </p>
         </div>
+
         <div class="grid grid-cols-12 gap-6">
           <div class="col-span-12 sm:col-span-5">
             <%== part("components/form/text", label: "New server name", name: "name", attributes: { placeholder: @pg.name + "-fork", required: true }) %>
           </div>
+
           <div class="col-span-12 sm:col-span-5">
             <%== part("components/form/datepicker", label: "Target Time (UTC)", name: "restore_target", default_date: max_date, max_date:, min_date:) %>
           </div>
+
           <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
             <%== part("components/form/submit_button", text: "Fork") %>
           </div>
@@ -43,7 +49,9 @@ backups = @pg.timeline.backups %>
   <div class="p-6">
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
-        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Backup Download Access</h3>
+        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+          Backup Download Access
+        </h3>
       </div>
     </div>
 
@@ -72,6 +80,7 @@ backups = @pg.timeline.backups %>
           <% fields.each do |label, value, revealable| %>
             <div class="flex items-baseline gap-3">
               <dt class="w-40 shrink-0 text-sm font-semibold text-gray-700"><%= label %></dt>
+
               <dd class="min-w-0 break-all font-mono text-sm text-gray-900">
                 <%== part("components/copyable_content", content: value, revealable:) %>
               </dd>
@@ -84,6 +93,7 @@ backups = @pg.timeline.backups %>
             <span class="text-sm font-semibold text-gray-700">Example command</span>
             <%== part("components/form/select", name: "backup-credentials-format", options: [["aws", "aws s3 sync"], ["mc", "mc mirror"], ["walg", "wal-g env"]]) %>
           </div>
+
           <% examples.each do |tool, cmd| %>
             <div
               class="backup-example-box backup-example-box-<%= tool %> copyable-content relative"
@@ -91,6 +101,7 @@ backups = @pg.timeline.backups %>
               data-message="Copied command"
             >
               <pre class="whitespace-pre-wrap break-all rounded-md bg-gray-800 text-gray-100 text-xs p-3 pr-10"><%= cmd %></pre>
+
               <img
                 src="/icons/hero-clipboard-document.svg"
                 width="18px"
@@ -103,11 +114,10 @@ backups = @pg.timeline.backups %>
     <% else %>
       <% form(action: "#{path(@pg)}/backup-credentials", method: :post) do %>
         <div class="mt-1 mb-4 text-sm text-gray-500">
-          Create temporary, read-only credentials to download your backups directly with
-          <code>aws</code>,
-          <code>mc</code>, or
-          <code>wal-g</code>.
+          Create temporary, read-only credentials to download your backups directly with <code>aws</code>,
+          <code>mc</code>, or <code>wal-g</code>.
         </div>
+
         <%== part("components/form/submit_button", text: "Create download credentials") %>
       <% end %>
     <% end %>
@@ -126,17 +136,23 @@ backups = @pg.timeline.backups %>
       <table class="min-w-full divide-y divide-gray-300">
         <thead class="bg-gray-50">
           <tr>
-            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Backup Time</th>
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+              Backup Time
+            </th>
+
             <th scope="col" class="py-3.5 text-left text-sm font-semibold text-gray-900">Type</th>
             <th scope="col" class="py-3.5 text-left text-sm font-semibold text-gray-900">Fork</th>
           </tr>
         </thead>
+
         <tbody class="divide-y divide-gray-200 bg-white">
           <% backups.each do %>
             <% target_time = Time.at((it.last_modified.to_i / 60.0).ceil * 60) %>
+
             <tr>
               <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6"><%= target_time %></td>
               <td class="py-4 text-sm font-medium text-gray-900">Full Backup</td>
+
               <td class="py-4 text-sm font-medium text-gray-900">
                 <div class="cursor-pointer fork-icon" data-target-datetime="<%= target_time %>">
                   <%== part("components/icon", name: "fork", classes: "text-black-600 h-6 w-6") %>

--- a/views/postgres/backup_restore.erb
+++ b/views/postgres/backup_restore.erb
@@ -106,6 +106,7 @@ backups = @pg.timeline.backups %>
                 src="/icons/hero-clipboard-document.svg"
                 width="18px"
                 class="copy-button invert opacity-70 hover:opacity-100 absolute top-2 right-2 cursor-pointer"
+                alt="Copy command"
               />
             </div>
           <% end %>

--- a/views/postgres/charts.erb
+++ b/views/postgres/charts.erb
@@ -1,12 +1,21 @@
 <% @enable_echarts = true %>
 
-<div id="metrics-container" class="p-6" data-metrics-url="<%= path(@pg) %>" data-zoomable>
+<div
+  id="metrics-container"
+  class="p-6"
+  data-metrics-url="<%= path(@pg) %>"
+  data-zoomable
+>
   <% if @pg.display_state != "creating" %>
     <div class="mb-4 flex gap-2 justify-end">
       <%== part("components/button", attributes: {id: "reset-zoom-button"}, text: "Reset zoom", type: "primary", extra_class: "hidden") %>
+
       <select
         id="time-range"
-        class="py-1.5 md:align-top rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
+        class="
+          py-1.5 md:align-top rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring
+          focus:ring-indigo-200 focus:ring-opacity-50
+        "
         name="time-range"
       >
         <option value="30m">Last 30 minutes</option>
@@ -19,6 +28,7 @@
         <option value="7d">Last 7 days</option>
         <option value="30d">Last 30 days</option>
       </select>
+
       <%== part("components/button", attributes: {id: "refresh-button"}, text: "  Refresh", type: "primary", icon: "hero-refresh") %>
     </div>
     <div class="grid grid-cols-1 xl:grid-cols-2 gap-4 border-t-0">
@@ -26,19 +36,25 @@
         <div class="metric-chart-card p-4 bg-gray-50 rounded-lg border border-gray-100">
           <div class="flex items-start justify-between">
             <h4 class="text-sm font-medium text-gray-900 mb-2"><%= metric.name %></h4>
-            <button type="button" class="maximize-chart-button text-gray-400 hover:text-gray-600" title="Maximize chart">
+
+            <button
+              type="button"
+              class="maximize-chart-button text-gray-400 hover:text-gray-600"
+              title="Maximize chart"
+            >
               <span class="maximize-icon"><%== part("components/icon", name: "hero-arrows-pointing-out", classes: "h-4 w-4") %></span>
               <span class="minimize-icon hidden"><%== part("components/icon", name: "hero-x-mark", classes: "h-4 w-4") %></span>
             </button>
           </div>
+
           <p class="text-xs text-gray-500 mt-2"><%= metric.description %></p>
+
           <div
             class="metric-chart h-64 w-full"
             id="<%= key %>-chart"
             data-metric-key="<%= key %>"
             data-metric-unit="<%= metric.unit %>"
-          >
-          </div>
+          ></div>
         </div>
       <% end %>
     </div>
@@ -58,6 +74,7 @@
       </h3>
     </div>
   </div>
+
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <table class="min-w-full divide-y divide-gray-300">
       <thead class="bg-gray-50">
@@ -69,29 +86,42 @@
           <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
         </tr>
       </thead>
+
       <tbody class="divide-y divide-gray-200 bg-white">
         <% @pg.metric_destinations.each do |md| %>
           <tr>
             <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6"><%= md.url %></td>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6"><%= md.auth_methods.join(", ") %></td>
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6"><%= md.username %></td>
+
+            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+              <%= md.auth_methods.join(", ") %>
+            </td>
+
+            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+              <%= md.username %>
+            </td>
+
             <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">-</td>
+
             <td
-              id="md-delete-<%=md.ubid %>"
+              id="md-delete-<%= md.ubid %>"
               class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
             >
               <%== part("components/delete_button", url: "#{path(@pg)}/metric-destination/#{md.ubid}", text: "") %>
             </td>
           </tr>
         <% end %>
+
         <tr>
           <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
             <%== part("components/form/text", name: "url", attributes: { form: "form-pg-md-create", required: true }) %>
           </td>
+
           <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">basic_auth</td>
+
           <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
             <%== part("components/form/text", name: "username", attributes: { form: "form-pg-md-create", required: true }) %>
           </td>
+
           <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
             <%== part(
                 "components/form/text",
@@ -105,6 +135,7 @@
                 extra_class: "metric-destination-password"
               ) %>
           </td>
+
           <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
             <% form(action: "#{path(@pg)}/metric-destination", method: :post, id: "form-pg-md-create") do %>
               <%== part("components/form/submit_button", text: "Create", extra_class: "metric-destination-create-button") %>

--- a/views/postgres/config.erb
+++ b/views/postgres/config.erb
@@ -1,5 +1,4 @@
-<%
-  pg_config = @pg.user_config || {}
+<% pg_config = @pg.user_config || {}
   pgbouncer_config = @pg.pgbouncer_user_config || {}
 
   errors = flash.now["errors"] || {}
@@ -13,12 +12,12 @@
 
     pg_config = pg_keys.zip(pg_values).to_h
     pgbouncer_config = pgbouncer_keys.zip(pgbouncer_values).to_h
-  end
-%>
+  end %>
 
 <% form(action: "#{path(@pg)}/config", method: :post, class: "min-w-2/3 pg-config") do %>
   <%== part("components/config_card", title: "PostgreSQL Configuration", config: pg_config, extra_class: "pg-config-card", name: "pg_config", errors:, config_validator: Validation::PostgresConfigValidator.new(@pg.version)) %>
   <%== part("components/config_card", title: "PgBouncer Configuration", config: pgbouncer_config, extra_class: "pgbouncer-config-card", name: "pgbouncer_config", errors:) %>
+
   <div class="flex justify-end">
     <%== part("components/form/submit_button", text: "Save", extra_class: "save-config-btn") if @edit_perm %>
   </div>

--- a/views/postgres/connection.erb
+++ b/views/postgres/connection.erb
@@ -1,5 +1,4 @@
-<%
-  hostname = @pg.hostname
+<% hostname = @pg.hostname
   password = URI.encode_uri_component(@pg.superuser_password)
   hostnames = [[hostname, ""]]
   allow_private = @pg.private_subnet.connected_subnets.any?
@@ -26,8 +25,7 @@
       ssl_opt = (port == 5432) ? "&channelBinding=require" : ""
       connection_infos["jdbc-#{port}#{suffix}"] = "jdbc:postgresql://#{hostname}:#{port}/postgres?user=postgres&password=#{password}&ssl=true#{ssl_opt}"
     end
-  end
-%>
+  end %>
 
 <div class="p-6">
   <% if @pg.display_state != "creating" %>
@@ -47,24 +45,28 @@
           ) %>
         </div>
       </div>
-      <div><%== part("components/form/checkbox", name: :use_pgbouncer, options: [["1", "Use pgBouncer?", "", {}]]) %></div>
+
+      <div>
+        <%== part("components/form/checkbox", name: :use_pgbouncer, options: [["1", "Use pgBouncer?", "", {}]]) %>
+      </div>
+
       <% if allow_private %>
-        <div><%== part("components/form/checkbox", name: :use_private_dns, options: [["1", "Use Private DNS?", "", {}]]) %></div>
+        <div>
+          <%== part("components/form/checkbox", name: :use_private_dns, options: [["1", "Use Private DNS?", "", {}]]) %>
+        </div>
       <% end %>
     </div>
 
-    <%
-      connection_infos.each_with_index do |(key, value), index|
-      hidden_class = index == 0 ? "" : "hidden"
-    %>
+    <% connection_infos.each_with_index do |(key, value), index|
+      hidden_class = index == 0 ? "" : "hidden" %>
       <div class="bg-gray-200 rounded-md p-6 mt-5 connection-info-box connection-info-box-<%= key %> <%= hidden_class %>">
-      <%== part("components/copyable_content", content: value, revealable: true, classes: "!flex justify-between") %>
+        <%== part("components/copyable_content", content: value, revealable: true, classes: "!flex justify-between") %>
       </div>
     <% end %>
 
     <% if @pg.ca_certificates %>
       <div class="mt-5 flex items-center gap-2">
-        CA Certificates: <%== part("components/download_button", link: "#{path(@pg)}/ca-certificates")%>
+        CA Certificates: <%== part("components/download_button", link: "#{path(@pg)}/ca-certificates") %>
       </div>
     <% end %>
   <% else %>
@@ -74,5 +76,3 @@
     </div>
   <% end %>
 </div>
-
-

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -1,5 +1,4 @@
-<%
-  default_flavor = PostgresResource.default_flavor
+<% default_flavor = PostgresResource.default_flavor
   @flavor = typecast_params.nonempty_str("flavor", default_flavor)
   @flavor = default_flavor unless PostgresResource.postgres_flavors(@project).any? { |k,| k == @flavor }
   @prices = fetch_location_based_prices("PostgresVCpu", "PostgresStorage")
@@ -10,8 +9,7 @@
   @option_tree, @option_parents = PostgresResource.generate_postgres_options(@project, flavor: @flavor)
 
   @page_title, logo = PostgresResource.postgres_flavors(@project)[@flavor].yield_self { ["Create #{it.title}", "logo-#{it.brand}.png"] }
-  logo = nil if @flavor == default_flavor
-%>
+  logo = nil if @flavor == default_flavor %>
 
 <%== render("components/billing_warning") %>
 
@@ -26,8 +24,7 @@
   right_items: [logo ? "<img src=\"/#{logo}\" class=\"h-6 object-contain\"/>" : nil]
 ) %>
 
-<%
-  byoc_description_html, additional_element_html = if @project.get_ff_private_locations
+<% byoc_description_html, additional_element_html = if @project.get_ff_private_locations
     [
       "<p class='mt-1 text-sm leading-6 text-gray-600'><a href='https://www.ubicloud.com/postgresql-on-aws-high-iops' class='text-orange-600 hover:text-orange-700'>Learn more</a> about running Ubicloud Postgres on AWS, including in your own account with Bring-Your-Own-Cloud.</p>",
       "<label class=\"form_flavor form_flavor_standard cursor-pointer\"><a href=\"#{@project.path}/private-location/create\" class=\"radio-small-card justify-center p-3 text-sm font-semibold\">+ Create a new region (BYOC)</a></label>"
@@ -63,7 +60,6 @@
 
   # Without this the form checks the first version offered, which is the newest
   # rather than the one new databases default to.
-  pre_selected_values = {"version" => PostgresResource.default_version(@flavor)}
-%>
+  pre_selected_values = {"version" => PostgresResource.default_version(@flavor)} %>
 
 <%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents, pre_selected_values:, content_generator_class: ContentGenerator::Postgres) %>

--- a/views/postgres/index.erb
+++ b/views/postgres/index.erb
@@ -57,9 +57,10 @@
         <div class="rounded-lg shadow group relative bg-white p-6">
           <div>
             <span class="inline-flex rounded-lg overflow-hidden w-12 h-12">
-              <img src="/icons/pg-<%= it.brand.downcase %>.png" class="object-cover"/>
+              <img src="/icons/pg-<%= it.brand.downcase %>.png" class="object-cover" />
             </span>
           </div>
+
           <div class="mt-4">
             <h3 class="text-base font-semibold leading-6 text-gray-900">
               <a href="<%= @project.path %>/postgres/create?flavor=<%= it.name %>" class="focus:outline-none">
@@ -67,13 +68,15 @@
                 Create <%= it.title %>
               </a>
             </h3>
+
             <p class="mt-2 text-sm text-gray-500"><%= it.description %></p>
           </div>
+
           <span class="pointer-events-none absolute right-6 top-6 text-gray-300 group-hover:text-gray-400">
             <%== part("components/icon", name: "hero-arrow-up-right") %>
           </span>
         </div>
-    <% end %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/views/postgres/index.erb
+++ b/views/postgres/index.erb
@@ -57,7 +57,7 @@
         <div class="rounded-lg shadow group relative bg-white p-6">
           <div>
             <span class="inline-flex rounded-lg overflow-hidden w-12 h-12">
-              <img src="/icons/pg-<%= it.brand.downcase %>.png" class="object-cover" />
+              <img src="/icons/pg-<%= it.brand.downcase %>.png" class="object-cover" alt="" />
             </span>
           </div>
 

--- a/views/postgres/index.erb
+++ b/views/postgres/index.erb
@@ -57,7 +57,7 @@
         <div class="rounded-lg shadow group relative bg-white p-6">
           <div>
             <span class="inline-flex rounded-lg overflow-hidden w-12 h-12">
-              <img src="/icons/pg-<%= it.brand.downcase %>.png" class="object-cover" alt="" />
+              <img src="/icons/pg-<%= it.brand.downcase %>.png" class="object-cover" alt="">
             </span>
           </div>
 

--- a/views/postgres/index.erb
+++ b/views/postgres/index.erb
@@ -57,7 +57,7 @@
         <div class="rounded-lg shadow group relative bg-white p-6">
           <div>
             <span class="inline-flex rounded-lg overflow-hidden w-12 h-12">
-              <img src="/icons/pg-<%= it.brand.downcase %>.png" class="object-cover" alt="">
+              <img src="/icons/pg-<%= it.brand.downcase %>.png" class="object-cover" alt="<%= it.brand.downcase %>">
             </span>
           </div>
 

--- a/views/postgres/logs.erb
+++ b/views/postgres/logs.erb
@@ -29,9 +29,11 @@
             <div class="col-span-12 sm:col-span-3">
               <%== part("components/form/datepicker", name: "start", label: "Start (UTC)", default_date: @logs_start, date_format: "Y-m-d\\TH:i:00\\Z") %>
             </div>
+
             <div class="col-span-12 sm:col-span-3">
               <%== part("components/form/datepicker", name: "end", label: "End (UTC)", default_date: @logs_end, date_format: "Y-m-d\\TH:i:00\\Z") %>
             </div>
+
             <div class="col-span-12 sm:col-span-2">
               <%== part(
                 "components/form/select",
@@ -41,6 +43,7 @@
                 options: [["", "Any"], ["postgres", "postgres"], ["pgbouncer", "pgbouncer"], ["upgrade", "upgrade"]]
               ) %>
             </div>
+
             <div class="col-span-12 sm:col-span-2">
               <%== part(
                 "components/form/select",
@@ -50,6 +53,7 @@
                 options: [["", "Any"], ["primary", "primary"], ["standby", "standby"]]
               ) %>
             </div>
+
             <div class="col-span-12 sm:col-span-2">
               <%== part(
                 "components/form/select",
@@ -59,6 +63,7 @@
                 options: [["", "Any"], ["DEBUG", "DEBUG"], ["INFO", "INFO"], ["WARN", "WARN"], ["ERROR", "ERROR"], ["FATAL", "FATAL"]]
               ) %>
             </div>
+
             <div class="col-span-12 sm:col-span-4">
               <%== part(
                 "components/form/text",
@@ -68,6 +73,7 @@
                 attributes: { placeholder: "Substring match" }
               ) %>
             </div>
+
             <div class="col-span-12 sm:col-span-2">
               <%== part(
                 "components/form/select",
@@ -77,6 +83,7 @@
                 options: log_limit_options.map { |value| [value, value] }
               ) %>
             </div>
+
             <div class="col-span-12 sm:col-span-6 flex items-center justify-end gap-4">
               <a href="?" class="text-sm font-semibold leading-6 text-gray-900 hover:text-orange-600">Reset</a>
               <%== part("components/form/submit_button", text: "Apply") %>
@@ -97,15 +104,8 @@
       <% else %>
         <% if @pagination_key %>
           <div class="px-3 py-2 text-xs text-gray-600 bg-gray-50 border-b border-gray-200">
-            Showing
-            <%= @logs.size %>
-            most recent log lines. More logs are available
-            <a
-              href="?<%= to_query_string({"start" => @logs_start, "end" => @logs_end, "stream_name" => @stream_name, "server_role" => @server_role, "severity_level" => @severity_level, "query_pattern" => @query_pattern, "max_log_lines" => @max_log_lines, "pagination_key" => @pagination_key}.compact) %>"
-              class="text-orange-600 hover:underline"
-            >&uarr; load the next page</a><% if @max_log_lines == log_limit_options.last %>.<% else %>
-              or increase the limit above.
-            <% end %>
+            Showing <%= @logs.size %> most recent log lines. More logs are available
+            <a href="?<%= to_query_string({"start" => @logs_start, "end" => @logs_end, "stream_name" => @stream_name, "server_role" => @server_role, "severity_level" => @severity_level, "query_pattern" => @query_pattern, "max_log_lines" => @max_log_lines, "pagination_key" => @pagination_key}.compact) %>" class="text-orange-600 hover:underline">&uarr; load the next page</a><% if @max_log_lines == log_limit_options.last %>.<% else %> or increase the limit above. <% end %>
           </div>
         <% end %>
         <ul class="divide-y divide-gray-100 font-mono text-xs leading-5">
@@ -135,6 +135,7 @@
               context_entries = {server_ubid: log[:server_ubid]}.merge(context_entries) unless log[:server_ubid].to_s.empty?
               server_label = log[:server_role]
               row_classes = "grid grid-cols-[0.75rem_10.5rem_2.75rem_4rem_4rem_1fr] gap-3 items-start tabular-nums" %>
+
             <li class="px-2 py-1 hover:bg-gray-50">
               <% if context_entries.empty? %>
                 <div class="<%= row_classes %>">
@@ -143,6 +144,7 @@
                   <span class="<%= level_color %> font-semibold whitespace-nowrap"><%= level %></span>
                   <span class="text-purple-600 whitespace-nowrap"><%= log[:stream_name] %></span>
                   <span class="text-gray-500 whitespace-nowrap"><%= server_label %></span>
+
                   <span class="text-gray-900 whitespace-pre-wrap break-all"><%= log[:message] %></span>
                 </div>
               <% else %>
@@ -154,14 +156,24 @@
                       viewBox="0 0 24 24"
                       stroke="currentColor"
                       stroke-width="2.5"
-                    ><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+                    >
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+
                     <span class="text-gray-400 whitespace-nowrap"><%= time_display %></span>
                     <span class="<%= level_color %> font-semibold whitespace-nowrap"><%= level %></span>
                     <span class="text-purple-600 whitespace-nowrap"><%= log[:stream_name] %></span>
                     <span class="text-gray-500 whitespace-nowrap"><%= server_label %></span>
+
                     <span class="text-gray-900 whitespace-pre-wrap break-all"><%= log[:message] %></span>
                   </summary>
-                  <dl class="mt-1 ml-3 pl-3 border-l-2 border-gray-200 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-0.5 text-gray-500">
+
+                  <dl
+                    class="
+                      mt-1 ml-3 pl-3 border-l-2 border-gray-200 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-0.5
+                      text-gray-500
+                    "
+                  >
                     <% context_entries.each do |k, v| %>
                       <dt class="text-gray-400"><%= k %></dt>
                       <dd class="text-gray-700 break-all"><%= v %></dd>
@@ -191,6 +203,7 @@
         </h3>
       </div>
     </div>
+
     <div class="overflow-x-auto rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <table class="min-w-full divide-y divide-gray-300">
         <thead class="bg-gray-50">
@@ -198,15 +211,20 @@
             <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Name</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Type</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Endpoint</th>
-            <% if @edit_perm %><th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th><% end %>
+
+            <% if @edit_perm %>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+            <% end %>
           </tr>
         </thead>
+
         <tbody class="divide-y divide-gray-200 bg-white">
           <% @pg.log_destinations.each do |ld| %>
             <tr>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6"><%= ld.name %></td>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-500 sm:pl-6"><%= ld.type %></td>
               <td class="py-4 pl-4 pr-3 text-sm text-gray-500 sm:pl-6 break-all"><%= ld.url %></td>
+
               <% if @edit_perm %>
                 <td
                   id="ld-delete-<%= ld.ubid %>"
@@ -217,9 +235,12 @@
               <% end %>
             </tr>
           <% end %>
+
           <% if @pg.log_destinations.empty? %>
             <tr>
-              <td colspan="<%= @edit_perm ? 4 : 3 %>" class="py-4 pl-4 pr-3 text-sm text-gray-500 sm:pl-6">No log destinations configured.</td>
+              <td colspan="<%= @edit_perm ? 4 : 3 %>" class="py-4 pl-4 pr-3 text-sm text-gray-500 sm:pl-6">
+                No log destinations configured.
+              </td>
             </tr>
           <% end %>
         </tbody>
@@ -236,14 +257,22 @@
           </h3>
         </div>
       </div>
+
       <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
         <div class="px-4 py-5 sm:p-6">
           <% form(action: "#{path(@pg)}/log-destination", method: :post) do %>
-            <input type="hidden" name="type" id="log-destination-type" value="<%= form_type %>">
+            <input
+              type="hidden"
+              name="type"
+              id="log-destination-type"
+              value="<%= form_type %>"
+            >
+
             <div class="space-y-4">
               <div class="grid grid-cols-12 gap-6">
                 <div class="col-span-12 sm:col-span-4">
                   <label class="block text-sm font-medium leading-6 text-gray-900 mb-2">Provider</label>
+
                   <% providers = [
                      ["generic-otlp", "Generic OTLP HTTP", "otlp", "", []],
                      ["grafana", "Grafana Cloud", "otlp", "https://otlp-gateway-{zone}.grafana.net/otlp", [["Authorization", ""]]],
@@ -261,17 +290,27 @@
                      ["logentries", "Logentries (Rapid7)", "syslog", "tcp://data.logentries.com:443", []],
                      ["papertrail", "Papertrail", "syslog", "", []],
                    ] %>
+
                   <select
                     id="log-destination-provider"
-                    class="block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset text-gray-900 ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-orange-600 text-sm sm:leading-6"
+                    class="
+                      block w-full rounded-md border-0 py-1.5 pl-3 pr-10 shadow-sm ring-1 ring-inset text-gray-900
+                      ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-orange-600 text-sm sm:leading-6
+                    "
                   >
                     <% providers.each do |value, label, type, url, headers| %>
-                      <option value="<%= value %>" data-type="<%= type %>" data-url="<%= url %>" data-headers="<%= headers.to_json %>">
+                      <option
+                        value="<%= value %>"
+                        data-type="<%= type %>"
+                        data-url="<%= url %>"
+                        data-headers="<%= headers.to_json %>"
+                      >
                         <%= label %>
                       </option>
                     <% end %>
                   </select>
                 </div>
+
                 <div class="col-span-12 sm:col-span-4">
                   <%== part("components/form/text", name: "name", label: "Name", attributes: { required: true }) %>
                 </div>
@@ -279,32 +318,42 @@
 
               <div class="space-y-2 text-gray-900">
                 <label for="url-display" class="block text-sm font-medium leading-6"><%= (form_type == "syslog") ? "Syslog TCP Endpoint" : "OTLP Endpoint URL" %></label>
+
                 <div class="flex">
                   <span
                     id="url-prefix"
-                    class="flex shrink-0 items-center rounded-l-md bg-gray-50 px-3 text-base text-gray-500 outline outline-1 -outline-offset-1 outline-gray-300 sm:text-sm/6"
-                  ><%= url_protocol %></span>
+                    class="
+                      flex shrink-0 items-center rounded-l-md bg-gray-50 px-3 text-base text-gray-500 outline
+                      outline-1 -outline-offset-1 outline-gray-300 sm:text-sm/6
+                    "
+                  >
+                    <%= url_protocol %>
+                  </span>
+
                   <input
                     id="url-display"
                     type="text"
                     value="<%= url_suffix %>"
                     placeholder="host:port or domain/path"
                     required
-                    class="block w-full rounded-r-md border-0 py-1.5 pl-3 pr-3 shadow-sm ring-1 ring-inset text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-orange-600 sm:text-sm sm:leading-6"
+                    class="
+                      block w-full rounded-r-md border-0 py-1.5 pl-3 pr-3 shadow-sm ring-1 ring-inset text-gray-900
+                      ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-orange-600
+                      sm:text-sm sm:leading-6
+                    "
                   >
+
                   <input type="hidden" name="url" id="url-hidden">
                 </div>
               </div>
 
               <div id="log-destination-otlp-auth" class="<%= (form_type == "syslog") ? "hidden" : "" %>">
-                <label class="block text-sm font-medium text-gray-700 mb-1">HTTP Headers
-                  <span class="text-gray-400 font-normal">(optional &mdash; for authentication)</span></label>
+                <label class="block text-sm font-medium text-gray-700 mb-1">HTTP Headers <span class="text-gray-400 font-normal">(optional &mdash; for authentication)</span></label>
                 <%== part("components/config_card", title: nil, config: form_headers, extra_class: nil, name: "header", errors: {}, config_validator: nil) %>
               </div>
 
               <div id="log-destination-syslog-auth" class="<%= (form_type == "otlp") ? "hidden" : "" %>">
-                <label class="block text-sm font-medium text-gray-700 mb-1">Structured Data
-                  <span class="text-gray-400 font-normal">(optional &mdash; for providers requiring RFC 5424 SD authentication)</span></label>
+                <label class="block text-sm font-medium text-gray-700 mb-1">Structured Data <span class="text-gray-400 font-normal">(optional &mdash; for providers requiring RFC 5424 SD authentication)</span></label>
                 <%== part("components/structured_data_card", structured_data: form_structured_data) %>
               </div>
 

--- a/views/postgres/networking.erb
+++ b/views/postgres/networking.erb
@@ -1,16 +1,19 @@
 <div class="p-6">
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
-      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Firewall Rules</h3>
+      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+        Firewall Rules
+      </h3>
+
       <p class="text-gray-500 mt-2">
-      <% if firewall = @pg.customer_firewall %>
-          You can 
+        <% if firewall = @pg.customer_firewall %>
+          You can
           <a class="text-orange-600" href="<%= path(firewall) %>/networking">manage firewall rules using the firewall for this PostgreSQL database</a>.
-      <% else %>
-          The firewall related to this PostgreSQL database was deleted or detached from the related private subnet,
-          you can manage firewall rules using an appropriate firewall on the
+        <% else %>
+          The firewall related to this PostgreSQL database was deleted or detached from the related private subnet, you
+          can manage firewall rules using an appropriate firewall on the
           <a class="text-orange-600" href="<%= path(@pg.private_subnet) %>/networking">private subnet</a>.
-      <% end %>
+        <% end %>
       </p>
     </div>
   </div>

--- a/views/postgres/overview.erb
+++ b/views/postgres/overview.erb
@@ -1,10 +1,7 @@
-<%
-vm = @pg.representative_server.vm
-%>
+<% vm = @pg.representative_server.vm %>
 
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 p-6 database-overview">
-  <%
-    if (tsdb_client = PostgresServer.victoria_metrics_client)
+  <% if (tsdb_client = PostgresServer.victoria_metrics_client)
       query = Metrics::POSTGRES_METRICS[:disk_usage].series[0].query.gsub("$ubicloud_resource_id", @pg.ubid)
       disk_usage = begin
         tsdb_client.query_range(query:, start_ts: Time.now.to_i - 60 * 60, end_ts: Time.now.to_i)[0]
@@ -44,12 +41,9 @@ vm = @pg.representative_server.vm
       ["hero-square-2-stack-modified", ha_option.description, ""],
       ["hero-map-pin", @pg.location.display_name, h("#{location_details} (#{provider})")],
       ["postgres-logo", "Version #{@pg.version}", ""],
-    ].each do |icon, text, subtext_html|
-  %>
-  <%== part("components/icon_with_text", icon:, text:, subtext_html:) %>
-  <%
-    end
-  %>
+    ].each do |icon, text, subtext_html| %>
+    <%== part("components/icon_with_text", icon:, text:, subtext_html:) %>
+  <% end %>
 </div>
 
 <% @enable_echarts = true %>
@@ -57,22 +51,25 @@ vm = @pg.representative_server.vm
 <div id="metrics-container" class="p-6" data-metrics-url="<%= path(@pg) %>">
   <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
     <div class="min-w-0 flex-1">
-      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Metrics Summary</h3>
+      <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+        Metrics Summary
+      </h3>
     </div>
   </div>
+
   <% if @pg.display_state != "creating" %>
     <div class="grid grid-cols-1 xl:grid-cols-2 gap-4 border-t-0">
       <% Metrics::POSTGRES_METRICS.slice(:cpu_usage, :disk_usage).each do |key, metric| %>
         <div class="p-4 bg-gray-50 rounded-lg border border-gray-100">
           <h4 class="text-sm font-medium text-gray-900 mb-2"><%= metric.name %></h4>
           <p class="text-xs text-gray-500 mt-2"><%= metric.description %></p>
+
           <div
             class="metric-chart h-64 w-full"
             id="<%= key %>-chart"
             data-metric-key="<%= key %>"
             data-metric-unit="<%= metric.unit %>"
-          >
-          </div>
+          ></div>
         </div>
       <% end %>
     </div>

--- a/views/postgres/read_replica.erb
+++ b/views/postgres/read_replica.erb
@@ -2,7 +2,9 @@
   <% if @pg.timeline.earliest_restore_time %>
     <div class="md:flex md:items-center md:justify-between pb-2 lg:pb-4">
       <div class="min-w-0 flex-1">
-        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Read Replicas</h3>
+        <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+          Read Replicas
+        </h3>
       </div>
     </div>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
@@ -13,6 +15,7 @@
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">State</th>
           </tr>
         </thead>
+
         <tbody class="divide-y divide-gray-200 bg-white">
           <% @pg.read_replicas.each do |read_replica| %>
             <tr>
@@ -21,16 +24,19 @@
                   <%= read_replica.name %>
                 </a>
               </td>
+
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
                 <%== part("components/pg_state_label", state: read_replica.display_state, extra_class: "text-md") %>
               </td>
             </tr>
           <% end %>
+
           <% if @edit_perm %>
             <tr>
               <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
                 <%== part("components/form/text", name: "name", attributes: { placeholder: @pg.name + "-read-replica", required: true, form: "form-pg-read-replica-create" }) %>
               </td>
+
               <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                 <% form(action: "#{path(@pg)}/read-replica", method: :post, id: "form-pg-read-replica-create") do %>
                   <%== part("components/form/submit_button", text: "Create", extra_class: "pg-read-replica-create-btn") %>

--- a/views/postgres/resize.erb
+++ b/views/postgres/resize.erb
@@ -21,6 +21,7 @@ end %>
 
 <div class="p-6">
   <h3 class="text-base font-semibold text-gray-900 pb-4">Current configuration</h3>
+
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
     <%== part("components/icon_with_text", icon: "hero-cpu-chip", text: @pg.vm_size, subtext_html: compute_subtext) %>
     <%== part("components/icon_with_text", icon: "hero-circle-stack", text: "#{server.storage_size_gib} GB storage", subtext_html: storage_subtext) %>

--- a/views/postgres/settings.erb
+++ b/views/postgres/settings.erb
@@ -9,6 +9,7 @@
         </h3>
       </div>
     </div>
+
     <div class="overflow-hidden rounded-lg bg-white shadow ring-1 ring-black ring-opacity-5">
       <div class="px-4 py-5 sm:p-6">
         <% form(action: "#{path(@pg)}/set-maintenance-window", method: :post) do %>
@@ -25,14 +26,20 @@
                   ) %>
               </div>
             </div>
+
             <% if @project.get_ff_postgres_enable_maintenance_window_days %>
               <% day_names = %w[Monday Tuesday Wednesday Thursday Friday Saturday Sunday].freeze %>
               <fieldset>
                 <legend class="text-sm font-medium leading-6 text-gray-900">Preferred days</legend>
-                <p class="mt-1 text-sm text-gray-500">Select one or more days, or leave all unselected to allow any day.</p>
+
+                <p class="mt-1 text-sm text-gray-500">
+                  Select one or more days, or leave all unselected to allow any day.
+                </p>
+
                 <div class="mt-3 flex flex-wrap gap-2">
                   <% @pg.maintenance_window_day_options_state.each_with_index do |(day, checked), index| %>
                     <% id = "maintenance-window-day-#{day}" %>
+
                     <div>
                       <input
                         id="<%= id %>"
@@ -42,12 +49,14 @@
                         class="peer sr-only"
                         <%= "checked" if checked %>
                       >
+
                       <label for="<%= id %>" class="checkbox-chip px-3 py-2 text-sm font-medium transition"><%= day_names[index] %></label>
                     </div>
                   <% end %>
                 </div>
               </fieldset>
             <% end %>
+
             <div class="flex justify-end border-t border-gray-200 pt-5">
               <%== part("components/form/submit_button", text: "Set") %>
             </div>
@@ -65,6 +74,7 @@
           </h3>
         </div>
       </div>
+
       <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
         <% form_elements = [
               {name: "init_script", type: "textarea", required: "", placeholder: "Enter script to run on database creation"}
@@ -95,6 +105,7 @@ pre_selected_values = {
     </div>
   <% end %>
 <% end %>
+
 <!-- Cancel Storage Auto-Scale -->
 <% if @edit_perm && @pg.can_cancel_storage_auto_scale? %>
   <div class="p-6">
@@ -105,19 +116,27 @@ pre_selected_values = {
         </h3>
       </div>
     </div>
+
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-orange-300 bg-orange-50 divide-y divide-orange-200">
       <div class="px-4 py-5 sm:p-6">
         <% form(action: "#{path(@pg)}/cancel-storage-auto-scale", method: :post) do %>
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
               <h3 class="text-base font-semibold leading-6 text-gray-900">Cancel automatic storage scale-up</h3>
+
               <div class="mt-2 text-sm text-gray-600">
-                <p>A storage scale-up operation was triggered due to high disk utilization. The system is currently
-                  provisioning new servers. You can cancel this operation before the failover begins.</p>
-                <p class="mt-2 font-medium text-orange-700">Warning: If you cancel, automatic scale-up will not be re-triggered until disk usage drops below 80%
-                  and rises again.</p>
+                <p>
+                  A storage scale-up operation was triggered due to high disk utilization. The system is currently
+                  provisioning new servers. You can cancel this operation before the failover begins.
+                </p>
+
+                <p class="mt-2 font-medium text-orange-700">
+                  Warning: If you cancel, automatic scale-up will not be re-triggered until disk usage drops below 80%
+                  and rises again.
+                </p>
               </div>
             </div>
+
             <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
               <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                 <%== part("components/form/submit_button", text: "Cancel Scale-Up", extra_class: "bg-orange-600 hover:bg-orange-500") %>
@@ -129,6 +148,7 @@ pre_selected_values = {
     </div>
   </div>
 <% end %>
+
 <!-- Danger Zone -->
 <% if @edit_perm || delete_perm %>
   <div class="p-6">
@@ -139,6 +159,7 @@ pre_selected_values = {
         </h3>
       </div>
     </div>
+
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <!-- Promote Read Replica -->
       <% if @edit_perm && @pg.read_replica? %>
@@ -146,14 +167,23 @@ pre_selected_values = {
           <% form(action: "#{path(@pg)}/promote-read-replica", method: :post) do %>
             <div class="sm:flex sm:items-center sm:justify-between">
               <div>
-                <h3 class="text-base font-semibold leading-6 text-gray-900">Promote PostgreSQL read replica database</h3>
+                <h3 class="text-base font-semibold leading-6 text-gray-900">
+                  Promote PostgreSQL read replica database
+                </h3>
+
                 <div class="mt-2 text-sm text-gray-500">
-                  <p>This action will promote the read replica database to become an independent primary database. The
-                    database will stop replicating permanently. It will be offline momentarily, and all connections
-                    will be dropped.</p>
+                  <p>
+                    This action will promote the read replica database to become an independent primary database. The
+                    database will stop replicating permanently. It will be offline momentarily, and all connections will
+                    be dropped.
+                  </p>
                 </div>
               </div>
-              <div id="postgres-replica-promote-<%=@pg.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+
+              <div
+                id="postgres-replica-promote-<%= @pg.ubid %>"
+                class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
+              >
                 <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                   <%== part("components/form/submit_button", text: "Promote", extra_class: "promote-btn") %>
                 </div>
@@ -162,6 +192,7 @@ pre_selected_values = {
           <% end %>
         </div>
       <% end %>
+
       <!-- Add AAAA DNS Record -->
       <% if @edit_perm && @pg.can_add_aaaa_record? %>
         <div class="px-4 py-5 sm:p-6">
@@ -169,12 +200,19 @@ pre_selected_values = {
             <div class="sm:flex sm:items-center sm:justify-between">
               <div>
                 <h3 class="text-base font-semibold leading-6 text-gray-900">Add IPv6 (AAAA) DNS record</h3>
+
                 <div class="mt-2 text-sm text-gray-500">
-                  <p>This action will add an IPv6 (AAAA) DNS record for this PostgreSQL database. This enables
-                    connections over IPv6.</p>
+                  <p>
+                    This action will add an IPv6 (AAAA) DNS record for this PostgreSQL database. This enables
+                    connections over IPv6.
+                  </p>
                 </div>
               </div>
-              <div id="postgres-aaaa-<%=@pg.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+
+              <div
+                id="postgres-aaaa-<%= @pg.ubid %>"
+                class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
+              >
                 <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                   <%== part("components/form/submit_button", text: "Add AAAA Record", extra_class: "add-aaaa-btn") %>
                 </div>
@@ -183,6 +221,7 @@ pre_selected_values = {
           <% end %>
         </div>
       <% end %>
+
       <!-- Reset password -->
       <% if @edit_perm && !@pg.read_replica? %>
         <div class="px-4 py-5 sm:p-6">
@@ -191,6 +230,7 @@ pre_selected_values = {
               <div>
                 <h3 class="text-base font-semibold leading-6 text-gray-900">Reset superuser password</h3>
               </div>
+
               <div class="grid grid-cols-12 gap-6">
                 <div class="col-span-12 sm:col-span-5">
                   <%== part(
@@ -204,6 +244,7 @@ pre_selected_values = {
                       extra_class: "reset-superuser-password-new-password"
                     ) %>
                 </div>
+
                 <div class="col-span-12 sm:col-span-5">
                   <%== part(
                       "components/form/text",
@@ -216,6 +257,7 @@ pre_selected_values = {
                       extra_class: "reset-superuser-password-new-password-repeat"
                     ) %>
                 </div>
+
                 <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                   <%== part("components/form/submit_button", text: "Reset") %>
                 </div>
@@ -224,6 +266,7 @@ pre_selected_values = {
           <% end %>
         </div>
       <% end %>
+
       <% if @edit_perm %>
         <!-- Restart Card -->
         <div class="px-4 py-5 sm:p-6">
@@ -231,12 +274,19 @@ pre_selected_values = {
             <div class="sm:flex sm:items-center sm:justify-between">
               <div>
                 <h3 class="text-base font-semibold leading-6 text-gray-900">Restart PostgreSQL database</h3>
+
                 <div class="mt-2 text-sm text-gray-500">
-                  <p>This action will restart the PostgreSQL database. The database will be offline momentarily, and all
-                    connections will be dropped.</p>
+                  <p>
+                    This action will restart the PostgreSQL database. The database will be offline momentarily, and all
+                    connections will be dropped.
+                  </p>
                 </div>
               </div>
-              <div id="postgres-restart-<%=@pg.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+
+              <div
+                id="postgres-restart-<%= @pg.ubid %>"
+                class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
+              >
                 <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                   <%== part("components/form/submit_button", text: "Restart", extra_class: "restart-btn") %>
                 </div>
@@ -249,11 +299,16 @@ pre_selected_values = {
             <div class="sm:flex sm:items-center sm:justify-between">
               <div>
                 <h3 class="text-base font-semibold leading-6 text-gray-900">Failover PostgreSQL database</h3>
+
                 <div class="mt-2 text-sm text-gray-500">
                   <p>Will recycle primary of PostgreSQL database.</p>
                 </div>
               </div>
-              <div id="postgres-recycle-<%=@pg.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+
+              <div
+                id="postgres-recycle-<%= @pg.ubid %>"
+                class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
+              >
                 <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                   <%== part("components/form/submit_button", text: "Recycle") %>
                 </div>
@@ -267,17 +322,23 @@ pre_selected_values = {
           <% end %>
         </div>
       <% end %>
+
       <!-- Delete Card -->
       <% if delete_perm %>
         <div class="px-4 py-5 sm:p-6">
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
               <h3 class="text-base font-semibold leading-6 text-gray-900">Delete PostgreSQL database</h3>
+
               <div class="mt-2 text-sm text-gray-500">
                 <p>This action will permanently delete this PostgreSQL database.</p>
               </div>
             </div>
-            <div id="postgres-delete-<%=@pg.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+
+            <div
+              id="postgres-delete-<%= @pg.ubid %>"
+              class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
+            >
               <%== part("components/delete_button", url: path(@pg), confirmation: @pg.name) %>
             </div>
           </div>

--- a/views/postgres/upgrade.erb
+++ b/views/postgres/upgrade.erb
@@ -51,7 +51,9 @@ end %>
     <p class="text-gray-500 mt-2">Upgrade operation is not available while the database is being created.</p>
   <% elsif @pg.target_version != @pg.version %>
     <% if @pg.upgrade_stage == "upgrade_failed" %>
-      <p>Database upgrade failed. We have reverted the database to the previous version, and it is now available again.</p>
+      <p>
+        Database upgrade failed. We have reverted the database to the previous version, and it is now available again.
+      </p>
     <% else %>
       <p>Database upgrade is in progress.</p>
     <% end %>
@@ -82,8 +84,7 @@ end %>
     end %>
     <%== part("components/table_card", title: "", headers: ["Stage", "Database Availability", "Status"], rows: upgrade_progress_rows) %>
   <% elsif @pg.can_upgrade? %>
-    <p>Your database can be upgraded to Postgres
-      <%= @pg.version.to_i + 1 %>.</p>
+    <p>Your database can be upgraded to Postgres <%= @pg.version.to_i + 1 %>.</p>
 
     <% form(action: "#{path(@pg)}/restore", method: :post, class: "min-w-2/3 pg-config mt-6") do %>
       <%== part("components/form/section", label: "Preparing for an Upgrade",
@@ -95,6 +96,7 @@ end %>
 
       <%== part("components/form/hidden", name: "#{@pg.name}-upgrade-test") %>
       <%== part("components/form/hidden", restore_target: @pg.timeline.latest_restore_time.to_s) %>
+
       <div class="flex justify-end mt-6">
         <%== part("components/form/submit_button", text: "Create a test fork") if @edit_perm %>
       </div>

--- a/views/private-location/create.erb
+++ b/views/private-location/create.erb
@@ -7,7 +7,6 @@ options.add_option(name: "access_key")
 options.add_option(name: "secret_key")
 @option_tree, @option_parents = options.serialize %>
 
-
 <%== part(
   "components/page_header",
   breadcrumbs: [
@@ -18,14 +17,12 @@ options.add_option(name: "secret_key")
   ]
 ) %>
 
-<%
-  form_elements = [
+<% form_elements = [
     {name: "name", type: "text", label: "Ubicloud Region Name", required: "required", placeholder: "Enter name"},
     {name: "provider_location_name", type: "select", label: "AWS Region Name", required: "required", content_generator: ContentGenerator::PrivateLocation.method(:select_option), opening_tag: "<div class='col-span-6 col-start-1 md:col-end-4 xl:col-end-3'>"},
     {name: "access_key", type: "text", label: "AWS Access Key", required: "required", placeholder: "Enter AWS access key"},
     {name: "secret_key", type: "text", label: "AWS Secret Key", required: "required", placeholder: "Enter AWS secret key"}
   ]
-  action = "#{@project.path}/private-location"
-%>
+  action = "#{@project.path}/private-location" %>
 
 <%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents) %>

--- a/views/private-location/show.erb
+++ b/views/private-location/show.erb
@@ -32,6 +32,7 @@
       ]
     ) %>
   <% end %>
+
   <!-- Danger Zone -->
   <% if has_permission?("Location:delete", @project) %>
     <div>
@@ -42,17 +43,25 @@
           </h3>
         </div>
       </div>
+
       <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
         <!-- Delete Card -->
         <div class="px-4 py-5 sm:p-6">
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
               <h3 class="text-base font-semibold leading-6 text-gray-900">Delete region</h3>
+
               <div class="mt-2 text-sm text-gray-500">
-                <p>This action will permanently delete this region. Deleted data cannot be recovered. Use it carefully.</p>
+                <p>
+                  This action will permanently delete this region. Deleted data cannot be recovered. Use it carefully.
+                </p>
               </div>
             </div>
-            <div id="region-delete-<%=@location.ubid%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+
+            <div
+              id="region-delete-<%= @location.ubid %>"
+              class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
+            >
               <%== part("components/delete_button", confirmation: @location.ui_name) %>
             </div>
           </div>

--- a/views/project/access-control.erb
+++ b/views/project/access-control.erb
@@ -60,6 +60,7 @@ end
               <% table_headers.each do |type| %>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
                   <%= type %>
+
                   <% unless @token %>
                     <a
                       id="<%= type.downcase %>-tags-link"
@@ -71,18 +72,25 @@ end
                   <% end %>
                 </th>
               <% end %>
+
               <% if edit_perm %>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
               <% end %>
             </tr>
           </thead>
+
           <tbody class="divide-y divide-gray-200 bg-white">
             <% @aces.append(["template", [], true]).each do |ubid, tags, editable| %>
               <% editable &&= edit_perm %>
-              <tr id="ace-<%= ubid %>" class="<%= "existing-aces#{"-view" unless editable}" unless ubid == "template" %>">
+
+              <tr
+                id="ace-<%= ubid %>"
+                class="<%= "existing-aces#{"-view" unless editable}" unless ubid == "template" %>"
+              >
                 <% if editable %>
                   <% ace_options.each_with_index do | (name, options), index| %>
                     <% attributes = (!@token && index == 0 && ubid != "template") ? { required: "required" } : {} %>
+
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       <%== part(
                         "components/form/select",
@@ -111,20 +119,25 @@ end
                 <% end %>
               </tr>
             <% end %>
+
             <% if @aces.count == 1 %>
               <tr class="group-[&:has(tr:nth-child(n+3))]:hidden">
                 <td colspan="3" class="py-4 px-8">
                   <p class="mb-4">Currently, this token has no access to the project.</p>
-                  <p>You should grant the token the access you think the token should have. Be aware that the token can
+
+                  <p>
+                    You should grant the token the access you think the token should have. Be aware that the token can
                     never have more access to the project than your account has. Each access control entry has a single
                     action and object. Access is allowed if there is an access control entry allowing the token to take
                     the action on the object. Actions and objects can be tags, which are used for grouping multiple
-                    actions or multiple objects into a single entity.</p>
+                    actions or multiple objects into a single entity.
+                  </p>
                 </td>
               </tr>
             <% end %>
           </tbody>
         </table>
+
         <% if edit_perm %>
           <div class="px-3 py-4 flex justify-between">
             <%== part("components/button", icon: "hero-plus", text: "New Access Control Entry", attributes: { id: "new-ace-btn" }) %>
@@ -134,22 +147,25 @@ end
       </div>
     <% end %>
   <% end %>
+
   <% if @token %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <% form(action: restriction_path, method: :post) do %>
           <div class="sm:flex sm:items-center sm:justify-between">
             <div>
-              <h3 class="text-base font-semibold leading-6 text-gray-900"><%= restriction_title %>
-                Personal Access Token</h3>
+              <h3 class="text-base font-semibold leading-6 text-gray-900">
+                <%= restriction_title %> Personal Access Token
+              </h3>
+
               <div class="mt-2 text-sm text-gray-500">
                 <p>
                   <% if unrestricted %>
-                    This token currently has the same access to this project that your account has. If you would like
-                    to restrict the access of this token, use the "Restrict Token Access" button. After restricting
-                    token access, the token will have no access to the project, and you can grant the specific access
-                    you want the token to have. Be aware that the token can never have more access to the project than
-                    your account has.
+                    This token currently has the same access to this project that your account has. If you would like to
+                    restrict the access of this token, use the "Restrict Token Access" button. After restricting token
+                    access, the token will have no access to the project, and you can grant the specific access you want
+                    the token to have. Be aware that the token can never have more access to the project than your
+                    account has.
                   <% else %>
                     This token currently has access to the project based on the access control entries above. If you
                     would like to remove access control restrictions, and grant the token full access to your account,
@@ -158,7 +174,8 @@ end
                 </p>
               </div>
             </div>
-            <div id="restrict-<%=@token.ubid%>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+
+            <div id="restrict-<%= @token.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
               <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                 <%== part("components/form/submit_button", text: "#{restriction_title} Token Access") %>
               </div>

--- a/views/project/audit_log.erb
+++ b/views/project/audit_log.erb
@@ -20,6 +20,7 @@
               attributes: { placeholder: "Filter by action" }
             ) %>
           </div>
+
           <div class="col-span-12 sm:col-span-4">
             <%== part(
               "components/form/text",
@@ -29,6 +30,7 @@
               attributes: { placeholder: "Filter by account name/email/ID" }
             ) %>
           </div>
+
           <div class="col-span-12 sm:col-span-4">
             <%== part(
               "components/form/text",
@@ -38,6 +40,7 @@
               attributes: { placeholder: "Filter by object ID" }
             ) %>
           </div>
+
           <div class="col-span-12 sm:col-span-4">
             <%== part(
               "components/form/text",
@@ -48,6 +51,7 @@
               attributes: {required: true}
             ) %>
           </div>
+
           <div class="col-span-12 sm:col-span-2 flex items-end">
             <%== part("components/form/submit_button", text: "Search") %>
           </div>

--- a/views/project/authentication_audit_log.erb
+++ b/views/project/authentication_audit_log.erb
@@ -28,6 +28,7 @@
               attributes: { placeholder: "Filter by action" }
             ) %>
           </div>
+
           <div class="col-span-12 sm:col-span-4">
             <%== part(
               "components/form/text",
@@ -37,6 +38,7 @@
               attributes: { placeholder: "Filter by metadata, e.g. ip=1.2.3.4" }
             ) %>
           </div>
+
           <% if @project %>
             <div class="col-span-12 sm:col-span-4">
               <%== part(
@@ -48,6 +50,7 @@
               ) %>
             </div>
           <% end %>
+
           <div class="col-span-12 sm:col-span-4">
             <%== part(
               "components/form/text",
@@ -58,6 +61,7 @@
               attributes: {required: true}
             ) %>
           </div>
+
           <div class="col-span-12 sm:col-span-2 flex items-end">
             <%== part("components/form/submit_button", text: "Search") %>
           </div>

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -18,16 +18,25 @@ end
       <dl class="grid grid-cols-2 gap-5 <%= (@project.discount > 0) ? "sm:grid-cols-4" : "sm:grid-cols-3" %>">
         <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
           <dt class="truncate text-sm font-medium text-gray-500">Current Usage</dt>
-          <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= money(@invoices.first.subtotal) %></dd>
+
+          <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+            <%= money(@invoices.first.subtotal) %>
+          </dd>
         </div>
+
         <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
           <dt class="truncate text-sm font-medium text-gray-500">Last Month</dt>
-          <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= (@invoices.count > 1) ? money(@invoices[1].subtotal) : "-" %></dd>
+
+          <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+            <%= (@invoices.count > 1) ? money(@invoices[1].subtotal) : "-" %>
+          </dd>
         </div>
+
         <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
           <dt class="truncate text-sm font-medium text-gray-500">Remaining Credit</dt>
           <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= money(@project.credit.to_f) %></dd>
         </div>
+
         <% if @project.discount > 0 %>
           <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
             <dt class="truncate text-sm font-medium text-gray-500">Discount</dt>
@@ -36,8 +45,10 @@ end
         <% end %>
       </dl>
     </div>
+
     <!-- Billing Info Update Card -->
     <% stripe_data = billing_info.stripe_data %>
+
     <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
       <div class="min-w-0 flex-1">
         <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
@@ -45,6 +56,7 @@ end
         </h3>
       </div>
     </div>
+
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <% form(action: billing_path, method: :post) do %>
         <div class="px-4 py-5 sm:p-6">
@@ -62,6 +74,7 @@ end
                     }
                   ) %>
                 </div>
+
                 <div class="sm:col-span-4">
                   <%== part(
                     "components/form/text",
@@ -73,6 +86,7 @@ end
                     }
                   ) %>
                 </div>
+
                 <div class="sm:col-span-4 md:col-span-2">
                   <%== part(
                     "components/form/select",
@@ -91,15 +105,19 @@ end
                     }
                   ) %>
                 </div>
+
                 <div class="sm:col-span-4 md:col-span-2">
                   <%== part("components/form/text", name: "state", label: "State", value: stripe_data["state"]) %>
                 </div>
+
                 <div class="sm:col-span-4 md:col-span-2">
                   <%== part("components/form/text", name: "city", label: "City", value: stripe_data["city"]) %>
                 </div>
+
                 <div class="sm:col-span-4 md:col-span-2">
                   <%== part("components/form/text", name: "postal_code", label: "Postal Code", value: stripe_data["postal_code"]) %>
                 </div>
+
                 <div class="col-span-full">
                   <%== part(
                     "components/form/textarea",
@@ -111,6 +129,7 @@ end
                     }
                   ) %>
                 </div>
+
                 <div class="sm:col-span-4">
                   <%== part(
                     "components/form/text",
@@ -118,6 +137,7 @@ end
                     label: billing_info.country&.in_eu_vat? ? "VAT ID" : "Tax ID",
                     value: stripe_data["tax_id"]
                   ) %>
+
                   <% if billing_info.country&.in_eu_vat? %>
                     <div class="mt-2 text-sm text-gray-500">
                       <% if billing_info.valid_vat == false %>
@@ -133,9 +153,11 @@ end
                     </div>
                   <% end %>
                 </div>
+
                 <div class="sm:col-span-4">
                   <%== part("components/form/text", name: "company_name", label: "Company Name", value: stripe_data["company_name"]) %>
                 </div>
+
                 <div class="col-span-full">
                   <%== part(
                     "components/form/textarea",
@@ -159,8 +181,10 @@ end
         </div>
       <% end %>
     </div>
+
     <!-- Payment Methods Card -->
     <% allow_delete = billing_info.payment_methods.size > 1 %>
+
     <%== part(
       "components/table_card",
       title: "Payment Methods",
@@ -195,7 +219,9 @@ end
         end,
       empty_state: "No payment methods. Add new payment method to able create resources in project."
     ) %>
+
     <%== part("components/discount_code") %>
+
     <!-- Invoices -->
     <div>
       <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
@@ -205,16 +231,24 @@ end
           </h3>
         </div>
       </div>
+
       <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
         <div class="overflow-x-auto">
           <table class="min-w-full divide-y divide-gray-300">
             <thead class="bg-gray-50">
               <tr>
-                <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Invoice</th>
+                <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+                  Invoice
+                </th>
+
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Amount</th>
-                <th scope="col" class="py-3.5 pl-3 pr-4 sm:pr-6 text-left text-sm font-semibold text-gray-900">Status</th>
+
+                <th scope="col" class="py-3.5 pl-3 pr-4 sm:pr-6 text-left text-sm font-semibold text-gray-900">
+                  Status
+                </th>
               </tr>
             </thead>
+
             <tbody class="divide-y divide-gray-200 bg-white">
               <% @invoices.each do |inv| %>
                 <tr id="invoice-<%= inv.path_id %>">
@@ -222,6 +256,7 @@ end
                     <a href="<%= path(inv) %>" target="_blank" class="text-orange-600 hover:text-orange-700">
                       <%= inv.name %>
                     </a>
+
                     <span class="text-xs text-gray-400 italic">
                       <% if inv.invoice_number %>
                         #<%= inv.invoice_number %>
@@ -230,14 +265,18 @@ end
                       <% end %>
                     </span>
                   </td>
+
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     <%= money(inv.cost) %>
+
                     <% if inv.cost != inv.subtotal %>
                       <span class="text-xs italic">(<%= money(inv.subtotal) %>)</span>
                     <% end %>
                   </td>
+
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 flex items-center gap-2 justify-between">
                     <%= inv.status %>
+
                     <% if inv.payable? %>
                       <% form(action: "#{path(inv)}/pay", method: :post) do %>
                         <%== part("components/form/submit_button", text: "Pay Now") %>
@@ -246,11 +285,14 @@ end
                   </td>
                 </tr>
               <% end %>
+
               <% if @invoices.count == 1 %>
                 <tr>
                   <td colspan="3">
-                    <div class="text-center text-lg p-4">No invoices finalized yet. Invoice for the current month will be created on the first day of next
-                      month.</div>
+                    <div class="text-center text-lg p-4">
+                      No invoices finalized yet. Invoice for the current month will be created on the first day of next
+                      month.
+                    </div>
                   </td>
                 </tr>
               <% end %>
@@ -270,10 +312,12 @@ end
       button_title: "Add new billing information"
     ) %>
   <% end %>
-  <br/>
+  <br />
   <%== part("components/discount_code") %>
 <% end %>
-<br/>
+
+<br />
+
 <!-- Usage alerts -->
 <div>
   <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
@@ -283,6 +327,7 @@ end
       </h3>
     </div>
   </div>
+
   <div class="grid gap-6">
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <!-- Add usage alert -->
@@ -291,14 +336,16 @@ end
           <div class="space-y-4">
             <div>
               <h2 class="text-lg font-medium leading-6 text-gray-900">Add new usage alert</h2>
+
               <p class="mt-1 text-sm text-gray-500">
-                Usage alerts will be sent to your email address. If you want to send alerts to specific email
-                addresses, you need to log in with that email address.
-                <br/>
-                <br/>
+                Usage alerts will be sent to your email address. If you want to send alerts to specific email addresses,
+                you need to log in with that email address.
+                <br />
+                <br />
                 Please note that alerts are only for informational purposes and no action is taken automatically.
               </p>
             </div>
+
             <div class="grid grid-cols-12 gap-6">
               <div class="col-span-5 sm:col-span-3">
                 <%== part(
@@ -312,6 +359,7 @@ end
                   extra_class: "pr-3"
                 ) %>
               </div>
+
               <div class="col-span-5 sm:col-span-3">
                 <%== part(
                   "components/form/text",
@@ -325,14 +373,15 @@ end
                   extra_class: "pr-3"
                 ) %>
               </div>
+
               <div class="col-span-2 sm:col-span-3 flex justify-begin items-end">
                 <%== part("components/form/submit_button", text: "Add") %>
               </div>
             </div>
           </div>
         <% end %>
-
       </div>
+
       <!-- List alerts -->
       <% if @usage_alerts.count > 0 %>
         <div class="overflow-x-auto">
@@ -340,19 +389,28 @@ end
             <thead class="bg-gray-50">
               <tr>
                 <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-4">Name</th>
-                <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-4">Limit</th>
-                <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-4">E-mail</th>
+
+                <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-4">
+                  Limit
+                </th>
+
+                <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-4">
+                  E-mail
+                </th>
+
                 <th scope="col" class="py-3.5 pl-3 pr-4 sm:pr-4">
                   <span class="sr-only">Remove</span>
                 </th>
               </tr>
             </thead>
+
             <tbody class="divide-y divide-gray-200 bg-white">
               <% @usage_alerts.each do |alert| %>
                 <tr id="alert-<%= alert.ubid %>" class="whitespace-nowrap text-sm font-medium">
                   <td class="py-4 pl-4 pr-3 text-gray-900 sm:pl-6" scope="row"><%= alert.name %></td>
                   <td class="py-4 pl-4 pr-3 text-gray-900 sm:pl-6" scope="row"><%= alert.limit %></td>
                   <td class="py-4 pl-4 pr-3 text-gray-900 sm:pl-6" scope="row"><%= alert.user.email %></td>
+
                   <td class="py-4 pl-3 pr-4 text-right sm:pr-6">
                     <%== part(
                     "components/delete_button",

--- a/views/project/billing.erb
+++ b/views/project/billing.erb
@@ -312,11 +312,11 @@ end
       button_title: "Add new billing information"
     ) %>
   <% end %>
-  <br />
+  <br>
   <%== part("components/discount_code") %>
 <% end %>
 
-<br />
+<br>
 
 <!-- Usage alerts -->
 <div>
@@ -340,8 +340,8 @@ end
               <p class="mt-1 text-sm text-gray-500">
                 Usage alerts will be sent to your email address. If you want to send alerts to specific email addresses,
                 you need to log in with that email address.
-                <br />
-                <br />
+                <br>
+                <br>
                 Please note that alerts are only for informational purposes and no action is taken automatically.
               </p>
             </div>

--- a/views/project/create.erb
+++ b/views/project/create.erb
@@ -20,8 +20,8 @@
             ) %>
           </div>
         </div>
-
       </div>
+
       <div class="px-4 py-5 sm:p-6">
         <div class="flex items-center justify-end gap-x-6">
           <a href="/project" class="text-sm font-semibold leading-6 text-gray-900">Cancel</a>

--- a/views/project/dashboard.erb
+++ b/views/project/dashboard.erb
@@ -113,15 +113,20 @@ cards = [
 
 <div id="tiles" class="grid gap-6">
   <div
-    class="mb-5 grid grid-cols-2 divide-x divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow lg:grid-cols-3 xl:grid-cols-6 xl:divide-y-0"
+    class="
+      mb-5 grid grid-cols-2 divide-x divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow
+      lg:grid-cols-3 xl:grid-cols-6 xl:divide-y-0
+    "
   >
     <% tiles.each do |title, count, link, perm| %>
       <% if perm %>
         <a href="<%= link %>">
           <div class="px-4 py-5 sm:p-6">
             <dt class="truncate text-sm font-medium text-gray-900"><%= title %></dt>
+
             <dd class="mt-1 text-3xl font-semibold tracking-tight text-orange-600">
-              <%= count %></dd>
+              <%= count %>
+            </dd>
           </div>
         </a>
       <% else %>
@@ -130,18 +135,24 @@ cards = [
     <% end %>
   </div>
 
-  <h2 class="text-xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Getting Started with your Project</h2>
+  <h2 class="text-xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+    Getting Started with your Project
+  </h2>
 
   <div id="cards" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 lg:gap-8">
     <% cards.each do |icon, title, description, link| %>
       <div
-        class="rounded-lg shadow group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-orange-600"
+        class="
+          rounded-lg shadow group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset
+          focus-within:ring-orange-600
+        "
       >
         <div>
           <span class="inline-flex rounded-lg p-3 bg-orange-50 text-orange-700 ring-4 ring-white">
             <%== part("components/icon", name: icon) %>
           </span>
         </div>
+
         <div class="mt-8">
           <h3 class="text-base font-semibold leading-6 text-gray-900">
             <a href="<%= link %>" class="focus:outline-none">
@@ -150,8 +161,10 @@ cards = [
               <%= title %>
             </a>
           </h3>
+
           <p class="mt-2 text-sm text-gray-500"><%= description %></p>
         </div>
+
         <span class="pointer-events-none absolute right-6 top-6 text-gray-300 group-hover:text-gray-400">
           <%== part("components/icon", name: "hero-arrow-up-right") %>
         </span>

--- a/views/project/invoice.erb
+++ b/views/project/invoice.erb
@@ -10,8 +10,7 @@
   ]
 ) %>
 
-<%
-  footer_content = [
+<% footer_content = [
     ["Subtotal", @invoice_data.subtotal],
     (@invoice_data.discount != "$0.00") ? ["Discount", "-#{@invoice_data.discount}"] : nil,
     (@invoice_data.credit != "$0.00") ? ["Credit", "-#{@invoice_data.credit}"] : nil,
@@ -25,8 +24,7 @@
         <dd class="text-gray-500" id="invoice-#{name.downcase.tr(" ", "-")}">#{value}</dd>
       </dl>
     CONTENT
-  end.join
-%>
+  end.join %>
 
 <div class="grid gap-6">
   <div class="md:flex md:items-center md:justify-between text-2xl">
@@ -58,6 +56,5 @@
       end,
       empty_state: "No resources",
       footer: "<div class=\"px-4 py-5 sm:p-6 flex justify-end\"><div class=\"grid gap-2 text-right\">#{footer_content}</div></div>"
-    )
-  %>
+    ) %>
 </div>

--- a/views/project/show.erb
+++ b/views/project/show.erb
@@ -60,13 +60,17 @@
 
     <%== part("components/kv_data_card", data: rows) %>
   <% end %>
+
   <!-- Quota Card -->
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <div class="px-4 py-5 sm:p-6">
       <h3 class="text-base font-semibold leading-6 text-gray-900">Quotas</h3>
+
       <div class="mt-2 text-sm text-gray-500">
-        <p>If you want to increase your quota, please get in touch at
-          <a href="mailto:support@ubicloud.com" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">support@ubicloud.com</a>.</p>
+        <p>
+          If you want to increase your quota, please get in touch at
+          <a href="mailto:support@ubicloud.com" class="font-semibold leading-6 text-orange-500 hover:text-orange-700">support@ubicloud.com</a>.
+        </p>
       </div>
     </div>
 
@@ -82,8 +86,8 @@
         </div>
       <% end %>
     </div>
-
   </div>
+
   <!-- Delete Card -->
   <% if has_permission?("Project:delete", @project) %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
@@ -91,10 +95,14 @@
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
             <h3 class="text-base font-semibold leading-6 text-gray-900">Delete project</h3>
+
             <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this project. Deleted data cannot be recovered. Use it carefully.</p>
+              <p>
+                This action will permanently delete this project. Deleted data cannot be recovered. Use it carefully.
+              </p>
             </div>
           </div>
+
           <div class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
             <%== part("components/delete_button", confirmation: @project.name) %>
           </div>

--- a/views/project/tag-list.erb
+++ b/views/project/tag-list.erb
@@ -26,8 +26,8 @@ modification_allowed = has_project_permission("Project:#{@tag_type.sub(/(ect|ion
           <h3 class="text-lg font-medium leading-6 text-gray-900"><%= "Create #{@display_tag_type} Tag" %></h3>
 
           <p class="text-sm text-gray-500">
-            <% case @tag_type
-           when "subject" %>
+            <% case @tag_type %>
+            <% when "subject" %>
               Subject tags in Ubicloud are similar to roles or user groups. Instead of creating separate access control
               entries for each user, you can create a single access control entry for the subject tag, and add the
               appropriate users to the tag.

--- a/views/project/tag-list.erb
+++ b/views/project/tag-list.erb
@@ -24,6 +24,7 @@ modification_allowed = has_project_permission("Project:#{@tag_type.sub(/(ect|ion
       <% if modification_allowed %>
         <div class="px-4 py-5 sm:p-6 space-y-2">
           <h3 class="text-lg font-medium leading-6 text-gray-900"><%= "Create #{@display_tag_type} Tag" %></h3>
+
           <p class="text-sm text-gray-500">
             <% case @tag_type
            when "subject" %>
@@ -39,10 +40,8 @@ modification_allowed = has_project_permission("Project:#{@tag_type.sub(/(ect|ion
               entries for each object, you can create a single access control entry for the object tag, and add the
               appropriate objects to the tag.
             <% end %>
-            <%= @display_tag_type %>
-            tags can contain other
-            <%= @tag_type %>
-            tags, recursively, to allow for easier management.
+            <%= @display_tag_type %> tags can contain other <%= @tag_type %> tags, recursively, to allow for easier
+            management.
           </p>
 
           <% form(action: "#{@project.path}/user/access-control/tag/#{@tag_type}", method: :post) do %>
@@ -54,6 +53,7 @@ modification_allowed = has_project_permission("Project:#{@tag_type.sub(/(ect|ion
           <% end %>
         </div>
       <% end %>
+
       <% if @tags.empty? %>
         <div class="text-center py-4 px-8 lg:px-32">
           <h3 class="text-xl leading-10 font-medium mb-2"><%= "No managable #{@tag_type} tags to display" %></h3>
@@ -66,13 +66,16 @@ modification_allowed = has_project_permission("Project:#{@tag_type.sub(/(ect|ion
               <th scope="col" class="pl-3 pr-4 sm:pr-6 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
             </tr>
           </thead>
+
           <tbody class="divide-y divide-gray-200 bg-white">
             <% @tags.each do |tag| %>
               <% editable = !(@tag_type == "subject" && tag.name == "Admin") && modification_allowed %>
+
               <tr id="<%= tag.ubid %>">
                 <td class="pl-4 pr-3 sm:pl-6 py-4 whitespace-nowrap text-sm text-gray-500">
                   <%= tag.name %>
                 </td>
+
                 <td class="pl-3 pr-4 sm:pr-6 py-4 flex items-center space-x-2 justify-end">
                   <%== part(
                     "components/button",
@@ -82,6 +85,7 @@ modification_allowed = has_project_permission("Project:#{@tag_type.sub(/(ect|ion
                       id: "#{tag.ubid}-edit"
                     }
                   ) %>
+
                   <% if editable %>
                     <%== part(
                       "components/delete_button",

--- a/views/project/tag.erb
+++ b/views/project/tag.erb
@@ -38,6 +38,7 @@ current_members =
     @current_members.map { [ace_label(_2), _2.ubid] }
   end
 current_members.sort! %>
+
 <%== render("project/user-tabbar") %>
 
 <div class="space-y-1">
@@ -59,6 +60,7 @@ current_members.sort! %>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6 space-y-2">
         <h3 class="text-lg font-medium leading-6 text-gray-900"><%= "Update #{@display_tag_type} Tag" %></h3>
+
         <% form(action: path(@tag), method: :post) do %>
           <div class="grid grid-cols-12 gap-3">
             <div class="col-span-12 md:col-span-5">
@@ -79,17 +81,18 @@ current_members.sort! %>
       </div>
     </div>
   <% end %>
+
   <div>
     <% if current_members.empty? %>
       <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
-        No current members of
-        <%= @tag_type %>
-        tag.
+        No current members of <%= @tag_type %> tag.
       </div>
     <% else %>
       <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
         <div class="min-w-0 flex-1">
-          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Current Members</h3>
+          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+            Current Members
+          </h3>
         </div>
       </div>
       <% form(action: disassociate_path, method: :post) do %>
@@ -98,17 +101,20 @@ current_members.sort! %>
             <thead class="bg-gray-50">
               <tr>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Name</th>
+
                 <% if removal_allowed %>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Remove?</th>
                 <% end %>
               </tr>
             </thead>
+
             <tbody class="divide-y divide-gray-200 bg-white">
               <% current_members.each do |label, ubid| %>
                 <tr id="<%= ubid %>" class="cursor-pointer">
                   <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
                     <%= label %>
                   </td>
+
                   <% if removal_allowed %>
                     <td class="py-4 pl-3 pr-4 text-right sm:pr-6">
                       <%== part(
@@ -123,6 +129,7 @@ current_members.sort! %>
             </tbody>
           </table>
         </div>
+
         <% if removal_allowed %>
           <div class="py-4">
             <%== part("components/form/submit_button", text: "Remove Members") %>
@@ -131,11 +138,14 @@ current_members.sort! %>
       <% end %>
     <% end %>
   </div>
+
   <div>
     <% if addition_allowed && !add_groups.all? { _2.empty? } %>
       <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
         <div class="min-w-0 flex-1">
-          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">Add Members</h3>
+          <h3 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-2xl sm:tracking-tight">
+            Add Members
+          </h3>
         </div>
       </div>
       <% form(action: associate_path, method: :post) do %>
@@ -147,17 +157,21 @@ current_members.sort! %>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Add?</th>
               </tr>
             </thead>
+
             <tbody class="divide-y divide-gray-200 bg-white">
               <% add_groups.each do |name, available_to_add| %>
                 <% name = name["label"] if name.is_a?(Hash) %>
+
                 <tr>
                   <th colspan="2" class="text-left px-3 py-3.5 bg-gray-50"><%= name %></th>
                 </tr>
+
                 <% available_to_add.each do |label, ubid| %>
                   <tr id="<%= ubid %>" class="cursor-pointer">
                     <td class="whitespace-nowrap py-4 pl-5 pr-3 text-sm font-medium text-gray-900 sm:pl-7" scope="row">
                       <%= label %>
                     </td>
+
                     <td class="py-4 pl-3 pr-4 text-right sm:pr-6">
                       <%== part(
                         "components/form/checkbox",
@@ -171,6 +185,7 @@ current_members.sort! %>
             </tbody>
           </table>
         </div>
+
         <div class="py-4">
           <%== part("components/form/submit_button", text: "Add Members") %>
         </div>

--- a/views/project/user-tabbar.erb
+++ b/views/project/user-tabbar.erb
@@ -7,4 +7,5 @@
   )
 ]
 tabs.compact! %>
+
 <%== part("components/tabbar", tabs:) if tabs.length >= 2 %>

--- a/views/project/user.erb
+++ b/views/project/user.erb
@@ -5,6 +5,7 @@
 @allowed_add_tag_names = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:add").select_set(:name)
 @allowed_remove_tag_names = dataset_authorize(@project.subject_tags_dataset, "SubjectTag:remove").select_set(:name)
 @invitations = @project.invitations_dataset.order_by(:email).all %>
+
 <%== render("project/user-tabbar") %>
 
 <%== part(
@@ -23,6 +24,7 @@
         </h3>
       </div>
     </div>
+
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
       <div class="px-4 py-5 sm:p-6">
         <% form(action: user_path, method: :post) do %>
@@ -32,13 +34,16 @@
                 You can invite a new user to your project, adding them to the given subject tag (role).
               </p>
             </div>
+
             <div class="grid grid-cols-12 gap-3">
               <div class="col-span-12 sm:col-span-5">
                 <%== part("components/form/text", name: "email", type: "email", attributes: { required: true, placeholder: "Email" }) %>
               </div>
+
               <div class="col-span-12 sm:col-span-3">
                 <%== part("components/form/policy_select", name: "policy", selected: "Member", id: "invited-user-policy") %>
               </div>
+
               <div class="col-span-3 sm:col-span-2">
                 <%== part("components/form/submit_button", text: "Invite") %>
               </div>
@@ -48,14 +53,17 @@
       </div>
     </div>
   </div>
+
   <!-- User List -->
   <div>
     <% @users.each do |user| %>
       <%== form(action: "#{user_path}/#{user.ubid}/delete", method: :post, id: "delete-#{user.ubid}") %>
     <% end %>
+
     <% @invitations.each do |invitation| %>
       <%== form(action: "#{user_path}/invitation/#{invitation.email}/delete", method: :post, id: "delete-#{invitation.email}") %>
     <% end %>
+
     <% form(action: "#{user_path}/policy/managed", method: :post, id: "managed-policy") do %>
       <div class="md:flex md:items-center md:justify-between pb-1 lg:pb-2">
         <div class="min-w-0 flex-1">
@@ -64,6 +72,7 @@
           </h3>
         </div>
       </div>
+
       <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
         <table class="min-w-full divide-y divide-gray-300">
           <thead class="bg-gray-50">
@@ -73,12 +82,14 @@
               <th scope="col" class="py-3.5 pl-3 pr-4 sm:pr-6 text-left text-sm font-semibold text-gray-900"></th>
             </tr>
           </thead>
+
           <tbody class="divide-y divide-gray-200 bg-white">
             <% @users.each do |user| %>
               <tr id="user-<%= user.ubid %>">
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
                   <%= user.email %>
                 </td>
+
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                   <% if (tags = @subject_tag_map[user.id]) && tags.length >= 2 %>
                     <span title="You can manage this user's policies from the Access Control tab.">
@@ -97,6 +108,7 @@
                     ) %>
                   <% end %>
                 </td>
+
                 <td class="py-4 pl-3 pr-4 text-right sm:pr-6">
                   <%== part(
                     "components/delete_button",
@@ -108,20 +120,26 @@
                 </td>
               </tr>
             <% end %>
+
             <% @invitations.each do |invitation| %>
               <tr id="invitation-<%= invitation.email.gsub(/\W+/, "") %>">
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6" scope="row">
                   <%= invitation[:email] %>
+
                   <span
-                    class="inline-flex items-baseline rounded-full ml-1 px-2 text-xs font-semibold leading-5 bg-yellow-100 text-yellow-800"
+                    class="
+                      inline-flex items-baseline rounded-full ml-1 px-2 text-xs font-semibold leading-5
+                      bg-yellow-100 text-yellow-800
+                    "
                   >
-                    Invitation expires on
-                    <%= invitation.expires_at.strftime("%B %d, %Y") %>
+                    Invitation expires on <%= invitation.expires_at.strftime("%B %d, %Y") %>
                   </span>
                 </td>
+
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                   <%== part("components/form/policy_select", name: "invitation_policies[#{invitation.email}]", selected: invitation.policy) %>
                 </td>
+
                 <td class="py-4 pl-3 pr-4 text-right sm:pr-6">
                   <%== part(
                     "components/delete_button",
@@ -134,6 +152,7 @@
             <% end %>
           </tbody>
         </table>
+
         <div class="px-4 py-5 sm:p-6">
           <%== part("components/form/submit_button", text: "Update") %>
         </div>

--- a/views/ssh-public-key/register.erb
+++ b/views/ssh-public-key/register.erb
@@ -39,6 +39,7 @@ back = "#{@project.path}/ssh-public-key" %>
           </div>
         </div>
       </div>
+
       <div class="px-4 py-5 sm:p-6">
         <div class="flex items-center justify-end gap-x-6">
           <a href="<%= @project.path %>/ssh-public-key" class="text-sm font-semibold leading-6 text-gray-900">Cancel</a>

--- a/views/vm/create.erb
+++ b/views/vm/create.erb
@@ -7,7 +7,6 @@ current_usage = @project.current_resource_usage("VmVCpu")
 @option_tree, @option_parents = generate_vm_options
 @page_title = "Create #{"GPU " if @show_gpu}Virtual Machine" %>
 
-
 <%== render("components/billing_warning") %>
 
 <%== part(
@@ -20,8 +19,7 @@ current_usage = @project.current_resource_usage("VmVCpu")
   ]
 ) %>
 
-<%
-  ps_description = "<p class='mt-1 text-sm leading-6 text-gray-600'>We recommend using the default subnet for most use-cases. If you'd like to learn more about private subnets, please visit <a href='https://www.ubicloud.com/docs/networking/private-subnet' class='text-orange-600 hover:text-orange-700'>Private Subnets</a> page.</p>"
+<% ps_description = "<p class='mt-1 text-sm leading-6 text-gray-600'>We recommend using the default subnet for most use-cases. If you'd like to learn more about private subnets, please visit <a href='https://www.ubicloud.com/docs/networking/private-subnet' class='text-orange-600 hover:text-orange-700'>Private Subnets</a> page.</p>"
 
   form_elements = [
     {name: "name", type: "text", label: "Name", placeholder: "Enter name", required: "required", opening_tag: "<div class='sm:col-span-3'>"},
@@ -83,7 +81,6 @@ current_usage = @project.current_resource_usage("VmVCpu")
     form_elements << {name: "show_gpu", type: "hidden", value: @show_gpu}
   end
 
-  action = "#{@project.path}/vm"
-%>
+  action = "#{@project.path}/vm" %>
 
 <%== part("components/form/resource_creation_form", action:, form_elements:, option_tree: @option_tree, option_parents: @option_parents, content_generator_class: ContentGenerator::Vm) %>

--- a/views/vm/create_gpu_request_access.erb
+++ b/views/vm/create_gpu_request_access.erb
@@ -1,4 +1,3 @@
-
 <% @page_title = "Create GPU Virtual Machine" %>
 
 <%== part(
@@ -15,7 +14,6 @@
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white">
     <div class="px-4 py-5 sm:p-6">
       <div class="max-w-3xl">
-
         <% gpu_options = [
                     [
             "nvidia-rtx-pro-6000",
@@ -42,22 +40,16 @@
         </div>
 
         <div class="mt-6 text-sm text-gray-600">
-          GPU virtual machines are not enabled for this project.
-          Email
-          <a href="mailto:support@ubicloud.com"
-            class="font-medium text-orange-600 hover:text-orange-700">
-            support@ubicloud.com
-          </a>
+          GPU virtual machines are not enabled for this project. Email
+          <a href="mailto:support@ubicloud.com" class="font-medium text-orange-600 hover:text-orange-700"> support@ubicloud.com </a>
           to enable GPU VMs.
         </div>
       </div>
     </div>
+
     <div class="px-4 py-5 sm:p-6">
       <div class="flex items-center justify-end gap-x-6">
-        <a href="<%= @project.path %>/vm"
-           class="text-sm font-semibold leading-6 text-gray-900">
-          Cancel
-        </a>
+        <a href="<%= @project.path %>/vm" class="text-sm font-semibold leading-6 text-gray-900"> Cancel </a>
       </div>
     </div>
   </div>

--- a/views/vm/index.erb
+++ b/views/vm/index.erb
@@ -1,4 +1,5 @@
 <% @page_title = "Virtual Machines" %>
+
 <div class="auto-refresh hidden" data-interval="10"></div>
 
 <%== part(

--- a/views/vm/networking.erb
+++ b/views/vm/networking.erb
@@ -1,5 +1,4 @@
-<% 
-@vm.firewalls(eager: [:firewall_rules, :location])
+<% @vm.firewalls(eager: [:firewall_rules, :location])
 viewable_fws =
   dataset_authorize(@project.firewalls_dataset.where(id: @vm.firewalls.map(&:id)), "Firewall:view")
     .select_map(:id)

--- a/views/vm/settings.erb
+++ b/views/vm/settings.erb
@@ -14,6 +14,7 @@
       </h3>
     </div>
   </div>
+
   <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">
     <!-- Restart Card -->
     <% if edit_perm && @vm.location.provider_dispatcher_group_name == "metal" %>
@@ -27,13 +28,19 @@
             <% form(action: "#{path(@vm)}/#{action}", method: :post) do %>
               <div class="sm:flex sm:items-center sm:justify-between">
                 <div>
-                  <h3 class="text-base font-semibold leading-6 text-gray-900"><%= action.capitalize %>
-                    virtual machine</h3>
+                  <h3 class="text-base font-semibold leading-6 text-gray-900">
+                    <%= action.capitalize %> virtual machine
+                  </h3>
+
                   <div class="mt-2 text-sm text-gray-500">
                     <p><%= message %></p>
                   </div>
                 </div>
-                <div id="vm-<%= action %>-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
+
+                <div
+                  id="vm-<%= action %>-<%= @vm.ubid %>"
+                  class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center"
+                >
                   <div class="col-span-12 sm:col-span-2 flex justify-end items-end">
                     <%== part("components/form/submit_button", text: action.capitalize, extra_class: "#{action}-btn") %>
                   </div>
@@ -44,17 +51,22 @@
         <% end %>
       <% end %>
     <% end %>
+
     <!-- Delete Card -->
     <% if has_permission?("Vm:delete", @vm) %>
       <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-center sm:justify-between">
           <div>
             <h3 class="text-base font-semibold leading-6 text-gray-900">Delete virtual machine</h3>
+
             <div class="mt-2 text-sm text-gray-500">
-              <p>This action will permanently delete this virtual machine. Deleted data cannot be recovered. Use it
-                carefully.</p>
+              <p>
+                This action will permanently delete this virtual machine. Deleted data cannot be recovered. Use it
+                carefully.
+              </p>
             </div>
           </div>
+
           <div id="vm-delete-<%= @vm.ubid %>" class="mt-5 sm:ml-6 sm:mt-0 sm:flex sm:flex-shrink-0 sm:items-center">
             <%== part("components/delete_button", confirmation: @vm.name, url: path(@vm)) %>
           </div>


### PR DESCRIPTION
This uses only the herb formatter, not the herb linter. The herb linter needs more work before we can use it. It does find some actual problems, which I'll work to address separately.

The herb formatter inserts a lot of empty lines (for easier viewing?). The nature of this change makes most changes whitespace only. This might be best reviewed in the terminal with:`git diff --color-words --word-diff-regex='\\w+|[^[:space:]]'`