### PR TITLE
Restate premium runners as a third of the GitHub cost

### DIFF
--- a/lib/invoice_generator.rb
+++ b/lib/invoice_generator.rb
@@ -149,9 +149,9 @@ class InvoiceGenerator
           project_content[:cost] -= project_content[:credit]
         end
 
-        # Each project have 1250 minutes (2$) runner credit every month
+        # Each project have 1250 minutes (2.5$) runner credit every month
         github_usage = project_content[:resources].flat_map { it[:line_items] }.select { it[:resource_type] == "GitHubRunnerMinutes" }.sum { it[:cost] }
-        github_credit = [2.0, github_usage, project_content[:cost]].min
+        github_credit = [2.5, github_usage, project_content[:cost]].min
         if github_credit > 0
           project_content[:github_credit] = github_credit
           project_content[:credit] += project_content[:github_credit]

--- a/spec/lib/invoice_generator_spec.rb
+++ b/spec/lib/invoice_generator_spec.rb
@@ -356,8 +356,8 @@ RSpec.describe InvoiceGenerator do
 
     invoice = described_class.new(begin_time, end_time).run.first.content
 
-    expect(invoice["cost"]).to eq(invoice["subtotal"] - 2)
-    expect(invoice["credit"]).to eq(2)
+    expect(invoice["cost"]).to eq(invoice["subtotal"] - 2.5)
+    expect(invoice["credit"]).to eq(2.5)
     expect(p1.reload.credit).to eq(0)
   end
 
@@ -370,10 +370,10 @@ RSpec.describe InvoiceGenerator do
     p1.update(credit: 10, discount: 10)
     after = described_class.new(begin_time, end_time, save_result: true, eur_rate: 1.1).run.first.content
 
-    expect(before["cost"]).to eq(before["subtotal"].round(3) - 2)
-    expect(after["cost"]).to eq((before["subtotal"] * 0.9 - 12).round(3))
+    expect(before["cost"]).to eq(before["subtotal"].round(3) - 2.5)
+    expect(after["cost"]).to eq((before["subtotal"] * 0.9 - 12.5).round(3))
     expect(after["discount"]).to eq((before["subtotal"] * 0.1).round(3))
-    expect(after["credit"]).to eq(12)
+    expect(after["credit"]).to eq(12.5)
     expect(p1.reload.credit).to eq(0)
   end
 

--- a/views/github/setting.erb
+++ b/views/github/setting.erb
@@ -39,7 +39,7 @@
       <ul role="list" class="mt-4 grid grid-cols-1 gap-4 text-sm/6 text-gray-600 sm:grid-cols-2">
         <% [
         "Twice as fast",
-        "One fifth the cost",
+        "One third the cost",
         "10x better price-performance",
         "100GB free cache storage",
       ].each do |text| %>
@@ -66,7 +66,7 @@
           <%== part("components/form/toggle_form", name: "premium_runner_enabled", action: "#{@project.path}/github/#{@installation.ubid}/set-premium", active: @installation.premium_runner_enabled?) %>
 
           <div class="mt-6 text-sm/5 text-gray-600 italic">
-            <p class="font-semibold">1/5th the cost of GitHub runners</p>
+            <p class="font-semibold">1/3rd the cost of GitHub runners</p>
             <p>For example, 2 gaming vCPUs, 8GB of RAM, 80GB of NVMe storage comes at $0.0016/min.</p>
           </div>
         </div>


### PR DESCRIPTION
The premium runner card claimed one fifth of the GitHub runner cost. With the September 2026 price increase that claim no longer holds, so state a third instead.

The free runner credit moves with it. We give every project 1,250 free runner minutes a month, which was worth $2 at the old premium-2 rate of $0.0016 a minute and is worth $2.50 at the new one.