### PR TITLE
Do not stop configure when the monitoring grant fails

### DIFF
--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -188,21 +188,30 @@ r "systemctl", "enable", "--now", "io-throttle@#{v}-main.timer"
 # Reload the postmaster to apply changes
 r "pg_ctlcluster :v main reload || pg_ctlcluster :v main restart", v: v
 
-# Re-assert the privileges the control plane reads through. Both roles hold
-# them by way of PUBLIC, and a customer superuser can revoke that at any time.
-# GRANT is idempotent. A standby refuses writes, so only the primary runs it,
-# and physical replication carries pg_database to the standbys. The first
-# configure of a server precedes post-installation-script, so the database and
-# the roles may not exist yet; the statement then does nothing, and a later
-# configure applies it.
+# Re-apply the privileges that the control plane reads through. Both roles get
+# them from PUBLIC, and a customer superuser can revoke that at any time. Only
+# the primary runs this, because a standby refuses a write, and physical
+# replication carries pg_database to each standby.
+#
+# The statement writes only when a privilege is absent, and it changes a
+# failure into a warning. configure must not stop. The first configure of a
+# server runs before post-installation-script, so the database and the roles
+# can be absent. disk-full-check also makes a full primary read-only, and a
+# read-only server refuses a GRANT. The health pulse pages if the privilege
+# stays absent.
 if r("sudo -u postgres psql -t -c 'SELECT pg_catalog.pg_is_in_recovery();' 2>/dev/null || echo 't'").strip == "f"
   r "sudo", "-u", "postgres", "psql", "-v", "ON_ERROR_STOP=1", "-c", <<~SQL
     DO $$ BEGIN
       IF EXISTS (SELECT FROM pg_database WHERE datname = 'ubi_admin')
         AND EXISTS (SELECT FROM pg_roles WHERE rolname = 'ubi_monitoring')
-        AND EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgbouncer') THEN
+        AND EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgbouncer')
+        AND EXISTS (SELECT FROM pg_database d, pg_roles r
+                    WHERE d.datname = 'ubi_admin' AND r.rolname IN ('ubi_monitoring', 'pgbouncer')
+                      AND NOT pg_catalog.has_database_privilege(r.oid, d.oid, 'CONNECT')) THEN
         EXECUTE 'GRANT CONNECT ON DATABASE ubi_admin TO ubi_monitoring, pgbouncer';
       END IF;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'could not re-apply the monitoring grants: %', SQLERRM;
     END $$;
   SQL
 end


### PR DESCRIPTION
9348665f9 added a GRANT to `configure`, to repair the CONNECT privilege that a
customer superuser can revoke. The statement runs on each configure run of a
primary, and it always writes.

`disk-full-check` sets `default_transaction_read_only` on a primary that fills
its disk. A read-only server refuses a GRANT:

```
ERROR:  cannot execute GRANT in a read-only transaction
CONTEXT:  SQL statement "GRANT CONNECT ON DATABASE ubi_admin TO ubi_monitoring, pgbouncer"
```

psql then exits 3, and `configure` fails. `daemonizer2` reports Failed on each
retry, and the strand stays at the configure label. So a full disk now also
blocks every configuration change, which includes each change that could
relieve the disk.

This change makes two changes to the statement.

First, it writes only when a role does not hold CONNECT. Almost every server
holds the privilege through PUBLIC, so almost every configure run now makes no
write at all, and `datacl` keeps its default value. A read-only primary with a
healthy privilege therefore does nothing, which is the reported case.

Second, it changes a failure into a warning. A read-only primary that also lost
the privilege still cannot take the repair, but it must still accept a new
configuration. A later configure run applies the privilege after the disk
recovers, and ee8f13bbc pages while the privilege stays absent.

## Test

I ran the statement on a PostgreSQL 16 cluster in each state.

| State | Result |
| --- | --- |
| read-write, privilege present | exit 0, no write, `datacl` stays at its default |
| read-write, privilege revoked | exit 0, grants to both roles |
| read-only, privilege present (the report) | exit 0, no write |
| read-only, privilege revoked | exit 0, WARNING only |
| no `ubi_admin`, no roles (first configure) | exit 0, no write |
| `ubi_admin` only, or one role only | exit 0, no write |

The old statement fails with exit 3 in the third and the fourth state.

Full suite: 8025 examples, 0 failures, 100% line and branch coverage.
Rhizome suite: 797 examples, 0 failures, 100% line and branch coverage.
