### PR TITLE
Make cli pg ca-certificates command handle no CA certs

### DIFF
--- a/cli-commands/pg/post/ca-certificates.rb
+++ b/cli-commands/pg/post/ca-certificates.rb
@@ -2,12 +2,19 @@
 
 class UbiCli
   on("pg").run_on("ca-certificates") do
-    desc "Print CA certificates for a PostgreSQL database"
+    desc "Print CA certificates for a PostgreSQL database (if available)"
 
     banner "ubi pg (location/pg-name | pg-id) ca-certificates"
 
-    run do
-      response(sdk_object.ca_certificates)
+    run do |_, cmd|
+      unless (certs = sdk_object.ca_certificates)
+        cmd.raise_failure(<<~END)
+          CA certificates are not available for this database, either because it uses
+          publicly signed certificates or because a CA certificate has not been generated
+          yet.
+        END
+      end
+      response(certs)
     end
   end
 end

--- a/spec/routes/api/cli/golden-files/help -r.txt
+++ b/spec/routes/api/cli/golden-files/help -r.txt
@@ -699,7 +699,7 @@ Post Commands:
     add-otlp-log-destination           Add an OTLP HTTP log destination to a PostgreSQL database
     add-pgbouncer-config-entries       Add pgbouncer configuration entries to a PostgreSQL database
     add-syslog-log-destination         Add a syslog (RFC 5424 over TLS) log destination to a PostgreSQL database
-    ca-certificates                    Print CA certificates for a PostgreSQL database
+    ca-certificates                    Print CA certificates for a PostgreSQL database (if available)
     create                             Create a PostgreSQL database
     create-backup-credentials          Create temporary, read-only credentials for downloading PostgreSQL backups
     create-client-cert-keypair         Create client certificate keypair with given common name, expiring after a duration of seconds
@@ -803,7 +803,7 @@ Usage:
     ubi pg (location/pg-name | pg-id) add-syslog-log-destination name host [port] [sd-id/key=value [...]]
 
 
-Print CA certificates for a PostgreSQL database
+Print CA certificates for a PostgreSQL database (if available)
 
 Usage:
     ubi pg (location/pg-name | pg-id) ca-certificates

--- a/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg -X pg_dump.txt
+++ b/spec/routes/api/cli/golden-files/pg eu-central-h1_test-pg -X pg_dump.txt
@@ -18,7 +18,7 @@ Post Commands:
     add-otlp-log-destination           Add an OTLP HTTP log destination to a PostgreSQL database
     add-pgbouncer-config-entries       Add pgbouncer configuration entries to a PostgreSQL database
     add-syslog-log-destination         Add a syslog (RFC 5424 over TLS) log destination to a PostgreSQL database
-    ca-certificates                    Print CA certificates for a PostgreSQL database
+    ca-certificates                    Print CA certificates for a PostgreSQL database (if available)
     create                             Create a PostgreSQL database
     create-backup-credentials          Create temporary, read-only credentials for downloading PostgreSQL backups
     create-client-cert-keypair         Create client certificate keypair with given common name, expiring after a duration of seconds

--- a/spec/routes/api/cli/pg/ca-certificates_spec.rb
+++ b/spec/routes/api/cli/pg/ca-certificates_spec.rb
@@ -13,4 +13,18 @@ RSpec.describe Clover, "cli pg ca-certificates" do
     @pg.update(root_cert_1: "C1", root_cert_2: "C2")
     expect(cli(%w[pg eu-central-h1/test-pg ca-certificates])).to eq "C1\nC2\n"
   end
+
+  it "gives error if the server does not have root certificates" do
+    expect(cli(%w[pg eu-central-h1/test-pg ca-certificates], status: 400)).to eq <<~END
+      ! CA certificates are not available for this database, either because it uses
+      publicly signed certificates or because a CA certificate has not been generated
+      yet.
+
+
+      Print CA certificates for a PostgreSQL database (if available)
+
+      Usage:
+          ubi pg (location/pg-name | pg-id) ca-certificates
+    END
+  end
 end


### PR DESCRIPTION
Previously, this resulted in a NoMethodError. Handle this case by returning an error with an explanation.

Fixes a production exception.