### PR TITLE
Add GitHub Actions Setup Workflow

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -203,6 +203,11 @@ task "api_spec" do
   sh({"RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1", "EAGER_EC2_CLIENT" => "1"}, "bundle", "exec", "turbo_tests", "-n", nproc.call, "spec/routes/api")
 end
 
+desc "Run web tests in parallel"
+task "web_spec" do
+  sh({"RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1", "EAGER_EC2_CLIENT" => "1"}, "bundle", "exec", "turbo_tests", "-n", nproc.call, *Dir["spec/routes/web/{*_spec.rb,webhook,project}"])
+end
+
 desc "Run route specs checking no SSH access from web process"
 task "route_spec" do
   sh({"RUBYOPT" => "-w", "RACK_ENV" => "test", "FORCE_AUTOLOAD" => "1", "EAGER_EC2_CLIENT" => "1", "PROCESS_TYPE" => "web"}, "bundle", "exec", "turbo_tests", "-n", nproc.call, "spec/routes")

--- a/clover.rb
+++ b/clover.rb
@@ -1147,21 +1147,22 @@ class Clover < Roda
       rodauth.check_active_session
 
       r.root do
-        if typecast_params.str("setup") == "github_actions" && Config.omniauth_github_id && Config.github_app_name
+        if typecast_params.str("setup") == "github_actions" && Config.omniauth_github_id && Config.github_app_name && Config.stripe_secret_key
           @step = if current_account
             if (@project = current_account.default_project || current_account.projects_dataset.order(:created_at, :name).first)
               if @project.github_installations_dataset.empty?
-                session["github_actions_setup"] = true
                 2
+              elsif @project.payment_methods_dataset.empty?
+                3
               end
             else
               redirect_default_project_dashboard
             end
           else
-            session["github_actions_setup"] = true
             1
           end
 
+          session["github_actions_setup"] = true
           next view "github/actions-setup"
         end
 

--- a/clover.rb
+++ b/clover.rb
@@ -1144,6 +1144,15 @@ class Clover < Roda
       rodauth.check_active_session
 
       r.root do
+        if typecast_params.str("setup") == "github_actions" && Config.omniauth_github_id
+          @step = if current_account
+          else
+            1
+          end
+
+          next view "github/actions-setup"
+        end
+
         if current_account
           redirect_default_project_dashboard
         else

--- a/clover.rb
+++ b/clover.rb
@@ -524,6 +524,8 @@ class Clover < Roda
         add_audit_log(account_session_value, :login_failure, {"provider" => scope.omniauth_provider_name(omniauth_provider)})
         redirect "/login"
       end
+
+      @saved_login_redirect = "/?setup=github_actions" if session["github_actions_setup"]
     end
 
     after_login do

--- a/clover.rb
+++ b/clover.rb
@@ -664,6 +664,7 @@ class Clover < Roda
 
     after_omniauth_create_account do
       scope.after_rodauth_create_account(account_id)
+      session[login_redirect_session_key] = "/?setup=github_actions" if session["github_actions_setup"]
     end
 
     omniauth_on_failure do
@@ -1146,7 +1147,9 @@ class Clover < Roda
       r.root do
         if typecast_params.str("setup") == "github_actions" && Config.omniauth_github_id
           @step = if current_account
+            2
           else
+            session["github_actions_setup"] = true
             1
           end
 

--- a/clover.rb
+++ b/clover.rb
@@ -1154,6 +1154,8 @@ class Clover < Roda
                 2
               elsif @project.payment_methods_dataset.empty?
                 3
+              else
+                4
               end
             else
               redirect_default_project_dashboard
@@ -1162,7 +1164,7 @@ class Clover < Roda
             1
           end
 
-          session["github_actions_setup"] = true
+          session["github_actions_setup"] = true unless @step == 4
           next view "github/actions-setup"
         end
 

--- a/clover.rb
+++ b/clover.rb
@@ -1147,9 +1147,16 @@ class Clover < Roda
       rodauth.check_active_session
 
       r.root do
-        if typecast_params.str("setup") == "github_actions" && Config.omniauth_github_id
+        if typecast_params.str("setup") == "github_actions" && Config.omniauth_github_id && Config.github_app_name
           @step = if current_account
-            2
+            if (@project = current_account.default_project || current_account.projects_dataset.order(:created_at, :name).first)
+              if @project.github_installations_dataset.empty?
+                session["github_actions_setup"] = true
+                2
+              end
+            else
+              redirect_default_project_dashboard
+            end
           else
             session["github_actions_setup"] = true
             1

--- a/routes/github.rb
+++ b/routes/github.rb
@@ -67,7 +67,11 @@ class Clover
       )
 
       flash["notice"] = "GitHub runner integration is enabled for #{project.name} project."
-      r.redirect installation, "/runner"
+      if session["github_actions_setup"]
+        r.redirect "/?setup=github_actions"
+      else
+        r.redirect installation, "/runner"
+      end
     end
   end
 end

--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -130,7 +130,11 @@ class Clover
         end
 
         flash["notice"] = "Payment method added successfully. $#{preauth_amount / 100} is authorized on your card for verification purposes. It's canceled already and depending on your bank, it may take up to two weeks to refund the money."
-        r.redirect billing_path
+        if session["github_actions_setup"]
+          r.redirect "/?setup=github_actions"
+        else
+          r.redirect billing_path
+        end
       end
 
       r.on "payment-method" do

--- a/routes/project/github.rb
+++ b/routes/project/github.rb
@@ -24,11 +24,14 @@ class Clover
     end
 
     r.get web?, "create" do
-      handle_validation_failure("github/index")
-      unless @project.has_valid_payment_method?
-        raise_web_error("Project doesn't have valid billing information")
+      session["github_installation_project_id"] = @project.id
+
+      unless session["github_actions_setup"]
+        handle_validation_failure("github/index")
+        unless @project.has_valid_payment_method?
+          raise_web_error("Project doesn't have valid billing information")
+        end
       end
-      session[:github_installation_project_id] = @project.id
 
       r.redirect "https://github.com/apps/#{Config.github_app_name}/installations/new", 302
     end

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -1236,14 +1236,42 @@ RSpec.describe Clover, "auth" do
       visit "/set_github_installation_project_id/#{project.ubid}"
       GithubInstallation.create(installation_id: 0, name: "bogus", type: "bogus", project_id: project.id)
       visit "/github/callback?code=123123&installation_id=345"
-
-      expect(page).to have_content("Step 1: Create Ubicloud Account")
-      expect(page).to have_content("Step 2: Add GitHub Repositories")
-
-      visit "/?setup=github_actions"
       expect(page).to have_content("Step 1: Create Ubicloud Account")
       expect(page).to have_content("Step 2: Add GitHub Repositories")
       expect(page).to have_content("Step 3: Add Payment Method")
+
+      require "stripe"
+      customers_service = instance_double(Stripe::CustomerService)
+      payment_methods_service = instance_double(Stripe::PaymentMethodService)
+      payment_intents_service = instance_double(Stripe::PaymentIntentService)
+      setup_intents_service = instance_double(Stripe::SetupIntentService)
+      checkout_sessions_service = instance_double(Stripe::Checkout::SessionService)
+
+      expect(StripeClient).to receive_messages(
+        customers: customers_service,
+        payment_methods: payment_methods_service,
+        payment_intents: payment_intents_service,
+        setup_intents: setup_intents_service,
+        checkout: instance_double(Stripe::CheckoutService, sessions: checkout_sessions_service),
+      )
+
+      # rubocop:disable RSpec/VerifiedDoubles
+      expect(checkout_sessions_service).to receive(:create).and_return(double(Stripe::Checkout::Session, url: "#{project.path}/billing/success?session_id=session_123"))
+      expect(payment_intents_service).to receive(:create).and_return(double(Stripe::PaymentIntent, status: "requires_capture", id: "pi_1234567890"))
+      # rubocop:enable RSpec/VerifiedDoubles
+      expect(checkout_sessions_service).to receive(:retrieve).with("session_123").and_return({"setup_intent" => "st_123456790"})
+      expect(setup_intents_service).to receive(:retrieve).with("st_123456790").and_return({"customer" => "cs_1234567890", "payment_method" => "pm_1234567890"})
+      expect(customers_service).to receive(:retrieve).with("cs_1234567890").and_return({"name" => "ACME Inc.", "address" => {"line1" => "Test Rd", "country" => "NL"}, "metadata" => {"company_name" => "Foo Company Name"}})
+      def self.stripe_object(hash)
+        Stripe::StripeObject.construct_from(hash.transform_values { it.is_a?(Hash) ? stripe_object(it) : it })
+      end
+      expect(payment_methods_service).to receive(:retrieve).with("pm_1234567890").and_return(stripe_object("card" => {"brand" => "visa"}, "billing_details" => {}))
+
+      click_button "Add Payment Method"
+      expect(page).to have_content("Step 1: Create Ubicloud Account")
+      expect(page).to have_content("Step 2: Add GitHub Repositories")
+      expect(page).to have_content("Step 3: Add Payment Method")
+      expect(page).to have_flash_notice(/Payment method added successfully/)
     end
 
     it "can use github actions setup workflow even if github account already linked to Ubicloud account" do

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -1239,6 +1239,7 @@ RSpec.describe Clover, "auth" do
       expect(page).to have_content("Step 1: Create Ubicloud Account")
       expect(page).to have_content("Step 2: Add GitHub Repositories")
       expect(page).to have_content("Step 3: Add Payment Method")
+      expect(page).to have_no_content("Step 4: Update Workflow .yml Files")
 
       require "stripe"
       customers_service = instance_double(Stripe::CustomerService)
@@ -1271,7 +1272,11 @@ RSpec.describe Clover, "auth" do
       expect(page).to have_content("Step 1: Create Ubicloud Account")
       expect(page).to have_content("Step 2: Add GitHub Repositories")
       expect(page).to have_content("Step 3: Add Payment Method")
+      expect(page).to have_content("Step 4: Update Workflow .yml Files")
       expect(page).to have_flash_notice(/Payment method added successfully/)
+
+      click_link "Monitor GitHub Runners"
+      expect(page.title).to eq "Ubicloud - Active Runners"
     end
 
     it "can use github actions setup workflow even if github account already linked to Ubicloud account" do

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -1202,12 +1202,14 @@ RSpec.describe Clover, "auth" do
       expect(audit_log_hash).to eq({"create_account" => ip_hash("provider" => "GitHub"), "login" => ip_hash("via" => "GitHub")})
     end
 
-    it "can create new account using github actions setup workflow" do
+    it "can create new account, add repositories, and add payment method using github actions setup workflow" do
       expect(Config).to receive(:github_app_name).and_return("test").at_least(:once)
+      expect(Config).to receive(:stripe_secret_key).and_return("test").at_least(:once)
       mock_provider(:github, name: "foobar")
 
       visit "/?setup=github_actions"
       expect(page).to have_content("Step 1: Create Ubicloud Account")
+      expect(page).to have_no_content("Step 2: Add GitHub Repositories")
       click_button "Create Ubicloud Account Using GitHub"
 
       account = Account[email: TEST_USER_EMAIL]
@@ -1217,6 +1219,7 @@ RSpec.describe Clover, "auth" do
 
       expect(page).to have_content("Step 1: Create Ubicloud Account")
       expect(page).to have_content("Step 2: Add GitHub Repositories")
+      expect(page).to have_no_content("Step 3: Add Payment Method")
 
       click_link "Add GitHub Repositories"
       expect(page.status_code).to eq(200)
@@ -1236,10 +1239,16 @@ RSpec.describe Clover, "auth" do
 
       expect(page).to have_content("Step 1: Create Ubicloud Account")
       expect(page).to have_content("Step 2: Add GitHub Repositories")
+
+      visit "/?setup=github_actions"
+      expect(page).to have_content("Step 1: Create Ubicloud Account")
+      expect(page).to have_content("Step 2: Add GitHub Repositories")
+      expect(page).to have_content("Step 3: Add Payment Method")
     end
 
     it "can use github actions setup workflow even if github account already linked to Ubicloud account" do
       expect(Config).to receive(:github_app_name).and_return("test").at_least(:once)
+      expect(Config).to receive(:stripe_secret_key).and_return("test").at_least(:once)
       mock_provider(:github, name: "foobar")
 
       visit "/login"

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -1216,6 +1216,28 @@ RSpec.describe Clover, "auth" do
       expect(page).to have_content("Step 2: Add GitHub Repositories")
     end
 
+    it "can use github actions setup workflow even if github account already linked to Ubicloud account" do
+      mock_provider(:github, name: "foobar")
+
+      visit "/login"
+      click_button "GitHub"
+      click_button "Log out"
+
+      visit "/?setup=github_actions"
+      expect(page).to have_content("Step 1: Create Ubicloud Account")
+      click_button "Create Ubicloud Account Using GitHub"
+
+      expect(Account[email: TEST_USER_EMAIL].name).to eq "foobar"
+      expect(audit_log_hash).to eq({
+        "create_account" => ip_hash("provider" => "GitHub"),
+        "login" => [ip_hash("via" => "GitHub")] * 2,
+        "logout" => ip_hash,
+      })
+
+      expect(page).to have_content("Step 1: Create Ubicloud Account")
+      expect(page).to have_content("Step 2: Add GitHub Repositories")
+    end
+
     it "can create new account even if social account has a name that isn't a valid Ubicloud name" do
       mock_provider(:github, name: "123Foo..\u1234Bar")
 

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -1203,20 +1203,43 @@ RSpec.describe Clover, "auth" do
     end
 
     it "can create new account using github actions setup workflow" do
+      expect(Config).to receive(:github_app_name).and_return("test").at_least(:once)
       mock_provider(:github, name: "foobar")
 
       visit "/?setup=github_actions"
       expect(page).to have_content("Step 1: Create Ubicloud Account")
       click_button "Create Ubicloud Account Using GitHub"
 
-      expect(Account[email: TEST_USER_EMAIL].name).to eq "foobar"
+      account = Account[email: TEST_USER_EMAIL]
+      project = account.default_project
+      expect(account.name).to eq "foobar"
       expect(audit_log_hash).to eq({"create_account" => ip_hash("provider" => "GitHub"), "login" => ip_hash("via" => "GitHub")})
+
+      expect(page).to have_content("Step 1: Create Ubicloud Account")
+      expect(page).to have_content("Step 2: Add GitHub Repositories")
+
+      click_link "Add GitHub Repositories"
+      expect(page.status_code).to eq(200)
+      expect(page.driver.request.session["login_redirect"]).to eq("/apps/test/installations/new")
+
+      require "octokit"
+      oauth_client = instance_double(Octokit::Client)
+      adhoc_client = instance_double(Octokit::Client)
+      expect(Github).to receive(:oauth_client).and_return(oauth_client)
+      expect(Octokit::Client).to receive(:new).and_return(adhoc_client)
+      expect(oauth_client).to receive(:exchange_code_for_token).with("123123").and_return({access_token: "123"})
+      expect(adhoc_client).to receive(:get).with("/user/installations").and_return({installations: [{id: 345, account: {login: "test-user", type: "User"}}]})
+
+      visit "/set_github_installation_project_id/#{project.ubid}"
+      GithubInstallation.create(installation_id: 0, name: "bogus", type: "bogus", project_id: project.id)
+      visit "/github/callback?code=123123&installation_id=345"
 
       expect(page).to have_content("Step 1: Create Ubicloud Account")
       expect(page).to have_content("Step 2: Add GitHub Repositories")
     end
 
     it "can use github actions setup workflow even if github account already linked to Ubicloud account" do
+      expect(Config).to receive(:github_app_name).and_return("test").at_least(:once)
       mock_provider(:github, name: "foobar")
 
       visit "/login"
@@ -1227,7 +1250,8 @@ RSpec.describe Clover, "auth" do
       expect(page).to have_content("Step 1: Create Ubicloud Account")
       click_button "Create Ubicloud Account Using GitHub"
 
-      expect(Account[email: TEST_USER_EMAIL].name).to eq "foobar"
+      account = Account[email: TEST_USER_EMAIL]
+      expect(account.name).to eq "foobar"
       expect(audit_log_hash).to eq({
         "create_account" => ip_hash("provider" => "GitHub"),
         "login" => [ip_hash("via" => "GitHub")] * 2,
@@ -1236,6 +1260,10 @@ RSpec.describe Clover, "auth" do
 
       expect(page).to have_content("Step 1: Create Ubicloud Account")
       expect(page).to have_content("Step 2: Add GitHub Repositories")
+
+      account.default_project.destroy
+      visit "/?setup=github_actions"
+      expect(page).to have_current_path "/project", ignore_query: true
     end
 
     it "can create new account even if social account has a name that isn't a valid Ubicloud name" do

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -1206,10 +1206,14 @@ RSpec.describe Clover, "auth" do
       mock_provider(:github, name: "foobar")
 
       visit "/?setup=github_actions"
+      expect(page).to have_content("Step 1: Create Ubicloud Account")
       click_button "Create Ubicloud Account Using GitHub"
 
       expect(Account[email: TEST_USER_EMAIL].name).to eq "foobar"
       expect(audit_log_hash).to eq({"create_account" => ip_hash("provider" => "GitHub"), "login" => ip_hash("via" => "GitHub")})
+
+      expect(page).to have_content("Step 1: Create Ubicloud Account")
+      expect(page).to have_content("Step 2: Add GitHub Repositories")
     end
 
     it "can create new account even if social account has a name that isn't a valid Ubicloud name" do

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -1202,6 +1202,16 @@ RSpec.describe Clover, "auth" do
       expect(audit_log_hash).to eq({"create_account" => ip_hash("provider" => "GitHub"), "login" => ip_hash("via" => "GitHub")})
     end
 
+    it "can create new account using github actions setup workflow" do
+      mock_provider(:github, name: "foobar")
+
+      visit "/?setup=github_actions"
+      click_button "Create Ubicloud Account Using GitHub"
+
+      expect(Account[email: TEST_USER_EMAIL].name).to eq "foobar"
+      expect(audit_log_hash).to eq({"create_account" => ip_hash("provider" => "GitHub"), "login" => ip_hash("via" => "GitHub")})
+    end
+
     it "can create new account even if social account has a name that isn't a valid Ubicloud name" do
       mock_provider(:github, name: "123Foo..\u1234Bar")
 

--- a/views/auth/social_buttons.erb
+++ b/views/auth/social_buttons.erb
@@ -11,19 +11,8 @@
     </div>
 
     <div class="mt-4 grid sm:grid-cols-<%= omniauth_providers.length %> gap-4">
-      <% omniauth_providers.each do |provider, name| %>
-        <% form(action: rodauth.omniauth_request_path(provider), method: :post, class: :grow) do %>
-          <button
-            class="
-              flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm
-              ring-1 ring-inset ring-gray-300 hover:bg-gray-50
-            "
-            type="submit"
-          >
-            <%== part("components/icon", name: provider.to_s) %>
-            <span class="text-sm font-semibold leading-6"><%= name %></span>
-          </button>
-        <% end %>
+      <% omniauth_providers.each do |provider, label| %>
+        <%== part("components/social_button", provider:, label:) %>
       <% end %>
     </div>
   </div>

--- a/views/components/social_button.erb
+++ b/views/components/social_button.erb
@@ -1,0 +1,14 @@
+<%# locals: (provider:, label:) %>
+
+<% form(action: rodauth.omniauth_request_path(provider), method: :post, class: :grow) do %>
+  <button
+    class="
+      flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm
+      ring-1 ring-inset ring-gray-300 hover:bg-gray-50
+    "
+    type="submit"
+  >
+    <%== part("components/icon", name: provider.to_s) %>
+    <span class="text-sm font-semibold leading-6"><%= label %></span>
+  </button>
+<% end %>

--- a/views/github/actions-setup.erb
+++ b/views/github/actions-setup.erb
@@ -1,0 +1,26 @@
+<% steps = <<END.split("\n")
+Create Ubicloud Account
+END
+@page_message = "GitHub Actions Setup"
+@use_page_message = true %>
+
+<div class="mt-4">
+  <div class="mt-4 grid sm:grid-cols-1 gap-4">
+    <span class="bg-white px-6 text-gray-900">This process allows you to easily setup your GitHub repositories to run GitHub Actions on Ubicloud.</span>
+
+    <hr>
+
+    <% steps[0...@step].each_with_index do |step, i| %>
+      <% i += 1 %>
+      <span class="bg-white px-6 text-gray-900 <%= "line-through" unless i == @step %>">Step <%= i %>: <%= step %></span>
+    <% end %>
+
+    <hr>
+
+    <% case @step %>
+    <% when 1 %>
+      <span class="bg-white px-6 text-gray-900">Ubicloud supports multiple login methods, but since you'll be using GitHub anyway, you probably want to login to Ubicloud via GitHub:</span>
+      <%== part("components/social_button", provider: :github, label: "Create Ubicloud Account Using GitHub") %>
+    <% end %>
+  </div>
+</div>

--- a/views/github/actions-setup.erb
+++ b/views/github/actions-setup.erb
@@ -22,6 +22,9 @@ END
     <% when 1 %>
       <span class="bg-white px-6 text-gray-900">Ubicloud supports multiple login methods, but since you'll be using GitHub anyway, you probably want to login to Ubicloud via GitHub:</span>
       <%== part("components/social_button", provider: :github, label: "Create Ubicloud Account Using GitHub") %>
+    <% when 2 %>
+      <span class="bg-white px-6 text-gray-900">Your Ubicloud Account has been created! You can now connect your GitHub repositories to Ubicloud:</span>
+      <%== part("components/button", icon: "github", link: "#{@project.path}/github/create", text: "Add GitHub Repositories") %>
     <% end %>
   </div>
 </div>

--- a/views/github/actions-setup.erb
+++ b/views/github/actions-setup.erb
@@ -2,6 +2,7 @@
 Create Ubicloud Account
 Add GitHub Repositories
 Add Payment Method
+Update Workflow .yml Files
 END
 @page_message = "GitHub Actions Setup"
 @use_page_message = true %>
@@ -33,6 +34,14 @@ END
           <%== part("components/button", text: "Add Payment Method") %>
         <% end %>
       </span>
+    <% when 4 %>
+      <span class="bg-white px-6 text-gray-900">
+        Your payment method was added! You only needed to change the <code>runs-on</code> entries in your
+        <code>.github/workflows/*.yml</code> files to use <code>ubicloud-standard-2</code> (or
+        <a href="https://www.ubicloud.com/docs/github-actions-integration/runner-types" class="font-medium text-orange-600 hover:text-orange-700">another valid value with <code>ubicloud</code> prefix</a>).
+        Then you can monitor your runners:
+      </span>
+      <%== part("components/button", link: "#{@project.path}/github", text: "Monitor GitHub Runners") %>
     <% end %>
   </div>
 </div>

--- a/views/github/actions-setup.erb
+++ b/views/github/actions-setup.erb
@@ -1,6 +1,7 @@
 <% steps = <<END.split("\n")
 Create Ubicloud Account
 Add GitHub Repositories
+Add Payment Method
 END
 @page_message = "GitHub Actions Setup"
 @use_page_message = true %>
@@ -25,6 +26,13 @@ END
     <% when 2 %>
       <span class="bg-white px-6 text-gray-900">Your Ubicloud Account has been created! You can now connect your GitHub repositories to Ubicloud:</span>
       <%== part("components/button", icon: "github", link: "#{@project.path}/github/create", text: "Add GitHub Repositories") %>
+    <% when 3 %>
+      <span class="bg-white px-6 text-gray-900">Your GitHub repositories have been added! Ubicloud provides inexpensive GitHub Actions runners, but they aren't free, so you need to add a payment method:</span>
+      <span class="bg-white px-6 ml-12 text-gray-900">
+        <% form(action: billing_path, method: :post) do %>
+          <%== part("components/button", text: "Add Payment Method") %>
+        <% end %>
+      </span>
     <% end %>
   </div>
 </div>

--- a/views/github/actions-setup.erb
+++ b/views/github/actions-setup.erb
@@ -1,5 +1,6 @@
 <% steps = <<END.split("\n")
 Create Ubicloud Account
+Add GitHub Repositories
 END
 @page_message = "GitHub Actions Setup"
 @use_page_message = true %>


### PR DESCRIPTION
This adds a workflow designed to easily onboard a new GitHub Actions customer in 4 steps:

1. Create Account Using GitHub Login
2. Add GitHub Repositories
3. Add Payment Method
4. Update Workflow .yml Files

The most important part of the workflow design is that there is only a single button in each of the setup steps. The customer is not shown the Ubicloud Console UI until they have completed the steps. During the process, there are 2 redirects to GitHub and 1 redirect to Stripe, but the user is redirected back to the setup workflow page after. No choices eliminates choice paralysis, which should result in a high conversion rate.

Another important design idea is that we don't ask for payment information until after the app has been installed, so the customer is already more invested before we ask for money.

Finally, this workflow is designed to work with existing customers:

* If a customer is logged in, but their default project has no GithubInstallation, they start at step 2.
* If a customer's default project has a GithubInstallation but no PaymentMethod, they start at step 3.
* If the customer's default project has a GithubInstallation and a PaymentMethod, the start at step 4.

If the customer has an account but is not logged in:

* If their GitHub account is linked to an Ubicloud account, the button in step 1 will log them in instead of creating a new account for them, and they will move to step 2.
* If their GitHub account is not linked to an Ubicloud account, a new Ubicloud account will be created for them (there is no way for the system to know they have an existing account).

Note that using this workflow allows you to bypass the requirement that you need a payment method to add a GitHub repository. So we need checks elsewhere in the system to not allow GitHub runners for projects until a payment method is added. I'll handle that in a separate PR, which we should probably merge first.

Here are screenshots of each step (the last screenshot just shows where the link in step 4 takes yo (the github runner page):

<img width="130" height="155" alt="gha-setup-step-1" src="https://github.com/user-attachments/assets/6e56c892-034b-4fcf-88da-5b6885b2b422" />
<img width="130" height="172" alt="gha-setup-step-2" src="https://github.com/user-attachments/assets/7f7aaabb-e777-4ece-830e-1090cd7cf62c" />
<img width="130" height="172" alt="gha-setup-step-3" src="https://github.com/user-attachments/assets/ef62d509-9430-4770-acbb-698d2c1bf9ce" />
<img width="130" height="201" alt="gha-setup-step-4" src="https://github.com/user-attachments/assets/2025751b-a245-4eb0-9c2a-0c910d5b3af6" />
<img width="130" height="172" alt="gha-setup-step-5" src="https://github.com/user-attachments/assets/dd4df430-32f3-4711-8494-b592b48274c0" />

I think the UI could be polished a bit more, but I would prefer to handle that in a separate PR.

To implement this, I added a `components/social_button` template to display only a single button. I also added a web_spec Rake task so I could run all web specs in parallel to check for breakage, without running the full test suite (about 4x faster).