### PR TITLE
Extend GCP subnet destroy deadline for dedicated VPCs

### DIFF
--- a/prog/vnet/gcp/subnet_nexus.rb
+++ b/prog/vnet/gcp/subnet_nexus.rb
@@ -148,7 +148,9 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   end
 
   label def destroy
-    register_deadline("destroy", 5 * 60)
+    # Dedicated VPC teardown happens inline in finish_destroy and can be slow.
+    dedicated_vpc = private_subnet.gcp_vpc&.dedicated_for_subnet_id == private_subnet.id
+    register_deadline("destroy", dedicated_vpc ? 15 * 60 : 5 * 60)
     decr_destroy
     private_subnet.remove_all_firewalls
 

--- a/spec/prog/vnet/gcp/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_spec.rb
@@ -673,6 +673,46 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
 
       expect(Semaphore.where(strand_id: nic.id, name: "destroy").any?).to be true
       expect(Semaphore.where(strand_id: lb.id, name: "destroy").any?).to be true
+
+      frame = nx.strand.stack.first
+      expect(frame["deadline_target"]).to eq("destroy")
+      expect(Time.new(frame["deadline_at"])).to be_within(10).of(Time.now + 5 * 60)
+    end
+
+    it "registers a longer deadline when the subnet has a dedicated VPC" do
+      gcp_vpc.update(dedicated_for_subnet_id: ps.id)
+      vm = create_vm(project_id: project.id, location_id: location.id)
+      Strand.create_with_id(vm, prog: "Vm::Nexus", label: "wait")
+      nic = Nic.create(private_subnet_id: ps.id, private_ipv6: "fd10:9b0b:6b4b:8fbb:abc::",
+        private_ipv4: "10.0.0.5", mac: "00:00:00:00:00:00",
+        encryption_key: "0x736f6d655f656e6372797074696f6e5f6b6579",
+        name: "default-nic", vm_id: vm.id, state: "active")
+      Strand.create_with_id(nic, prog: "Vnet::NicNexus", label: "wait")
+
+      expect(nx).to receive(:rand).with(5..10).and_return(7)
+      expect { nx.destroy }.to nap(7)
+
+      frame = nx.strand.stack.first
+      expect(frame["deadline_target"]).to eq("destroy")
+      expect(Time.new(frame["deadline_at"])).to be_within(10).of(Time.now + 15 * 60)
+    end
+
+    it "registers the short deadline when the subnet has no VPC linked" do
+      DB[:private_subnet_gcp_vpc].where(private_subnet_id: ps.id).delete
+      vm = create_vm(project_id: project.id, location_id: location.id)
+      Strand.create_with_id(vm, prog: "Vm::Nexus", label: "wait")
+      nic = Nic.create(private_subnet_id: ps.id, private_ipv6: "fd10:9b0b:6b4b:8fbb:abc::",
+        private_ipv4: "10.0.0.5", mac: "00:00:00:00:00:00",
+        encryption_key: "0x736f6d655f656e6372797074696f6e5f6b6579",
+        name: "default-nic", vm_id: vm.id, state: "active")
+      Strand.create_with_id(nic, prog: "Vnet::NicNexus", label: "wait")
+
+      expect(nx).to receive(:rand).with(5..10).and_return(7)
+      expect { nx.destroy }.to nap(7)
+
+      frame = nx.strand.stack.first
+      expect(frame["deadline_target"]).to eq("destroy")
+      expect(Time.new(frame["deadline_at"])).to be_within(10).of(Time.now + 5 * 60)
     end
 
     it "handles policy not found during rule cleanup" do


### PR DESCRIPTION
When a subnet has a dedicated VPC, finish_destroy tears the VPC down inline: it drops the join row, fires destroy on the GcpVpc, and naps until VpcNexus deletes the VPC row. GCP can take well over five minutes to delete a VPC (firewall policies, tag bindings, then the network itself), so healthy teardowns blow the 5-minute deadline and page.

Register a 15-minute deadline instead when the subnet's VPC is dedicated. The check mirrors finish_destroy's own condition (gcp_vpc.dedicated_for_subnet_id == private_subnet.id) rather than the project's gcp_dedicated_subnet_vpcs flag: the flag is a creation-time knob that can be flipped off while dedicated-VPC subnets still exist, and the VPC row is the authoritative signal for which teardown path destroy takes.