### PR TITLE
Coerce lscpu cpu/node fields to Integer in LearnCpu

### DIFF
--- a/prog/learn_cpu.rb
+++ b/prog/learn_cpu.rb
@@ -16,7 +16,7 @@ class Prog::LearnCpu < Prog::Base
     total_cpus = parsed.count
     sockets = parsed.map { |socket, _| socket }.uniq.count
     cores = parsed.uniq.count
-    cpu_numa_nodes = cpus.sort_by! { |cpu| cpu.fetch("cpu") }.map! { |cpu| cpu["node"] }
+    cpu_numa_nodes = cpus.sort_by! { |cpu| cpu.fetch("cpu").to_i }.map! { |cpu| cpu["node"]&.to_i }
 
     {total_cpus:, total_cores: cores, total_sockets: sockets, cpu_numa_nodes:}
   end

--- a/spec/prog/learn_cpu_spec.rb
+++ b/spec/prog/learn_cpu_spec.rb
@@ -58,6 +58,64 @@ RSpec.describe Prog::LearnCpu do
 JSON
   end
 
+  # Ubuntu 22.04's older util-linux quotes every lscpu field, including
+  # "cpu" and "node", as a JSON string, and lists cpus out of numeric
+  # order across sockets/NUMA nodes.
+  let(:twelve_thread_six_core_two_numa_two_socket_string_fields) do
+    <<JSON
+{
+   "cpus": [
+      {"cpu": "0", "node": "0", "socket": "0", "core": "0", "l1d:l1i:l2:l3": "0:0:0:0", "online": "yes", "maxmhz": "3200.0000", "minmhz": "800.0000", "mhz": "800.000"},
+      {"cpu": "1", "node": "0", "socket": "0", "core": "0", "l1d:l1i:l2:l3": "0:0:0:0", "online": "yes", "maxmhz": "3200.0000", "minmhz": "800.0000", "mhz": "3100.000"},
+      {"cpu": "2", "node": "0", "socket": "0", "core": "1", "l1d:l1i:l2:l3": "1:1:1:0", "online": "yes", "maxmhz": "3200.0000", "minmhz": "800.0000", "mhz": "800.000"},
+      {"cpu": "3", "node": "0", "socket": "0", "core": "1", "l1d:l1i:l2:l3": "1:1:1:0", "online": "yes", "maxmhz": "3200.0000", "minmhz": "800.0000", "mhz": "2900.000"},
+      {"cpu": "10", "node": "1", "socket": "1", "core": "4", "l1d:l1i:l2:l3": "4:4:4:1", "online": "yes", "maxmhz": "3200.0000", "minmhz": "800.0000", "mhz": "800.000"},
+      {"cpu": "11", "node": "1", "socket": "1", "core": "4", "l1d:l1i:l2:l3": "4:4:4:1", "online": "yes", "maxmhz": "3200.0000", "minmhz": "800.0000", "mhz": "2700.000"},
+      {"cpu": "4", "node": "1", "socket": "1", "core": "2", "l1d:l1i:l2:l3": "2:2:2:1", "online": "yes", "maxmhz": "3200.0000", "minmhz": "800.0000", "mhz": "800.000"},
+      {"cpu": "5", "node": "1", "socket": "1", "core": "2", "l1d:l1i:l2:l3": "2:2:2:1", "online": "yes", "maxmhz": "3200.0000", "minmhz": "800.0000", "mhz": "2600.000"},
+      {"cpu": "6", "node": "0", "socket": "0", "core": "3", "l1d:l1i:l2:l3": "3:3:3:0", "online": "yes", "maxmhz": "3200.0000", "minmhz": "800.0000", "mhz": "800.000"},
+      {"cpu": "7", "node": "0", "socket": "0", "core": "3", "l1d:l1i:l2:l3": "3:3:3:0", "online": "yes", "maxmhz": "3200.0000", "minmhz": "800.0000", "mhz": "3000.000"},
+      {"cpu": "8", "node": "1", "socket": "1", "core": "5", "l1d:l1i:l2:l3": "5:5:5:1", "online": "yes", "maxmhz": "3200.0000", "minmhz": "800.0000", "mhz": "800.000"},
+      {"cpu": "9", "node": "1", "socket": "1", "core": "5", "l1d:l1i:l2:l3": "5:5:5:1", "online": "yes", "maxmhz": "3200.0000", "minmhz": "800.0000", "mhz": "2800.000"}
+   ]
+}
+JSON
+  end
+
+  # Ubuntu 24.04's util-linux emits numeric lscpu fields as JSON numbers,
+  # and includes extra columns LearnCpu doesn't use.
+  let(:eight_thread_four_core_two_numa_two_socket_numeric_fields) do
+    <<JSON
+{
+   "cpus": [
+      {"cpu": 0, "node": 0, "socket": 0, "core": 0, "l1d:l1i:l2:l3": "0:0:0:0", "online": true, "maxmhz": 5300.0000, "minmhz": 400.0000, "mhz": 4312.5000},
+      {"cpu": 1, "node": 0, "socket": 0, "core": 0, "l1d:l1i:l2:l3": "0:0:0:0", "online": true, "maxmhz": 5300.0000, "minmhz": 400.0000, "mhz": 400.0000},
+      {"cpu": 2, "node": 0, "socket": 0, "core": 1, "l1d:l1i:l2:l3": "1:1:1:0", "online": true, "maxmhz": 5300.0000, "minmhz": 400.0000, "mhz": 4801.2200},
+      {"cpu": 3, "node": 0, "socket": 0, "core": 1, "l1d:l1i:l2:l3": "1:1:1:0", "online": true, "maxmhz": 5300.0000, "minmhz": 400.0000, "mhz": 400.0000},
+      {"cpu": 4, "node": 1, "socket": 1, "core": 2, "l1d:l1i:l2:l3": "2:2:2:1", "online": true, "maxmhz": 5300.0000, "minmhz": 400.0000, "mhz": 4600.3300},
+      {"cpu": 5, "node": 1, "socket": 1, "core": 2, "l1d:l1i:l2:l3": "2:2:2:1", "online": true, "maxmhz": 5300.0000, "minmhz": 400.0000, "mhz": 400.0000},
+      {"cpu": 6, "node": 1, "socket": 1, "core": 3, "l1d:l1i:l2:l3": "3:3:3:1", "online": true, "maxmhz": 5300.0000, "minmhz": 400.0000, "mhz": 4700.4400},
+      {"cpu": 7, "node": 1, "socket": 1, "core": 3, "l1d:l1i:l2:l3": "3:3:3:1", "online": true, "maxmhz": 5300.0000, "minmhz": 400.0000, "mhz": 400.0000}
+   ]
+}
+JSON
+  end
+
+  # Hosts without NUMA support at the kernel/sysfs level (no
+  # /sys/devices/system/node) omit the "node" field entirely.
+  let(:four_thread_two_core_no_numa) do
+    <<JSON
+{
+   "cpus": [
+      {"cpu": 0, "socket": 0, "core": 0},
+      {"cpu": 1, "socket": 0, "core": 0},
+      {"cpu": 2, "socket": 0, "core": 1},
+      {"cpu": 3, "socket": 0, "core": 1}
+   ]
+}
+JSON
+  end
+
   describe "#get_arch" do
     it "returns the architecture" do
       expect(lc.sshable).to receive(:_cmd).with("common/bin/arch").and_return("x64")
@@ -76,6 +134,27 @@ JSON
         eight_thread_four_core_four_numa_two_socket,
       )
       expect(lc.get_topology).to eq({total_cpus: 8, total_cores: 4, total_sockets: 2, cpu_numa_nodes: [0, 0, 1, 1, 2, 2, 3, 3]})
+    end
+
+    it "ignores extra lscpu columns and a boolean online field (Ubuntu 24.04-style output)" do
+      expect(lc.sshable).to receive(:_cmd).with("/usr/bin/lscpu -Jye").and_return(
+        eight_thread_four_core_two_numa_two_socket_numeric_fields,
+      )
+      expect(lc.get_topology).to eq({total_cpus: 8, total_cores: 4, total_sockets: 2, cpu_numa_nodes: [0, 0, 0, 0, 1, 1, 1, 1]})
+    end
+
+    it "coerces string cpu/node fields to integers and sorts numerically, not lexicographically (Ubuntu 22.04-style output)" do
+      expect(lc.sshable).to receive(:_cmd).with("/usr/bin/lscpu -Jye").and_return(
+        twelve_thread_six_core_two_numa_two_socket_string_fields,
+      )
+      expect(lc.get_topology).to eq(
+        {total_cpus: 12, total_cores: 6, total_sockets: 2, cpu_numa_nodes: [0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1]},
+      )
+    end
+
+    it "reports nil numa nodes when the host has no NUMA data at all" do
+      expect(lc.sshable).to receive(:_cmd).with("/usr/bin/lscpu -Jye").and_return(four_thread_two_core_no_numa)
+      expect(lc.get_topology).to eq({total_cpus: 4, total_cores: 2, total_sockets: 1, cpu_numa_nodes: [nil, nil, nil, nil]})
     end
   end
 


### PR DESCRIPTION
## Summary
- Ubuntu 22.04's util-linux quotes lscpu -Jye's "cpu" and "node" fields as JSON strings, unlike 24.04's, which emits them as numbers.
- Sorting by the raw string "cpu" value orders CPUs lexicographically instead of numerically, misassigning numa_node values across CPUs.
- String-typed numa_node values also fail to persist: Sequel.case renders them as SQL string literals, which Postgres rejects against vm_host_cpu.numa_node's integer column with a PG::DatatypeMismatch error.
- Coerce both fields with .to_i/&.to_i so the sort and resulting numa_node values are correct regardless of which lscpu version reports them.