### PR TITLE
Backfill WAL segments the old primary did not archive after a failover

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -149,6 +149,7 @@ class PostgresServer < Sequel::Model
       if standby?
         configs[:primary_conninfo] = "'#{resource.replication_connection_string(application_name: ubid)}'"
         configs[:primary_slot_name] = "'#{ubid}'" if physical_slot_ready_id == resource.representative_server.id
+        configs["wal_keep_size"] = (vm.family == "burstable") ? "512MB" : "2GB"
       end
 
       if doing_pitr? && resource.restore_target
@@ -852,7 +853,7 @@ class PostgresServer < Sequel::Model
   REPLICA_LAG_SOFT_THRESHOLD_BYTES = 1024 * 1024 * 1024
   REPLICA_LAG_HARD_THRESHOLD_BYTES = 10 * 1024 * 1024 * 1024
   REPLICA_LAG_THRESHOLD_SECONDS = 15 * 60
-  FAILOVER_LABELS = ["prepare_for_unplanned_take_over", "prepare_for_planned_take_over", "wait_fencing_of_old_primary", "taking_over", "lockout", "wait_lockout_attempt", "wait_representative_lockout"].freeze
+  FAILOVER_LABELS = ["prepare_for_unplanned_take_over", "prepare_for_planned_take_over", "wait_fencing_of_old_primary", "taking_over", "backfill_wal_archive", "lockout", "wait_lockout_attempt", "wait_representative_lockout"].freeze
   CATCH_UP_LABELS = ["wait_catch_up", "wait_synchronization"].freeze
   MIN_ARCHIVAL_RATE_BYTES_PER_SEC = 10 * 1024 * 1024
   DISK_THROUGHPUT_BASELINE_MBPS = {

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -645,12 +645,12 @@ SQL
     end
 
     when_unplanned_take_over_set? do
-      register_deadline("wait", 5 * 60)
+      register_deadline("backfill_wal_archive", 5 * 60)
       hop_prepare_for_unplanned_take_over
     end
 
     when_planned_take_over_set? do
-      register_deadline("wait", 5 * 60)
+      register_deadline("backfill_wal_archive", 5 * 60)
       hop_prepare_for_planned_take_over
     end
 
@@ -922,13 +922,33 @@ SQL
       resource.incr_refresh_dns_record
       resource.server_incr("configure", "configure_metrics", "configure_logs")
       resource.servers.reject(&:primary?).each { it.update(synchronization_status: "catching_up") }
-      hop_finalize_taking_over
+      hop_backfill_wal_archive
     when "Failed"
       vm.sshable.d_run("promote_postgres", "sudo", "postgres/bin/promote", postgres_server.version)
       nap 0
     when "NotStarted"
       vm.sshable.d_run("promote_postgres", "sudo", "postgres/bin/promote", postgres_server.version)
       nap 0
+    end
+
+    nap 5
+  end
+
+  label def backfill_wal_archive
+    register_deadline("wait", 10 * 60)
+    hop_finalize_taking_over if postgres_server.timeline.blob_storage.nil?
+
+    case vm.sshable.d_check("backfill_wal_archive")
+    when "Succeeded"
+      vm.sshable.d_clean("backfill_wal_archive")
+      hop_finalize_taking_over
+    when "Failed"
+      Prog::PageNexus.assemble("#{postgres_server.ubid} WAL archive backfill after failover failed",
+        ["PGWalArchiveBackfillFailed", postgres_server.id], postgres_server.ubid, severity: "warning")
+      vm.sshable.d_clean("backfill_wal_archive")
+      hop_finalize_taking_over
+    when "NotStarted"
+      vm.sshable.d_run("backfill_wal_archive", "sudo", "postgres/bin/backfill-wal-archive", postgres_server.version)
     end
 
     nap 5
@@ -943,7 +963,7 @@ SQL
   label def destroy
     decr_destroy
     # Resolve server-keyed pages so they don't orphan after the server is gone.
-    %w[PGDiskUsageHigh PGRootDiskUsageHigh PGArchivalBacklogHigh PGMetricsBacklogHigh PGIOThrottleStale PGInitializeDatabaseFromBackupFailed PGReplicaLagHigh].each do |tag|
+    %w[PGDiskUsageHigh PGRootDiskUsageHigh PGArchivalBacklogHigh PGMetricsBacklogHigh PGIOThrottleStale PGInitializeDatabaseFromBackupFailed PGReplicaLagHigh PGWalArchiveBackfillFailed].each do |tag|
       Page.from_tag_parts(tag, postgres_server.id)&.incr_resolve
     end
     Semaphore.incr(strand.children_dataset.exclude(prog: "Postgres::PostgresServerNexus").select(:id), "destroy")

--- a/rhizome/postgres/bin/backfill-wal-archive
+++ b/rhizome/postgres/bin/backfill-wal-archive
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "logger"
+require_relative "../lib/wal_archive_backfill"
+
+if ARGV.count != 1
+  fail "Wrong number of arguments. Expected 1, Given #{ARGV.count}"
+end
+
+WalArchiveBackfill.new(Integer(ARGV[0]), Logger.new($stdout)).run

--- a/rhizome/postgres/lib/wal_archive_backfill.rb
+++ b/rhizome/postgres/lib/wal_archive_backfill.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+
+class WalArchiveBackfill
+  WAL_SEGMENT_RE = /\A[0-9A-F]{24}\z/
+
+  def initialize(version, logger, max_segments: 128)
+    @pg_wal_path = "/dat/#{version}/data/pg_wal"
+    @logger = logger
+    @max_segments = max_segments
+  end
+
+  def current_timeline
+    timelines = Dir.glob("#{@pg_wal_path}/*.history").map { |f| File.basename(f, ".history").to_i(16) }
+    fail "no timeline history file in #{@pg_wal_path}" if timelines.empty?
+    timelines.max
+  end
+
+  def candidates
+    timeline = current_timeline
+    Dir.children(@pg_wal_path)
+      .select { |f| WAL_SEGMENT_RE.match?(f) && f[0, 8].to_i(16) < timeline }
+      .max(@max_segments)
+  end
+
+  def run
+    segments = candidates
+    @logger.info("#{segments.count} old-timeline segments to check")
+    uploaded = archived = recycled = 0
+
+    segments.each do |segment|
+      path = File.join(@pg_wal_path, segment)
+
+      unless File.exist?(path)
+        @logger.info("recycled meanwhile: #{segment}")
+        recycled += 1
+        next
+      end
+
+      output = r "sudo -u postgres env WALG_PREVENT_WAL_OVERWRITE=true WALG_UPLOAD_CONCURRENCY=1 wal-g wal-push :path --config /etc/postgresql/wal-g.env 2>&1", path: path
+      if output.include?("already archived")
+        @logger.info("already archived: #{segment}")
+        archived += 1
+      else
+        @logger.info("uploaded: #{segment}")
+        uploaded += 1
+      end
+    end
+
+    @logger.info("done: #{uploaded} uploaded, #{archived} already archived, #{recycled} recycled meanwhile")
+  end
+end

--- a/rhizome/postgres/spec/wal_archive_backfill_spec.rb
+++ b/rhizome/postgres/spec/wal_archive_backfill_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "logger"
+require_relative "../lib/wal_archive_backfill"
+
+RSpec.describe WalArchiveBackfill do
+  let(:logger) { instance_double(Logger, info: nil) }
+  let(:backfill) { described_class.new(17, logger, max_segments: 3) }
+  let(:pg_wal) { "/dat/17/data/pg_wal" }
+
+  describe "#current_timeline" do
+    it "reads the newest history file" do
+      expect(Dir).to receive(:glob).with("#{pg_wal}/*.history").and_return(["#{pg_wal}/00000007.history", "#{pg_wal}/00000010.history", "#{pg_wal}/00000008.history"])
+      expect(backfill.current_timeline).to eq(16)
+    end
+
+    it "fails when there is no history file" do
+      expect(Dir).to receive(:glob).with("#{pg_wal}/*.history").and_return([])
+      expect { backfill.current_timeline }.to raise_error(RuntimeError, "no timeline history file in /dat/17/data/pg_wal")
+    end
+  end
+
+  describe "#candidates" do
+    it "returns complete segments from older timelines, newest first, up to the cap" do
+      expect(backfill).to receive(:current_timeline).and_return(8)
+      expect(Dir).to receive(:children).with(pg_wal).and_return([
+        "00000008.history",
+        "00000007000002F2000000B5.partial",
+        "00000008000002F2000000B5",
+        "00000008000002F2000000B6",
+        "00000007000002F2000000B1",
+        "00000007000002F2000000B4",
+        "00000007000002F2000000B2",
+        "00000006000002F2000000A9",
+        "00000007000002F2000000B3",
+        "archive_status",
+      ])
+      expect(backfill.candidates).to eq(["00000007000002F2000000B4", "00000007000002F2000000B3", "00000007000002F2000000B2"])
+    end
+  end
+
+  describe "#run" do
+    it "pushes the candidates that still exist and reports which ones wal-g actually uploaded" do
+      expect(backfill).to receive(:candidates).and_return(["00000007000002F2000000B4", "00000007000002F2000000B3", "00000007000002F2000000B2"])
+      expect(File).to receive(:exist?).with("#{pg_wal}/00000007000002F2000000B4").and_return(true)
+      expect(File).to receive(:exist?).with("#{pg_wal}/00000007000002F2000000B3").and_return(true)
+      expect(File).to receive(:exist?).with("#{pg_wal}/00000007000002F2000000B2").and_return(false)
+      expect(backfill).to receive(:_run_command).with(
+        "sudo -u postgres env WALG_PREVENT_WAL_OVERWRITE=true WALG_UPLOAD_CONCURRENCY=1 wal-g wal-push #{pg_wal}/00000007000002F2000000B4 --config /etc/postgresql/wal-g.env 2>&1",
+      ).and_return("INFO: 2026/08/24 21:43:56.354760 FILE PATH: 00000007000002F2000000B4.lz4\n")
+      expect(backfill).to receive(:_run_command).with(
+        "sudo -u postgres env WALG_PREVENT_WAL_OVERWRITE=true WALG_UPLOAD_CONCURRENCY=1 wal-g wal-push #{pg_wal}/00000007000002F2000000B3 --config /etc/postgresql/wal-g.env 2>&1",
+      ).and_return("INFO: 2026/08/24 21:43:57.100000 WAL file '#{pg_wal}/00000007000002F2000000B3' already archived with equal content, skipping\n")
+      expect(logger).to receive(:info).with("3 old-timeline segments to check")
+      expect(logger).to receive(:info).with("uploaded: 00000007000002F2000000B4")
+      expect(logger).to receive(:info).with("already archived: 00000007000002F2000000B3")
+      expect(logger).to receive(:info).with("recycled meanwhile: 00000007000002F2000000B2")
+      expect(logger).to receive(:info).with("done: 1 uploaded, 1 already archived, 1 recycled meanwhile")
+      backfill.run
+    end
+  end
+end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -112,6 +112,17 @@ RSpec.describe PostgresServer do
       expect(postgres_server.configure_hash[:configs]).to include(:primary_conninfo, :restore_command)
     end
 
+    it "keeps more WAL on standbys so the archive can be backfilled after a failover" do
+      expect(postgres_server.configure_hash[:configs]).to include("wal_keep_size" => "96MB")
+
+      postgres_server.timeline_access = "fetch"
+      expect(resource).to receive(:replication_connection_string).with(application_name: postgres_server.ubid).twice
+      expect(postgres_server.configure_hash[:configs]).to include("wal_keep_size" => "2GB")
+
+      postgres_server.vm.update(family: "burstable")
+      expect(postgres_server.configure_hash[:configs]).to include("wal_keep_size" => "512MB")
+    end
+
     it "sets configs that are specific to PITR-by-time restore" do
       postgres_server.update(timeline_access: "fetch")
       resource.update(restore_target: Time.now)
@@ -1071,6 +1082,11 @@ RSpec.describe PostgresServer do
   describe "#taking_over?" do
     it "returns true if the strand label is 'taking_over'" do
       expect(postgres_server).to receive(:strand).and_return(instance_double(Strand, label: "taking_over"))
+      expect(postgres_server.taking_over?).to be true
+    end
+
+    it "returns true if the strand label is 'backfill_wal_archive'" do
+      Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "backfill_wal_archive")
       expect(postgres_server.taking_over?).to be true
     end
 

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -1315,13 +1315,13 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
     it "hops to prepare_for_unplanned_take_over if take_over is set" do
       nx.incr_unplanned_take_over
-      expect(nx).to receive(:register_deadline).with("wait", 5 * 60)
+      expect(nx).to receive(:register_deadline).with("backfill_wal_archive", 5 * 60)
       expect { nx.wait }.to hop("prepare_for_unplanned_take_over")
     end
 
     it "hops to prepare_for_planned_take_over if take_over is set" do
       nx.incr_planned_take_over
-      expect(nx).to receive(:register_deadline).with("wait", 5 * 60)
+      expect(nx).to receive(:register_deadline).with("backfill_wal_archive", 5 * 60)
       expect { nx.wait }.to hop("prepare_for_planned_take_over")
     end
 
@@ -1754,6 +1754,48 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
   end
 
+  describe "#backfill_wal_archive" do
+    let(:minio_cluster) { MinioCluster.create(project_id: Config.postgres_service_project_id, location_id:, name: "pgminio", admin_user: "root", admin_password: "root") }
+
+    it "registers a deadline to reach wait and skips to finalize_taking_over when there is no blob storage" do
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60)
+      expect { nx.backfill_wal_archive }.to hop("finalize_taking_over")
+    end
+
+    it "starts the backfill if it is not started yet" do
+      minio_cluster
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60)
+      expect(sshable).to receive(:d_check).with("backfill_wal_archive").and_return("NotStarted")
+      expect(sshable).to receive(:d_run).with("backfill_wal_archive", "sudo", "postgres/bin/backfill-wal-archive", "18")
+      expect { nx.backfill_wal_archive }.to nap(5)
+    end
+
+    it "naps while the backfill is in progress" do
+      minio_cluster
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60)
+      expect(sshable).to receive(:d_check).with("backfill_wal_archive").and_return("InProgress")
+      expect { nx.backfill_wal_archive }.to nap(5)
+    end
+
+    it "hops to finalize_taking_over when the backfill succeeds" do
+      minio_cluster
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60)
+      expect(sshable).to receive(:d_check).with("backfill_wal_archive").and_return("Succeeded")
+      expect(sshable).to receive(:d_clean).with("backfill_wal_archive")
+      expect { nx.backfill_wal_archive }.to hop("finalize_taking_over")
+      expect(Page.from_tag_parts("PGWalArchiveBackfillFailed", server.id)).to be_nil
+    end
+
+    it "pages and hops to finalize_taking_over when the backfill fails" do
+      minio_cluster
+      expect(nx).to receive(:register_deadline).with("wait", 10 * 60)
+      expect(sshable).to receive(:d_check).with("backfill_wal_archive").and_return("Failed")
+      expect(sshable).to receive(:d_clean).with("backfill_wal_archive")
+      expect { nx.backfill_wal_archive }.to hop("finalize_taking_over")
+      expect(Page.from_tag_parts("PGWalArchiveBackfillFailed", server.id).severity).to eq("warning")
+    end
+  end
+
   describe "#finalize_taking_over" do
     it "hops to configure" do
       expect { nx.finalize_taking_over }.to hop("configure")
@@ -1775,7 +1817,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect { nx.taking_over }.to nap(0)
     end
 
-    it "updates the metadata and hops to finalize_taking_over if promote command is succeeded" do
+    it "updates the metadata and hops to backfill_wal_archive if promote command is succeeded" do
       postgres_server
       standby = create_postgres_server(resource: postgres_resource, timeline: postgres_timeline, is_representative: false)
       standby_nx = described_class.new(standby.strand)
@@ -1783,7 +1825,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
       expect(standby_sshable).to receive(:d_check).with("promote_postgres").and_return("Succeeded")
 
-      expect { standby_nx.taking_over }.to hop("finalize_taking_over")
+      expect { standby_nx.taking_over }.to hop("backfill_wal_archive")
 
       postgres_server.reload
       expect(Semaphore.where(strand_id: postgres_server.id, name: "destroy").count).to eq(1)
@@ -1834,7 +1876,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
     end
 
     it "resolves server-keyed pages so they do not orphan after the server is gone" do
-      tags = %w[PGDiskUsageHigh PGRootDiskUsageHigh PGArchivalBacklogHigh PGMetricsBacklogHigh PGIOThrottleStale PGInitializeDatabaseFromBackupFailed PGReplicaLagHigh]
+      tags = %w[PGDiskUsageHigh PGRootDiskUsageHigh PGArchivalBacklogHigh PGMetricsBacklogHigh PGIOThrottleStale PGInitializeDatabaseFromBackupFailed PGReplicaLagHigh PGWalArchiveBackfillFailed]
       pages = tags.map { Prog::PageNexus.assemble("#{postgres_server.ubid} #{it}", [it, postgres_server.id], postgres_server.ubid).subject }
 
       expect { nx.destroy }.to hop("wait_children_destroy")


### PR DESCRIPTION
After a failover, WAL segments that the old primary generated and streamed to the standby, but did not get to archive before it went away, are missing from the archive. PostgreSQL never fills that hole: with archive_mode=on the walreceiver marks every streamed segment .done as soon as it is complete, that marker survives promotion, and the archiver only looks at .ready files. Promotion itself only archives the .partial switch segment and the history file. A new standby built from a backup taken on the old timeline then stalls on the missing segment (recovery does not look at the new timeline's copy for segments before the switch), and PITR into that window is broken as well.

Add a backfill_wal_archive step between taking_over and finalize_taking_over. It runs postgres/bin/backfill-wal-archive on the promoted server, which pushes the complete old-timeline segments still in pg_wal with wal-g. The push runs with WALG_PREVENT_WAL_OVERWRITE so segments the old primary did archive are only fetched and compared, not re-uploaded, and a content mismatch fails instead of overwriting. It is capped at 128 segments and wrapped in a timeout; a failure pages and the failover proceeds.

The step runs after promotion so it adds nothing to the outage and can rely on PostgreSQL having already removed old-timeline files past the switch point and renamed the switch segment to .partial. The checkpoint that promotion requests would recycle those segments, so standbys now keep wal_keep_size at 2GB, which restartpoints honor as well; the post-failover configure lowers it back once the backfill is done.