### PR TITLE
Log the archive daemon's log tail when a machine image archive fails 

### DIFF
--- a/model/sshable.rb
+++ b/model/sshable.rb
@@ -192,8 +192,12 @@ class Sshable < Sequel::Model
     cmd("common/bin/daemonizer2 stop :unit_name", unit_name:)
   end
 
-  def d_logs(unit_name)
-    cmd("sudo journalctl -u :unit_name --no-pager", unit_name:)
+  def d_logs(unit_name, lines: nil)
+    if lines
+      cmd("sudo journalctl -u :unit_name -n :lines --no-pager", unit_name:, lines:)
+    else
+      cmd("sudo journalctl -u :unit_name --no-pager", unit_name:)
+    end
   end
 
   # A huge number of settings are needed to isolate net-ssh from the

--- a/prog/machine_image/version_metal_nexus.rb
+++ b/prog/machine_image/version_metal_nexus.rb
@@ -84,6 +84,11 @@ class Prog::MachineImage::VersionMetalNexus < Prog::Base
       hop_finish_archive
     when "Failed"
       self.archive_failures = (archive_failures || 0) + 1
+      Clog.emit("Machine image archive failed", {
+        machine_image_version_metal: machine_image_version_metal.ubid,
+        archive_failures:,
+        logs: sshable.d_logs(archive_unit, lines: 50),
+      })
       if archive_failures >= MAX_ARCHIVE_FAILURES
         machine_image_version_metal.update(status: "failed", pinned_source_vm_id: nil)
         hop_destroy_objects

--- a/spec/model/sshable_spec.rb
+++ b/spec/model/sshable_spec.rb
@@ -317,5 +317,10 @@ LOCK
       expect(sa).to receive(:_cmd).with("sudo journalctl -u test_unit --no-pager")
       sa.d_logs(unit_name)
     end
+
+    it "calls cmd with the correct journalctl command when limiting the number of lines" do
+      expect(sa).to receive(:_cmd).with("sudo journalctl -u test_unit -n 10 --no-pager")
+      sa.d_logs(unit_name, lines: 10)
+    end
   end
 end

--- a/spec/prog/machine_image/version_metal_nexus_spec.rb
+++ b/spec/prog/machine_image/version_metal_nexus_spec.rb
@@ -126,7 +126,9 @@ RSpec.describe Prog::MachineImage::VersionMetalNexus do
     it "cleans the daemon and naps on Failed when below MAX retries" do
       sshable = prog.sshable
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check #{daemon}").and_return("Failed")
+      expect(sshable).to receive(:_cmd).with("sudo journalctl -u #{daemon} -n 50 --no-pager").and_return("archive logs")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 clean #{daemon}")
+      expect(Clog).to receive(:emit).with("Machine image archive failed", {machine_image_version_metal: metal.ubid, archive_failures: 1, logs: "archive logs"}).and_call_original
       expect { prog.archive }.to nap(60)
       expect(strand.stack.first["archive_failures"]).to eq(1)
       expect(metal.reload.status).to eq("creating")
@@ -136,6 +138,7 @@ RSpec.describe Prog::MachineImage::VersionMetalNexus do
     it "marks the metal failed and hops to destroy_objects after MAX retries" do
       refresh_frame(prog, new_values: {"archive_failures" => described_class::MAX_ARCHIVE_FAILURES - 1})
       expect(prog.sshable).to receive(:_cmd).with("common/bin/daemonizer2 check #{daemon}").and_return("Failed")
+      expect(prog.sshable).to receive(:_cmd).with("sudo journalctl -u #{daemon} -n 50 --no-pager").and_return("archive logs")
       expect { prog.archive }.to hop("destroy_objects")
       expect(metal.reload.status).to eq("failed")
       expect(metal.pinned_source_vm_id).to be_nil


### PR DESCRIPTION
### Allow limiting the number of lines Sshable#d_logs returns 

d_logs dumps the entire journal for a daemonizer2 unit, which is more than we want when we just need the last lines to explain a failure in a Clog entry. Add a lines keyword argument that passes -n to journalctl; it defaults to nil, which keeps the existing unlimited output.

### Log the archive daemon's log tail when a machine image archive fails 

When the archive daemonizer2 unit fails, the only record of why was in the journal on the host, and by the time anyone looked the unit had been cleaned and the failure was several retries old. Emit the last 50 lines along with the failure count, so the reason is in our logs.