### PR TITLE
Support GCP Cloud KMS for column encryption key

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,10 @@ group :aws_kms do
   gem "aws-sdk-kms"
 end
 
+group :gcp_kms do
+  gem "google-apis-cloudkms_v1"
+end
+
 group :aws_rds_iam do
   gem "pg-aws_rds_iam", github: "haines/pg-aws_rds_iam", ref: "fb91b9232837e350aa9c8440b7340346adae845e"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,8 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
+    google-apis-cloudkms_v1 (0.77.0)
+      google-apis-core (>= 0.15.0, < 2.a)
     google-apis-cloudresourcemanager_v3 (0.62.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-core (1.2.5)
@@ -605,6 +607,7 @@ DEPENDENCIES
   excon
   foreman
   forme
+  google-apis-cloudkms_v1
   google-apis-cloudresourcemanager_v3
   google-apis-iam_v1
   google-cloud-compute-v1 (~> 3.4)

--- a/config.rb
+++ b/config.rb
@@ -56,6 +56,7 @@ module Config
   override :clover_admin_links_to_clover, false, bool
   optional :clover_runtime_token_secret, base64, clear: true
   optional :kms_decrypt_clover_column_encryption_key_with_arn, string
+  optional :kms_decrypt_clover_column_encryption_key_with_gcp_kms_key, string
   optional :heartbeat_url, string
   optional :clover_database_root_certs, string
   override :max_health_monitor_threads, 32, int

--- a/lib/kms_key_decryptor.rb
+++ b/lib/kms_key_decryptor.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module KmsKeyDecryptor
+  def self.aws_kms(key_id, ciphertext)
+    require "aws-sdk-kms"
+    Aws::KMS::Client.new.decrypt(ciphertext_blob: ciphertext, key_id:).plaintext
+  end
+
+  def self.gcp_kms(key_id, ciphertext)
+    require "google/apis/cloudkms_v1"
+    require "googleauth"
+    kms = Google::Apis::CloudkmsV1::CloudKMSService.new
+    kms.authorization = Google::Auth.get_application_default(["https://www.googleapis.com/auth/cloudkms"])
+    kms.decrypt_crypto_key(key_id, Google::Apis::CloudkmsV1::DecryptRequest.new(ciphertext:)).plaintext
+  end
+end

--- a/model.rb
+++ b/model.rb
@@ -19,11 +19,10 @@ Sequel::Model.plugin :singular_table_names
 Sequel::Model.plugin :subclasses unless ENV["RACK_ENV"] == "development"
 Sequel::Model.plugin :column_encryption do |enc|
   key = Config.clover_column_encryption_key
-  if Config.kms_decrypt_clover_column_encryption_key_with_arn
-    require "aws-sdk-kms"
-    kms_client = Aws::KMS::Client.new
-    response = kms_client.decrypt(ciphertext_blob: key, key_id: Config.kms_decrypt_clover_column_encryption_key_with_arn)
-    key = response.plaintext
+  if (aws_kms_arn = Config.kms_decrypt_clover_column_encryption_key_with_arn)
+    key = KmsKeyDecryptor.aws_kms(aws_kms_arn, key)
+  elsif (gcp_kms_key = Config.kms_decrypt_clover_column_encryption_key_with_gcp_kms_key)
+    key = KmsKeyDecryptor.gcp_kms(gcp_kms_key, key)
   end
   enc.key 0, key
 end

--- a/spec/lib/kms_key_decryptor_spec.rb
+++ b/spec/lib/kms_key_decryptor_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+require "aws-sdk-kms"
+require "google/apis/cloudkms_v1"
+require "googleauth"
+
+RSpec.describe KmsKeyDecryptor do
+  let(:ciphertext) { "\x01\x02ciphertext-bytes".b }
+  let(:plaintext) { "\x03\x04plaintext-bytes".b }
+
+  it "decrypts via AWS KMS" do
+    key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+    client = instance_double(Aws::KMS::Client)
+    expect(Aws::KMS::Client).to receive(:new).and_return(client)
+    expect(client).to receive(:decrypt).with(ciphertext_blob: ciphertext, key_id:).and_return(instance_double(Aws::KMS::Types::DecryptResponse, plaintext:))
+    expect(described_class.aws_kms(key_id, ciphertext)).to eq(plaintext)
+  end
+
+  it "decrypts via GCP Cloud KMS" do
+    key_id = "projects/test-project/locations/us-central1/keyRings/test-ring/cryptoKeys/test-key"
+    kms = instance_double(Google::Apis::CloudkmsV1::CloudKMSService)
+    authorization = instance_double(Google::Auth::ServiceAccountCredentials)
+    expect(Google::Apis::CloudkmsV1::CloudKMSService).to receive(:new).and_return(kms)
+    expect(Google::Auth).to receive(:get_application_default).with(["https://www.googleapis.com/auth/cloudkms"]).and_return(authorization)
+    expect(kms).to receive(:authorization=).with(authorization)
+    expect(kms).to receive(:decrypt_crypto_key) do |name, request|
+      expect(name).to eq(key_id)
+      expect(request).to be_a(Google::Apis::CloudkmsV1::DecryptRequest)
+      expect(request.ciphertext).to eq(ciphertext)
+      Google::Apis::CloudkmsV1::DecryptResponse.new(plaintext:)
+    end
+    expect(described_class.gcp_kms(key_id, ciphertext)).to eq(plaintext)
+  end
+end


### PR DESCRIPTION
## Summary

Adds GCP Cloud KMS as a second way to unwrap the Clover column encryption key at boot, alongside the existing AWS KMS path. New optional config var `kms_decrypt_clover_column_encryption_key_with_gcp_kms_key` takes a Cloud KMS crypto key resource name; when set, the key is decrypted via Application Default Credentials. Deployments that do not set it are unaffected.

## Why

A control plane running on GCP has no equivalent of `kms_decrypt_clover_column_encryption_key_with_arn`, so it has to keep the column encryption key in plaintext in the environment. ClickHouse runs a GCP-hosted control plane, and this is the path it uses.

If both config vars are set, the AWS one wins. Happy to add a guard, or to fold both into the existing `..._with_arn` var and dispatch on the `arn:` vs `projects/` prefix, if you would prefer either shape.

## Test

`spec/lib/kms_key_decryptor_spec.rb` covers both branches. `rake coverage_sspec`: 8010 examples, 0 failures, branch coverage 100%.

Verified end to end against a real Cloud KMS key, not just mocks: encrypted a fresh 32-byte column key with `gcloud kms encrypt`, booted with that ciphertext plus the new config var, wrote a row with an encrypted column, then rebooted with the plaintext key and no KMS var and read the row back, with bytes matching exactly. Booting with an unrelated key fails closed with `OpenSSL::Cipher::AuthTagError`. Re-ran the same three phases under `FORCE_AUTOLOAD=1` to cover the production eager-load path.

## Rollback

Unset the config var. No migration, no schema change, no behavior change for deployments that do not use it.
