### PR TITLE
Fix the invalid password message

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -488,7 +488,7 @@ class Clover < Roda
         DB.ignore_duplicate_queries { super(password) } && password.match?(/[a-z]/) && password.match?(/[A-Z]/) && password.match?(/[0-9]/)
       end
 
-      invalid_password_message = "Password must have 8 characters minimum and contain at least one lowercase letter, one uppercase letter, and one digit. Password cannot be the same as a previous password."
+      invalid_password_message = "Password must have 8 characters minimum and contain at least one lowercase letter, one uppercase letter, and one digit. Password cannot be the same as your current password."
       password_does_not_meet_requirements_message invalid_password_message
       password_too_short_message invalid_password_message
     end

--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -524,7 +524,7 @@ RSpec.describe Clover, "auth" do
       click_button "Change Password"
       expect(page.title).to eq("Ubicloud - Change Password")
       expect(page).to have_flash_error("There was an error changing your password")
-      expect(page).to have_text(/invalid password, same as current password|Password cannot be the same as a previous password/)
+      expect(page).to have_text(/invalid password, same as current password|Password cannot be the same as your current password/)
 
       new_password = TEST_USER_PASSWORD + "_new"
       fill_in "New Password", with: new_password


### PR DESCRIPTION
We removed previous password storage and checking, so we should update the invalid password message to reflect that.