### PR TITLE
Remove the use_old_walg_command semaphore

### DIFF
--- a/lib/validation/postgres_config_validator_schema.rb
+++ b/lib/validation/postgres_config_validator_schema.rb
@@ -42,7 +42,7 @@ module Validation
       "archive_command" => {
         description: "Sets the shell command that will be called to archive a WAL file.",
         type: :string,
-        default: "/usr/bin/wal-g wal-push %p --config /etc/postgresql/wal-g.env",
+        default: "/usr/bin/walg-daemon-client /tmp/wal-g wal-push %f",
       },
       "archive_library" => {
         description: "Sets the library that will be called to archive a WAL file.",

--- a/model/postgres/postgres_resource.rb
+++ b/model/postgres/postgres_resource.rb
@@ -24,7 +24,7 @@ class PostgresResource < Sequel::Model
     encrypted_columns: [:superuser_password, :root_cert_key_1, :root_cert_key_2, :server_cert_key, :client_root_cert_key_1, :client_root_cert_key_2, :client_cert_key, :parseable_password]
   plugin ProviderDispatcher, __FILE__
   plugin SemaphoreMethods, :initial_provisioning, :refresh_dns_record, :update_billing_records,
-    :destroy, :refresh_certificates, :use_different_az, :use_old_walg_command, :check_disk_usage,
+    :destroy, :refresh_certificates, :use_different_az, :check_disk_usage,
     :storage_auto_scale_action_performed_80, :storage_auto_scale_action_performed_85, :storage_auto_scale_action_performed_90,
     :storage_auto_scale_canceled, :storage_auto_scale_not_cancellable, :skip_strict_memory_overcommit,
     :bypass_maintenance_window

--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -134,11 +134,7 @@ class PostgresServer < Sequel::Model
     if timeline.blob_storage
       configs[:archive_mode] = "on"
       configs[:archive_timeout] = "60"
-      configs[:archive_command] = if resource.use_old_walg_command_set?
-        "'/usr/bin/wal-g wal-push %p --config /etc/postgresql/wal-g.env'"
-      else
-        "'/usr/bin/walg-daemon-client /tmp/wal-g wal-push %f'"
-      end
+      configs[:archive_command] = "'/usr/bin/walg-daemon-client /tmp/wal-g wal-push %f'"
 
       if primary?
         caught_up_standbys = resource.servers.select { it.standby? && it.synchronization_status == "ready" }
@@ -638,7 +634,7 @@ class PostgresServer < Sequel::Model
   def switch_to_new_timeline(parent_id: timeline.id)
     # We have to stop wal-g before updating the timeline to avoid WAL files
     # being pushed to the old bucket.
-    vm.sshable.cmd("sudo systemctl stop wal-g") if timeline.blob_storage && !resource.use_old_walg_command_set?
+    vm.sshable.cmd("sudo systemctl stop wal-g") if timeline.blob_storage
     previous_timeline = timeline
     update(
       timeline_id: Prog::Postgres::PostgresTimelineNexus.assemble(location_id: resource.location_id, parent_id:).id,
@@ -657,10 +653,8 @@ class PostgresServer < Sequel::Model
     walg_config = timeline.generate_walg_config(version, self)
     vm.sshable.cmd("sudo -u postgres tee /etc/postgresql/wal-g.env > /dev/null", stdin: walg_config)
     refresh_walg_blob_storage_credentials
-    unless resource.use_old_walg_command_set?
-      ensure_walg_stop_timeout_override
-      vm.sshable.cmd("sudo systemctl restart wal-g")
-    end
+    ensure_walg_stop_timeout_override
+    vm.sshable.cmd("sudo systemctl restart wal-g")
   end
 
   def ensure_walg_stop_timeout_override

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -401,7 +401,7 @@ TIMER
       vm.sshable.cmd("sudo systemctl enable --now prometheus")
       vm.sshable.cmd("sudo systemctl enable --now postgres-metrics.timer")
       vm.sshable.cmd("sudo systemctl enable --now pg-collect-metrics.timer")
-      vm.sshable.cmd("sudo systemctl enable --now wal-g") if postgres_server.timeline.blob_storage && !resource.use_old_walg_command_set?
+      vm.sshable.cmd("sudo systemctl enable --now wal-g") if postgres_server.timeline.blob_storage
 
       hop_configure_logs
     end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -70,10 +70,7 @@ RSpec.describe PostgresServer do
       expect(postgres_server.configure_hash[:configs]).to include(:synchronized_standby_slots)
     end
 
-    it "sets archive_command for walg client according to resource.use_old_walg_command_set?" do
-      expect(resource).to receive(:use_old_walg_command_set?).and_return(true)
-      expect(postgres_server.configure_hash[:configs]).to include(archive_command: "'/usr/bin/wal-g wal-push %p --config /etc/postgresql/wal-g.env'")
-      expect(resource).to receive(:use_old_walg_command_set?).and_return(false).at_least(:once)
+    it "sets archive_command to use the walg daemon client" do
       expect(postgres_server.configure_hash[:configs]).to include(archive_command: "'/usr/bin/walg-daemon-client /tmp/wal-g wal-push %f'")
     end
 
@@ -1145,16 +1142,6 @@ RSpec.describe PostgresServer do
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo tee /etc/systemd/system/wal-g.service.d/stop-timeout.conf > /dev/null", stdin: "[Service]\nTimeoutStopSec=5s\n")
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo systemctl daemon-reload")
       expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo systemctl restart wal-g")
-      expect { postgres_server.refresh_walg_credentials }.not_to raise_error
-    end
-
-    it "does not restart wal-g if use_old_walg_command_set is true" do
-      expect(postgres_server.resource).to receive(:use_old_walg_command_set?).and_return(true)
-      expect(timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, root_certs: "root_certs")).at_least(:once)
-      expect(timeline).to receive(:generate_walg_config).and_return("walg_config")
-      expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo -u postgres tee /etc/postgresql/wal-g.env > /dev/null", stdin: "walg_config")
-      expect(postgres_server.vm.sshable).to receive(:_cmd).with("sudo tee /usr/lib/ssl/certs/blob_storage_ca.crt > /dev/null", stdin: "root_certs")
-      expect(postgres_server.vm.sshable).not_to receive(:_cmd).with("sudo systemctl restart wal-g")
       expect { postgres_server.refresh_walg_credentials }.not_to raise_error
     end
   end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -736,7 +736,6 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       server.update(timeline: aws_timeline)
 
       nx.incr_initial_provisioning
-      expect(nx.postgres_server.resource).to receive(:use_old_walg_command_set?).and_return(false)
       expect(sshable).to receive(:_cmd).with("sudo mkdir -p /usr/local/share/postgresql")
       expect(sshable).to receive(:_cmd).with("sudo tee /usr/local/share/postgresql/postgres_exporter_queries.yaml > /dev/null", stdin: anything)
       expect(sshable).to receive(:_cmd).with("sudo -u prometheus tee /home/prometheus/web-config.yml > /dev/null", stdin: anything)


### PR DESCRIPTION
The semaphore let PostgreSQL resources keep archiving with the legacy `wal-g wal-push %p --config ...` command while the fleet was migrated to the wal-g daemon and its walg-daemon-client. Every resource now runs the daemon-based command set, so the fallback paths are dead code.

Drop the semaphore from PostgresResource and make the daemon behaviour unconditional: the archive_command always points at walg-daemon-client, the wal-g service is always enabled during initial provisioning, stopped when switching timelines, and restarted after refreshing credentials. Also update the archive_command default in the config validator schema, which still documented the legacy command.