### PR TITLE
Triple the machine image archive deadline for VM sources

### DIFF
--- a/prog/machine_image/version_metal_nexus.rb
+++ b/prog/machine_image/version_metal_nexus.rb
@@ -73,8 +73,8 @@ class Prog::MachineImage::VersionMetalNexus < Prog::Base
   end
 
   label def archive
-    # 4 minutes per 10 GiB for VM sources, fixed 1 hour for URL sources.
-    register_deadline("wait", source_vm_id ? Vm[source_vm_id].storage_size_gib * 24 : 3600)
+    # 12 minutes per 10 GiB for VM sources, fixed 1 hour for URL sources.
+    register_deadline("wait", source_vm_id ? Vm[source_vm_id].storage_size_gib * 72 : 3600)
 
     state = sshable.d_check(archive_unit)
     case state


### PR DESCRIPTION
We had archives in production that failed initially but succeeded after a retry, which was past the deadline.

Now 12 minutes per 10 GiB for VM sources, fixed 1 hour for URL sources.