### PR TITLE
Recognize Seahorse::Client::NetworkingError as a multipart upload error

### DIFF
--- a/routes/runtime/github.rb
+++ b/routes/runtime/github.rb
@@ -131,7 +131,7 @@ class Clover
           retries = 0
           begin
             upload_id = blob_storage_client.create_multipart_upload(bucket:, key: blob_key).upload_id
-          rescue Aws::S3::Errors::Unauthorized, Aws::S3::Errors::InternalError, Aws::S3::Errors::NoSuchBucket => ex
+          rescue Aws::S3::Errors::Unauthorized, Aws::S3::Errors::InternalError, Aws::S3::Errors::NoSuchBucket, Seahorse::Client::NetworkingError => ex
             retries += 1
             if retries < 3
               # simplecov:disable


### PR DESCRIPTION
I'm not 100% sure this is the cause of the issue, as the production logs only include 50 backtrace lines, and all of the backtraces are in the aws-sdk code. The error is being raised inside POST /runtime/github/caches, and looking at the code, this appears to be the only code calling into the aws-sdk.

Assuming this is the correct fix, this fixes multiple production exceptions.