### PR TITLE
Fall back to unprivileged systemctl for runner script

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -20,6 +20,9 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     Config.github_ubuntu_2604_arm64_aws_ami_version,
   ].freeze
 
+  SHOW_RUNNER_SCRIPT_SUBSTATE = "systemctl show -p SubState --value runner-script"
+  RUNNER_SCRIPT_SUBSTATE_COMMAND = "sudo #{SHOW_RUNNER_SCRIPT_SUBSTATE} 2>/dev/null || #{SHOW_RUNNER_SCRIPT_SUBSTATE}".freeze
+
   def self.assemble(installation, repository_name:, label:, actual_label: nil, default_branch: nil)
     unless Github.runner_labels[label]
       fail "Invalid GitHub runner label: #{label}"
@@ -564,7 +567,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
     runner_id = runner.fetch(:id)
     # If the runner script is not started yet, we can delete the runner and
     # register it again.
-    if vm.sshable.cmd("sudo systemctl show -p SubState --value runner-script").chomp == "dead"
+    if vm.sshable.cmd(RUNNER_SCRIPT_SUBSTATE_COMMAND).chomp == "dead"
       Clog.emit("Deregistering runner because it already exists", [github_runner, {existing_runner: {runner_id:}}])
       client.delete(runners_path(runner_id))
       nap 5
@@ -580,7 +583,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
   label def wait
     register_deadline(nil, 5 * 24 * 60 * 60)
     substate = begin
-      vm.sshable.cmd("sudo systemctl show -p SubState --value runner-script").chomp
+      vm.sshable.cmd(RUNNER_SCRIPT_SUBSTATE_COMMAND).chomp
     rescue *Sshable::SSH_CONNECTION_ERRORS
       if vm.location.aws? && vm.aws_instance
         instance_id = vm.aws_instance.instance_id

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -769,7 +769,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(client).to receive(:paginate)
         .and_yield({runners: [{name: runner.ubid.to_s, id: 123}]}, instance_double(Sawyer::Response, data: {runners: []}))
         .and_return({runners: [{name: runner.ubid.to_s, id: 123}]})
-      expect(vm.sshable).to receive(:_cmd).with("sudo systemctl show -p SubState --value runner-script").and_return("dead")
+      expect(vm.sshable).to receive(:_cmd).with(described_class::RUNNER_SCRIPT_SUBSTATE_COMMAND).and_return("dead")
       expect(client).to receive(:delete).with("/repos/#{runner.repository_name}/actions/runners/123")
       expect(Clog).to receive(:emit).with("Deregistering runner because it already exists", instance_of(Array)).and_call_original
       expect { nx.register_runner }.to nap(5)
@@ -782,7 +782,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       expect(client).to receive(:paginate)
         .and_yield({runners: [{name: runner.ubid.to_s, id: 123}]}, instance_double(Sawyer::Response, data: {runners: []}))
         .and_return({runners: [{name: runner.ubid.to_s, id: 123}]})
-      expect(vm.sshable).to receive(:_cmd).with("sudo systemctl show -p SubState --value runner-script").and_return("running")
+      expect(vm.sshable).to receive(:_cmd).with(described_class::RUNNER_SCRIPT_SUBSTATE_COMMAND).and_return("running")
       expect { nx.register_runner }.to hop("wait")
       expect(runner.runner_id).to eq(123)
       expect(runner.ready_at).to eq(now)
@@ -973,7 +973,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     it "does not destroy runner if it does not pick a job in five minutes, and busy" do
       runner.update(ready_at: now - 6 * 60, workflow_job: nil)
       expect(client).to receive(:get).and_return({busy: true})
-      expect(vm.sshable).to receive(:_cmd).with("sudo systemctl show -p SubState --value runner-script").and_return("running")
+      expect(vm.sshable).to receive(:_cmd).with(described_class::RUNNER_SCRIPT_SUBSTATE_COMMAND).and_return("running")
       expect(nx).not_to receive(:register_deadline).with(nil, 7200)
 
       expect { nx.wait }.to nap(60)
@@ -983,7 +983,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     it "destroys runner if it does not pick a job in five minutes and not busy" do
       runner.update(ready_at: now - 6 * 60, workflow_job: nil)
       expect(client).to receive(:get).and_return({busy: false})
-      expect(vm.sshable).to receive(:_cmd).with("sudo systemctl show -p SubState --value runner-script").and_return("running")
+      expect(vm.sshable).to receive(:_cmd).with(described_class::RUNNER_SCRIPT_SUBSTATE_COMMAND).and_return("running")
       expect(nx).to receive(:register_deadline).twice
       expect(Clog).to receive(:emit).with("The runner did not pick a job", instance_of(GithubRunner)).and_call_original
 
@@ -994,7 +994,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     it "destroys runner if it does not pick a job in five minutes and already deleted" do
       runner.update(ready_at: now - 6 * 60, workflow_job: nil)
       expect(client).to receive(:get).and_raise(Octokit::NotFound)
-      expect(vm.sshable).to receive(:_cmd).with("sudo systemctl show -p SubState --value runner-script").and_return("running")
+      expect(vm.sshable).to receive(:_cmd).with(described_class::RUNNER_SCRIPT_SUBSTATE_COMMAND).and_return("running")
       expect(nx).to receive(:register_deadline).twice
       expect(Clog).to receive(:emit).with("The runner did not pick a job", instance_of(GithubRunner)).and_call_original
 
@@ -1004,21 +1004,21 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
     it "does not destroy runner if it doesn not pick a job but two minutes not pass yet" do
       runner.update(ready_at: now - 60, workflow_job: nil)
-      expect(vm.sshable).to receive(:_cmd).with("sudo systemctl show -p SubState --value runner-script").and_return("running")
+      expect(vm.sshable).to receive(:_cmd).with(described_class::RUNNER_SCRIPT_SUBSTATE_COMMAND).and_return("running")
 
       expect { nx.wait }.to nap(60)
       expect(runner.destroy_set?).to be(false)
     end
 
     it "destroys the runner if the runner-script is succeeded" do
-      expect(vm.sshable).to receive(:_cmd).with("sudo systemctl show -p SubState --value runner-script").and_return("exited")
+      expect(vm.sshable).to receive(:_cmd).with(described_class::RUNNER_SCRIPT_SUBSTATE_COMMAND).and_return("exited")
 
       expect { nx.wait }.to nap(15)
       expect(runner.destroy_set?).to be(true)
     end
 
     it "provisions a spare runner and destroys the current one if the runner-script is failed" do
-      expect(vm.sshable).to receive(:_cmd).with("sudo systemctl show -p SubState --value runner-script").and_return("failed")
+      expect(vm.sshable).to receive(:_cmd).with(described_class::RUNNER_SCRIPT_SUBSTATE_COMMAND).and_return("failed")
       expect(runner).to receive(:provision_spare_runner)
 
       expect { nx.wait }.to nap(0)
@@ -1026,7 +1026,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     end
 
     it "naps if the runner-script is running" do
-      expect(vm.sshable).to receive(:_cmd).with("sudo systemctl show -p SubState --value runner-script").and_return("running")
+      expect(vm.sshable).to receive(:_cmd).with(described_class::RUNNER_SCRIPT_SUBSTATE_COMMAND).and_return("running")
 
       expect { nx.wait }.to nap(60)
     end


### PR DESCRIPTION
We query the runner-script unit state as root since a2ed904f5, because root systemctl reaches the systemd private socket and survives a customer job that leaves the D-Bus socket unreachable.

But customer jobs own the runner VM, and some of them break sudo itself. The check then fails with "/usr/bin/sudo: Permission denied", and the strand keeps failing until the deadline pages us.

Try sudo first and fall back to a plain systemctl call, so the check works whether D-Bus or sudo is the broken one. We discard the stderr of the sudo attempt only, so a true failure of both calls still reports its error.