### PR TITLE
Add CloudHypervisor 53.0 as a supported version in Rhizome for Ubuntu 24

### DIFF
--- a/prog/download_cloud_hypervisor.rb
+++ b/prog/download_cloud_hypervisor.rb
@@ -46,6 +46,10 @@ class Prog::DownloadCloudHypervisor < Prog::Base
     ["ch-remote", "x64", "46.0"] => "526c91cf6b2d30b24af6eb39511f4f562f7bbc50a4dfb17d486274057a162445",
     ["ch-bin", "arm64", "46.0"] => "a5a19c7e7326a5ca5dcf83a7b895a03e81cdac8c7d0690d4e94133cc89d38561",
     ["ch-remote", "arm64", "46.0"] => "6395a86db76f1f50d8b8c0ae1debbbb6a08e572b6f8c57cfbd9511e9beb4126a",
+    ["ch-bin", "x64", "53.0"] => "448af3d4e59b22c2987f7df94c213ad40fb53a10d437e42b5ee6c4fce7c29ecc",
+    ["ch-remote", "x64", "53.0"] => "13f32ba952e6791fd901f2279be2055fbacc64005f96c42a8e90d58860df84a7",
+    ["ch-bin", "arm64", "53.0"] => "f192b510eea1c710cbc439d716bb0573c223fc463dbe3e6523788a2b7ef62850",
+    ["ch-remote", "arm64", "53.0"] => "ade26617f74264467e1381f146fd1face6b8b0fb13c5ec84f4acedd72f972596",
   }
 
   def sha_256(bin)

--- a/rhizome/host/lib/cloud_hypervisor.rb
+++ b/rhizome/host/lib/cloud_hypervisor.rb
@@ -124,6 +124,10 @@ module CloudHypervisor
         x64: new("46.0", "00b5cf2976847d2f21d2b7266038c8fc40bd14f2a542115055e9e214867edc9e", "526c91cf6b2d30b24af6eb39511f4f562f7bbc50a4dfb17d486274057a162445"),
         arm64: new("46.0", "a5a19c7e7326a5ca5dcf83a7b895a03e81cdac8c7d0690d4e94133cc89d38561", "6395a86db76f1f50d8b8c0ae1debbbb6a08e572b6f8c57cfbd9511e9beb4126a"),
       )
+      SUPPORTED["53.0"] = Arch.render(
+        x64: new("53.0", "448af3d4e59b22c2987f7df94c213ad40fb53a10d437e42b5ee6c4fce7c29ecc", "13f32ba952e6791fd901f2279be2055fbacc64005f96c42a8e90d58860df84a7"),
+        arm64: new("53.0", "f192b510eea1c710cbc439d716bb0573c223fc463dbe3e6523788a2b7ef62850", "ade26617f74264467e1381f146fd1face6b8b0fb13c5ec84f4acedd72f972596"),
+      )
       default = SUPPORTED["46.0"]
     end
     # simplecov:enable


### PR DESCRIPTION
This is the first step in upgrading CloudHypervisor from 46.0 to 53.0, supporting the installation of CloudHypervisor 53.0 (on Ubuntu 24.04 hosts), while keeping CloudHypervisor 46.0 as the default.

With this, you can install CloudHypervisor 53.0 on VM hosts via (for amd64 hosts):

```
vm_host.download_cloud_hypervisor(version_x64: "53.0")
```

While this does not change the default CloudHypervisor version, it marks CloudHypervisor 53.0 as a supported version on Ubuntu 24 hosts in Rhizome. This will make it so that new hosts install both CloudHypervisor 46.0 and 53.0.

After this goes into production, we'll need to update rhizome on hosts and install CloudHypervisor 53.0 on them. After that, we can start gradually testing CloudHypervisor 53.0 for VMs.