### PR TITLE
Propagate superuser password resets to read replica records

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -50,6 +50,9 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
           fail "No existing parent"
         end
 
+        # Serializes the password copy against a concurrent reset
+        parent.lock!
+
         if target_version && target_version != parent.version
           fail Validation::ValidationFailed.new({version: "Version must be the same as the parent"})
         end

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -623,6 +623,7 @@ SQL
     if !is_in_recovery
       postgres_server.switch_to_new_timeline
       decr_initial_provisioning
+      incr_update_superuser_password
       hop_configure
     end
 
@@ -652,6 +653,13 @@ SQL
 
     when_refresh_certificates_set? do
       hop_refresh_certificates
+    end
+
+    when_promote_read_replica_set? do
+      decr_promote_read_replica
+      register_deadline("wait", 10 * 60)
+      postgres_server.switch_to_new_timeline
+      hop_promote_read_replica
     end
 
     when_update_superuser_password_set? do
@@ -704,13 +712,6 @@ SQL
       decr_install_rhizome
       register_deadline("wait", 10 * 60)
       hop_install_rhizome
-    end
-
-    when_promote_read_replica_set? do
-      decr_promote_read_replica
-      register_deadline("wait", 10 * 60)
-      postgres_server.switch_to_new_timeline
-      hop_promote_read_replica
     end
 
     when_refresh_walg_credentials_set? do

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -518,6 +518,8 @@ class Clover
 
         DB.transaction do
           pg.update(superuser_password: password)
+          # Per-instance: a dataset update would bypass column encryption
+          pg.read_replicas.each { it.update(superuser_password: password) }
           pg.representative_server.incr_update_superuser_password
           audit_log(pg, "reset_superuser_password")
         end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1289,6 +1289,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(server).to receive(:_run_query).with("SELECT pg_is_in_recovery()").and_return("f")
       expect(server).to receive(:switch_to_new_timeline)
       expect { nx.wait_recovery_completion }.to hop("configure")
+      expect(Semaphore.where(strand_id: server.id, name: "update_superuser_password").count).to eq(1)
     end
   end
 
@@ -1356,6 +1357,15 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       nx.incr_configure_metrics
       expect(nx).to receive(:register_deadline).with("wait", 3 * 60)
       expect { nx.wait }.to hop("configure_metrics")
+    end
+
+    it "drains promotion before a queued password update" do
+      nx.incr_promote_read_replica
+      nx.incr_update_superuser_password
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60)
+      expect(server).to receive(:switch_to_new_timeline)
+      expect { nx.wait }.to hop("promote_read_replica")
+      expect(Semaphore.where(strand_id: server.id, name: "update_superuser_password").count).to eq(1)
     end
 
     it "hops to promote_read_replica if promote_read_replica is set" do

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -799,6 +799,45 @@ RSpec.describe Clover, "postgres" do
         expect(last_response.status).to eq(200)
       end
 
+      it "reset password also updates read replica records" do
+        replica = Prog::Postgres::PostgresResourceNexus.assemble(
+          project_id: project.id,
+          location_id: pg.location_id,
+          name: "my-replica",
+          target_vm_size: pg.target_vm_size,
+          target_storage_size_gib: pg.target_storage_size_gib,
+          parent_id: pg.id,
+        ).subject
+
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password", {
+          password: "DummyPassword123",
+        }.to_json
+
+        expect(last_response.status).to eq(200)
+        expect(pg.reload.superuser_password).to eq("DummyPassword123")
+        expect(replica.reload.superuser_password).to eq("DummyPassword123")
+      end
+
+      it "reset password does not touch promoted children" do
+        promoted = Prog::Postgres::PostgresResourceNexus.assemble(
+          project_id: project.id,
+          location_id: pg.location_id,
+          name: "my-promoted",
+          target_vm_size: pg.target_vm_size,
+          target_storage_size_gib: pg.target_storage_size_gib,
+          parent_id: pg.id,
+        ).subject
+        promoted.update(restore_target: Time.now)
+        original_password = promoted.superuser_password
+
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/reset-superuser-password", {
+          password: "DummyPassword123",
+        }.to_json
+
+        expect(last_response.status).to eq(200)
+        expect(promoted.reload.superuser_password).to eq(original_password)
+      end
+
       it "reset password invalid restore" do
         pg.update(parent_id: "cde85384-4cf1-8ad0-aeb0-639f2ad94870")
 


### PR DESCRIPTION
Fixes a customer-reported bug: after a superuser password reset, a read
replica's Connection tab and `ubi pg psql` serve the old password, while the
replica server already accepts the new one through WAL.

The reset now updates replica records in the same transaction. Promotion and
recovery completion push the recorded password onto the newly writable server,
which also fixes PITR forks and timeline restores. The `wait` label drains
promotion before the password push, so a mid-promotion reset cannot wedge the
strand. Replica assembly locks the parent row, so a concurrent reset cannot
produce a stale copy. Details are in the commit message.

Verification: `coverage_pspec` exit 0 (8002 examples), rubocop clean, two
adversarial Codex review rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)