### PR TITLE
Add an admin action to force stop a GitHub installation's runners

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -524,6 +524,17 @@ class CloverAdmin < Roda
         type :direct
         run(&github_page_run)
       end
+
+      action "force_stop_runners", "Force Stop All Runners" do
+        flash "Force stop scheduled for all runners of GitHub installation"
+        run do |obj|
+          runner_ids = obj.runners_dataset.select(:id)
+          DB.transaction do
+            GithubRunner.incr_skip_deregistration(runner_ids)
+            GithubRunner.incr_destroy(runner_ids)
+          end
+        end
+      end
     end
 
     model GithubRepository do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -1752,6 +1752,19 @@ RSpec.describe CloverAdmin do
     expect(page.driver.response.headers["Location"]).to eq "http://github.com/test-org"
   end
 
+  it "supports force stopping all runners for GithubInstallation" do
+    ins = GithubInstallation.create(installation_id: 123, name: "test-org", type: "Organization")
+    runner = GithubRunner.create(installation_id: ins.id, repository_name: "test-org/test-repo", label: "ubicloud")
+    Strand.create(prog: "Github::GithubRunnerNexus", label: "start") { it.id = runner.id }
+
+    visit "/model/GithubInstallation/#{ins.ubid}"
+    click_link "Force Stop All Runners"
+    click_button "Force Stop All Runners"
+    expect(page.title).to eq "Ubicloud Admin - GithubInstallation #{ins.ubid}"
+    expect(page).to have_flash_notice "Force stop scheduled for all runners of GitHub installation"
+    expect(runner.reload.semaphores.map(&:name).sort).to eq ["destroy", "skip_deregistration"]
+  end
+
   it "links to GitHub page for GithubRepository" do
     ins = GithubInstallation.create(installation_id: 123, name: "test-org", type: "Organization")
     repo = GithubRepository.create(name: "test-org/test-repo", installation_id: ins.id)


### PR DESCRIPTION
When we catch an installation being used for fraud, every runner it has running is costing us until it is gone, so a single button that force stops all of them is useful. The admin panel already reaches every runner through the installation, so put the bulk form there.

Set skip_deregistration alongside destroy, the same pair DestroyGithubInstallation and the customer runner delete route use. Without it the destroy label asks GitHub whether the runner is busy and naps until the job finishes, which is exactly what we do not want here: the job is the thing we are stopping, and it can run for hours.

Both semaphores go in by id subquery rather than per runner, so a big installation costs the same two statements as a small one.