### PR TITLE
Introduce binaries and enable modprobe

### DIFF
--- a/kubernetes/csi/Dockerfile
+++ b/kubernetes/csi/Dockerfile
@@ -9,12 +9,21 @@ RUN bundle config set without 'development test' && bundle install
 
 FROM ruby:4.0.2-slim
 
+ARG UBIBLK_VERSION=v0.5.1
+ARG UBIBLK_SHA256=7b82f4769a7ee52b1fa71d17f12dbe02a4795e4bdb5e8fe4cea98bb3a7913972
+
 RUN apt update && apt install -y apt-transport-https ca-certificates curl gnupg openssh-client e2fsprogs xfsprogs
 RUN curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.35/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 RUN echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.35/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list && \
     chmod 644 /etc/apt/sources.list.d/kubernetes.list
 RUN apt update && apt install -y kubectl iputils-ping dnsutils curl telnet \
     net-tools iproute2 netcat-openbsd mtr-tiny traceroute
+
+RUN curl -fsSL -o /tmp/ubiblk.tar.gz "https://github.com/ubicloud/ubiblk/releases/download/${UBIBLK_VERSION}/ubiblk-x64.tar.gz" && \
+    echo "${UBIBLK_SHA256}  /tmp/ubiblk.tar.gz" | sha256sum -c - && \
+    mkdir -p "/opt/ubiblk/${UBIBLK_VERSION}" && \
+    tar xzf /tmp/ubiblk.tar.gz --no-same-owner -C "/opt/ubiblk/${UBIBLK_VERSION}" ublk-backend init-metadata remote-stripe-server && \
+    rm /tmp/ubiblk.tar.gz
 
 COPY --from=builder /usr/local/bundle /usr/local/bundle
 

--- a/kubernetes/csi/Gemfile.lock
+++ b/kubernetes/csi/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ubi-csi (0.15.0)
+    ubi-csi (0.16.0)
       base64
       grpc (= 1.83.0)
       grpc-tools (= 1.83.0)

--- a/kubernetes/csi/bin/ubi-csi-server
+++ b/kubernetes/csi/bin/ubi-csi-server
@@ -58,6 +58,11 @@ if role == "controller"
   server.handle(controller_service)
 else
   Csi::V1::NodeService.mkdir_p
+  begin
+    Csi::Ubiblk.new(logger:).setup
+  rescue => e
+    logger.info("Could not set up ubiblk: #{e.message}. This node will use loop devices and copy volumes to migrate them.")
+  end
   node_service = Csi::V1::NodeService.new(logger:, node_id:)
   server.handle(node_service)
 end

--- a/kubernetes/csi/lib/ubi_csi.rb
+++ b/kubernetes/csi/lib/ubi_csi.rb
@@ -5,7 +5,7 @@ require "csi_pb"
 require "csi_services_pb"
 
 module Csi
-  VERSION = "0.15.0"
+  VERSION = "0.16.0"
 end
 
 require_relative "ubi_csi/identity_service"

--- a/kubernetes/csi/lib/ubi_csi.rb
+++ b/kubernetes/csi/lib/ubi_csi.rb
@@ -9,6 +9,7 @@ module Csi
 end
 
 require_relative "ubi_csi/identity_service"
+require_relative "ubi_csi/ubiblk"
 require_relative "ubi_csi/node_service"
 require_relative "ubi_csi/capacity_manager"
 require_relative "ubi_csi/controller_service"

--- a/kubernetes/csi/lib/ubi_csi/ubiblk.rb
+++ b/kubernetes/csi/lib/ubi_csi/ubiblk.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require_relative "service_helper"
+
+module Csi
+  class Ubiblk
+    include ServiceHelper
+
+    VERSION = "v0.5.1"
+    BINARIES = %w[ublk-backend init-metadata remote-stripe-server].freeze
+    IMAGE_DIR = "/opt/ubiblk/#{VERSION}"
+    # The node's /opt/ubiblk/<version>, as this container sees it.
+    HOST_DIR = "/host/opt/ubiblk/#{VERSION}"
+
+    def initialize(logger:)
+      @logger = logger
+      @req_id = "ubiblk-setup"
+    end
+
+    def setup
+      stage_binaries
+      load_kernel_module
+    end
+
+    def stage_binaries
+      FileUtils.mkdir_p(HOST_DIR)
+      BINARIES.each do |name|
+        path = File.join(HOST_DIR, name)
+        next if File.executable?(path)
+
+        tmp_path = "#{path}.tmp"
+        FileUtils.cp(File.join(IMAGE_DIR, name), tmp_path)
+        File.chmod(0o755, tmp_path)
+        File.rename(tmp_path, path)
+        log_with_id(@req_id, "Staged #{name} at #{path}")
+      end
+    end
+
+    def load_kernel_module
+      output, status = run_cmd("nsenter", "-t", "1", "-a", "modprobe", "ublk_drv", req_id: @req_id)
+      raise "Failed to load the ublk_drv kernel module: #{output}" unless status.success?
+    end
+  end
+end

--- a/kubernetes/csi/spec/csi/v1/identity_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/identity_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Csi::V1::IdentityService do
       request = Csi::V1::GetPluginInfoRequest.new
       response = service.get_plugin_info(request, call)
       expect(response.name).to eq("csi.ubicloud.com")
-      expect(response.vendor_version).to eq("0.15.0")
+      expect(response.vendor_version).to eq("0.16.0")
     end
   end
 

--- a/kubernetes/csi/spec/ubi_csi/ubiblk_spec.rb
+++ b/kubernetes/csi/spec/ubi_csi/ubiblk_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "logger"
+require "tmpdir"
+require "spec_helper"
+
+RSpec.describe Csi::Ubiblk do
+  let(:logger) { Logger.new(File::NULL) }
+  let(:ubiblk) { described_class.new(logger:) }
+  let(:success_status) { instance_double(Process::Status, success?: true) }
+  let(:failure_status) { instance_double(Process::Status, success?: false) }
+
+  describe "#setup" do
+    it "stages the binaries and loads the kernel module" do
+      expect(ubiblk).to receive(:stage_binaries)
+      expect(ubiblk).to receive(:load_kernel_module)
+
+      ubiblk.setup
+    end
+  end
+
+  describe "#stage_binaries" do
+    it "copies every binary to the node as an executable" do
+      Dir.mktmpdir do |dir|
+        image_dir = File.join(dir, "image")
+        host_dir = File.join(dir, "host")
+        FileUtils.mkdir_p(image_dir)
+        described_class::BINARIES.each { |name| File.write(File.join(image_dir, name), "#{name} contents") }
+        stub_const("Csi::Ubiblk::IMAGE_DIR", image_dir)
+        stub_const("Csi::Ubiblk::HOST_DIR", host_dir)
+
+        ubiblk.stage_binaries
+
+        described_class::BINARIES.each do |name|
+          path = File.join(host_dir, name)
+          expect(File.read(path)).to eq("#{name} contents")
+          expect(File.stat(path).mode & 0o777).to eq(0o755)
+        end
+      end
+    end
+
+    it "leaves an already staged binary alone" do
+      Dir.mktmpdir do |dir|
+        image_dir = File.join(dir, "image")
+        host_dir = File.join(dir, "host")
+        FileUtils.mkdir_p(image_dir)
+        FileUtils.mkdir_p(host_dir)
+        described_class::BINARIES.each { |name| File.write(File.join(image_dir, name), "new contents") }
+        staged_path = File.join(host_dir, "ublk-backend")
+        File.write(staged_path, "staged contents")
+        File.chmod(0o755, staged_path)
+        stub_const("Csi::Ubiblk::IMAGE_DIR", image_dir)
+        stub_const("Csi::Ubiblk::HOST_DIR", host_dir)
+
+        ubiblk.stage_binaries
+
+        expect(File.read(staged_path)).to eq("staged contents")
+      end
+    end
+  end
+
+  describe "#load_kernel_module" do
+    it "loads ublk_drv in the host namespaces" do
+      expect(ubiblk).to receive(:run_cmd).with(
+        "nsenter", "-t", "1", "-a", "modprobe", "ublk_drv", req_id: "ubiblk-setup",
+      ).and_return(["", success_status])
+
+      ubiblk.load_kernel_module
+    end
+
+    it "raises when modprobe fails" do
+      expect(ubiblk).to receive(:run_cmd).and_return(["module not found", failure_status])
+
+      expect { ubiblk.load_kernel_module }.to raise_error(RuntimeError, "Failed to load the ublk_drv kernel module: module not found")
+    end
+  end
+end

--- a/kubernetes/csi/ubi-csi.gemspec
+++ b/kubernetes/csi/ubi-csi.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "ubi-csi"
-  spec.version = "0.15.0"
+  spec.version = "0.16.0"
   spec.authors = ["Ubicloud"]
   spec.email = ["support@ubicloud.com"]
 

--- a/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:v0.15.0
+          image: ubicloud/ubicsi:v0.16.0
           imagePullPolicy: IfNotPresent
           args: ["node"]
           env:

--- a/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
@@ -65,6 +65,8 @@ spec:
             - name: ubicsi-local-data
               mountPath: /var/lib/ubicsi
               mountPropagation: Bidirectional
+            - name: ubiblk-bin
+              mountPath: /host/opt/ubiblk
           resources:
             {}
         - name: driver-registrar
@@ -125,4 +127,8 @@ spec:
         - name: ubicsi-local-data
           hostPath:
             path: /var/lib/ubicsi
+            type: DirectoryOrCreate
+        - name: ubiblk-bin
+          hostPath:
+            path: /opt/ubiblk
             type: DirectoryOrCreate

--- a/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:v0.15.0
+          image: ubicloud/ubicsi:v0.16.0
           imagePullPolicy: IfNotPresent
           args: ["controller"]
           env:


### PR DESCRIPTION
**Bundle ubiblk binaries in the ubicsi image**
The CSI driver is moving from loop devices to ublk-backed volumes, which needs the ubiblk binaries present on every node. Shipping them in the image rather than the node image means an existing cluster picks them up by rolling the DaemonSet, with no node replacement and no rhizome push.

Only the three binaries the driver will invoke are extracted. The tarball is checksummed against a hardcoded digest, and the x64 asset is hardcoded because csi-build.yml only builds linux/amd64.

**Stage ubiblk on the node and load the ublk_drv module**
A ublk device is owned by a userspace process, so the backend cannot run inside the node plugin pod: a DaemonSet roll would take down the filesystems mounted from it. The binaries are copied to a versioned directory under the node's /opt/ubiblk instead, where the host can run them, and an already staged binary is left alone so a running backend keeps its inode.

Nothing depends on ublk yet, so a failure to load ublk_drv is logged rather than fatal. That makes this rollout a read on which clusters can support ublk at all, without changing how any volume is served.