### PR TITLE
Make postgres_exporter robust to slow queries

### DIFF
--- a/config/postgres_exporter_queries.yml
+++ b/config/postgres_exporter_queries.yml
@@ -111,6 +111,7 @@ pg_database:
       AND datname NOT IN ('template0', 'template1')
     ORDER BY pg_database_size(datname) DESC
     LIMIT 5
+  cache_seconds: 300
   metrics:
     - datname:
         usage: "LABEL"

--- a/lib/metrics_target_methods.rb
+++ b/lib/metrics_target_methods.rb
@@ -32,6 +32,7 @@ module MetricsTargetMethods
 
   def export_metrics(session:, tsdb_client:)
     scrape_results = scrape_endpoints(session)
+    session[:last_export_bytes] = scrape_results.sum { it.samples.bytesize }
 
     if scrape_results.empty?
       return

--- a/lib/metrics_target_resource.rb
+++ b/lib/metrics_target_resource.rb
@@ -34,7 +34,7 @@ class MetricsTargetResource
       @session[:last_export] = Time.now
       @export_success_streak += 1
       if @export_success_streak % 20 == 1
-        Clog.emit("Metrics export has finished.", {metrics_export_success: {ubid: @resource.ubid, count:, streak: @export_success_streak}})
+        Clog.emit("Metrics export has finished.", {metrics_export_success: {ubid: @resource.ubid, count:, bytes: @session[:last_export_bytes], streak: @export_success_streak}})
       end
       @last_export_success = true
     rescue => ex

--- a/rhizome/common/bin/metrics-collector
+++ b/rhizome/common/bin/metrics-collector
@@ -47,6 +47,8 @@ File.open(pending_file_path, "w") do |file|
     endpoint = {"url" => endpoint} if endpoint.is_a?(String)
     uri = URI(endpoint["url"])
     http = Net::HTTP.new(uri.host, uri.port)
+    http.open_timeout = 5
+    http.read_timeout = 10
     http.use_ssl = uri.scheme == "https"
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE # Equivalent to --insecure
 

--- a/rhizome/common/bin/metrics-collector
+++ b/rhizome/common/bin/metrics-collector
@@ -74,6 +74,10 @@ File.open(pending_file_path, "w") do |file|
   file.fsync
 end
 
+# The done directory mtime is how the control plane sees that a scrape landed.
+# An empty response must not move it.
+fail "All endpoints returned an empty response" if File.empty?(pending_file_path)
+
 # Move complete file to "done" and make confirm rename persistence via
 # directory fsync.
 File.rename(pending_file_path, "#{metrics_dir}/done/#{filename}.txt")

--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -13,6 +13,11 @@ class PostgresSetup
     "node_exporter" => "128MiB",
   }.freeze
 
+  # postgres_exporter keeps one connection and runs its custom queries without a
+  # context, so a query that never returns blocks every later scrape. The quotes
+  # are load-bearing: systemd splits an unquoted Environment= value on the space.
+  POSTGRES_EXPORTER_ENVIRONMENT = %(Environment="PGOPTIONS=-c statement_timeout=5000"\n)
+
   def initialize(version)
     @version = version
   end
@@ -88,21 +93,27 @@ class PostgresSetup
       MemoryHigh=2G
       MemoryMax=2560M
     SLICE
-    GO_SERVICES.each do |svc, gomemlimit|
+    rewritten = GO_SERVICES.filter_map do |svc, gomemlimit|
       r "mkdir", "-p", "/etc/systemd/system/#{svc}.service.d"
-      safe_write_to_file("/etc/systemd/system/#{svc}.service.d/override.conf", <<~OVERRIDE)
+      path = "/etc/systemd/system/#{svc}.service.d/override.conf"
+      override = <<~OVERRIDE
         [Service]
         Slice=system-go_services.slice
         Environment=GOMEMLIMIT=#{gomemlimit}
       OVERRIDE
+      override += POSTGRES_EXPORTER_ENVIRONMENT if svc == "postgres_exporter"
+      changed = !File.file?(path) || File.read(path) != override
+      safe_write_to_file(path, override)
+      svc if changed
     end
     r "systemctl daemon-reload"
-    # Apply cap so without restarting. Slice= and GOMEMLIMIT are load-time directives,
-    # so only restart services not yet in slice.
+    # Apply cap so without restarting. Slice=, GOMEMLIMIT and Environment= are all
+    # load-time directives, so restart a service only when it is not in the slice
+    # yet, or when its drop-in just changed.
     r "systemctl set-property system-go_services.slice MemoryHigh=2G MemoryMax=2560M"
     GO_SERVICES.each_key do |svc|
       current_slice = r("systemctl", "show", "#{svc}.service", "-p", "Slice", "--value").strip
-      next if current_slice == "system-go_services.slice"
+      next if current_slice == "system-go_services.slice" && !rewritten.include?(svc)
       r "systemctl", "try-restart", "#{svc}.service"
     end
   end

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -184,22 +184,46 @@ RSpec.describe PostgresSetup do
   end
 
   describe "#configure_service_slice" do
-    it "writes slice + drop-ins, reloads, sets slice property, restarts only services not yet in the slice" do
+    def override_for(svc, lim)
+      content = <<~OVERRIDE
+        [Service]
+        Slice=system-go_services.slice
+        Environment=GOMEMLIMIT=#{lim}
+      OVERRIDE
+      content += PostgresSetup::POSTGRES_EXPORTER_ENVIRONMENT if svc == "postgres_exporter"
+      content
+    end
+
+    def expect_slice_and_reload
       expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/system-go_services.slice", <<~SLICE)
         [Slice]
         MemoryHigh=2G
         MemoryMax=2560M
       SLICE
-      PostgresSetup::GO_SERVICES.each do |svc, lim|
-        expect(pg_setup).to receive(:_run_command).with("mkdir", "-p", "/etc/systemd/system/#{svc}.service.d")
-        expect(pg_setup).to receive(:safe_write_to_file).with("/etc/systemd/system/#{svc}.service.d/override.conf", <<~OVERRIDE)
-          [Service]
-          Slice=system-go_services.slice
-          Environment=GOMEMLIMIT=#{lim}
-        OVERRIDE
-      end
       expect(pg_setup).to receive(:_run_command).with("systemctl daemon-reload")
       expect(pg_setup).to receive(:_run_command).with("systemctl set-property system-go_services.slice MemoryHigh=2G MemoryMax=2560M")
+    end
+
+    before do
+      allow(File).to receive(:file?).and_call_original
+      allow(File).to receive(:read).and_call_original
+    end
+
+    it "gives only postgres_exporter a statement timeout, quoted for systemd" do
+      expect(PostgresSetup::POSTGRES_EXPORTER_ENVIRONMENT).to eq(%(Environment="PGOPTIONS=-c statement_timeout=5000"\n))
+      expect(override_for("postgres_exporter", "384MiB")).to end_with(%(Environment="PGOPTIONS=-c statement_timeout=5000"\n))
+      expect(override_for("node_exporter", "128MiB")).to end_with("Environment=GOMEMLIMIT=128MiB\n")
+    end
+
+    it "writes slice + drop-ins, reloads, sets slice property, restarts only services not yet in the slice" do
+      expect_slice_and_reload
+      PostgresSetup::GO_SERVICES.each do |svc, lim|
+        path = "/etc/systemd/system/#{svc}.service.d/override.conf"
+        allow(File).to receive(:file?).with(path).and_return(true)
+        allow(File).to receive(:read).with(path).and_return(override_for(svc, lim))
+        expect(pg_setup).to receive(:_run_command).with("mkdir", "-p", "/etc/systemd/system/#{svc}.service.d")
+        expect(pg_setup).to receive(:safe_write_to_file).with(path, override_for(svc, lim))
+      end
 
       # First two services already in system-go_services.slice -> skip restart.
       # Last two still in system.slice / missing -> try-restart.
@@ -209,6 +233,34 @@ RSpec.describe PostgresSetup do
         if slices[i] != "system-go_services.slice"
           expect(pg_setup).to receive(:_run_command).with("systemctl", "try-restart", "#{svc}.service")
         end
+      end
+
+      pg_setup.configure_service_slice
+    end
+
+    it "restarts a service already in the slice when its drop-in changed" do
+      expect_slice_and_reload
+      changed = ["postgres_exporter", "node_exporter"]
+      PostgresSetup::GO_SERVICES.each do |svc, lim|
+        path = "/etc/systemd/system/#{svc}.service.d/override.conf"
+        case svc
+        when "postgres_exporter"
+          # Drop-in from before the timeout was added.
+          allow(File).to receive(:file?).with(path).and_return(true)
+          allow(File).to receive(:read).with(path).and_return(override_for(svc, lim).sub(PostgresSetup::POSTGRES_EXPORTER_ENVIRONMENT, ""))
+        when "node_exporter"
+          allow(File).to receive(:file?).with(path).and_return(false)
+        else
+          allow(File).to receive(:file?).with(path).and_return(true)
+          allow(File).to receive(:read).with(path).and_return(override_for(svc, lim))
+        end
+        expect(pg_setup).to receive(:_run_command).with("mkdir", "-p", "/etc/systemd/system/#{svc}.service.d")
+        expect(pg_setup).to receive(:safe_write_to_file).with(path, override_for(svc, lim))
+      end
+
+      PostgresSetup::GO_SERVICES.each_key do |svc|
+        expect(pg_setup).to receive(:_run_command).with("systemctl", "show", "#{svc}.service", "-p", "Slice", "--value").and_return("system-go_services.slice\n")
+        expect(pg_setup).to receive(:_run_command).with("systemctl", "try-restart", "#{svc}.service") if changed.include?(svc)
       end
 
       pg_setup.configure_service_slice

--- a/spec/lib/metrics_target_methods_spec.rb
+++ b/spec/lib/metrics_target_methods_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe MetricsTargetMethods do
         expect(mock_ssh_session).not_to receive(:_exec!).with(/xargs.*rm/)
 
         test_instance.export_metrics(session:, tsdb_client: mock_tsdb_client)
+        expect(session[:last_export_bytes]).to eq(0)
       end
     end
 
@@ -81,6 +82,7 @@ RSpec.describe MetricsTargetMethods do
         expect(mock_ssh_session).to receive(:_exec!).with(/xargs.*rm/)
 
         test_instance.export_metrics(session:, tsdb_client: mock_tsdb_client)
+        expect(session[:last_export_bytes]).to eq(22)
       end
     end
   end

--- a/spec/monitor_smoke_test.rb
+++ b/spec/monitor_smoke_test.rb
@@ -105,7 +105,8 @@ lines.each_value(&:uniq!).each_value { it.sort_by!(&:inspect) }
   expected_lines = Array.new(lines[r].size - 1) do
     {"got_pulse" => {"ubid" => r, "pulse" => {"reading" => reading, "reading_rpt" => it + 1}}, "message" => "Got new pulse."}
   end
-  expected_lines << {"metrics_export_success" => {"ubid" => r, "count" => count, "streak" => 1}, "message" => "Metrics export has finished."}
+  # MonitorResourceStub has no scrapes to measure, so it never sets the byte count.
+  expected_lines << {"metrics_export_success" => {"ubid" => r, "count" => count, "bytes" => nil, "streak" => 1}, "message" => "Metrics export has finished."}
   unless lines[r] == expected_lines
     warn "unexpected lines for #{r}: #{lines[r]}"
     exit 1


### PR DESCRIPTION
Changes to detect missing metrics in more cases and add timeouts to skip slow queries.