### PR TITLE
Auto exit rollout strands started on admin site after completion by default

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1619,7 +1619,7 @@ class CloverAdmin < Roda
             wait ||= true
           end
 
-          Prog.const_get(prog).assemble(semaphore:, ids:, gap:, increment:, wait:)
+          Prog.const_get(prog).assemble(semaphore:, ids:, gap:, increment:, wait:, auto_exit: typecast_params.bool("auto_exit", false))
         elsif prog == "RolloutBootImage"
           image_name, version, arch = typecast_params.nonempty_str!(%w[image_name version arch].freeze)
           concurrency = typecast_params.pos_int!("concurrency")
@@ -1645,7 +1645,7 @@ class CloverAdmin < Roda
           Prog.const_get(prog).assemble(image_name:, version:, arch:, concurrency:,
             exclude_minio_hosts:, exclude_vm_host_ids:, pause_stages:)
         else
-          Prog.const_get(prog).assemble
+          Prog.const_get(prog).assemble(auto_exit: typecast_params.bool("auto_exit", false))
         end
 
         flash["notice"] = "Started rollout strand: #{st.ubid}"

--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1591,6 +1591,7 @@ class CloverAdmin < Roda
       end
 
       r.post "start", ROLLOUT_PROGS do |prog|
+        started_by = rodauth.account_from_session[:login]
         st = if prog == "RolloutSemaphore"
           class_semaphore, increment = typecast_params.nonempty_str!(%w[class_semaphore increment].freeze)
           gap = typecast_params.pos_int!("gap")
@@ -1619,7 +1620,7 @@ class CloverAdmin < Roda
             wait ||= true
           end
 
-          Prog.const_get(prog).assemble(semaphore:, ids:, gap:, increment:, wait:, auto_exit: typecast_params.bool("auto_exit", false))
+          Prog.const_get(prog).assemble(semaphore:, ids:, gap:, increment:, wait:, started_by:, auto_exit: typecast_params.bool("auto_exit", false))
         elsif prog == "RolloutBootImage"
           image_name, version, arch = typecast_params.nonempty_str!(%w[image_name version arch].freeze)
           concurrency = typecast_params.pos_int!("concurrency")
@@ -1643,9 +1644,9 @@ class CloverAdmin < Roda
           end
 
           Prog.const_get(prog).assemble(image_name:, version:, arch:, concurrency:,
-            exclude_minio_hosts:, exclude_vm_host_ids:, pause_stages:)
+            exclude_minio_hosts:, exclude_vm_host_ids:, pause_stages:, started_by:)
         else
-          Prog.const_get(prog).assemble(auto_exit: typecast_params.bool("auto_exit", false))
+          Prog.const_get(prog).assemble(started_by:, auto_exit: typecast_params.bool("auto_exit", false))
         end
 
         flash["notice"] = "Started rollout strand: #{st.ubid}"

--- a/prog/rollout_boot_image.rb
+++ b/prog/rollout_boot_image.rb
@@ -13,7 +13,7 @@ class Prog::RolloutBootImage < Prog::Base
   ].freeze
 
   def self.assemble(image_name:, version:, concurrency:, arch: "x64",
-    exclude_minio_hosts: true, exclude_vm_host_ids: [], pause_stages: false)
+    exclude_minio_hosts: true, exclude_vm_host_ids: [], pause_stages: false, started_by: nil)
     fail "Invalid arch: #{arch}" unless ["x64", "arm64"].include?(arch)
 
     ds = VmHost.where(arch:).exclude(id: exclude_vm_host_ids)
@@ -41,6 +41,7 @@ class Prog::RolloutBootImage < Prog::Base
         "version" => version,
         "arch" => arch,
         "pause_stages" => pause_stages,
+        "started_by" => started_by,
       }],
     )
   end

--- a/prog/rollout_rhizome.rb
+++ b/prog/rollout_rhizome.rb
@@ -6,7 +6,7 @@ class Prog::RolloutRhizome < Prog::Base
   frame_accessor :next_runner_time, :remaining_host_ids, :completed, :monitor_github_runners_until,
     :initial_vm_ids, :initial_vms_keypair
 
-  def self.assemble(vm_project_id: Config.rollouts_project_id, auto_exit: false)
+  def self.assemble(vm_project_id: Config.rollouts_project_id, auto_exit: false, started_by: nil)
     vm_host_ds = VmHost
       .order(Sequel.function(:random))
       .where(allocation_state: "accepting")
@@ -53,6 +53,7 @@ class Prog::RolloutRhizome < Prog::Base
         "remaining_host_ids" => remaining_host_ids,
         "completed" => [],
         "auto_exit" => auto_exit,
+        "started_by" => started_by,
       }],
     )
   end

--- a/prog/rollout_rhizome.rb
+++ b/prog/rollout_rhizome.rb
@@ -2,11 +2,11 @@
 
 class Prog::RolloutRhizome < Prog::Base
   semaphore :pause, :github_runners_work, :destroy
-  frame_reader :vm_project_id, :initial_host_ids, :initial_github_runner_host_ids
+  frame_reader :vm_project_id, :initial_host_ids, :initial_github_runner_host_ids, :auto_exit
   frame_accessor :next_runner_time, :remaining_host_ids, :completed, :monitor_github_runners_until,
     :initial_vm_ids, :initial_vms_keypair
 
-  def self.assemble(vm_project_id: Config.rollouts_project_id)
+  def self.assemble(vm_project_id: Config.rollouts_project_id, auto_exit: false)
     vm_host_ds = VmHost
       .order(Sequel.function(:random))
       .where(allocation_state: "accepting")
@@ -52,6 +52,7 @@ class Prog::RolloutRhizome < Prog::Base
         "initial_github_runner_host_ids" => initial_github_runner_host_ids,
         "remaining_host_ids" => remaining_host_ids,
         "completed" => [],
+        "auto_exit" => auto_exit,
       }],
     )
   end
@@ -165,9 +166,7 @@ class Prog::RolloutRhizome < Prog::Base
   end
 
   label def destroy
-    when_destroy_set? do
-      pop("rollout completed")
-    end
+    pop("rollout completed") if auto_exit || destroy_set?
 
     nap(60 * 60 * 24 * 365)
   end

--- a/prog/rollout_semaphore.rb
+++ b/prog/rollout_semaphore.rb
@@ -40,7 +40,7 @@ class Prog::RolloutSemaphore < Prog::Base
   #            of waiting for the destroy semaphore. Use this only for rollouts kicked
   #            off automatically (e.g. from another prog); manually-triggered rollouts
   #            should keep the default so an operator confirms completion.
-  def self.assemble(semaphore:, ids:, gap: 60, initial_gap: gap * 5, initial_range: 2..15, increment: true, wait: true, auto_exit: false)
+  def self.assemble(semaphore:, ids:, gap: 60, initial_gap: gap * 5, initial_range: 2..15, increment: true, wait: true, auto_exit: false, started_by: nil)
     classes = ids.map { UBID.class_for_ubid(UBID.to_ubid(it)) }.uniq
 
     raise "There cannot be more than one class type in a rollout" unless classes.count == 1
@@ -70,6 +70,7 @@ class Prog::RolloutSemaphore < Prog::Base
         "increment" => increment,
         "wait_label" => wait,
         "auto_exit" => auto_exit,
+        "started_by" => started_by,
       }],
     )
   end

--- a/spec/prog/rollout_boot_image_spec.rb
+++ b/spec/prog/rollout_boot_image_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe Prog::RolloutBootImage do
       expect(frame["version"]).to eq("20260312.1.0")
       expect(frame["arch"]).to eq("x64")
       expect(frame["pause_stages"]).to be false
+      expect(frame["started_by"]).to be_nil
 
       expect(frame["todo"]).to eq([github_runner_host.id])
       expect(frame["stages"]).to eq([[vm_host1.id, vm_host2.id, vm_host3.id], [hel1_host.id], [wdc02_host.id]])
@@ -122,15 +123,16 @@ RSpec.describe Prog::RolloutBootImage do
       expect(strand.stack.first["todo"]).to eq([vm_host1.id, vm_host2.id, vm_host3.id, minio_host.id])
     end
 
-    it "excludes explicitly given host ids" do
+    it "excludes explicitly given host ids and respects started_by" do
       vm_host1
 
       strand = described_class.assemble(
         concurrency: 2, image_name: "github-ubuntu-2404", version: "20260312.1.0",
-        exclude_vm_host_ids: [vm_host2.id, vm_host3.id],
+        exclude_vm_host_ids: [vm_host2.id, vm_host3.id], started_by: "admin",
       )
 
       expect(strand.stack.first["todo"]).to eq([vm_host1.id])
+      expect(strand.stack.first["started_by"]).to eq "admin"
     end
   end
 

--- a/spec/prog/rollout_rhizome_spec.rb
+++ b/spec/prog/rollout_rhizome_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Prog::RolloutRhizome do
       expect(frame["vm_project_id"]).to eq(project_id)
       expect(frame["initial_host_ids"]).to eq([fsn1_host.id, wdc2_host.id])
       expect(frame["completed"]).to eq([])
+      expect(frame["auto_exit"]).to be false
 
       remaining_host_ids = frame["remaining_host_ids"]
       expect(remaining_host_ids).to include(hel1_host.id)
@@ -50,9 +51,9 @@ RSpec.describe Prog::RolloutRhizome do
       expect(ghr_hosts.map(&:id).sort!).to eq((frame["initial_github_runner_host_ids"] << remaining_host_ids.first).sort!)
     end
 
-    it "respects Config.rollouts_project_id" do
+    it "respects Config.rollouts_project_id and auto_exit argument" do
       expect(Config).to receive(:rollouts_project_id).and_return(project_id)
-      st = described_class.assemble
+      st = described_class.assemble(auto_exit: true)
       expect(st.label).to eq("start")
       expect(st.prog).to eq("RolloutRhizome")
 
@@ -62,6 +63,7 @@ RSpec.describe Prog::RolloutRhizome do
       expect(frame["initial_github_runner_host_ids"]).to eq([])
       expect(frame["remaining_host_ids"]).to eq([])
       expect(frame["completed"]).to eq([])
+      expect(frame["auto_exit"]).to be true
     end
   end
 
@@ -252,6 +254,11 @@ RSpec.describe Prog::RolloutRhizome do
   describe "#destroy" do
     it "exits if destroy semaphore is set" do
       nx.incr_destroy
+      expect { nx.destroy }.to exit("msg" => "rollout completed")
+    end
+
+    it "exits if auto_exit is set" do
+      refresh_frame(nx, new_values: {"auto_exit" => true})
       expect { nx.destroy }.to exit("msg" => "rollout completed")
     end
 

--- a/spec/prog/rollout_rhizome_spec.rb
+++ b/spec/prog/rollout_rhizome_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Prog::RolloutRhizome do
       expect(frame["initial_host_ids"]).to eq([fsn1_host.id, wdc2_host.id])
       expect(frame["completed"]).to eq([])
       expect(frame["auto_exit"]).to be false
+      expect(frame["started_by"]).to be_nil
 
       remaining_host_ids = frame["remaining_host_ids"]
       expect(remaining_host_ids).to include(hel1_host.id)
@@ -51,9 +52,9 @@ RSpec.describe Prog::RolloutRhizome do
       expect(ghr_hosts.map(&:id).sort!).to eq((frame["initial_github_runner_host_ids"] << remaining_host_ids.first).sort!)
     end
 
-    it "respects Config.rollouts_project_id and auto_exit argument" do
+    it "respects Config.rollouts_project_id and auto_exit and started_by argument" do
       expect(Config).to receive(:rollouts_project_id).and_return(project_id)
-      st = described_class.assemble(auto_exit: true)
+      st = described_class.assemble(auto_exit: true, started_by: "admin")
       expect(st.label).to eq("start")
       expect(st.prog).to eq("RolloutRhizome")
 
@@ -64,6 +65,7 @@ RSpec.describe Prog::RolloutRhizome do
       expect(frame["remaining_host_ids"]).to eq([])
       expect(frame["completed"]).to eq([])
       expect(frame["auto_exit"]).to be true
+      expect(frame["started_by"]).to eq "admin"
     end
   end
 

--- a/spec/prog/rollout_semaphore_spec.rb
+++ b/spec/prog/rollout_semaphore_spec.rb
@@ -25,10 +25,11 @@ RSpec.describe Prog::RolloutSemaphore do
       expect(frame.fetch("wait_label")).to be true
       expect(frame.fetch("current")).to be_nil
       expect(frame["auto_exit"]).to be false
+      expect(frame["started_by"]).to be_nil
     end
 
-    it "supports gap, initial_gap, initial_range, increment, wait_label, and auto_exit arguments" do
-      st = described_class.assemble(semaphore: "resolve", ids: page_ids, gap: 10, initial_gap: 15, initial_range: 1..5, increment: false, wait: "wait", auto_exit: true)
+    it "supports gap, initial_gap, initial_range, increment, wait_label, auto_exit, and started_by arguments" do
+      st = described_class.assemble(semaphore: "resolve", ids: page_ids, gap: 10, initial_gap: 15, initial_range: 1..5, increment: false, wait: "wait", auto_exit: true, started_by: "admin")
       expect(st.label).to eq("start")
       expect(st.prog).to eq("RolloutSemaphore")
 
@@ -42,7 +43,7 @@ RSpec.describe Prog::RolloutSemaphore do
       expect(frame["increment"]).to be false
       expect(frame["wait_label"]).to eq "wait"
       expect(frame.fetch("current")).to be_nil
-      expect(frame["auto_exit"]).to be true
+      expect(frame["started_by"]).to eq "admin"
     end
 
     it "raises when ids reference more than one class" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2120,6 +2120,7 @@ RSpec.describe CloverAdmin do
       expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
       expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", st.ubid, "{}", "", "", ""]
       expect(st.stack[0]["auto_exit"]).to be false
+      expect(st.stack[0]["started_by"]).to eq "admin"
     end
 
     it "shows error for an invalid class/semaphore selection" do
@@ -2148,6 +2149,7 @@ RSpec.describe CloverAdmin do
       expect(st.stack[0]["increment"]).to be true
       expect(st.stack[0]["wait_label"]).to be true
       expect(st.stack[0]["auto_exit"]).to be true
+      expect(st.stack[0]["started_by"]).to eq "admin"
 
       st.run
       page.refresh
@@ -2320,6 +2322,7 @@ RSpec.describe CloverAdmin do
       expect(frame["concurrency"]).to eq 10
       expect(frame["pause_stages"]).to be false
       expect(frame["todo"]).to eq [vm_host.id]
+      expect(frame["started_by"]).to eq "admin"
     end
 
     it "allows creation of boot image rollout strands with custom options" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2109,6 +2109,17 @@ RSpec.describe CloverAdmin do
       st = Strand.first(prog: "RolloutRhizome")
       expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
       expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", st.ubid, "{}", "", "", ""]
+      expect(st.stack[0]["auto_exit"]).to be true
+    end
+
+    it "allows creation of rhizome rollout strands with auto exit disabled" do
+      uncheck "rhizome_auto_exit"
+      click_button "Start Rhizome Rollout"
+
+      st = Strand.first(prog: "RolloutRhizome")
+      expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", st.ubid, "{}", "", "", ""]
+      expect(st.stack[0]["auto_exit"]).to be false
     end
 
     it "shows error for an invalid class/semaphore selection" do
@@ -2136,6 +2147,7 @@ RSpec.describe CloverAdmin do
       expect(st.stack[0]["gap"]).to eq 90
       expect(st.stack[0]["increment"]).to be true
       expect(st.stack[0]["wait_label"]).to be true
+      expect(st.stack[0]["auto_exit"]).to be true
 
       st.run
       page.refresh
@@ -2147,7 +2159,7 @@ RSpec.describe CloverAdmin do
       expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{\"remaining\" => 0, \"completed\" => 1}", "", "", "increment resolve"]
     end
 
-    it "allows creation of semaphore increment rollout strands with locations and wait labels" do
+    it "allows creation of semaphore increment rollout strands with locations and wait labels and auto exit disabled" do
       fsn1_vm = create_vm
       hel1_vm = create_vm(location_id: Location::HETZNER_HEL1_ID)
 
@@ -2157,6 +2169,7 @@ RSpec.describe CloverAdmin do
       select "Vm - update_firewall_rules", from: "Class - Semaphore"
       select "hetzner-fsn1"
       fill_in "Wait Label", with: "wait"
+      uncheck "semaphore_auto_exit"
       click_button "Start Semaphore Rollout"
 
       st = Strand.first(prog: "RolloutSemaphore")
@@ -2168,6 +2181,7 @@ RSpec.describe CloverAdmin do
       expect(st.stack[0]["gap"]).to eq 60
       expect(st.stack[0]["increment"]).to be true
       expect(st.stack[0]["wait_label"]).to eq "wait"
+      expect(st.stack[0]["auto_exit"]).to be false
     end
 
     it "allows creation of semaphore increment without wait rollout strands" do
@@ -2186,6 +2200,7 @@ RSpec.describe CloverAdmin do
       expect(st.stack[0]["gap"]).to eq 60
       expect(st.stack[0]["increment"]).to be true
       expect(st.stack[0]["wait_label"]).to be false
+      expect(st.stack[0]["auto_exit"]).to be true
 
       st.run
       page.refresh
@@ -2208,6 +2223,7 @@ RSpec.describe CloverAdmin do
       expect(st.stack[0]["remaining"]).to eq [page_st.id]
       expect(st.stack[0]["gap"]).to eq 90
       expect(st.stack[0]["increment"]).to be false
+      expect(st.stack[0]["auto_exit"]).to be true
 
       st.run
       page.refresh

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2094,13 +2094,13 @@ RSpec.describe CloverAdmin do
       rollouts_path = page.current_path
       strand = Prog::RolloutRhizome.assemble
       page.refresh
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", strand.ubid, "{}", "", "", ""]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", strand.ubid, "", "{}", "", "", ""]
       click_link strand.ubid
       expect(page.title).to eq "Ubicloud Admin - Strand #{strand.ubid}"
 
       strand.run
       visit rollouts_path
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "wait_initial_rhizome_install", "0", strand.ubid, "{}", "", "", ""]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "wait_initial_rhizome_install", "0", strand.ubid, "", "{}", "", "", ""]
     end
 
     it "allows creation of rhizome rollout strands" do
@@ -2108,7 +2108,7 @@ RSpec.describe CloverAdmin do
 
       st = Strand.first(prog: "RolloutRhizome")
       expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", st.ubid, "{}", "", "", ""]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", st.ubid, "admin", "{}", "", "", ""]
       expect(st.stack[0]["auto_exit"]).to be true
     end
 
@@ -2118,7 +2118,7 @@ RSpec.describe CloverAdmin do
 
       st = Strand.first(prog: "RolloutRhizome")
       expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", st.ubid, "{}", "", "", ""]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutRhizome", "start", "0", st.ubid, "admin", "{}", "", "", ""]
       expect(st.stack[0]["auto_exit"]).to be false
       expect(st.stack[0]["started_by"]).to eq "admin"
     end
@@ -2140,7 +2140,7 @@ RSpec.describe CloverAdmin do
       click_button "Start Semaphore Rollout"
 
       st = Strand.first(prog: "RolloutSemaphore")
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{}", "", "", "increment resolve"]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "admin", "{}", "", "", "increment resolve"]
       expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
 
       expect(st.stack[0]["semaphore"]).to eq "resolve"
@@ -2153,12 +2153,12 @@ RSpec.describe CloverAdmin do
 
       st.run
       page.refresh
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "wait_current", "0", st.ubid, "{}", "", "", "increment resolve"]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "wait_current", "0", st.ubid, "admin", "{}", "", "", "increment resolve"]
 
       Semaphore.where(strand_id: page_st.id, name: "resolve").delete
       st.run
       page.refresh
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{\"remaining\" => 0, \"completed\" => 1}", "", "", "increment resolve"]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "admin", "{\"remaining\" => 0, \"completed\" => 1}", "", "", "increment resolve"]
     end
 
     it "allows creation of semaphore increment rollout strands with locations and wait labels and auto exit disabled" do
@@ -2175,7 +2175,7 @@ RSpec.describe CloverAdmin do
       click_button "Start Semaphore Rollout"
 
       st = Strand.first(prog: "RolloutSemaphore")
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{}", "", "", "increment update_firewall_rules"]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "admin", "{}", "", "", "increment update_firewall_rules"]
       expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
 
       expect(st.stack[0]["semaphore"]).to eq "update_firewall_rules"
@@ -2194,7 +2194,7 @@ RSpec.describe CloverAdmin do
       click_button "Start Semaphore Rollout"
 
       st = Strand.first(prog: "RolloutSemaphore")
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{}", "", "", "increment resolve"]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "admin", "{}", "", "", "increment resolve"]
       expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
 
       expect(st.stack[0]["semaphore"]).to eq "resolve"
@@ -2206,7 +2206,7 @@ RSpec.describe CloverAdmin do
 
       st.run
       page.refresh
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{\"remaining\" => 0, \"completed\" => 1}", "", "", "increment resolve"]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "admin", "{\"remaining\" => 0, \"completed\" => 1}", "", "", "increment resolve"]
     end
 
     it "allows creation of semaphore decrement rollout strands" do
@@ -2218,7 +2218,7 @@ RSpec.describe CloverAdmin do
       click_button "Start Semaphore Rollout"
 
       st = Strand.first(prog: "RolloutSemaphore")
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{}", "", "", "decrement resolve"]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "admin", "{}", "", "", "decrement resolve"]
       expect(page).to have_flash_notice("Started rollout strand: #{st.ubid}")
 
       expect(st.stack[0]["semaphore"]).to eq "resolve"
@@ -2229,7 +2229,7 @@ RSpec.describe CloverAdmin do
 
       st.run
       page.refresh
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "{\"remaining\" => 0, \"completed\" => 1}", "", "", "decrement resolve"]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutSemaphore", "start", "0", st.ubid, "admin", "{\"remaining\" => 0, \"completed\" => 1}", "", "", "decrement resolve"]
     end
 
     it "allows pausing and unpausing strands" do
@@ -2376,7 +2376,7 @@ RSpec.describe CloverAdmin do
       version = Prog::DownloadBootImage::BOOT_IMAGE_SHA256.dig("ubuntu-noble", "x64").keys.max
       st = Prog::RolloutBootImage.assemble(image_name: "ubuntu-noble", version:, concurrency: 10)
       page.refresh
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutBootImage", "wait", "0", st.ubid, "{\"image\" => \"ubuntu-noble #{version} x64\"}", "", "", ""]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutBootImage", "wait", "0", st.ubid, "", "{\"image\" => \"ubuntu-noble #{version} x64\"}", "", "", ""]
 
       frame = st.stack[0]
       frame["todo"] = []
@@ -2386,7 +2386,7 @@ RSpec.describe CloverAdmin do
       st.modified!(:stack)
       st.save_changes
       page.refresh
-      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutBootImage", "wait", "0", st.ubid, "{\"remaining\" => 1, \"completed\" => 1, \"image\" => \"ubuntu-noble #{version} x64\"}", "", "", ""]
+      expect(page.all(".rollouts-table td").map(&:text)).to eq ["RolloutBootImage", "wait", "0", st.ubid, "", "{\"remaining\" => 1, \"completed\" => 1, \"image\" => \"ubuntu-noble #{version} x64\"}", "", "", ""]
 
       click_button "Rollback"
       expect(page).to have_flash_notice("Strand #{st.ubid} updated")

--- a/views/admin/rollouts.erb
+++ b/views/admin/rollouts.erb
@@ -4,6 +4,7 @@
   h = strand.values.slice(:prog, :label, :try)
   h[:id] = strand.ubid
   frame = strand.stack[0]
+  h[:started_by] = frame["started_by"]
   data = h[:data] = {}
 
   if frame["completed"].empty?

--- a/views/admin/rollouts.erb
+++ b/views/admin/rollouts.erb
@@ -74,6 +74,7 @@ end %>
       <%== f.input(:text, key: :wait_label, label: "Wait Label", wrapper_attr: {id: "wait-label-wrapper"}) %>
       <%== f.input(:number, key: :gap, label: "Gap (seconds)", required: true, attr: {min: 5, max: 3600}, value: 60) %>
       <%== f.input(:radioset, key: :increment, required: true, options: [["Increment", "increment"], ["Increment Without Waiting", "increment-no-wait"], ["Decrement", "decrement"]], value: "increment", wrapper_attr: {class: "rollout-radioset"}) %>
+      <%== f.input(:checkbox, key: :auto_exit, id: "semaphore_auto_exit", label: "Exit After Completion", checked: true) %>
     <% end %>
   </section>
 
@@ -81,6 +82,9 @@ end %>
     <h3>Rhizome</h3>
 
     <p class="rollout-desc">Deploy the latest rhizome code to all hosts.</p>
-    <%== form({action: "/rollouts/start/RolloutRhizome", method: "post", class: "rollout-form"}, button: "Start Rhizome Rollout") %>
+
+    <% form({action: "/rollouts/start/RolloutRhizome", method: "post", class: "rollout-form"}, button: "Start Rhizome Rollout", wrapper: :div) do |f| %>
+      <%== f.input(:checkbox, key: :auto_exit, id: "rhizome_auto_exit", label: "Exit After Completion", checked: true) %>
+    <% end %>
   </section>
 </div>


### PR DESCRIPTION
Boot image rollouts already auto exited on completion. Semaphore rollouts supported it, but it wasn't enabled on the admin site rollout form. Rhizome rollouts didn't support it.  This first adds support for rhizome rollouts to auto exit. Then it adds support for using auto exit for semaphore and rhizome rollouts on the admin site rollouts page, enabling auto exit by default.

Additionally, this sets a started_by frame entry for rollout strands, and on the admin site, populates it with the admin that started it. Finally, the rollouts page table shows the admin who started the rollout as an additional column.