### PR TITLE
Schedule the runner strand when its vm is provisioned

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -179,6 +179,14 @@ SQL
     end
   end
 
+  # Dispatch the strand as soon as possible, for use by a strand that
+  # finished work another strand waits for. A strand that is already
+  # overdue keeps its schedule, so waking it cannot demote it.
+  def self.wakeup(id)
+    return unless id
+    where(id:).update(schedule: SCHEDULE_NO_LATER_THAN_NOW)
+  end
+
   def self.prog_verify(prog)
     case prog.name
     when /\AProg::(.*)\z/

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -107,6 +107,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       private_subnet_id: ps.id,
       alternative_families:,
       use_eip: false,
+      waiting_strand_id: strand.id,
     )
 
     vm_st.subject
@@ -443,10 +444,10 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
   end
 
   label def wait_vm
-    # If the vm is not allocated yet, we know that the vm provisioning will take
-    # definitely more than 10 seconds.
-    nap 10 unless vm.allocated_at
-    nap 1 unless vm.provisioned_at
+    # The vm prog schedules this strand once the vm is ready, so the nap is only
+    # a fallback for a signal we never receive.
+    nap 10 unless vm.provisioned_at
+
     register_deadline("wait", 10 * 60)
     hop_setup_environment
   end

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -370,7 +370,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
 
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, instance_id: vm.aws_instance.instance_id, duration: (Time.now - vm.allocated_at).round(3)}}])
 
-    Strand.where(id: waiting_strand_id).update(schedule: Sequel::CURRENT_TIMESTAMP) if waiting_strand_id
+    Strand.wakeup(waiting_strand_id)
 
     project = vm.project
     hop_wait unless project.billable

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -2,7 +2,7 @@
 
 class Prog::Vm::Aws::Nexus < Prog::Base
   subject_is :vm, :aws_instance
-  frame_reader :alternative_families, :private_subnet_id
+  frame_reader :alternative_families, :private_subnet_id, :waiting_strand_id
   frame_accessor :unsupported_azs, :exclude_availability_zones, :use_separate_management_nic
 
   def before_destroy
@@ -369,6 +369,8 @@ class Prog::Vm::Aws::Nexus < Prog::Base
     vm.update(display_state: "running", provisioned_at: Time.now)
 
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, instance_id: vm.aws_instance.instance_id, duration: (Time.now - vm.allocated_at).round(3)}}])
+
+    Strand.where(id: waiting_strand_id).update(schedule: Sequel::CURRENT_TIMESTAMP) if waiting_strand_id
 
     project = vm.project
     hop_wait unless project.billable

--- a/prog/vm/gcp/nexus.rb
+++ b/prog/vm/gcp/nexus.rb
@@ -4,7 +4,7 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
   include GcpLro
 
   subject_is :vm
-  frame_reader :unsupported_azs
+  frame_reader :unsupported_azs, :waiting_strand_id
   frame_accessor :retry_zone_delay, :gcp_zone_suffix, :exclude_zones
 
   def before_destroy
@@ -233,6 +233,8 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
     vm.update(display_state: "running", provisioned_at: time)
 
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, duration: (time - vm.allocated_at).round(3)}}])
+
+    Strand.where(id: waiting_strand_id).update(schedule: Sequel::CURRENT_TIMESTAMP) if waiting_strand_id
 
     project = vm.project
     hop_wait unless project.billable

--- a/prog/vm/gcp/nexus.rb
+++ b/prog/vm/gcp/nexus.rb
@@ -234,7 +234,7 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
 
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, duration: (time - vm.allocated_at).round(3)}}])
 
-    Strand.where(id: waiting_strand_id).update(schedule: Sequel::CURRENT_TIMESTAMP) if waiting_strand_id
+    Strand.wakeup(waiting_strand_id)
 
     project = vm.project
     hop_wait unless project.billable

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -209,7 +209,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     vm.update(display_state: "running", provisioned_at: Time.now)
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: (Time.now - vm.allocated_at).round(3)}}])
 
-    Strand.where(id: waiting_strand_id).update(schedule: Sequel::CURRENT_TIMESTAMP) if waiting_strand_id
+    Strand.wakeup(waiting_strand_id)
 
     hop_wait
   end

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -7,7 +7,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
 
   subject_is :vm
   frame_reader :distinct_storage_devices, :exclude_host_ids, :exclude_data_centers, :gpu_count, :gpu_device,
-    :force_host_id, :storage_volumes
+    :force_host_id, :storage_volumes, :waiting_strand_id
   frame_accessor :reason_determined
 
   def vm_name
@@ -208,6 +208,8 @@ class Prog::Vm::Metal::Nexus < Prog::Base
 
     vm.update(display_state: "running", provisioned_at: Time.now)
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: (Time.now - vm.allocated_at).round(3)}}])
+
+    Strand.where(id: waiting_strand_id).update(schedule: Sequel::CURRENT_TIMESTAMP) if waiting_strand_id
 
     hop_wait
   end

--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -13,7 +13,8 @@ class Prog::Vm::Nexus < Prog::Base
     hugepages: true, hypervisor: nil, ch_version: nil, firmware_version: nil, new_private_subnet_name: nil,
     exclude_availability_zones: [], availability_zone: nil, alternative_families: [],
     allow_private_subnet_in_other_project: false, init_script: nil, exclude_data_centers: [],
-    use_separate_management_nic: false, use_eip: true, remote_storage_server_id: nil)
+    use_separate_management_nic: false, use_eip: true, remote_storage_server_id: nil,
+    waiting_strand_id: nil)
 
     unless (project = Project[project_id])
       fail "No existing project"
@@ -204,6 +205,7 @@ class Prog::Vm::Nexus < Prog::Base
           "firmware_version" => firmware_version,
           "alternative_families" => alternative_families,
           "private_subnet_id" => subnet.id,
+          "waiting_strand_id" => waiting_strand_id,
           "use_separate_management_nic" => use_separate_management_nic,
           # AZs permanently excluded: seeded from multi-AZ policy (use_different_az),
           # grows with Unsupported errors at runtime. Never cleared during retries.

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -123,9 +123,7 @@ class Prog::Vnet::CertNexus < Prog::Base
     when "valid"
       cert.update(cert: acme_order.certificate, created_at: Time.now)
       cleanup_dns_challenge_records
-      if (waiting_strand_id = frame["waiting_strand_id"])
-        Strand.where(id: waiting_strand_id).update(schedule: Sequel::CURRENT_TIMESTAMP)
-      end
+      Strand.wakeup(frame["waiting_strand_id"])
       hop_wait
     else
       Clog.emit("Certificate finalization failed", {order_status:})

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -131,6 +131,29 @@ RSpec.describe Strand do
     expect(Semaphore.where(strand_id: st.id, name: "late_signal")).not_to be_empty
   end
 
+  it "wakes up a strand scheduled in the future" do
+    st.update(schedule: Time.now + 10000)
+
+    described_class.wakeup(st.id)
+
+    expect(st.reload.schedule).to be_within(10).of(Time.now)
+  end
+
+  it "keeps the schedule of an overdue strand on wakeup" do
+    schedule = Time.now - 100
+    st.update(schedule:)
+
+    described_class.wakeup(st.id)
+
+    expect(st.reload.schedule).to be_within(1).of(schedule)
+  end
+
+  it "does nothing when there is no strand waiting" do
+    st.update(schedule: Time.now + 10000)
+
+    expect { described_class.wakeup(nil) }.not_to change { st.reload.schedule }
+  end
+
   it "logs end of strand if it took long" do
     now = Time.now
     st.label = "napper"

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(vm.id).not_to eq(picked_vm.id)
       expect(picked_vm.pool_id).to be_nil
       expect(picked_vm.vm_storage_volumes.first.track_written).to be(false)
+      expect(picked_vm.strand.stack.first["waiting_strand_id"]).to eq(runner.id)
     end
 
     it "uses alien vms by given ratio" do
@@ -602,14 +603,9 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
   end
 
   describe "#wait_vm" do
-    it "naps 10 seconds if vm is not allocated yet" do
-      vm.update(allocated_at: nil)
+    it "naps until the vm prog schedules it if the vm is not provisioned yet" do
+      vm.update(provisioned_at: nil)
       expect { nx.wait_vm }.to nap(10)
-    end
-
-    it "naps a second if vm is allocated but not provisioned yet" do
-      vm.update(allocated_at: now)
-      expect { nx.wait_vm }.to nap(1)
     end
 
     it "hops if vm is ready" do

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -992,6 +992,14 @@ usermod -L ubuntu
       expect(vm.active_billing_records.first.billing_rate["resource_type"]).to eq("VmVCpu")
       expect(vm.provisioned_at).to be_within(1).of(now)
     end
+
+    it "schedules the waiting strand if the frame has one" do
+      waiting_strand = Strand.create(prog: "Test", label: "start", schedule: Time.now + 10000)
+      refresh_frame(nx, new_values: {"waiting_strand_id" => waiting_strand.id})
+
+      expect { nx.create_billing_record }.to hop("wait")
+      expect(waiting_strand.reload.schedule).to be_within(10).of(Time.now)
+    end
   end
 
   describe "#wait" do

--- a/spec/prog/vm/gcp/nexus_spec.rb
+++ b/spec/prog/vm/gcp/nexus_spec.rb
@@ -922,6 +922,14 @@ RSpec.describe Prog::Vm::Gcp::Nexus do
       expect(vm.active_billing_records.first.billing_rate["resource_type"]).to eq("VmVCpu")
       expect(vm.provisioned_at).to be_within(2).of(Time.now)
     end
+
+    it "schedules the waiting strand if the frame has one" do
+      waiting_strand = Strand.create(prog: "Test", label: "start", schedule: Time.now + 10000)
+      refresh_frame(nx, new_values: {"waiting_strand_id" => waiting_strand.id})
+
+      expect { nx.create_billing_record }.to hop("wait")
+      expect(waiting_strand.reload.schedule).to be_within(10).of(Time.now)
+    end
   end
 
   describe "#wait" do

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -1042,6 +1042,16 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       expect(vm.reload.display_state).to eq("running")
       expect(vm.provisioned_at).to be_within(10).of(Time.now)
     end
+
+    it "schedules the waiting strand if the frame has one" do
+      vm.update(allocated_at: Time.now - 100)
+      vm.incr_update_firewall_rules
+      waiting_strand = Strand.create(prog: "Test", label: "start", schedule: Time.now + 10000)
+      refresh_frame(nx, new_values: {"waiting_strand_id" => waiting_strand.id})
+
+      expect { nx.wait_sshable }.to hop("wait")
+      expect(waiting_strand.reload.schedule).to be_within(10).of(Time.now)
+    end
   end
 
   describe "#wait_storage_catchup" do

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe Prog::Vnet::CertNexus do
     end
 
     it "schedules waiting strand if waiting_strand_id is set" do
-      waiting_strand = Strand.create(prog: "Test", label: "start", schedule: Time.now - 10000)
+      waiting_strand = Strand.create(prog: "Test", label: "start", schedule: Time.now + 10000)
       refresh_frame(nx, new_values: {"waiting_strand_id" => waiting_strand.id})
       expect(@acme_order).to receive(:status).and_return("valid")
       expect(@acme_order).to receive(:certificate).and_return("test-certificate")


### PR DESCRIPTION
wait_vm polled every second while the vm prog provisioned the vm, so a
runner woke up once per second for the whole provisioning time, and each
wake up is a full strand dispatch: take the lease, reload the strand,
snapshot the semaphores, write the new schedule.

Vm::Nexus.assemble now takes a waiting_strand_id and keeps it in the
stack, the same way CertNexus has since https://github.com/ubicloud/ubicloud/commit/94500c921edf5da3c1b94cf7e2352b87aa3c0604, and both vm progs
schedule that strand once they record provisioned_at. The runner passes
its own strand, so it starts within a dispatcher scan of the vm becoming
sshable rather than up to a second later.

The nap in wait_vm stays as a fallback for a schedule we never receive.
A vm taken from a pool carries provisioned_at from the time the pool
created it, so it hops out of wait_vm on the first run.