### PR TITLE
Reduce polling for postgres resource/server vm to reach wait

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -182,9 +182,11 @@ SQL
   # Dispatch the strand as soon as possible, for use by a strand that
   # finished work another strand waits for. A strand that is already
   # overdue keeps its schedule, so waking it cannot demote it.
-  def self.wakeup(id)
-    return unless id
-    where(id:).update(schedule: SCHEDULE_NO_LATER_THAN_NOW)
+  def wakeup_waiting_strand
+    if (id = stack[0].delete("waiting_strand_id"))
+      modified!(:stack)
+      Strand.where(id:).update(schedule: SCHEDULE_NO_LATER_THAN_NOW)
+    end
   end
 
   def self.prog_verify(prog)

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -385,6 +385,10 @@ end
     @frame = nil
   end
 
+  def wakeup_waiting_strand
+    strand.wakeup_waiting_strand
+  end
+
   # A hop is a kind of jump, as in, like a jump instruction.
   private def dynamic_hop(label)
     raise Strand::InternalError, "BUG: #hop only accepts a symbol" unless label.is_a? Symbol

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -237,7 +237,7 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   label def start
     postgres_resource.setup_log_aggregation
 
-    nap 5 unless representative_server.vm.strand.label == "wait"
+    nap 60 unless representative_server.vm.strand.label == "wait"
 
     postgres_resource.incr_initial_provisioning
     if postgres_resource.parent

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -15,6 +15,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   def self.assemble(resource_id:, timeline_id:, timeline_access:, is_representative: false, exclude_host_ids: [], exclude_availability_zones: [], availability_zone: nil, exclude_data_centers: [])
     DB.transaction do
       ubid = PostgresServer.generate_ubid
+      uuid = ubid.to_uuid
 
       postgres_resource = PostgresResource[resource_id]
       # For read replicas and representative servers (initial creation), use
@@ -50,11 +51,12 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
         exclude_data_centers:,
         swap_size_bytes: postgres_resource.target_vm_size.start_with?("hobby") ? 4 * 1024 * 1024 * 1024 : nil,
         use_separate_management_nic: postgres_resource.location.aws?,
+        waiting_strand_id: uuid,
       )
 
       synchronization_status = (is_representative && !postgres_resource.read_replica?) ? "ready" : "catching_up"
-      postgres_server = PostgresServer.create_with_id(
-        ubid.to_uuid,
+      PostgresServer.create_with_id(
+        uuid,
         resource_id:,
         timeline_id:,
         timeline_access:,
@@ -66,7 +68,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
 
       vm_st.subject.add_vm_firewall(postgres_resource.internal_firewall)
 
-      Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "start")
+      Strand.create_with_id(uuid, prog: "Postgres::PostgresServerNexus", label: "start")
     end
   end
 
@@ -91,7 +93,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
   end
 
   label def start
-    nap 5 unless vm.strand.label == "wait"
+    nap 60 unless vm.strand.label == "wait"
 
     postgres_server.incr_initial_provisioning
     hop_bootstrap_rhizome

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -51,7 +51,7 @@ class Prog::Postgres::PostgresServerNexus < Prog::Base
         exclude_data_centers:,
         swap_size_bytes: postgres_resource.target_vm_size.start_with?("hobby") ? 4 * 1024 * 1024 * 1024 : nil,
         use_separate_management_nic: postgres_resource.location.aws?,
-        waiting_strand_id: uuid,
+        waiting_strand_id: (is_representative ? [uuid, resource_id] : uuid),
       )
 
       synchronization_status = (is_representative && !postgres_resource.read_replica?) ? "ready" : "catching_up"

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -2,7 +2,7 @@
 
 class Prog::Vm::Aws::Nexus < Prog::Base
   subject_is :vm, :aws_instance
-  frame_reader :alternative_families, :private_subnet_id, :waiting_strand_id
+  frame_reader :alternative_families, :private_subnet_id
   frame_accessor :unsupported_azs, :exclude_availability_zones, :use_separate_management_nic
 
   def before_destroy
@@ -370,7 +370,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
 
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, instance_id: vm.aws_instance.instance_id, duration: (Time.now - vm.allocated_at).round(3)}}])
 
-    Strand.wakeup(waiting_strand_id)
+    wakeup_waiting_strand
 
     project = vm.project
     hop_wait unless project.billable

--- a/prog/vm/gcp/nexus.rb
+++ b/prog/vm/gcp/nexus.rb
@@ -4,7 +4,7 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
   include GcpLro
 
   subject_is :vm
-  frame_reader :unsupported_azs, :waiting_strand_id
+  frame_reader :unsupported_azs
   frame_accessor :retry_zone_delay, :gcp_zone_suffix, :exclude_zones
 
   def before_destroy
@@ -234,7 +234,7 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
 
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, duration: (time - vm.allocated_at).round(3)}}])
 
-    Strand.wakeup(waiting_strand_id)
+    wakeup_waiting_strand
 
     project = vm.project
     hop_wait unless project.billable

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -7,7 +7,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
 
   subject_is :vm
   frame_reader :distinct_storage_devices, :exclude_host_ids, :exclude_data_centers, :gpu_count, :gpu_device,
-    :force_host_id, :storage_volumes, :waiting_strand_id
+    :force_host_id, :storage_volumes
   frame_accessor :reason_determined
 
   def vm_name
@@ -210,8 +210,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     vm.update(display_state: "running", provisioned_at: Time.now)
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: (Time.now - vm.allocated_at).round(3)}}])
 
-    Strand.wakeup(waiting_strand_id)
-
+    wakeup_waiting_strand
     hop_wait
   end
 

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -127,7 +127,7 @@ class Prog::Vnet::CertNexus < Prog::Base
     when "valid"
       cert.update(cert: acme_order.certificate, created_at: Time.now)
       cleanup_dns_challenge_records
-      Strand.wakeup(frame["waiting_strand_id"])
+      wakeup_waiting_strand
       hop_wait
     else
       Clog.emit("Certificate finalization failed", {order_status:})

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -139,6 +139,14 @@ RSpec.describe Strand do
     expect(st.reload.schedule).to be_within(10).of(Time.now)
   end
 
+  it "supports an array of strands" do
+    st.update(schedule: Time.now + 10000, stack: [{"waiting_strand_id" => [st.id]}])
+
+    st.wakeup_waiting_strand
+
+    expect(st.reload.schedule).to be_within(10).of(Time.now)
+  end
+
   it "keeps the schedule of an overdue strand on wakeup" do
     schedule = Time.now - 100
     st.update(schedule:, stack: [{"waiting_strand_id" => st.id}])

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -132,18 +132,18 @@ RSpec.describe Strand do
   end
 
   it "wakes up a strand scheduled in the future" do
-    st.update(schedule: Time.now + 10000)
+    st.update(schedule: Time.now + 10000, stack: [{"waiting_strand_id" => st.id}])
 
-    described_class.wakeup(st.id)
+    st.wakeup_waiting_strand
 
     expect(st.reload.schedule).to be_within(10).of(Time.now)
   end
 
   it "keeps the schedule of an overdue strand on wakeup" do
     schedule = Time.now - 100
-    st.update(schedule:)
+    st.update(schedule:, stack: [{"waiting_strand_id" => st.id}])
 
-    described_class.wakeup(st.id)
+    st.wakeup_waiting_strand
 
     expect(st.reload.schedule).to be_within(1).of(schedule)
   end
@@ -151,7 +151,7 @@ RSpec.describe Strand do
   it "does nothing when there is no strand waiting" do
     st.update(schedule: Time.now + 10000)
 
-    expect { described_class.wakeup(nil) }.not_to change { st.reload.schedule }
+    expect { st.wakeup_waiting_strand }.not_to change { st.reload.schedule }
   end
 
   it "logs end of strand if it took long" do

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -415,7 +415,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
   describe "#start" do
     it "naps if postgres server is not ready" do
       postgres_server
-      expect { nx.start }.to nap(5)
+      expect { nx.start }.to nap(60)
     end
 
     it "sets up log aggregation if parseable is available" do
@@ -424,7 +424,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       expect(client).to receive_messages(create_stream: "test-stream", create_role: "test-role", create_user: "test-parseable-pass")
       expect(client).to receive(:set_retention).with(stream_name: postgres_resource.ubid, duration_days: ParseableResource::LOG_RETENTION_DAYS)
       postgres_server
-      expect { nx.start }.to nap(5)
+      expect { nx.start }.to nap(60)
     end
 
     it "hops if postgres server is ready" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(postgres_server.vm).not_to be_nil
       expect(postgres_server.vm.sshable).not_to be_nil
       expect(postgres_server.vm.vm_storage_volumes.map(&:track_written)).to eq([false, false])
+      expect(postgres_server.vm.strand.stack[0]["waiting_strand_id"]).to eq(postgres_server.id)
 
       st = described_class.assemble(resource_id: postgres_resource.id, timeline_id: postgres_timeline.id, timeline_access: "push")
       expect(st.subject.synchronization_status).to eq("catching_up")
@@ -231,7 +232,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
 
   describe "#start" do
     it "naps if vm not ready" do
-      expect { nx.start }.to nap(5)
+      expect { nx.start }.to nap(60)
     end
 
     it "update sshable host and hops" do

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -62,10 +62,11 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       expect(postgres_server.vm).not_to be_nil
       expect(postgres_server.vm.sshable).not_to be_nil
       expect(postgres_server.vm.vm_storage_volumes.map(&:track_written)).to eq([false, false])
-      expect(postgres_server.vm.strand.stack[0]["waiting_strand_id"]).to eq(postgres_server.id)
+      expect(postgres_server.vm.strand.stack[0]["waiting_strand_id"]).to eq([postgres_server.id, postgres_resource.id])
 
       st = described_class.assemble(resource_id: postgres_resource.id, timeline_id: postgres_timeline.id, timeline_access: "push")
       expect(st.subject.synchronization_status).to eq("catching_up")
+      expect(st.subject.vm.strand.stack[0]["waiting_strand_id"]).to eq(st.id)
     end
 
     it "creates read replica server with catching_up status even when representative" do


### PR DESCRIPTION
This uses the waiting_strand_id support, so that when the Vm reaches out, it automatically schedules the server, and if the server is representative, also the resource. This should reduce respirate load and decrease provisioning time for postgres resources and servers by 2.5 seconds on average.