### PR TITLE
Fix Rodauth domain/base_url for production admin site

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -325,7 +325,7 @@ class CloverAdmin < Roda
       # simplecov:disable
     else
       admin_uri = URI(Config.base_url)
-      admin_uri.host = "admin.#{admin_uri.host}"
+      admin_uri.host = "admin.#{admin_uri.host.delete_prefix("console.")}"
       # simplecov:enable
     end
     domain admin_uri.host


### PR DESCRIPTION
Production site is console.ubicloud.com, so admin site ended up specifying admin.console.ubicloud.com instead of admin.ubicloud.com.