### PR TITLE
Update postgres images to 20260821.1.0

### DIFF
--- a/migrate/20260821_update_postgres_images.rb
+++ b/migrate/20260821_update_postgres_images.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  ami_ids = [
+    ["us-west-2", "x64", "ami-02e82031ed2430dd8", "ami-010d53641c2b9287f"],
+    ["us-east-1", "x64", "ami-02ff3ac69d4df45b9", "ami-0bd811e319dc2ce2b"],
+    ["us-east-2", "x64", "ami-024456b38ae333a25", "ami-0230a90cc05e8f698"],
+    ["eu-west-1", "x64", "ami-0131a0421722fcc06", "ami-0f603cb43d36474a1"],
+    ["ap-southeast-2", "x64", "ami-0d4ae3bf8ddc5bbcd", "ami-0731d3f2300f73606"],
+    ["us-west-2", "arm64", "ami-0c49015eb68b7993b", "ami-06d37081edad11ea9"],
+    ["us-east-1", "arm64", "ami-0808444637a1b3d1a", "ami-0de73865a0fc5c394"],
+    ["us-east-2", "arm64", "ami-069a09c4834d00912", "ami-0003652cecea35f39"],
+    ["eu-west-1", "arm64", "ami-043ea2071d55f1b89", "ami-0fd7bfa51c7be900d"],
+    ["ap-southeast-2", "arm64", "ami-042b781ef7e20b296", "ami-0df89d755109831aa"],
+  ]
+  gce_images = [
+    ["x64", "postgres-ubuntu-2204-x64-20260821-1-0", "postgres-ubuntu-2204-x64-20260611-2-0"],
+    ["arm64", "postgres-ubuntu-2204-arm64-20260821-1-0", "postgres-ubuntu-2204-arm64-20260611-2-0"],
+  ]
+
+  up do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: old_ami)
+        .update(aws_ami_id: new_ami)
+    end
+
+    gce_images.each do |arch, new_name, _old_name|
+      from(:pg_gce_image).where(arch:).update(gce_image_name: new_name)
+    end
+  end
+
+  down do
+    ami_ids.each do |location_name, arch, new_ami, old_ami|
+      from(:pg_aws_ami)
+        .where(aws_location_name: location_name, arch:, aws_ami_id: new_ami)
+        .update(aws_ami_id: old_ami)
+    end
+
+    gce_images.each do |arch, _new_name, old_name|
+      raise Sequel::Error, "irreversible: previous GCE image name unknown" if old_name.empty?
+      from(:pg_gce_image).where(arch:).update(gce_image_name: old_name)
+    end
+  end
+end

--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -186,7 +186,7 @@ class Prog::DownloadBootImage < Prog::Base
     },
     "postgres-ubuntu-2204" => {
       "x64" => {
-        "20260812.1.0" => "5e63c883d314618044f27e4f977984950ef00bb29899ea35486b79892d02e63b",
+        "20260821.1.0" => "8bae68828580a30eb4452933c91213da74984e87d2242464def3e380d312e372",
       },
     },
     "postgres16-lantern-ubuntu-2204" => {


### PR DESCRIPTION
## Summary
- Updates boot image version and SHA256 hashes in `prog/download_boot_image.rb`
- Adds a single migration updating AWS AMI IDs in `pg_aws_ami` and GCE image names in `pg_gce_image`

## Image Version
`20260821.1.0`

## Changes
- x64 SHA256: `8bae68828580a30eb4452933c91213da74984e87d2242464def3e380d312e372`
- arm64 SHA256: `856c8e064b744c18cd21b3f8214e766c146ea246eb318475fa3a4601740b0424`
- GCE x64: `postgres-ubuntu-2204-x64-20260821-1-0`
- GCE arm64: `postgres-ubuntu-2204-arm64-20260821-1-0`

🤖 Generated by [postgres-vm-images](https://github.com/ubicloud/postgres-vm-images) workflow