### PR TITLE
Mark `VmStorageVolume#key_encryption_key_2` as readonly

### DIFF
--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -9,7 +9,7 @@ class VmStorageVolume < Sequel::Model
   many_to_one :vhost_block_backend, read_only: true
   many_to_one :storage_device
   many_to_one :key_encryption_key_1, class: :StorageKeyEncryptionKey
-  many_to_one :key_encryption_key_2, class: :StorageKeyEncryptionKey
+  many_to_one :key_encryption_key_2, class: :StorageKeyEncryptionKey, read_only: true
   many_to_one :boot_image, read_only: true
   many_to_one :machine_image_version, read_only: true
   many_to_one :remote_storage_server, read_only: true


### PR DESCRIPTION
Daily CI was failing with:

> Associations Option That Can Be Added:
> VmStorageVolume#key_encryption_key_2: , read_only: true