### PR TITLE
Fix DockerHub rate limit telemetry parsing

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -629,14 +629,15 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       TOKEN=$(curl -m 10 -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
       curl -m 10 -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
     COMMAND
-    quota_output = vm.sshable.cmd(docker_quota_limit_command, log: false)
-    if quota_output && (match = quota_output.match(/ratelimit-limit:\s*(\d+);w=(\d+).*?ratelimit-remaining:\s*(\d+);w=(\d+).*?docker-ratelimit-source:\s*([^\s]+)/m))
+    quota_output = vm.sshable.cmd(docker_quota_limit_command, log: false).to_s
+    if (/^ratelimit-limit:\s*(?<limit>\d+);w=(?<limit_window>\d+)/ =~ quota_output) &&
+        (/^ratelimit-remaining:\s*(?<remaining>\d+);w=(?<remaining_window>\d+)/ =~ quota_output)
       dockerhub_rate_limits = {
-        limit: match[1].to_i,
-        limit_window: match[2].to_i,
-        remaining: match[3].to_i,
-        remaining_window: match[4].to_i,
-        source: match[5],
+        limit: limit.to_i,
+        limit_window: limit_window.to_i,
+        remaining: remaining.to_i,
+        remaining_window: remaining_window.to_i,
+        source: quota_output[/^docker-ratelimit-source:\s*(\S+)/, 1],
       }
       Clog.emit("Remaining DockerHub rate limits", {dockerhub_rate_limits:})
     end

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -1089,7 +1089,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
     it "Logs docker limits and cache proxy log if workflow_job is successful" do
       runner.update(workflow_job: {"conclusion" => "success"})
-      expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, log: false).and_return("ratelimit-limit: 100;w=21600\nratelimit-remaining: 98;w=21600\ndocker-ratelimit-source: 192.168.1.1\n")
+      expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, log: false).and_return("docker-ratelimit-source: 192.168.1.1\nx-ratelimit-limit: 100;w=21600\nratelimit-limit: 100;w=21600\nx-ratelimit-remaining: 98;w=21600\nratelimit-remaining: 98;w=21600\n")
         TOKEN=$(curl -m 10 -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         curl -m 10 -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
       COMMAND
@@ -1144,7 +1144,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
     it "Logs docker limits and empty cache proxy log if workflow_job is successful" do
       runner.update(workflow_job: {"conclusion" => "success"})
-      expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, log: false).and_return("ratelimit-limit: 100;w=21600\nratelimit-remaining: 98;w=21600\ndocker-ratelimit-source: 192.168.1.1\n")
+      expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, log: false).and_return("docker-ratelimit-source: 192.168.1.1\nx-ratelimit-limit: 100;w=21600\nratelimit-limit: 100;w=21600\nx-ratelimit-remaining: 98;w=21600\nratelimit-remaining: 98;w=21600\n")
         TOKEN=$(curl -m 10 -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         curl -m 10 -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
       COMMAND
@@ -1156,11 +1156,23 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
     it "Logs docker limits and nil cache proxy log if workflow_job is successful" do
       runner.update(workflow_job: {"conclusion" => "success"})
-      expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, log: false).and_return("ratelimit-limit: 100;w=21600\nratelimit-remaining: 98;w=21600\ndocker-ratelimit-source: 192.168.1.1\n")
+      expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, log: false).and_return("docker-ratelimit-source: 192.168.1.1\nx-ratelimit-limit: 100;w=21600\nratelimit-limit: 100;w=21600\nx-ratelimit-remaining: 98;w=21600\nratelimit-remaining: 98;w=21600\n")
         TOKEN=$(curl -m 10 -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         curl -m 10 -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
       COMMAND
       expect(Clog).to receive(:emit).with("Remaining DockerHub rate limits", {dockerhub_rate_limits: {limit: 100, limit_window: 21600, remaining: 98, remaining_window: 21600, source: "192.168.1.1"}})
+      expect(vm.sshable).to receive(:_cmd).with("sudo cat /var/log/cacheproxy.log", log: false).and_return(nil)
+
+      nx.collect_final_telemetry
+    end
+
+    it "Logs docker limits whatever the header order is, and without the source header" do
+      runner.update(workflow_job: {"conclusion" => "success"})
+      expect(vm.sshable).to receive(:_cmd).with(<<~COMMAND, log: false).and_return("ratelimit-remaining: 98;w=21600\nratelimit-limit: 100;w=21600\n")
+        TOKEN=$(curl -m 10 -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl -m 10 -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit
+      COMMAND
+      expect(Clog).to receive(:emit).with("Remaining DockerHub rate limits", {dockerhub_rate_limits: {limit: 100, limit_window: 21600, remaining: 98, remaining_window: 21600, source: nil}})
       expect(vm.sshable).to receive(:_cmd).with("sudo cat /var/log/cacheproxy.log", log: false).and_return(nil)
 
       nx.collect_final_telemetry


### PR DESCRIPTION
The parser expected the rate limit headers in a single ordered sequence of limit, remaining, and source. DockerHub returns the source header first, so the match never succeeded and we never emitted the log.

```
docker-ratelimit-source: <ip>
x-ratelimit-limit: 100;w=3600
ratelimit-limit: 100;w=3600
x-ratelimit-remaining: 100;w=3600
ratelimit-remaining: 100;w=3600
```

Match each header on its own line instead, which makes the order irrelevant and keeps the duplicate x-ratelimit-* headers from interfering. The source header is now optional, so we still log the limits without it.