### PR TITLE
Avoid race conditions in the DELETE RETURNING queries to select a presigned cert

### DIFF
--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -77,6 +77,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
           .where(postgres_resource_id: DB[:presigned_postgres_cert]
             .order(:created_at)
             .limit(1)
+            .for_update
+            .skip_locked
             .select(:postgres_resource_id))
           .returning(:postgres_resource_id, :cert_id)
           .delete

--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -35,6 +35,8 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
           .where(load_balancer_id: DB[:presigned_load_balancer_cert]
             .order(:created_at)
             .limit(1)
+            .for_update
+            .skip_locked
             .select(:load_balancer_id))
           .returning(:load_balancer_id, :cert_id)
           .delete


### PR DESCRIPTION
Without the FOR UPDATE, the row could be deleted between the subquery and outer query. Use a CTE to prevent potentially locking more than a single row (can happen if the subquery is used directly and not in a CTE). Also use SKIP LOCKED, because it's better to pick the next available cert instead of blocking during contention.