### PR TITLE
Account for SPDK cores in the VmGroup capacity check

### DIFF
--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -142,7 +142,8 @@ class Prog::Test::HetznerServer < Prog::Test::Base
   end
 
   label def verify_resources_reclaimed
-    fail_test "used_cores is expected to be zero, actual: #{vm_host.used_cores}" unless vm_host.used_cores.zero?
+    spdk_cores = vm_host.cpus.count(&:spdk) * vm_host.total_cores / vm_host.total_cpus
+    fail_test "used_cores is expected to be #{spdk_cores}, actual: #{vm_host.used_cores}" unless vm_host.used_cores == spdk_cores
     fail_test "used_hugepages_1g is expected to be zero, actual: #{vm_host.used_hugepages_1g}" unless vm_host.used_hugepages_1g.zero?
     reclaimed_storage_gib = vm_host.available_storage_gib + vm_host.boot_images.sum(&:size_gib)
     fail_test "available_storage_gib was not reclaimed as expected: #{available_storage_gib}, actual: #{reclaimed_storage_gib}" unless available_storage_gib == reclaimed_storage_gib

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -81,8 +81,9 @@ class Prog::Test::VmGroup < Prog::Test::Base
     if verify_host_capacity? && first_boot
       vm_cores = vm_host.vms.sum(&:cores)
       slice_cores = vm_host.slices.sum(&:cores)
+      spdk_cores = vm_host.cpus.count(&:spdk) * vm_host.total_cores / vm_host.total_cpus
 
-      fail_test "Host used cores does not match the allocated VMs cores (vm_cores=#{vm_cores}, slice_cores=#{slice_cores}, used_cores=#{vm_host.used_cores})" if vm_cores + slice_cores != vm_host.used_cores
+      fail_test "Host used cores does not match the allocated VMs cores (spdk_cores=#{spdk_cores}, vm_cores=#{vm_cores}, slice_cores=#{slice_cores}, used_cores=#{vm_host.used_cores})" if spdk_cores + vm_cores + slice_cores != vm_host.used_cores
     end
 
     hop_verify_vm_host_slices

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -204,13 +204,21 @@ RSpec.describe Prog::Test::HetznerServer do
 
   describe "#verify_resources_reclaimed" do
     before {
+      vm_host.update(total_cpus: 16, total_cores: 8)
       vm_host.add_storage_device(name: "DEFAULT", total_storage_gib: 6800, available_storage_gib: 860)
     }
 
     it "fails if used_cores not reclaimed" do
-      vm_host.update(used_cores: 10)
+      vm_host.update(used_cores: 5)
       expect { hs_test.verify_resources_reclaimed }.to hop("failed")
-      expect(strand.reload.exitval).to eq({"msg" => "used_cores is expected to be zero, actual: 10"})
+      expect(strand.reload.exitval).to eq({"msg" => "used_cores is expected to be 0, actual: 5"})
+    end
+
+    it "allows the SPDK-reserved cores to remain in used_cores" do
+      2.times { |i| VmHostCpu.create(vm_host_id: vm_host.id, cpu_number: i, spdk: true) }
+      vm_host.update(used_cores: 1)
+      refresh_frame(hs_test, new_values: {"available_storage_gib" => 860})
+      expect { hs_test.verify_resources_reclaimed }.to hop("destroy_vm_host")
     end
 
     it "fails if used_hugepages_1g not reclaimed" do

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -144,6 +144,16 @@ RSpec.describe Prog::Test::VmGroup do
       expect { vg_test.verify_host_capacity }.to hop("verify_vm_host_slices")
     end
 
+    it "accounts for the SPDK-reserved cores in used_cores" do
+      vm_host = create_vm_host(total_cpus: 16, total_cores: 8, used_cores: 4)
+      2.times { |i| VmHostCpu.create(vm_host_id: vm_host.id, cpu_number: i, spdk: true) }
+      vm1 = create_vm(vm_host_id: vm_host.id, cores: 2, name: "test-vm-1")
+      create_vm_host_slice(vm_host_id: vm_host.id)
+      refresh_frame(vg_test, new_values: {"vms" => [vm1.id], "verify_host_capacity?" => true})
+
+      expect { vg_test.verify_host_capacity }.to hop("verify_vm_host_slices")
+    end
+
     it "skips if verify_host_capacity is not set" do
       refresh_frame(vg_test, new_values: {"verify_host_capacity?" => false})
       expect(vg_test).not_to receive(:vm_host)
@@ -164,7 +174,7 @@ RSpec.describe Prog::Test::VmGroup do
       refresh_frame(vg_test, new_values: {"vms" => [vm1.id], "verify_host_capacity?" => true})
 
       expect { vg_test.verify_host_capacity }.to hop("failed")
-      expect(st.reload.exitval).to eq({"msg" => "Host used cores does not match the allocated VMs cores (vm_cores=2, slice_cores=1, used_cores=5)"})
+      expect(st.reload.exitval).to eq({"msg" => "Host used cores does not match the allocated VMs cores (spdk_cores=0, vm_cores=2, slice_cores=1, used_cores=5)"})
     end
   end
 


### PR DESCRIPTION
### Account for SPDK cores in the VmGroup capacity check

host_nexus now seeds a host's used_cores with the SPDK CPU reservation (spdk_cpu_count * total_cores / total_cpus), but VmGroup's verify_host_capacity still compared used_cores to only vm + slice cores. The E2E then failed on any host running SPDK:


>  FAILED: Host used cores does not match the allocated VMs cores
>  (vm_cores=0, slice_cores=8, used_cores=9)

Add the SPDK reservation to the expected total: the SPDK CPUs converted to cores the same way host_nexus computes it. used_cores is in cores, so the raw SPDK CPU count would be off by threads_per_core.

### Expect the SPDK reservation in the reclaim check 

host_nexus seeds a host's used_cores with the SPDK CPU reservation, and that reservation is permanent: it comes from spdk_cpu_count during prep, independent of any SPDK installation. HetznerServer's verify_resources_reclaimed still expected used_cores to reach zero after destroying every VM, so the E2E failed:

>>  FAILED: used_cores is expected to be zero, actual: 1

Expect used_cores to return to the SPDK reservation rather than zero, computed as in host_nexus. used_hugepages_1g still expects zero: it only carries an SPDK baseline when SPDK is installed, which is not the case here.
