### PR TITLE
Small vm provisioning improvements

### DIFF
--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -191,7 +191,8 @@ class Prog::Vm::Metal::Nexus < Prog::Base
 
   label def wait_sshable
     unless vm.update_firewall_rules_set?
-      vm.incr_update_firewall_rules
+      # vm.incr rewrites schedule and strand rerun immediately instead of napping 6s
+      Semaphore.incr(vm.id, :update_firewall_rules, wake: false)
       # This is the first time we get into this state and we know that
       # wait_sshable will take definitely more than 6 seconds. So, we nap here
       # to reduce the amount of load on the control plane unnecessarily.

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -606,6 +606,8 @@ DNSMASQ_CONF
         "ssh_authorized_keys" => public_keys,
       }],
       "ssh_pwauth" => false,
+      "ssh_genkeytypes" => ["ed25519"],
+      "ssh_quiet_keygen" => true,
       "runcmd" => runcmd,
       "bootcmd" => nft_bootcmd,
     }

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -65,6 +65,9 @@ RSpec.describe VmSetup do
           ssh_authorized_keys:
           - some_ssh_key
         ssh_pwauth: false
+        ssh_genkeytypes:
+        - ed25519
+        ssh_quiet_keygen: true
         runcmd:
         - systemctl daemon-reload
         bootcmd:

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -1010,8 +1010,10 @@ RSpec.describe Prog::Vm::Metal::Nexus do
 
   describe "#wait_sshable" do
     it "naps 6 seconds if it's the first time we execute wait_sshable" do
+      schedule = st.schedule
       expect { nx.wait_sshable }.to nap(6)
         .and change { vm.update_firewall_rules_set?(cached: false) }.from(false).to(true)
+      expect(st.reload.schedule).to eq(schedule)
     end
 
     it "naps if not sshable" do


### PR DESCRIPTION
- **Generate only the ed25519 SSH host key in guest VMs**

cloud-init regenerates all three host key types (rsa, ecdsa, ed25519)
during its network stage, which gates sysinit.target and with it
ssh.socket. RSA-3072 generation dominates the cost: on a profiled
github runner the config-ssh step took 330ms of the 7.4 seconds until
port 22 opened. All maintained SSH clients (OpenSSH >= 6.5, 2014)
support ed25519 host keys, so generate only that one.

ssh_quiet_keygen also drops the fingerprint and randomart dump from
the serial console.

- **Do not wake own strand when entering wait_sshable**

wait_sshable sets the update_firewall_rules semaphore on its own
strand and then naps for 6 seconds, expecting the VM to need at least
that long to boot. The nap never held: Semaphore.incr wakes the target
strand by rewriting its schedule, and since the schedule doubles as
the optimistic concurrency key for the nap's compare-and-set, the nap
was silently discarded and the strand re-ran immediately. A profiled
provision showed wait_sshable running three times with 1-second TCP
connect timeouts while the guest was still booting.

Set the semaphore with wake: false. Waking is pointless here anyway:
the semaphore is consumed by the wait label, which this same strand
only reaches after wait_sshable hops.
