### PR TITLE
Fix nondeterministic admin web BillingInfo model spec

### DIFF
--- a/spec/routes/web/admin/model/billing_info_spec.rb
+++ b/spec/routes/web/admin/model/billing_info_spec.rb
@@ -21,11 +21,15 @@ RSpec.describe CloverAdmin, "BillingInfo" do
   end
 
   it "paginates the browse page" do
-    oldest = Array.new(25) { |i| BillingInfo.create(stripe_id: "cus_test#{i}", created_at: Time.now - i - 1) }.last
+    oldest_ubid = Array.new(25) do |i|
+      ubid = BillingInfo.generate_ubid
+      BillingInfo.insert(id: ubid.to_uuid, stripe_id: "cus_test#{i}", created_at: Sequel::CURRENT_TIMESTAMP - Sequel.cast("#{i + 1} minutes", :interval))
+      ubid.to_s
+    end.last
     click_link "BillingInfo"
     click_link "Next"
     expect(page.status_code).to eq 200
     expect(page.title).to eq "Ubicloud Admin - BillingInfo - Browse"
-    expect(page).to have_content oldest.ubid
+    expect(page).to have_content oldest_ubid
   end
 end


### PR DESCRIPTION
I ran into this nondeterministic spec failure:

```
  1) CloverAdmin BillingInfo paginates the browse page
     Failure/Error: expect(page).to have_content oldest.ubid
       expected `#<Capybara::Session>.has_content?("b1d23asjtrnj1jejvmfrgdzfx3")` to be truthy, got false
     # ./spec/routes/web/admin/model/billing_info_spec.rb:29:in 'block (2 levels) in <top (required)>'
```

I guess on an overloaded system, the transaction time and Time.now can become far enough distant that the initial row's subtraction of 1 second is not enough to cover the distance.  Switch to using a dataset insert based on CURRENT_TIMESTAMP, and subtract minutes instead of seconds to be extra sure.