### PR TITLE
Fix pgbouncer peer socket path so cancels get forwarded

### DIFF
--- a/rhizome/postgres/lib/pg_bouncer_setup.rb
+++ b/rhizome/postgres/lib/pg_bouncer_setup.rb
@@ -71,7 +71,8 @@ PGBOUNCER_SOCKET
 
   def peer_config
     peers = (1..@num_instances.to_i).map do |i|
-      "#{i} = host=/tmp/.s.PGSQL.#{port_num(i)}"
+      # host is the socket directory, pgbouncer appends /.s.PGSQL.<port> itself.
+      "#{i} = host=/tmp port=#{port_num(i)}"
     end.join("\n")
 
     <<PGBOUNCER_PEER

--- a/rhizome/postgres/spec/pg_bouncer_setup_spec.rb
+++ b/rhizome/postgres/spec/pg_bouncer_setup_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe PgBouncerSetup do
       config = pgbouncer_setup.peer_config
 
       expect(config).to include("[peers]")
-      expect(config).to include("1 = host=/tmp/.s.PGSQL.50001")
-      expect(config).to include("2 = host=/tmp/.s.PGSQL.50002")
+      expect(config).to include("1 = host=/tmp port=50001")
+      expect(config).to include("2 = host=/tmp port=50002")
     end
   end
 


### PR DESCRIPTION
A [peers] host must be a Unix socket directory. pgbouncer appends /.s.PGSQL.<port> itself, so passing the socket file path made it connect to /tmp/.s.PGSQL.50002/.s.PGSQL.6432 and fail with ENOTDIR. Cancel requests landing on a process other than the one holding the client's session were never forwarded, so only about 1 in N took effect.