### PR TITLE
Lift the IO bandwidth cap while a burstable disk warms up from its image

### DIFF
--- a/model/metal/vm.rb
+++ b/model/metal/vm.rb
@@ -154,6 +154,10 @@ class Vm < Sequel::Model
           v["cpus"] = cpus if add_cpus
           v["archive_source"] = storage_archive_source(s) if s.machine_image_version_id
           v["remote_source"] = storage_remote_source(s) if s.remote_storage_server_id
+          # Base machine images (service project) only.
+          v["boost_io_until_caught_up"] = true if s.machine_image_version_id &&
+            (s.max_read_mbytes_per_sec || s.max_write_mbytes_per_sec) &&
+            s.machine_image_version.machine_image.project_id == Config.machine_images_service_project_id
         }
       }
     end

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -213,8 +213,10 @@ class Prog::Vm::Metal::Nexus < Prog::Base
   end
 
   label def wait_storage_catchup
+    warmed_up_from_image = false
     vm.vm_storage_volumes.each do |vol|
       next unless vol.machine_image_version_id || vol.remote_storage_server_id
+      warmed_up_from_image = true
       if vol.caught_up?
         vol.remote_storage_server&.incr_destroy
         vol.update(machine_image_version_id: nil, remote_storage_server_id: nil)
@@ -222,6 +224,8 @@ class Prog::Vm::Metal::Nexus < Prog::Base
         nap 30
       end
     end
+    # Reapply any IO cap lifted for the first-boot warm-up.
+    host.sshable.cmd("sudo host/bin/setup-vm apply_storage_io_limits :vm_name", vm_name:) if warmed_up_from_image
     hop_wait
   end
 

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -127,6 +127,8 @@ when "reassign-ip6"
     slice_name, cpu_percent_limit, cpu_burst_percent_limit, ipv6_disabled, init_script)
 when "restart"
   vm_setup.restart(slice_name, cpu_burst_percent_limit)
+when "apply_storage_io_limits"
+  vm_setup.apply_storage_io_limits(storage_volumes)
 else
   puts "Invalid action #{action}"
   exit 1

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -253,15 +253,17 @@ class StorageVolume
     SERVICE
   end
 
-  def systemd_io_rate_limits
+  def io_rate_limit_properties
     limits = {IOReadBandwidthMax: @max_read_mbytes_per_sec,
               IOWriteBandwidthMax: @max_write_mbytes_per_sec}.compact
-    return "" if limits.empty?
+    return [] if limits.empty?
 
     dev = persistent_device_id(storage_dir)
-    limits
-      .map { |(key, mb)| "#{key}=#{dev} #{mb * 1024 * 1024}" }
-      .join("\n")
+    limits.map { |(key, mb)| "#{key}=#{dev} #{mb * 1024 * 1024}" }
+  end
+
+  def systemd_io_rate_limits
+    io_rate_limit_properties.join("\n")
   end
 
   def wrap_key_b64(storage_key_encryption, key)

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -47,6 +47,7 @@ class StorageVolume
     @cpus = params["cpus"]
     @archive_source = params["archive_source"]
     @remote_source = params["remote_source"]
+    @boost_io_until_caught_up = params.fetch("boost_io_until_caught_up", false)
   end
 
   def vp
@@ -263,7 +264,18 @@ class StorageVolume
   end
 
   def systemd_io_rate_limits
+    # Uncapped during warm-up; apply_io_limits reapplies the cap afterward.
+    return "" if @boost_io_until_caught_up
+
     io_rate_limit_properties.join("\n")
+  end
+
+  # Persisted (not --runtime) so the cap survives a restart or host reboot.
+  def apply_io_limits
+    props = io_rate_limit_properties
+    return if props.empty?
+
+    r "systemctl", "set-property", vhost_user_block_service, *props
   end
 
   def wrap_key_b64(storage_key_encryption, key)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -78,6 +78,13 @@ class VmSetup
     enable_bursting(slice_name, cpu_burst_percent_limit) unless cpu_burst_percent_limit == 0
   end
 
+  def apply_storage_io_limits(storage_params)
+    storage_params.each do |params|
+      next unless params["boost_io_until_caught_up"]
+      StorageVolume.new(@vm_name, params).apply_io_limits
+    end
+  end
+
   def reassign_ip6(unix_user, public_keys, nics, gua, ip4, local_ip4, max_vcpus, cpu_topology,
     mem_gib, ndp_needed, storage_params, storage_secrets, swap_size_bytes, pci_devices, boot_image,
     dns_ipv4, slice_name, cpu_percent_limit, cpu_burst_percent_limit, ipv6_disabled, init_script)

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -939,6 +939,46 @@ RSpec.describe StorageVolume do
       })
       expect(sv.systemd_io_rate_limits).to eq("")
     end
+
+    it "returns empty string while boosting for a first-boot warm-up" do
+      sv = described_class.new("test", {
+        "disk_index" => 1,
+        "device_id" => "xyz01",
+        "max_read_mbytes_per_sec" => 2000,
+        "encrypted" => true,
+        "boost_io_until_caught_up" => true,
+      })
+      expect(sv.systemd_io_rate_limits).to eq("")
+    end
+  end
+
+  describe "#apply_io_limits" do
+    it "sets the rate limits on the service" do
+      sv = described_class.new("test", {
+        "disk_index" => 1,
+        "device_id" => "xyz01",
+        "vhost_block_backend_version" => "v0.1",
+        "max_read_mbytes_per_sec" => 2000,
+        "max_write_mbytes_per_sec" => 3000,
+        "encrypted" => true,
+      })
+      expect(sv).to receive(:persistent_device_id).with("/var/storage/test/1").and_return("/dev/disk/by-id/dev1")
+      expect(sv).to receive(:_run_command).with("systemctl", "set-property", "test-1-storage.service",
+        "IOReadBandwidthMax=/dev/disk/by-id/dev1 2097152000",
+        "IOWriteBandwidthMax=/dev/disk/by-id/dev1 3145728000")
+      sv.apply_io_limits
+    end
+
+    it "does nothing when no rate limits are set" do
+      sv = described_class.new("test", {
+        "disk_index" => 1,
+        "device_id" => "xyz01",
+        "vhost_block_backend_version" => "v0.1",
+        "encrypted" => true,
+      })
+      expect(sv).not_to receive(:_run_command)
+      sv.apply_io_limits
+    end
   end
 
   describe "#persistent_device_id" do

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -575,6 +575,18 @@ RSpec.describe VmSetup do
     end
   end
 
+  describe "#apply_storage_io_limits" do
+    it "reapplies limits only for volumes that were boosted for warm-up" do
+      boosted = {"disk_index" => 0, "boost_io_until_caught_up" => true}
+      plain = {"disk_index" => 1}
+      sv = instance_double(StorageVolume)
+      expect(StorageVolume).to receive(:new).with("test", boosted).and_return(sv)
+      expect(sv).to receive(:apply_io_limits)
+
+      vs.apply_storage_io_limits([boosted, plain])
+    end
+  end
+
   describe "#setup_networking" do
     it "can setup networking" do
       vps = instance_spy(VmPath)

--- a/spec/model/vm_spec.rb
+++ b/spec/model/vm_spec.rb
@@ -455,6 +455,23 @@ RSpec.describe Vm do
       expect(volumes[1]).not_to have_key("archive_source")
     end
 
+    it "boosts IO warm-up for a capped volume from a base machine image" do
+      project_id = Project.create(name: "base-images").id
+      allow(Config).to receive(:machine_images_service_project_id).and_return(project_id)
+      miv = create_machine_image_version_metal(project_id:)
+      VmStorageVolume.where(vm_id: vm.id, disk_index: 0).update(machine_image_version_id: miv.id, boot_image_id: nil, max_write_mbytes_per_sec: 200)
+
+      expect(vm.storage_volumes[0]["boost_io_until_caught_up"]).to be(true)
+    end
+
+    it "does not boost a capped volume from a customer (non-base) machine image" do
+      allow(Config).to receive(:machine_images_service_project_id).and_return(Project.create(name: "service").id)
+      miv = create_machine_image_version_metal(project_id: Project.create(name: "customer").id)
+      VmStorageVolume.where(vm_id: vm.id, disk_index: 0).update(machine_image_version_id: miv.id, boot_image_id: nil, max_write_mbytes_per_sec: 200)
+
+      expect(vm.storage_volumes[0]).not_to have_key("boost_io_until_caught_up")
+    end
+
     it "adds remote_source when volume has remote_storage_server_id" do
       source_vm = create_archive_ready_vm
       source_volume = VmStorageVolume.first(vm_id: source_vm.id)

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -1076,6 +1076,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       payload = {command: "status"}
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm.inhost_name}/1/rpc.sock -q 2 -w 2 | head -n 1", stdin: payload.to_json).and_return('{"status": {"stripes": {"fetched": 100, "source": 100}}}')
       expect(vm.vm_host.sshable).to receive(:_cmd).with("sudo nc -U /var/storage/#{vm.inhost_name}/2/rpc.sock -q 2 -w 2 | head -n 1", stdin: payload.to_json).and_return('{"status": {"stripes": {"fetched": 100, "source": 100}}}')
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/setup-vm apply_storage_io_limits #{vm.inhost_name}")
       expect { nx.wait_storage_catchup }.to hop("wait")
         .and change { rss.destroy_set?(cached: false) }.from(false).to(true)
         .and change { vm.vm_storage_volumes_dataset.where(machine_image_version_id: nil).where(remote_storage_server_id: nil).count }.from(1).to(3)


### PR DESCRIPTION
A burstable VM restored from an image materializes its disk in the background on first boot, and the per-VM IO bandwidth cap throttles that warm-up, so first boot is slow. Run the warm-up uncapped and reapply the normal cap once the disk has caught up.

Limit this to base machine images, whose machine image belongs to the machine-images service project. We make no sshable-time guarantee for customer UMI VMs, so such a VM keeps its cap throughout and only base-image VMs get the boost.

Time from VM creation until the strand reaches the wait state, for a burstable VM booting a base image on a dev host with a 50 MB/s cap, mean of two runs:

-  ubuntu-noble:     94s -> 28s
-  ubuntu-resolute: 102s -> 35s
