### PR TITLE
Log instead of paging when a customer-image VM isn't sshable in time

### DIFF
--- a/model/project.rb
+++ b/model/project.rb
@@ -28,6 +28,27 @@ class Project < Sequel::Model
 
   RESOURCE_ASSOCIATIONS = %i[vms minio_clusters private_subnets postgres_resources firewalls load_balancers kubernetes_clusters github_runners github_installations]
 
+  SERVICE_PROJECT_ID_CONFIGS = %i[
+    dns_service_project_id
+    github_runner_service_project_id
+    inference_endpoint_service_project_id
+    kubernetes_service_project_id
+    load_balancer_service_project_id
+    machine_images_service_project_id
+    minio_service_project_id
+    monitoring_service_project_id
+    parseable_service_project_id
+    postgres_service_project_id
+    victoria_metrics_service_project_id
+  ].freeze
+
+  def self.service_project?(id)
+    SERVICE_PROJECT_ID_CONFIGS.any? do
+      sp_id = Config.send(it)
+      sp_id && sp_id == id
+    end
+  end
+
   # Only used for #has_resources?, which is only used for project deletion,
   # and we allow deleting projects with github installations, since
   # Project#soft_delete removes the github installation.

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -205,6 +205,7 @@ SQL
       top_frame.delete("deadline_target")
       top_frame.delete("deadline_at")
       top_frame.delete("deadline_start")
+      top_frame.delete("deadline_page")
       top_frame.delete("deadline_notified")
 
       modified!(:stack)
@@ -230,7 +231,12 @@ SQL
           {}
         end
         extra_data.compact!
-        Prog::PageNexus.assemble("#{ubid} has an expired deadline! #{effective_prog}.#{label} did not reach #{frame["deadline_target"]} on time", ["Deadline", id, effective_prog, frame["deadline_target"]], ubid, extra_data:)
+        summary = "#{ubid} has an expired deadline! #{effective_prog}.#{label} did not reach #{frame["deadline_target"]} on time"
+        if frame["deadline_page"] == false
+          Clog.emit(summary, {expired_deadline: {strand: ubid, prog: effective_prog, label:, deadline_target: frame["deadline_target"]}.merge(extra_data)})
+        else
+          Prog::PageNexus.assemble(summary, ["Deadline", id, effective_prog, frame["deadline_target"]], ubid, extra_data:)
+        end
         frame["deadline_notified"] = true
         modified!(:stack)
       end

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -38,7 +38,7 @@ class Prog::Base
   end
 
   frame_reader :link
-  frame_accessor :deadline_at, :deadline_target, :deadline_start
+  frame_accessor :deadline_at, :deadline_target, :deadline_start, :deadline_page
 
   # Searches the stack for the Prog that caused execution of the code,
   # which can be useful in logging from nested method calls.
@@ -398,7 +398,7 @@ end
     strand.time_string(time)
   end
 
-  def register_deadline(new_deadline_target, deadline_in, allow_extension: false)
+  def register_deadline(new_deadline_target, deadline_in, allow_extension: false, page: true)
     time = Time.now
     new_deadline = time + deadline_in
 
@@ -410,6 +410,7 @@ end
       resolve_deadline_target(deadline_target) if deadline_target != new_deadline_target
 
       self.deadline_target = new_deadline_target
+      self.deadline_page = page
 
       if allow_extension.is_a?(Integer)
         self.deadline_start ||= time_string(time)
@@ -423,7 +424,7 @@ end
 
   def unregister_deadline(deadline_target)
     resolve_deadline_target(deadline_target)
-    delete_from_stack("deadline_at", "deadline_target", "deadline_start")
+    delete_from_stack("deadline_at", "deadline_target", "deadline_start", "deadline_page")
   end
 
   def resolve_deadline_target(deadline_target)

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -163,6 +163,11 @@ class Prog::Test < Prog::Base
     hop_pusher1
   end
 
+  label def set_expired_no_page_deadline
+    register_deadline("pusher2", -1, page: false)
+    hop_pusher1
+  end
+
   label def extend_deadline
     register_deadline("pusher2", 1, allow_extension: true)
     hop_pusher1

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -33,6 +33,14 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     strand.save_changes
   end
 
+  def boots_from_customer_machine_image?
+    project_id = vm.vm_storage_volumes_dataset
+      .where(boot: true)
+      .association_join(machine_image_version: :machine_image)
+      .get(Sequel[:machine_image][:project_id])
+    !!project_id && !Project.service_project?(project_id)
+  end
+
   def before_destroy
     register_deadline(nil, 5 * 60)
     vm.active_billing_records.each(&:finalize)
@@ -118,7 +126,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       page.incr_resolve
     end
 
-    register_deadline("wait", 10 * 60)
+    register_deadline("wait", 10 * 60, page: !boots_from_customer_machine_image?)
 
     # We don't need storage_volume info anymore, so delete it before
     # transitioning to the next state.

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -287,4 +287,17 @@ RSpec.describe Project do
   it "defaults gcp_dedicated_subnet_vpcs to false for new projects" do
     expect(project.gcp_dedicated_subnet_vpcs).to be false
   end
+
+  describe ".service_project?" do
+    it "is true for the id of any configured service project" do
+      p = described_class.create(name: "svc")
+      allow(Config).to receive(:kubernetes_service_project_id).and_return(p.id)
+      expect(described_class.service_project?(p.id)).to be true
+    end
+
+    it "is false for a regular customer project" do
+      p = described_class.create(name: "customer")
+      expect(described_class.service_project?(p.id)).to be false
+    end
+  end
 end

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -339,6 +339,41 @@ RSpec.describe Prog::Base do
       }.not_to change { Page.active.count }.from(1)
     end
 
+    it "records whether the deadline should page in the frame" do
+      st = Strand.create(prog: "Test", label: :set_expired_no_page_deadline)
+      st.unsynchronized_run
+      expect(st.stack.first["deadline_page"]).to be false
+    end
+
+    it "logs the expired deadline instead of paging when the deadline opts out" do
+      st = Strand.create(prog: "Test", label: :set_expired_no_page_deadline)
+      st.unsynchronized_run
+
+      allow(Clog).to receive(:emit)
+      expect(Prog::PageNexus).not_to receive(:assemble)
+      expect {
+        st.unsynchronized_run
+      }.not_to change { Page.active.count }.from(0)
+
+      expect(Clog).to have_received(:emit).with(
+        "#{st.ubid} has an expired deadline! Test.pusher1 did not reach pusher2 on time",
+        {expired_deadline: {strand: st.ubid, prog: "Test", label: "pusher1", deadline_target: "pusher2"}},
+      )
+      expect(st.stack.last["deadline_notified"]).to be true
+    end
+
+    it "emits the log only once across repeated runs" do
+      st = Strand.create(prog: "Test", label: :set_expired_no_page_deadline)
+
+      allow(Clog).to receive(:emit)
+      3.times { st.unsynchronized_run }
+
+      expect(Clog).to have_received(:emit).with(
+        "#{st.ubid} has an expired deadline! Test.pusher1 did not reach pusher2 on time",
+        {expired_deadline: {strand: st.ubid, prog: "Test", label: "pusher1", deadline_target: "pusher2"}},
+      ).once
+    end
+
     it "automatically shortens nap if there is an unnotified deadline before it" do
       t = Time.now + 10
       st = Strand.create(prog: "Test", label: :napper, stack: [{"deadline_at" => t.to_s, "deadline_target" => "foo"}])
@@ -433,6 +468,7 @@ RSpec.describe Prog::Base do
       expect(st.stack.first).to receive(:delete).with("deadline_target")
       expect(st.stack.first).to receive(:delete).with("deadline_at")
       expect(st.stack.first).to receive(:delete).with("deadline_start")
+      expect(st.stack.first).to receive(:delete).with("deadline_page")
       expect(st.stack.first).to receive(:delete).with("deadline_notified")
 
       st.unsynchronized_run

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -517,9 +517,28 @@ RSpec.describe Prog::Vm::Metal::Nexus do
         "boot" => true,
       }]
     }
+    let(:service_project) { Project.create(name: "machine-images") }
 
     before do
       st.stack = [{"storage_volumes" => storage_volumes}]
+      allow(Config).to receive(:machine_images_service_project_id).and_return(service_project.id)
+    end
+
+    def make_allocatable_host(**args)
+      args = {total_cpus: 96, total_cores: 48, used_cores: 2, total_hugepages_1g: 375, used_hugepages_1g: 16, location_id: Location::HETZNER_FSN1_ID, arch: "x64", family: "standard"}.merge(args)
+      vmh = create_vm_host(**args)
+      BootImage.create(name: "ubuntu-jammy", version: "20220202", vm_host_id: vmh.id, activated_at: Time.now, size_gib: 3)
+      StorageDevice.create(vm_host_id: vmh.id, name: "stor1", available_storage_gib: 100, total_storage_gib: 100)
+      create_vhost_block_backend(vm_host_id: vmh.id, version: "v0.4.1", allocation_weight: 100)
+      vmh
+    end
+
+    def provision_boot_volume(metal: nil)
+      make_allocatable_host
+      volume = {size_gib: 11, boot: true, use_bdev_ubi: false, encrypted: false, vring_workers: 1}
+      volume[:machine_image_version_id] = metal.id if metal
+      vm.create_storage_volumes([volume])
+      st.stack = [{"storage_volumes" => [volume].map { it.transform_keys(&:to_s) }}]
     end
 
     it "creates a page if no capacity left and naps" do
@@ -633,6 +652,30 @@ RSpec.describe Prog::Vm::Metal::Nexus do
         family_filter: ["standard"],
       )
       expect { nx.start }.to hop("create_unix_user")
+    end
+
+    it "registers the wait deadline with page: false for a customer machine image vm" do
+      metal = create_machine_image_version_metal
+      expect(metal.machine_image_version.machine_image.project_id).not_to eq(service_project.id)
+      provision_boot_volume(metal:)
+
+      expect { nx.start }.to hop("create_unix_user")
+      expect(st.stack.first["deadline_page"]).to be false
+    end
+
+    it "registers the wait deadline with page: true for a base image vm" do
+      metal = create_machine_image_version_metal(project_id: service_project.id)
+      provision_boot_volume(metal:)
+
+      expect { nx.start }.to hop("create_unix_user")
+      expect(st.stack.first["deadline_page"]).to be true
+    end
+
+    it "registers the wait deadline with page: true when the vm does not boot from a machine image" do
+      provision_boot_volume
+
+      expect { nx.start }.to hop("create_unix_user")
+      expect(st.stack.first["deadline_page"]).to be true
     end
 
     it "considers EU locations for github-runners" do
@@ -941,6 +984,27 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     it "removes storage volume info" do
       st.update(stack: [{"storage_volumes" => [{"size_gib" => 11}]}])
       expect { nx.clear_stack_storage_volumes }.to change { st.reload.stack.first["storage_volumes"] }.from([{"size_gib" => 11}]).to(nil)
+    end
+  end
+
+  describe "#boots_from_customer_machine_image?" do
+    it "is true when the boot volume's machine image belongs to a customer project" do
+      metal = create_machine_image_version_metal
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0, machine_image_version_id: metal.id)
+      expect(nx.boots_from_customer_machine_image?).to be(true)
+    end
+
+    it "is false when the boot volume's machine image belongs to a service project" do
+      service_project = Project.create(name: "base-mi")
+      allow(Config).to receive(:machine_images_service_project_id).and_return(service_project.id)
+      metal = create_machine_image_version_metal(project_id: service_project.id)
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0, machine_image_version_id: metal.id)
+      expect(nx.boots_from_customer_machine_image?).to be(false)
+    end
+
+    it "is false when the boot volume has no machine image" do
+      VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0)
+      expect(nx.boots_from_customer_machine_image?).to be(false)
     end
   end
 


### PR DESCRIPTION
### Support suppressing the deadline page with register_deadline 

Add a page: keyword to register_deadline (default true). When it is false, an expired deadline is logged via Clog.emit instead of paging, for deadlines whose expiry is not necessarily an infrastructure problem. The flag is stored on the frame and cleared along with the other deadline fields, and the log, like the page, fires only once.

### Add Project.service_project? 

Add a frozen list of the *_service_project_id configs and a Project.service_project?(id) predicate that checks whether a project id is one of the internal service projects (as opposed to a customer project).

### Log instead of paging when a customer-image VM isn't sshable in time 

When a metal VM fails to provision (reach the sshable state) before its deadline, we page. For a VM booting from a customer-provided machine image (UMI), that can be because of how the customer configured the image, which the operator can't do anything about since we don't have access to what the image contains. We only investigate further if the customer emails us about it.

Register the provisioning deadline with page: false for such VMs, so an expiry is logged via Clog.emit instead of paging. Base images and every other VM are unchanged.

Once the serial log feature is merged we'll point customers to it in the docs so they can inspect their image themselves before contacting us.
