### PR TITLE
Do not allow GithubRunner creation if there is no payment method

### DIFF
--- a/helpers/webhook_github.rb
+++ b/helpers/webhook_github.rb
@@ -53,6 +53,7 @@ class Clover
 
     if data["action"] == "queued"
       unless installation.has_billing_info?
+        Clog.emit("Github runner queue request without billing info", {github_runner_billing_info_missing: {installation_id: installation.id}})
         return {error: {message: "Must setup payment method before using Ubicloud runners"}}
       end
 

--- a/helpers/webhook_github.rb
+++ b/helpers/webhook_github.rb
@@ -52,6 +52,10 @@ class Clover
     end
 
     if data["action"] == "queued"
+      unless installation.has_billing_info?
+        return {error: {message: "Must setup payment method before using Ubicloud runners"}}
+      end
+
       runner = Prog::Github::GithubRunnerNexus.assemble(
         installation,
         repository_name:,

--- a/model/github/github_installation.rb
+++ b/model/github/github_installation.rb
@@ -36,6 +36,13 @@ class GithubInstallation < Sequel::Model
     !!allocator_preferences["family_filter"]&.include?("premium")
   end
 
+  def has_billing_info?
+    !Project
+      .where(Sequel[:project][:id] => project_id)
+      .exclude(billing_info_id: nil)
+      .empty?
+  end
+
   def client(**)
     Github.installation_client(installation_id, **)
   end

--- a/model/github/github_installation.rb
+++ b/model/github/github_installation.rb
@@ -37,10 +37,7 @@ class GithubInstallation < Sequel::Model
   end
 
   def has_billing_info?
-    !Project
-      .where(Sequel[:project][:id] => project_id)
-      .exclude(billing_info_id: nil)
-      .empty?
+    project_dataset.get(:billing_info_id) != nil
   end
 
   def client(**)

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -152,6 +152,7 @@ RSpec.describe Clover, "github" do
     end
 
     it "does not create runner if there is no billing info" do
+      expect(Clog).to receive(:emit).with("Github runner queue request without billing info", {github_runner_billing_info_missing: {installation_id: installation.id}}).and_call_original
       send_webhook("workflow_job", workflow_job_payload(action: "queued"))
 
       expect(page.status_code).to eq(200)

--- a/spec/routes/web/webhook/github_spec.rb
+++ b/spec/routes/web/webhook/github_spec.rb
@@ -129,6 +129,8 @@ RSpec.describe Clover, "github" do
     end
 
     it "uses custom label if label is an existing custom label" do
+      billing_info_id = BillingInfo.create(stripe_id: "0").id
+      installation.project.update(billing_info_id:)
       GithubCustomLabel.create(installation_id: installation.id, name: "custom-label-1", alias_for: "ubicloud-standard-4")
       send_webhook("workflow_job", workflow_job_payload(action: "queued", workflow_job: workflow_job_object(label: "custom-label-1")))
 
@@ -139,12 +141,23 @@ RSpec.describe Clover, "github" do
     end
 
     it "creates runner when receive queued action" do
+      billing_info_id = BillingInfo.create(stripe_id: "0").id
+      installation.project.update(billing_info_id:)
       send_webhook("workflow_job", workflow_job_payload(action: "queued"))
 
       expect(page.status_code).to eq(200)
       created_runner = GithubRunner.first(installation_id: installation.id, repository_name: "my-repo", label: "ubicloud", actual_label: "ubicloud")
       expect(created_runner).not_to be_nil
       expect(page.body).to eq({message: "GithubRunner[#{created_runner.ubid}] created"}.to_json)
+    end
+
+    it "does not create runner if there is no billing info" do
+      send_webhook("workflow_job", workflow_job_payload(action: "queued"))
+
+      expect(page.status_code).to eq(200)
+      created_runner = GithubRunner.first(installation_id: installation.id, repository_name: "my-repo", label: "ubicloud", actual_label: "ubicloud")
+      expect(created_runner).to be_nil
+      expect(page.body).to eq({error: {message: "Must setup payment method before using Ubicloud runners"}}.to_json)
     end
 
     it "fails if not queued and runner_id is empty" do


### PR DESCRIPTION
With proposed changes to the GitHub Actions setup workflow, we would allow GitHub app installation without a valid payment method, where previously it required a payment method to setup the GitHub app. I'm not sure if there are other checks for a valid payment method, but I'm going to assume that because we required a payment method to setup the GitHub app, and we don't allow deleting the last payment of the project, that we assumed that a runner must have a valid payment method.  If that is no longer the case, I think we need to have a check for that somewhere, and this seems like the best place for it.

I know this is a fairly hot path. I've set this up to use a single query, but that single query has joins. If we want to avoid the query, we could denormalize and add a github_installation.has_payment_method boolean column, populate that when payment methods are added, and check that in the webhook.

I think we are going to want to merge this or some similar PR before merging #6311, unless there is some existing check for a payment method.