### PR TITLE
Give GitHub repository runners time to drain before destroying

### DIFF
--- a/prog/github/github_repository_nexus.rb
+++ b/prog/github/github_repository_nexus.rb
@@ -156,10 +156,10 @@ class Prog::Github::GithubRepositoryNexus < Prog::Base
   label def destroy
     decr_destroy
 
-    register_deadline(nil, 5 * 60)
+    register_deadline(nil, 400)
     unless github_repository.runners.empty?
       Clog.emit("Cannot destroy repository with active runners", {not_destroyed_repository: {repository_name: github_repository.name}})
-      nap 5 * 60
+      nap 2 * 60
     end
 
     github_repository.cache_entries_dataset.destroy

--- a/spec/prog/github/github_repository_nexus_spec.rb
+++ b/spec/prog/github/github_repository_nexus_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe Prog::Github::GithubRepositoryNexus do
   describe "#destroy" do
     it "does not destroy if has active runner" do
       GithubRunner.create(repository_id: repository.id, repository_name: "ubicloud/ubicloud", label: "ubicloud")
-      expect { nx.destroy }.to nap(5 * 60)
+      expect { nx.destroy }.to nap(2 * 60)
     end
 
     it "destroys blob storage if has one" do


### PR DESCRIPTION
With a 5-minute deadline and a 5-minute nap, a repository that still had runners napped once and immediately blew the deadline, which often created a transient page that resolved on its own moments later once the runners drained and the repository was destroyed.

Extend the deadline slightly (300 -> 400 seconds) and shorten the nap to 2 minutes so the repository gets a few retries (~3) to drain its runners before the deadline pages.