### PR TITLE
Only pick rollout initial hosts with a free IPv4

### DIFF
--- a/prog/rollout_rhizome.rb
+++ b/prog/rollout_rhizome.rb
@@ -12,14 +12,18 @@ class Prog::RolloutRhizome < Prog::Base
       .where(allocation_state: "accepting")
       .where { total_cores >= used_cores + 4 }
 
-    initial_vm_host_ds = vm_host_ds.where(
-      DB[:ipv4_address]
-        .left_join(:assigned_vm_address, [:ip])
-        .join(:address, [:cidr])
-        .where(Sequel[:assigned_vm_address][:ip] => nil)
-        .where(Sequel[:address][:routed_to_host_id] => Sequel[:vm_host][:id])
-        .exists,
-    )
+    vm_memory_gib = Option::VmSizes.find { it.name == Prog::Vm::Nexus::DEFAULT_SIZE && it.arch == "x64" }.memory_gib
+
+    initial_vm_host_ds = vm_host_ds
+      .where { total_hugepages_1g >= used_hugepages_1g + vm_memory_gib }
+      .where(
+        DB[:ipv4_address]
+          .left_join(:assigned_vm_address, [:ip])
+          .join(:address, [:cidr])
+          .where(Sequel[:assigned_vm_address][:ip] => nil)
+          .where(Sequel[:address][:routed_to_host_id] => Sequel[:vm_host][:id])
+          .exists,
+      )
 
     initial_host_ids = [
       initial_vm_host_ds.where(location_id: Location::HETZNER_FSN1_ID).get(:id),

--- a/prog/rollout_rhizome.rb
+++ b/prog/rollout_rhizome.rb
@@ -12,9 +12,18 @@ class Prog::RolloutRhizome < Prog::Base
       .where(allocation_state: "accepting")
       .where { total_cores >= used_cores + 4 }
 
+    initial_vm_host_ds = vm_host_ds.where(
+      DB[:ipv4_address]
+        .left_join(:assigned_vm_address, [:ip])
+        .join(:address, [:cidr])
+        .where(Sequel[:assigned_vm_address][:ip] => nil)
+        .where(Sequel[:address][:routed_to_host_id] => Sequel[:vm_host][:id])
+        .exists,
+    )
+
     initial_host_ids = [
-      vm_host_ds.where(location_id: Location::HETZNER_FSN1_ID).get(:id),
-      vm_host_ds.where(location_id: Location::LEASEWEB_WDC02_ID).get(:id),
+      initial_vm_host_ds.where(location_id: Location::HETZNER_FSN1_ID).get(:id),
+      initial_vm_host_ds.where(location_id: Location::LEASEWEB_WDC02_ID).get(:id),
     ]
     initial_host_ids.compact!
 

--- a/spec/prog/rollout_rhizome_spec.rb
+++ b/spec/prog/rollout_rhizome_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe Prog::RolloutRhizome do
 
   let(:st) {
     vm_hosts
+    [fsn1_host, wdc2_host].each_with_index do |h, i|
+      Address.create(cidr: "1.#{i + 1}.1.0/30", routed_to_host_id: h.id).populate_ipv4_addresses
+    end
     described_class.assemble(vm_project_id: project_id)
   }
   let(:project_id) { Project.create(name: "RolloutRhizomeTest").id }
@@ -50,6 +53,27 @@ RSpec.describe Prog::RolloutRhizome do
       remaining_host_ids.delete(hel1_host.id)
 
       expect(ghr_hosts.map(&:id).sort!).to eq((frame["initial_github_runner_host_ids"] << remaining_host_ids.first).sort!)
+    end
+
+    it "skips an initial location whose host has no available IPv4 address" do
+      fsn1_host
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: wdc2_host.id).populate_ipv4_addresses
+      st = described_class.assemble(vm_project_id: project_id)
+
+      expect(st.stack.first["initial_host_ids"]).to eq([wdc2_host.id])
+    end
+
+    it "skips an initial host whose IPv4 pool is fully assigned" do
+      vm = create_vm
+      fsn1_address = Address.create(cidr: "1.1.1.0/30", routed_to_host_id: fsn1_host.id)
+      fsn1_address.populate_ipv4_addresses
+      fsn1_address.cidr.len.times do |i|
+        AssignedVmAddress.create(dst_vm_id: vm.id, ip: fsn1_address.cidr.nth(i).to_s, address_id: fsn1_address.id)
+      end
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: wdc2_host.id).populate_ipv4_addresses
+      st = described_class.assemble(vm_project_id: project_id)
+
+      expect(st.stack.first["initial_host_ids"]).to eq([wdc2_host.id])
     end
 
     it "respects Config.rollouts_project_id and auto_exit and started_by argument" do

--- a/spec/prog/rollout_rhizome_spec.rb
+++ b/spec/prog/rollout_rhizome_spec.rb
@@ -76,6 +76,15 @@ RSpec.describe Prog::RolloutRhizome do
       expect(st.stack.first["initial_host_ids"]).to eq([wdc2_host.id])
     end
 
+    it "skips an initial host without enough free hugepages for the rollout VM" do
+      fsn1_host.update(total_hugepages_1g: 8, used_hugepages_1g: 8)
+      Address.create(cidr: "1.1.1.0/30", routed_to_host_id: fsn1_host.id).populate_ipv4_addresses
+      Address.create(cidr: "2.1.1.0/30", routed_to_host_id: wdc2_host.id).populate_ipv4_addresses
+      st = described_class.assemble(vm_project_id: project_id)
+
+      expect(st.stack.first["initial_host_ids"]).to eq([wdc2_host.id])
+    end
+
     it "respects Config.rollouts_project_id and auto_exit and started_by argument" do
       expect(Config).to receive(:rollouts_project_id).and_return(project_id)
       st = described_class.assemble(auto_exit: true, started_by: "admin")


### PR DESCRIPTION
RolloutRhizome.assemble chose the initial FSN1 and WDC02 hosts by core capacity alone, but setup_vms_on_initial_hosts then provisions a VM with enable_ip4: true on each. A host with no free IPv4 address gets picked and its VM fails to provision, stalling the rollout.

Filter the initial-host selection to hosts that still have a free IPv4 address, mirroring the allocator's availability check.