### PR TITLE
Give a freshly configured target time to collect

### DIFF
--- a/lib/metrics_target_methods.rb
+++ b/lib/metrics_target_methods.rb
@@ -53,10 +53,11 @@ module MetricsTargetMethods
   def observe_metrics_backlog(session)
     tag = metrics_backlog_page_tag
     metrics_done_dir = "#{metrics_dir}/done"
-    fields = session[:ssh_session].exec!("test -d :metrics_done_dir && echo $(date +%s) $(stat -c %Y :metrics_done_dir) $(ls :metrics_done_dir | wc -l) || echo missing", metrics_done_dir:).split
-    now, touched_at, metrics_backlog = fields.map { Integer(it, 10) } unless fields == ["missing"]
+    config_path = "#{metrics_dir}/config.json"
+    fields = session[:ssh_session].exec!("echo $(date +%s) $(stat -c %Y :config_path) $(test -d :metrics_done_dir && stat -c %Y :metrics_done_dir || echo 0) $(test -d :metrics_done_dir && ls :metrics_done_dir | wc -l || echo 0)", config_path:, metrics_done_dir:).split
+    now, configured_at, collected_at, metrics_backlog = fields.map { Integer(it, 10) }
 
-    if fields == ["missing"] || now - touched_at > METRICS_BACKLOG_THRESHOLD_SECONDS
+    if now - [configured_at, collected_at].max > METRICS_BACKLOG_THRESHOLD_SECONDS
       Prog::PageNexus.assemble("#{ubid} is not collecting metrics",
         [tag, id], ubid, severity: "warning")
       return

--- a/spec/model/kubernetes/kubernetes_node_spec.rb
+++ b/spec/model/kubernetes/kubernetes_node_spec.rb
@@ -103,9 +103,9 @@ RSpec.describe KubernetesNode do
   end
 
   describe "#observe_metrics_backlog" do
-    let(:find_command) { "test -d /home/ubi/kubernetes/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/kubernetes/metrics/done) $(ls /home/ubi/kubernetes/metrics/done | wc -l) || echo missing" }
+    let(:find_command) { "echo $(date +%s) $(stat -c %Y /home/ubi/kubernetes/metrics/config.json) $(test -d /home/ubi/kubernetes/metrics/done && stat -c %Y /home/ubi/kubernetes/metrics/done || echo 0) $(test -d /home/ubi/kubernetes/metrics/done && ls /home/ubi/kubernetes/metrics/done | wc -l || echo 0)" }
     let(:now) { Time.now.utc.to_i }
-    let(:reading) { ->(count, touched_secs_ago: 0) { "#{now} #{now - touched_secs_ago} #{count}\n" } }
+    let(:reading) { ->(count, touched_secs_ago: 0, configured_secs_ago: 60 * 60) { "#{now} #{now - configured_secs_ago} #{now - touched_secs_ago} #{count}\n" } }
 
     it "does nothing when the backlog is within limits" do
       expect(ssh_session).to receive(:_exec!).with(find_command).and_return(reading.call(10))
@@ -149,7 +149,7 @@ RSpec.describe KubernetesNode do
     end
 
     it "pages when the metrics directory is missing" do
-      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("missing\n")
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("#{now} #{now - 60 * 60} 0 0\n")
 
       kn.observe_metrics_backlog(session)
 
@@ -164,6 +164,14 @@ RSpec.describe KubernetesNode do
       kn.observe_metrics_backlog(session)
 
       expect(Page.from_tag_parts("KubernetesMetricsBacklogHigh", kn.id).summary).to eq "#{kn.ubid} is not collecting metrics"
+    end
+
+    it "does not page a target whose metrics were only just configured" do
+      expect(ssh_session).to receive(:_exec!).with(find_command).and_return("#{now} #{now - 30} 0 0\n")
+
+      kn.observe_metrics_backlog(session)
+
+      expect(Page.from_tag_parts("KubernetesMetricsBacklogHigh", kn.id)).to be_nil
     end
 
     it "does nothing when the exporter has just drained the directory" do

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -1452,7 +1452,7 @@ RSpec.describe PostgresServer do
       {ssh_session: Net::SSH::Connection::Session.allocate}
     }
     let(:now) { Time.now.utc.to_i }
-    let(:reading) { ->(count, touched_secs_ago: 0) { "#{now} #{now - touched_secs_ago} #{count}\n" } }
+    let(:reading) { ->(count, touched_secs_ago: 0, configured_secs_ago: 60 * 60) { "#{now} #{now - configured_secs_ago} #{now - touched_secs_ago} #{count}\n" } }
 
     before do
       allow(postgres_server).to receive(:metrics_config).and_return({
@@ -1463,7 +1463,7 @@ RSpec.describe PostgresServer do
 
     it "checks metrics backlog and does nothing if it is within limits" do
       expect(session[:ssh_session]).to receive(:_exec!).with(
-        "test -d /home/ubi/postgres/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/done) $(ls /home/ubi/postgres/metrics/done | wc -l) || echo missing",
+        "echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/config.json) $(test -d /home/ubi/postgres/metrics/done && stat -c %Y /home/ubi/postgres/metrics/done || echo 0) $(test -d /home/ubi/postgres/metrics/done && ls /home/ubi/postgres/metrics/done | wc -l || echo 0)",
       ).and_return(reading.call(10))
 
       postgres_server.observe_metrics_backlog(session)
@@ -1474,7 +1474,7 @@ RSpec.describe PostgresServer do
     it "checks metrics backlog and creates a page if it exceeds threshold" do
       # 30 files * 15 seconds = 450 > 300 threshold
       expect(session[:ssh_session]).to receive(:_exec!).with(
-        "test -d /home/ubi/postgres/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/done) $(ls /home/ubi/postgres/metrics/done | wc -l) || echo missing",
+        "echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/config.json) $(test -d /home/ubi/postgres/metrics/done && stat -c %Y /home/ubi/postgres/metrics/done || echo 0) $(test -d /home/ubi/postgres/metrics/done && ls /home/ubi/postgres/metrics/done | wc -l || echo 0)",
       ).and_return(reading.call(30))
 
       postgres_server.observe_metrics_backlog(session)
@@ -1498,7 +1498,7 @@ RSpec.describe PostgresServer do
       existing_page = Page.from_tag_parts("PGMetricsBacklogHigh", postgres_server.id)
       # 10 files * 15 seconds = 150 < 300 threshold
       expect(session[:ssh_session]).to receive(:_exec!).with(
-        "test -d /home/ubi/postgres/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/done) $(ls /home/ubi/postgres/metrics/done | wc -l) || echo missing",
+        "echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/config.json) $(test -d /home/ubi/postgres/metrics/done && stat -c %Y /home/ubi/postgres/metrics/done || echo 0) $(test -d /home/ubi/postgres/metrics/done && ls /home/ubi/postgres/metrics/done | wc -l || echo 0)",
       ).and_return(reading.call(10))
 
       postgres_server.observe_metrics_backlog(session)
@@ -1508,8 +1508,8 @@ RSpec.describe PostgresServer do
 
     it "pages when the metrics directory is missing" do
       expect(session[:ssh_session]).to receive(:_exec!).with(
-        "test -d /home/ubi/postgres/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/done) $(ls /home/ubi/postgres/metrics/done | wc -l) || echo missing",
-      ).and_return("missing\n")
+        "echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/config.json) $(test -d /home/ubi/postgres/metrics/done && stat -c %Y /home/ubi/postgres/metrics/done || echo 0) $(test -d /home/ubi/postgres/metrics/done && ls /home/ubi/postgres/metrics/done | wc -l || echo 0)",
+      ).and_return("#{now} #{now - 60 * 60} 0 0\n")
 
       postgres_server.observe_metrics_backlog(session)
 
@@ -1519,13 +1519,23 @@ RSpec.describe PostgresServer do
 
     it "pages when the directory has not been written to or drained recently" do
       expect(session[:ssh_session]).to receive(:_exec!).with(
-        "test -d /home/ubi/postgres/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/done) $(ls /home/ubi/postgres/metrics/done | wc -l) || echo missing",
+        "echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/config.json) $(test -d /home/ubi/postgres/metrics/done && stat -c %Y /home/ubi/postgres/metrics/done || echo 0) $(test -d /home/ubi/postgres/metrics/done && ls /home/ubi/postgres/metrics/done | wc -l || echo 0)",
       ).and_return(reading.call(0, touched_secs_ago: 20 * 60))
 
       postgres_server.observe_metrics_backlog(session)
 
       page = Page.from_tag_parts("PGMetricsBacklogHigh", postgres_server.id)
       expect(page.summary).to eq "#{postgres_server.ubid} is not collecting metrics"
+    end
+
+    it "does not page a target whose metrics were only just configured" do
+      expect(session[:ssh_session]).to receive(:_exec!).with(
+        "echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/config.json) $(test -d /home/ubi/postgres/metrics/done && stat -c %Y /home/ubi/postgres/metrics/done || echo 0) $(test -d /home/ubi/postgres/metrics/done && ls /home/ubi/postgres/metrics/done | wc -l || echo 0)",
+      ).and_return("#{now} #{now - 30} 0 0\n")
+
+      postgres_server.observe_metrics_backlog(session)
+
+      expect(Page.from_tag_parts("PGMetricsBacklogHigh", postgres_server.id)).to be_nil
     end
 
     it "does not resolve page if it is still high" do
@@ -1538,7 +1548,7 @@ RSpec.describe PostgresServer do
       )
       existing_page = Page.from_tag_parts("PGMetricsBacklogHigh", postgres_server.id)
       expect(session[:ssh_session]).to receive(:_exec!).with(
-        "test -d /home/ubi/postgres/metrics/done && echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/done) $(ls /home/ubi/postgres/metrics/done | wc -l) || echo missing",
+        "echo $(date +%s) $(stat -c %Y /home/ubi/postgres/metrics/config.json) $(test -d /home/ubi/postgres/metrics/done && stat -c %Y /home/ubi/postgres/metrics/done || echo 0) $(test -d /home/ubi/postgres/metrics/done && ls /home/ubi/postgres/metrics/done | wc -l || echo 0)",
       ).and_return(reading.call(19))
 
       postgres_server.observe_metrics_backlog(session)


### PR DESCRIPTION
The done directory is created by the collector's first run, so between a target joining the export pool and that run it is indistinguishable from one that stopped collecting months ago. Every new Postgres server pages for the couple of minutes it takes, and the same waits for every Kubernetes node.

Read the mtime of config.json alongside the one of the done directory and measure staleness from whichever is newer. configure_metrics rewrites that file every time it runs, so it dates the configuration the collector is working from, and a target has a full threshold to produce its first scrape before anyone hears about it. A target reconfigured after a long outage gets the same grace, which is what you want while the fix takes effect.

The done directory no longer has to exist for the read to succeed, so the missing case is just a collection timestamp of zero rather than a separate answer.