### PR TITLE
Improve k8s specs

### DIFF
--- a/spec/model/kubernetes/kubernetes_cluster_spec.rb
+++ b/spec/model/kubernetes/kubernetes_cluster_spec.rb
@@ -156,26 +156,29 @@ RSpec.describe KubernetesCluster do
 
   describe "#kubeadm_recorded_version" do
     let(:ssh_session) { Net::SSH::Connection::Session.allocate }
-    let(:client) { Kubernetes::Client.new(kc, ssh_session) }
+    let(:get_kubeadm_config) { "sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s -n kube-system get cm kubeadm-config -o jsonpath='{.data.ClusterConfiguration}'" }
 
-    before { expect(kc).to receive(:client).and_return(client) }
+    before do
+      vm = create_vm
+      Sshable.create_with_id(vm)
+      KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kc.id)
+      expect(kc.sshable).to receive(:connect).and_return(ssh_session)
+    end
 
     it "returns the kubernetesVersion field from the kubeadm-config ConfigMap" do
       cluster_config = "apiServer: {}\nkubernetesVersion: v1.34.0\n"
-      response = Net::SSH::Connection::Session::StringWithExitstatus.new(cluster_config, 0)
-      expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s -n kube-system get cm kubeadm-config -o jsonpath='{.data.ClusterConfiguration}'").and_return(response)
+      expect(ssh_session).to receive(:_exec!).with(get_kubeadm_config).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(cluster_config, 0))
       expect(kc.kubeadm_recorded_version).to eq("v1.34.0")
     end
-  end
 
-  describe "#kubeadm_recorded_minor_version" do
     it "extracts the major.minor portion of the recorded version" do
-      expect(kc).to receive(:kubeadm_recorded_version).and_return("v1.34.5")
+      cluster_config = "apiServer: {}\nkubernetesVersion: v1.34.5\n"
+      expect(ssh_session).to receive(:_exec!).with(get_kubeadm_config).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(cluster_config, 0))
       expect(kc.kubeadm_recorded_minor_version).to eq("v1.34")
     end
 
-    it "returns nil when the recorded version is missing" do
-      expect(kc).to receive(:kubeadm_recorded_version).and_return(nil)
+    it "returns no minor version when the ConfigMap does not record one" do
+      expect(ssh_session).to receive(:_exec!).with(get_kubeadm_config).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("apiServer: {}\n", 0))
       expect(kc.kubeadm_recorded_minor_version).to be_nil
     end
   end
@@ -199,24 +202,22 @@ RSpec.describe KubernetesCluster do
   end
 
   it "initiates a new health monitor session" do
-    sshable = Sshable.new
-    expect(kc).to receive(:sshable).and_return(sshable)
-    expect(sshable).to receive(:start_fresh_session)
-    kc.init_health_monitor_session
+    vm = create_vm
+    Sshable.create_with_id(vm)
+    KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kc.id)
+    expect(kc.sshable).to receive(:start_fresh_session).and_return("session")
+
+    expect(kc.init_health_monitor_session).to eq({ssh_session: "session"})
   end
 
   describe "#check_pulse" do
     let(:ssh_session) { Net::SSH::Connection::Session.allocate }
     let(:session) { {ssh_session:} }
     let(:lb) { LoadBalancer.create(private_subnet_id: kc.private_subnet_id, name: "services_lb", health_check_endpoint: "/", project_id: kc.project_id) }
-    let(:client) { Kubernetes::Client.new(kc, ssh_session) }
     let(:down_pulse) { {reading: "down", reading_rpt: 5, reading_chg: Time.now - 30} }
     let(:up_pulse) { {reading: "up", reading_rpt: 5, reading_chg: Time.now - 30} }
 
-    before {
-      kc.update(services_lb_id: lb.id)
-      expect(kc).to receive(:client).and_return(client)
-    }
+    before { kc.update(services_lb_id: lb.id) }
 
     it "checks pulse" do
       LoadBalancerPort.create(load_balancer_id: lb.id, src_port: 80, dst_port: 30000)
@@ -267,7 +268,6 @@ RSpec.describe KubernetesCluster do
       expect(kc.check_pulse(session:, previous_pulse: up_pulse)[:reading]).to eq("down")
 
       page = Page.from_tag_parts("KubernetesClusterPVMigrationStuck", kc.id)
-      expect(page).not_to be_nil
       expect(page.summary).to eq("#{kc.ubid} PV migration stuck")
       expect(page.details["stuck_pvs"]).to eq(["pv-stuck"])
     end
@@ -276,7 +276,6 @@ RSpec.describe KubernetesCluster do
       Prog::PageNexus.assemble("#{kc.ubid} PV migration stuck",
         ["KubernetesClusterPVMigrationStuck", kc.id], kc.ubid,
         extra_data: {stuck_pvs: ["pv-stuck"]})
-      expect(Page.from_tag_parts("KubernetesClusterPVMigrationStuck", kc.id)).not_to be_nil
 
       lb_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate({"items" => []}), 0)
       pv_response = Net::SSH::Connection::Session::StringWithExitstatus.new(JSON.generate({"items" => []}), 0)
@@ -296,8 +295,8 @@ RSpec.describe KubernetesCluster do
     end
   end
 
-  describe "#kubectl" do
-    it "create a new client" do
+  describe "#client" do
+    it "creates a new client" do
       session = Net::SSH::Connection::Session.allocate
       expect(kc.client(session:)).to be_an_instance_of(Kubernetes::Client)
     end
@@ -357,75 +356,71 @@ RSpec.describe KubernetesCluster do
     it "adds error if cp_node_count is nil" do
       kc.cp_node_count = nil
       expect(kc.valid?).to be false
-      expect(kc.errors[:cp_node_count]).to include("must be a positive integer")
+      expect(kc.errors[:cp_node_count]).to eq(["is not present", "must be a positive integer"])
     end
 
     it "adds error if cp_node_count is not an integer" do
       kc.cp_node_count = "three"
       expect(kc.valid?).to be false
-      expect(kc.errors[:cp_node_count]).to include("must be a positive integer")
+      expect(kc.errors[:cp_node_count]).to eq(["is not a valid integer", "must be a positive integer"])
     end
   end
 
-  describe "#kubeconfig" do
-    kubeconfig = <<~YAML
-      apiVersion: v1
-      kind: Config
-      users:
-        - name: admin
-          user:
-            client-certificate-data: "mocked_cert_data"
-            client-key-data: "mocked_key_data"
-    YAML
+  describe "#generate_kubeconfig" do
+    let(:sshable) {
+      vm = create_vm
+      KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kc.id)
+      Sshable.create_with_id(vm)
+      kc.cp_vms.first.sshable
+    }
 
     it "removes client certificate and key data from users and adds an RBAC token to users" do
-      sshable = Sshable.new
-      KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id)
-      expect(kc.cp_vms.first).to receive(:sshable).and_return(sshable).twice
+      admin_config = <<~YAML
+        apiVersion: v1
+        kind: Config
+        users:
+          - name: admin
+            user:
+              client-certificate-data: "mocked_cert_data"
+              client-key-data: "mocked_key_data"
+      YAML
       expect(sshable).to receive(:_cmd).with("kubectl --kubeconfig <(sudo cat /etc/kubernetes/admin.conf) -n kube-system get secret k8s-access -o jsonpath='{.data.token}' | base64 -d", log: false).and_return("mocked_rbac_token")
-      expect(sshable).to receive(:_cmd).with("sudo cat /etc/kubernetes/admin.conf", log: false).and_return(kubeconfig)
-      customer_config = kc.generate_kubeconfig
-      YAML.safe_load(customer_config)["users"].each do |user|
-        expect(user["user"]).not_to have_key("client-certificate-data")
-        expect(user["user"]).not_to have_key("client-key-data")
-        expect(user["user"]["token"]).to eq("mocked_rbac_token")
-      end
+      expect(sshable).to receive(:_cmd).with("sudo cat /etc/kubernetes/admin.conf", log: false).and_return(admin_config)
+
+      expect(YAML.safe_load(kc.generate_kubeconfig)).to eq({
+        "apiVersion" => "v1",
+        "kind" => "Config",
+        "users" => [{"name" => "admin", "user" => {"token" => "mocked_rbac_token"}}],
+      })
     end
 
     it "supports swallow_connection_exception: true to suppress connection errors" do
-      sshable = Sshable.new
-      KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id)
-      expect(kc.cp_vms.first).to receive(:sshable).and_return(sshable).at_least(:once)
       expect(sshable).to receive(:_cmd).with("kubectl --kubeconfig <(sudo cat /etc/kubernetes/admin.conf) -n kube-system get secret k8s-access -o jsonpath='{.data.token}' | base64 -d", log: false).and_raise(IOError).twice
       expect { kc.generate_kubeconfig }.to raise_error(IOError)
       expect(kc.generate_kubeconfig(swallow_connection_exception: true)).to be_nil
     end
   end
 
-  describe "vm_diff_for_lb" do
-    it "finds the extra and missing nodes" do
+  describe "#vm_diff_for_lb" do
+    it "finds the extra and missing vms" do
       lb = Prog::Vnet::LoadBalancerNexus.assemble(kc.private_subnet.id, name: kc.services_load_balancer_name, src_port: 443, dst_port: 8443).subject
       extra_vm = Prog::Vm::Nexus.assemble("k y", kc.project.id, name: "extra-vm", private_subnet_id: kc.private_subnet.id).subject
       missing_vm = Prog::Vm::Nexus.assemble("k y", kc.project.id, name: "missing-vm", private_subnet_id: kc.private_subnet.id).subject
       lb.add_vm(extra_vm)
       kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np", node_count: 1, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
       KubernetesNode.create(vm_id: missing_vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
-      extra_vms, missing_vms = kc.vm_diff_for_lb(lb)
-      expect(extra_vms.count).to eq(1)
-      expect(extra_vms[0].id).to eq(extra_vm.id)
-      expect(missing_vms.count).to eq(1)
-      expect(missing_vms[0].id).to eq(missing_vm.id)
+
+      expect(kc.vm_diff_for_lb(lb)).to eq [[extra_vm], [missing_vm]]
     end
   end
 
-  describe "port_diff_for_lb" do
-    it "finds the extra and missing nodes" do
+  describe "#port_diff_for_lb" do
+    it "finds the extra and missing ports" do
       lb = Prog::Vnet::LoadBalancerNexus.assemble(kc.private_subnet.id, name: kc.services_load_balancer_name, src_port: 80, dst_port: 8000).subject
+
       extra_ports, missing_ports = kc.port_diff_for_lb(lb, [[443, 8443]])
-      expect(extra_ports.count).to eq(1)
-      expect(extra_ports[0].src_port).to eq(80)
-      expect(missing_ports.count).to eq(1)
-      expect(missing_ports[0][0]).to eq(443)
+      expect(extra_ports).to eq lb.ports
+      expect(missing_ports).to eq [[443, 8443]]
     end
   end
 
@@ -433,27 +428,33 @@ RSpec.describe KubernetesCluster do
     it "creates a strand for each control plane node to update the contents of rhizome folder" do
       node = Prog::Kubernetes::KubernetesNodeNexus.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name: "test-node", location_id: Location::HETZNER_FSN1_ID, size: "standard-2", storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-#{kc.version.tr(".", "_")}", enable_ip4: true, kubernetes_cluster_id: kc.id).subject
 
-      result = kc.install_rhizome
-      expect(result.count).to eq(1)
-      strand = result.first
-
-      expect(strand.prog).to eq "InstallRhizome"
-      expect(strand.stack.first["subject_id"]).to eq node.vm.sshable.id
+      expect(kc.install_rhizome.map { [it.prog, it.stack.first["subject_id"]] }).to eq [["InstallRhizome", node.vm.sshable.id]]
     end
   end
 
   describe "#all_nodes" do
-    it "returns all nodes in the cluster" do
-      expect(kc).to receive(:nodes).and_return([1, 2])
-      expect(kc).to receive(:nodepools).and_return([instance_double(KubernetesNodepool, nodes: [3, 4]), instance_double(KubernetesNodepool, nodes: [5, 6])])
-      expect(kc.all_nodes).to eq([1, 2, 3, 4, 5, 6])
+    it "returns the control plane nodes followed by the nodes of every nodepool" do
+      cp_node = KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id)
+      np1 = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np1", node_count: 1, kubernetes_cluster_id: kc.id).subject
+      np2 = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np2", node_count: 1, kubernetes_cluster_id: kc.id).subject
+      np1_node = KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: np1.id)
+      np2_node = KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: np2.id)
+
+      expect(kc.all_nodes).to eq [cp_node, np1_node, np2_node]
     end
   end
 
   describe "#worker_vms" do
-    it "returns all worker vms in the cluster" do
-      expect(kc).to receive(:nodepools).and_return([instance_double(KubernetesNodepool, vms: [3, 4]), instance_double(KubernetesNodepool, vms: [5, 6])])
-      expect(kc.worker_vms).to eq([3, 4, 5, 6])
+    it "returns the vms of every nodepool node" do
+      KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kc.id)
+      np1 = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np1", node_count: 1, kubernetes_cluster_id: kc.id).subject
+      np2 = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np2", node_count: 1, kubernetes_cluster_id: kc.id).subject
+      np1_vm = create_vm
+      np2_vm = create_vm
+      KubernetesNode.create(vm_id: np1_vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: np1.id)
+      KubernetesNode.create(vm_id: np2_vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: np2.id)
+
+      expect(kc.worker_vms).to eq [np1_vm, np2_vm]
     end
   end
 
@@ -468,7 +469,6 @@ RSpec.describe KubernetesCluster do
 
   describe "#all_functional_nodes_ready?" do
     let(:ssh_session) { Net::SSH::Connection::Session.allocate }
-    let(:client) { Kubernetes::Client.new(kc, ssh_session) }
     let(:node) {
       Prog::Kubernetes::KubernetesNodeNexus.assemble(
         project.id,
@@ -484,26 +484,27 @@ RSpec.describe KubernetesCluster do
     }
 
     before do
-      expect(kc).to receive(:client).and_return(client)
+      node
+      kc.reload
+      expect(kc.sshable).to receive(:connect).and_return(ssh_session)
     end
 
     it "returns true when every functional node has Ready=True" do
       body = JSON.generate("items" => [{"metadata" => {"name" => node.name}, "status" => {"conditions" => [{"type" => "Ready", "status" => "True"}]}}])
       expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
-      expect(kc.reload.all_functional_nodes_ready?).to be true
+      expect(kc.all_functional_nodes_ready?).to be true
     end
 
     it "returns false when a functional node reports Ready=False" do
       body = JSON.generate("items" => [{"metadata" => {"name" => node.name}, "status" => {"conditions" => [{"type" => "Ready", "status" => "False"}]}}])
       expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
-      expect(kc.reload.all_functional_nodes_ready?).to be false
+      expect(kc.all_functional_nodes_ready?).to be false
     end
 
     it "returns false when a functional node is missing from the API response" do
-      node
       body = JSON.generate("items" => [])
       expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -ojson").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(body, 0))
-      expect(kc.reload.all_functional_nodes_ready?).to be false
+      expect(kc.all_functional_nodes_ready?).to be false
     end
   end
 end

--- a/spec/model/kubernetes/kubernetes_etcd_backup_spec.rb
+++ b/spec/model/kubernetes/kubernetes_etcd_backup_spec.rb
@@ -53,20 +53,7 @@ RSpec.describe KubernetesEtcdBackup do
   end
 
   describe "#need_backup?" do
-    let(:minio_cluster) { MinioCluster.create(project_id: project.id, location_id: location.id, name: "minio-cluster", admin_user: "admin", admin_password: "password", root_cert_1: "certs") }
-
-    before do
-      allow(minio_cluster).to receive(:url).and_return("https://minio.test")
-    end
-
     it "returns false if blob storage is nil" do
-      expect(keb).to receive(:blob_storage).and_return(nil)
-      expect(keb.need_backup?).to be false
-    end
-
-    it "returns false if functional nodes are empty" do
-      keb.kubernetes_cluster.functional_nodes.each { it.destroy }
-      keb.kubernetes_cluster.reload
       expect(keb.need_backup?).to be false
     end
 
@@ -74,7 +61,14 @@ RSpec.describe KubernetesEtcdBackup do
       let(:sshable) { keb.kubernetes_cluster.functional_nodes.first.vm.sshable }
 
       before do
+        MinioCluster.create(project_id: project.id, location_id: location.id, name: "minio-cluster", admin_user: "admin", admin_password: "password", root_cert_1: "certs")
         keb.kubernetes_cluster.strand.update(label: "wait")
+      end
+
+      it "returns false if functional nodes are empty" do
+        keb.kubernetes_cluster.functional_nodes.each { it.destroy }
+        keb.kubernetes_cluster.reload
+        expect(keb.need_backup?).to be false
       end
 
       it "returns false if kubernetes cluster strand label is not wait" do
@@ -148,34 +142,35 @@ RSpec.describe KubernetesEtcdBackup do
         snapshot = instance_double(Minio::Client::Blob, key: "etcd-snapshot-20260508120000.db")
         unrelated = instance_double(Minio::Client::Blob, key: "unrelated.txt")
         expect(client).to receive(:list_objects).with(keb.ubid, "").and_return([snapshot, unrelated])
-        expect(keb.backups.map(&:key)).to eq(["etcd-snapshot-20260508120000.db"])
+        expect(keb.backups).to eq([snapshot])
       end
 
       it "returns empty array on recoverable errors" do
-        expect(client).to receive(:list_objects).and_raise(RuntimeError.new("The specified bucket does not exist"))
-        expect(Clog).to receive(:emit).with("Etcd backup fetch exception", instance_of(Hash))
+        expect(client).to receive(:list_objects).and_raise(error_with_backtrace("The specified bucket does not exist"))
+        expect(Clog).to receive(:emit).with("Etcd backup fetch exception", {exception: {message: "The specified bucket does not exist", class: "RuntimeError", backtrace: ["minio.rb:1"]}})
         expect(keb.backups).to eq([])
       end
 
       it "re-raises non-recoverable errors" do
-        expect(client).to receive(:list_objects).and_raise(RuntimeError.new("some unexpected error"))
-        expect(Clog).to receive(:emit).with("Etcd backup fetch exception", instance_of(Hash))
+        expect(client).to receive(:list_objects).and_raise(error_with_backtrace("some unexpected error"))
+        expect(Clog).to receive(:emit).with("Etcd backup fetch exception", {exception: {message: "some unexpected error", class: "RuntimeError", backtrace: ["minio.rb:1"]}})
         expect { keb.backups }.to raise_error(RuntimeError, "some unexpected error")
+      end
+
+      def error_with_backtrace(message)
+        RuntimeError.new(message).tap { it.set_backtrace(["minio.rb:1"]) }
       end
     end
   end
 
   describe "#next_backup_time" do
     it "returns tomorrow if blob_storage is not configured" do
-      expect(keb).to receive(:blob_storage).and_return(nil)
       expect(keb.next_backup_time).to be_within(1).of(Time.now + 86400)
     end
 
     context "when blob storage is configured" do
-      let(:minio_cluster) { MinioCluster.create(project_id: project.id, location_id: location.id, name: "minio-cluster", admin_user: "admin", admin_password: "password", root_cert_1: "certs") }
-
       before do
-        allow(minio_cluster).to receive(:url).and_return("https://minio.test")
+        MinioCluster.create(project_id: project.id, location_id: location.id, name: "minio-cluster", admin_user: "admin", admin_password: "password", root_cert_1: "certs")
       end
 
       it "returns Time.now if latest_backup_started_at is nil" do

--- a/spec/model/kubernetes/kubernetes_node_spec.rb
+++ b/spec/model/kubernetes/kubernetes_node_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe KubernetesNode do
   let(:kc) { Prog::Kubernetes::KubernetesClusterNexus.assemble(name: "kc-name", version: Option.selectable_kubernetes_versions.first, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 1, project_id: project.id, target_node_size: "standard-2").subject }
   let(:session) { {ssh_session: Net::SSH::Connection::Session.allocate} }
   let(:ssh_session) { session[:ssh_session] }
+  let(:read_mesh_status) { "cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n" }
 
   before do
     allow(Config).to receive(:kubernetes_service_project_id).and_return(Project.create(name: "UbicloudKubernetesService").id)
@@ -191,9 +192,15 @@ RSpec.describe KubernetesNode do
         reading_chg: Time.now - 30,
       }
     }
+    let(:unreachable_pod_status) {
+      JSON.generate({
+        "node_id" => "node-1",
+        "pods" => {"ubicsi-nodeplugin-abc" => {"ip" => "10.0.0.2", "reachable" => false}},
+      })
+    }
 
     it "returns up when file is empty (CSI not installed yet)" do
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return("")
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return("")
       expect(kn.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
     end
 
@@ -206,7 +213,7 @@ RSpec.describe KubernetesNode do
         },
         "external_endpoints" => {},
       })
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return(status_json)
       expect(kn.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
     end
 
@@ -218,29 +225,29 @@ RSpec.describe KubernetesNode do
           "ubicsi-nodeplugin-xyz" => {"ip" => "10.0.0.3", "reachable" => false, "last_check" => Time.now.utc.iso8601},
         },
       })
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return(status_json)
       expect(kn.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "returns up when pods hash is empty" do
       status_json = JSON.generate({"node_id" => "node-1", "pods" => {}, "external_endpoints" => {}})
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return(status_json)
       expect(kn.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
     end
 
     it "returns down on JSON parse error" do
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return("not valid json {")
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return("not valid json {")
       expect(kn.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     it "returns down on other SSH errors" do
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_raise Sshable::SshError
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_raise Sshable::SshError
       expect(kn.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
     [IOError.new("closed stream"), Errno::ECONNRESET.new("recvfrom(2)")].each do |ex|
       it "reraises the exception for exception class: #{ex.class}" do
-        expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_raise(ex)
+        expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_raise(ex)
         expect { kn.check_pulse(session:, previous_pulse: pulse) }.to raise_error(ex)
       end
     end
@@ -256,7 +263,7 @@ RSpec.describe KubernetesNode do
           "api.example.com:8080" => {"reachable" => false, "last_check" => Time.now.utc.iso8601},
         },
       })
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return(status_json)
       expect(kn.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("down")
     end
 
@@ -271,16 +278,12 @@ RSpec.describe KubernetesNode do
           "api.example.com:8080" => {"reachable" => true, "last_check" => Time.now.utc.iso8601},
         },
       })
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return(status_json)
       expect(kn.check_pulse(session:, previous_pulse: pulse)[:reading]).to eq("up")
     end
 
     it "increments checkup semaphore after sustained down readings" do
-      status_json = JSON.generate({
-        "node_id" => "node-1",
-        "pods" => {"ubicsi-nodeplugin-abc" => {"ip" => "10.0.0.2", "reachable" => false}},
-      })
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return(unreachable_pod_status)
 
       previous_pulse = {reading: "down", reading_rpt: 6, reading_chg: Time.now - 31}
 
@@ -289,11 +292,7 @@ RSpec.describe KubernetesNode do
     end
 
     it "keeps a single checkup semaphore when one was set after the node was loaded" do
-      status_json = JSON.generate({
-        "node_id" => "node-1",
-        "pods" => {"ubicsi-nodeplugin-abc" => {"ip" => "10.0.0.2", "reachable" => false}},
-      })
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return(unreachable_pod_status)
       expect(kn.checkup_set?).to be false
       described_class[kn.id].incr_checkup
 
@@ -302,11 +301,7 @@ RSpec.describe KubernetesNode do
     end
 
     it "does not increment checkup when reading_rpt is too low" do
-      status_json = JSON.generate({
-        "node_id" => "node-1",
-        "pods" => {"ubicsi-nodeplugin-abc" => {"ip" => "10.0.0.2", "reachable" => false}},
-      })
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return(unreachable_pod_status)
 
       previous_pulse = {reading: "down", reading_rpt: 4, reading_chg: Time.now - 31}
 
@@ -315,11 +310,7 @@ RSpec.describe KubernetesNode do
     end
 
     it "does not increment checkup when reading_chg is too recent" do
-      status_json = JSON.generate({
-        "node_id" => "node-1",
-        "pods" => {"ubicsi-nodeplugin-abc" => {"ip" => "10.0.0.2", "reachable" => false}},
-      })
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return(unreachable_pod_status)
 
       previous_pulse = {reading: "down", reading_rpt: 6, reading_chg: Time.now - 10}
 
@@ -328,42 +319,38 @@ RSpec.describe KubernetesNode do
     end
 
     it "does not increment checkup when checkup is already set" do
-      status_json = JSON.generate({
-        "node_id" => "node-1",
-        "pods" => {"ubicsi-nodeplugin-abc" => {"ip" => "10.0.0.2", "reachable" => false}},
-      })
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return(unreachable_pod_status)
 
       previous_pulse = {reading: "down", reading_rpt: 6, reading_chg: Time.now - 31}
       kn.incr_checkup
 
       kn.check_pulse(session:, previous_pulse:)
-      expect(kn.reload.strand.semaphores.count { it.name == "checkup" }).to eq(1)
+      expect(Semaphore.where(strand_id: kn.id, name: "checkup").count).to eq 1
     end
   end
 
   describe "#available?" do
     it "returns true when mesh is available" do
       status_json = JSON.generate({"pods" => {"pod-1" => {"reachable" => true}}, "external_endpoints" => {}})
-      expect(kn.sshable).to receive(:_cmd).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(kn.sshable).to receive(:_cmd).with(read_mesh_status).and_return(status_json)
       expect(kn.available?).to be true
     end
 
     it "returns false when mesh is not available" do
       status_json = JSON.generate({"pods" => {"pod-1" => {"reachable" => false}}, "external_endpoints" => {}})
-      expect(kn.sshable).to receive(:_cmd).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
+      expect(kn.sshable).to receive(:_cmd).with(read_mesh_status).and_return(status_json)
       expect(kn.available?).to be false
     end
 
     it "returns false on any error" do
-      expect(kn.sshable).to receive(:_cmd).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_raise(Sshable::SshError)
+      expect(kn.sshable).to receive(:_cmd).with(read_mesh_status).and_raise(Sshable::SshError)
       expect(kn.available?).to be false
     end
   end
 
   describe "#check_mesh_availability" do
     it "returns available when file is empty" do
-      expect(kn.sshable).to receive(:_cmd).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return("")
+      expect(kn.sshable).to receive(:_cmd).with(read_mesh_status).and_return("")
       expect(kn.check_mesh_availability).to eq({available: true})
     end
 
@@ -372,8 +359,8 @@ RSpec.describe KubernetesNode do
         "pods" => {"pod-1" => {"reachable" => true}},
         "external_endpoints" => {},
       })
-      expect(kn.sshable).to receive(:_cmd).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
-      expect(kn.check_mesh_availability[:available]).to be true
+      expect(kn.sshable).to receive(:_cmd).with(read_mesh_status).and_return(status_json)
+      expect(kn.check_mesh_availability).to eq({available: true})
     end
 
     it "returns not available with details when pods are unreachable" do
@@ -382,12 +369,16 @@ RSpec.describe KubernetesNode do
         "external_endpoints" => {},
         "mtr_results" => {"pod-1" => {"ip" => "10.0.0.2", "output" => "HOST: ...", "exit_status" => 0, "last_check" => "2026-01-01T00:00:00Z"}},
       })
-      expect(kn.sshable).to receive(:_cmd).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
-      result = kn.check_mesh_availability
-      expect(result[:available]).to be false
-      expect(result[:unreachable_pods]).to eq(["pod-1"])
-      expect(result[:pod_errors]).to eq([{"name" => "pod-1", "reachable" => false, "error" => "timeout"}])
-      expect(result[:mtr_results]).to eq([{"name" => "pod-1", "ip" => "10.0.0.2", "output" => "HOST: ...", "exit_status" => 0, "last_check" => "2026-01-01T00:00:00Z"}])
+      expect(kn.sshable).to receive(:_cmd).with(read_mesh_status).and_return(status_json)
+
+      expect(kn.check_mesh_availability).to eq({
+        available: false,
+        unreachable_pods: ["pod-1"],
+        unreachable_external: [],
+        pod_errors: [{"name" => "pod-1", "reachable" => false, "error" => "timeout"}],
+        external_errors: [],
+        mtr_results: [{"name" => "pod-1", "ip" => "10.0.0.2", "output" => "HOST: ...", "exit_status" => 0, "last_check" => "2026-01-01T00:00:00Z"}],
+      })
     end
 
     it "returns not available when api_error is present" do
@@ -397,10 +388,9 @@ RSpec.describe KubernetesNode do
         "mtr_results" => {},
         "api_error" => "connection refused",
       })
-      expect(kn.sshable).to receive(:_cmd).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
-      result = kn.check_mesh_availability
-      expect(result[:available]).to be false
-      expect(result[:api_error]).to eq("connection refused")
+      expect(kn.sshable).to receive(:_cmd).with(read_mesh_status).and_return(status_json)
+
+      expect(kn.check_mesh_availability).to eq({available: false, api_error: "connection refused", mtr_results: []})
     end
 
     it "returns not available when external endpoints are unreachable" do
@@ -408,15 +398,20 @@ RSpec.describe KubernetesNode do
         "pods" => {},
         "external_endpoints" => {"10.0.0.1:443" => {"reachable" => false, "error" => "connection refused"}},
       })
-      expect(kn.sshable).to receive(:_cmd).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return(status_json)
-      result = kn.check_mesh_availability
-      expect(result[:available]).to be false
-      expect(result[:unreachable_external]).to eq(["10.0.0.1:443"])
-      expect(result[:external_errors]).to eq([{"name" => "10.0.0.1:443", "reachable" => false, "error" => "connection refused"}])
+      expect(kn.sshable).to receive(:_cmd).with(read_mesh_status).and_return(status_json)
+
+      expect(kn.check_mesh_availability).to eq({
+        available: false,
+        unreachable_pods: [],
+        unreachable_external: ["10.0.0.1:443"],
+        pod_errors: [],
+        external_errors: [{"name" => "10.0.0.1:443", "reachable" => false, "error" => "connection refused"}],
+        mtr_results: nil,
+      })
     end
 
     it "uses ssh_session when provided" do
-      expect(ssh_session).to receive(:_exec!).with("cat /var/lib/ubicsi/mesh_status.json 2>/dev/null || echo -n").and_return("")
+      expect(ssh_session).to receive(:_exec!).with(read_mesh_status).and_return("")
       expect(kn.check_mesh_availability(ssh_session)).to eq({available: true})
     end
   end
@@ -425,7 +420,7 @@ RSpec.describe KubernetesNode do
     it "creates an InstallRhizome strand" do
       st = kn.install_rhizome
       expect(st).to have_attributes(prog: "InstallRhizome", label: "start")
-      expect(st.stack.first).to include("subject_id" => kn.vm.sshable.id, "target_folder" => "kubernetes")
+      expect(st.stack).to eq [{"subject_id" => kn.vm.sshable.id, "target_folder" => "kubernetes"}]
     end
   end
 

--- a/spec/prog/kubernetes/etcd_backup_nexus_spec.rb
+++ b/spec/prog/kubernetes/etcd_backup_nexus_spec.rb
@@ -61,7 +61,13 @@ RSpec.describe Prog::Kubernetes::EtcdBackupNexus do
     let(:admin_client) { instance_double(Minio::Client) }
 
     it "sets up user and policy in minio and hops" do
-      expect(Minio::Client).to receive(:new).and_return(admin_client)
+      expect(kubernetes_etcd_backup.blob_storage).to receive(:url).and_return("https://minio.test")
+      expect(Minio::Client).to receive(:new).with(
+        endpoint: "https://minio.test",
+        access_key: "admin",
+        secret_key: "password",
+        ssl_ca_data: kubernetes_etcd_backup.blob_storage.root_certs,
+      ).and_return(admin_client)
       expect(admin_client).to receive(:admin_add_user).with(kubernetes_etcd_backup.access_key, kubernetes_etcd_backup.secret_key)
       expect(admin_client).to receive(:admin_policy_add).with(kubernetes_etcd_backup.ubid, kubernetes_etcd_backup.blob_storage_policy)
       expect(admin_client).to receive(:admin_policy_set).with(kubernetes_etcd_backup.ubid, kubernetes_etcd_backup.access_key)
@@ -92,8 +98,8 @@ RSpec.describe Prog::Kubernetes::EtcdBackupNexus do
 
     it "calls setup_bucket on model and hops" do
       expect(kubernetes_etcd_backup.blob_storage).to receive(:url).and_return("https://minio.test")
-      expect(client).to receive(:create_bucket)
-      expect(client).to receive(:set_lifecycle_policy)
+      expect(client).to receive(:create_bucket).with(kubernetes_etcd_backup.ubid)
+      expect(client).to receive(:set_lifecycle_policy).with(kubernetes_etcd_backup.ubid, kubernetes_etcd_backup.ubid, KubernetesEtcdBackup::BACKUP_BUCKET_EXPIRATION_DAYS)
       expect { nx.setup_bucket }.to hop("wait")
     end
   end
@@ -107,26 +113,31 @@ RSpec.describe Prog::Kubernetes::EtcdBackupNexus do
 
     context "when backup is not needed" do
       let(:now) { Time.now }
+      let(:sshable) { kubernetes_etcd_backup.kubernetes_cluster.functional_nodes.first.vm.sshable }
 
       before do
         expect(Time).to receive(:now).and_return(now).at_least(:once)
-        expect(kubernetes_etcd_backup.kubernetes_cluster.functional_nodes.first.vm.sshable).to receive(:d_check).with("backup_etcd").and_return("Succeeded")
-        kubernetes_etcd_backup.update(latest_backup_started_at: Time.now)
         allow(kubernetes_etcd_backup).to receive(:backups).and_return([])
       end
 
-      it "naps for the difference between next_backup_time and now + 1" do
-        expect(nx.kubernetes_etcd_backup).to receive(:next_backup_time).and_return(now + 1200)
+      it "naps until an hour has passed since the last backup started" do
+        expect(sshable).to receive(:d_check).with("backup_etcd").and_return("Succeeded")
+        kubernetes_etcd_backup.update(latest_backup_started_at: now - 2400)
+
         expect { nx.wait }.to nap(1201)
       end
 
       it "naps for at least 1 second" do
-        expect(nx.kubernetes_etcd_backup).to receive(:next_backup_time).and_return(now - 100)
+        expect(sshable).to receive(:d_check).with("backup_etcd").and_return("Unknown")
+        kubernetes_etcd_backup.update(latest_backup_started_at: now - 4000)
+
         expect { nx.wait }.to nap(1)
       end
 
       it "naps for at most 3601 seconds" do
-        expect(nx.kubernetes_etcd_backup).to receive(:next_backup_time).and_return(now + 4000)
+        expect(sshable).to receive(:d_check).with("backup_etcd").and_return("Succeeded")
+        kubernetes_etcd_backup.update(latest_backup_started_at: now + 400)
+
         expect { nx.wait }.to nap(3601)
       end
     end
@@ -147,14 +158,14 @@ RSpec.describe Prog::Kubernetes::EtcdBackupNexus do
       it "creates a missing backup page if last completed backup is older than 6 hours" do
         expect(kubernetes_etcd_backup).to receive(:backups).and_return([backup_fixture(hours_ago: 7)])
         expect { nx.wait }.to nap(3601)
-        expect(Page.from_tag_parts("MissingEtcdBackup", kubernetes_etcd_backup.id)).not_to be_nil
+        expect(Page.from_tag_parts("MissingEtcdBackup", kubernetes_etcd_backup.id).summary).to eq "Missing etcd backup at #{kubernetes_etcd_backup}!"
       end
 
       it "creates a missing backup page if no backups and creation is older than 6 hours" do
         kubernetes_etcd_backup.update(created_at: now - 7 * 60 * 60)
         expect(kubernetes_etcd_backup).to receive(:backups).and_return([])
         expect { nx.wait }.to nap(3601)
-        expect(Page.from_tag_parts("MissingEtcdBackup", kubernetes_etcd_backup.id)).not_to be_nil
+        expect(Page.from_tag_parts("MissingEtcdBackup", kubernetes_etcd_backup.id).summary).to eq "Missing etcd backup at #{kubernetes_etcd_backup}!"
       end
 
       it "does not page during the grace period if no backups exist yet" do
@@ -165,11 +176,12 @@ RSpec.describe Prog::Kubernetes::EtcdBackupNexus do
       end
 
       it "resolves the missing backup page if last completed backup is recent" do
-        page = Page.create(tag: Page.generate_tag(["MissingEtcdBackup", kubernetes_etcd_backup.id]), summary: "Missing etcd backup")
-        Strand.create_with_id(page, prog: "PageNexus", label: "wait")
+        Prog::PageNexus.assemble("Missing etcd backup", ["MissingEtcdBackup", kubernetes_etcd_backup.id], kubernetes_etcd_backup.ubid)
         expect(kubernetes_etcd_backup).to receive(:backups).and_return([backup_fixture(hours_ago: 1)])
+
         expect { nx.wait }.to nap(3601)
-        expect(Semaphore.where(strand_id: page.id, name: "resolve").count).to eq(1)
+
+        expect(Page.from_tag_parts("MissingEtcdBackup", kubernetes_etcd_backup.id).resolve_set?).to be true
       end
 
       it "does nothing when last completed backup is recent and no page exists" do
@@ -212,14 +224,6 @@ RSpec.describe Prog::Kubernetes::EtcdBackupNexus do
       )
 
       expect { nx.run_backup }.to hop("wait")
-    end
-
-    it "updates latest_backup_started_at" do
-      kc.strand.update(label: "wait")
-
-      expect(nx.kubernetes_cluster.functional_nodes.first.vm.sshable).to receive(:d_run)
-
-      expect { nx.run_backup }.to hop("wait")
       expect(kubernetes_etcd_backup.reload.latest_backup_started_at).to be_within(1).of(Time.now)
     end
   end
@@ -229,7 +233,12 @@ RSpec.describe Prog::Kubernetes::EtcdBackupNexus do
 
     it "removes user and policy from minio" do
       expect(kubernetes_etcd_backup.blob_storage).to receive(:url).and_return("https://minio.test")
-      expect(Minio::Client).to receive(:new).and_return(admin_client)
+      expect(Minio::Client).to receive(:new).with(
+        endpoint: "https://minio.test",
+        access_key: "admin",
+        secret_key: "password",
+        ssl_ca_data: kubernetes_etcd_backup.blob_storage.root_certs,
+      ).and_return(admin_client)
 
       expect(admin_client).to receive(:admin_remove_user).with(kubernetes_etcd_backup.access_key)
       expect(admin_client).to receive(:admin_policy_remove).with(kubernetes_etcd_backup.ubid)

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -160,10 +160,11 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
   describe "#before_destroy" do
     it "finalizes billing records" do
       expect { nx.update_billing_records }.to hop("wait")
+      # Billing records cannot be finalized within the second they were created.
+      kubernetes_cluster.active_billing_records_dataset.update(span: Sequel.lit("tstzrange(lower(span) - interval '10 seconds', NULL)"))
       kubernetes_cluster.reload
-      expect(kubernetes_cluster.active_billing_records).not_to be_empty
-      expect(kubernetes_cluster.active_billing_records).to all(receive(:finalize))
-      nx.before_destroy
+
+      expect { nx.before_destroy }.to change { kubernetes_cluster.reload.active_billing_records.count }.from(2).to(0)
     end
   end
 
@@ -590,49 +591,47 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       "v#{major}.#{minor + 1}"
     }
 
-    before do
-      sshable0, sshable1 = Sshable.new, instance_double(Sshable)
-      expect(first_node).to receive(:sshable).and_return(sshable0).at_least(:once)
-      allow(second_node).to receive(:sshable).and_return(sshable1)
-      allow(sshable0).to receive(:connect)
-      allow(sshable1).to receive(:connect)
-
-      expect(kubernetes_cluster).to receive(:client).and_return(client).at_least(:once)
+    # The nodes are visited in order, and the walk stops at the first one that is behind,
+    # so a caller passes only the versions it expects to be read.
+    def expect_reported_versions(*versions)
+      versions.each_with_index do |version, i|
+        node_session = Net::SSH::Connection::Session.allocate
+        expect(kubernetes_cluster.nodes[i].sshable).to receive(:connect).and_return(node_session)
+        expect(node_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s version --client").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("Client Version: #{version}.0\n", 0))
+      end
     end
 
     it "selects a Node with minor version one less than the cluster's version" do
-      expect(client).to receive(:version).and_return(cluster_version, older_version)
+      expect_reported_versions(cluster_version, older_version)
       expect { nx.upgrade }.to hop("wait_upgrade")
-      child = st.children.first
-      expect(child.prog).to eq "Kubernetes::UpgradeKubernetesNode"
-      expect(child.stack.first["old_node_id"]).to eq second_node.id
+      expect(st.children.map { [it.prog, it.stack.first["old_node_id"]] }).to eq [["Kubernetes::UpgradeKubernetesNode", second_node.id]]
     end
 
     it "hops to wait when all nodes are at the cluster's version" do
-      expect(client).to receive(:version).and_return(cluster_version, cluster_version)
+      expect_reported_versions(cluster_version, cluster_version)
       expect { nx.upgrade }.to hop("wait")
     end
 
     it "does not select a node with minor version more than one less than the cluster's version" do
-      expect(client).to receive(:version).and_return(much_older_version, cluster_version)
+      expect_reported_versions(much_older_version, cluster_version)
       expect { nx.upgrade }.to hop("wait")
     end
 
     it "skips node with invalid version formats" do
+      [first_node, second_node].each { expect(it.sshable).to receive(:connect) }
+      expect(kubernetes_cluster).to receive(:client).and_return(client).twice
       expect(client).to receive(:version).and_return("invalid", cluster_version)
       expect { nx.upgrade }.to hop("wait")
     end
 
     it "selects the first node that is one minor version behind" do
-      expect(client).to receive(:version).and_return(older_version)
+      expect_reported_versions(older_version)
       expect { nx.upgrade }.to hop("wait_upgrade")
-      child = st.children.first
-      expect(child.prog).to eq "Kubernetes::UpgradeKubernetesNode"
-      expect(child.stack.first["old_node_id"]).to eq first_node.id
+      expect(st.children.map { [it.prog, it.stack.first["old_node_id"]] }).to eq [["Kubernetes::UpgradeKubernetesNode", first_node.id]]
     end
 
     it "does not select a node with a higher minor version than the cluster" do
-      expect(client).to receive(:version).and_return(newer_version, cluster_version)
+      expect_reported_versions(newer_version, cluster_version)
       expect { nx.upgrade }.to hop("wait")
     end
   end
@@ -654,7 +653,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
     it "applies the rbac manifest and reconfigures metrics on the control plane nodes" do
       nx.incr_install_prometheus_rbac
       ssh_session = Net::SSH::Connection::Session.allocate
-      expect(nx.kubernetes_cluster).to receive(:client).and_return(Kubernetes::Client.new(kubernetes_cluster, ssh_session))
+      expect(kubernetes_cluster.sshable).to receive(:connect).and_return(ssh_session)
       expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s apply -f /home/ubi/kubernetes/lib/prometheus-rbac.yaml").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("", 0))
 
       expect { nx.install_prometheus_rbac }.to hop("wait")
@@ -665,12 +664,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
   end
 
   describe "#install_metrics_server" do
-    let(:sshable) { Sshable.new }
-    let(:node) { KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kubernetes_cluster.id) }
-
-    before do
-      allow(kubernetes_cluster.cp_vms.first).to receive(:sshable).and_return(sshable)
-    end
+    let(:sshable) { kubernetes_cluster.cp_vms.first.sshable }
 
     it "runs install_metrics_server and naps when not started" do
       expect(sshable).to receive(:d_check).with("install_metrics_server").and_return("NotStarted")
@@ -767,8 +761,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
   describe "#install_csi" do
     it "installs the ubicsi on the cluster" do
-      client = Kubernetes::Client.new(kubernetes_cluster, session)
-      expect(kubernetes_cluster).to receive(:client).and_return(client)
+      expect(kubernetes_cluster.sshable).to receive(:connect).and_return(session)
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s apply -f kubernetes/manifests/ubicsi").and_return(response)
       expect { nx.install_csi }.to hop("wait")
@@ -777,9 +770,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
   describe "#sync_kubeconfig" do
     it "generates the kubeconfig and stores it base64-encoded" do
-      sshable = Sshable.new
-      KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kubernetes_cluster.id)
-      allow(kubernetes_cluster.cp_vms.first).to receive(:sshable).and_return(sshable)
+      sshable = kubernetes_cluster.cp_vms.first.sshable
       expect(sshable).to receive(:_cmd).with("kubectl --kubeconfig <(sudo cat /etc/kubernetes/admin.conf) -n kube-system get secret k8s-access -o jsonpath='{.data.token}' | base64 -d", log: false).and_return("mocked_rbac_token")
       expect(sshable).to receive(:_cmd).with("sudo cat /etc/kubernetes/admin.conf", log: false).and_return(<<~YAML)
         users:
@@ -797,13 +788,10 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
   end
 
   describe "#sync_internal_dns_config" do
-    let(:client) { Kubernetes::Client.new(kubernetes_cluster, session) }
-    let(:sshable) { Sshable.new }
-    let(:node) { KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kubernetes_cluster.id) }
+    let(:sshable) { kubernetes_cluster.sshable }
 
     before do
-      expect(kubernetes_cluster).to receive(:client).and_return(client)
-      allow(kubernetes_cluster).to receive(:sshable).and_return(sshable)
+      expect(sshable).to receive(:connect).and_return(session)
     end
 
     it "returns early if Corefile is not found" do

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
   describe "#configure_prometheus" do
     def expect_token_read(encoded)
       ssh_session = Net::SSH::Connection::Session.allocate
-      expect(nx.cluster).to receive(:client).and_return(Kubernetes::Client.new(kc, ssh_session))
+      expect(nx.cluster.sshable).to receive(:connect).and_return(ssh_session)
       expect(ssh_session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s -n kube-system get secret prometheus-metrics -o jsonpath='{.data.token}' --ignore-not-found").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new(encoded, 0))
     end
 
@@ -268,7 +268,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
 
     it "starts the drain process when run for the first time and naps" do
       expect(cluster_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check drain_node_vm").and_return("NotStarted")
-      expect(cluster_sshable).to receive(:_cmd).with("common/bin/daemonizer2 run drain_node_vm sudo kubectl --kubeconfig\\=/etc/kubernetes/admin.conf drain vm --ignore-daemonsets --delete-emptydir-data", hash_including(log: true))
+      expect(cluster_sshable).to receive(:_cmd).with("common/bin/daemonizer2 run drain_node_vm sudo kubectl --kubeconfig\\=/etc/kubernetes/admin.conf drain vm --ignore-daemonsets --delete-emptydir-data", {log: true, stdin: nil})
       expect { nx.drain }.to nap(10)
     end
 
@@ -285,8 +285,12 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
 
     it "naps when daemonizer something unexpected and waits for the page" do
       expect(cluster_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check drain_node_vm").and_return("UnexpectedState")
-      expect(nx).to receive(:register_deadline).with("destroy", 0)
+
       expect { nx.drain }.to nap(3 * 60 * 60)
+
+      frame = nx.strand.stack.first
+      expect(frame["deadline_target"]).to eq "destroy"
+      expect(Time.new(frame["deadline_at"])).to be_within(3).of(Time.now)
     end
 
     it "drains the old node and hops to wait_for_detach" do
@@ -297,11 +301,10 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
 
   describe "#wait_for_detach" do
     let(:session) { Net::SSH::Connection::Session.allocate }
-    let(:client) { Kubernetes::Client.new(nx.cluster, session) }
     let(:success_response) { Net::SSH::Connection::Session::StringWithExitstatus.new("", 0) }
 
     before do
-      expect(nx.cluster).to receive(:client).and_return(client)
+      expect(nx.cluster.sshable).to receive(:connect).and_return(session)
     end
 
     it "naps when ubicsi VolumeAttachments still reference this node" do
@@ -337,11 +340,10 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
 
   describe "#wait_for_copy" do
     let(:session) { Net::SSH::Connection::Session.allocate }
-    let(:client) { Kubernetes::Client.new(nx.cluster, session) }
     let(:success_response) { Net::SSH::Connection::Session::StringWithExitstatus.new("", 0) }
 
     before do
-      expect(nx.cluster).to receive(:client).and_return(client)
+      expect(nx.cluster.sshable).to receive(:connect).and_return(session)
     end
 
     it "naps when a Bound PV without a migration annotation still lives on this node" do
@@ -427,11 +429,10 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
 
   describe "#retain_volumes" do
     let(:session) { Net::SSH::Connection::Session.allocate }
-    let(:client) { Kubernetes::Client.new(nx.cluster, session) }
     let(:success_response) { Net::SSH::Connection::Session::StringWithExitstatus.new("", 0) }
 
     before do
-      allow(nx.cluster).to receive(:client).and_return(client)
+      allow(nx.cluster.sshable).to receive(:connect).and_return(session)
     end
 
     def pv(name:, phase:, policy:, node:, driver: "csi.ubicloud.com")
@@ -469,7 +470,6 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
 
   describe "#remove_node_from_cluster" do
     let(:session) { Net::SSH::Connection::Session.allocate }
-    let(:client) { Kubernetes::Client.new(cluster, session) }
     let(:success_response) { Net::SSH::Connection::Session::StringWithExitstatus.new("", 0) }
 
     def node_sshable
@@ -481,23 +481,27 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
     end
 
     before do
-      expect(cluster).to receive(:client).and_return(client)
+      expect(cluster.sshable).to receive(:connect).and_return(session)
+      expect(node_sshable).to receive(:_cmd).with("sudo kubeadm reset --force")
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete node vm").and_return(success_response)
     end
 
-    it "runs kubeadm reset and remove nodepool node from services_lb and deletes the node from cluster" do
+    it "detaches a nodepool node from the services load balancer" do
       kn = Prog::Kubernetes::KubernetesNodepoolNexus.assemble(name: "np", node_count: 1, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
       nx.kubernetes_node.update(kubernetes_nodepool_id: kn.id)
-      expect(node_sshable).to receive(:_cmd).with("sudo kubeadm reset --force")
-      expect(cluster.services_lb).to receive(:detach_vm).with(nx.kubernetes_node.vm)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete node vm").and_return(success_response)
+      cluster.services_lb.add_vm(nx.kubernetes_node.vm)
+
       expect { nx.remove_node_from_cluster }.to hop("destroy")
+
+      expect(cluster.services_lb.vm_ports_by_vm(nx.kubernetes_node.vm).order(:stack).select_map([:stack, :state])).to eq [["ipv4", "detaching"], ["ipv6", "detaching"]]
     end
 
-    it "runs kubeadm reset and remove cluster node from api_server_lb and deletes the node from cluster" do
-      expect(node_sshable).to receive(:_cmd).with("sudo kubeadm reset --force")
-      expect(cluster.api_server_lb).to receive(:detach_vm).with(nx.kubernetes_node.vm)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete node vm").and_return(success_response)
+    it "detaches a control plane node from the api server load balancer" do
+      cluster.api_server_lb.add_vm(nx.kubernetes_node.vm)
+
       expect { nx.remove_node_from_cluster }.to hop("destroy")
+
+      expect(cluster.api_server_lb.vm_ports_by_vm(nx.kubernetes_node.vm).order(:stack).select_map([:stack, :state])).to eq [["ipv4", "detaching"], ["ipv6", "detaching"]]
     end
   end
 

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
   let(:kn) {
     kn = described_class.assemble(name: "k8stest-np", node_count: 2, kubernetes_cluster_id: kc.id, target_node_size: "standard-2").subject
     [create_vm, create_vm].each do |vm|
-      KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
+      Sshable.create_with_id(vm)
+      node = KubernetesNode.create(vm_id: vm.id, kubernetes_cluster_id: kc.id, kubernetes_nodepool_id: kn.id)
+      Strand.create_with_id(node, prog: "Kubernetes::KubernetesNodeNexus", label: "wait")
     end
     kn
   }
@@ -108,20 +110,28 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
   describe "#bootstrap_worker_nodes" do
     it "buds enough number of times ProvisionKubernetesNode progs when we need to provision more nodes" do
       kn.update(node_count: 4)
-      (kn.node_count - kn.functional_nodes.count).times do
-        expect(nx).to receive(:bud).with(Prog::Kubernetes::ProvisionKubernetesNode, {"nodepool_id" => kn.id, "subject_id" => kn.cluster.id, "machine_image_version_id" => nil})
-      end
+
       expect { nx.bootstrap_worker_nodes }.to hop("wait_worker_node")
+
+      expect(kn.strand.children.map { [it.prog, it.stack.first] }).to eq [
+        ["Kubernetes::ProvisionKubernetesNode", {"nodepool_id" => kn.id, "subject_id" => kn.cluster.id, "machine_image_version_id" => nil}],
+        ["Kubernetes::ProvisionKubernetesNode", {"nodepool_id" => kn.id, "subject_id" => kn.cluster.id, "machine_image_version_id" => nil}],
+      ]
     end
 
     it "retires enough number of nodes when we need to decommission some" do
       kn.update(node_count: 1)
-      expect(kn.functional_nodes.first).to receive(:incr_retire)
+
       expect { nx.bootstrap_worker_nodes }.to hop("wait_worker_node")
+
+      expect(kn.functional_nodes.map { it.retire_set?(cached: false) }).to eq [true, false]
     end
 
     it "does nothing when we have the right number of nodes" do
       expect { nx.bootstrap_worker_nodes }.to hop("wait_worker_node")
+
+      expect(kn.strand.children).to eq []
+      expect(kn.functional_nodes.map { it.retire_set?(cached: false) }).to eq [false, false]
     end
   end
 
@@ -146,7 +156,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
     end
 
     it "hops to upgrade when semaphore is set" do
-      expect(nx).to receive(:when_upgrade_set?).and_yield
+      nx.incr_upgrade
       expect { nx.wait }.to hop("upgrade")
     end
 
@@ -160,7 +170,6 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
   describe "#upgrade" do
     let(:first_node) { kn.nodes[0] }
     let(:second_node) { kn.nodes[1] }
-    let(:client) { instance_double(Kubernetes::Client) }
     let(:cluster_version) { Option.kubernetes_versions[0] }
     let(:older_version) { Option.kubernetes_versions[1] }
     let(:much_older_version) { Option.kubernetes_versions[2] }
@@ -170,66 +179,64 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
     }
 
     context "when cluster is not upgrading" do
-      before do
-        kc.strand.update(label: "wait")
-        sshable0, sshable1 = Sshable.new, instance_double(Sshable)
-        allow(first_node).to receive(:sshable).and_return(sshable0)
-        allow(second_node).to receive(:sshable).and_return(sshable1)
-        allow(sshable0).to receive(:connect)
-        allow(sshable1).to receive(:connect)
+      before { kc.strand.update(label: "wait") }
 
-        expect(kn.cluster).to receive(:client).and_return(client).at_least(:once)
+      # The nodes are visited in order, and the walk stops at the first one that is behind,
+      # so a caller passes only the versions it expects to be read.
+      def expect_reported_versions(*versions)
+        versions.each_with_index do |version, i|
+          session = Net::SSH::Connection::Session.allocate
+          expect(kn.nodes[i].sshable).to receive(:connect).and_return(session)
+          expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s version --client").and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("Client Version: #{version}.0\n", 0))
+        end
       end
 
       it "selects a node with minor version one less than the cluster's version" do
-        expect(client).to receive(:version).and_return(cluster_version, older_version)
+        expect_reported_versions(cluster_version, older_version)
         expect { nx.upgrade }.to hop("wait_upgrade")
-        st = Strand[prog: "Kubernetes::UpgradeKubernetesNode"]
-        expect(st).not_to be_nil
-        expect(st.stack.first).to eq({"nodepool_id" => kn.id, "old_node_id" => second_node.id, "subject_id" => kn.cluster.id})
+        expect(Strand.where(prog: "Kubernetes::UpgradeKubernetesNode").map { it.stack.first }).to eq [{"nodepool_id" => kn.id, "old_node_id" => second_node.id, "subject_id" => kn.cluster.id}]
       end
 
       it "hops to wait when all nodes are at the cluster's version" do
-        expect(client).to receive(:version).and_return(cluster_version, cluster_version)
+        expect_reported_versions(cluster_version, cluster_version)
         expect { nx.upgrade }.to hop("wait")
       end
 
       it "selects a node multiple minor versions behind the nodepool version" do
-        expect(client).to receive(:version).and_return(much_older_version)
+        expect_reported_versions(much_older_version)
         expect { nx.upgrade }.to hop("wait_upgrade")
-        st = Strand[prog: "Kubernetes::UpgradeKubernetesNode"]
-        expect(st.stack.first).to eq({"nodepool_id" => kn.id, "old_node_id" => first_node.id, "subject_id" => kn.cluster.id})
+        expect(Strand.where(prog: "Kubernetes::UpgradeKubernetesNode").map { it.stack.first }).to eq [{"nodepool_id" => kn.id, "old_node_id" => first_node.id, "subject_id" => kn.cluster.id}]
       end
 
       it "selects a node one minor version behind the nodepool version" do
         kn.update(version: older_version)
-        expect(client).to receive(:version).and_return(much_older_version)
+        expect_reported_versions(much_older_version)
         expect { nx.upgrade }.to hop("wait_upgrade")
-        st = Strand[prog: "Kubernetes::UpgradeKubernetesNode"]
-        expect(st.stack.first).to eq({"nodepool_id" => kn.id, "old_node_id" => first_node.id, "subject_id" => kn.cluster.id})
+        expect(Strand.where(prog: "Kubernetes::UpgradeKubernetesNode").map { it.stack.first }).to eq [{"nodepool_id" => kn.id, "old_node_id" => first_node.id, "subject_id" => kn.cluster.id}]
       end
 
       it "skips nodes with invalid version formats and creates a page" do
+        [first_node, second_node].each { expect(it.sshable).to receive(:connect) }
+        client = instance_double(Kubernetes::Client)
+        expect(kn.cluster).to receive(:client).and_return(client).twice
         expect(client).to receive(:version).and_return("invalid", "invalid")
+
         expect { nx.upgrade }.to hop("wait")
 
         page = Page.from_tag_parts("K8sInvalidVersion", kc.ubid, first_node.name)
-        expect(page).not_to be_nil
         expect(page.summary).to eq "Invalid version format for #{first_node.name} of cluster #{kc.ubid}"
         expect(page.details["node_version"]).to eq "invalid"
         expect(page.details["nodepool_version"]).to eq kn.version
       end
 
       it "selects the first node that is one minor version behind" do
-        expect(client).to receive(:version).and_return(older_version)
+        expect_reported_versions(older_version)
         expect { nx.upgrade }.to hop("wait_upgrade")
-        st = Strand[prog: "Kubernetes::UpgradeKubernetesNode"]
-        expect(st).not_to be_nil
-        expect(st.stack.first).to eq({"nodepool_id" => kn.id, "old_node_id" => first_node.id, "subject_id" => kn.cluster.id})
+        expect(Strand.where(prog: "Kubernetes::UpgradeKubernetesNode").map { it.stack.first }).to eq [{"nodepool_id" => kn.id, "old_node_id" => first_node.id, "subject_id" => kn.cluster.id}]
       end
 
       it "does not select a node with a higher minor version than the cluster" do
-        expect(client).to receive(:version).and_return(newer_version, newer_version)
+        expect_reported_versions(newer_version, newer_version)
         expect { nx.upgrade }.to hop("wait")
       end
     end
@@ -255,20 +262,19 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       expect { nx.destroy }.to nap(120)
     end
 
-    it "completes destroy when nodes are gone" do
-      KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kn.cluster.id, kubernetes_nodepool_id: kn.id)
+    it "destroys the remaining nodes and naps" do
       kn.strand.update(label: "destroy")
-      expect(kn.nodes).to all(receive(:incr_destroy))
 
       expect { nx.destroy }.to nap(5)
+
+      expect(kn.nodes.map { it.destroy_set?(cached: false) }).to eq [true, true]
     end
 
-    it "destroys the nodepool and its nodes" do
+    it "destroys the nodepool once its nodes are gone" do
       kn.nodes_dataset.destroy
 
-      expect(kn.nodes).to all(receive(:incr_destroy))
-      expect(kn).to receive(:destroy)
       expect { nx.destroy }.to exit({"msg" => "kubernetes nodepool is deleted"})
+        .and change { KubernetesNodepool.where(id: kn.id).count }.from(1).to(0)
     end
 
     it "resolves the node version pages" do

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     allow(Config).to receive(:kubernetes_service_project_id).and_return(project.id)
   end
 
-  describe "random_ula_cidr" do
+  describe "#random_ula_cidr" do
     it "returns a /108 subnet" do
       cidr = prog.random_ula_cidr
       expect(cidr.netmask.prefix_len).to eq(108)
@@ -68,18 +68,17 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
     end
   end
 
-  describe "node" do
+  describe "#node" do
     it "finds the right node" do
       node = KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kubernetes_cluster.id)
       refresh_frame(prog, new_values: {"node_id" => node.id})
-      expect(prog.node.id).to eq(node.id)
+      expect(prog.node).to eq(node)
     end
   end
 
   describe "#before_run" do
     it "destroys itself if the kubernetes cluster is getting deleted" do
       prog.kubernetes_cluster.strand.update(label: "something")
-      expect(prog.kubernetes_cluster.strand.label).to eq("something")
       prog.before_run # Nothing happens
 
       prog.kubernetes_cluster.strand.label = "destroy"
@@ -293,13 +292,22 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   end
 
   describe "#init_cluster" do
-    before { allow(prog.vm).to receive(:sshable).and_return(Sshable.new) }
-
     it "runs the init_cluster script if it's not started" do
       expect(prog.vm.sshable).to receive(:d_check).with("init_kubernetes_cluster").and_return("NotStarted")
+      # The service subnet cidr is randomly generated, so only the leading fields can be matched exactly.
+      params = JSON.generate({
+        node_name: "test-vm",
+        cluster_name: "k8scluster",
+        lb_hostname: kubernetes_cluster.endpoint,
+        port: "443",
+        private_subnet_cidr4: kubernetes_cluster.private_subnet.net4,
+        private_subnet_cidr6: kubernetes_cluster.private_subnet.net6,
+        node_ipv4: "172.19.145.65",
+        node_ipv6: "2001:db8:85a3:73f2:1c4a::2",
+      }).delete_suffix("}")
       expect(prog.vm.sshable).to receive(:d_run).with(
         "init_kubernetes_cluster", "/home/ubi/kubernetes/bin/init-cluster",
-        stdin: /{"node_name":"test-vm","cluster_name":"k8scluster","lb_hostname":"somelb\..*","port":"443","private_subnet_cidr4":"#{kubernetes_cluster.private_subnet.net4}","private_subnet_cidr6":"#{kubernetes_cluster.private_subnet.net6}","node_ipv4":"172.19.145.65","node_ipv6":"2001:db8:85a3:73f2:1c4a::2"/, log: false,
+        stdin: /\A#{Regexp.escape(params)},"service_subnet_cidr6":"fd[0-9a-f:]+\/108"\}\z/, log: false,
       )
 
       expect { prog.init_cluster }.to nap(30)
@@ -314,7 +322,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(prog.vm.sshable).to receive(:d_check).with("init_kubernetes_cluster").and_return("Failed")
       expect(prog.vm.sshable).to receive(:d_logs).with("init_kubernetes_cluster").and_return("error logs")
       expect { prog.init_cluster }.to nap(30)
-      expect(Page.from_tag_parts("KubernetesNodeInitClusterFailed", prog.node.ubid)).not_to be_nil
+      expect(Page.from_tag_parts("KubernetesNodeInitClusterFailed", prog.node.ubid).summary).to eq "init kubernetes cluster failed on node #{prog.node.ubid}"
     end
 
     it "resolves any open page and hops if the init_cluster script is successful" do
@@ -356,19 +364,25 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   end
 
   describe "#join_control_plane" do
-    before { allow(prog.vm).to receive(:sshable).and_return(Sshable.new) }
-
     it "runs the join_control_plane script if it's not started" do
       expect(prog.vm.sshable).to receive(:d_check).with("join_control_plane").and_return("NotStarted")
 
-      sshable = Sshable.new
-      expect(kubernetes_cluster.functional_nodes.first).to receive(:sshable).and_return(sshable)
-      expect(sshable).to receive(:_cmd).with("sudo kubeadm token create --ttl 24h --usages signing,authentication", log: false).and_return("jt\n")
-      expect(sshable).to receive(:_cmd).with("sudo kubeadm init phase upload-certs --upload-certs", log: false).and_return("something\ncertificate key:\nck")
-      expect(sshable).to receive(:_cmd).with("sudo kubeadm token create --print-join-command", log: false).and_return("discovery-token-ca-cert-hash dtcch")
+      cp_sshable = kubernetes_cluster.sshable
+      expect(cp_sshable).to receive(:_cmd).with("sudo kubeadm token create --ttl 24h --usages signing,authentication", log: false).and_return("jt\n")
+      expect(cp_sshable).to receive(:_cmd).with("sudo kubeadm init phase upload-certs --upload-certs", log: false).and_return("something\ncertificate key:\nck")
+      expect(cp_sshable).to receive(:_cmd).with("sudo kubeadm token create --print-join-command", log: false).and_return("discovery-token-ca-cert-hash dtcch")
       expect(prog.vm.sshable).to receive(:d_run).with(
         "join_control_plane", "kubernetes/bin/join-node",
-        stdin: /{"is_control_plane":true,"node_name":"test-vm","endpoint":"somelb\..*:443","join_token":"jt","certificate_key":"ck","discovery_token_ca_cert_hash":"dtcch","node_ipv4":"172.19.145.65","node_ipv6":"2001:db8:85a3:73f2:1c4a::2"}/,
+        stdin: JSON.generate({
+          is_control_plane: true,
+          node_name: "test-vm",
+          endpoint: "#{kubernetes_cluster.endpoint}:443",
+          join_token: "jt",
+          certificate_key: "ck",
+          discovery_token_ca_cert_hash: "dtcch",
+          node_ipv4: "172.19.145.65",
+          node_ipv6: "2001:db8:85a3:73f2:1c4a::2",
+        }),
         log: false,
       )
 
@@ -384,7 +398,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(prog.vm.sshable).to receive(:d_check).with("join_control_plane").and_return("Failed")
       expect(prog.vm.sshable).to receive(:d_logs).with("join_control_plane").and_return("error logs")
       expect { prog.join_control_plane }.to nap(30)
-      expect(Page.from_tag_parts("KubernetesNodeJoinControlPlaneFailed", prog.node.ubid)).not_to be_nil
+      expect(Page.from_tag_parts("KubernetesNodeJoinControlPlaneFailed", prog.node.ubid).summary).to eq "join cp node to cluster failed on node #{prog.node.ubid}"
     end
 
     it "resolves any open page and hops if the join_control_plane script is successful" do
@@ -408,21 +422,25 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   end
 
   describe "#join_worker" do
-    before {
-      allow(prog.vm).to receive(:sshable).and_return(Sshable.new)
-      refresh_frame(prog, new_values: {"nodepool_id" => kubernetes_nodepool.id})
-    }
+    before { refresh_frame(prog, new_values: {"nodepool_id" => kubernetes_nodepool.id}) }
 
     it "runs the join-worker-node script if it's not started" do
       expect(prog.vm.sshable).to receive(:d_check).with("join_worker").and_return("NotStarted")
 
-      sshable = Sshable.new
-      expect(kubernetes_cluster.functional_nodes.first).to receive(:sshable).and_return(sshable)
-      expect(sshable).to receive(:_cmd).with("sudo kubeadm token create --ttl 24h --usages signing,authentication", log: false).and_return("\njt\n")
-      expect(sshable).to receive(:_cmd).with("sudo kubeadm token create --print-join-command", log: false).and_return("discovery-token-ca-cert-hash dtcch")
+      cp_sshable = kubernetes_cluster.sshable
+      expect(cp_sshable).to receive(:_cmd).with("sudo kubeadm token create --ttl 24h --usages signing,authentication", log: false).and_return("\njt\n")
+      expect(cp_sshable).to receive(:_cmd).with("sudo kubeadm token create --print-join-command", log: false).and_return("discovery-token-ca-cert-hash dtcch")
       expect(prog.vm.sshable).to receive(:d_run).with(
         "join_worker", "kubernetes/bin/join-node",
-        stdin: /{"is_control_plane":false,"node_name":"test-vm","endpoint":"somelb\..*:443","join_token":"jt","discovery_token_ca_cert_hash":"dtcch","node_ipv4":"172.19.145.65","node_ipv6":"2001:db8:85a3:73f2:1c4a::2"}/,
+        stdin: JSON.generate({
+          is_control_plane: false,
+          node_name: "test-vm",
+          endpoint: "#{kubernetes_cluster.endpoint}:443",
+          join_token: "jt",
+          discovery_token_ca_cert_hash: "dtcch",
+          node_ipv4: "172.19.145.65",
+          node_ipv6: "2001:db8:85a3:73f2:1c4a::2",
+        }),
         log: false,
       )
 
@@ -438,7 +456,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
       expect(prog.vm.sshable).to receive(:d_check).with("join_worker").and_return("Failed")
       expect(prog.vm.sshable).to receive(:d_logs).with("join_worker").and_return("error logs")
       expect { prog.join_worker }.to nap(30)
-      expect(Page.from_tag_parts("KubernetesNodeJoinWorkerFailed", prog.node.ubid)).not_to be_nil
+      expect(Page.from_tag_parts("KubernetesNodeJoinWorkerFailed", prog.node.ubid).summary).to eq "join worker node to cluster failed on node #{prog.node.ubid}"
     end
 
     it "resolves any open page and hops if the join-worker-node script is successful" do

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -57,16 +57,19 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
   end
 
   describe "#start" do
-    it "provisions a new kubernetes node" do
-      expect(prog).to receive(:register_deadline).with(nil, 30 * 60).twice
-
-      expect(prog).to receive(:frame).and_return({})
-      expect(prog).to receive(:bud).with(Prog::Kubernetes::ProvisionKubernetesNode, {})
+    it "registers a deadline and provisions a replacement control plane node" do
       expect { prog.start }.to hop("wait_new_node")
 
-      expect(prog).to receive(:frame).and_return({"nodepool_id" => kubernetes_nodepool.id})
-      expect(prog).to receive(:bud).with(Prog::Kubernetes::ProvisionKubernetesNode, {"nodepool_id" => kubernetes_nodepool.id})
+      expect(Time.new(prog.strand.stack.first["deadline_at"])).to be_within(60).of(Time.now + 30 * 60)
+      expect(st.children.map { [it.prog, it.stack.first] }).to eq [["Kubernetes::ProvisionKubernetesNode", {"subject_id" => kubernetes_cluster.id}]]
+    end
+
+    it "passes the nodepool on to the replacement worker node" do
+      st.update(stack: [{"subject_id" => kubernetes_cluster.id, "nodepool_id" => kubernetes_nodepool.id}])
+
       expect { prog.start }.to hop("wait_new_node")
+
+      expect(st.children.map { it.stack.first }).to eq [{"subject_id" => kubernetes_cluster.id, "nodepool_id" => kubernetes_nodepool.id}]
     end
   end
 
@@ -87,19 +90,7 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
 
   describe "#wait_node_ready" do
     let(:session) { Net::SSH::Connection::Session.allocate }
-    let(:new_node) {
-      Prog::Kubernetes::KubernetesNodeNexus.assemble(
-        Config.kubernetes_service_project_id,
-        sshable_unix_user: "ubi",
-        name: "#{kubernetes_cluster.ubid}-#{SecureRandom.alphanumeric(5).downcase}",
-        location_id: kubernetes_cluster.location_id,
-        size: kubernetes_cluster.target_node_size,
-        storage_volumes: [{encrypted: true, size_gib: 40}],
-        boot_image: "kubernetes-#{kubernetes_cluster.version.tr(".", "_")}",
-        enable_ip4: true,
-        kubernetes_cluster_id: kubernetes_cluster.id,
-      ).subject
-    }
+    let(:new_node) { assemble_node("new-node") }
 
     before do
       st.update(stack: [{"subject_id" => kubernetes_cluster.id, "new_node_id" => new_node.id, "old_node_id" => "old"}])
@@ -120,11 +111,17 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
   end
 
   describe "#upgrade_kubeadm" do
-    let(:new_node) { KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kubernetes_cluster.id) }
+    let(:new_node) { assemble_node("new-node") }
+    let(:session) { Net::SSH::Connection::Session.allocate }
+    let(:get_kubeadm_config) { "sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s -n kube-system get cm kubeadm-config -o jsonpath='{.data.ClusterConfiguration}'" }
 
     before do
-      Sshable.create_with_id(new_node.vm.id)
       st.update(stack: [{"subject_id" => kubernetes_cluster.id, "new_node_id" => new_node.id, "old_node_id" => "old"}])
+    end
+
+    def expect_recorded_version(version)
+      expect(prog.kubernetes_cluster.sshable).to receive(:connect).and_return(session)
+      expect(session).to receive(:_exec!).with(get_kubeadm_config).and_return(Net::SSH::Connection::Session::StringWithExitstatus.new("kubernetesVersion: #{version}.0\n", 0))
     end
 
     it "skips kubeadm upgrade for worker (nodepool) replacements" do
@@ -134,14 +131,14 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
     end
 
     it "skips kubeadm upgrade when the cluster is already recorded at the target version" do
-      expect(prog.kubernetes_cluster).to receive(:kubeadm_recorded_minor_version).at_least(:once).and_return(prog.kubernetes_cluster.version)
+      expect_recorded_version(kubernetes_cluster.version)
       expect(prog.new_node.vm.sshable).not_to receive(:d_check)
       expect { prog.upgrade_kubeadm }.to hop("drain_old_node")
     end
 
     context "when the ConfigMap is behind the cluster version" do
       before do
-        expect(prog.kubernetes_cluster).to receive(:kubeadm_recorded_minor_version).at_least(:once).and_return("v1.99")
+        expect_recorded_version("v1.99")
       end
 
       it "starts kubeadm upgrade apply on the new node when not started yet" do
@@ -176,26 +173,20 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
   end
 
   describe "#drain_old_node" do
-    let(:sshable) { Sshable.new }
-    let(:old_node) { KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kubernetes_cluster.id) }
+    it "retires the old node and hops" do
+      old_node = assemble_node("old-node")
+      st.update(stack: [{"subject_id" => kubernetes_cluster.id, "old_node_id" => old_node.id}])
 
-    before do
-      expect(prog).to receive(:frame).and_return({"old_node_id" => old_node.id})
-      expect(prog.old_node.id).to eq(old_node.id)
-    end
-
-    it "starts the drain process when run for the first time and naps" do
-      expect(prog.old_node).to receive(:incr_retire)
       expect { prog.drain_old_node }.to hop("wait_for_drain")
+      expect(old_node.retire_set?).to be true
     end
   end
 
   describe "#wait_for_drain" do
-    let(:old_node) { KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kubernetes_cluster.id) }
+    let(:old_node) { assemble_node("old-node") }
 
     before do
-      expect(prog).to receive(:frame).and_return({"old_node_id" => old_node.id})
-      expect(prog.old_node.id).to eq(old_node.id)
+      st.update(stack: [{"subject_id" => kubernetes_cluster.id, "old_node_id" => old_node.id}])
     end
 
     it "naps if node is not drained yet" do
@@ -203,14 +194,18 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
     end
 
     it "hops to destroy when node is retired" do
-      expect(prog).to receive(:old_node).and_return(nil)
+      old_node.destroy
       expect { prog.wait_for_drain }.to hop("destroy")
     end
   end
 
-  describe "#destroy_node" do
-    it "destroys the old node" do
+  describe "#destroy" do
+    it "pops after the old node is gone" do
       expect { prog.destroy }.to exit({"msg" => "upgraded node"})
     end
+  end
+
+  def assemble_node(name)
+    Prog::Kubernetes::KubernetesNodeNexus.assemble(Config.kubernetes_service_project_id, sshable_unix_user: "ubi", name:, location_id: kubernetes_cluster.location_id, size: kubernetes_cluster.target_node_size, storage_volumes: [{encrypted: true, size_gib: 40}], boot_image: "kubernetes-#{kubernetes_cluster.version.tr(".", "_")}", enable_ip4: true, kubernetes_cluster_id: kubernetes_cluster.id).subject
   end
 end


### PR DESCRIPTION
**Stop mocking model methods in kubernetes model specs**
Create the real MinioCluster, KubernetesNode and Sshable rows the code under test looks up, so cluster, node and etcd backup methods run their real lookups with ssh mocked at connect/_cmd/_exec! only. Assert whole return values instead of individual keys, and give the raised Minio errors a fixed backtrace so the emitted Clog hash can be compared exactly.

**Exercise the real kubectl client in the kubernetes nexus specs**
Mock the cluster sshable's connect instead of returning a client from the cluster, so the version walk, the volume checks and the CoreDNS sync run through a real Kubernetes::Client. Assert the budded children, the retire and destroy semaphores, the load balancer ports moving to detaching, the registered deadlines and the closed billing record spans instead of mocking bud, register_deadline, incr_retire, detach_vm, destroy and when_upgrade_set?.

**Drive the node and backup progs through real strand state**
Set the frame on the strand instead of mocking frame, and use the sshables the provisioned vm and the control plane node already have, so the join payloads and the kubeadm ConfigMap read can be matched exactly. Derive the etcd backup nap from a real latest_backup_started_at rather than stubbing next_backup_time, and match the Minio client constructor and bucket arguments in full.