### PR TITLE
Set noatime on Postgres data volume mounts

### DIFF
--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -127,8 +127,8 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
 
       vm.sshable.cmd("sudo mkdir -p /dat")
       device_uuid = vm.sshable.cmd("sudo blkid -s UUID -o value :device_path", device_path:).strip
-      vm.sshable.cmd("sudo common/bin/add_to_fstab UUID=:device_uuid /dat ext4 defaults 0 0", device_uuid:)
-      vm.sshable.cmd("sudo mount :device_path /dat", device_path:)
+      vm.sshable.cmd("sudo common/bin/add_to_fstab UUID=:device_uuid /dat ext4 defaults,noatime 0 0", device_uuid:)
+      vm.sshable.cmd("sudo mount /dat")
 
       hop_run_init_script
     when "Failed", "NotStarted"

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -339,8 +339,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check format_disk").and_return("Succeeded")
       expect(sshable).to receive(:_cmd).with("sudo mkdir -p /dat")
       expect(sshable).to receive(:_cmd).with("sudo blkid -s UUID -o value /dev/vdb").and_return("11111111-2222-3333-4444-555555555555\n")
-      expect(sshable).to receive(:_cmd).with("sudo common/bin/add_to_fstab UUID=11111111-2222-3333-4444-555555555555 /dat ext4 defaults 0 0")
-      expect(sshable).to receive(:_cmd).with("sudo mount /dev/vdb /dat")
+      expect(sshable).to receive(:_cmd).with("sudo common/bin/add_to_fstab UUID=11111111-2222-3333-4444-555555555555 /dat ext4 defaults,noatime 0 0")
+      expect(sshable).to receive(:_cmd).with("sudo mount /dat")
       expect { nx.mount_data_disk }.to hop("run_init_script")
     end
 
@@ -353,8 +353,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(sshable).to receive(:_cmd).with("sudo tune2fs /dev/md0 -r 1677721").and_return("Succeeded")
       expect(sshable).to receive(:_cmd).with("sudo mkdir -p /dat")
       expect(sshable).to receive(:_cmd).with("sudo blkid -s UUID -o value /dev/md0").and_return("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\n")
-      expect(sshable).to receive(:_cmd).with("sudo common/bin/add_to_fstab UUID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee /dat ext4 defaults 0 0")
-      expect(sshable).to receive(:_cmd).with("sudo mount /dev/md0 /dat")
+      expect(sshable).to receive(:_cmd).with("sudo common/bin/add_to_fstab UUID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee /dat ext4 defaults,noatime 0 0")
+      expect(sshable).to receive(:_cmd).with("sudo mount /dat")
       expect { nx.mount_data_disk }.to hop("run_init_script")
     end
 


### PR DESCRIPTION
Reduces unnecessary write amplification from atime updates on every read of the data directory.