### PR TITLE
Support a reply-to address in Util.send_email

### DIFF
--- a/lib/email_renderer.rb
+++ b/lib/email_renderer.rb
@@ -10,13 +10,14 @@ class EmailRenderer < Roda
   plugin :mailer, terminal: true
 
   route do |r|
-    r.mail "" do |receiver, subject, greeting: nil, body: nil, button_title: nil, button_link: nil, author_name: "Ubicloud", cc: nil, bcc: nil, attachments: []|
+    r.mail "" do |receiver, subject, greeting: nil, body: nil, button_title: nil, button_link: nil, author_name: "Ubicloud", cc: nil, bcc: nil, reply_to: nil, attachments: []|
       no_mail! if Array(receiver).compact.empty?
       from Config.mail_from
       to receiver
       subject subject
       cc cc
       bcc bcc
+      response.mail.reply_to reply_to
 
       attachments.each do |name, file|
         add_file filename: name, content: file

--- a/spec/lib/util_spec.rb
+++ b/spec/lib/util_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe Util do
       expect(Mail::TestMailer.deliveries.length).to eq 1
       expect(Mail::TestMailer.deliveries.first.html_part.body.to_s).to include("The Ubicloud Team")
     end
+
+    it "sets the reply-to address when provided" do
+      described_class.send_email("user@example.com", "Hello", greeting: "Hi", body: "Welcome", reply_to: "support@ubicloud.com")
+      expect(Mail::TestMailer.deliveries.length).to eq 1
+      expect(Mail::TestMailer.deliveries.first.reply_to).to eq ["support@ubicloud.com"]
+    end
+
+    it "leaves the reply-to address unset by default" do
+      described_class.send_email("user@example.com", "Hello", greeting: "Hi", body: "Welcome")
+      expect(Mail::TestMailer.deliveries.length).to eq 1
+      expect(Mail::TestMailer.deliveries.first.reply_to).to be_nil
+    end
   end
 
   describe "#parse_key" do


### PR DESCRIPTION
CCing a shared inbox puts every outbound message in front of whoever watches it. Setting Reply-To instead keeps the outbound message out of that inbox while still routing customer replies there.

The Roda mailer plugin only delegates from/to/cc/bcc/subject into the route block, so reply_to is set on the response mail object. Mail#reply_to with a nil argument reads rather than writes, so it stays unset by default.