### PR TITLE
Remove use of disallow_password_reuse Rodauth feature

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -382,7 +382,7 @@ class Clover < Roda
   plugin :rodauth do
     enable :argon2, :change_login, :change_password, :close_account, :create_account,
       :lockout, :login, :logout, :remember, :reset_password,
-      :disallow_password_reuse, :password_grace_period, :active_sessions,
+      :password_grace_period, :active_sessions,
       :verify_login_change, :change_password_notify, :confirm_password,
       :otp, :webauthn, :recovery_codes, :omniauth, :otp_unlock, :otp_lockout_email,
       :audit_logging, :close_account_email

--- a/routes/account.rb
+++ b/routes/account.rb
@@ -47,7 +47,6 @@ class Clover
           DB.transaction do
             if provider == "password"
               DB[:account_password_hashes].where(id: current_account.id).delete
-              DB[:account_previous_password_hashes].where(account_id: current_account.id).delete
               rodauth.add_audit_log(current_account_id, :remove_password)
               flash[:notice] = "Your password has been deleted"
             elsif (identity = identities.find { it.provider == provider && it.uid == uid })

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -516,37 +516,23 @@ RSpec.describe Clover, "auth" do
       })
     end
 
-    it "does not allow duplicate passwords" do
-      # Update account_previous_password_hashes, which isn't done by default in the specs
-      password_hash = Argon2::Password.new({
-        t_cost: 1,
-        m_cost: 5,
-        secret: Config.clover_session_secret,
-      }).create(TEST_USER_PASSWORD)
-      DB[:account_previous_password_hashes].insert(account_id: Account.get(:id), password_hash:)
-
+    it "does not allow same password as current password" do
       visit "/account/change-password"
-      passwords = [TEST_USER_PASSWORD]
-      3.times do
-        passwords.each do |password|
-          fill_in "New Password", with: password
-          fill_in "New Password Confirmation", with: password
+      fill_in "New Password", with: TEST_USER_PASSWORD
+      fill_in "New Password Confirmation", with: TEST_USER_PASSWORD
 
-          click_button "Change Password"
-          expect(page.title).to eq("Ubicloud - Change Password")
-          expect(page).to have_flash_error("There was an error changing your password")
-          expect(page).to have_text(/invalid password, same as current password|Password cannot be the same as a previous password/)
-        end
+      click_button "Change Password"
+      expect(page.title).to eq("Ubicloud - Change Password")
+      expect(page).to have_flash_error("There was an error changing your password")
+      expect(page).to have_text(/invalid password, same as current password|Password cannot be the same as a previous password/)
 
-        new_password = passwords.last + "_new"
-        passwords << new_password
-        fill_in "New Password", with: new_password
-        fill_in "New Password Confirmation", with: new_password
-        click_button "Change Password"
-        expect(page.title).to eq("Ubicloud - Change Password")
-        expect(page).to have_flash_notice("Your password has been changed")
-      end
-      expect(audit_log_hash).to eq({"change_password" => [ip_hash] * 3})
+      new_password = TEST_USER_PASSWORD + "_new"
+      fill_in "New Password", with: new_password
+      fill_in "New Password Confirmation", with: new_password
+      click_button "Change Password"
+      expect(page.title).to eq("Ubicloud - Change Password")
+      expect(page).to have_flash_notice("Your password has been changed")
+      expect(audit_log_hash).to eq({"change_password" => ip_hash})
     end
 
     [true, false].each do |clear_last_password_entry|


### PR DESCRIPTION
Rodauth itself recommends against its use unless you have a security policy that requires it, and we do not.

If you had an alternative login method setup, it was trivial to bypass by deleting the password (which also deleted previous passwords) before adding the same password back.

This does not drop the account_previous_password_hashes table or the related previous password database functions. Doing so requires use of the ph database account, which is left disabled by default. If we need to use the ph database account for some other reason, we can include the table and function drops at that point.  The table can be cleared manually after this commit goes into production.