### PR TITLE
Return decrypted init scripts as UTF-8

### DIFF
--- a/lib/resource_methods.rb
+++ b/lib/resource_methods.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 module ResourceMethods
+  # Serialization format for encrypted columns that hold text.  Sequel's
+  # column_encryption plugin returns decrypted data with BINARY encoding, and a
+  # BINARY string with non-ASCII characters cannot be concatenated with the UTF-8
+  # strings that template rendering and JSON generation use.
+  UTF8_FORMAT = [
+    :itself.to_proc,
+    ->(data) { data.force_encoding(Encoding::UTF_8) },
+  ].freeze
+
   def self.configure(model, etc_type: false, redacted_columns: nil, encrypted_columns: nil, referencing: nil)
     model.instance_exec do
       @ubid_type = if referencing

--- a/model/postgres/postgres_init_script.rb
+++ b/model/postgres/postgres_init_script.rb
@@ -3,7 +3,7 @@
 require_relative "../../model"
 
 class PostgresInitScript < Sequel::Model
-  plugin ResourceMethods, referencing: UBID::TYPE_POSTGRES_RESOURCE, encrypted_columns: :init_script
+  plugin ResourceMethods, referencing: UBID::TYPE_POSTGRES_RESOURCE, encrypted_columns: {init_script: {format: ResourceMethods::UTF8_FORMAT}}
 
   def validate
     super

--- a/model/vm_init_script.rb
+++ b/model/vm_init_script.rb
@@ -3,7 +3,7 @@
 require_relative "../model"
 
 class VmInitScript < Sequel::Model
-  plugin ResourceMethods, referencing: UBID::TYPE_VM, encrypted_columns: :init_script
+  plugin ResourceMethods, referencing: UBID::TYPE_VM, encrypted_columns: {init_script: {format: ResourceMethods::UTF8_FORMAT}}
 
   def validate
     super

--- a/spec/model/postgres/postgres_init_script_spec.rb
+++ b/spec/model/postgres/postgres_init_script_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe PostgresInitScript do
+  let(:project) { Project.create(name: "pg-init-script-test-project") }
+
+  it "returns the init_script as UTF-8" do
+    pg = create_postgres_resource(project:, location_id: Location::HETZNER_FSN1_ID)
+    described_class.create_with_id(pg, init_script: "echo 'héllo'")
+
+    init_script = described_class[pg.id].init_script
+    expect(init_script.encoding).to eq Encoding::UTF_8
+    expect(init_script).to eq "echo 'héllo'"
+  end
+end

--- a/spec/model/vm_init_script_spec.rb
+++ b/spec/model/vm_init_script_spec.rb
@@ -9,4 +9,13 @@ RSpec.describe VmInitScript do
     vm.init_script = "a" * 2000
     expect(vm.valid?).to be true
   end
+
+  it "returns the init_script as UTF-8" do
+    vm = Prog::Vm::Nexus.assemble("k y", Project.create(name: "test").id).subject
+    described_class.create_with_id(vm, init_script: "echo 'héllo'")
+
+    init_script = described_class[vm.id].init_script
+    expect(init_script.encoding).to eq Encoding::UTF_8
+    expect(init_script).to eq "echo 'héllo'"
+  end
 end

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -556,6 +556,15 @@ RSpec.describe Clover, "postgres" do
         expect(pg.init_script.init_script).to eq("sudo ls")
       end
 
+      it "shows an initialization script that contains non-ASCII characters" do
+        PostgresInitScript.create_with_id(pg, init_script: "echo 'héllo wörld'")
+        project.set_ff_postgres_init_script(true)
+        visit "#{project.path}#{pg.path}/settings"
+
+        expect(page.status_code).to eq(200)
+        expect(page).to have_field("init_script", with: "echo 'héllo wörld'")
+      end
+
       it "raises forbidden when does not have permissions" do
         visit "#{project_wo_permissions.path}#{pg_wo_permission.path}/overview"
 


### PR DESCRIPTION
Sequel's column_encryption plugin builds the decrypted value from OpenSSL::Cipher#update, which returns a string with BINARY encoding. The init_script columns hold text, so a script with a non-ASCII character produced a value that cannot be concatenated with the UTF-8 strings that template rendering and JSON generation use. The Postgres settings page failed with a 500:

  "GET /project/pj.../postgres/staging-chonky/settings" 500 60103
  Encoding::CompatibilityError - incompatible character encodings:
  UTF-8 and BINARY (ASCII-8BIT)

The raise came from the textarea that shows the current script, reached through components/form/resource_creation_form. The same value also reaches JSON.generate in that form's option_dirty script tag, which warned separately.

VmInitScript had the same latent bug. Vm#params_json passes the script to JSON.pretty_generate, so a non-ASCII init script would have broken VM provisioning too.

Fix this with a serialization format that labels the decrypted value UTF-8, and apply it only to the two text columns. Most encrypted columns hold base64, hex, or PEM, where the encoding label makes no difference. Sshable#raw_private_key_1 holds a raw Ed25519 keypair and Cert#csr_key holds DER, though, and labelling those UTF-8 corrupts them, because String#[] then slices characters rather than bytes.