### PR TITLE
Set HTTP timeouts for the ACME client

### DIFF
--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -10,6 +10,11 @@ class Prog::Vnet::CertNexus < Prog::Base
 
   REVOKE_REASON = "cessationOfOperation"
 
+  ACME_CLIENT_OPTIONS = {
+    connection_options: {request: {open_timeout: 5, timeout: 10}.freeze}.freeze,
+    bad_nonce_retry: 3,
+  }.freeze
+
   def self.assemble(hostname, dns_zone_id, private_hostname: nil, waiting_strand_id: nil)
     unless Config.development? || DnsZone[dns_zone_id]
       fail "Given DNS zone doesn't exist with the id #{dns_zone_id}"
@@ -38,7 +43,7 @@ class Prog::Vnet::CertNexus < Prog::Base
     end
 
     account_key = OpenSSL::PKey::EC.generate("prime256v1")
-    client = Acme::Client.new(private_key: account_key, directory: Config.acme_directory)
+    client = Acme::Client.new(private_key: account_key, directory: Config.acme_directory, **ACME_CLIENT_OPTIONS)
     account = client.new_account(contact: "mailto:#{Config.acme_email}", terms_of_service_agreed: true, external_account_binding: {kid: Config.acme_eab_kid, hmac_key: Config.acme_eab_hmac_key})
     identifiers = cert.hostnames
     order = client.new_order(identifiers:)
@@ -179,7 +184,7 @@ class Prog::Vnet::CertNexus < Prog::Base
     # If the private_key is not yet set, we did not start the communication with
     # ACME server yet, therefore, we return nil.
     if cert.account_key
-      @acme_client ||= Acme::Client.new(private_key: Util.parse_key(cert.account_key), directory: Config.acme_directory, kid: cert.kid)
+      @acme_client ||= Acme::Client.new(private_key: Util.parse_key(cert.account_key), directory: Config.acme_directory, kid: cert.kid, **ACME_CLIENT_OPTIONS)
     end
   end
 

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Prog::Vnet::CertNexus do
       identifiers = [cert.hostname]
       order = setup_order(new_order: true)
       expect(OpenSSL::PKey::EC).to receive(:generate).with("prime256v1").and_return(account_key)
-      expect(Acme::Client).to receive(:new).with(private_key: account_key, directory: Config.acme_directory).and_return(client)
+      expect(Acme::Client).to receive(:new).with(private_key: account_key, directory: Config.acme_directory, **described_class::ACME_CLIENT_OPTIONS).and_return(client)
       expect(client).to receive(:new_account).with(contact: "mailto:#{Config.acme_email}", terms_of_service_agreed: true, external_account_binding: {kid: Config.acme_eab_kid, hmac_key: Config.acme_eab_hmac_key}).and_return(instance_double(Acme::Client::Resources::Account, kid: "test-kid"))
       expect(client).to receive(:new_order).with(identifiers:).and_return(order)
 
@@ -104,7 +104,7 @@ RSpec.describe Prog::Vnet::CertNexus do
       # With add_private, ACME returns two authorizations (one per domain)
       order = setup_order(new_order: true, add_private: true)
       expect(OpenSSL::PKey::EC).to receive(:generate).with("prime256v1").and_return(account_key)
-      expect(Acme::Client).to receive(:new).with(private_key: account_key, directory: Config.acme_directory).and_return(client)
+      expect(Acme::Client).to receive(:new).with(private_key: account_key, directory: Config.acme_directory, **described_class::ACME_CLIENT_OPTIONS).and_return(client)
       expect(client).to receive(:new_account).with(contact: "mailto:#{Config.acme_email}", terms_of_service_agreed: true, external_account_binding: {kid: Config.acme_eab_kid, hmac_key: Config.acme_eab_hmac_key}).and_return(instance_double(Acme::Client::Resources::Account, kid: "test-kid"))
       expect(client).to receive(:new_order).with(identifiers:).and_return(order)
 
@@ -428,7 +428,7 @@ RSpec.describe Prog::Vnet::CertNexus do
     it "returns a new acme client" do
       key = Clec::Cert.ec_key
       cert.update(account_key: key.to_der, kid: "test-kid")
-      expect(Acme::Client).to receive(:new).with(private_key: instance_of(OpenSSL::PKey::EC), directory: Config.acme_directory, kid: "test-kid").and_return("client")
+      expect(Acme::Client).to receive(:new).with(private_key: instance_of(OpenSSL::PKey::EC), directory: Config.acme_directory, kid: "test-kid", **described_class::ACME_CLIENT_OPTIONS).and_return("client")
 
       expect(nx.acme_client).to eq "client"
     end


### PR DESCRIPTION
The certificate progs talked to the ACME provider without any HTTP timeout, so a stalled connection blocked the strand thread forever. Respirate gives a strand 91 seconds (LEASE_EXPIRATION - 29) before the apoptosis thread dumps the threads and kills the process, so a single hung request took down a whole respirate process along with the work of its other strand threads. A degraded provider then produced a restart loop, because the strand was picked up again as soon as its lease expired.

Give both clients a 5 second open timeout and a 10 second read timeout. A slow provider now raises inside the strand run, which respirate handles as a normal failure and retries with backoff.

The read timeout applies per request, so the worst case for a whole run is what matters. wait_dns_validation makes about 1 + 3N requests for N identifiers: one authorizations GET, then a nonce GET and a POST for each. At 10 seconds, a fully stalled run for two identifiers ends near 70 seconds, still below the 91 second apoptosis limit. A larger value would let a bad run cross that limit again. The open timeout is lower because a connection to the provider either forms quickly or not at all.

Also set bad_nonce_retry to 3. The gem defaults it to 0, so a stale replay nonce failed the whole run even though a retry with a fresh nonce is the expected response. The retry middleware sits outside AcmeMiddleware, so it catches the error that middleware raises.