### PR TITLE
Stop leaking a lock file into /tmp for every write

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -390,8 +390,10 @@ TIMER
     vm.sshable.cmd("sudo systemctl daemon-reload")
     # The old User=ubi unit leaves its safe_write_to_file lock and possibly
     # a stale tmp file owned ubi:ubi 0644, which the new user cannot write.
-    vm.sshable.cmd("sudo rm -f :lock_path :tmp_path",
-      lock_path: "/tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock",
+    # The lock used to live in /tmp under a digest name, so drop both paths.
+    vm.sshable.cmd("sudo rm -f :old_lock_path :lock_path :tmp_path",
+      old_lock_path: "/tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock",
+      lock_path: "/var/lib/node_exporter/pg_metrics.prom.tmp.lock",
       tmp_path: "/var/lib/node_exporter/pg_metrics.prom.tmp")
 
     when_initial_provisioning_set? do

--- a/rhizome/common/lib/util.rb
+++ b/rhizome/common/lib/util.rb
@@ -112,7 +112,7 @@ def safe_write_to_file(filename, content = nil, perm: nil)
   raise ArgumentError, "must provide either content or block" if content.nil? ^ block_given?
 
   temp_filename = filename + ".tmp"
-  lock_filename = "/tmp/#{OpenSSL::Digest::SHA256.hexdigest(temp_filename)}.lock"
+  lock_filename = "#{temp_filename}.lock"
   File.open(lock_filename, File::RDWR | File::CREAT) do |lock_file|
     lock_file.flock(File::LOCK_EX)
     # Create the temp at its final mode so content is never written through the

--- a/rhizome/common/spec/util_spec.rb
+++ b/rhizome/common/spec/util_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe "util" do
       expect { safe_write_to_file("test", "content") {} }.to raise_error(ArgumentError, /must provide either content or block/)
     end
 
+    it "locks next to the target instead of leaking a digest-named file into /tmp" do
+      Dir.mktmpdir do |dir|
+        path = "#{dir}/test.txt"
+        safe_write_to_file(path, "string content")
+        expect(File.exist?("#{path}.tmp.lock")).to be true
+        # The old scheme keyed on a digest of the temp path, so every distinct
+        # target left a permanent inode in /tmp. Nothing lands there now.
+        expect(File.exist?("/tmp/#{OpenSSL::Digest::SHA256.hexdigest("#{path}.tmp")}.lock")).to be false
+      end
+    end
+
     it "supports passing a string for file content" do
       Dir.mktmpdir do |dir|
         path = "#{dir}/test.txt"

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -716,7 +716,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       )
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
-      expect(sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
+      expect(sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now postgres-metrics.timer")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now pg-collect-metrics.timer")
 
@@ -757,7 +757,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
-      expect(sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
+      expect(sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now postgres-metrics.timer")
       expect(sshable).to receive(:_cmd).with("sudo systemctl enable --now pg-collect-metrics.timer")
 
@@ -792,7 +792,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
-      expect(standby_sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
+      expect(standby_sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
 
       expect { standby_nx.configure_metrics }.to hop("wait")
     end
@@ -826,7 +826,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
-      expect(standby_sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
+      expect(standby_sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
 
       expect { standby_nx.configure_metrics }.to hop("wait")
     end
@@ -876,7 +876,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.service > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/pg-collect-metrics.timer > /dev/null", stdin: anything)
       expect(standby_sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
-      expect(standby_sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
+      expect(standby_sshable).to receive(:_cmd).with("sudo rm -f /tmp/#{OpenSSL::Digest::SHA256.hexdigest("/var/lib/node_exporter/pg_metrics.prom.tmp")}.lock /var/lib/node_exporter/pg_metrics.prom.tmp.lock /var/lib/node_exporter/pg_metrics.prom.tmp")
 
       expect { standby_nx.configure_metrics }.to hop("wait")
 


### PR DESCRIPTION
safe_write_to_file locked on /tmp/<sha256 of the temp path>.lock and never unlinked it. Call sites whose target path carries the VM name -- the vhost-backend configs and metadata under /var/storage/<vm_name>, and the certificate pair under /vm/<vm_name>/cert -- hash to a fresh name per VM, so every VM left four to six permanent zero-byte inodes behind. A runner host ran out of the 262144 inodes on its /tmp and apt-get began failing with ENOSPC while df -h showed the partition at 1% used.

Lock next to the temp file instead, as the control plane copy in lib/util.rb already does. That bounds the key space at one lock per target file, and the per-VM ones now go away with the directory purge_storage removes. The name ends in .tmp.lock, so it stays out of the *.conf and *.prom globs that nftables, sysctl.d, systemd drop-ins, postgres include_dir and the node_exporter textfile collector read.

Hosts provisioned before this keep their old /tmp files. Clear them with a find over /tmp for zero-byte *.lock entries older than a day. The postgres metrics cleanup drops both the old and the new path.