### PR TITLE
Enable esn for all private subnets

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -306,7 +306,6 @@ class Project < Sequel::Model
     :postgres_walg_optimized_config_disabled,
     :postgres_walg_direct_io_disabled,
     :cache_proxy_download_url,
-    :ipsec_esn,
   )
 end
 

--- a/prog/vnet/metal/subnet_nexus.rb
+++ b/prog/vnet/metal/subnet_nexus.rb
@@ -109,11 +109,9 @@ class Prog::Vnet::Metal::SubnetNexus < Prog::Base
 
     check_nic_phases(nics, %w[idle].freeze, "freshly locked NICs should all be idle")
 
-    esn = private_subnet.project.get_ff_ipsec_esn
     nics.each do |nic|
-      rekey_payload = {spi4: gen_spi, spi6: gen_spi, reqid: gen_reqid}
-      rekey_payload[:esn] = true if esn
-      nic.update(encryption_key: gen_encryption_key, rekey_payload:)
+      nic.update(encryption_key: gen_encryption_key,
+        rekey_payload: {spi4: gen_spi, spi6: gen_spi, reqid: gen_reqid, esn: true})
       private_subnet.create_tunnels(nics, nic)
     end
     Nic.incr_start_rekey(nics.map(&:id))

--- a/spec/prog/vnet/metal/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/metal/subnet_nexus_spec.rb
@@ -185,16 +185,9 @@ RSpec.describe Prog::Vnet::Metal::SubnetNexus do
       nic.reload
       expect(nic.rekey_coordinator_id).to eq ps.id
       expect(nic.encryption_key).to be_a String
-      expect(nic.rekey_payload.keys).to eq ["spi4", "spi6", "reqid"]
+      expect(nic.rekey_payload.keys).to eq ["esn", "spi4", "spi6", "reqid"]
       expect(nic.start_rekey_set?).to be true
       expect(ps.reload.state).to eq "refreshing_keys"
-    end
-
-    it "asks for esn in the rekey payload if the project has the flag set" do
-      prj.set_ff_ipsec_esn(true)
-      nic.update(state: "active")
-      expect { nx.refresh_keys }.to hop("wait_inbound_setup")
-      expect(nic.reload.rekey_payload["esn"]).to be true
     end
   end
 


### PR DESCRIPTION
Put esn in every rekey payload and drop the ipsec_esn flag now that the canary has soaked. Each mesh picks esn up when it next rotates, and a NIC rekeyed by older code simply omits the field until then.