### PR TITLE
Gate esn on a per-project feature flag

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -283,6 +283,7 @@ class Project < Sequel::Model
     :postgres_walg_optimized_config_disabled,
     :postgres_walg_direct_io_disabled,
     :cache_proxy_download_url,
+    :ipsec_esn,
   )
 end
 

--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -109,9 +109,11 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
 
     check_nic_phases(nics, %w[idle].freeze, "freshly locked NICs should all be idle")
 
+    esn = private_subnet.project.get_ff_ipsec_esn
     nics.each do |nic|
-      nic.update(encryption_key: gen_encryption_key,
-        rekey_payload: {spi4: gen_spi, spi6: gen_spi, reqid: gen_reqid})
+      rekey_payload = {spi4: gen_spi, spi6: gen_spi, reqid: gen_reqid}
+      rekey_payload[:esn] = true if esn
+      nic.update(encryption_key: gen_encryption_key, rekey_payload:)
       private_subnet.create_tunnels(nics, nic)
     end
     Nic.incr_start_rekey(nics.map(&:id))

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -189,6 +189,13 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       expect(nic.start_rekey_set?).to be true
       expect(ps.reload.state).to eq "refreshing_keys"
     end
+
+    it "asks for esn in the rekey payload if the project has the flag set" do
+      prj.set_ff_ipsec_esn(true)
+      nic.update(state: "active")
+      expect { nx.refresh_keys }.to hop("wait_inbound_setup")
+      expect(nic.reload.rekey_payload["esn"]).to be true
+    end
   end
 
   describe "#wait_inbound_setup" do


### PR DESCRIPTION
Set esn in the generated rekey payload only when the leader subnet's project has the new ipsec_esn flag, so it reaches one mesh at a time instead of every NIC in the fleet on the next pass. The flag is read from the leader, so it covers the whole connected mesh that leader rekeys.

A rotation creates SAs under fresh SPIs, so an esn SA coexists with the old non-esn one until the outbound barrier flips senders over; rollback is a flag flip and the next rotation drops esn. On a canary, read the window from the anti-replay esn context, not from the "replay-window 0" summary line that iproute2 leaves zeroed on every esn SA.