### PR TITLE
Add a staged rollout for downloading CloudHypervisor to hosts

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -958,6 +958,7 @@ class CloverAdmin < Roda
 
   ROLLOUT_PROGS = %w[
     RolloutBootImage
+    RolloutCloudHypervisor
     RolloutRhizome
     RolloutSemaphore
   ].freeze
@@ -1644,6 +1645,35 @@ class CloverAdmin < Roda
 
           Prog.const_get(prog).assemble(image_name:, version:, arch:, concurrency:,
             exclude_minio_hosts:, exclude_vm_host_ids:, pause_stages:)
+        elsif prog == "RolloutCloudHypervisor"
+          version, arch = typecast_params.nonempty_str!(%w[version arch].freeze)
+          concurrency = typecast_params.pos_int!("concurrency")
+          pause_stages = typecast_params.bool("pause_stages")
+          min_os_version = typecast_params.str("min_os_version")
+          min_os_version = nil if min_os_version&.empty?
+
+          unless Prog::DownloadCloudHypervisor::HASHES.key?(["ch-bin", arch, version])
+            flash["error"] = "invalid version for cloud hypervisor"
+            r.redirect "/rollouts"
+          end
+
+          if min_os_version && !VmHost.where(os_version: min_os_version).any?
+            flash["error"] = "invalid minimum os version"
+            r.redirect "/rollouts"
+          end
+
+          exclude_vm_host_ids = typecast_params.str("exclude_vm_host_ids").to_s.split(",").filter_map do |id|
+            id = id.strip
+            next if id.empty?
+            uuid = UUID_REGEXP.match?(id) ? id : UBID.to_uuid(id)
+            unless uuid
+              flash["error"] = "invalid vm host id: #{id}"
+              r.redirect "/rollouts"
+            end
+            uuid
+          end
+
+          Prog.const_get(prog).assemble(version:, arch:, concurrency:, min_os_version:, exclude_vm_host_ids:, pause_stages:)
         else
           Prog.const_get(prog).assemble
         end
@@ -1653,7 +1683,7 @@ class CloverAdmin < Roda
       end
 
       strand_semaphore_action(strand_ds, ROLLOUT_PROGS,
-        additional_semaphores: {"RolloutRhizome" => %w[github_runners_work].freeze, "RolloutBootImage" => %w[rollback].freeze})
+        additional_semaphores: {"RolloutRhizome" => %w[github_runners_work].freeze, "RolloutBootImage" => %w[rollback].freeze, "RolloutCloudHypervisor" => %w[cancel].freeze})
     end
 
     r.on "remove-boot-images" do

--- a/prog/download_cloud_hypervisor.rb
+++ b/prog/download_cloud_hypervisor.rb
@@ -5,11 +5,11 @@ class Prog::DownloadCloudHypervisor < Prog::Base
   frame_reader :version
 
   def sha256_ch_bin
-    @sha256_ch_bin ||= frame.fetch("sha256_ch_bin") || sha_256("ch-bin")
+    @sha256_ch_bin ||= frame["sha256_ch_bin"] || sha_256("ch-bin")
   end
 
   def sha256_ch_remote
-    @sha256_ch_remote ||= frame.fetch("sha256_ch_remote") || sha_256("ch-remote")
+    @sha256_ch_remote ||= frame["sha256_ch_remote"] || sha_256("ch-remote")
   end
 
   label def start

--- a/prog/rollout_cloud_hypervisor.rb
+++ b/prog/rollout_cloud_hypervisor.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+class Prog::RolloutCloudHypervisor < Prog::Base
+  semaphore :cancel, :pause
+  frame_reader :concurrency, :version, :arch, :todo, :in_progress, :completed, :failures, :stages, :pause_stages
+
+  STAGE_LOCATION_IDS = [
+    Location::GITHUB_RUNNERS_ID,
+    Location::HETZNER_FSN1_ID,
+    Location::HETZNER_HEL1_ID,
+    Location::LEASEWEB_WDC02_ID,
+  ].freeze
+
+  def self.assemble(version:, concurrency:, arch: "x64", min_os_version: nil, exclude_vm_host_ids: [], pause_stages: false)
+    fail "Invalid arch: #{arch}" unless ["x64", "arm64"].include?(arch)
+
+    ds = VmHost.where(arch:).exclude(id: exclude_vm_host_ids)
+    ds = ds.where { Sequel[:vm_host][:os_version] >= min_os_version } if min_os_version
+
+    stages = DB.ignore_duplicate_queries do
+      STAGE_LOCATION_IDS.map { |location_id| ds.where(location_id:).order(:created_at, :id).select_map(:id) }
+    end
+    stages.reject!(&:empty?)
+    todo = stages.shift || []
+
+    Strand.create(
+      prog: "RolloutCloudHypervisor",
+      label: "wait",
+      stack: [{
+        "todo" => todo,
+        "stages" => stages,
+        "in_progress" => [],
+        "completed" => [],
+        "failures" => {},
+        "concurrency" => concurrency,
+        "version" => version,
+        "arch" => arch,
+        "pause_stages" => pause_stages,
+      }],
+    )
+  end
+
+  label def wait
+    when_cancel_set? do
+      hop_cancel
+    end
+
+    when_pause_set? do
+      nap 60 * 60
+    end
+
+    reaper = lambda do |child|
+      host_id = child.stack.first["subject_id"]
+      in_progress.delete(host_id)
+      case child.exitval["msg"]
+      when "cloud hypervisor downloaded"
+        completed.push(host_id)
+      else
+        failures[host_id] = (failures[host_id] || 0) + 1
+        todo.push(host_id)
+      end
+    end
+
+    reap(fallthrough: true, reaper:) do
+      if todo.empty? && in_progress.empty?
+        pop "rollout completed" if stages.empty?
+        incr_pause if pause_stages
+        hop_next_stage
+      end
+    end
+
+    # Fill concurrency slots from the todo queue
+    slots_to_fill = concurrency - strand.children_dataset.count
+    while slots_to_fill > 0 && !todo.empty?
+      host_id = todo.shift
+      bud Prog::DownloadCloudHypervisor, {"subject_id" => host_id, "version" => version}
+      in_progress.push(host_id)
+      slots_to_fill -= 1
+    end
+
+    strand.modified!(:stack)
+    strand.save_changes
+
+    nap 15
+  end
+
+  label def next_stage
+    todo.concat(stages.shift)
+    strand.modified!(:stack)
+    hop_wait
+  end
+
+  label def cancel
+    reap { pop "rollout cancelled" }
+  end
+end

--- a/spec/prog/download_cloud_hypervisor_spec.rb
+++ b/spec/prog/download_cloud_hypervisor_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe Prog::DownloadCloudHypervisor do
       expect { df.start }.to hop("download")
     end
 
+    it "hops to download when the frame omits the sha256 keys entirely" do
+      refresh_frame(df, new_frame: {"version" => "35.1"})
+      expect { df.start }.to hop("download")
+    end
+
     it "fails if version is nil" do
       refresh_frame(df, new_frame: {"version" => nil, "sha256_ch_bin" => "thesha", "sha256_ch_remote" => "anothersha"})
       expect { df.start }.to raise_error RuntimeError, "Version is required"
@@ -46,6 +51,13 @@ RSpec.describe Prog::DownloadCloudHypervisor do
 
     it "uses known sha256s" do
       strand.update(stack: [{"version" => "35.1", "sha256_ch_bin" => nil, "sha256_ch_remote" => nil}])
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check download_ch_35.1").and_return("NotStarted")
+      expect(sshable).to receive(:_cmd).with("common/bin/daemonizer host/bin/download-cloud-hypervisor\\ 35.1\\ e8426b0733248ed559bea64eb04d732ce8a471edc94807b5e2ecfdfc57136ab4\\ 337bd88183f6886f1c7b533499826587360f23168eac5aabf38e6d6b977c93b0 download_ch_35.1")
+      expect { df.download }.to nap(15)
+    end
+
+    it "uses known sha256s when the frame omits the keys entirely" do
+      strand.update(stack: [{"version" => "35.1"}])
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check download_ch_35.1").and_return("NotStarted")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer host/bin/download-cloud-hypervisor\\ 35.1\\ e8426b0733248ed559bea64eb04d732ce8a471edc94807b5e2ecfdfc57136ab4\\ 337bd88183f6886f1c7b533499826587360f23168eac5aabf38e6d6b977c93b0 download_ch_35.1")
       expect { df.download }.to nap(15)

--- a/spec/prog/rollout_cloud_hypervisor_spec.rb
+++ b/spec/prog/rollout_cloud_hypervisor_spec.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+require_relative "../model/spec_helper"
+
+RSpec.describe Prog::RolloutCloudHypervisor do
+  subject(:nx) { described_class.new(st) }
+
+  let(:vm_host1) { create_vm_host(os_version: "ubuntu-24.04", created_at: Time.utc(2024, 1, 1)) }
+  let(:vm_host2) { create_vm_host(os_version: "ubuntu-24.04", created_at: Time.utc(2024, 1, 2)) }
+  let(:vm_host3) { create_vm_host(os_version: "ubuntu-24.04", created_at: Time.utc(2024, 1, 3)) }
+  let(:st) {
+    [vm_host1, vm_host2, vm_host3]
+    described_class.assemble(concurrency: 2, version: "53.0", min_os_version: "ubuntu-24.04")
+  }
+
+  def set_lists(todo: nil, stages: nil, in_progress: nil, completed: nil, failures: nil)
+    frame = st.stack.first
+    frame["todo"] = todo if todo
+    frame["stages"] = stages if stages
+    frame["in_progress"] = in_progress if in_progress
+    frame["completed"] = completed if completed
+    frame["failures"] = failures if failures
+    st.modified!(:stack)
+    st.save_changes
+  end
+
+  def create_child(vm_host, exitval: nil, lease: nil, label: "download")
+    Strand.create(
+      parent_id: st.id,
+      prog: "DownloadCloudHypervisor",
+      label:,
+      stack: [{"subject_id" => vm_host.id, "version" => "53.0"}],
+      **({exitval: Sequel.pg_jsonb_wrap(exitval)} if exitval),
+      **({lease:} if lease),
+    )
+  end
+
+  def reload_frame
+    st.reload.stack.first
+  end
+
+  describe ".assemble" do
+    it "creates strand with hosts grouped into location stages in rollout order" do
+      github_runner_host = create_vm_host(os_version: "ubuntu-24.04", location_id: Location::GITHUB_RUNNERS_ID)
+      hel1_host = create_vm_host(os_version: "ubuntu-24.04", location_id: Location::HETZNER_HEL1_ID)
+      wdc02_host = create_vm_host(os_version: "ubuntu-24.04", location_id: Location::LEASEWEB_WDC02_ID)
+
+      expect(st.label).to eq("wait")
+      expect(st.prog).to eq("RolloutCloudHypervisor")
+
+      frame = st.stack.first
+      expect(frame["concurrency"]).to eq(2)
+      expect(frame["version"]).to eq("53.0")
+      expect(frame["arch"]).to eq("x64")
+      expect(frame["pause_stages"]).to be false
+
+      expect(frame["todo"]).to eq([github_runner_host.id])
+      expect(frame["stages"]).to eq([[vm_host1.id, vm_host2.id, vm_host3.id], [hel1_host.id], [wdc02_host.id]])
+      expect(frame["in_progress"]).to eq([])
+      expect(frame["completed"]).to eq([])
+      expect(frame["failures"]).to eq({})
+    end
+
+    it "sorts hosts by created_at within a stage and drops empty stages" do
+      expect(st.stack.first["todo"]).to eq([vm_host1.id, vm_host2.id, vm_host3.id])
+      expect(st.stack.first["stages"]).to eq([])
+    end
+
+    it "fails for invalid arch" do
+      expect {
+        described_class.assemble(concurrency: 2, version: "53.0", arch: "s390x")
+      }.to raise_error(RuntimeError, "Invalid arch: s390x")
+    end
+
+    it "only includes hosts with the given arch" do
+      arm64_host = create_vm_host(arch: "arm64", os_version: "ubuntu-24.04", location_id: Location::GITHUB_RUNNERS_ID)
+      vm_host1
+
+      strand = described_class.assemble(concurrency: 2, version: "53.0", arch: "arm64")
+
+      expect(strand.stack.first["todo"]).to eq([arm64_host.id])
+      expect(strand.stack.first["stages"]).to eq([])
+    end
+
+    it "only includes hosts with os_version >= min_os_version" do
+      create_vm_host(os_version: "ubuntu-22.04", location_id: Location::GITHUB_RUNNERS_ID)
+      newer_host = create_vm_host(os_version: "ubuntu-26.04", location_id: Location::HETZNER_HEL1_ID)
+
+      [vm_host1, vm_host2, vm_host3]
+      strand = described_class.assemble(concurrency: 2, version: "53.0", min_os_version: "ubuntu-24.04")
+
+      expect(strand.stack.first["todo"]).to eq([vm_host1.id, vm_host2.id, vm_host3.id])
+      expect(strand.stack.first["stages"]).to eq([[newer_host.id]])
+    end
+
+    it "includes hosts regardless of os_version when min_os_version is not given" do
+      host_without_os_version = create_vm_host(location_id: Location::GITHUB_RUNNERS_ID)
+
+      strand = described_class.assemble(concurrency: 2, version: "53.0")
+
+      expect(strand.stack.first["todo"]).to eq([host_without_os_version.id])
+    end
+
+    it "excludes explicitly given host ids" do
+      vm_host1
+
+      strand = described_class.assemble(
+        concurrency: 2, version: "53.0",
+        exclude_vm_host_ids: [vm_host2.id, vm_host3.id],
+      )
+
+      expect(strand.stack.first["todo"]).to eq([vm_host1.id])
+    end
+  end
+
+  describe "#wait" do
+    it "naps when pause semaphore is set" do
+      nx.incr_pause
+      expect { nx.wait }.to nap(60 * 60)
+    end
+
+    it "hops to cancel when cancel semaphore is set" do
+      nx.incr_cancel
+      expect { nx.wait }.to hop("cancel")
+    end
+
+    it "reaps completed children and moves them to completed" do
+      set_lists(todo: [vm_host3.id], in_progress: [vm_host1.id, vm_host2.id])
+      create_child(vm_host1, exitval: {"msg" => "cloud hypervisor downloaded"}, lease: Time.now - 1)
+      create_child(vm_host2, lease: Time.now + 100)
+
+      expect { nx.wait }.to nap(15)
+
+      frame = reload_frame
+      expect(frame["completed"]).to eq([vm_host1.id])
+      expect(frame["in_progress"]).not_to include(vm_host1.id)
+    end
+
+    it "moves failed host back to todo with incremented failure count" do
+      set_lists(todo: [vm_host3.id], in_progress: [vm_host1.id, vm_host2.id])
+      create_child(vm_host1, exitval: {"msg" => "operation cancelled"}, lease: Time.now - 1)
+      create_child(vm_host2, lease: Time.now + 100)
+
+      expect { nx.wait }.to nap(15)
+
+      frame = reload_frame
+      expect(frame["in_progress"]).not_to include(vm_host1.id)
+      expect(frame["todo"]).to eq([vm_host1.id])
+      expect(frame["failures"]).to eq({vm_host1.id => 1})
+    end
+
+    it "re-buds failed host on next cycle" do
+      set_lists(todo: [vm_host1.id], in_progress: [], completed: [vm_host2.id, vm_host3.id], failures: {vm_host1.id => 2})
+
+      expect { nx.wait }.to nap(15)
+
+      frame = reload_frame
+      expect(frame["todo"]).to eq([])
+      expect(frame["in_progress"]).to eq([vm_host1.id])
+
+      child = st.children_dataset.first
+      expect(child.prog).to eq("DownloadCloudHypervisor")
+      expect(child.stack.first["subject_id"]).to eq(vm_host1.id)
+      expect(child.stack.first["version"]).to eq("53.0")
+    end
+
+    it "fills concurrency slots from todo in order" do
+      expect { nx.wait }.to nap(15)
+
+      frame = reload_frame
+      expect(frame["todo"]).to eq([vm_host3.id])
+      expect(frame["in_progress"]).to contain_exactly(vm_host1.id, vm_host2.id)
+      expect(frame["completed"]).to eq([])
+
+      children = st.children_dataset.all
+      expect(children.length).to eq(2)
+      subject_ids = children.map { it.stack.first["subject_id"] }
+      expect(subject_ids).to contain_exactly(vm_host1.id, vm_host2.id)
+    end
+
+    it "respects concurrency limit" do
+      set_lists(todo: [vm_host3.id], in_progress: [vm_host1.id, vm_host2.id])
+      create_child(vm_host1)
+      create_child(vm_host2)
+
+      expect { nx.wait }.to nap(15)
+
+      expect(reload_frame["todo"]).to eq([vm_host3.id])
+      expect(st.children_dataset.count).to eq(2)
+    end
+
+    it "pops when all stages are done and all children are reaped" do
+      set_lists(todo: [], stages: [], in_progress: [], completed: [vm_host1.id, vm_host2.id, vm_host3.id])
+
+      expect { nx.wait }.to exit({"msg" => "rollout completed"})
+    end
+
+    it "hops to next_stage when the current stage is done" do
+      set_lists(todo: [], stages: [[vm_host3.id]], in_progress: [], completed: [vm_host1.id, vm_host2.id])
+
+      expect { nx.wait }.to hop("next_stage")
+
+      expect(Semaphore.where(strand_id: st.id, name: "pause")).to be_empty
+    end
+
+    it "increments pause before hopping to next_stage when pause_stages is set" do
+      st.stack.first["pause_stages"] = true
+      set_lists(todo: [], stages: [[vm_host3.id]], in_progress: [], completed: [vm_host1.id, vm_host2.id])
+
+      expect { nx.wait }.to hop("next_stage")
+
+      expect(Semaphore.where(strand_id: st.id, name: "pause").count).to eq(1)
+    end
+
+    it "naps when children are still active" do
+      set_lists(todo: [], in_progress: [vm_host1.id])
+      create_child(vm_host1, lease: Time.now + 100)
+
+      expect { nx.wait }.to nap(15)
+    end
+
+    it "does not start the next stage while children are still active" do
+      set_lists(todo: [], stages: [[vm_host3.id]], in_progress: [vm_host1.id], completed: [vm_host2.id])
+      create_child(vm_host1, lease: Time.now + 100)
+
+      expect { nx.wait }.to nap(15)
+
+      expect(reload_frame["stages"]).to eq([[vm_host3.id]])
+    end
+  end
+
+  describe "#next_stage" do
+    it "moves the next stage into todo and hops to wait" do
+      set_lists(todo: [], stages: [[vm_host3.id]], in_progress: [], completed: [vm_host1.id, vm_host2.id])
+
+      expect { nx.next_stage }.to hop("wait")
+
+      frame = st.stack.first
+      expect(frame["todo"]).to eq([vm_host3.id])
+      expect(frame["stages"]).to eq([])
+    end
+  end
+
+  describe "#cancel" do
+    it "waits for active children to finish on their own, without signalling them" do
+      child = create_child(vm_host1, lease: Time.now + 100)
+
+      expect { nx.cancel }.to nap
+
+      expect(Semaphore.where(strand_id: child.id).count).to eq(0)
+    end
+
+    it "pops once all children are reaped" do
+      expect { nx.cancel }.to exit({"msg" => "rollout cancelled"})
+    end
+  end
+end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2290,9 +2290,11 @@ RSpec.describe CloverAdmin do
       create_minio_vm_host
       version = Prog::DownloadBootImage::BOOT_IMAGE_SHA256.dig("ubuntu-noble", "x64").keys.max
 
-      select "ubuntu-noble", from: "Image Name"
-      fill_in "Version", with: version
-      click_button "Start Boot Image Rollout"
+      within "#start-rollout" do
+        select "ubuntu-noble", from: "Image Name"
+        fill_in "Version", with: version
+        click_button "Start Boot Image Rollout"
+      end
 
       st = Strand.first(prog: "RolloutBootImage")
       expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
@@ -2312,14 +2314,16 @@ RSpec.describe CloverAdmin do
       minio_host = create_minio_vm_host(arch: "arm64", created_at: Time.utc(2024, 1, 3))
       version = Prog::DownloadBootImage::BOOT_IMAGE_SHA256.dig("ubuntu-noble", "arm64").keys.max
 
-      select "ubuntu-noble", from: "Image Name"
-      fill_in "Version", with: version
-      select "arm64", from: "Arch"
-      fill_in "Concurrency", with: "3"
-      uncheck "Exclude Minio Hosts"
-      check "Pause Between Stages"
-      fill_in "Exclude VM Host IDs (comma separated)", with: " #{vm_host1.ubid}, #{vm_host2.id},, "
-      click_button "Start Boot Image Rollout"
+      within "#start-rollout" do
+        select "ubuntu-noble", from: "Image Name"
+        fill_in "Version", with: version
+        select "arm64", from: "Arch"
+        fill_in "Concurrency", with: "3"
+        uncheck "Exclude Minio Hosts"
+        check "Pause Between Stages"
+        fill_in "Exclude VM Host IDs (comma separated)", with: " #{vm_host1.ubid}, #{vm_host2.id},, "
+        click_button "Start Boot Image Rollout"
+      end
 
       st = Strand.first(prog: "RolloutBootImage")
       expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
@@ -2332,9 +2336,11 @@ RSpec.describe CloverAdmin do
     end
 
     it "shows error when starting boot image rollout with invalid version" do
-      select "ubuntu-noble", from: "Image Name"
-      fill_in "Version", with: "20990101"
-      click_button "Start Boot Image Rollout"
+      within "#start-rollout" do
+        select "ubuntu-noble", from: "Image Name"
+        fill_in "Version", with: "20990101"
+        click_button "Start Boot Image Rollout"
+      end
 
       expect(page).to have_flash_error("invalid version for boot image")
       expect(Strand.first(prog: "RolloutBootImage")).to be_nil
@@ -2343,10 +2349,12 @@ RSpec.describe CloverAdmin do
     it "shows error when starting boot image rollout with invalid excluded vm host id" do
       version = Prog::DownloadBootImage::BOOT_IMAGE_SHA256.dig("ubuntu-noble", "x64").keys.max
 
-      select "ubuntu-noble", from: "Image Name"
-      fill_in "Version", with: version
-      fill_in "Exclude VM Host IDs (comma separated)", with: "not-an-id"
-      click_button "Start Boot Image Rollout"
+      within "#start-rollout" do
+        select "ubuntu-noble", from: "Image Name"
+        fill_in "Version", with: version
+        fill_in "Exclude VM Host IDs (comma separated)", with: "not-an-id"
+        click_button "Start Boot Image Rollout"
+      end
 
       expect(page).to have_flash_error("invalid vm host id: not-an-id")
       expect(Strand.first(prog: "RolloutBootImage")).to be_nil
@@ -2372,6 +2380,99 @@ RSpec.describe CloverAdmin do
       click_button "Rollback"
       expect(page).to have_flash_notice("Strand #{st.ubid} updated")
       expect(st.semaphores.map(&:name)).to eq ["rollback"]
+    end
+
+    it "allows creation of cloud hypervisor rollout strands" do
+      vm_host = create_vm_host(os_version: "ubuntu-24.04")
+      create_vm_host(os_version: "ubuntu-22.04")
+      page.refresh
+
+      within "#start-cloud-hypervisor-rollout" do
+        select "53.0", from: "Version"
+        select "ubuntu-24.04", from: "Minimum OS Version"
+        click_button "Start Cloud Hypervisor Rollout"
+      end
+
+      st = Strand.first(prog: "RolloutCloudHypervisor")
+      expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
+
+      frame = st.stack[0]
+      expect(frame["version"]).to eq "53.0"
+      expect(frame["arch"]).to eq "x64"
+      expect(frame["concurrency"]).to eq 10
+      expect(frame["pause_stages"]).to be false
+      expect(frame["todo"]).to eq [vm_host.id]
+    end
+
+    it "allows creation of cloud hypervisor rollout strands with custom options" do
+      vm_host1 = create_vm_host(arch: "arm64", os_version: "ubuntu-24.04", created_at: Time.utc(2024, 1, 1))
+      vm_host2 = create_vm_host(arch: "arm64", os_version: "ubuntu-24.04", created_at: Time.utc(2024, 1, 2))
+
+      within "#start-cloud-hypervisor-rollout" do
+        select "53.0", from: "Version"
+        select "arm64", from: "Arch"
+        fill_in "Concurrency", with: "3"
+        check "Pause Between Stages"
+        fill_in "Exclude VM Host IDs (comma separated)", with: " #{vm_host1.ubid}, "
+        click_button "Start Cloud Hypervisor Rollout"
+      end
+
+      st = Strand.first(prog: "RolloutCloudHypervisor")
+      expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
+
+      frame = st.stack[0]
+      expect(frame["arch"]).to eq "arm64"
+      expect(frame["concurrency"]).to eq 3
+      expect(frame["pause_stages"]).to be true
+      expect(frame["todo"]).to eq [vm_host2.id]
+    end
+
+    it "shows error when starting cloud hypervisor rollout with invalid version" do
+      csrf = find("#start-cloud-hypervisor-rollout input[name=_csrf]", visible: false).value
+      page.driver.submit :post, "/rollouts/start/RolloutCloudHypervisor", _csrf: csrf, version: "20990101", arch: "x64", concurrency: "10"
+
+      expect(page).to have_flash_error("invalid version for cloud hypervisor")
+      expect(Strand.first(prog: "RolloutCloudHypervisor")).to be_nil
+    end
+
+    it "shows error when starting cloud hypervisor rollout with a minimum os version no host has" do
+      csrf = find("#start-cloud-hypervisor-rollout input[name=_csrf]", visible: false).value
+      page.driver.submit :post, "/rollouts/start/RolloutCloudHypervisor", _csrf: csrf, version: "53.0", arch: "x64", concurrency: "10", min_os_version: "ubuntu-99.04"
+
+      expect(page).to have_flash_error("invalid minimum os version")
+      expect(Strand.first(prog: "RolloutCloudHypervisor")).to be_nil
+    end
+
+    it "shows error when starting cloud hypervisor rollout with invalid excluded vm host id" do
+      within "#start-cloud-hypervisor-rollout" do
+        select "53.0", from: "Version"
+        fill_in "Exclude VM Host IDs (comma separated)", with: "not-an-id"
+        click_button "Start Cloud Hypervisor Rollout"
+      end
+
+      expect(page).to have_flash_error("invalid vm host id: not-an-id")
+      expect(Strand.first(prog: "RolloutCloudHypervisor")).to be_nil
+    end
+
+    it "allows cancelling cloud hypervisor rollout strands and shows their status" do
+      vm_host = create_vm_host(os_version: "ubuntu-24.04")
+      st = Prog::RolloutCloudHypervisor.assemble(version: "53.0", concurrency: 10)
+      page.refresh
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutCloudHypervisor", "wait", "0", st.ubid, "{\"cloud_hypervisor\" => \"53.0 x64\"}", "", "", ""]
+
+      frame = st.stack[0]
+      frame["todo"] = []
+      frame["in_progress"] = []
+      frame["stages"] = [[vm_host.id]]
+      frame["completed"] = [vm_host.id]
+      st.modified!(:stack)
+      st.save_changes
+      page.refresh
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutCloudHypervisor", "wait", "0", st.ubid, "{\"remaining\" => 1, \"completed\" => 1, \"cloud_hypervisor\" => \"53.0 x64\"}", "", "", ""]
+
+      click_button "Cancel"
+      expect(page).to have_flash_notice("Strand #{st.ubid} updated")
+      expect(st.semaphores.map(&:name)).to eq ["cancel"]
     end
   end
 

--- a/views/admin/rollouts.erb
+++ b/views/admin/rollouts.erb
@@ -11,7 +11,7 @@
       data["monitor_github_runners_until"] = Time.at(time).utc.strftime("%F %T UTC")
     end
   else
-    data["remaining"] = if strand.prog == "RolloutBootImage"
+    data["remaining"] = if ["RolloutBootImage", "RolloutCloudHypervisor"].include?(strand.prog)
       frame["todo"].size + frame["in_progress"].size + frame["stages"].sum(&:size)
     else
       (frame["remaining_host_ids"] || frame["remaining"])&.size
@@ -19,6 +19,7 @@
     data["completed"] = frame["completed"]&.size
   end
   data["image"] = "#{frame["image_name"]} #{frame["version"]} #{frame["arch"]}" if strand.prog == "RolloutBootImage"
+  data["cloud_hypervisor"] = "#{frame["version"]} #{frame["arch"]}" if strand.prog == "RolloutCloudHypervisor"
   data.compact!
 
   h[:pause] = if strand.semaphores.find { it.name == "pause" }
@@ -35,6 +36,8 @@
     "#{frame["increment"] ? "increment" : "decrement"} #{frame["semaphore"]}"
   elsif strand.prog == "RolloutBootImage"
     table_form_button("Rollback", action: "/rollouts/#{strand.ubid}/rollback", method: "post")
+  elsif strand.prog == "RolloutCloudHypervisor"
+    table_form_button("Cancel", action: "/rollouts/#{strand.ubid}/cancel", method: "post")
   end
 
   h
@@ -57,6 +60,21 @@ end %>
       <%== f.input(:number, key: :concurrency, label: "Concurrency", required: true, attr: {min: 1}, value: 10) %>
       <%== f.input(:text, key: :exclude_vm_host_ids, label: "Exclude VM Host IDs (comma separated)") %>
       <%== f.input(:checkbox, key: :exclude_minio_hosts, label: "Exclude Minio Hosts", checked: true) %>
+      <%== f.input(:checkbox, key: :pause_stages, label: "Pause Between Stages") %>
+    <% end %>
+  </section>
+
+  <section class="rollout-card">
+    <h3>Cloud Hypervisor</h3>
+
+    <p class="rollout-desc">Download a CloudHypervisor version to hosts, a few at a time.</p>
+
+    <% form({action: "/rollouts/start/RolloutCloudHypervisor", method: "post", id: "start-cloud-hypervisor-rollout", class: "rollout-form"}, button: "Start Cloud Hypervisor Rollout", wrapper: :div) do |f| %>
+      <%== f.input(:select, key: :version, label: "Version", required: true, add_blank: true, options: Prog::DownloadCloudHypervisor::HASHES.keys.map { it[2] }.uniq.sort) %>
+      <%== f.input(:select, key: :arch, label: "Arch", required: true, options: %w[x64 arm64].freeze, value: "x64") %>
+      <%== f.input(:number, key: :concurrency, label: "Concurrency", required: true, attr: {min: 1}, value: 10) %>
+      <%== f.input(:select, key: :min_os_version, label: "Minimum OS Version", add_blank: true, options: VmHost.exclude(os_version: nil).distinct.order(:os_version).select_map(:os_version)) %>
+      <%== f.input(:text, key: :exclude_vm_host_ids, label: "Exclude VM Host IDs (comma separated)") %>
       <%== f.input(:checkbox, key: :pause_stages, label: "Pause Between Stages") %>
     <% end %>
   </section>


### PR DESCRIPTION
Part of the transition to CloudHypervisor 53.0, building on #6203.

This adds `Prog::RolloutCloudHypervisor`, which buds `Prog::DownloadCloudHypervisor` across hosts a few at a time, staged by location, the same way `Prog::RolloutBootImage` stages boot image downloads. It lets a new CloudHypervisor version land on hosts gradually before any VM is asked to use it, driven from the same `/rollouts` admin page as the other rollouts.

Which hosts are eligible is left to the caller via an optional `min_os_version`, rather than hardcoding a table of which CloudHypervisor version requires which host OS — that mapping only lives in rhizome, which the control plane has no way to consult ahead of time.

WIP: marking as draft until the CloudHypervisor 53.0 binaries have actually been rolled out to hosts with this and we're ready to move to the next step (using it for a percentage of GitHub Action VMs).