### PR TITLE
Minor improvements on k8s

### DIFF
--- a/lib/kubernetes/client.rb
+++ b/lib/kubernetes/client.rb
@@ -42,7 +42,7 @@ class Kubernetes::Client
   end
 
   def delete_node(node_name)
-    kubectl("delete node :node_name", node_name:)
+    kubectl("delete node :node_name --ignore-not-found", node_name:)
   end
 
   def retain_pv(pv_name)

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -201,6 +201,8 @@ TIMER
       hop_retire
     end
 
+    nap 30 if kubernetes_node.vm.strand.label == "wait_sshable"
+
     if available?
       decr_checkup
       hop_wait

--- a/prog/kubernetes/kubernetes_node_nexus.rb
+++ b/prog/kubernetes/kubernetes_node_nexus.rb
@@ -237,7 +237,7 @@ TIMER
     when "Succeeded"
       hop_wait_for_detach
     when "NotStarted"
-      sshable.d_run(unit_name, "sudo", "kubectl", "--kubeconfig=/etc/kubernetes/admin.conf",
+      sshable.d_run(unit_name, "kubectl", "--kubeconfig=/etc/kubernetes/admin.conf",
         "drain", kubernetes_node.name, "--ignore-daemonsets", "--delete-emptydir-data")
       nap 10
     when "InProgress"

--- a/prog/kubernetes/upgrade_kubernetes_node.rb
+++ b/prog/kubernetes/upgrade_kubernetes_node.rb
@@ -71,7 +71,7 @@ class Prog::Kubernetes::UpgradeKubernetesNode < Prog::Base
       new_node.vm.sshable.d_run(
         "kubeadm_upgrade_apply",
         "bash", "-c",
-        "sudo kubeadm upgrade apply --yes $(kubeadm version -o short)",
+        "kubeadm upgrade apply --yes $(kubeadm version -o short)",
       )
       nap 30
     when "InProgress"

--- a/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
+++ b/rhizome/kubernetes/lib/kubernetes_build_node_image.rb
@@ -28,30 +28,30 @@ class KubernetesBuildNodeImage
   def run
     ENV["DEBIAN_FRONTEND"] = "noninteractive"
 
-    r "sudo tee /etc/sysctl.d/72-clover-forward-packets.conf > /dev/null", stdin: SYSCTL_CONF
+    r "tee /etc/sysctl.d/72-clover-forward-packets.conf > /dev/null", stdin: SYSCTL_CONF
 
-    r "sudo -E apt-get update"
-    r "sudo -E apt-get full-upgrade -y"
-    r "sudo -E apt-get install -y ca-certificates curl gpg"
+    r "apt-get update"
+    r "apt-get full-upgrade -y"
+    r "apt-get install -y ca-certificates curl gpg"
 
-    r "sudo install -m 0755 -d /etc/apt/keyrings"
+    r "install -m 0755 -d /etc/apt/keyrings"
     r "curl -fsSL :url -o :path", url: "#{repo_url}Release.key", path: KEY_PATH
-    r "sudo gpg --batch --yes --dearmor -o :keyring :path", keyring: KEYRING, path: KEY_PATH
+    r "gpg --batch --yes --dearmor -o :keyring :path", keyring: KEYRING, path: KEY_PATH
     r "rm -f :path", path: KEY_PATH
-    r "echo :line | sudo tee /etc/apt/sources.list.d/kubernetes.list > /dev/null", line: "deb [signed-by=#{KEYRING}] #{repo_url} /"
+    r "echo :line | tee /etc/apt/sources.list.d/kubernetes.list > /dev/null", line: "deb [signed-by=#{KEYRING}] #{repo_url} /"
 
-    r "sudo -E apt-get update"
-    r "sudo -E apt-get install -y containerd cri-tools kubelet kubeadm kubectl ruby-bundler"
+    r "apt-get update"
+    r "apt-get install -y containerd cri-tools kubelet kubeadm kubectl ruby-bundler"
 
-    r "sudo -E apt-get install -y linux-modules-extra-$(linux-version list | linux-version sort | tail -1)"
+    r "apt-get install -y linux-modules-extra-$(linux-version list | linux-version sort | tail -1)"
 
-    r "sudo mkdir -p /etc/containerd"
-    r "sudo tee /etc/containerd/config.toml > /dev/null", stdin: r("containerd config default").gsub("SystemdCgroup = false", "SystemdCgroup = true")
+    r "mkdir -p /etc/containerd"
+    r "tee /etc/containerd/config.toml > /dev/null", stdin: r("containerd config default").gsub("SystemdCgroup = false", "SystemdCgroup = true")
 
     r "kubernetes/bin/install-node-exporter"
     r "kubernetes/bin/install-prometheus"
 
-    r "sudo apt-mark hold kubelet kubeadm kubectl"
-    r "sudo systemctl disable unattended-upgrades"
+    r "apt-mark hold kubelet kubeadm kubectl"
+    r "systemctl disable unattended-upgrades"
   end
 end

--- a/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
+++ b/rhizome/kubernetes/spec/kubernetes_build_node_image_spec.rb
@@ -32,29 +32,29 @@ RSpec.describe KubernetesBuildNodeImage do
       builder.run
 
       expect(commands).to eq [
-        "sudo tee /etc/sysctl.d/72-clover-forward-packets.conf > /dev/null",
-        "sudo -E apt-get update",
-        "sudo -E apt-get full-upgrade -y",
-        "sudo -E apt-get install -y ca-certificates curl gpg",
-        "sudo install -m 0755 -d /etc/apt/keyrings",
+        "tee /etc/sysctl.d/72-clover-forward-packets.conf > /dev/null",
+        "apt-get update",
+        "apt-get full-upgrade -y",
+        "apt-get install -y ca-certificates curl gpg",
+        "install -m 0755 -d /etc/apt/keyrings",
         "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.35/deb/Release.key -o /tmp/kubernetes-release.key",
-        "sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg /tmp/kubernetes-release.key",
+        "gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg /tmp/kubernetes-release.key",
         "rm -f /tmp/kubernetes-release.key",
-        "echo deb\\ \\[signed-by\\=/etc/apt/keyrings/kubernetes-apt-keyring.gpg\\]\\ https://pkgs.k8s.io/core:/stable:/v1.35/deb/\\ / | sudo tee /etc/apt/sources.list.d/kubernetes.list > /dev/null",
-        "sudo -E apt-get update",
-        "sudo -E apt-get install -y containerd cri-tools kubelet kubeadm kubectl ruby-bundler",
-        "sudo -E apt-get install -y linux-modules-extra-$(linux-version list | linux-version sort | tail -1)",
-        "sudo mkdir -p /etc/containerd",
+        "echo deb\\ \\[signed-by\\=/etc/apt/keyrings/kubernetes-apt-keyring.gpg\\]\\ https://pkgs.k8s.io/core:/stable:/v1.35/deb/\\ / | tee /etc/apt/sources.list.d/kubernetes.list > /dev/null",
+        "apt-get update",
+        "apt-get install -y containerd cri-tools kubelet kubeadm kubectl ruby-bundler",
+        "apt-get install -y linux-modules-extra-$(linux-version list | linux-version sort | tail -1)",
+        "mkdir -p /etc/containerd",
         "containerd config default",
-        "sudo tee /etc/containerd/config.toml > /dev/null",
+        "tee /etc/containerd/config.toml > /dev/null",
         "kubernetes/bin/install-node-exporter",
         "kubernetes/bin/install-prometheus",
-        "sudo apt-mark hold kubelet kubeadm kubectl",
-        "sudo systemctl disable unattended-upgrades",
+        "apt-mark hold kubelet kubeadm kubectl",
+        "systemctl disable unattended-upgrades",
       ]
       expect(stdins).to eq(
-        "sudo tee /etc/sysctl.d/72-clover-forward-packets.conf > /dev/null" => described_class::SYSCTL_CONF,
-        "sudo tee /etc/containerd/config.toml > /dev/null" => "  SystemdCgroup = true\n",
+        "tee /etc/sysctl.d/72-clover-forward-packets.conf > /dev/null" => described_class::SYSCTL_CONF,
+        "tee /etc/containerd/config.toml > /dev/null" => "  SystemdCgroup = true\n",
       )
       expect(ENV["DEBIAN_FRONTEND"]).to eq "noninteractive"
     end

--- a/spec/lib/kubernetes/client_spec.rb
+++ b/spec/lib/kubernetes/client_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Kubernetes::Client do
   describe "delete_node" do
     it "deletes a node" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("node deleted", 0)
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete node asdf").and_return(response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete node asdf --ignore-not-found").and_return(response)
       kubernetes_client.delete_node("asdf")
     end
   end

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -483,7 +483,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
     before do
       expect(cluster.sshable).to receive(:connect).and_return(session)
       expect(node_sshable).to receive(:_cmd).with("sudo kubeadm reset --force")
-      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete node vm").and_return(success_response)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s delete node vm --ignore-not-found").and_return(success_response)
     end
 
     it "detaches a nodepool node from the services load balancer" do

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
 
     it "starts the drain process when run for the first time and naps" do
       expect(cluster_sshable).to receive(:_cmd).with("common/bin/daemonizer2 check drain_node_vm").and_return("NotStarted")
-      expect(cluster_sshable).to receive(:_cmd).with("common/bin/daemonizer2 run drain_node_vm sudo kubectl --kubeconfig\\=/etc/kubernetes/admin.conf drain vm --ignore-daemonsets --delete-emptydir-data", {log: true, stdin: nil})
+      expect(cluster_sshable).to receive(:_cmd).with("common/bin/daemonizer2 run drain_node_vm kubectl --kubeconfig\\=/etc/kubernetes/admin.conf drain vm --ignore-daemonsets --delete-emptydir-data", {log: true, stdin: nil})
       expect { nx.drain }.to nap(10)
     end
 

--- a/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_node_nexus_spec.rb
@@ -229,6 +229,12 @@ RSpec.describe Prog::Kubernetes::KubernetesNodeNexus do
       expect { nx.unavailable }.to hop("retire")
     end
 
+    it "naps without checking the mesh while the vm waits to become sshable" do
+      kd.vm.strand.update(label: "wait_sshable")
+      expect { nx.unavailable }.to nap(30)
+      expect(nx.strand.stack.first["deadline_target"]).to be_nil
+    end
+
     it "hops to wait when node becomes available" do
       nx.incr_checkup
       status_json = JSON.generate({"pods" => {"pod-1" => {"reachable" => true}}, "external_endpoints" => {}})

--- a/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/upgrade_kubernetes_node_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Prog::Kubernetes::UpgradeKubernetesNode do
         expect(prog.new_node.vm.sshable).to receive(:d_check).with("kubeadm_upgrade_apply").and_return("NotStarted")
         expect(prog.new_node.vm.sshable).to receive(:d_run).with(
           "kubeadm_upgrade_apply", "bash", "-c",
-          "sudo kubeadm upgrade apply --yes $(kubeadm version -o short)",
+          "kubeadm upgrade apply --yes $(kubeadm version -o short)",
         )
         expect { prog.upgrade_kubeadm }.to nap(30)
       end


### PR DESCRIPTION
**Ignore a missing node when deleting it from the cluster**
remove_node_from_cluster runs kubeadm reset, detaches the VM from the load balancer and deletes the node object. A retry after the node object is already gone fails the label permanently, so pass --ignore-not-found.

**Skip the mesh check while the node vm waits to become sshable**
The monitor pulses every kubernetes node, including one whose vm has not finished downloading its boot image and is not sshable yet. The resulting down readings set checkup, and the unavailable label then logged a connection failure with a full backtrace on every pass.

**Drop the redundant sudo from the node image build**
daemonizer2 starts the unit with sudo systemd-run, so build-node-image already runs as root. The install-node-exporter and install-prometheus scripts it calls rely on that.

**Drop the redundant sudo from the node drain and kubeadm upgrade**
daemonizer2 starts the unit with sudo systemd-run, so both already run as root.