### PR TITLE
github_runner.location_id step 4: Use github_runner.location_id to avoid a join to vm

### DIFF
--- a/model/github/github_runner.rb
+++ b/model/github/github_runner.rb
@@ -24,17 +24,16 @@ class GithubRunner < Sequel::Model
     end
 
     def metal_active_runner_vcpus
-      ds = join(:vm, id: Sequel[:github_runner][:vm_id])
+      ds = self
       if (aws_location_id = Config.github_runner_aws_location_id)
-        ds = ds.exclude(Sequel[:vm][:location_id] => aws_location_id)
+        ds = ds.exclude(location_id: aws_location_id)
       end
       ds.total_active_runner_vcpus
     end
 
     def aws_active_runner_vcpus
       return 0 unless (aws_location_id = Config.github_runner_aws_location_id)
-      join(:vm, id: Sequel[:github_runner][:vm_id])
-        .where(Sequel[:vm][:location_id] => aws_location_id)
+      where(location_id: aws_location_id)
         .total_active_runner_vcpus
     end
   end


### PR DESCRIPTION
This is the reason github_runner.location_id was added.