### PR TITLE
Show network access as cards on Postgres create

### DIFF
--- a/lib/content_generator.rb
+++ b/lib/content_generator.rb
@@ -132,8 +132,8 @@ module ContentGenerator
       ]
     end
 
-    def self.restrict_by_default(_)
-      "Restrict access by default"
+    def self.restrict_by_default(restrict)
+      (restrict == "true") ? ["No access yet", "No firewall rules"] : ["Open to the internet", "Any address"]
     end
 
     def self.partnership_notice(flavor)

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -700,7 +700,7 @@ class PostgresResource < Sequel::Model
 
     options.add_option(name: "ha_type", values: Option::POSTGRES_HA_OPTIONS.keys, parent: "storage_size")
 
-    options.add_option(name: "restrict_by_default", values: ["1"])
+    options.add_option(name: "restrict_by_default", values: %w[false true])
 
     if project.get_ff_postgres_init_script
       options.add_option(name: "init_script")

--- a/spec/routes/api/cli/pg/create_spec.rb
+++ b/spec/routes/api/cli/pg/create_spec.rb
@@ -20,7 +20,12 @@ RSpec.describe Clover, "cli pg create" do
     expect(pg.ha_type).to eq "none"
     expect(pg.version).to eq "18"
     expect(pg.flavor).to eq "standard"
-    expect(pg.pg_firewall_rules_dataset.count).to eq 4
+    expect(pg.pg_firewall_rules.map { "#{it.cidr}:#{it.port_range.to_range}" }.sort).to eq [
+      "0.0.0.0/0:5432...5433",
+      "0.0.0.0/0:6432...6433",
+      "::/0:5432...5433",
+      "::/0:6432...6433",
+    ]
     expect(pg.tags).to eq([])
     expect(body).to eq "PostgreSQL database created with id: #{pg.ubid}\n"
   end

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Clover, "postgres" do
         choose option: Location::HETZNER_FSN1_UBID
         choose option: "standard-2"
         choose option: PostgresResource::HaType::NONE
-        check "Restrict access by default"
+        choose "No access yet No firewall rules"
 
         click_button "Create"
 

--- a/views/postgres/create.erb
+++ b/views/postgres/create.erb
@@ -45,7 +45,8 @@
     {name: "storage_size", type: "radio_small_cards", label: "Storage size", required: "required"},
     {name: "version", type: "radio_small_cards", label: "Version", required: "required"},
     {name: "ha_type", type: "radio_small_cards", label: "High Availability", required: "required"},
-    {name: "restrict_by_default", type: "checkbox", label: "Firewall Rules", description: "By default, the subnet for the database will have firewall rules that allow access to the database from any location. Check this box to skip adding firewall rules. You can add specific firewall rules afterward.", default_unchecked: true},
+    {name: "restrict_by_default", type: "radio_small_cards", label: "Network access", required: "required",
+     description_html: "<p class='mt-1 text-sm leading-6 text-gray-600'>Opening the database creates rules for ports 5432 and 6432 from any address. Ubicloud always requires a password and TLS, and you can change the rules later on the Networking tab.</p>"},
   ]
 
   if PostgresResource.partner_notification_flavors.include?(@flavor)


### PR DESCRIPTION
The firewall control was a checkbox labelled "Restrict access by default",
described as "check this box to skip adding firewall rules". The customer
had to invert twice to see what leaving it alone does: it opens ports 5432
and 6432 to 0.0.0.0/0 and ::/0, which the description mentioned in passing.
"By default" was the API parameter name leaking into the UI, since the
customer is choosing that default right there.

The same choice is two radio cards now, like the rest of the form: open to
the internet, and no access yet. Each card says which rules it creates, so
nothing is left for the reader to invert, and the default is unchanged.
restrict_by_default keeps its name and its meaning, because the cards post
"false" and "true" to it, so the API and the Terraform provider are
untouched.

Cards in a row also share the height of the tallest one now. Two cards whose
subtitles wrap differently used to leave the row ragged.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## New
<img width="2146" height="350" alt="CleanShot 2026-08-20 at 18 16 28@2x" src="https://github.com/user-attachments/assets/6a7c3db7-28c2-4913-b401-5a441a0ab5a0" />

## Old
<img width="2142" height="204" alt="CleanShot 2026-08-20 at 18 16 59@2x" src="https://github.com/user-attachments/assets/a8d92b25-5067-4ba7-8efe-b7c685de1100" />
