### PR TITLE
Dual-stack resilient DNS for metal VMs

### DIFF
--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -414,6 +414,17 @@ class VmHost < Sequel::Model
       check_clock_source(ssh_session)
   end
 
+  # The same upstream resolvers the per-VM dnsmasq forwards to (see
+  # cloudinit in rhizome/host/lib/vm_setup.rb): the host's root
+  # namespace shares the uplink path with the VM DNS egress leg of
+  # each family.
+  DNS_EGRESS_UPSTREAMS = {"4" => "8.8.8.8", "6" => "2606:4700:4700::1111"}.freeze
+
+  # A root SOA query has an answer at every resolver, so a negative DNS
+  # answer cannot read as an egress failure: only a response that never
+  # arrives (Resolv::ResolvError, or the timeout kill) exits nonzero.
+  DNS_EGRESS_PROBE = "timeout 5 ruby -rresolv -e 'd = Resolv::DNS.new(nameserver: [ARGV[0]]); d.timeouts = 2; d.getresource(\".\", Resolv::DNS::Resource::IN::SOA)' -- :nameserver"
+
   def check_pulse(session:, previous_pulse:)
     reading = begin
       perform_health_checks(session[:ssh_session]) ? "up" : "down"
@@ -429,7 +440,37 @@ class VmHost < Sequel::Model
       incr_checkup
     end
 
+    pulse.merge!(dns_egress_pulse(session, previous_pulse, "4"))
+    pulse.merge!(dns_egress_pulse(session, previous_pulse, "6")) if net6
+
     pulse
+  end
+
+  # DNS egress failures page (severity warning) instead of feeding the
+  # up/down pulse: an upstream DNS family outage must not make a healthy
+  # host look down, but it silently halves the failover margin of the
+  # dual-stack VM resolvers, so it must not stay unnoticed either.
+  def dns_egress_pulse(session, previous_pulse, family)
+    reading = begin
+      (session[:ssh_session].exec!(DNS_EGRESS_PROBE, nameserver: DNS_EGRESS_UPSTREAMS.fetch(family)).exitstatus == 0) ? "up" : "down"
+    rescue IOError, Errno::ECONNRESET
+      raise
+    rescue => e
+      Clog.emit("DNS egress probe exception on VmHost #{ubid}", Util.exception_to_hash(e))
+      "down"
+    end
+
+    repeat = previous_pulse[:"dns_egress#{family}"] == reading
+    rpt = repeat ? previous_pulse[:"dns_egress#{family}_rpt"] + 1 : 1
+    chg = repeat ? previous_pulse[:"dns_egress#{family}_chg"] : Time.now
+
+    if reading == "up"
+      Page.from_tag_parts("VmHostDnsEgressIpv#{family}", id)&.incr_resolve
+    elsif rpt >= 5 && Time.now - chg >= 300
+      Prog::PageNexus.assemble("#{ubid} IPv#{family} DNS egress failing", ["VmHostDnsEgressIpv#{family}", id], ubid, severity: "warning")
+    end
+
+    {"dns_egress#{family}": reading, "dns_egress#{family}_rpt": rpt, "dns_egress#{family}_chg": chg}
   end
 
   def available_storage_gib

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -436,6 +436,10 @@ TIMER
       nap 15
     end
 
+    # Resolve host-keyed pages so they don't orphan after the host is gone.
+    %w[VmHostDnsEgressIpv4 VmHostDnsEgressIpv6].each do |tag|
+      Page.from_tag_parts(tag, vm_host.id)&.incr_resolve
+    end
     vm_host.destroy
     sshable.destroy
 

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -255,6 +255,12 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
 
     r "ip", "netns", "add", @vm_name
 
+    # A fresh netns has lo down, which makes the kernel silently drop
+    # host-side test traffic to netns-local addresses (dnsmasq's listen
+    # addresses): sendto succeeds, the packet vanishes, and nothing
+    # shows in tcpdump.
+    r "ip", "-n", @vm_name, "link", "set", "lo", "up"
+
     # Generate MAC addresses rather than letting Linux do it to avoid
     # a vexing bug whereby a freshly created link will, at least once,
     # spontaneously change its MAC address sometime soon after

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -43,7 +43,7 @@ class VmSetup
     boot_image, dns_ipv4, slice_name, cpu_percent_limit, cpu_burst_percent_limit,
     init_script, ipv6_disabled, gpu_partition_id)
 
-    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4, ipv6_disabled: ipv6_disabled, init_script: init_script)
+    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4, ipv6_disabled: ipv6_disabled, ip4: ip4, init_script: init_script)
     network_thread = Thread.new do
       setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, dns_ipv4, multiqueue: max_vcpus > 1)
     end
@@ -82,7 +82,7 @@ class VmSetup
     mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices, boot_image,
     dns_ipv4, slice_name, cpu_percent_limit, cpu_burst_percent_limit, ipv6_disabled, init_script)
 
-    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4, ipv6_disabled: ipv6_disabled, init_script: init_script)
+    cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4, ipv6_disabled: ipv6_disabled, ip4: ip4, init_script: init_script)
     setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, dns_ipv4, multiqueue: max_vcpus > 1)
     hugepages(mem_gib)
     storage(storage_params, storage_secrets, false)
@@ -114,7 +114,7 @@ class VmSetup
     setup_veths_6(guest_ephemeral, clover_ephemeral, gua, ndp_needed)
     setup_taps_6(gua, nics, dns_ipv4)
     routes4(ip4, local_ip4, nics)
-    write_nftables_conf(ip4, gua, nics)
+    write_nftables_conf(ip4, local_ip4, gua, nics)
     forwarding
   end
 
@@ -388,18 +388,22 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     end
   end
 
-  def write_nftables_conf(ip4, gua, nics)
-    config = build_nftables_config(gua, nics, ip4)
+  def write_nftables_conf(ip4, local_ip4, gua, nics)
+    config = build_nftables_config(gua, nics, ip4, local_ip4)
     vp.write_nftables_conf(config)
     apply_nftables
   end
 
-  def generate_nat4_rules(ip4, private_ip)
+  def generate_nat4_rules(ip4, private_ip, local_ip4)
     return unless ip4
 
     public_ipv4 = NetAddr::IPv4Net.parse(ip4).network.to_s
     private_ipv4_addr = NetAddr::IPv4Net.parse(private_ip)
     private_ipv4 = (private_ipv4_addr.netmask.prefix_len == 32) ? private_ipv4_addr.network.to_s : private_ipv4_addr.nth(1).to_s
+    # dnsmasq sources its upstream IPv4 DNS queries from the vethi link
+    # address, a 169.254.0.0/16 address that is not routable beyond the
+    # host, so they must be NATed to the public address.
+    vethi_ipv4 = NetAddr::IPv4Net.parse(local_ip4).next_sib.network.to_s
     <<~NAT4_RULES
     table ip nat {
       chain prerouting {
@@ -411,6 +415,8 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
         type nat hook postrouting priority srcnat; policy accept;
         ip saddr #{private_ipv4} ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to #{public_ipv4}
         ip saddr #{private_ipv4} ip daddr #{private_ipv4} snat to #{public_ipv4}
+        ip saddr #{vethi_ipv4} udp dport 53 snat to #{public_ipv4}
+        ip saddr #{vethi_ipv4} tcp dport 53 snat to #{public_ipv4}
       }
     }
     NAT4_RULES
@@ -434,7 +440,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     nics.map { "ether saddr #{_1.mac} ip6 saddr != #{_1.net6} drop" }.join("\n")
   end
 
-  def build_nftables_config(gua, nics, ip4)
+  def build_nftables_config(gua, nics, ip4, local_ip4)
     guest_ephemeral = subdivide_network(NetAddr.parse_net(gua)).first
     <<~NFTABLES_CONF
       table ip raw {
@@ -470,7 +476,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
       }
 
       # NAT4 rules
-      #{generate_nat4_rules(ip4, nics.first.net4)}
+      #{generate_nat4_rules(ip4, nics.first.net4, local_ip4)}
       table inet fw_table {
         chain forward_ingress {
           type filter hook forward priority filter; policy drop;
@@ -486,7 +492,7 @@ add element inet drop_unused_ip_packets allowed_ipv4_addresses { #{ip_net} }
     r "ip", "netns", "exec", @vm_name, "nft", "-f", vp.nftables_conf
   end
 
-  def cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4, ipv6_disabled:, init_script: nil)
+  def cloudinit(unix_user, public_keys, gua, nics, swap_size_bytes, boot_image, dns_ipv4, ipv6_disabled:, ip4: nil, init_script: nil)
     vp.write_yaml_meta_data({"instance-id" => @vm_name, "local-hostname" => @vm_name})
 
     guest_network = subdivide_network(NetAddr.parse_net(gua)).first unless ipv6_disabled
@@ -518,16 +524,25 @@ DHCP
 dhcp-option=6,8.8.8.8
       IP6_CONFIG
     else
+      # all-servers: forward each query to every listed upstream and use
+      # the first answer, so resolution survives the loss of either IP
+      # family or either provider.  The IPv4 upstream is reachable only
+      # through the port-53 SNAT to the VM's public IPv4 (see
+      # generate_nat4_rules), so IPv4-less VMs list two IPv6 upstreams.
+      dns_servers = if ip4.nil? || ip4.empty?
+        ["2001:4860:4860::8888", "2606:4700:4700::1111"]
+      else
+        ["8.8.8.8", "2606:4700:4700::1111"]
+      end
       <<~IP4_CONFIG
 dhcp-range=#{guest_network.nth(2)},#{guest_network.nth(2)},#{guest_network.netmask.prefix_len}
-server=2001:4860:4860::8888
-server=2606:4700:4700::1111
+all-servers
+#{dns_servers.map { "server=#{_1}" }.join("\n")}
 dhcp-option=6,#{dns_ipv4}
 listen-address=#{dns_ipv4}
 dhcp-option=54,#{dns_ipv4}
 dhcp-option=option6:dns-server,#{dnsmasq_address_ip6}
 listen-address=#{dnsmasq_address_ip6}
-strict-order
       IP4_CONFIG
     end
     vp.write_dnsmasq_conf(<<DNSMASQ_CONF)

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -268,6 +268,29 @@ RSpec.describe VmSetup do
       expect(dnsmasq_conf).to include("dhcp-host=3e:bd:a5:96:f7:b9,id:*,192.168.5.50")
       expect(dnsmasq_conf).to include("dhcp-host=fb:55:dd:ba:21:0a,id:*,10.10.10.10")
     end
+
+    it "queries one upstream per family when the VM has a public IPv4" do
+      vs.cloudinit("user", ["key"], "fddf:53d2:4c89:2305:46a0::/79", nics, nil, "ubuntu-noble", "10.0.0.2", ipv6_disabled: false, ip4: "123.123.123.123/32")
+      dnsmasq_conf = vps.writes["dnsmasq.conf"]
+      expect(dnsmasq_conf).to include("all-servers\nserver=8.8.8.8\nserver=2606:4700:4700::1111")
+      expect(dnsmasq_conf).not_to include("strict-order")
+      expect(dnsmasq_conf).not_to include("server=2001:4860:4860::8888")
+      expect(dnsmasq_conf).not_to include("server=1.1.1.1")
+    end
+
+    it "queries two IPv6 upstreams when the VM has no public IPv4" do
+      vs.cloudinit("user", ["key"], "fddf:53d2:4c89:2305:46a0::/79", nics, nil, "ubuntu-noble", "10.0.0.2", ipv6_disabled: false, ip4: "")
+      dnsmasq_conf = vps.writes["dnsmasq.conf"]
+      expect(dnsmasq_conf).to include("all-servers\nserver=2001:4860:4860::8888\nserver=2606:4700:4700::1111")
+      expect(dnsmasq_conf).not_to include("server=8.8.8.8")
+    end
+
+    it "queries two IPv6 upstreams when the ip4 kwarg is omitted" do
+      vs.cloudinit("user", ["key"], "fddf:53d2:4c89:2305:46a0::/79", nics, nil, "ubuntu-noble", "10.0.0.2", ipv6_disabled: false)
+      dnsmasq_conf = vps.writes["dnsmasq.conf"]
+      expect(dnsmasq_conf).to include("all-servers\nserver=2001:4860:4860::8888\nserver=2606:4700:4700::1111")
+      expect(dnsmasq_conf).not_to include("server=8.8.8.8")
+    end
   end
 
   describe "#purge" do
@@ -572,7 +595,7 @@ RSpec.describe VmSetup do
       }
       expect(vs).to receive(:setup_taps_6).with(gua, [], "10.0.0.2")
       expect(vs).to receive(:routes4).with(ip4, "local_ip4", [])
-      expect(vs).to receive(:write_nftables_conf).with(ip4, gua, [])
+      expect(vs).to receive(:write_nftables_conf).with(ip4, "local_ip4", gua, [])
       expect(vs).to receive(:forwarding)
 
       expect(vps).to receive(:write_guest_ephemeral).with(guest_ephemeral.to_s)
@@ -682,6 +705,8 @@ table ip nat {
     type nat hook postrouting priority srcnat; policy accept;
     ip saddr 192.168.5.50 ip daddr != { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 } snat to 123.123.123.123
     ip saddr 192.168.5.50 ip daddr 192.168.5.50 snat to 123.123.123.123
+    ip saddr 169.254.0.11 udp dport 53 snat to 123.123.123.123
+    ip saddr 169.254.0.11 tcp dport 53 snat to 123.123.123.123
   }
 }
 
@@ -694,7 +719,7 @@ table inet fw_table {
 }
 NFTABLES_CONF
       expect(vs).to receive(:apply_nftables)
-      vs.write_nftables_conf(ip4, gua, nics)
+      vs.write_nftables_conf(ip4, "169.254.0.10/32", gua, nics)
     end
   end
 
@@ -1256,12 +1281,18 @@ NFTABLES_CONF
 
   describe "#generate_nat4_rules" do
     it "returns nil when ip4 is nil" do
-      expect(vs.send(:generate_nat4_rules, nil, "10.0.0.1/24")).to be_nil
+      expect(vs.send(:generate_nat4_rules, nil, "10.0.0.1/24", "169.254.0.10/32")).to be_nil
     end
 
     it "uses nth(1) for non-/32 private_ip" do
-      result = vs.send(:generate_nat4_rules, "1.2.3.4/32", "192.168.1.0/24")
+      result = vs.send(:generate_nat4_rules, "1.2.3.4/32", "192.168.1.0/24", "169.254.0.10/32")
       expect(result).to include("dnat to 192.168.1.1")
+    end
+
+    it "NATs dnsmasq's vethi-sourced DNS queries to the public IPv4" do
+      result = vs.send(:generate_nat4_rules, "1.2.3.4/32", "192.168.1.0/24", "169.254.0.10/32")
+      expect(result).to include("ip saddr 169.254.0.11 udp dport 53 snat to 1.2.3.4")
+      expect(result).to include("ip saddr 169.254.0.11 tcp dport 53 snat to 1.2.3.4")
     end
   end
 
@@ -1311,7 +1342,8 @@ NFTABLES_CONF
       vs.cloudinit("user", ["key"], "fddf:53d2:4c89:2305:46a0::/79", nics, nil, "ubuntu-noble", "10.0.0.2", ipv6_disabled: true)
       dnsmasq_conf = vps.writes["dnsmasq.conf"]
       expect(dnsmasq_conf).to include("dhcp-option=6,8.8.8.8")
-      expect(dnsmasq_conf).not_to include("server=2001:4860:4860::8888")
+      expect(dnsmasq_conf).not_to include("server=")
+      expect(dnsmasq_conf).not_to include("all-servers")
     end
   end
 

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -1530,6 +1530,7 @@ NFTABLES_CONF
       expect(vs).to receive(:sleep).with(0.1).once
 
       expect(vs).to receive(:_run_command).with("ip", "netns", "add", "test")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "link", "set", "lo", "up")
       expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
       expect(vs).to receive(:_run_command).with("ip", "link", "add", "vethotest", "addr", "00:00:00:00:00:00", "type", "veth", "peer", "name", "vethitest", "addr", "00:00:00:00:00:00", "netns", "test")
       nics = [VmSetup::Nic.new(nil, nil, "nctest", nil, "1.1.1.1")]
@@ -1543,6 +1544,7 @@ NFTABLES_CONF
       expect(File).to receive(:exist?).with("/sys/class/net/vethotest").and_return(false)
 
       expect(vs).to receive(:_run_command).with("ip", "netns", "add", "test")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "link", "set", "lo", "up")
       expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
       expect(vs).to receive(:_run_command).with("ip", "link", "add", "vethotest", "addr", "00:00:00:00:00:00", "type", "veth", "peer", "name", "vethitest", "addr", "00:00:00:00:00:00", "netns", "test")
       nics = [VmSetup::Nic.new(nil, nil, "nctest", nil, "1.1.1.1")]
@@ -1562,6 +1564,7 @@ NFTABLES_CONF
       )
       expect(File).to receive(:exist?).with("/sys/class/net/vethotest").and_return(false)
       expect(vs).to receive(:_run_command).with("ip", "netns", "add", "test")
+      expect(vs).to receive(:_run_command).with("ip", "-n", "test", "link", "set", "lo", "up")
       expect(vs).to receive(:gen_mac).and_return("00:00:00:00:00:00").at_least(:once)
       expect(vs).to receive(:_run_command).with("ip", "link", "add", "vethotest", "addr", "00:00:00:00:00:00", "type", "veth", "peer", "name", "vethitest", "addr", "00:00:00:00:00:00", "netns", "test")
       vs.interfaces([], false)

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -477,9 +477,19 @@ RSpec.describe VmHost do
       }
     }
 
+    def dns_probe_cmd(nameserver)
+      "timeout 5 ruby -rresolv -e 'd = Resolv::DNS.new(nameserver: [ARGV[0]]); d.timeouts = 2; d.getresource(\".\", Resolv::DNS::Resource::IN::SOA)' -- #{nameserver}"
+    end
+
+    def stub_dns_probe(nameserver, exitstatus)
+      expect(ssh_session).to receive(:_exec!).with(dns_probe_cmd(nameserver)).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", exitstatus))
+    end
+
     before do
       StorageDevice.create(vm_host_id: vm_host.id, name: "DEFAULT", total_storage_gib: 100, available_storage_gib: 100, unix_device_list: ["wwn-random-id1"])
       allow(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_return("sda")
+      allow(ssh_session).to receive(:_exec!).with(dns_probe_cmd("8.8.8.8")).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))
+      allow(ssh_session).to receive(:_exec!).with(dns_probe_cmd("2606:4700:4700::1111")).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))
     end
 
     it "checks pulse" do
@@ -494,7 +504,7 @@ RSpec.describe VmHost do
       expect(ssh_session).to receive(:_exec!).with("cat /sys/devices/system/clocksource/clocksource0/available_clocksource").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("tsc hpet acpi_pm \n", 0))
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
 
-      expect(ssh_session).to receive(:_exec!).and_raise Sshable::SshError
+      expect(ssh_session).to receive(:_exec!).with("readlink -f /dev/disk/by-id/wwn-random-id1").and_raise Sshable::SshError
       expect(vm_host.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
       expect(Semaphore.where(strand_id: vm_host.id, name: "checkup").count).to eq(1)
     end
@@ -621,6 +631,83 @@ RSpec.describe VmHost do
         expect(vm_host).to receive(:perform_health_checks).and_raise(ex)
         expect { vm_host.check_pulse(session:, previous_pulse: "notnil") }.to raise_error(ex)
       end
+    end
+
+    def stub_health_checks_pass
+      stub_smartctl_sda_passes
+      stub_remaining_health_checks_pass
+    end
+
+    it "reads dns egress up on both families and resolves an active page" do
+      Prog::PageNexus.assemble("#{vm_host.ubid} IPv6 DNS egress failing", ["VmHostDnsEgressIpv6", vm_host.id], vm_host.ubid, severity: "warning")
+      page = Page.from_tag_parts("VmHostDnsEgressIpv6", vm_host.id)
+      stub_health_checks_pass
+      pulse = vm_host.check_pulse(session:, previous_pulse: {})
+      expect(pulse[:dns_egress4]).to eq("up")
+      expect(pulse[:dns_egress4_rpt]).to eq(1)
+      expect(pulse[:dns_egress6]).to eq("up")
+      expect(pulse[:dns_egress6_rpt]).to eq(1)
+      expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
+    end
+
+    it "does not page when dns egress is down for less than five probes" do
+      stub_health_checks_pass
+      stub_dns_probe("8.8.8.8", 1)
+      previous = {dns_egress4: "down", dns_egress4_rpt: 3, dns_egress4_chg: Time.now - 600}
+      pulse = vm_host.check_pulse(session:, previous_pulse: previous)
+      expect(pulse[:dns_egress4]).to eq("down")
+      expect(pulse[:dns_egress4_rpt]).to eq(4)
+      expect(pulse[:dns_egress4_chg]).to eq(previous[:dns_egress4_chg])
+      expect(Page.from_tag_parts("VmHostDnsEgressIpv4", vm_host.id)).to be_nil
+    end
+
+    it "does not page when dns egress is down for less than 300 seconds" do
+      stub_health_checks_pass
+      stub_dns_probe("8.8.8.8", 1)
+      previous = {dns_egress4: "down", dns_egress4_rpt: 4, dns_egress4_chg: Time.now - 30}
+      pulse = vm_host.check_pulse(session:, previous_pulse: previous)
+      expect(pulse[:dns_egress4_rpt]).to eq(5)
+      expect(Page.from_tag_parts("VmHostDnsEgressIpv4", vm_host.id)).to be_nil
+    end
+
+    it "pages once when dns egress stays down past both thresholds" do
+      # The host reading is not under test: fail the health checks at
+      # their first, cheapest command so both check_pulse calls need only
+      # one stub, and drive the dns state through previous_pulse.
+      expect(ssh_session).to receive(:_exec!).with("sudo smartctl -j -H /dev/sda -d scsi | jq .smart_status.passed").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("false\n", 0)).twice
+      expect(ssh_session).to receive(:_exec!).with(dns_probe_cmd("8.8.8.8")).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)).twice
+      expect(ssh_session).to receive(:_exec!).with(dns_probe_cmd("2606:4700:4700::1111")).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 1)).twice
+      previous = {dns_egress6: "down", dns_egress6_rpt: 4, dns_egress6_chg: Time.now - 300}
+      pulse = vm_host.check_pulse(session:, previous_pulse: previous)
+      expect(pulse[:dns_egress6_rpt]).to eq(5)
+      page = Page.from_tag_parts("VmHostDnsEgressIpv6", vm_host.id)
+      expect(page.severity).to eq("warning")
+      expect(page.summary).to eq("#{vm_host.ubid} IPv6 DNS egress failing")
+      vm_host.check_pulse(session:, previous_pulse: pulse)
+      expect(Page.count).to eq(1)
+    end
+
+    it "skips the IPv6 probe when the host has no IPv6" do
+      vm_host.update(net6: nil)
+      stub_health_checks_pass
+      pulse = vm_host.check_pulse(session:, previous_pulse: {})
+      expect(pulse[:dns_egress4]).to eq("up")
+      expect(pulse).not_to have_key(:dns_egress6)
+    end
+
+    it "treats a dns probe exception as down" do
+      stub_health_checks_pass
+      expect(ssh_session).to receive(:_exec!).with(dns_probe_cmd("8.8.8.8")).and_raise(Sshable::SshError.new("cmd", "", "", nil, nil))
+      expect(Clog).to receive(:emit).with("DNS egress probe exception on VmHost #{vm_host.ubid}", instance_of(Hash)).and_call_original
+      pulse = vm_host.check_pulse(session:, previous_pulse: {})
+      expect(pulse[:dns_egress4]).to eq("down")
+      expect(pulse[:dns_egress6]).to eq("up")
+    end
+
+    it "reraises connection errors from the dns probe" do
+      stub_health_checks_pass
+      expect(ssh_session).to receive(:_exec!).with(dns_probe_cmd("8.8.8.8")).and_raise(IOError.new("closed stream"))
+      expect { vm_host.check_pulse(session:, previous_pulse: {}) }.to raise_error(IOError)
     end
   end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -570,11 +570,14 @@ RSpec.describe Prog::Vm::HostNexus do
       expect { nx.destroy }.to nap(15)
     end
 
-    it "deletes and exits" do
+    it "deletes and exits, resolving dns egress pages" do
       vm_host.update(allocation_state: "draining")
+      Prog::PageNexus.assemble("#{vm_host.ubid} IPv6 DNS egress failing", ["VmHostDnsEgressIpv6", vm_host.id], vm_host.ubid, severity: "warning")
+      page = Page.from_tag_parts("VmHostDnsEgressIpv6", vm_host.id)
       expect(vm_host).to receive(:destroy)
       expect(sshable).to receive(:destroy)
       expect { nx.destroy }.to exit({"msg" => "vm host deleted"})
+      expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
     end
   end
 


### PR DESCRIPTION
At a site behind a FortiGate, the upstream provider stopped routing IPv6 beyond the WAN gateway on 2026-08-21 and every VM there lost DNS entirely while IPv4 kept working: the per-VM dnsmasq forwards queries only to IPv6 upstreams, so guest DNS had a hard single-family dependency.

Three commits:

* **Give VM dnsmasq a working upstream per IP family** — dnsmasq now forwards every query to one upstream per family with `all-servers` (8.8.8.8 + 2606:4700:4700::1111) and takes the first answer, so the loss of either family or either provider is invisible to guests with zero added latency. The IPv4 leg needs two new dport-53 SNAT rules in the netns nat table, since dnsmasq sources those queries from the non-routable vethi 169.254 address. VMs without a public IPv4 keep two IPv6 upstreams. `all-servers` knowingly accepts the lying-upstream race (an upstream answering fast with empty NOERROR/NXDOMAIN wins the race; the Quad9 history) — the trade-off is argued in the commit message.

* **Bring lo up in VM network namespaces** — a fresh netns has lo down, so host-side test queries to dnsmasq's netns-local listen addresses vanish silently; this cost hours during the incident.

* **Page when a VM host loses DNS egress on one family** — each host probes both upstreams from its root namespace on every pulse; a family down for at least 5 consecutive probes and 300 seconds opens one warning page per host and family, and the first up reading (or host destroy) resolves it. The probes stay out of `perform_health_checks` so an upstream outage can never make a healthy host look down.

Existing VMs converge at their next prep or reassign-ip6; a host reboot regenerates only the nftables half. The hand-patched host at the incident site gets overwritten by the merged version, as intended.

cberp: 8116 examples, 0 failures, 100% line / 100% branch. rhizome_spec: 433 examples, 100% line / 100% branch. rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
