### PR TITLE
 Lower page severity when a customer-image VM isn't sshable in time

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -28,6 +28,28 @@ class Project < Sequel::Model
 
   RESOURCE_ASSOCIATIONS = %i[vms minio_clusters private_subnets postgres_resources firewalls load_balancers kubernetes_clusters github_runners github_installations]
 
+  SERVICE_PROJECT_ID_CONFIGS = %i[
+    dns_service_project_id
+    github_runner_service_project_id
+    inference_endpoint_service_project_id
+    kubernetes_service_project_id
+    load_balancer_service_project_id
+    machine_images_service_project_id
+    minio_service_project_id
+    monitoring_service_project_id
+    parseable_service_project_id
+    postgres_service_project_id
+    victoria_metrics_service_project_id
+  ].freeze
+
+  def self.service_project_ids
+    SERVICE_PROJECT_ID_CONFIGS.filter_map { Config.send(it) }
+  end
+
+  def service_project?
+    self.class.service_project_ids.include?(id)
+  end
+
   # Only used for #has_resources?, which is only used for project deletion,
   # and we allow deleting projects with github installations, since
   # Project#soft_delete removes the github installation.

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -205,6 +205,7 @@ SQL
       top_frame.delete("deadline_target")
       top_frame.delete("deadline_at")
       top_frame.delete("deadline_start")
+      top_frame.delete("deadline_severity")
       top_frame.delete("deadline_notified")
 
       modified!(:stack)
@@ -230,7 +231,7 @@ SQL
           {}
         end
         extra_data.compact!
-        Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{effective_prog}.#{label} did not reach #{frame["deadline_target"]} on time", ["Deadline", id, effective_prog, frame["deadline_target"]], ubid, extra_data:)
+        Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{effective_prog}.#{label} did not reach #{frame["deadline_target"]} on time", ["Deadline", id, effective_prog, frame["deadline_target"]], ubid, severity: frame["deadline_severity"] || "error", extra_data:)
         frame["deadline_notified"] = true
         modified!(:stack)
       end

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -38,7 +38,7 @@ class Prog::Base
   end
 
   frame_reader :link
-  frame_accessor :deadline_at, :deadline_target, :deadline_start
+  frame_accessor :deadline_at, :deadline_target, :deadline_start, :deadline_severity
 
   # Searches the stack for the Prog that caused execution of the code,
   # which can be useful in logging from nested method calls.
@@ -398,7 +398,7 @@ end
     strand.time_string(time)
   end
 
-  def register_deadline(new_deadline_target, deadline_in, allow_extension: false)
+  def register_deadline(new_deadline_target, deadline_in, allow_extension: false, severity: "error")
     time = Time.now
     new_deadline = time + deadline_in
 
@@ -410,6 +410,7 @@ end
       resolve_deadline_target(deadline_target) if deadline_target != new_deadline_target
 
       self.deadline_target = new_deadline_target
+      self.deadline_severity = severity
 
       if allow_extension.is_a?(Integer)
         self.deadline_start ||= time_string(time)
@@ -423,7 +424,7 @@ end
 
   def unregister_deadline(deadline_target)
     resolve_deadline_target(deadline_target)
-    delete_from_stack("deadline_at", "deadline_target", "deadline_start")
+    delete_from_stack("deadline_at", "deadline_target", "deadline_start", "deadline_severity")
   end
 
   def resolve_deadline_target(deadline_target)

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -163,6 +163,11 @@ class Prog::Test < Prog::Base
     hop_pusher1
   end
 
+  label def set_expired_warning_deadline
+    register_deadline("pusher2", -1, severity: "warning")
+    hop_pusher1
+  end
+
   label def extend_deadline
     register_deadline("pusher2", 1, allow_extension: true)
     hop_pusher1

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -33,6 +33,12 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     strand.save_changes
   end
 
+  def wait_deadline_severity
+    miv_id = vm.vm_storage_volumes_dataset.where(boot: true).get(:machine_image_version_id)
+    customer_machine_image = miv_id && !MachineImageVersion[miv_id].machine_image.project.service_project?
+    customer_machine_image ? "warning" : "error"
+  end
+
   def before_destroy
     register_deadline(nil, 5 * 60)
     vm.active_billing_records.each(&:finalize)
@@ -118,7 +124,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       page.incr_resolve
     end
 
-    register_deadline("wait", 10 * 60)
+    register_deadline("wait", 10 * 60, severity: wait_deadline_severity)
 
     # We don't need storage_volume info anymore, so delete it before
     # transitioning to the next state.

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -287,4 +287,16 @@ RSpec.describe Project do
   it "defaults gcp_dedicated_subnet_vpcs to false for new projects" do
     expect(project.gcp_dedicated_subnet_vpcs).to be false
   end
+
+  describe "#service_project?" do
+    it "is true when the project is any configured service project" do
+      p = described_class.create(name: "svc")
+      allow(Config).to receive(:kubernetes_service_project_id).and_return(p.id)
+      expect(p.service_project?).to be true
+    end
+
+    it "is false for a regular customer project" do
+      expect(described_class.create(name: "customer").service_project?).to be false
+    end
+  end
 end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -430,12 +430,10 @@ RSpec.describe Prog::Base do
       st.stack.first["deadline_target"] = "napper"
       st.stack.first["deadline_at"] = st.time_string(Time.now - 1)
 
-      expect(st.stack.first).to receive(:delete).with("deadline_target")
-      expect(st.stack.first).to receive(:delete).with("deadline_at")
-      expect(st.stack.first).to receive(:delete).with("deadline_start")
-      expect(st.stack.first).to receive(:delete).with("deadline_notified")
-
       st.unsynchronized_run
+
+      deadline_keys = %w[deadline_target deadline_at deadline_start deadline_notified]
+      expect(st.stack.first.keys & deadline_keys).to be_empty
     end
 
     it "can create pages for progs that are not on the top of the stack" do

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -339,6 +339,19 @@ RSpec.describe Prog::Base do
       }.not_to change { Page.active.count }.from(1)
     end
 
+    it "records the deadline severity in the frame" do
+      st = Strand.create(prog: "Test", label: :set_expired_warning_deadline)
+      st.unsynchronized_run
+      expect(st.stack.first["deadline_severity"]).to eq("warning")
+    end
+
+    it "triggers the deadline page at the registered severity" do
+      st = Strand.create(prog: "Test", label: :set_expired_warning_deadline)
+      st.unsynchronized_run
+      st.unsynchronized_run
+      expect(Page.active.first.severity).to eq("warning")
+    end
+
     it "automatically shortens nap if there is an unnotified deadline before it" do
       t = Time.now + 10
       st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => t.to_s, "deadline_target" => "foo"}])
@@ -432,7 +445,7 @@ RSpec.describe Prog::Base do
 
       st.unsynchronized_run
 
-      deadline_keys = %w[deadline_target deadline_at deadline_start deadline_notified]
+      deadline_keys = %w[deadline_target deadline_at deadline_start deadline_severity deadline_notified]
       expect(st.stack.first.keys & deadline_keys).to be_empty
     end
 

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -944,6 +944,27 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     end
   end
 
+  describe "#wait_deadline_severity" do
+    it "is warning when the boot volume's machine image belongs to a customer project" do
+      metal = create_machine_image_version_metal
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0, machine_image_version_id: metal.id)
+      expect(nx.wait_deadline_severity).to eq("warning")
+    end
+
+    it "is error when the boot volume's machine image belongs to a service project" do
+      service_project = Project.create(name: "base-mi")
+      allow(Config).to receive(:machine_images_service_project_id).and_return(service_project.id)
+      metal = create_machine_image_version_metal(project_id: service_project.id)
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0, machine_image_version_id: metal.id)
+      expect(nx.wait_deadline_severity).to eq("error")
+    end
+
+    it "is error when the boot volume has no machine image" do
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0)
+      expect(nx.wait_deadline_severity).to eq("error")
+    end
+  end
+
   describe "#wait_sshable" do
     it "naps 6 seconds if it's the first time we execute wait_sshable" do
       expect { nx.wait_sshable }.to nap(6)


### PR DESCRIPTION
### Assert deadline frame contents instead of delete calls
The test asserted that delete was called for each deadline key rather than that the keys were actually gone from the frame. Assert the resulting frame state instead, so a later commit can extend it by listing one more key.

### Support a severity for register_deadline

The page raised when a deadline expires was always "error". Add a severity argument to register_deadline so a prog can request a lower-priority page for deadlines whose expiry is not necessarily an infrastructure problem.

The severity is stored on the frame (only when it differs from the default "error", to keep frames unchanged for existing callers) and used when the deadline page is created. unregister_deadline clears it along with the other deadline fields.


### Add Project#service_project? 

Identifies internal service projects (the projects that own base machine images, Kubernetes control planes, monitoring, etc.) as opposed to customer projects, by checking the project id against the configured *_service_project_id values.

###  Lower page severity when a customer-image VM isn't sshable in time 

When a metal VM fails to provision (reach the sshable state) before its deadline, we page. For a VM booting from a customer-provided machine image (UMI), that can be because of how the customer configured the image, which the operator can't do anything about since we don't have access to what the image contains. We only investigate further if the customer emails us about it.

Register the provisioning deadline at "warning" instead of "error" for such VMs, using the severity argument added to register_deadline. Base images and every other VM are unchanged.

Once the serial log feature is merged we'll point customers to it in the docs so they can inspect their image themselves before contacting us.