### PR TITLE
Fix nondeterministic test failures in web/routes/auth_spec.rb

### DIFF
--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -22,7 +22,12 @@ RSpec.describe Clover, "auth" do
   end
 
   def audit_log_hash
-    DB[:account_authentication_audit_log].select_hash(:message, :metadata)
+    DB[:account_authentication_audit_log]
+      .order(:metadata)
+      .select_hash_groups(:message, :metadata)
+      .transform_values do |v|
+        (v.length == 1) ? v[0] : v
+      end
   end
 
   before do
@@ -538,7 +543,7 @@ RSpec.describe Clover, "auth" do
         expect(page.title).to eq("Ubicloud - Change Password")
         expect(page).to have_flash_notice("Your password has been changed")
       end
-      expect(audit_log_hash).to eq({"change_password" => ip_hash})
+      expect(audit_log_hash).to eq({"change_password" => [ip_hash] * 3})
     end
 
     [true, false].each do |clear_last_password_entry|
@@ -793,13 +798,13 @@ RSpec.describe Clover, "auth" do
         expect(page).to have_flash_notice "One-time password authentication has been disabled"
         if clear_last_password_entry
           expect(audit_log_hash).to eq({
-            "login" => ip_hash("via" => "password"),
-            "logout" => ip_hash,
-            "otp_authentication_failure" => ip_hash,
+            "login" => [ip_hash("via" => "password")] * 2,
+            "logout" => [ip_hash] * 2,
+            "otp_authentication_failure" => [ip_hash] * 5,
             "otp_disable" => ip_hash,
             "otp_setup" => ip_hash,
-            "otp_unlock_auth_success" => ip_hash,
-            "two_factor_authentication" => ip_hash("via" => "totp"),
+            "otp_unlock_auth_success" => [ip_hash] * 3,
+            "two_factor_authentication" => [ip_hash("via" => "totp")] * 2,
           })
         else
           expect(audit_log_hash).to eq({"otp_setup" => ip_hash, "otp_disable" => ip_hash})
@@ -862,12 +867,15 @@ RSpec.describe Clover, "auth" do
           expect(audit_log_hash).to eq({
             "login" => ip_hash("via" => "password"),
             "logout" => ip_hash,
-            "webauthn_setup" => ip_hash("key_name" => "My Key 1"),
+            "webauthn_setup" => [ip_hash("key_name" => "My Key 0"), ip_hash("key_name" => "My Key 1")],
             "webauthn_remove" => ip_hash("key_name" => "My Key 1"),
             "two_factor_authentication" => ip_hash("via" => "webauthn", "key_name" => "My Key 0"),
           })
         else
-          expect(audit_log_hash).to eq({"webauthn_setup" => ip_hash("key_name" => "My Key 1"), "webauthn_remove" => ip_hash("key_name" => "My Key 1")})
+          expect(audit_log_hash).to eq({
+            "webauthn_setup" => [ip_hash("key_name" => "My Key 0"), ip_hash("key_name" => "My Key 1")],
+            "webauthn_remove" => ip_hash("key_name" => "My Key 1"),
+          })
         end
       end
     end


### PR DESCRIPTION
This fixes a set of nondeterministic test failures. Here's one example:

```
  1) Clover auth authenticated allows setting up and removing Webauthn authentication when password entry is not required
     Failure/Error: expect(audit_log_hash).to eq({"webauthn_setup" => ip_hash("key_name" => "My Key 1"), "webauthn_remove" => ip_hash("key_name" => "My Key 1")})

       expected: {"webauthn_remove" => {"ip" => "127.0.0.1", "key_name" => "My Key 1"}, "webauthn_setup" => {"ip" => "127.0.0.1", "key_name" => "My Key 1"}}
            got: {"webauthn_remove" => #<Sequel::Postgres::JSONBHash({"ip" => "127.0.0.1", "key_name" => "My Key 1"})>..."webauthn_setup" => #<Sequel::Postgres::JSONBHash({"ip" => "127.0.0.1", "key_name" => "My Key 0"})>}
     # ./spec/routes/web/auth_spec.rb:846:in 'block (4 levels) in <top (required)>'
```

The reason for this failure is there were multiple entries in the authentication audit log, and there was no order defined. Defining an order on `metadata` is enough to fix the nondeterminism, but this goes a step farther, and for every case where there are multiple entries, this checks all of the entries to make sure they are expected.