### PR TITLE
Add esn flag to receiver side

### DIFF
--- a/prog/vnet/rekey_nic_tunnel.rb
+++ b/prog/vnet/rekey_nic_tunnel.rb
@@ -109,6 +109,8 @@ class Prog::Vnet::RekeyNicTunnel < Prog::Base
       begin
         cmd = "sudo -- xargs -I {} -- ip -n :namespace xfrm state add src :src dst :dst proto esp spi :spi reqid :reqid mode tunnel aead 'rfc4106(gcm(aes))' {} 128"
 
+        cmd = NetSsh.combine(cmd, "flag esn replay-window 4096") if @args["esn"]
+
         cmd = NetSsh.combine(cmd, "sel src 0.0.0.0/0 dst 0.0.0.0/0") if is_ipv4
 
         @nic.vm.vm_host.sshable.cmd(cmd, namespace: @namespace, src:, dst:, spi:, reqid: @reqid, stdin: key)

--- a/prog/vnet/rekey_nic_tunnel.rb
+++ b/prog/vnet/rekey_nic_tunnel.rb
@@ -50,7 +50,7 @@ class Prog::Vnet::RekeyNicTunnel < Prog::Base
     end.flatten
 
     vm_name = nic.src_ipsec_tunnels.first.vm_name(nic)
-    state_data = nic.vm.vm_host.sshable.cmd("sudo ip -n :vm_name xfrm state", vm_name:)
+    state_data = nic.vm.vm_host.sshable.cmd("sudo ip -n :vm_name xfrm state", vm_name:, log: :on_error)
 
     # Extract SPIs along with src and dst from state data
     states = state_data.scan(/^src (\S+) dst (\S+).*?proto esp spi (0x[0-9a-f]+)/m)

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -84,6 +84,15 @@ RSpec.describe Prog::Vnet::RekeyNicTunnel do
       expect { nx.setup_inbound }.to exit({"msg" => "inbound_setup is complete"})
     end
 
+    it "creates states with the esn flag when the rekey payload sets esn" do
+      tunnel.src_nic.update(rekey_payload: {"reqid" => 86879, "spi4" => "0xe2222222", "spi6" => "0xe3333333", "esn" => true})
+      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo -- xargs -I {} -- ip -n hellovm xfrm state add src 2a01:4f8:10a:128b:4919:8000:: dst 2a01:4f8:10a:128b:4919:8000:: proto esp spi 0xe2222222 reqid 86879 mode tunnel aead 'rfc4106(gcm(aes))' {} 128 flag esn replay-window 4096 sel src 0.0.0.0/0 dst 0.0.0.0/0", stdin: "0x736f6d655f656e6372797074696f6e5f6b6579").and_return(true)
+      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo -- xargs -I {} -- ip -n hellovm xfrm state add src 2a01:4f8:10a:128b:4919:8000:: dst 2a01:4f8:10a:128b:4919:8000:: proto esp spi 0xe3333333 reqid 86879 mode tunnel aead 'rfc4106(gcm(aes))' {} 128 flag esn replay-window 4096", stdin: "0x736f6d655f656e6372797074696f6e5f6b6579").and_return(true)
+      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo ip -n hellovm xfrm policy show src 10.0.0.1/32 dst 10.0.0.2/32 dir fwd").and_return("not_empty")
+      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo ip -n hellovm xfrm policy show src fd10:9b0b:6b4b:8fbb:abc::/128 dst fd10:9b0b:6b4b:8fbb:def::/128 dir fwd").and_return("not_empty")
+      expect { nx.setup_inbound }.to exit({"msg" => "inbound_setup is complete"})
+    end
+
     it "skips tunnel if its src_nic doesn't have rekey_payload" do
       expect(tunnel.src_nic).to receive(:rekey_payload).and_return(nil)
       expect { nx.setup_inbound }.to exit({"msg" => "inbound_setup is complete"})

--- a/spec/prog/vnet/rekey_nic_tunnel_spec.rb
+++ b/spec/prog/vnet/rekey_nic_tunnel_spec.rb
@@ -165,7 +165,7 @@ sel src 0.0.0.0/0 dst 0.0.0.0/0"
 
     it "drops old states and pops" do
       expect(tunnel.src_nic).to receive(:dst_ipsec_tunnels).and_return([tunnel]).at_least(:once)
-      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo ip -n hellovm xfrm state").and_return(states_data)
+      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo ip -n hellovm xfrm state", log: :on_error).and_return(states_data)
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo ip -n hellovm xfrm state delete src 2a01:4f8:10a:128b:4919:: dst 2a01:4f8:10a:128b:7537:: proto esp spi 0x610a9eb5").and_return(true)
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo ip -n hellovm xfrm state delete src 2a01:4f8:10a:128b:4919:: dst 2a01:4f8:10a:128b:7537:: proto esp spi 0x059e11e6").and_return(true)
       expect { nx.drop_old_state }.to exit({"msg" => "drop_old_state is complete"})
@@ -182,7 +182,7 @@ sel src 0.0.0.0/0 dst 0.0.0.0/0"
       src_nic = instance_double(Nic, rekey_payload: nil)
       not_rekeying_nic_tun = instance_double(IpsecTunnel, src_nic:)
       expect(tunnel.src_nic).to receive(:dst_ipsec_tunnels).and_return([not_rekeying_nic_tun])
-      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo ip -n hellovm xfrm state").and_return(states_data)
+      expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo ip -n hellovm xfrm state", log: :on_error).and_return(states_data)
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo ip -n hellovm xfrm state delete src 2a01:4f8:10a:128b:4919:: dst 2a01:4f8:10a:128b:7537:: proto esp spi 0x610a9eb5").and_return(true)
       expect(tunnel.src_nic.vm.vm_host.sshable).to receive(:_cmd).with("sudo ip -n hellovm xfrm state delete src 2a01:4f8:10a:128b:4919:: dst 2a01:4f8:10a:128b:7537:: proto esp spi 0x059e11e6").and_return(true)
       expect { nx.drop_old_state }.to exit({"msg" => "drop_old_state is complete"})


### PR DESCRIPTION
**Accept an esn flag in the rekey payload**
ESP sequence numbers are 32 bits by default, so an SA that carries enough packets wraps the counter and stops being safe to use. Extended Sequence Numbers widen it to 64 bits, which an SA cannot exhaust within its lifetime.

create_xfrm_state now asks for esn when the rekey payload carries it; no payload generator sets the field yet. ESN also needs a replay window, because the kernel tracks replay through the ESN bitmap and iproute2 refuses the command when the window is 0. Ask for 4096, the largest the kernel accepts, so the anti-replay checking this turns on drops nothing that reordering delivers.

**Log the xfrm state dump only on error**
drop_old_state lists every SA in the namespace, and Sshable#cmd logs the whole output. With esn the kernel also prints the 4096-bit replay bitmap per SA, turning one listing into a few hundred lines, once per NIC per rotation.

Pass log: :on_error like other bulk commands. Failures still carry the full output, and each state delete is already logged on its own.