### PR TITLE
Label Postgres metrics with the resource name

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -568,6 +568,7 @@ class PostgresServer < Sequel::Model
     query_str = URI.encode_www_form(query_params)
     additional_labels = resource.tags.to_h { |tag| ["pg_tags_label_#{tag["key"]}", tag["value"]] }
     additional_labels.merge!({
+      resource_name: resource.name,
       location_id: UBID.to_ubid(resource.location_id),
       location_name: resource.location.name,
       location_provider: resource.location.provider,

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -2009,6 +2009,20 @@ RSpec.describe PostgresServer do
     end
   end
 
+  describe "#metrics_config" do
+    it "labels the exported metrics with the resource name, location, and tags" do
+      resource.update(tags: [{"key" => "env", "value" => "prod"}])
+
+      expect(postgres_server.metrics_config[:additional_labels]).to eq({"pg_tags_label_env" => "prod"}.merge(
+        resource_name: resource.name,
+        location_id: location.ubid,
+        location_name: "us-west-2",
+        location_provider: "ubicloud",
+        location_display_name: "us-west-2",
+      ))
+    end
+  end
+
   describe "#logs_config" do
     it "returns config with resource_name, resource_id, instance, server_role, version, and empty destinations" do
       config = postgres_server.logs_config


### PR DESCRIPTION
Metrics carry ubicloud_resource_id, so finding the series for a database means resolving its ubid first. The logs pipeline already ships resource_name as a log attribute, so adopt the same label name here and let a metrics query and a log query use the same field.

The label rides on additional_labels, which the control plane applies at import time. The on-VM collector reads only endpoints, max_file_retention and exclude_metrics from config.json, so existing servers pick this up without a reconfigure.

Two consequences are worth noting. Adding a label creates a new time series for every existing one, a one-time churn of the VictoriaMetrics index. And a rename creates another set, so a rate() window that spans the rename reports a dip. Every customer-facing query in lib/metrics.rb aggregates with sum() or avg(), which drops the label, so the charts themselves are unaffected.