### PR TITLE
Remove pattern from project name in openapi.yml

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -4139,7 +4139,6 @@ components:
           description: Name of the project
           type: string
           example: my-project
-          pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$
       additionalProperties: false
       required:
         - credit


### PR DESCRIPTION
We have projects with names that don't match this from before the time we started enforcing the pattern. Unless and until we change all of those projects to match this pattern, we should remove it.

Fixes a production exception.