### PR TITLE
Do not raise when destroying a firewall if it was already destroyed

### DIFF
--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -54,6 +54,8 @@ class Clover
         end
 
         DB.transaction do
+          # Ignore case where firewall was already destroyed
+          firewall.require_modification = false
           firewall.destroy
           audit_log(firewall, "destroy")
         end


### PR DESCRIPTION
Fixes about 10 production exceptions in the last week.