### PR TITLE
Apply the September 2026 price increase to existing resources

### DIFF
--- a/migrate/20260901_finalize_billing_records_at_old_rates.rb
+++ b/migrate/20260901_finalize_billing_records_at_old_rates.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+Sequel.migration do
+  up do
+    affected_types = %w[
+      VmVCpu VmStorage
+      PostgresVCpu PostgresStorage
+      PostgresStandbyVCpu PostgresStandbyStorage
+      KubernetesControlPlaneVCpu KubernetesWorkerVCpu KubernetesWorkerStorage
+    ].to_set
+    affected_locations = %w[hetzner-fsn1 hetzner-hel1].to_set
+
+    cutoff = new_rate_active_from = Time.utc(2026, 9, 1)
+    br_type_n = 376 # UBID.to_base32_n("br")
+
+    rates = Dir["config/billing_rates/*.yml"]
+      .flat_map { |f| YAML.load_file(f, permitted_classes: [Time]) }
+      .select { |r| affected_types.include?(r["resource_type"]) && affected_locations.include?(r["location"]) }
+
+    # For each (resource_type, resource_family, location, byoc) bucket, map
+    # every old rate (active_from < 2026-09-01) to the new September-1 rate.
+    mapping = {}
+    rates.group_by { |r| [r["resource_type"], r["resource_family"], r["location"], r["byoc"]] }.each_value do |group|
+      new_rate = group.find { |r| r["active_from"] == new_rate_active_from }
+      next unless new_rate
+
+      group.each do |r|
+        mapping[r["id"]] = new_rate["id"] if r["active_from"] < new_rate_active_from
+      end
+    end
+
+    mapping.each do |old_id, new_id|
+      run <<~SQL
+        INSERT INTO billing_record (id, project_id, resource_id, resource_name, span, amount, billing_rate_id, resource_tags)
+        SELECT gen_random_ubid_uuid(#{br_type_n}),
+               project_id, resource_id, resource_name,
+               tstzrange('#{cutoff.iso8601}'::timestamptz, NULL),
+               amount, '#{new_id}'::uuid, resource_tags
+        FROM billing_record
+        WHERE billing_rate_id = '#{old_id}'::uuid AND upper(span) IS NULL AND lower(span) < '#{cutoff.iso8601}'::timestamptz
+      SQL
+
+      run <<~SQL
+        UPDATE billing_record
+        SET span = tstzrange(lower(span), '#{cutoff.iso8601}'::timestamptz)
+        WHERE billing_rate_id = '#{old_id}'::uuid AND upper(span) IS NULL AND lower(span) < '#{cutoff.iso8601}'::timestamptz
+      SQL
+    end
+  end
+
+  down do
+    nil
+  end
+end


### PR DESCRIPTION
We raised prices for VMs, PostgreSQL, Kubernetes, and GitHub runners in Germany and Finland by 25%, effective September 1, 2026. New resources pick up the new rates on their own, because the rate lookup resolves by (resource_type, resource_family, location) at creation time. Existing resources keep pointing at the rate they were created with, so they need this migration.

The migration closes every active billing record on a pre-September-1 rate at 2026-09-01T00:00:00Z and opens a fresh record at the corresponding new rate. The pairing is computed from the YAML configs by bucketing each rate on (resource_type, resource_family, location, byoc) and mapping every old rate in the bucket to the bucket's September-1 rate. Buckets without a new rate, such as retired instance families and unaffected regions, are left untouched.

Deploy this on or after September 1. Running it earlier would close a record at a timestamp in the future, and destroying that resource before the cutoff would then try to build an inverted span. The lower(span) guard only keeps records that started after the cutoff out of the way; it cannot fix an early deploy.

GitHub runner billing records are short-lived and finalize themselves within a day, so the GitHubRunnerMinutes rates are not in scope here.