### PR TITLE
Remove Brakeman from the Gemfile and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Run rubocop
         run: bundle exec rake linter:rubocop
 
-      - name: Run brakeman
-        run: bundle exec rake linter:brakeman
-
       - name: Run linter:openapi
         run: bundle exec rake linter:openapi
 

--- a/Gemfile
+++ b/Gemfile
@@ -100,10 +100,6 @@ group :rubocop do
   gem "standard", ">= 1.24.3"
 end
 
-group :lint do
-  gem "brakeman"
-end
-
 group :test do
   gem "capybara"
   gem "capybara-validate_html5", ">= 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,8 +76,6 @@ GEM
     bcrypt_pbkdf (1.1.2)
     bigdecimal (3.3.1)
     bindata (2.5.1)
-    brakeman (8.0.5)
-      racc
     by (1.1.0)
     byebug (13.0.0)
       reline (>= 0.6.0)
@@ -586,7 +584,6 @@ DEPENDENCIES
   aws-sdk-kms
   aws-sdk-s3
   bcrypt_pbkdf
-  brakeman
   by (>= 1.1.0)
   capybara
   capybara-validate_html5 (>= 2.1)

--- a/Rakefile
+++ b/Rakefile
@@ -408,13 +408,13 @@ namespace :linter do
     sh "BUNDLE_WITH=rubocop bundle exec rubocop"
   end
 
-  desc "Run Brakeman"
+  desc "Run Brakeman (requires: gem install brakeman)"
   task :brakeman do
     require "bundler"
-    Bundler.setup(:lint)
-    puts "Running Brakeman..."
-    require "brakeman"
-    Brakeman.run app_path: ".", quiet: true, force_scan: true, print_report: true, run_all_checks: true
+    # Brakeman is not in the Gemfile, so run it outside the bundle.
+    Bundler.with_unbundled_env do
+      sh "brakeman --quiet --force-scan --run-all-checks --no-exit-on-warn"
+    end
   end
 
   desc "Run Herb linter and formatter"
@@ -541,4 +541,4 @@ namespace :linter do
 end
 
 desc "Run all linters"
-task linter: ["rubocop", "brakeman", "erb_formatter", "openapi", "go", "xss_check", "cmd_exec"].map { "linter:#{it}" }
+task linter: ["rubocop", "erb_formatter", "openapi", "go", "xss_check", "cmd_exec"].map { "linter:#{it}" }


### PR DESCRIPTION
Running Brakeman in CI does not help.  The rake task ignored the result of
Brakeman.run and printed a report, so the step passed regardless of what
Brakeman found.

This removes Brakeman from the Gemfile and from CI.  It was the only gem in
the lint group, so the group is removed as well.  That keeps it out of the
container image, and out of the bundle in a checkout.

The rake task is kept, and now runs the brakeman command outside the bundle.
bundle exec exports RUBYOPT, so a gem installed Brakeman would otherwise
load the bundle and fail to find itself in the Gemfile.  Running the task
locally requires gem install brakeman.

The command passes --no-exit-on-warn, because Brakeman exits non-zero when
it finds warnings by default, and it does find some in this repository.
Without the option the task would start failing, and the intent is to keep
printing a report.  Brakeman is also no longer part of the linter task, as
the gem is not guaranteed to be installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)