### PR TITLE
Update postgres images to 20260819.1.0

### DIFF
--- a/migrate/20260819_update_pg_amis.rb
+++ b/migrate/20260819_update_pg_amis.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  ami_ids = [
+    ["us-west-2", "x64", "ami-0cbace51caabec97a", "ami-010d53641c2b9287f"],
+    ["us-east-1", "x64", "ami-04a7a887f111b1f0f", "ami-0bd811e319dc2ce2b"],
+    ["us-east-2", "x64", "ami-06a192dfd1dc56729", "ami-0230a90cc05e8f698"],
+    ["eu-west-1", "x64", "ami-0a51fcd2701a000e7", "ami-0f603cb43d36474a1"],
+    ["ap-southeast-2", "x64", "ami-0b01616cb86235e89", "ami-0731d3f2300f73606"],
+    ["us-west-2", "arm64", "ami-03b31c4be58330dee", "ami-06d37081edad11ea9"],
+    ["us-east-1", "arm64", "ami-01ebe8b84117a11d5", "ami-0de73865a0fc5c394"],
+    ["us-east-2", "arm64", "ami-0a54050720be6dae5", "ami-0003652cecea35f39"],
+    ["eu-west-1", "arm64", "ami-0079ed1fa774ef229", "ami-0fd7bfa51c7be900d"],
+    ["ap-southeast-2", "arm64", "ami-0725176a44c8385af", "ami-0df89d755109831aa"],
+  ]
+
+  up do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: old_ami)
+        .update(aws_ami_id: new_ami)
+    end
+  end
+
+  down do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: new_ami)
+        .update(aws_ami_id: old_ami)
+    end
+  end
+end

--- a/migrate/20260819_update_pg_gce_images.rb
+++ b/migrate/20260819_update_pg_gce_images.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    from(:pg_gce_image)
+      .where(gcp_project_id: "", arch: "x64")
+      .update(gce_image_name: "postgres-ubuntu-2204-x64-20260819-1-0")
+    from(:pg_gce_image)
+      .where(gcp_project_id: "", arch: "arm64")
+      .update(gce_image_name: "postgres-ubuntu-2204-arm64-20260819-1-0")
+  end
+
+  down do
+    raise Sequel::Error, "irreversible: previous GCE image names unknown"
+  end
+end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -186,7 +186,7 @@ class Prog::DownloadBootImage < Prog::Base
     },
     "postgres-ubuntu-2204" => {
       "x64" => {
-        "20260812.1.0" => "5e63c883d314618044f27e4f977984950ef00bb29899ea35486b79892d02e63b",
+        "20260819.1.0" => "4fc6419010368cf226c66ec1efadef6f731599a5e68d4ccaf3d6e3c09ab2b916",
       },
     },
     "postgres16-lantern-ubuntu-2204" => {


### PR DESCRIPTION
## Summary
- Updates boot image version and SHA256 hashes in `prog/download_boot_image.rb`
- Adds migration to update AWS AMI IDs in `pg_aws_ami` table
- Adds migration to update GCE image names in `pg_gce_image` table (if GCE images built)

## Image Version
`20260819.1.0`

## Changes
- x64 SHA256: `4fc6419010368cf226c66ec1efadef6f731599a5e68d4ccaf3d6e3c09ab2b916`
- arm64 SHA256: `0ce7de345ac7e129d82c0eefe8c2a06396769064f4138c6c9ad7017ac6f87469`
- GCE x64: `postgres-ubuntu-2204-x64-20260819-1-0`
- GCE arm64: `postgres-ubuntu-2204-arm64-20260819-1-0`
- GCE project: ``

🤖 Generated by [postgres-vm-images](https://github.com/ubicloud/postgres-vm-images) workflow