### PR TITLE
Change presigned certs to not cause CertNexus pages

### DIFF
--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -5,7 +5,7 @@ require "openssl"
 
 class Prog::Vnet::CertNexus < Prog::Base
   subject_is :cert
-  frame_reader :add_private
+  frame_reader :add_private, :wait_deadline
   frame_accessor :last_dns_validation_request, :restarted
 
   REVOKE_REASON = "cessationOfOperation"
@@ -15,7 +15,7 @@ class Prog::Vnet::CertNexus < Prog::Base
     bad_nonce_retry: 3,
   }.freeze
 
-  def self.assemble(hostname, dns_zone_id, private_hostname: nil, waiting_strand_id: nil)
+  def self.assemble(hostname, dns_zone_id, private_hostname: nil, waiting_strand_id: nil, wait_deadline: nil)
     unless Config.development? || DnsZone[dns_zone_id]
       fail "Given DNS zone doesn't exist with the id #{dns_zone_id}"
     end
@@ -23,12 +23,12 @@ class Prog::Vnet::CertNexus < Prog::Base
     DB.transaction do
       cert = Cert.create(hostname:, dns_zone_id:, private_hostname:)
 
-      Strand.create_with_id(cert, prog: "Vnet::CertNexus", label: "start", stack: [{"restarted" => 0, "waiting_strand_id" => waiting_strand_id}])
+      Strand.create_with_id(cert, prog: "Vnet::CertNexus", label: "start", stack: [{"restarted" => 0, "waiting_strand_id" => waiting_strand_id, "wait_deadline" => wait_deadline}])
     end
   end
 
   label def start
-    register_deadline("wait", 10 * 60)
+    register_deadline("wait", wait_deadline || 10 * 60)
 
     if Config.development? && cert.dns_zone_id.nil?
       san = "subjectAltName=DNS:#{cert.hostname}"

--- a/prog/vnet/maintain_presigned_certs.rb
+++ b/prog/vnet/maintain_presigned_certs.rb
@@ -5,7 +5,7 @@ class Prog::Vnet::MaintainPresignedCerts < Prog::Base
 
   MIN_CERTS = 20
   MIN_WAIT_BETWEEN_CERTS_SECONDS = 60
-  MAX_WAIT_SIGNING_SECONDS = 60 * 30
+  MAX_WAIT_SIGNING_SECONDS = 60 * 15
   OLD_CERTS_COND = Sequel[:created_at] < Sequel::CURRENT_TIMESTAMP - Sequel.cast("#{60 * 60 * 24 * 30} seconds", :interval)
 
   def self.schedule_strand
@@ -32,13 +32,15 @@ class Prog::Vnet::MaintainPresignedCerts < Prog::Base
 
   def request_cert
     ubid = generate_ubid
+    wait_deadline = MAX_WAIT_SIGNING_SECONDS + 5 * 60
     st = Prog::Vnet::CertNexus.assemble("*.#{ubid}.#{domain}", dns_zone.id,
       private_hostname: "*.#{ubid}.private.#{domain}",
-      waiting_strand_id: strand.id)
+      waiting_strand_id: strand.id,
+      wait_deadline:)
     self.resource_id = ubid.to_uuid
     self.cert_id = st.id
     self.last_cert_created = now
-    register_deadline("wait", MAX_WAIT_SIGNING_SECONDS + 15 * 60)
+    register_deadline("wait", wait_deadline)
     hop_wait_for_signed_cert
   end
 
@@ -47,7 +49,7 @@ class Prog::Vnet::MaintainPresignedCerts < Prog::Base
       if cert_strand.label == "wait"
         ds.insert(id_key.to_sym => resource_id, :cert_id => cert_id)
       elsif now - last_cert_created < MAX_WAIT_SIGNING_SECONDS
-        nap(10 * 60)
+        nap(2 * 60)
       else
         Clog.emit("Strand for presigned cert not finished in time, destroying", {"presigned_cert_strand_destroyed" => UBID.to_ubid(cert_id)})
         cert_strand.subject.incr_destroy

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe Prog::Vnet::CertNexus do
       expect(st.stack[0]["waiting_strand_id"]).to eq waiting_strand_id
     end
 
+    it "supports wait_dealine: argument" do
+      st = described_class.assemble("test-hostname", dns_zone.id, wait_deadline: 100)
+      expect(st.subject.hostname).to eq "test-hostname"
+      expect(st.stack[0]["wait_deadline"]).to eq 100
+    end
+
     it "fails if dns_zone is not valid" do
       id = SecureRandom.uuid
       expect {
@@ -96,6 +102,7 @@ RSpec.describe Prog::Vnet::CertNexus do
       expect(cert.reload.kid).to eq("test-kid")
       expect(cert.order_url).to eq("test-order-url")
       expect(DnsRecord.where(dns_zone_id: dns_zone.id, name: "test-record-name.cert-hostname.test-dns-zone.com.").count).to eq(1)
+      expect(Time.new(nx.strand.stack[0]["deadline_at"])).to be_within(10).of(Time.now + 600)
     end
 
     it "registers a deadline and starts the certificate creation process when adding private DNS name" do
@@ -108,12 +115,14 @@ RSpec.describe Prog::Vnet::CertNexus do
       expect(client).to receive(:new_account).with(contact: "mailto:#{Config.acme_email}", terms_of_service_agreed: true, external_account_binding: {kid: Config.acme_eab_kid, hmac_key: Config.acme_eab_hmac_key}).and_return(instance_double(Acme::Client::Resources::Account, kid: "test-kid"))
       expect(client).to receive(:new_order).with(identifiers:).and_return(order)
 
+      refresh_frame(nx, new_values: {"wait_deadline" => 100})
       expect { nx.start }.to hop("wait_dns_update")
       expect(cert.reload.kid).to eq("test-kid")
       expect(cert.order_url).to eq("test-order-url")
       # Each authorization creates ONE DNS record for its own domain
       expect(DnsRecord.where(dns_zone_id: dns_zone.id, name: "test-record-name.cert-hostname.test-dns-zone.com.").count).to eq(1)
       expect(DnsRecord.where(dns_zone_id: dns_zone.id, name: "test-record-name.private.cert-hostname.test-dns-zone.com.").count).to eq(1)
+      expect(Time.new(nx.strand.stack[0]["deadline_at"])).to be_within(10).of(Time.now + 100)
     end
 
     it "creates a self-signed certificate in development environments without dns" do

--- a/spec/prog/vnet/maintain_presigned_load_balancer_certs_spec.rb
+++ b/spec/prog/vnet/maintain_presigned_load_balancer_certs_spec.rb
@@ -65,11 +65,12 @@ RSpec.describe Prog::Vnet::MaintainPresignedLoadBalancerCerts do
       expect(cert_id).to eq cert.id
       expect(cert.strand.label).to eq "start"
       expect(cert.strand.stack[0]["waiting_strand_id"]).to eq prog.strand.id
+      expect(cert.strand.stack[0]["wait_deadline"]).to eq(60 * 20)
       expect(cert.hostname).to eq "*.#{lb_ubid}.lb2.ubicloud.com"
       expect(cert.private_hostname).to eq "*.#{lb_ubid}.private.lb2.ubicloud.com"
       expect(cert.dns_zone_id).to eq dns_zone.id
       expect(frame["deadline_target"]).to eq "wait"
-      expect(Time.new(frame["deadline_at"])).to be_within(5).of(Time.now + 60 * 45)
+      expect(Time.new(frame["deadline_at"])).to be_within(5).of(Time.now + 60 * 20)
       expect(last_cert_created).to be_within(5).of(Time.now.to_i)
     end
   end
@@ -96,14 +97,14 @@ RSpec.describe Prog::Vnet::MaintainPresignedLoadBalancerCerts do
       frame = prog.strand.stack[0]
       Strand.create_with_id(frame.fetch("cert_id"), prog: "Vnet::CertNexus", label: "start")
       refresh_frame(prog, new_values: {"last_cert_created" => Time.now.to_i - 50})
-      expect { prog.wait_for_signed_cert }.to nap(600)
+      expect { prog.wait_for_signed_cert }.to nap(120)
     end
 
     it "destroys cert and hops if cert strand is not in wait and it has been too long" do
       frame = prog.strand.stack[0]
       Strand.create_with_id(frame.fetch("cert_id"), prog: "Vnet::CertNexus", label: "start")
       cert = Cert.create_with_id(frame.fetch("cert_id"), hostname: "test")
-      refresh_frame(prog, new_values: {"last_cert_created" => Time.now.to_i - 35 * 60})
+      refresh_frame(prog, new_values: {"last_cert_created" => Time.now.to_i - 16 * 60})
       expect(Clog).to receive(:emit).with("Strand for presigned cert not finished in time, destroying", {"presigned_cert_strand_destroyed" => UBID.to_ubid(prog.strand.stack[0]["cert_id"])}).and_call_original
       expect { prog.wait_for_signed_cert }.to hop("wait")
         .and not_change { DB[:presigned_load_balancer_cert].count }

--- a/spec/prog/vnet/maintain_presigned_postgres_certs_spec.rb
+++ b/spec/prog/vnet/maintain_presigned_postgres_certs_spec.rb
@@ -62,11 +62,12 @@ RSpec.describe Prog::Vnet::MaintainPresignedPostgresCerts do
       expect(cert_id).to eq cert.id
       expect(cert.strand.label).to eq "start"
       expect(cert.strand.stack[0]["waiting_strand_id"]).to eq prog.strand.id
+      expect(cert.strand.stack[0]["wait_deadline"]).to eq(60 * 20)
       expect(cert.hostname).to eq "*.#{pg_ubid}.pg.ubicloud.app"
       expect(cert.private_hostname).to eq "*.#{pg_ubid}.private.pg.ubicloud.app"
       expect(cert.dns_zone_id).to eq dns_zone.id
       expect(frame["deadline_target"]).to eq "wait"
-      expect(Time.new(frame["deadline_at"])).to be_within(5).of(Time.now + 60 * 45)
+      expect(Time.new(frame["deadline_at"])).to be_within(5).of(Time.now + 60 * 20)
       expect(last_cert_created).to be_within(5).of(Time.now.to_i)
     end
   end
@@ -93,14 +94,14 @@ RSpec.describe Prog::Vnet::MaintainPresignedPostgresCerts do
       frame = prog.strand.stack[0]
       Strand.create_with_id(frame.fetch("cert_id"), prog: "Vnet::CertNexus", label: "start")
       refresh_frame(prog, new_values: {"last_cert_created" => Time.now.to_i - 50})
-      expect { prog.wait_for_signed_cert }.to nap(600)
+      expect { prog.wait_for_signed_cert }.to nap(120)
     end
 
     it "destroys cert and hops if cert strand is not in wait and it has been too long" do
       frame = prog.strand.stack[0]
       Strand.create_with_id(frame.fetch("cert_id"), prog: "Vnet::CertNexus", label: "start")
       cert = Cert.create_with_id(frame.fetch("cert_id"), hostname: "test")
-      refresh_frame(prog, new_values: {"last_cert_created" => Time.now.to_i - 35 * 60})
+      refresh_frame(prog, new_values: {"last_cert_created" => Time.now.to_i - 16 * 60})
       expect(Clog).to receive(:emit).with("Strand for presigned cert not finished in time, destroying", {"presigned_cert_strand_destroyed" => UBID.to_ubid(prog.strand.stack[0]["cert_id"])}).and_call_original
       expect { prog.wait_for_signed_cert }.to hop("wait")
         .and not_change { DB[:presigned_postgres_cert].count }


### PR DESCRIPTION
For the presigned certs, lower the max wait time for cert creation from
30 minutes (page after 45) to 15 (page after 20). Use the new
CertNexus.assemble wait_deadline support to set the related CertNexus to
also page after 20 minutes, instead of the usual 10. Instead of checking
every 10 minutes, check every 2 minutes for progress. This should result
in presigned certs recognizing they were not issued after 15-17 minutes,
hopping back to wait (avoiding the page for the MaintainPresigned*Cert
strands), and incr_destroying the related cert (avoiding the CertNexus
page for the cert).