### PR TITLE
Show the new AWS GitHub runner quotas in the admin panel

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1876,17 +1876,31 @@ class CloverAdmin < Roda
         ),
       )
 
+      aws_quota_default = ProjectQuota.default_quotas[(@arch == "arm64") ? "GithubRunnerVCpuArmAws" : "GithubRunnerVCpuAws"]
+      aws_quota_expr = Sequel.function(
+        :coalesce,
+        Sequel[:pq_aws][:value],
+        Sequel.case(
+          {"new" => aws_quota_default["new_value"], "verified" => aws_quota_default["verified_value"], "limited" => aws_quota_default["limited_value"]},
+          nil,
+          Sequel[:p][:reputation],
+        ),
+      )
+      spill_expr = Sequel.cast(Sequel.pg_jsonb_op(Sequel[:p][:feature_flags]).get_text("spill_to_alien_runners"), :boolean)
+      aws_quota_display_expr = Sequel.case({spill_expr => aws_quota_expr}, nil)
+
       @data = DB.from(runners.as(:r))
         .left_join(Sequel[:github_installation].as(:i), id: Sequel[:r][:installation_id])
         .left_join(Sequel[:project].as(:p), id: Sequel[:i][:project_id])
         .left_join(Sequel[:project_quota].as(:pq), project_id: Sequel[:p][:id], quota_id: quota_default["id"])
+        .left_join(Sequel[:project_quota].as(:pq_aws), project_id: Sequel[:p][:id], quota_id: aws_quota_default["id"])
         .left_join(Sequel[:vm].as(:v), id: Sequel[:r][:vm_id])
         .select(
           Sequel[:i][:id],
           Sequel[:i][:name],
           Sequel.pg_jsonb(Sequel[:i][:allocator_preferences]).get("family_filter").contains(["premium"]).as(:prem),
-          Sequel.cast(Sequel.pg_jsonb_op(Sequel[:p][:feature_flags]).get_text("spill_to_alien_runners"), :boolean).as(:spill),
           quota_expr.as(:quota),
+          aws_quota_display_expr.as(:aws_quota),
         )
         .select_append(
           *standard_sizes.map { count_f.call(r_vcpus => it).as(:"r#{it}") },
@@ -1900,7 +1914,7 @@ class CloverAdmin < Roda
           *premium_sizes.map { count_f.call(v_family => "premium", v_vcpus => it).as(:"p#{it}") },
           *alien_sizes.map { count_f.call(v_family.like("m%") & Sequel.expr(v_vcpus => it)).as(:"a#{it}") },
         )
-        .group(Sequel[:i][:id], Sequel[:i][:name], :prem, :spill, :quota)
+        .group(Sequel[:i][:id], Sequel[:i][:name], :prem, :quota, :aws_quota)
         .reverse(:runner_vcpus, :vm_vcpus)
         .all
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -796,6 +796,8 @@ RSpec.describe CloverAdmin do
       ["VmVCpu", "32", "16"],
       ["GithubRunnerVCpu", "400", "0"],
       ["GithubRunnerVCpuArm", "100", "0"],
+      ["GithubRunnerVCpuAws", "100", "0"],
+      ["GithubRunnerVCpuArmAws", "50", "0"],
       ["PostgresVCpu", "128", "0"],
       ["KubernetesVCpu", "32", "0"],
       ["MachineImageVersion", "16", "0"],
@@ -2937,6 +2939,7 @@ RSpec.describe CloverAdmin do
   it "shows GitHub runner x64 VM usage" do
     project = Project.create(name: "test-project")
     project.add_quota(quota_id: ProjectQuota.default_quotas["GithubRunnerVCpu"]["id"], value: 400)
+    project.set_ff_spill_to_alien_runners(true)
     installation = GithubInstallation.create(installation_id: 123, name: "test-installation", type: "User", project_id: project.id)
     installation_id = installation.id
     repository_name = "test-repo"
@@ -2960,13 +2963,13 @@ RSpec.describe CloverAdmin do
     expect(page).to have_link "Show arm64"
     expect(page).to have_css("p", exact_text: "standard: vcpu 25.0%, hugepage 4.27%, spilled vcpus 12 - premium: vcpu 50.0%, hugepage 4.27%")
     expect(page.all("#content td").map(&:text)).to eq [
-      "TOTAL", "", "", "400",
+      "TOTAL", "", "400", "100",
       "2", "1", "1", "0", "1", "0",
       "16 / 46", "2 / 14",
       "1", "0", "0", "0", "0", "0",
       "0", "1", "0", "0", "0",
       "0", "0", "1", "0",
-      "test-installation", "true", "", "400",
+      "test-installation", "true", "400", "100",
       "2", "1", "1", "0", "1", "0",
       "16 / 46", "2 / 14",
       "1", "0", "0", "0", "0", "0",
@@ -2995,13 +2998,13 @@ RSpec.describe CloverAdmin do
     expect(page).to have_link "Show x64"
     expect(page).to have_css("p", exact_text: "standard: vcpu 25.0%, hugepage 4.27%, spilled vcpus 8")
     expect(page.all("#content td").map(&:text)).to eq [
-      "TOTAL", "", "", "100",
+      "TOTAL", "", "100", "0",
       "1", "0", "0", "0", "0", "0",
       "0 / 2", "0 / 0",
       "0", "0", "0", "0", "0", "0",
       "0", "0", "0", "0", "0",
       "0", "0", "0", "0",
-      "test-installation", "true", "", "100",
+      "test-installation", "true", "100", "",
       "1", "0", "0", "0", "0", "0",
       "0 / 2", "0 / 0",
       "0", "0", "0", "0", "0", "0",

--- a/views/admin/extras/Project.erb
+++ b/views/admin/extras/Project.erb
@@ -3,7 +3,7 @@
 <%== part("components/collapsible_table",
   title: "Quotas",
   table_class: "project-quota-table",
-  data: ["VmVCpu", "GithubRunnerVCpu", "GithubRunnerVCpuArm", "PostgresVCpu", "KubernetesVCpu", "MachineImageVersion"].map {
+  data: ["VmVCpu", "GithubRunnerVCpu", "GithubRunnerVCpuArm", "GithubRunnerVCpuAws", "GithubRunnerVCpuArmAws", "PostgresVCpu", "KubernetesVCpu", "MachineImageVersion"].map {
     {
       "Resource" => it,
       "Quota" => obj.effective_quota_value(it),

--- a/views/admin/github_runner_usage.erb
+++ b/views/admin/github_runner_usage.erb
@@ -1,6 +1,8 @@
 <% @page_title = "GitHub Runner #{@arch} VM Usage" %>
 
 <% total = Hash.new(0)
+total[:quota] = 0
+total[:aws_quota] = 0
 types = %w[runner vm].freeze
 @data.each do |row|
     row[:name] = table_link(value: row[:name], link: "/model/GithubInstallation/#{UBID.to_ubid(row.delete(:id))}")
@@ -12,7 +14,7 @@ end
 types.each do |type|
   total[:"#{type}_vcpus"] = "#{total.delete(:"allocated_#{type}_vcpus")} / #{total[:"#{type}_vcpus"]}"
 end
-@data.prepend({name: "TOTAL", prem: "", spill: "", **total}) if @data.any? %>
+@data.prepend({name: "TOTAL", prem: "", **total}) if @data.any? %>
 
 <% other_arch = (@arch == "x64") ? "arm64" : "x64" %>
 
@@ -37,8 +39,13 @@ end
   standard.
 </p>
 
-<p><strong>spill:</strong> Whether the spill_to_alien_runners feature flag is enabled for the project.</p>
 <p><strong>quota:</strong> Effective GithubRunnerVCpu quota for the project.</p>
+
+<p>
+  <strong>aws_quota:</strong> Effective GithubRunnerVCpuAws (spill) quota for the project, blank if the
+  spill_to_alien_runners feature flag isn't enabled for the project.
+</p>
+
 <p><strong>r*:</strong> Number of requested runners with the specified vCPU count.</p>
 
 <p>


### PR DESCRIPTION
## Summary
Continue from the PR (#6112):

- The project "Quotas" table (admin extras page) had `GithubRunnerVCpu`/`Arm` hardcoded but not the new `GithubRunnerVCpuAws`/`ArmAws` types.
- The "GitHub Runner VM Usage" table showed the metal quota per installation but not the AWS (spill) quota.

## Changes
- `views/admin/extras/Project.erb`: added the two new resource types to the quota list.
- `clover_admin.rb`: added a second quota lookup/join (`aws_quota`), computed the same way as the existing `quota` column, joined against `GithubRunnerVCpuAws`/`ArmAws` instead.
- `views/admin/github_runner_usage.erb`: documented the new `aws_quota` column (table itself renders it automatically since columns come from the data hash).
