### PR TITLE
Wait for ssh access, not just an open port, on aws

### DIFF
--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -3,7 +3,7 @@
 class Prog::Vm::Aws::Nexus < Prog::Base
   subject_is :vm, :aws_instance
   frame_reader :alternative_families, :private_subnet_id
-  frame_accessor :unsupported_azs, :exclude_availability_zones, :use_separate_management_nic
+  frame_accessor :unsupported_azs, :exclude_availability_zones, :use_separate_management_nic, :ssh_port_open
 
   def before_destroy
     register_deadline(nil, 5 * 60)
@@ -353,13 +353,26 @@ class Prog::Vm::Aws::Nexus < Prog::Base
       nap 6
     end
 
-    addr = use_separate_management_nic ? vm.sshable.host : vm.ip4
-    hop_create_billing_record unless addr
+    unless ssh_port_open
+      addr = use_separate_management_nic ? vm.sshable.host : vm.ip4
+      hop_create_billing_record unless addr
 
-    begin
-      Socket.tcp(addr.to_s, 22, connect_timeout: 1) {}
-    rescue SystemCallError
-      nap 1
+      begin
+        Socket.tcp(addr.to_s, 22, connect_timeout: 1) {}
+      rescue SystemCallError
+        nap 1
+      end
+    end
+
+    # An open port is not enough: cloud-init installs the key after sshd starts.
+    if (sshable = vm.sshable)
+      begin
+        sshable.cmd("true", timeout: 5)
+      rescue Net::SSH::AuthenticationFailed, Sshable::SshTimeout, *Sshable::SSH_CONNECTION_ERRORS
+        # The port answered, so the next tick can go straight to ssh.
+        self.ssh_port_open = true
+        nap 1
+      end
     end
 
     hop_create_billing_record

--- a/spec/prog/vm/aws/nexus_spec.rb
+++ b/spec/prog/vm/aws/nexus_spec.rb
@@ -934,37 +934,69 @@ usermod -L ubuntu
   end
 
   describe "#wait_sshable" do
+    before { AssignedVmAddress.create(dst_vm_id: vm.id, ip: "10.0.0.1/32") }
+
     it "naps 6 seconds if it's the first time we execute wait_sshable" do
       expect { nx.wait_sshable }.to nap(6)
         .and change { vm.update_firewall_rules_set?(cached: false) }.from(false).to(true)
     end
 
-    it "naps if not sshable" do
-      AssignedVmAddress.create(dst_vm_id: vm.id, ip: "10.0.0.1/32")
+    it "naps if the port is not open yet" do
       vm.incr_update_firewall_rules
       expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1).and_raise Errno::ECONNREFUSED
       expect { nx.wait_sshable }.to nap(1)
     end
 
     it "hops to create_billing_record if sshable" do
-      AssignedVmAddress.create(dst_vm_id: vm.id, ip: "10.0.0.1/32")
+      vm.incr_update_firewall_rules
+      expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1)
+      expect(nx.vm.sshable).to receive(:_cmd).with("true", timeout: 5)
+      expect { nx.wait_sshable }.to hop("create_billing_record")
+    end
+
+    it "naps and remembers the open port if the ssh key is not installed yet" do
+      vm.incr_update_firewall_rules
+      expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1)
+      expect(nx.vm.sshable).to receive(:_cmd).and_raise Net::SSH::AuthenticationFailed.new("runneradmin")
+      expect { nx.wait_sshable }.to nap(1)
+      expect(nx.ssh_port_open).to be true
+    end
+
+    it "does not check the port again once it answered" do
+      refresh_frame(nx, new_values: {"ssh_port_open" => true})
+      vm.incr_update_firewall_rules
+      expect(Socket).not_to receive(:tcp)
+      expect(nx.vm.sshable).to receive(:_cmd).with("true", timeout: 5)
+      expect { nx.wait_sshable }.to hop("create_billing_record")
+    end
+
+    it "naps if the ssh command times out" do
+      vm.incr_update_firewall_rules
+      expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1)
+      expect(nx.vm.sshable).to receive(:_cmd).and_raise Sshable::SshTimeout.new("true", "", "", nil, nil)
+      expect { nx.wait_sshable }.to nap(1)
+    end
+
+    it "probes the management NIC's EIP when use_separate_management_nic is set" do
+      refresh_frame(nx, new_values: {"use_separate_management_nic" => true})
+      nx.vm.sshable.host = "9.9.9.9"
+      vm.incr_update_firewall_rules
+      expect(Socket).to receive(:tcp).with("9.9.9.9", 22, connect_timeout: 1)
+      expect(nx.vm.sshable).to receive(:_cmd).with("true", timeout: 5)
+      expect { nx.wait_sshable }.to hop("create_billing_record")
+    end
+
+    it "does not check ssh access for a vm without an sshable" do
+      vm.sshable.destroy
       vm.incr_update_firewall_rules
       expect(Socket).to receive(:tcp).with("10.0.0.1", 22, connect_timeout: 1)
       expect { nx.wait_sshable }.to hop("create_billing_record")
     end
 
     it "skips a check if ipv4 is not enabled" do
+      vm.assigned_vm_address.destroy
       vm.incr_update_firewall_rules
-      expect(vm.ip4).to be_nil
-      expect { nx.wait_sshable }.to hop("create_billing_record")
-    end
-
-    it "probes the management NIC's EIP (sshable.host) when use_separate_management_nic is set" do
-      refresh_frame(nx, new_values: {"use_separate_management_nic" => true})
-      vm.sshable.update(host: "9.9.9.9")
-      AssignedVmAddress.create(dst_vm_id: vm.id, ip: "10.0.0.1/32")
-      vm.incr_update_firewall_rules
-      expect(Socket).to receive(:tcp).with("9.9.9.9", 22, connect_timeout: 1)
+      expect(nx.vm.ip4).to be_nil
       expect { nx.wait_sshable }.to hop("create_billing_record")
     end
   end


### PR DESCRIPTION
An aws instance installs its unix user and authorized_keys from
user_data, which cloud-init runs after sshd already accepts connections.
wait_sshable only opened a tcp connection, so it declared the vm
provisioned while nobody could log in yet. Every alien github runner
then took the Net::SSH::AuthenticationFailed branch in
GithubRunnerNexus#setup_environment and retried once a second until
cloud-init caught up, which is time the customer waits for their job.

Run a command over ssh once the port answers, for vms that have an
sshable. The tcp connect stays and runs first: it is what fails while
the instance boots, and it costs a second at most, where an ssh attempt
against a port that neither answers nor refuses would spend the ten
seconds Net::SSH.start waits for a connection, a banner, and key
negotiation. A vm with no sshable keeps the tcp check alone, since ssh
is not an option for it.

https://github.com/ubicloud/ubicloud/commit/a2d46967515994d9a279c53b066545d4d1d76212 replaced an up-check that shelled out to the ssh binary
with the tcp connect, because the ssh program pulls in environmental
configuration that can conflict with our intent, and spawning a process
per check is wasteful. Neither objection applies here: this runs in the
process through Net::SSH with our own key material. That check also
could not have caught this, since it passed
PreferredAuthentications=none and only looked for a host key error,
which sshd answers before the key is installed.

Reporting the vm as provisioned now waits for ssh to work, so aws
provisioning durations will read higher than before without anything
having become slower.