### PR TITLE
Allow disabling the IPv4 subnet collision check

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -123,6 +123,7 @@ module Config
   optional :git_commit_hash, string
   optional :ip_from_header, string
   optional :ubid_routing_stamp, match?(/\A[0-9a-hj-km-np-tv-z]{2}\z/)
+  optional :ipv4_subnet_collision_check_disabled, bool
 
   # GitHub Runner App
   optional :github_app_name, string

--- a/prog/vnet/subnet_nexus.rb
+++ b/prog/vnet/subnet_nexus.rb
@@ -118,7 +118,7 @@ class Prog::Vnet::SubnetNexus < Prog::Base
 
     failure_message = if PrivateSubnet::BANNED_IPV4_SUBNETS.any? { it.rel(selected_addr) }
       "Selected IPv4 subnet #{selected_addr} is banned"
-    elsif (private_subnet = project.private_subnets_dataset[net4: selected_addr.to_s, location_id: location.id])
+    elsif !Config.ipv4_subnet_collision_check_disabled && (private_subnet = project.private_subnets_dataset[net4: selected_addr.to_s, location_id: location.id])
       "Selected IPv4 subnet #{selected_addr} is already in use by #{private_subnet.ubid}"
     end
 

--- a/spec/prog/vnet/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/subnet_nexus_spec.rb
@@ -150,6 +150,28 @@ RSpec.describe Prog::Vnet::SubnetNexus do
       expect(SecureRandom).to receive(:random_number).with(2**(10 - 8) - 1).and_return(1)
       expect(described_class.random_private_ipv4(Location[name: "hetzner-fsn1"], project, 10).to_s).to eq("10.128.0.0/10")
     end
+
+    context "when ipv4_subnet_collision_check_disabled is set" do
+      before do
+        allow(Config).to receive(:ipv4_subnet_collision_check_disabled).and_return(true)
+      end
+
+      it "returns the selected subnet even if it is already taken" do
+        expect(PrivateSubnet).to receive(:random_subnet).once.and_return("10.0.0.0/8")
+        project = Project.create(name: "test-project")
+        described_class.assemble(project.id, location_id: Location::HETZNER_FSN1_ID, name: "test-subnet", ipv4_range: "10.0.0.128/26")
+        allow(SecureRandom).to receive(:random_number).with(2**(26 - 8) - 1).and_return(1)
+        expect(described_class.random_private_ipv4(Location[name: "hetzner-fsn1"], project).to_s).to eq("10.0.0.128/26")
+      end
+
+      it "still finds a new subnet if the one it found is banned" do
+        expect(PrivateSubnet).to receive(:random_subnet).and_return("172.16.0.0/16", "10.0.0.0/8")
+        project = Project.create(name: "test-project")
+        allow(SecureRandom).to receive(:random_number).with(2**(26 - 16) - 1).and_return(1)
+        allow(SecureRandom).to receive(:random_number).with(2**(26 - 8) - 1).and_return(1)
+        expect(described_class.random_private_ipv4(Location[name: "hetzner-fsn1"], project).to_s).to eq("10.0.0.128/26")
+      end
+    end
   end
 
   describe ".create_aws_subnet_records" do


### PR DESCRIPTION
Adds an optional `IPV4_SUBNET_COLLISION_CHECK_DISABLED` config that skips the "range already in use in this project and location" lookup when picking an IPv4 range for a new private subnet. The lookup is best effort anyway: no unique constraint backs it, and it runs outside the insert transaction, so concurrent creates can still collide.

The collision check also caps AWS. Each private subnet there is a separate VPC and defaults to a /16, and only `10.0.0.0/8` and `172.16.0.0/12` are wide enough to draw a /16 from, leaving 268 ranges once the banned `172.16.0.0/16`–`172.18.0.0/16` blocks are removed (`10.1.0.0/16`–`10.255.0.0/16` plus `172.19.0.0/16`–`172.31.0.0/16`). So a project cannot exceed 268 VPCs in one location, even though overlapping ranges are only a problem for peered subnets.

The banned-range check and the retry loop are untouched, and the config defaults to false, so the default behavior is unchanged.

Testing: `rspec spec/prog/vnet/subnet_nexus_spec.rb` 23 examples / 0 failures, rubocop clean. New specs cover the disabled path, including that a banned range is still rejected and retried.
