### PR TITLE
Handle Vm without user_nic in Serializers::Vm subnet field

### DIFF
--- a/serializers/vm.rb
+++ b/serializers/vm.rb
@@ -21,7 +21,7 @@ class Serializers::Vm < Serializers::Base
         firewalls: Serializers::Firewall.serialize(vm.firewalls(eager: [:location, :firewall_rules]), {include_path: true}),
         private_ipv4: vm.private_ipv4,
         private_ipv6: vm.private_ipv6,
-        subnet: vm.user_nic.private_subnet.name,
+        subnet: vm.user_nic&.private_subnet&.name,
         gpu: vm.display_gpu,
       )
     end

--- a/spec/serializers/vm_spec.rb
+++ b/spec/serializers/vm_spec.rb
@@ -63,5 +63,13 @@ RSpec.describe Serializers::Vm do
 
       expect(prepare_for_comparison(described_class.serialize_internal(vm, {detailed: true}))).to eq(expected_result)
     end
+
+    it "serializes a VM whose user_nic is gone (mid-destroy) without raising" do
+      vm.user_nic.update(vm_id: nil)
+      vm.reload
+
+      serialized = described_class.serialize_internal(vm, {detailed: true})
+      expect(serialized[:subnet]).to be_nil
+    end
   end
 end


### PR DESCRIPTION
The detailed VM serializer read vm.user_nic.private_subnet.name, which raised NoMethodError when the VM had no user_nic. A GET on a VM caught mid-destroy (its nic already torn down), or any VM without a user nic, paged with "Unexpected NoMethodError in Clover web request".

Use safe navigation so the subnet serializes as nil in that case, mirroring the user_nic&.private_ipv{4,6} handling added in db09a8f56.