### PR TITLE
 Add disable_others option to SetupVhostBlockBackend

### DIFF
--- a/prog/storage/setup_vhost_block_backend.rb
+++ b/prog/storage/setup_vhost_block_backend.rb
@@ -2,8 +2,7 @@
 
 class Prog::Storage::SetupVhostBlockBackend < Prog::Base
   subject_is :sshable, :vm_host
-  frame_reader :version, :allocation_weight
-  frame_accessor :vhost_block_backend_id
+  frame_reader :version, :allocation_weight, :vhost_block_backend_id
 
   SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS = [
     ["v0.5.1", "x64"],
@@ -17,29 +16,26 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
   ].freeze.each(&:freeze)
 
   def self.assemble(vm_host_id, version, allocation_weight: 0)
-    Strand.create(
-      prog: "Storage::SetupVhostBlockBackend",
-      label: "start",
-      stack: [{
-        "subject_id" => vm_host_id,
-        "version" => version,
-        "allocation_weight" => allocation_weight,
-      }],
-    )
+    arch = VmHost.with_pk!(vm_host_id).arch
+    fail "Unsupported version: #{version}, #{arch}" unless SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS.include? [version, arch]
+
+    DB.transaction do
+      vbb = VhostBlockBackend.create(version:, allocation_weight: 0, vm_host_id:)
+
+      Strand.create(
+        prog: "Storage::SetupVhostBlockBackend",
+        label: "start",
+        stack: [{
+          "subject_id" => vm_host_id,
+          "version" => version,
+          "allocation_weight" => allocation_weight,
+          "vhost_block_backend_id" => vbb.id,
+        }],
+      )
+    end
   end
 
   label def start
-    arch = vm_host.arch
-    fail "Unsupported version: #{version}, #{arch}" unless SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS.include? [version, arch]
-
-    vbb = VhostBlockBackend.create(
-      version:,
-      allocation_weight: 0,
-      vm_host_id: vm_host.id,
-    )
-
-    self.vhost_block_backend_id = vbb.id
-
     register_deadline(nil, 5 * 60)
     hop_install_vhost_backend
   end
@@ -49,7 +45,7 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
     case sshable.cmd("common/bin/daemonizer --check :name", name:)
     when "Succeeded"
       sshable.cmd("common/bin/daemonizer --clean :name", name:)
-      VhostBlockBackend[vhost_block_backend_id].update(allocation_weight:)
+      VhostBlockBackend.with_pk!(vhost_block_backend_id).update(allocation_weight:)
       pop "VhostBlockBackend was setup"
     when "Failed", "NotStarted"
       d_command = NetSsh.command("sudo host/bin/setup-vhost-block-backend install :version", version:)

--- a/prog/storage/setup_vhost_block_backend.rb
+++ b/prog/storage/setup_vhost_block_backend.rb
@@ -2,7 +2,7 @@
 
 class Prog::Storage::SetupVhostBlockBackend < Prog::Base
   subject_is :sshable, :vm_host
-  frame_reader :version, :allocation_weight, :vhost_block_backend_id
+  frame_reader :version, :allocation_weight, :disable_others, :vhost_block_backend_id
 
   SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS = [
     ["v0.5.1", "x64"],
@@ -15,7 +15,7 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
     ["v0.2.2", "arm64"],
   ].freeze.each(&:freeze)
 
-  def self.assemble(vm_host_id, version, allocation_weight: 0)
+  def self.assemble(vm_host_id, version, allocation_weight: 0, disable_others: true)
     arch = VmHost.with_pk!(vm_host_id).arch
     fail "Unsupported version: #{version}, #{arch}" unless SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS.include? [version, arch]
 
@@ -29,6 +29,7 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
           "subject_id" => vm_host_id,
           "version" => version,
           "allocation_weight" => allocation_weight,
+          "disable_others" => disable_others,
           "vhost_block_backend_id" => vbb.id,
         }],
       )
@@ -46,6 +47,7 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
     when "Succeeded"
       sshable.cmd("common/bin/daemonizer --clean :name", name:)
       VhostBlockBackend.with_pk!(vhost_block_backend_id).update(allocation_weight:)
+      vm_host.vhost_block_backends_dataset.exclude(id: vhost_block_backend_id).update(allocation_weight: 0) if disable_others
       pop "VhostBlockBackend was setup"
     when "Failed", "NotStarted"
       d_command = NetSsh.command("sudo host/bin/setup-vhost-block-backend install :version", version:)

--- a/prog/storage/setup_vhost_block_backend.rb
+++ b/prog/storage/setup_vhost_block_backend.rb
@@ -15,7 +15,7 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
     ["v0.2.2", "arm64"],
   ].freeze.each(&:freeze)
 
-  def self.assemble(vm_host_id, version, allocation_weight: 0, disable_others: true)
+  def self.assemble(vm_host_id, version, allocation_weight: 100, disable_others: true)
     arch = VmHost.with_pk!(vm_host_id).arch
     fail "Unsupported version: #{version}, #{arch}" unless SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS.include? [version, arch]
 

--- a/prog/storage/setup_vhost_block_backend.rb
+++ b/prog/storage/setup_vhost_block_backend.rb
@@ -16,6 +16,8 @@ class Prog::Storage::SetupVhostBlockBackend < Prog::Base
   ].freeze.each(&:freeze)
 
   def self.assemble(vm_host_id, version, allocation_weight: 100, disable_others: true)
+    fail "Cannot disable other backends without enabling this one" if allocation_weight == 0 && disable_others
+
     arch = VmHost.with_pk!(vm_host_id).arch
     fail "Unsupported version: #{version}, #{arch}" unless SUPPORTED_VHOST_BLOCK_BACKEND_VERSIONS.include? [version, arch]
 

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -140,7 +140,7 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def setup_storage_backend
-    strand.add_child(Prog::Storage::SetupVhostBlockBackend.assemble(vm_host.id, vhost_block_backend_version, allocation_weight: 100))
+    strand.add_child(Prog::Storage::SetupVhostBlockBackend.assemble(vm_host.id, vhost_block_backend_version))
     hop_wait_storage_backend
   end
 

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -140,12 +140,12 @@ class Prog::Vm::HostNexus < Prog::Base
   end
 
   label def setup_storage_backend
-    hop_download_boot_images if retval&.dig("msg") == "VhostBlockBackend was setup"
+    strand.add_child(Prog::Storage::SetupVhostBlockBackend.assemble(vm_host.id, vhost_block_backend_version, allocation_weight: 100))
+    hop_wait_storage_backend
+  end
 
-    push Prog::Storage::SetupVhostBlockBackend, {
-      "version" => vhost_block_backend_version,
-      "allocation_weight" => 100,
-    }
+  label def wait_storage_backend
+    reap(:download_boot_images)
   end
 
   label def download_boot_images

--- a/spec/prog/storage/setup_vhost_block_backend_spec.rb
+++ b/spec/prog/storage/setup_vhost_block_backend_spec.rb
@@ -4,26 +4,34 @@ require_relative "../../model/spec_helper"
 
 RSpec.describe Prog::Storage::SetupVhostBlockBackend do
   subject(:setup_vhost_block_backend) {
-    described_class.new(described_class.assemble(
-      vm_host.id,
-      Config.vhost_block_backend_version,
-      allocation_weight: 50,
-    ))
+    described_class.new(described_class.assemble(vm_host.id, version, allocation_weight: 50))
   }
 
-  let(:version) { Config.vhost_block_backend_version }
+  let(:version) { "v0.4.2" }
 
   let(:sshable) { setup_vhost_block_backend.sshable }
   let(:vm_host) { create_vm_host(used_hugepages_1g: 0, total_hugepages_1g: 20, total_cpus: 96, os_version: "ubuntu-24.04") }
+  let(:vbb) { VhostBlockBackend.with_pk!(setup_vhost_block_backend.vhost_block_backend_id) }
+
+  describe ".assemble" do
+    it "creates a disabled backend and records the options in the frame" do
+      st = described_class.assemble(vm_host.id, version, allocation_weight: 50)
+      backend = VhostBlockBackend.with_pk!(st.stack.first["vhost_block_backend_id"])
+      expect(backend.version).to eq(version)
+      expect(backend.allocation_weight).to eq(0)
+      expect(st.stack.first).to eq({"subject_id" => vm_host.id, "version" => version, "allocation_weight" => 50, "vhost_block_backend_id" => backend.id})
+    end
+
+    it "fails if version/arch combination is not supported" do
+      expect {
+        described_class.assemble(vm_host.id, "v1.0")
+      }.to raise_error RuntimeError, "Unsupported version: v1.0, x64"
+    end
+  end
 
   describe "#start" do
     it "hops to install_vhost_backend" do
       expect { setup_vhost_block_backend.start }.to hop("install_vhost_backend")
-    end
-
-    it "fails if version/arch combination is not supported" do
-      refresh_frame(setup_vhost_block_backend, new_values: {"version" => "v1.0"})
-      expect { setup_vhost_block_backend.start }.to raise_error RuntimeError, "Unsupported version: v1.0, x64"
     end
   end
 
@@ -35,23 +43,19 @@ RSpec.describe Prog::Storage::SetupVhostBlockBackend do
     end
 
     it "starts the daemonizer if failed" do
-      create_vhost_block_backend(version: version.to_s, allocation_weight: 0, vm_host_id: vm_host.id)
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check setup-vhost-block-backend-#{version}").and_return("Failed")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer sudo\\ host/bin/setup-vhost-block-backend\\ install\\ #{version} setup-vhost-block-backend-#{version}")
       expect { setup_vhost_block_backend.install_vhost_backend }.to nap
     end
 
     it "updates and pops if succeeded" do
-      vbb = create_vhost_block_backend(version: version.to_s, allocation_weight: 0, vm_host_id: vm_host.id)
-      refresh_frame(setup_vhost_block_backend, new_values: {"vhost_block_backend_id" => vbb.id})
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check setup-vhost-block-backend-#{version}").and_return("Succeeded")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --clean setup-vhost-block-backend-#{version}")
       expect { setup_vhost_block_backend.install_vhost_backend }.to exit({"msg" => "VhostBlockBackend was setup"})
-      expect(VhostBlockBackend.first.allocation_weight).to eq(50)
+      expect(vbb.reload.allocation_weight).to eq(50)
     end
 
     it "naps if the daemonizer is already running" do
-      create_vhost_block_backend(version: version.to_s, allocation_weight: 0, vm_host_id: vm_host.id)
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check setup-vhost-block-backend-#{version}").and_return("InProgress")
       expect { setup_vhost_block_backend.install_vhost_backend }.to nap(5)
     end

--- a/spec/prog/storage/setup_vhost_block_backend_spec.rb
+++ b/spec/prog/storage/setup_vhost_block_backend_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe Prog::Storage::SetupVhostBlockBackend do
       expect(st.stack.first).to eq({"subject_id" => vm_host.id, "version" => version, "allocation_weight" => 50, "disable_others" => false, "vhost_block_backend_id" => backend.id})
     end
 
+    it "enables the backend and disables the other ones by default" do
+      st = described_class.assemble(vm_host.id, version)
+      expect(st.stack.first.values_at("allocation_weight", "disable_others")).to eq([100, true])
+    end
+
     it "fails if version/arch combination is not supported" do
       expect {
         described_class.assemble(vm_host.id, "v1.0")

--- a/spec/prog/storage/setup_vhost_block_backend_spec.rb
+++ b/spec/prog/storage/setup_vhost_block_backend_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe Prog::Storage::SetupVhostBlockBackend do
         described_class.assemble(vm_host.id, "v1.0")
       }.to raise_error RuntimeError, "Unsupported version: v1.0, x64"
     end
+
+    it "fails if the backend is not enabled but the other ones are disabled" do
+      expect {
+        described_class.assemble(vm_host.id, version, allocation_weight: 0)
+      }.to raise_error RuntimeError, "Cannot disable other backends without enabling this one"
+    end
   end
 
   describe "#start" do

--- a/spec/prog/storage/setup_vhost_block_backend_spec.rb
+++ b/spec/prog/storage/setup_vhost_block_backend_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe Prog::Storage::SetupVhostBlockBackend do
       }.to raise_error RuntimeError, "Unsupported version: v1.0, x64"
     end
 
+    it "fails if the version is already set up on the host" do
+      described_class.assemble(vm_host.id, version)
+      expect {
+        described_class.assemble(vm_host.id, version)
+      }.to raise_error Sequel::ValidationFailed, "vm_host_id and version_code is already taken"
+    end
+
     it "fails if the backend is not enabled but the other ones are disabled" do
       expect {
         described_class.assemble(vm_host.id, version, allocation_weight: 0)

--- a/spec/prog/storage/setup_vhost_block_backend_spec.rb
+++ b/spec/prog/storage/setup_vhost_block_backend_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Prog::Storage::SetupVhostBlockBackend do
 
   describe ".assemble" do
     it "creates a disabled backend and records the options in the frame" do
-      st = described_class.assemble(vm_host.id, version, allocation_weight: 50)
+      st = described_class.assemble(vm_host.id, version, allocation_weight: 50, disable_others: false)
       backend = VhostBlockBackend.with_pk!(st.stack.first["vhost_block_backend_id"])
       expect(backend.version).to eq(version)
       expect(backend.allocation_weight).to eq(0)
-      expect(st.stack.first).to eq({"subject_id" => vm_host.id, "version" => version, "allocation_weight" => 50, "vhost_block_backend_id" => backend.id})
+      expect(st.stack.first).to eq({"subject_id" => vm_host.id, "version" => version, "allocation_weight" => 50, "disable_others" => false, "vhost_block_backend_id" => backend.id})
     end
 
     it "fails if version/arch combination is not supported" do
@@ -48,11 +48,27 @@ RSpec.describe Prog::Storage::SetupVhostBlockBackend do
       expect { setup_vhost_block_backend.install_vhost_backend }.to nap
     end
 
-    it "updates and pops if succeeded" do
+    it "updates, disables the other backends and pops if succeeded" do
+      older = create_vhost_block_backend(version: "v0.3.1", allocation_weight: 100, vm_host_id: vm_host.id)
+      newer = create_vhost_block_backend(version: "v0.5.1", allocation_weight: 100, vm_host_id: vm_host.id)
+      other_host_backend = create_vhost_block_backend(version: "v0.4.2", allocation_weight: 100)
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check setup-vhost-block-backend-#{version}").and_return("Succeeded")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --clean setup-vhost-block-backend-#{version}")
       expect { setup_vhost_block_backend.install_vhost_backend }.to exit({"msg" => "VhostBlockBackend was setup"})
       expect(vbb.reload.allocation_weight).to eq(50)
+      expect(older.reload.allocation_weight).to eq(0)
+      expect(newer.reload.allocation_weight).to eq(0)
+      expect(other_host_backend.reload.allocation_weight).to eq(100)
+    end
+
+    it "keeps the other backends enabled if disable_others is false" do
+      other = create_vhost_block_backend(version: "v0.3.1", allocation_weight: 100, vm_host_id: vm_host.id)
+      refresh_frame(setup_vhost_block_backend, new_values: {"disable_others" => false})
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check setup-vhost-block-backend-#{version}").and_return("Succeeded")
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --clean setup-vhost-block-backend-#{version}")
+      expect { setup_vhost_block_backend.install_vhost_backend }.to exit({"msg" => "VhostBlockBackend was setup"})
+      expect(vbb.reload.allocation_weight).to eq(50)
+      expect(other.reload.allocation_weight).to eq(100)
     end
 
     it "naps if the daemonizer is already running" do

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -370,16 +370,23 @@ RSpec.describe Prog::Vm::HostNexus do
   end
 
   describe "#setup_storage_backend" do
-    it "pushes the vhost_block_backend program by default" do
+    it "buds the vhost_block_backend program" do
       vm_host.update(arch: "x64")
-      expect { nx.setup_storage_backend }.to hop("start", "Storage::SetupVhostBlockBackend") { |hop|
-        expect(hop.strand_update_args[:stack].first).to include("allocation_weight" => 100)
-      }
+      expect { nx.setup_storage_backend }.to hop("wait_storage_backend")
+      child = Strand.where(parent_id: st.id, prog: "Storage::SetupVhostBlockBackend").first
+      expect(child.stack.first).to include("version" => Config.vhost_block_backend_version, "allocation_weight" => 100)
+      expect(VhostBlockBackend.where(vm_host_id: vm_host.id).all.map(&:allocation_weight)).to eq([0])
+    end
+  end
+
+  describe "#wait_storage_backend" do
+    it "hops to download_boot_images once the backend is set up" do
+      expect { nx.wait_storage_backend }.to hop("download_boot_images")
     end
 
-    it "hops once SetupVhostBlockBackend has returned" do
-      nx.strand.retval = {"msg" => "VhostBlockBackend was setup"}
-      expect { nx.setup_storage_backend }.to hop("download_boot_images")
+    it "donates its time while the backend is being set up" do
+      Strand.create(parent_id: st.id, prog: "Storage::SetupVhostBlockBackend", label: "start", lease: Time.now + 10)
+      expect { nx.wait_storage_backend }.to nap(120)
     end
   end
 


### PR DESCRIPTION
### Validate and create the backend in assemble 

Assembling an unsupported version, or a version the host already has, only failed once the strand ran start, leaving a strand that retries an error forever. Move both the validation and the backend record to assemble, in one transaction, so the caller finds out.

HostNexus now assembles the setup as a child strand and reaps it, rather than pushing the prog with a frame it builds itself.

### Add disable_others option to SetupVhostBlockBackend 

Installing a backend is most of the time followed by disabling the other versions on the host. disable_others automates that, and defaults to true.

### Default the vhost block backend allocation weight to 100 

We almost always use 100. The old default of 0 installs a backend that nothing is ever allocated to.

### Reject setting up a disabled backend that disables the other ones 

allocation_weight: 0 with disable_others would zero every backend on the host, leaving it with nothing to allocate to.

### Test that a version can only be set up once per host 

The unique index on (vm_host_id, version_code) is what stops a second setup of the same version.