### PR TITLE
KEK Rotation (ubiblk with config v2)

### DIFF
--- a/model/vhost_block_backend.rb
+++ b/model/vhost_block_backend.rb
@@ -6,7 +6,6 @@ class VhostBlockBackend < Sequel::Model
   MIN_REMOTE_STORAGE_SERVER_VERSION = 500
   MIN_ARCHIVE_SUPPORT_VERSION = 401
   MIN_DUMP_METADATA_SUPPORT_VERSION = 400
-  MIN_CONFIG_V2_VERSION = 400
 
   plugin ResourceMethods, etc_type: true
 
@@ -24,10 +23,6 @@ class VhostBlockBackend < Sequel::Model
 
   def supports_dump_metadata?
     version_code >= MIN_DUMP_METADATA_SUPPORT_VERSION
-  end
-
-  def config_v2?
-    version_code >= MIN_CONFIG_V2_VERSION
   end
 end
 

--- a/prog/storage/rotate_kek.rb
+++ b/prog/storage/rotate_kek.rb
@@ -5,7 +5,7 @@ require "json"
 class Prog::Storage::RotateKek < Prog::Base
   subject_is :vm_storage_volume
 
-  def self.assemble(vm_storage_volume_id)
+  def self.assemble(vm_storage_volume_id, parent_id: nil)
     DB.transaction do
       # Lock the row so two rotations can't start at once.
       vm_storage_volume = VmStorageVolume.where(id: vm_storage_volume_id).for_update.first
@@ -16,7 +16,7 @@ class Prog::Storage::RotateKek < Prog::Base
       key_encryption_key = StorageKeyEncryptionKey.create_random(auth_data: vm_storage_volume.device_id)
       vm_storage_volume.update(key_encryption_key_2_id: key_encryption_key.id)
 
-      Strand.create_with_id(vm_storage_volume, prog: "Storage::RotateKek", label: "back_up_key")
+      Strand.create_with_id(vm_storage_volume, prog: "Storage::RotateKek", label: "back_up_key", parent_id:)
     end
   end
 

--- a/prog/storage/rotate_kek.rb
+++ b/prog/storage/rotate_kek.rb
@@ -12,8 +12,6 @@ class Prog::Storage::RotateKek < Prog::Base
       fail "storage volume not found" unless vm_storage_volume
       fail "storage volume is not encrypted" unless vm_storage_volume.key_encryption_key_1_id
       fail "a key rotation is already in progress" if vm_storage_volume.key_encryption_key_2_id
-      # TODO: support config-v2 (TOML) volumes once TOML parsing is resolved.
-      fail "config-v2 (TOML) storage KEK rotation is not supported yet" if vm_storage_volume.vhost_block_backend&.config_v2?
 
       key_encryption_key = StorageKeyEncryptionKey.create_random(auth_data: vm_storage_volume.device_id)
       vm_storage_volume.update(key_encryption_key_2_id: key_encryption_key.id)

--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -35,8 +35,9 @@ class Prog::Test::Vm < Prog::Test::Base
         sha256 = sshable.cmd("head -c 1M /dev/urandom | tee /tmp/persistence-test | sha256sum | awk '{print $1}'").strip
         sshable.cmd("mv /tmp/persistence-test :file", file: File.join("/home/ubi/persistence_test", sha256))
       end
-      # The pre-reboot pass is on the critical path, so it keeps only the disk and network checks plus seeding the persistence data.
-      hop_ping_google
+      # Rotate each encrypted volume's KEK before the reboot, so the post-reboot
+      # pass only succeeds if the rotated volumes still open with the new KEK.
+      hop_rotate_storage_keys
     else
       files = sshable.cmd("ls ~/persistence_test").split
       fail_test "persistence test: unexpected number of files" if files.size != num_files
@@ -47,6 +48,18 @@ class Prog::Test::Vm < Prog::Test::Base
       end
       hop_install_packages
     end
+  end
+
+  label def rotate_storage_keys
+    vm.vm_storage_volumes.each do |volume|
+      Prog::Storage::RotateKek.assemble(volume.id, parent_id: strand.id)
+    end
+    hop_wait_rotate_storage_keys
+  end
+
+  label def wait_rotate_storage_keys
+    # Resume the pre-reboot pass at ping_google when KEK rotations are done.
+    reap(:ping_google, nap: 10)
   end
 
   label def install_packages

--- a/rhizome/host/bin/storage-key-tool
+++ b/rhizome/host/bin/storage-key-tool
@@ -17,7 +17,6 @@ volume_params = JSON.parse(File.read(VmPath.new(vm_name).prep_json)).fetch("stor
   .find { |v| v["disk_index"].to_s == disk_index } ||
   raise("no storage volume with disk_index #{disk_index} in prep.json")
 volume = StorageVolume.new(vm_name, volume_params)
-volume.ensure_kek_rotatable
 old_key = keys.fetch("old_key")
 
 case action

--- a/rhizome/host/lib/storage_key_encryption.rb
+++ b/rhizome/host/lib/storage_key_encryption.rb
@@ -22,6 +22,17 @@ class StorageKeyEncryption
     nonce << cipher.update(plaintext) << cipher.final << cipher.auth_tag
   end
 
+  # Inverse of aes256gcm_encrypt.
+  def self.aes256gcm_decrypt(key, auth_data, wrapped)
+    cipher = OpenSSL::Cipher.new("aes-256-gcm")
+    cipher.decrypt
+    cipher.key = key
+    cipher.iv = wrapped[0, 12]
+    cipher.auth_data = auth_data
+    cipher.auth_tag = wrapped[-16..]
+    cipher.update(wrapped[12...-16]) + cipher.final
+  end
+
   def encrypted_dek_json(data_encryption_key)
     JSON.pretty_generate({
       cipher: data_encryption_key[:cipher],

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -553,11 +553,6 @@ class StorageVolume
     StorageKeyEncryption.new(kek).read_encrypted_dek(path)
   end
 
-  def ensure_kek_rotatable
-    # config-v2 (TOML) volumes keep their wrapped secrets in a TOML config we can't parse yet.
-    fail "config-v2 (TOML) storage KEK rotation is not supported yet" if use_config_v2?
-  end
-
   def back_up_key(old_kek)
     write_config_file(key_file_backup(old_kek), File.read(config_key_file))
   end

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -620,19 +620,54 @@ class StorageVolume
   end
 
   def rotated_secrets(source, old_kek, new_kek)
-    dek = read_config_dek(source, old_kek)
-    ke = StorageKeyEncryption.new(new_kek)
     if !@vhost_backend_version
-      ke.encrypted_dek_json(dek)
+      StorageKeyEncryption.new(new_kek).encrypted_dek_json(read_config_dek(source, old_kek))
+    elsif use_config_v2?
+      rewrap_config_v2_secrets(source, old_kek, new_kek)
     else
+      dek = read_config_dek(source, old_kek)
+      ke = StorageKeyEncryption.new(new_kek)
       config = YAML.safe_load_file(source)
       config["encryption_key"] = [wrap_key_b64(ke, dek[:key]), wrap_key_b64(ke, dek[:key2])]
       config.to_yaml
     end
   end
 
+  def unwrap_encrypted_inline_secret(name, secret, kek_key)
+    fail "config-v2 secret #{name} is not wrapped by the kek" unless secret.dig("encrypted_by", "ref") == "kek"
+    fail "config-v2 secret #{name} is not base64 encoded" unless secret["encoding"] == "base64"
+    inline = secret.dig("source", "inline")
+    fail "config-v2 secret #{name} has no inline value" unless inline
+    StorageKeyEncryption.aes256gcm_decrypt(kek_key, name, Base64.strict_decode64(inline))
+  end
+
+  def rewrap_config_v2_secrets(source, old_kek, new_kek)
+    old_key = Base64.decode64(old_kek["key"])
+    new_key = Base64.decode64(new_kek["key"])
+    config = PerfectTOML.load_file(source)
+    config.fetch("secrets").each do |name, secret|
+      next if name == "kek"
+
+      plaintext = unwrap_encrypted_inline_secret(name, secret, old_key)
+      secret["source"]["inline"] = Base64.strict_encode64(StorageKeyEncryption.aes256gcm_encrypt(new_key, name, plaintext))
+    end
+    PerfectTOML.generate(config)
+  end
+
+  def config_v2_secret_plaintexts(path, kek)
+    key = Base64.decode64(kek["key"])
+    PerfectTOML.load_file(path).fetch("secrets").filter_map { |name, secret|
+      [name, unwrap_encrypted_inline_secret(name, secret, key)] unless name == "kek"
+    }.to_h
+  end
+
   def verify_rotated_secrets(source, old_kek, new, new_kek)
-    fail "data-encryption key changed after rotation" if read_config_dek(source, old_kek) != read_config_dek(new, new_kek)
+    changed = if use_config_v2?
+      config_v2_secret_plaintexts(source, old_kek) != config_v2_secret_plaintexts(new, new_kek)
+    else
+      read_config_dek(source, old_kek) != read_config_dek(new, new_kek)
+    end
+    fail "secrets changed after rotation" if changed
   end
 
   def verify_imaged_disk_size

--- a/rhizome/host/spec/storage_key_encryption_spec.rb
+++ b/rhizome/host/spec/storage_key_encryption_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe StorageKeyEncryption do
     expect { described_class.aes256gcm_decrypt(key, "other", wrapped) }.to raise_error(OpenSSL::Cipher::CipherError)
   end
 
+  it "fails aes256gcm_decrypt when the key does not match" do
+    wrapped = described_class.aes256gcm_encrypt(OpenSSL::Cipher.new("aes-256-gcm").random_key, "xts-key", "secret")
+    other_key = OpenSSL::Cipher.new("aes-256-gcm").random_key
+    expect { described_class.aes256gcm_decrypt(other_key, "xts-key", wrapped) }.to raise_error(OpenSSL::Cipher::CipherError)
+  end
+
   it "can wrap a key" do
     dek = OpenSSL::Cipher.new("aes-256-xts").random_key.unpack1("H*")
     r1 = sek.wrap_key(dek[..63])

--- a/rhizome/host/spec/storage_key_encryption_spec.rb
+++ b/rhizome/host/spec/storage_key_encryption_spec.rb
@@ -21,6 +21,19 @@ RSpec.describe StorageKeyEncryption do
     expect(sek.unwrap_key(sek.wrap_key(key))).to eq(key)
   end
 
+  it "round-trips a secret through aes256gcm_encrypt/decrypt" do
+    key = OpenSSL::Cipher.new("aes-256-gcm").random_key
+    plaintext = "the-xts-key-material"
+    wrapped = described_class.aes256gcm_encrypt(key, "xts-key", plaintext)
+    expect(described_class.aes256gcm_decrypt(key, "xts-key", wrapped)).to eq(plaintext)
+  end
+
+  it "fails aes256gcm_decrypt when the auth_data does not match" do
+    key = OpenSSL::Cipher.new("aes-256-gcm").random_key
+    wrapped = described_class.aes256gcm_encrypt(key, "xts-key", "secret")
+    expect { described_class.aes256gcm_decrypt(key, "other", wrapped) }.to raise_error(OpenSSL::Cipher::CipherError)
+  end
+
   it "can wrap a key" do
     dek = OpenSSL::Cipher.new("aes-256-xts").random_key.unpack1("H*")
     r1 = sek.wrap_key(dek[..63])

--- a/rhizome/host/spec/storage_key_encryption_spec.rb
+++ b/rhizome/host/spec/storage_key_encryption_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe StorageKeyEncryption do
     expect { described_class.aes256gcm_decrypt(other_key, "xts-key", wrapped) }.to raise_error(OpenSSL::Cipher::CipherError)
   end
 
+  it "fails aes256gcm_decrypt when the encrypted data is modified" do
+    key = OpenSSL::Cipher.new("aes-256-gcm").random_key
+    wrapped = described_class.aes256gcm_encrypt(key, "xts-key", "secret")
+    wrapped[12] = (wrapped[12].ord ^ 1).chr
+    expect { described_class.aes256gcm_decrypt(key, "xts-key", wrapped) }.to raise_error(OpenSSL::Cipher::CipherError)
+  end
+
   it "can wrap a key" do
     dek = OpenSSL::Cipher.new("aes-256-xts").random_key.unpack1("H*")
     r1 = sek.wrap_key(dek[..63])

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -1093,6 +1093,17 @@ RSpec.describe StorageVolume do
       File.write(legacy_file, {"path" => "/d/disk.raw", "encryption_key" => [wrap.call(dek_key), wrap.call(dek_key2)]}.to_yaml)
     end
 
+    def kek_secret(vol, kek, name, plaintext)
+      inline = Base64.strict_encode64(StorageKeyEncryption.aes256gcm_encrypt(Base64.decode64(kek["key"]), name, plaintext))
+      vol.wrapped_kek_secret(inline)
+    end
+
+    def expect_secret_rejected(vol, secret, msg)
+      File.write(v2_file, PerfectTOML.generate({"secrets" => {"xts-key" => secret}}))
+      expect { vol.rewrap_config_v2_secrets(v2_file, old_kek, new_kek) }.to raise_error(msg)
+      expect { vol.config_v2_secret_plaintexts(v2_file, old_kek) }.to raise_error(msg)
+    end
+
     # After rotation the live file unwraps to the original DEK under the new KEK,
     # and no longer under the old KEK.
     def expect_rotated(vol)
@@ -1145,6 +1156,40 @@ RSpec.describe StorageVolume do
       expect(File.stat(legacy_file).mode & 0o777).to eq(0o600)
     end
 
+    it "rotates a config-v2 (TOML) volume, re-wrapping every secret 0600 owned by the VM user" do
+      vol = volume("v0.4.2")
+      xts_plaintext = [dek_key].pack("H*") + [dek_key2].pack("H*")
+      File.write(v2_file, PerfectTOML.generate({"secrets" => {
+        "xts-key" => kek_secret(vol, old_kek, "xts-key", xts_plaintext),
+        "kek" => {"source" => {"file" => "/kek.pipe"}, "encoding" => "base64"},
+        "archive-access-key" => kek_secret(vol, old_kek, "archive-access-key", "AKIA-secret"),
+      }}))
+      expect(FileUtils).to receive(:chown).with("vm12345", "vm12345", "#{vol.key_file_backup(old_kek)}.tmp")
+      expect(FileUtils).to receive(:chown).with("vm12345", "vm12345", "#{v2_file}.new.tmp")
+      rotate(vol)
+      expect(File.stat(v2_file).mode & 0o777).to eq(0o600)
+      expect(File.exist?("#{v2_file}.new")).to be(false)
+      # Every secret now unwraps under the new KEK to its original plaintext, and no longer under the old KEK.
+      expect(vol.config_v2_secret_plaintexts(v2_file, new_kek)).to eq("xts-key" => xts_plaintext, "archive-access-key" => "AKIA-secret")
+      expect { vol.config_v2_secret_plaintexts(v2_file, old_kek) }.to raise_error(OpenSSL::Cipher::CipherError)
+    end
+
+    it "fails on a config-v2 secret that is not an inline base64 kek secret" do
+      vol = volume("v0.4.2")
+
+      secret = kek_secret(vol, old_kek, "xts-key", "secret")
+      secret["encrypted_by"]["ref"] = "other"
+      expect_secret_rejected(vol, secret, "config-v2 secret xts-key is not wrapped by the kek")
+
+      secret = kek_secret(vol, old_kek, "xts-key", "secret")
+      secret["encoding"] = "hex"
+      expect_secret_rejected(vol, secret, "config-v2 secret xts-key is not base64 encoded")
+
+      secret = kek_secret(vol, old_kek, "xts-key", "secret")
+      secret["source"].delete("inline")
+      expect_secret_rejected(vol, secret, "config-v2 secret xts-key has no inline value")
+    end
+
     it "removes the stale spdk key file when rotating a migrated ubiblk volume" do
       write_spdk(old_kek) # leftover from before the spdk -> ubiblk migration
       write_legacy(old_kek)
@@ -1185,8 +1230,24 @@ RSpec.describe StorageVolume do
       StorageKeyEncryption.new(old_kek).write_encrypted_dek(backup, dek)
       different = {cipher: "AES_XTS", key: SecureRandom.random_bytes(32).unpack1("H*"), key2: dek_key2}
       StorageKeyEncryption.new(new_kek).write_encrypted_dek(rotated, different)
-      expect { vol.verify_rotated_secrets(backup, old_kek, rotated, new_kek) }.to raise_error(/data-encryption key changed after rotation/)
+      expect { vol.verify_rotated_secrets(backup, old_kek, rotated, new_kek) }.to raise_error("secrets changed after rotation")
       expect(File.exist?(rotated)).to be(true)
+    end
+
+    it "verify_rotated_secrets catches a config-v2 non-xts secret that rewrapped to a different value" do
+      vol = volume("v0.4.2")
+      source = "#{v2_file}.old"
+      rotated = "#{v2_file}.new"
+      xts_plaintext = [dek_key].pack("H*") + [dek_key2].pack("H*")
+      File.write(source, PerfectTOML.generate({"secrets" => {
+        "xts-key" => kek_secret(vol, old_kek, "xts-key", xts_plaintext),
+        "archive-access-key" => kek_secret(vol, old_kek, "archive-access-key", "AKIA-original"),
+      }}))
+      File.write(rotated, PerfectTOML.generate({"secrets" => {
+        "xts-key" => kek_secret(vol, new_kek, "xts-key", xts_plaintext),
+        "archive-access-key" => kek_secret(vol, new_kek, "archive-access-key", "AKIA-corrupted"),
+      }}))
+      expect { vol.verify_rotated_secrets(source, old_kek, rotated, new_kek) }.to raise_error("secrets changed after rotation")
     end
 
     it "retire_key_backup removes the old key's backup, leaving the live file" do

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -1037,21 +1037,6 @@ RSpec.describe StorageVolume do
     end
   end
 
-  describe "#ensure_kek_rotatable" do
-    def volume(version)
-      StorageVolume.new("vm12345", {"disk_index" => 0, "encrypted" => true, "size_gib" => 20, "vhost_block_backend_version" => version})
-    end
-
-    it "rejects config-v2 (TOML) volumes, which aren't supported yet" do
-      expect { volume("v0.4.0").ensure_kek_rotatable }.to raise_error("config-v2 (TOML) storage KEK rotation is not supported yet")
-    end
-
-    it "allows spdk and legacy ubiblk volumes" do
-      expect { volume(nil).ensure_kek_rotatable }.not_to raise_error
-      expect { volume("v0.3.1").ensure_kek_rotatable }.not_to raise_error
-    end
-  end
-
   describe "#rewrite_secrets" do
     let(:dir) { Dir.mktmpdir }
     let(:old_kek) { make_kek }

--- a/spec/prog/storage/rotate_kek_spec.rb
+++ b/spec/prog/storage/rotate_kek_spec.rb
@@ -56,13 +56,6 @@ RSpec.describe Prog::Storage::RotateKek do
         key_2_id: StorageKeyEncryptionKey.create_random(auth_data: "k2").id)
       expect { described_class.assemble(vol.id) }.to raise_error("a key rotation is already in progress")
     end
-
-    it "fails for a config-v2 (TOML) volume, which is not supported yet" do
-      backend = create_vhost_block_backend(version: "v0.4.0")
-      vol = create_volume(key_1_id: StorageKeyEncryptionKey.create_random(auth_data: "k").id,
-        vhost_block_backend_id: backend.id, vring_workers: 1)
-      expect { described_class.assemble(vol.id) }.to raise_error("config-v2 (TOML) storage KEK rotation is not supported yet")
-    end
   end
 
   describe "#back_up_key" do

--- a/spec/prog/storage/rotate_kek_spec.rb
+++ b/spec/prog/storage/rotate_kek_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe Prog::Storage::RotateKek do
       expect(vol.reload.key_encryption_key_2.auth_data).to eq(vol.device_id)
     end
 
+    it "sets the strand's parent when a parent_id is given" do
+      parent = Strand.create(prog: "Vm::Nexus", label: "wait", stack: [{}])
+      vol = create_volume(key_1_id: StorageKeyEncryptionKey.create_random(auth_data: "somedata").id)
+      strand = described_class.assemble(vol.id, parent_id: parent.id)
+      expect(strand.parent_id).to eq(parent.id)
+    end
+
     it "fails when the volume does not exist" do
       expect { described_class.assemble(VmStorageVolume.generate_uuid) }.to raise_error("storage volume not found")
     end

--- a/spec/prog/test/vm_spec.rb
+++ b/spec/prog/test/vm_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Prog::Test::Vm do
   end
 
   describe "#storage_persistence" do
-    it "creates files on first boot and skips the heavy checks to ping_google" do
+    it "creates files on first boot and continues to rotate_storage_keys" do
       refresh_frame(vm_test, new_values: {"first_boot" => true})
       expect(sshable).to receive(:_cmd).with("mkdir ~/persistence_test")
       (1..5).each do |i|
@@ -85,7 +85,7 @@ RSpec.describe Prog::Test::Vm do
         expect(sshable).to receive(:_cmd).with("head -c 1M /dev/urandom | tee /tmp/persistence-test | sha256sum | awk '{print $1}'").and_return(some_sha256)
         expect(sshable).to receive(:_cmd).with("mv /tmp/persistence-test /home/ubi/persistence_test/#{some_sha256}")
       end
-      expect { vm_test.storage_persistence }.to hop("ping_google")
+      expect { vm_test.storage_persistence }.to hop("rotate_storage_keys")
     end
 
     it "verifies files on subsequent boots and continues to the full suite" do
@@ -111,6 +111,24 @@ RSpec.describe Prog::Test::Vm do
       expect(sshable).to receive(:_cmd).with("sha256sum /home/ubi/persistence_test/sha256_1 | awk '{print $1}'").and_return("different_sha256")
       expect { vm_test.storage_persistence }.to hop("failed")
       expect(strand.reload.exitval).to eq({"msg" => "persistence test: file content mismatch"})
+    end
+  end
+
+  describe "#rotate_storage_keys" do
+    it "assembles a KEK rotation child for each volume and waits" do
+      expect { vm_test.rotate_storage_keys }.to hop("wait_rotate_storage_keys")
+      expect(vm_test.strand.children.map(&:prog)).to eq(["Storage::RotateKek", "Storage::RotateKek"])
+    end
+  end
+
+  describe "#wait_rotate_storage_keys" do
+    it "naps while a rotation child is still running" do
+      Strand.create(prog: "Storage::RotateKek", label: "rotate", stack: [{}], parent_id: vm_test.strand.id)
+      expect { vm_test.wait_rotate_storage_keys }.to nap(10)
+    end
+
+    it "continues to ping_google once the rotations finish" do
+      expect { vm_test.wait_rotate_storage_keys }.to hop("ping_google")
     end
   end
 


### PR DESCRIPTION
### Add aes256gcm_decrypt to StorageKeyEncryption 

This is the inverse of aes256gcm_encrypt, which wraps the config-v2 secrets. KEK rotation for those volumes needs to recover each secret's plaintext before re-wrapping it under the new key.

### Rotate config-v2 (TOML) secrets in StorageVolume 

Teach read_config_dek and rotated_secrets the config-v2 layout, where the wrapped secrets live in a TOML file that perfect_toml now parses. Rotation re-wraps every inline secret the KEK protects, so a volume that also carries archive or remote credentials is carried across the rotation, not just its xts key.

### Enable config-v2 (TOML) KEK rotation 

The host can now rotate config-v2 volumes, so drop the guards that refused them.

### Rotate storage keys before reboot in the VM e2e test 

Rotate every volume's key before the test reboots the VM, so the reboot only succeeds if each volume still opens with its freshly rotated key. This catches a rotation that quietly corrupts a key file.
