### PR TITLE
Page the operator when Clover serves an unexpected 500

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -253,6 +253,10 @@ class Clover < Roda
       code = 400
       type = "InvalidRequest"
       message = e.to_s
+    when Rack::BadRequest
+      code = 400
+      type = "BadRequest"
+      message = e.message
     when CloverError
       code = e.code
       type = e.type

--- a/clover.rb
+++ b/clover.rb
@@ -294,6 +294,18 @@ class Clover < Roda
 
       Clog.emit("route exception", Util.exception_to_hash(e, into: {request: request.inspect}))
 
+      begin
+        exception_class = e.class.name
+        Prog::PageNexus.assemble(
+          "Unexpected #{exception_class} in Clover web request",
+          ["Clover500", exception_class],
+          [],
+          extra_data: {exception_class:, request_method: request.request_method, request_path: request.path},
+        )
+      rescue => page_exception
+        Clog.emit("failed to page for unexpected error", Util.exception_to_hash(page_exception, into: {unexpected_error_page_failure: {original_exception: exception_class, request_path: request.path}}))
+      end
+
       code = 500
       type = "UnexpectedError"
       message = "Sorry, we couldn’t process your request because of an unexpected error."

--- a/spec/routes/web/access_control_spec.rb
+++ b/spec/routes/web/access_control_spec.rb
@@ -891,6 +891,7 @@ RSpec.describe Clover, "access control" do
         click_button "Add Members"
         expect(page).to have_flash_error "There was a temporary error attempting to make this change, please try again."
       end
+      expect(Page.count).to eq 0
 
       expect(UBID).to receive(:class_match?).and_return(false)
       click_button "Add Members"

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Clover do
 
     expect(page.title).to eq("Ubicloud - Invalid Parameter Type")
     expect(page.status_code).to eq(400)
+    expect(Page.count).to eq 0
   end
 
   it "returns 400 without paging for malformed query strings" do
@@ -118,6 +119,51 @@ RSpec.describe Clover do
     expect(Clog).not_to receive(:emit)
 
     expect { visit "/webhook/test-error?message=treat+as+unexpected+error" }.to raise_error(RuntimeError, "treat as unexpected error")
+  end
+
+  it "pages for unexpected errors and deduplicates repeats" do
+    visit "/webhook/test-error"
+    expect(page.title).to eq("Ubicloud - UnexpectedError")
+
+    pg = Page.active.first!(tag: "Clover500-RuntimeError")
+    expect(pg.severity).to eq("error")
+    expect(pg.details).not_to have_key("exception_message")
+    expect(pg.details["exception_class"]).to eq("RuntimeError")
+    expect(pg.details["request_method"]).to eq("GET")
+    expect(pg.details["request_path"]).to eq("/webhook/test-error")
+
+    visit "/webhook/test-error"
+    expect(Page.active.where(tag: "Clover500-RuntimeError").count).to eq 1
+  end
+
+  it "still serves the error response when paging fails" do
+    expect(Prog::PageNexus).to receive(:assemble).with(
+      "Unexpected RuntimeError in Clover web request",
+      ["Clover500", "RuntimeError"],
+      [],
+      extra_data: {
+        exception_class: "RuntimeError",
+        request_method: "GET",
+        request_path: "/webhook/test-error",
+      },
+    ).and_raise(RuntimeError.new("paging failure"))
+    allow(Clog).to receive(:emit).and_call_original
+    expect(Clog).to receive(:emit).with("failed to page for unexpected error", instance_of(Hash)).and_call_original
+
+    visit "/webhook/test-error"
+
+    expect(page.title).to eq("Ubicloud - UnexpectedError")
+    expect(Page.count).to eq 0
+  end
+
+  it "pages for unexpected errors on the runtime host" do
+    expect(Vm).to receive(:from_runtime_jwt_payload).and_raise(RuntimeError.new("test error"))
+
+    get "/runtime/test", {}, {"HTTP_ACCEPT" => "application/json"}
+
+    expect(last_response.status).to eq(500)
+    expect(JSON.parse(last_response.body)["type"]).to eq("UnexpectedError")
+    expect(Page.count).to eq 1
   end
 
   if ENV["PROCESS_TYPE"] == "web"

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe Clover do
     expect(page.status_code).to eq(400)
   end
 
+  it "returns 400 without paging for malformed query strings" do
+    post "/login", {}, {"QUERY_STRING" => "x=%zz", "HTTP_ACCEPT" => "application/json"}
+
+    expect(last_response.status).to eq(400)
+    expect(JSON.parse(last_response.body).dig("error", "type")).to eq("BadRequest")
+    expect(Page.count).to eq 0
+  end
+
   it "handles missing handle_validation_failure_call" do
     expect(Clog).to receive(:emit).with("web error without handle_validation_failure", instance_of(Hash)).and_call_original
     expect { visit "/webhook/test-missing-handle-validation-failure" }.to raise_error(RuntimeError, /Request failure without handle_validation_failure/)


### PR DESCRIPTION
Unexpected 500s (the error handler's UnexpectedError branch, on the web and api hosts) now assemble a Page through Prog::PageNexus, reusing the operator paging pipeline. The tag is Clover500-<ExceptionClass>, so the unique index on active pages folds a hot failure into one page. Page details carry the exception class, request method, and path. The message is left out because it can embed customer PII or secrets; it still reaches the log through the existing route exception emit. Runtime hosts are excluded for now: unlike web and api they do not yet map client faults to 4xx as completely, so paging on their 500s would be noisy. Paging is best effort: a failure to assemble is logged and the 500 is served unchanged.

The first commit fixes a pre-existing misclassification this would have amplified: malformed query strings and multipart bodies (Rack::BadRequest) were served as 500 UnexpectedError, so an unauthenticated request with bad percent-encoding would have paged. They are now 400 BadRequest.
