### PR TITLE
Unload the irdma driver while preparing a host

### DIFF
--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -87,6 +87,12 @@ blacklist irdma
 CONF
 r "update-initramfs -u"
 
+# The blacklist only applies from the next boot, but SetupHugepages sizes the
+# reservation from MemAvailable before that reboot, and it would then hold the
+# driver's memory back from hugepages for the host's whole life. Unload the
+# driver now so the measurement matches the host the reservation lands on.
+r "modprobe -r irdma" if File.directory?("/sys/module/irdma")
+
 # OS images.
 
 # For qemu-image convert and mcopy for cloud-init with the nocloud


### PR DESCRIPTION
972cb2730 blacklists irdma so it stops holding gigabytes of DMA memory that VmHosts never use for RDMA, and eed23f559 clamps the hugepage count to measured MemAvailable so a platform with less usable memory than dmidecode implies cannot starve the host OS. The two interact badly: the blacklist only applies from the next boot, while SetupHugepages reads MemAvailable before that reboot, with the driver still loaded and its memory still held. The clamp then fires on memory the host is about to get back, and the reduced count is written to grub for good.

A 128 GB host at a new provider showed this as 112 hugepages instead of 120: the formula asked for 120, prep-time MemAvailable of about 116 GiB clamped it to 112, and the boot that followed had irdma blacklisted and 8 GiB spare. Reserving 120 pages on it at runtime left 4 GiB of MemAvailable, the same figure a healthy host of this class reaches.

Unload the driver right after writing the blacklist, so the measurement sees the memory the host actually runs with. The check on /sys/module keeps modprobe off hosts where the driver is absent, where it would exit non-zero and fail prep.