### PR TITLE
Consider hugepage utilization for runner provisioning

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -363,10 +363,17 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       nap rand(5..15)
     end
 
-    # check utilization, if it's high, wait for it to go down
+    # check utilization, if it's high, wait for it to go down. Some hosts run
+    # out of hugepages before cores, so use the more utilized resource.
     family_utilization = VmHost.where(allocation_state: "accepting", location_id: [Location::GITHUB_RUNNERS_ID, Location::HETZNER_FSN1_ID, Location::HETZNER_HEL1_ID], arch:)
+      .where { (total_cores > 0) & (total_hugepages_1g > 0) }
       .select_group(:family)
-      .select_append { round(sum(:used_cores) * 100.0 / sum(:total_cores), 2).cast(:float).as(:utilization) }
+      .select_append {
+        round(greatest(
+          sum(:used_cores) * 100.0 / sum(:total_cores),
+          sum(:used_hugepages_1g) * 100.0 / sum(:total_hugepages_1g),
+        ), 2).cast(:float).as(:utilization)
+      }
       .to_hash(:family, :utilization)
 
     std_util = family_utilization.fetch("standard", 100)

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -457,6 +457,19 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
         expect { nx.wait_concurrency_limit }.to hop("allocate_vm")
       end
 
+      it "waits if hugepage utilization is high although core utilization is low" do
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
+        VmHost.where(arch: "x64", family: "standard").update(used_cores: 8, used_hugepages_1g: 350)
+        expect { nx.wait_concurrency_limit }.to nap
+      end
+
+      it "ignores hosts that don't report their cores or hugepages yet" do
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
+        VmHost.where(arch: "x64", family: "standard").update(used_cores: 8)
+        create_vm_host(location_id: Location::GITHUB_RUNNERS_ID, arch: "x64", family: "standard", total_cores: 0, used_cores: 0, total_hugepages_1g: 0, used_hugepages_1g: 0)
+        expect { nx.wait_concurrency_limit }.to hop("allocate_vm")
+      end
+
       it "hops to apply_custom_label_quota if standard utilization is low and the label is a custom label" do
         GithubCustomLabel.create(installation_id: installation.id, name: "custom-label-1", alias_for: "ubicloud-standard-4", concurrent_runner_count_limit: 10, allocated_runner_count: 0)
         expect(runner).to receive(:actual_label).and_return("custom-label-1")


### PR DESCRIPTION
The concurrency limit check treated core utilization as the sole measure of how full the runner fleet is. That held while every host had more memory than its cores could consume, but the AX162s we recently added have fewer hugepages than cores. They exhaust their hugepages while cores are still free, so the fleet reported utilization well below the threshold, we let runners past the limit, and the allocator then found no host with room for them.

Take the greater of the core and hugepage utilization per family, so whichever resource is the real bottleneck drives the decision. This also lets the AWS spill over trigger on a memory bottleneck, not only on a core one.

Skip hosts that report no cores or no hugepages. They are still in setup, contribute no capacity, and would divide by zero.