### PR TITLE
Resolve postgres pages by id suffix on teardown

### DIFF
--- a/model/page.rb
+++ b/model/page.rb
@@ -165,6 +165,12 @@ class Page < Sequel::Model
     Page.active.first(tag:)
   end
 
+  # Every active page whose tag ends with the given parts. Entity-keyed
+  # pages put the raw id as the last tag part.
+  def self.from_tag_suffix(*tag_parts)
+    Page.active.where(Sequel.like(:tag, "%-#{generate_tag(tag_parts)}"))
+  end
+
   SEVERITY_ORDER = {"info" => 0, "warning" => 1, "error" => 2, "critical" => 3}.freeze
 
   SUPPRESSING_SEVERITIES = SEVERITY_ORDER.to_h do |severity, order|

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -481,9 +481,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
       Cert.incr_destroy(current_cert_id) if current_cert_id
       postgres_resource.dns_zone&.delete_record(record_name: postgres_resource.hostname)
       # Resolve resource-keyed pages so they don't orphan after the resource is gone.
-      %w[PGStorageAutoScaleMaxSize PGStorageAutoScaleQuotaInsufficient PGStorageAutoScaleCanceled PostgresUpgradeFailed].each do |tag|
-        Page.from_tag_parts(tag, postgres_resource.id)&.incr_resolve
-      end
+      Page.incr_resolve(Page.from_tag_suffix(postgres_resource.id).select(:id))
       postgres_resource.destroy
 
       pop "postgres resource is deleted"

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -939,9 +939,7 @@ SQL
   label def destroy
     decr_destroy
     # Resolve server-keyed pages so they don't orphan after the server is gone.
-    %w[PGDiskUsageHigh PGRootDiskUsageHigh PGArchivalBacklogHigh PGMetricsBacklogHigh PGIOThrottleStale PGInitializeDatabaseFromBackupFailed PGReplicaLagHigh].each do |tag|
-      Page.from_tag_parts(tag, postgres_server.id)&.incr_resolve
-    end
+    Page.incr_resolve(Page.from_tag_suffix(postgres_server.id).select(:id))
     Semaphore.incr(strand.children_dataset.exclude(prog: "Postgres::PostgresServerNexus").select(:id), "destroy")
     hop_wait_children_destroy
   end

--- a/prog/postgres/postgres_timeline_nexus.rb
+++ b/prog/postgres/postgres_timeline_nexus.rb
@@ -105,8 +105,8 @@ class Prog::Postgres::PostgresTimelineNexus < Prog::Base
   label def destroy
     decr_destroy
     postgres_timeline.destroy_blob_storage if postgres_timeline.blob_storage
-    # Resolve the timeline-keyed page so it doesn't orphan after the timeline is gone.
-    Page.from_tag_parts("MissingBackup", postgres_timeline.id)&.incr_resolve
+    # Resolve timeline-keyed pages so they don't orphan after the timeline is gone.
+    Page.incr_resolve(Page.from_tag_suffix(postgres_timeline.id).select(:id))
     postgres_timeline.destroy
     pop "postgres timeline is deleted"
   end

--- a/spec/model/page_spec.rb
+++ b/spec/model/page_spec.rb
@@ -64,6 +64,17 @@ RSpec.describe Page do
     end
   end
 
+  describe ".from_tag_suffix" do
+    it "returns the active pages whose tag ends with the given parts" do
+      id = described_class.generate_uuid
+      matching = ["PGDiskUsageHigh-#{id}", "PGReplicaLagHigh-#{id}"].map { described_class.create(tag: it) }
+      described_class.create(tag: "Deadline-#{id}-Prog-wait")
+      described_class.create(tag: "PGDiskUsageHigh-#{described_class.generate_uuid}")
+      described_class.create(tag: "PGIOThrottleStale-#{id}", resolved_at: Time.now)
+      expect(described_class.from_tag_suffix(id).all).to match_array(matching)
+    end
+  end
+
   context "with pager duty" do
     before do
       expect(Config).to receive(:pagerduty_key).and_return("dummy-key").at_least(:once)

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -1010,12 +1010,14 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
         postgres_server
         tags = %w[PGStorageAutoScaleMaxSize PGStorageAutoScaleQuotaInsufficient PGStorageAutoScaleCanceled PostgresUpgradeFailed]
         pages = tags.map { Prog::PageNexus.assemble("#{postgres_resource.ubid} #{it}", [it, postgres_resource.id], postgres_resource.ubid).subject }
+        deadline_page = Prog::PageNexus.assemble("#{postgres_resource.ubid} deadline", ["Deadline", postgres_resource.id, "Postgres::PostgresResourceNexus", "wait"], postgres_resource.ubid).subject
 
         expect { nx.wait_children_destroyed }.to exit({"msg" => "postgres resource is deleted"})
 
         pages.each do |page|
           expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
         end
+        expect(Semaphore.where(strand_id: deadline_page.id, name: "resolve").count).to eq(0)
       end
     end
   end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1819,14 +1819,17 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "resolves server-keyed pages so they do not orphan after the server is gone" do
-      tags = %w[PGDiskUsageHigh PGRootDiskUsageHigh PGArchivalBacklogHigh PGMetricsBacklogHigh PGIOThrottleStale PGInitializeDatabaseFromBackupFailed PGReplicaLagHigh]
+      tags = %w[PGDiskUsageHigh PGRootDiskUsageHigh PGArchivalBacklogHigh PGMetricsBacklogHigh PGIOThrottleStale PGInitializeDatabaseFromBackupFailed PGReplicaLagHigh PGMonitoringAccessDenied]
       pages = tags.map { Prog::PageNexus.assemble("#{postgres_server.ubid} #{it}", [it, postgres_server.id], postgres_server.ubid).subject }
+      deadline_page = Prog::PageNexus.assemble("#{postgres_server.ubid} deadline", ["Deadline", postgres_server.id, "Postgres::PostgresServerNexus", "wait"], postgres_server.ubid).subject
+      resource_page = Prog::PageNexus.assemble("#{postgres_resource.ubid} upgrade failed", ["PostgresUpgradeFailed", postgres_resource.id], postgres_resource.ubid).subject
 
       expect { nx.destroy }.to hop("wait_children_destroy")
 
       pages.each do |page|
         expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
       end
+      expect(Semaphore.where(strand_id: [deadline_page.id, resource_page.id], name: "resolve").count).to eq(0)
     end
   end
 


### PR DESCRIPTION
The destroy labels resolved entity-keyed pages by enumerating their tag names, and the list went stale immediately: commit ee8f13bbc added the `PGMonitoringAccessDenied` page, whose only other resolve path is the pulse reading "up" again, ten days after commit 67ec6252e introduced the lists. Destroying a resource while that page was active orphaned it until someone resolved it by hand.

Drop the lists. `Page.from_tag_suffix` returns every active page whose tag ends with the given parts, and the server, resource, and timeline destroy labels resolve their pages with a single suffix match on the entity id. This works because entity-keyed pages put the raw id as the last tag part. The suffix anchor keeps Deadline pages out of the sweep, since they embed the strand id mid-tag; the deadline machinery owns their resolution.