### PR TITLE
Replace the coredns ConfigMap through the Kubernetes client

### DIFF
--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -404,7 +404,8 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
 
     dns_records = kubernetes_cluster.all_functional_nodes.flat_map { |n| ["#{n.vm.ip4} #{n.name}", "#{n.vm.ip6} #{n.name}"] }
 
-    coredns_configmap = YAML.load(kubernetes_cluster.client.kubectl("-n kube-system get cm coredns -oyaml"))
+    client = kubernetes_cluster.client
+    coredns_configmap = YAML.load(client.kubectl("-n kube-system get cm coredns -oyaml"))
     unless (corefile = coredns_configmap.dig("data", "Corefile"))
       # Customers may have deleted this entry or have custom tunings.
       # We will ignore such cases and return early.
@@ -444,7 +445,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     new_lines = lines[0...kubernetes_block_end + 1] + hosts_lines.split("\n") + lines[kubernetes_block_end + 1..]
     new_corefile = new_lines.join("\n")
     coredns_configmap["data"]["Corefile"] = new_corefile
-    kubernetes_cluster.sshable.cmd("sudo kubectl --kubeconfig /etc/kubernetes/admin.conf replace -f -", stdin: YAML.dump(coredns_configmap))
+    client.kubectl("replace -f -", stdin: YAML.dump(coredns_configmap))
 
     hop_wait
   end

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -991,7 +991,8 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
       response = Net::SSH::Connection::Session::StringWithExitstatus.new(get_cm, 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s -n kube-system get cm coredns -oyaml").and_return(response)
-      expect(sshable).to receive(:_cmd).with("sudo kubectl --kubeconfig /etc/kubernetes/admin.conf replace -f -", stdin: replace_cm)
+      replace_response = Net::SSH::Connection::Session::StringWithExitstatus.new("configmap/coredns replaced", 0)
+      expect(session).to receive(:_exec!).with("printf '%s' #{replace_cm.shellescape} | sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s replace -f -").and_return(replace_response)
       expect { nx.sync_internal_dns_config }.to hop("wait")
     end
 


### PR DESCRIPTION
exec! takes stdin now, so the label no longer needs to reach for the cluster sshable and spell out the kubectl invocation by hand.