### PR TITLE
Delete extra IAM policy versions on timeline destroy

### DIFF
--- a/model/postgres/aws/postgres_timeline.rb
+++ b/model/postgres/aws/postgres_timeline.rb
@@ -129,7 +129,32 @@ PGDATA=/dat/#{version}/data
       iam_client = location.location_credential_aws.iam_client
 
       sweep_iam_leftovers(iam_client) if Config.aws_postgres_blob_storage_iam_sweep
-      ignore_missing_entity { iam_client.delete_policy(policy_arn: aws_s3_policy_arn) }
+      delete_s3_policy(iam_client)
+    end
+
+    # delete_policy refuses a policy that holds more than its default version, and
+    # aws_refresh_blob_storage_policy leaves a version behind for every policy-document
+    # change the timeline has lived through. Clear the extra versions only after the
+    # conflict reports them, so a timeline that never got a second version stays
+    # destroyable without version-level IAM permissions.
+    def delete_s3_policy(iam_client)
+      attempts = 0
+      begin
+        ignore_missing_entity { iam_client.delete_policy(policy_arn: aws_s3_policy_arn) }
+      rescue ::Aws::IAM::Errors::DeleteConflict
+        raise if (attempts += 1) > 1
+        delete_nondefault_policy_versions(iam_client)
+        retry
+      end
+    end
+
+    # Delete every version but the default one, which goes with the policy itself. A
+    # managed policy holds at most 5 versions, so one listing covers all of them.
+    def delete_nondefault_policy_versions(iam_client)
+      versions = ignore_missing_entity { iam_client.list_policy_versions(policy_arn: aws_s3_policy_arn).versions } || []
+      versions.reject(&:is_default_version).each do |version|
+        ignore_missing_entity { iam_client.delete_policy_version(policy_arn: aws_s3_policy_arn, version_id: version.version_id) }
+      end
     end
 
     # A deployment that stays in iam-access mode has none of this. Setup creates

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -517,6 +517,53 @@ PGDATA=/dat/17/data
         postgres_timeline.destroy_blob_storage
       end
 
+      it "clears the extra policy versions when the policy will not delete with them" do
+        # Every policy-document refresh leaves a version behind, and delete_policy
+        # refuses until only the default one is left.
+        iam_client.stub_responses(:delete_policy, "DeleteConflict", {})
+        iam_client.stub_responses(:list_policy_versions, versions: [
+          {version_id: "v1", is_default_version: false},
+          {version_id: "v2", is_default_version: false},
+          {version_id: "v3", is_default_version: true},
+        ])
+
+        expect(iam_client).to receive(:delete_policy_version).with(policy_arn:, version_id: "v1")
+        expect(iam_client).to receive(:delete_policy_version).with(policy_arn:, version_id: "v2")
+        expect(iam_client).to receive(:delete_policy).twice.and_call_original
+
+        postgres_timeline.destroy_blob_storage
+      end
+
+      it "leaves the policy versions alone when the policy deletes on the first try" do
+        expect(iam_client).not_to receive(:list_policy_versions)
+        expect(iam_client).to receive(:delete_policy).with(policy_arn:)
+
+        postgres_timeline.destroy_blob_storage
+      end
+
+      it "tolerates a policy that goes away between the conflict and the version listing" do
+        gone = Aws::IAM::Errors::NoSuchEntity.new(nil, "NoSuchEntity")
+        iam_client.stub_responses(:delete_policy, "DeleteConflict", gone)
+        expect(iam_client).to receive(:list_policy_versions).and_raise(gone)
+
+        expect(iam_client).to receive(:delete_policy).twice.and_call_original
+
+        postgres_timeline.destroy_blob_storage
+      end
+
+      it "gives up when the policy still will not delete without its extra versions" do
+        # An attachment the sweep could not clear blocks the delete as well, so the
+        # retry is bounded rather than a loop over version listings.
+        iam_client.stub_responses(:delete_policy, "DeleteConflict")
+        iam_client.stub_responses(:list_policy_versions, versions: [{version_id: "v1", is_default_version: false}, {version_id: "v2", is_default_version: true}])
+        allow(iam_client).to receive(:delete_policy_version)
+
+        expect(iam_client).to receive(:list_policy_versions).once.and_call_original
+        expect(iam_client).to receive(:delete_policy).twice.and_call_original
+
+        expect { postgres_timeline.destroy_blob_storage }.to raise_error(Aws::IAM::Errors::DeleteConflict)
+      end
+
       it "treats a missing bucket as already deleted" do
         s3_client.stub_responses(:list_objects_v2, "NoSuchBucket")
 


### PR DESCRIPTION
AWS Postgres timeline destroy has been failing since we started refreshing the blob storage policy document in place:

  Aws::IAM::Errors::DeleteConflict: This policy has more than one
  version. Before you delete a policy, you must delete the policy's
  versions. The default version is deleted with the policy.

create_policy_version keeps the version it supersedes, so every timeline whose policy we refreshed holds two or more versions, and IAM refuses delete_policy until only the default one is left. The destroy label then raises on every retry, and the timeline, its bucket and its policy all outlive the deletion.

Delete the non-default versions and retry the delete once. Do this after the conflict reports them rather than listing versions on every destroy, so a deployment whose timelines never got a second version still destroys one without version-level IAM permissions. One retry is enough because the only other cause of this conflict is a policy that is still attached, which no amount of version deletion clears.