### PR TITLE
Reduce page chance when destroying machine image versions

### DIFF
--- a/prog/machine_image/version_metal_nexus.rb
+++ b/prog/machine_image/version_metal_nexus.rb
@@ -132,7 +132,7 @@ class Prog::MachineImage::VersionMetalNexus < Prog::Base
   end
 
   label def destroy
-    register_deadline(nil, 600)
+    register_deadline(nil, 1800)
     decr_destroy
 
     if machine_image_version_metal.status == "creating"

--- a/prog/machine_image/version_metal_nexus.rb
+++ b/prog/machine_image/version_metal_nexus.rb
@@ -184,26 +184,32 @@ class Prog::MachineImage::VersionMetalNexus < Prog::Base
     )
 
     # delete one page of objects at a time to avoid a long running label
-    page = s3_client.list_objects_v2(
-      bucket: store.bucket,
-      prefix: machine_image_version_metal.store_prefix,
-      max_keys: 1000,
-    )
+    begin
+      page = s3_client.list_objects_v2(
+        bucket: store.bucket,
+        prefix: machine_image_version_metal.store_prefix,
+        max_keys: 1000,
+      )
 
-    if page.contents.empty?
-      if machine_image_version_metal.status == "failed"
-        hop_failed
-      else
-        hop_finish_destroy
+      if page.contents.empty?
+        if machine_image_version_metal.status == "failed"
+          hop_failed
+        else
+          hop_finish_destroy
+        end
       end
-    end
 
-    response = s3_client.delete_objects(
-      bucket: store.bucket,
-      delete: {
-        objects: page.contents.map { |obj| {key: obj.key} },
-      },
-    )
+      response = s3_client.delete_objects(
+        bucket: store.bucket,
+        delete: {
+          objects: page.contents.map { |obj| {key: obj.key} },
+        },
+      )
+    rescue Aws::Errors::ServiceError, Seahorse::Client::NetworkingError => e
+      miv = machine_image_version_metal.machine_image_version
+      Clog.emit("Error deleting machine image archive objects", machine_image_archive_delete_error: Util.exception_to_hash(e, into: {machine_image: miv.machine_image.ubid, version: miv.version}))
+      nap 30
+    end
 
     unless response.errors.empty?
       miv = machine_image_version_metal.machine_image_version

--- a/prog/machine_image/version_metal_nexus.rb
+++ b/prog/machine_image/version_metal_nexus.rb
@@ -180,7 +180,7 @@ class Prog::MachineImage::VersionMetalNexus < Prog::Base
       force_path_style: true,
       http_open_timeout: 5,
       http_read_timeout: 20,
-      retry_limit: 0,
+      retry_limit: 1,
     )
 
     # delete one page of objects at a time to avoid a long running label

--- a/spec/prog/machine_image/version_metal_nexus_spec.rb
+++ b/spec/prog/machine_image/version_metal_nexus_spec.rb
@@ -329,6 +329,12 @@ RSpec.describe Prog::MachineImage::VersionMetalNexus do
       )
       expect { prog.destroy_objects }.to nap(30)
     end
+
+    it "logs and naps on transient object-store errors instead of raising" do
+      allow(s3).to receive(:list_objects_v2).and_raise(Seahorse::Client::NetworkingError.new(Net::ReadTimeout.new))
+      expect(Clog).to receive(:emit).with("Error deleting machine image archive objects", machine_image_archive_delete_error: hash_including(exception: hash_including(class: "Seahorse::Client::NetworkingError")))
+      expect { prog.destroy_objects }.to nap(30)
+    end
   end
 
   describe "#finish_destroy" do


### PR DESCRIPTION
### Retry transient object-store errors in destroy_objects 

Set the S3 client retry_limit to 1 (was 0) so destroy_objects retries a transient list/delete error within the label instead of failing on the first one.

The label must finish within Sshable::MAX_TIMEOUT (Strand::LEASE_EXPIRATION - 39 = 81s). retry_limit: 1 keeps each S3 call's worst case at 2 * (5 + 20) = 50s (http_open_timeout + http_read_timeout, doubled for the retry), leaving room for the other call. Benchmarks against R2 measured list at ~0.9s and delete at ~6.5s for a 1000-object page, comfortably within the 20s read timeout.

### Nap predictably on transient errors in destroy_objects 

An unhandled transient object-store or networking error lets the strand back off exponentially (up to 600s between runs), which burns through the destroy deadline and pages.

Catch those errors and nap a fixed 30s instead (the same nap the per-object delete-error path already uses), so retries stay frequent and the version is more likely to finish destroying before the deadline.

### Increase destroy deadline for VersionMetalNexus 

Raise the destroy deadline from 600s to 1800s so a slow object cleanup doesn't page. Destroying a version's archived objects is not urgent:

- Billing has already stopped: #destroy finalizes the version's billing records  before destroy_objects, so a slow cleanup costs the customer nothing.
- It blocks nothing but quota: the only thing waiting on it is finish_destroy  removing the MachineImageVersion, which frees a MachineImageVersion quota slot.
- The likely cause is transient object-store (R2) errors, which the added retries  and naps are meant to ride out.