### PR TITLE
Enable standard runners for new customers again

### DIFF
--- a/model/github/github_installation.rb
+++ b/model/github/github_installation.rb
@@ -32,10 +32,6 @@ class GithubInstallation < Sequel::Model
     end
   end
 
-  def standard_runner_allowed?
-    created_at < Time.utc(2026, 6, 5)
-  end
-
   def premium_runner_enabled?
     !!allocator_preferences["family_filter"]&.include?("premium")
   end

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -51,10 +51,6 @@ class Clover
       end
 
       r.post web?, "set-premium" do
-        handle_validation_failure("github/setting")
-        unless @installation.standard_runner_allowed?
-          raise_web_error("You are not allowed to switch runner types")
-        end
         enabled = typecast_params.bool("premium_runner_enabled")
         if @installation.premium_runner_enabled? != enabled
           flash["notice"] = "Premium runners #{enabled ? "enabled" : "disabled"}"

--- a/spec/model/github/github_installation_spec.rb
+++ b/spec/model/github/github_installation_spec.rb
@@ -30,18 +30,6 @@ RSpec.describe GithubInstallation do
     expect(installation.total_active_runner_vcpus).to eq(6)
   end
 
-  describe "#standard_runner_allowed?" do
-    it "returns true if created before 2026-06-05" do
-      installation.update(created_at: Time.utc(2026, 6, 4))
-      expect(installation.standard_runner_allowed?).to be true
-    end
-
-    it "returns false if created on or after 2026-06-05" do
-      installation.update(created_at: Time.utc(2026, 6, 6))
-      expect(installation.standard_runner_allowed?).to be false
-    end
-  end
-
   describe "#cache_storage_gib" do
     it "returns effective quota if the premium is not enabled" do
       installation.update(allocator_preferences: {})

--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -146,25 +146,6 @@ RSpec.describe Clover, "github" do
       expect(page).to have_content "You’re eligible for an exclusive 50% off premium runners"
     end
 
-    it "hides premium runners section when standard runner is not allowed" do
-      installation.update(created_at: Time.utc(2026, 6, 6))
-
-      visit "#{project.path}/github/#{installation.ubid}/setting"
-      expect(page.status_code).to eq(200)
-      expect(page).to have_no_content "Premium Runners"
-    end
-
-    it "does not allow toggling premium when standard runner is not allowed" do
-      installation.update(allocator_preferences: {}, created_at: Time.utc(2026, 5, 1))
-
-      visit "#{project.path}/github/#{installation.ubid}/setting"
-      installation.update(created_at: Time.utc(2026, 6, 6))
-      within("form#premium_runner_enabled_toggle") { click_button }
-      expect(page.status_code).to eq(400)
-      expect(page.body).to include("You are not allowed to switch runner types")
-      expect(installation.reload.premium_runner_enabled?).to be false
-    end
-
     it "toggles cache for installation" do
       installation.update(cache_enabled: false)
 

--- a/views/github/setting.erb
+++ b/views/github/setting.erb
@@ -3,78 +3,76 @@
 <%== render("github/tabbar") %>
 
 <div class="grid gap-6">
-  <% if @installation.standard_runner_allowed? %>
-    <!-- Premium runners -->
-    <div class="overflow-hidden rounded-lg ring-1 ring-black ring-opacity-5 bg-white lg:flex shadow">
-      <div class="p-8 sm:p-10 lg:flex-auto">
-        <div class="flex items-center">
-          <h3 class="text-3xl font-semibold tracking-tight text-gray-900 whitespace-nowrap">
-            Premium Runners
-          </h3>
+  <!-- Premium runners -->
+  <div class="overflow-hidden rounded-lg ring-1 ring-black ring-opacity-5 bg-white lg:flex shadow">
+    <div class="p-8 sm:p-10 lg:flex-auto">
+      <div class="flex items-center">
+        <h3 class="text-3xl font-semibold tracking-tight text-gray-900 whitespace-nowrap">
+          Premium Runners
+        </h3>
 
-          <% if @installation.premium_runner_enabled? %>
-            <span class="rounded-full bg-orange-600/10 px-2.5 py-1 text-xs/5 font-semibold text-orange-600 ml-2">
-              Enabled
-            </span>
-          <% end %>
-        </div>
-
-        <% if @installation.free_runner_upgrade? %>
-          <span class="rounded-full bg-green-600/10 px-2.5 py-1 text-xs/5 font-medium text-green-600">
-            You’re eligible for an exclusive <span class="font-semibold">50% off</span> premium runners until
-            <span class="font-semibold"><%= @installation.free_runner_upgrade_expires_at.strftime("%B %d, %Y") %></span>
+        <% if @installation.premium_runner_enabled? %>
+          <span class="rounded-full bg-orange-600/10 px-2.5 py-1 text-xs/5 font-semibold text-orange-600 ml-2">
+            Enabled
           </span>
         <% end %>
-
-        <p class="mt-4 text-base/7 text-gray-600">
-          Speed up your builds with cutting edge gaming CPUs! We automatically route your jobs to premium machines. If
-          capacity's full, you seamlessly fall back to standard runners with no extra wait time. You always get billed
-          by the minute and for the runner type you're using.
-        </p>
-
-        <div class="mt-6 flex items-center gap-x-4">
-          <h4 class="flex-none text-sm/6 font-semibold text-orange-600">What’s different</h4>
-          <div class="h-px flex-auto bg-gray-100"></div>
-        </div>
-
-        <ul role="list" class="mt-4 grid grid-cols-1 gap-4 text-sm/6 text-gray-600 sm:grid-cols-2">
-          <% [
-          "Twice as fast",
-          "One fifth the cost",
-          "10x better price-performance",
-          "100GB free cache storage",
-        ].each do |text| %>
-            <li class="flex gap-x-3">
-              <%== part("components/icon", name: "hero-check", classes: "h-6 w-5 flex-none text-orange-600") %>
-              <%= text %>
-            </li>
-          <% end %>
-        </ul>
       </div>
 
-      <div class="-mt-2 p-2 lg:mt-0 lg:w-full lg:max-w-sm lg:shrink-0">
-        <div
-          class="
-            rounded-lg h-full bg-gray-50 py-10 text-center ring-1 ring-inset ring-gray-900/5 lg:flex lg:flex-col
-            lg:justify-center lg:py-16
-          "
-        >
-          <div class="mx-auto max-w-sm px-8 space-y-8">
-            <p class="flex items-baseline justify-center gap-x-2">
-              <span class="text-4xl font-semibold tracking-tight text-gray-900">Boost your builds</span>
-            </p>
+      <% if @installation.free_runner_upgrade? %>
+        <span class="rounded-full bg-green-600/10 px-2.5 py-1 text-xs/5 font-medium text-green-600">
+          You’re eligible for an exclusive <span class="font-semibold">50% off</span> premium runners until
+          <span class="font-semibold"><%= @installation.free_runner_upgrade_expires_at.strftime("%B %d, %Y") %></span>
+        </span>
+      <% end %>
 
-            <%== part("components/form/toggle_form", name: "premium_runner_enabled", action: "#{@project.path}/github/#{@installation.ubid}/set-premium", active: @installation.premium_runner_enabled?) %>
+      <p class="mt-4 text-base/7 text-gray-600">
+        Speed up your builds with cutting edge gaming CPUs! We automatically route your jobs to premium machines. If
+        capacity's full, you seamlessly fall back to standard runners with no extra wait time. You always get billed by
+        the minute and for the runner type you're using.
+      </p>
 
-            <div class="mt-6 text-sm/5 text-gray-600 italic">
-              <p class="font-semibold">1/5th the cost of GitHub runners</p>
-              <p>For example, 2 gaming vCPUs, 8GB of RAM, 80GB of NVMe storage comes at $0.0016/min.</p>
-            </div>
+      <div class="mt-6 flex items-center gap-x-4">
+        <h4 class="flex-none text-sm/6 font-semibold text-orange-600">What’s different</h4>
+        <div class="h-px flex-auto bg-gray-100"></div>
+      </div>
+
+      <ul role="list" class="mt-4 grid grid-cols-1 gap-4 text-sm/6 text-gray-600 sm:grid-cols-2">
+        <% [
+        "Twice as fast",
+        "One fifth the cost",
+        "10x better price-performance",
+        "100GB free cache storage",
+      ].each do |text| %>
+          <li class="flex gap-x-3">
+            <%== part("components/icon", name: "hero-check", classes: "h-6 w-5 flex-none text-orange-600") %>
+            <%= text %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+
+    <div class="-mt-2 p-2 lg:mt-0 lg:w-full lg:max-w-sm lg:shrink-0">
+      <div
+        class="
+          rounded-lg h-full bg-gray-50 py-10 text-center ring-1 ring-inset ring-gray-900/5 lg:flex lg:flex-col
+          lg:justify-center lg:py-16
+        "
+      >
+        <div class="mx-auto max-w-sm px-8 space-y-8">
+          <p class="flex items-baseline justify-center gap-x-2">
+            <span class="text-4xl font-semibold tracking-tight text-gray-900">Boost your builds</span>
+          </p>
+
+          <%== part("components/form/toggle_form", name: "premium_runner_enabled", action: "#{@project.path}/github/#{@installation.ubid}/set-premium", active: @installation.premium_runner_enabled?) %>
+
+          <div class="mt-6 text-sm/5 text-gray-600 italic">
+            <p class="font-semibold">1/5th the cost of GitHub runners</p>
+            <p>For example, 2 gaming vCPUs, 8GB of RAM, 80GB of NVMe storage comes at $0.0016/min.</p>
           </div>
         </div>
       </div>
     </div>
-  <% end %>
+  </div>
 
   <div>
     <div class="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 bg-white divide-y divide-gray-200">


### PR DESCRIPTION
This reverts commit c5812d5adbc3574e52c84972ca1c1ea1f23ec8ca. We decided to offer standard runners to new customers again, so the June 5, 2026 cutoff on the installation and the guard on the set-premium route both go away, and the premium runner card is no longer hidden for the installations that were caught by it.

The view could not be reverted verbatim because the herb formatter has reflowed it since. The conditional is unwrapped in place instead, and the file is passed back through the formatter.