### PR TITLE
Guard GCP subnet finish_destroy against destroy semaphore floods

### DIFF
--- a/prog/vnet/gcp/subnet_nexus.rb
+++ b/prog/vnet/gcp/subnet_nexus.rb
@@ -217,7 +217,7 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
       # next entry the lookup above returns nil and we fall through to
       # the standard subnet-delete path.
       DB[:private_subnet_gcp_vpc].where(private_subnet_id: private_subnet.id).delete
-      gcp_vpc.incr_destroy
+      gcp_vpc.incr_destroy unless gcp_vpc.destroy_set?
       nap 5
     end
 
@@ -231,7 +231,7 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
 
     private_subnet.destroy
 
-    if gcp_vpc && gcp_vpc.private_subnets_dataset.empty?
+    if gcp_vpc && gcp_vpc.private_subnets_dataset.empty? && !gcp_vpc.destroy_set?
       gcp_vpc.incr_destroy
     end
 

--- a/spec/prog/vnet/gcp/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_spec.rb
@@ -772,6 +772,12 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
       expect(Semaphore.where(strand_id: gcp_vpc.id, name: "destroy").count).to eq(1)
     end
 
+    it "does not add another destroy semaphore when one is already pending (last subnet out)" do
+      gcp_vpc.incr_destroy
+      expect { nx.finish_destroy }.to exit({"msg" => "subnet destroyed"})
+      expect(Semaphore.where(strand_id: gcp_vpc.id, name: "destroy").count).to eq(1)
+    end
+
     it "loads the gcp_vpc with a FOR NO KEY UPDATE lock so concurrent teardowns serialize" do
       captured = nil
       allow(nx.private_subnet).to receive(:gcp_vpc).and_wrap_original do |original, &block|
@@ -825,6 +831,14 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         expect(DB[:private_subnet_gcp_vpc].where(private_subnet_id: ps.id).count).to eq(0)
         expect(ps.exists?).to be true
         expect(gcp_vpc.exists?).to be true
+      end
+
+      it "does not stack another destroy semaphore on re-entry while one is pending" do
+        ps
+        expect { nx.finish_destroy }.to nap(5)
+        expect { nx.finish_destroy }.to nap(5)
+
+        expect(Semaphore.where(strand_id: gcp_vpc.id, name: "destroy").count).to eq(1)
       end
 
       it "still finds the dedicated VPC via dedicated_for_subnet_id when the join row is already gone" do


### PR DESCRIPTION
## Problem

`Prog::Vnet::Gcp::SubnetNexus#finish_destroy` incrs the dedicated VPC's `destroy` semaphore on every 5s nap until the `gcp_vpc` row is deleted. Nothing consumes `destroy` semaphores while the VPC teardown is already in progress (`before_run` skips the destroy check once `destroying` is set, and the `destroy` label decrs only once on entry), so each nap inserts a new row: ~17k rows/day per strand.

In production we hit VPC teardowns that stalled for days (CRM tag LRO retries), accumulating ~200k semaphore rows per strand. When `finalize_destroy` finally popped, the exit self-reap (`semaphores_dataset.destroy`, row by row in one transaction) could not finish within the apoptosis timeout, so respirate exited with code 2, the rollback resurrected the `gcp_vpc` row (keeping the pump alive), and every partition crash-looped on the strand indefinitely.

## Fix

Only incr when no `destroy` semaphore is already pending, at both call sites (dedicated-VPC wait loop and last-subnet-out). The semaphore is a flag, not a counter, so one pending row is sufficient; steady state becomes ~2 rows per strand instead of unbounded growth. `destroy_set?(cached: false)` keeps the check an indexed exists query instead of loading the semaphores association, which matters when recovering strands that are already flooded.

A follow-up PR will make the strand exit self-reap set-based (`semaphores_dataset.delete`) so a flood from any future source cannot wedge respirate.

## Testing

- New specs reproduce the double-incr at each call site (fail with `expected: 1, got: 2` without the guard)
- Full `spec/prog/vnet/gcp/subnet_nexus_spec.rb` green (111 examples)