### PR TITLE
Build node images for versions customers cannot select

### DIFF
--- a/helpers/kubernetes_cluster.rb
+++ b/helpers/kubernetes_cluster.rb
@@ -6,6 +6,7 @@ class Clover
     fail Validation::ValidationFailed.new({billing_info: "Project doesn't have valid billing information"}) unless @project.has_valid_payment_method?
 
     version, target_node_size = typecast_params.nonempty_str!(["version", "worker_size"])
+    Validation.validate_kubernetes_version(version)
     node_count = typecast_params.pos_int("worker_nodes", 1)
     cp_node_count = typecast_params.pos_int("cp_nodes", 1)
     node_size = Validation.validate_vm_size(target_node_size, "x64")

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -12,7 +12,6 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
         fail "No existing project"
       end
 
-      Validation.validate_kubernetes_version(version)
       Validation.validate_kubernetes_name(name)
       Validation.validate_kubernetes_cp_node_count(cp_node_count)
       Validation.validate_kubernetes_location(location_id)

--- a/spec/prog/kubernetes/build_node_image_spec.rb
+++ b/spec/prog/kubernetes/build_node_image_spec.rb
@@ -330,6 +330,16 @@ RSpec.describe Prog::Kubernetes::BuildNodeImage do
       expect(cluster.nodepools.map { [it.name, it.node_count, it.strand.stack.first["machine_image_version_id"]] })
         .to eq [["#{name}-np", 1, metal.id]]
     end
+
+    it "creates a cluster for a version that customers can no longer select" do
+      version = Option.kubernetes_versions.last
+      old_version_prog = described_class.new(described_class.assemble(kubernetes_version: version, location_id:, image_version: "20260730.1.0"))
+      metal = create_machine_image_version_metal
+      refresh_frame(old_version_prog, new_values: {"machine_image_version_id" => metal.id})
+
+      expect { old_version_prog.verify }.to hop("wait_verify")
+      expect(KubernetesCluster[old_version_prog.strand.stack.first["verify_cluster_id"]].version).to eq version
+    end
   end
 
   describe "#wait_verify" do

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
       expect {
         described_class.assemble(version: "v1.30", project_id: customer_project.id, name: "k8stest", location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3)
-      }.to raise_error Validation::ValidationFailed, "Validation failed for following fields: version"
+      }.to raise_error Sequel::ValidationFailed, "version must be a valid Kubernetes version"
 
       expect {
         described_class.assemble(name: "Uppercase", project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3)
@@ -137,6 +137,13 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
         "#{kc.private_subnet.net6}:0...65536:tcp",
         "#{kc.private_subnet.net6}:0...65536:udp",
       ]
+    end
+
+    it "creates a kubernetes cluster with a supported version that is not selectable" do
+      version = (Option.kubernetes_versions - Option.selectable_kubernetes_versions).first
+      kc = described_class.assemble(name: "k8stest", version:, project_id: customer_project.id, location_id: Location::HETZNER_FSN1_ID, cp_node_count: 3).subject
+
+      expect(kc.version).to eq version
     end
 
     it "has defaults for node size, storage size, version and subnet" do

--- a/spec/routes/api/project/location/kubernetes_cluster_spec.rb
+++ b/spec/routes/api/project/location/kubernetes_cluster_spec.rb
@@ -135,6 +135,19 @@ RSpec.describe Clover, "kubernetes-cluster" do
         expect(parsed_body["error"]["details"]["version"]).to include("Kubernetes version \"v1.30\" is not supported")
         expect(parsed_body["error"]["details"]["version"]).to include("Available versions:")
       end
+
+      it "returns 400 for a supported kubernetes version that is not selectable" do
+        version = (Option.kubernetes_versions - Option.selectable_kubernetes_versions).first
+        post "/project/#{project.ubid}/location/#{TEST_LOCATION}/kubernetes-cluster/test-cluster", {
+          version:,
+          worker_size: "standard-2",
+          worker_nodes: 2,
+          cp_nodes: 1,
+        }.to_json
+
+        expect(last_response).to have_api_error(400, "Validation failed for following fields: version")
+        expect(KubernetesCluster[name: "test-cluster"]).to be_nil
+      end
     end
 
     describe "show" do


### PR DESCRIPTION
BuildNodeImage's verify step creates a real cluster at the version being built, so it went through KubernetesClusterNexus.assemble, which called Validation.validate_kubernetes_version. That check only accepts Option.selectable_kubernetes_versions, the two newest, so rebuilding the image for an older but still supported version raised ValidationFailed on every tick of verify and the image was never promoted. Nodes added to an existing cluster on such a version then kept booting the stale image.

Move the check to kubernetes_cluster_post, the only customer-facing entry point for cluster creation, which the web, API and CLI all share. The "two newest versions" rule is about what a customer may pick, not an invariant of a cluster: KubernetesCluster#validate still rejects any version outside Option.kubernetes_versions, so the verify cluster and the E2E progs can use a supported version that is no longer selectable.