### PR TITLE
Reserve the storage-backend CPUs in a host's used_cores

### DIFF
--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -129,6 +129,7 @@ class Prog::Vm::HostNexus < Prog::Base
             numa_node: cpu_numa_nodes[cpu],
           )
         end
+        vm_host.update(used_cores: vm_host.spdk_cpu_count * total_cores / total_cpus)
       end
     end
 

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -340,6 +340,7 @@ RSpec.describe Prog::Vm::HostNexus do
       expect(vm_host.total_dies).to eq 3
       expect(vm_host.total_sockets).to eq 2
       expect(VmHostCpu.where(vm_host_id: vm_host.id).select_order_map([:cpu_number, :spdk, :numa_node])).to eq [[0, true, 0], [1, true, 0], [2, false, 1], [3, false, 1], [4, false, nil]]
+      expect(vm_host.used_cores).to eq 1
     end
 
     it "crashes if an expected field is not set for LearnMemory" do


### PR DESCRIPTION
When preparing a host, depending on its size we mark 2 or 4 of its cpus as reserved for IO by setting the `VmHostCpu#spdk` field. These cpus are excluded from cpus that can be allocated to VMs. However, we initialize
`VmHost#used_cores` with 0, which tells the allocator that all cpus are available.

As a result, the allocator might select a host assuming it has enough free cpus, but then allocating specific cpus fails and the allocation is retried. So, allocation time can be longer than it needs to be.

We used to set `used_cores` correctly when preparing a host with SPDK, which was dropped in https://github.com/ubicloud/ubicloud/commit/cc2b69fcf4d66073a7bd11ffaa243dad43a343c6 when SPDK was removed from host preparation, while the cpu reservation itself stayed in the `VmHostCpu` records.

This commit fixes that for future host setups by setting `VmHost#used_cores` appropriately when preparing a host. Previously prepared hosts will be updated separately by staff, since it is preferred to double check and keep a log of the updated hosts for future reference.

Note that although we have marked these cpus as `spdk` cpus, we'll use them in future for ubiblk cpu pools for better performance and will relabel them.