### PR TITLE
Fix the PostgresServer state enum for servers in failover

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -4023,7 +4023,7 @@ components:
             - creating
             - updating
             - unavailable
-            - failover
+            - failing_over
             - restarting
             - synchronizing
             - deleting

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -1539,6 +1539,15 @@ RSpec.describe Clover, "postgres" do
         expect(server).to have_key("state")
         expect(server).to have_key("synchronization_status")
       end
+
+      it "returns servers during failover" do
+        pg.representative_server.strand.update(label: "taking_over")
+
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/servers"
+
+        expect(last_response.status).to eq(200)
+        expect(JSON.parse(last_response.body)["items"].first["state"]).to eq("failing_over")
+      end
     end
 
     describe "logs" do


### PR DESCRIPTION
PostgresServer#display_state returns "failing_over" while a server is going through any of the FAILOVER_LABELS, but the openapi.yml enum for PostgresServer.state listed "failover" instead. Nothing ever produced "failover", so listing servers during a failover made Committee raise InvalidResponse on the /servers endpoint.

Replace the stale value with "failing_over" and add a spec that lists servers while the representative server is taking over.