### PR TITLE
Move the resource name label to the on-VM Prometheus

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -568,7 +568,6 @@ class PostgresServer < Sequel::Model
     query_str = URI.encode_www_form(query_params)
     additional_labels = resource.tags.to_h { |tag| ["pg_tags_label_#{tag["key"]}", tag["value"]] }
     additional_labels.merge!({
-      resource_name: resource.name,
       location_id: UBID.to_ubid(resource.location_id),
       location_name: resource.location.name,
       location_provider: resource.location.provider,

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -296,6 +296,7 @@ global:
   scrape_interval: 10s
   external_labels:
     ubicloud_resource_id: #{resource.ubid}
+    ubicloud_resource_name: #{resource.name}
     ubicloud_resource_role: #{(postgres_server.id == resource.representative_server.id) ? "primary" : "standby"}
 
 scrape_configs:

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -125,6 +125,8 @@ class Clover
       r.rename pg, perm: "Postgres:edit", serializer: Serializers::Postgres, template_prefix: "postgres" do
         pg.incr_refresh_dns_record
         pg.incr_refresh_certificates unless pg.hostname_version == "v3"
+        pg.server_incr("configure_metrics")
+        pg.server_incr("configure_logs")
       end
 
       show_actions = if pg.read_replica?

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -2070,11 +2070,10 @@ RSpec.describe PostgresServer do
   end
 
   describe "#metrics_config" do
-    it "labels the exported metrics with the resource name, location, and tags" do
+    it "labels the exported metrics with the location and tags" do
       resource.update(tags: [{"key" => "env", "value" => "prod"}])
 
       expect(postgres_server.metrics_config[:additional_labels]).to eq({"pg_tags_label_env" => "prod"}.merge(
-        resource_name: resource.name,
         location_id: location.ubid,
         location_name: "us-west-2",
         location_provider: "ubicloud",

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -831,7 +831,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { standby_nx.configure_metrics }.to hop("wait")
     end
 
-    it "includes remote_write config when metric_destinations exist" do
+    it "labels the metrics with the resource and includes remote_write config when metric_destinations exist" do
       server
       PostgresMetricDestination.create(
         postgres_resource:,
@@ -880,7 +880,13 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
       expect { standby_nx.configure_metrics }.to hop("wait")
 
-      expect(YAML.safe_load(prometheus_config)["remote_write"].sort_by { it["url"] }).to eq([
+      config = YAML.safe_load(prometheus_config)
+      expect(config["global"]["external_labels"]).to eq(
+        "ubicloud_resource_id" => postgres_resource.ubid,
+        "ubicloud_resource_name" => postgres_resource.name,
+        "ubicloud_resource_role" => "standby",
+      )
+      expect(config["remote_write"].sort_by { it["url"] }).to eq([
         {"url" => "https://basic.example.com/write", "basic_auth" => {"username" => "metrics_user", "password" => "metrics_pass"}},
         {"url" => "https://bearer.example.com/write", "authorization" => {"type" => "Bearer", "credentials" => "my_token"}},
         {"url" => "https://headers.example.com/write", "headers" => {"X-Scope-OrgID" => "tenant1"}},

--- a/spec/routes/web/project/postgres_spec.rb
+++ b/spec/routes/web/project/postgres_spec.rb
@@ -1321,6 +1321,7 @@ RSpec.describe Clover, "postgres" do
         expect(pg.reload.name).to eq "new-name"
         expect(page).to have_content("new-name")
         expect(pg.semaphores_dataset.select_order_map(:name)).to eq %w[refresh_certificates refresh_dns_record].freeze
+        expect(pg.representative_server.semaphores_dataset.select_order_map(:name)).to eq %w[configure_logs configure_metrics].freeze
       end
 
       it "does not refresh certificates when renaming PostgreSQL database with hostname version v3" do


### PR DESCRIPTION
Commit 8f772dbb9 put resource_name on metrics_config[:additional_labels]. Those labels never leave the control plane: MetricsTargetMethods#export_metrics passes them to import_prometheus, so they are stamped on the samples as they land in our own VictoriaMetrics. Metrics that a customer receives take a different path entirely. The on-VM Prometheus remote_writes them straight to the metric destinations the customer configured, without the control plane in the loop, so it never saw the label.

Set it as a Prometheus external label instead. Federation and remote_write both apply external labels, so the name now reaches a customer's own Prometheus and our VictoriaMetrics from a single definition, next to the ubicloud_resource_id and ubicloud_resource_role it belongs with. Name it ubicloud_resource_name to match those two: these labels land in a customer's time series database, where an unprefixed resource_name would be free to collide with their own.

Unlike additional_labels, which the control plane recomputes on every import, prometheus.yml is a file on the server. A rename would leave the old name in place indefinitely, which is worse than no label at all, so the rename now bumps configure_metrics. It bumps configure_logs for the same reason: logs_config has carried resource_name as a log attribute since it was introduced, with the same staleness.

Bump the two semaphores from separate lines. PostgresResource#server_incr issues one insert per name from a single line inside its map, and the duplicate query detection that wraps every request spec keys on the SQL plus the call stack, so passing both names to one call reads as an N+1.

Existing servers pick this up through the configure_metrics semaphore, which prog/rollout_semaphore.rb already lists for PostgresServer.