### PR TITLE
Upgrade the kernel in kubernetes machine images

### DIFF
--- a/prog/kubernetes/build_node_image.rb
+++ b/prog/kubernetes/build_node_image.rb
@@ -4,7 +4,7 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
   semaphore :destroy
 
   frame_reader :kubernetes_version, :location_id, :image_version, :machine_image_id, :vm_id, :skip_verification
-  frame_accessor :machine_image_version_id, :verify_cluster_id
+  frame_accessor :machine_image_version_id, :verify_cluster_id, :boot_id
 
   BUILD_UNIT = "build_node_image"
 
@@ -53,7 +53,7 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
     case (state = vm.sshable.d_check(BUILD_UNIT))
     when "Succeeded"
       vm.sshable.d_clean(BUILD_UNIT)
-      hop_sanitize
+      hop_restart
     when "NotStarted"
       vm.sshable.d_run(BUILD_UNIT, "kubernetes/bin/build-node-image", kubernetes_version)
       nap 10
@@ -63,6 +63,20 @@ class Prog::Kubernetes::BuildNodeImage < Prog::Base
       trigger_page("build #{state}")
       hop_failed
     end
+  end
+
+  label def restart
+    vm.sshable.cmd("sync")
+    self.boot_id = vm.sshable.cmd("cat /proc/sys/kernel/random/boot_id").strip
+    vm.incr_restart
+    hop_wait_restart
+  end
+
+  label def wait_restart
+    nap 5 unless vm.sshable.available?
+    nap 5 if vm.sshable.cmd("cat /proc/sys/kernel/random/boot_id").strip == boot_id
+
+    hop_sanitize
   end
 
   label def sanitize

--- a/rhizome/common/lib/node_exporter_setup.rb
+++ b/rhizome/common/lib/node_exporter_setup.rb
@@ -49,8 +49,8 @@ class NodeExporterSetup
       Type=simple
       ExecStart=/usr/local/bin/node_exporter #{flags.join(" ")}
       Restart=always
-      User=nobody
-      Group=nogroup
+      User=node_exporter
+      Group=node_exporter
 
       [Install]
       WantedBy=multi-user.target
@@ -66,6 +66,9 @@ class NodeExporterSetup
 
     r "tar", "xfz", tarball, "-C", "/usr/local/bin", "--no-same-owner", "--strip-components=1", "#{file_name}/node_exporter"
     r "rm", tarball
+
+    r "groupadd -f --system node_exporter"
+    r "useradd --no-create-home --system -g node_exporter node_exporter", expect: [0, 9] # 9 is "already exists"
 
     safe_write_to_file("/etc/systemd/system/node_exporter.service", service)
 

--- a/rhizome/common/spec/node_exporter_setup_spec.rb
+++ b/rhizome/common/spec/node_exporter_setup_spec.rb
@@ -24,7 +24,11 @@ RSpec.describe NodeExporterSetup do
   describe "#run" do
     it "installs the binary and starts the service" do
       commands = []
-      allow(setup).to receive(:_run_command) { |*command| commands << command.join(" ") }
+      accepted_exit_codes = {}
+      allow(setup).to receive(:_run_command) do |*command, **kw|
+        commands << command.join(" ")
+        accepted_exit_codes[command.join(" ")] = kw[:expect] if kw[:expect]
+      end
       written = {}
       allow(setup).to receive(:safe_write_to_file) { |path, content| written[path] = content }
       expect(setup).to receive(:curl_file).with(url, tarball).and_return(described_class::CHECKSUM)
@@ -34,11 +38,14 @@ RSpec.describe NodeExporterSetup do
       expect(commands).to eq [
         "tar xfz #{tarball} -C /usr/local/bin --no-same-owner --strip-components=1 #{file_name}/node_exporter",
         "rm #{tarball}",
+        "groupadd -f --system node_exporter",
+        "useradd --no-create-home --system -g node_exporter node_exporter",
         "systemctl daemon-reload",
         "systemctl enable node_exporter",
         "systemctl start node_exporter",
       ]
       expect(written).to eq("/etc/systemd/system/node_exporter.service" => setup.service)
+      expect(accepted_exit_codes).to eq("useradd --no-create-home --system -g node_exporter node_exporter" => [0, 9])
     end
 
     it "fails when the download does not match the pinned checksum" do

--- a/rhizome/kubernetes/bin/sanitize-node-image
+++ b/rhizome/kubernetes/bin/sanitize-node-image
@@ -1,21 +1,6 @@
 #!/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../../common/lib/util"
+require_relative "../lib/kubernetes_sanitize_node_image"
 
-r("bash", "-s", stdin: <<~SH)
-  set -ueo pipefail
-  export DEBIAN_FRONTEND=noninteractive
-
-  sudo -E apt-get autoremove -y
-  sudo -E apt-get clean
-  sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
-
-  sudo rm -rf /var/lib/cloud
-  sudo cloud-init clean --logs
-  sudo journalctl --rotate
-  sudo journalctl --vacuum-time=1s
-  sudo rm -f /etc/ssh/ssh_host_*
-  sudo truncate -s 0 /etc/machine-id
-  sudo truncate -s 0 /home/ubi/.ssh/authorized_keys
-SH
+KubernetesSanitizeNodeImage.new.run

--- a/rhizome/kubernetes/bin/sanitize-node-image
+++ b/rhizome/kubernetes/bin/sanitize-node-image
@@ -5,6 +5,11 @@ require_relative "../../common/lib/util"
 
 r("bash", "-s", stdin: <<~SH)
   set -ueo pipefail
+  export DEBIAN_FRONTEND=noninteractive
+
+  sudo -E apt-get autoremove -y
+  sudo -E apt-get clean
+  sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
   sudo rm -rf /var/lib/cloud
   sudo cloud-init clean --logs

--- a/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
+++ b/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
@@ -43,6 +43,8 @@ class KubernetesBuildNodeImage
     r "sudo -E apt-get update"
     r "sudo -E apt-get install -y containerd cri-tools kubelet kubeadm kubectl ruby-bundler"
 
+    r "sudo -E apt-get install -y linux-modules-extra-$(linux-version list | linux-version sort | tail -1)"
+
     r "sudo mkdir -p /etc/containerd"
     r "sudo tee /etc/containerd/config.toml > /dev/null", stdin: r("containerd config default").gsub("SystemdCgroup = false", "SystemdCgroup = true")
 

--- a/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
+++ b/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
@@ -31,7 +31,7 @@ class KubernetesBuildNodeImage
     r "sudo tee /etc/sysctl.d/72-clover-forward-packets.conf > /dev/null", stdin: SYSCTL_CONF
 
     r "sudo -E apt-get update"
-    r "sudo -E apt-get upgrade -y"
+    r "sudo -E apt-get full-upgrade -y"
     r "sudo -E apt-get install -y ca-certificates curl gpg"
 
     r "sudo install -m 0755 -d /etc/apt/keyrings"

--- a/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
+++ b/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
@@ -51,9 +51,5 @@ class KubernetesBuildNodeImage
 
     r "sudo apt-mark hold kubelet kubeadm kubectl"
     r "sudo systemctl disable unattended-upgrades"
-
-    r "sudo -E apt-get autoremove -y"
-    r "sudo -E apt-get clean"
-    r "sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*"
   end
 end

--- a/rhizome/kubernetes/lib/kubernetes_sanitize_node_image.rb
+++ b/rhizome/kubernetes/lib/kubernetes_sanitize_node_image.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+class KubernetesSanitizeNodeImage
+  SCRIPT = <<~SH
+    set -ueo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+
+    sudo -E apt-get autoremove -y
+    sudo -E apt-get clean
+    sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+    sudo rm -rf /var/lib/cloud
+    sudo cloud-init clean --logs
+    sudo journalctl --rotate
+    sudo journalctl --vacuum-time=1s
+    sudo rm -f /etc/ssh/ssh_host_*
+    sudo truncate -s 0 /etc/machine-id
+    sudo truncate -s 0 /home/ubi/.ssh/authorized_keys
+  SH
+
+  def run
+    r("bash", "-s", stdin: SCRIPT)
+  end
+end

--- a/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe KubernetesBuildNodeImage do
         "echo deb\\ \\[signed-by\\=/etc/apt/keyrings/kubernetes-apt-keyring.gpg\\]\\ https://pkgs.k8s.io/core:/stable:/v1.35/deb/\\ / | sudo tee /etc/apt/sources.list.d/kubernetes.list > /dev/null",
         "sudo -E apt-get update",
         "sudo -E apt-get install -y containerd cri-tools kubelet kubeadm kubectl ruby-bundler",
+        "sudo -E apt-get install -y linux-modules-extra-$(linux-version list | linux-version sort | tail -1)",
         "sudo mkdir -p /etc/containerd",
         "containerd config default",
         "sudo tee /etc/containerd/config.toml > /dev/null",

--- a/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe KubernetesBuildNodeImage do
       expect(commands).to eq [
         "sudo tee /etc/sysctl.d/72-clover-forward-packets.conf > /dev/null",
         "sudo -E apt-get update",
-        "sudo -E apt-get upgrade -y",
+        "sudo -E apt-get full-upgrade -y",
         "sudo -E apt-get install -y ca-certificates curl gpg",
         "sudo install -m 0755 -d /etc/apt/keyrings",
         "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.35/deb/Release.key -o /tmp/kubernetes-release.key",

--- a/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
@@ -50,9 +50,6 @@ RSpec.describe KubernetesBuildNodeImage do
         "kubernetes/bin/install-prometheus",
         "sudo apt-mark hold kubelet kubeadm kubectl",
         "sudo systemctl disable unattended-upgrades",
-        "sudo -E apt-get autoremove -y",
-        "sudo -E apt-get clean",
-        "sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*",
       ]
       expect(stdins).to eq(
         "sudo tee /etc/sysctl.d/72-clover-forward-packets.conf > /dev/null" => described_class::SYSCTL_CONF,

--- a/rhizome/kubernetes/spec/kubernetes_sanitize_node_image_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_sanitize_node_image_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "../lib/kubernetes_sanitize_node_image"
+
+RSpec.describe KubernetesSanitizeNodeImage do
+  subject(:sanitizer) { described_class.new }
+
+  describe "#run" do
+    it "runs the sanitize script" do
+      expect(sanitizer).to receive(:_run_command).with("bash", "-s", stdin: described_class::SCRIPT)
+
+      sanitizer.run
+    end
+  end
+end

--- a/spec/prog/kubernetes/build_node_image_spec.rb
+++ b/spec/prog/kubernetes/build_node_image_spec.rb
@@ -125,11 +125,11 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
       expect { prog.build }.to nap(10)
     end
 
-    it "cleans the unit and hops to sanitize when the build succeeds" do
+    it "cleans the unit and hops to restart when the build succeeds" do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check build_node_image").and_return("Succeeded")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 clean build_node_image")
 
-      expect { prog.build }.to hop("sanitize")
+      expect { prog.build }.to hop("restart")
     end
 
     it "pages and hops to failed when the build fails" do
@@ -202,6 +202,41 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
 
       expect { prog.destroy }.to nap(120)
       expect(vm.destroy_set?).to be false
+    end
+  end
+
+  describe "#restart" do
+    it "flushes the build's writes, records the current boot id and restarts the builder vm" do
+      expect(sshable).to receive(:_cmd).with("sync")
+      expect(sshable).to receive(:_cmd).with("cat /proc/sys/kernel/random/boot_id").and_return("old-boot-id\n")
+
+      expect { prog.restart }.to hop("wait_restart")
+      expect(prog.strand.stack.first["boot_id"]).to eq "old-boot-id"
+      expect(vm.restart_set?).to be true
+    end
+  end
+
+  describe "#wait_restart" do
+    before { strand.update(stack: [strand.stack.first.merge("boot_id" => "old-boot-id")]) }
+
+    it "naps while the builder vm is unreachable" do
+      expect(sshable).to receive(:_cmd).with("true").and_raise(Errno::ECONNREFUSED)
+
+      expect { prog.wait_restart }.to nap(5)
+    end
+
+    it "naps while the builder vm is still running the boot it was restarted from" do
+      expect(sshable).to receive(:_cmd).with("true").and_return("")
+      expect(sshable).to receive(:_cmd).with("cat /proc/sys/kernel/random/boot_id").and_return("old-boot-id\n")
+
+      expect { prog.wait_restart }.to nap(5)
+    end
+
+    it "hops to sanitize once the builder vm comes back on a new boot" do
+      expect(sshable).to receive(:_cmd).with("true").and_return("")
+      expect(sshable).to receive(:_cmd).with("cat /proc/sys/kernel/random/boot_id").and_return("new-boot-id\n")
+
+      expect { prog.wait_restart }.to hop("sanitize")
     end
   end
 


### PR DESCRIPTION
**Upgrade the kernel when building the kubernetes node image**
A kernel update arrives as a new package, and apt-get upgrade never installs new packages, so the kernel never moved: every node image carried the 6.8.0-59-generic of the noble cloud image it was built from, no matter when the build ran.

That is what blocks modprobe ublk_drv. The driver is built as a module and ships in linux-modules-extra, which is versioned per kernel ABI, and the archive publishes only the current ABI. noble-updates carries linux-modules-extra-6.8.0-138-generic and nothing for 6.8.0-59, so a node on the old kernel has no way to install the module.

Use full-upgrade, which may install new packages, so the image lands on a kernel whose extra modules are still in the archive.

**Reboot the node image builder before capturing it**
full-upgrade installs a newer kernel but leaves the builder running the old one, and apt refuses to autoremove the running kernel, so the captured image carried both kernels.

Restart the builder once the build unit succeeds and wait for the boot id to change, then run the apt cleanup from the sanitize step, where the replaced kernel is no longer in use.