### PR TITLE
Relax deadlines for CertNexus Destroy

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -243,7 +243,8 @@ SQL
         if frame["deadline_page"] == false
           Clog.emit(summary, {expired_deadline: {strand: ubid, prog: effective_prog, label:, deadline_target: frame["deadline_target"]}.merge(extra_data)})
         else
-          Prog::PageNexus.assemble(summary, ["Deadline", id, effective_prog, frame["deadline_target"]], ubid, extra_data:)
+          severity = (page = frame["deadline_page"]).is_a?(String) ? page : "error"
+          Prog::PageNexus.assemble(summary, ["Deadline", id, effective_prog, frame["deadline_target"]], ubid, severity:, extra_data:)
         end
         frame["deadline_notified"] = true
         modified!(:stack)

--- a/prog/base.rb
+++ b/prog/base.rb
@@ -399,6 +399,10 @@ end
   end
 
   def register_deadline(new_deadline_target, deadline_in, allow_extension: false, page: true)
+    if page.is_a?(String) && !Page::SEVERITY_ORDER.key?(page)
+      raise Strand::InternalError, "BUG: invalid deadline page severity: #{page.inspect}"
+    end
+
     time = Time.now
     new_deadline = time + deadline_in
 

--- a/prog/test.rb
+++ b/prog/test.rb
@@ -168,6 +168,11 @@ class Prog::Test < Prog::Base
     hop_pusher1
   end
 
+  label def set_expired_warning_deadline
+    register_deadline("pusher2", -1, page: "warning")
+    hop_pusher1
+  end
+
   label def extend_deadline
     register_deadline("pusher2", 1, allow_extension: true)
     hop_pusher1

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -27,6 +27,10 @@ class Prog::Vnet::CertNexus < Prog::Base
     end
   end
 
+  def before_destroy
+    register_deadline(nil, 3 * 60 * 60, page: "warning")
+  end
+
   label def start
     register_deadline("wait", wait_deadline || 10 * 60)
 

--- a/spec/prog/base_spec.rb
+++ b/spec/prog/base_spec.rb
@@ -345,6 +345,22 @@ RSpec.describe Prog::Base do
       expect(st.stack.first["deadline_page"]).to be false
     end
 
+    it "pages with the given severity when the deadline expires" do
+      st = Strand.create(prog: "Test", label: :set_expired_warning_deadline)
+      st.unsynchronized_run
+      expect(st.stack.first["deadline_page"]).to eq "warning"
+
+      expect {
+        st.unsynchronized_run
+      }.to change { Page.active.count }.from(0).to(1)
+      expect(Page.active.first.severity).to eq "warning"
+    end
+
+    it "raises for an invalid page severity" do
+      nx = Prog::Test.new(Strand.create(prog: "Test", label: :start))
+      expect { nx.register_deadline("pusher2", 1, page: "bogus") }.to raise_error(Strand::InternalError, 'BUG: invalid deadline page severity: "bogus"')
+    end
+
     it "logs the expired deadline instead of paging when the deadline opts out" do
       st = Strand.create(prog: "Test", label: :set_expired_no_page_deadline)
       st.unsynchronized_run

--- a/spec/prog/vnet/cert_nexus_spec.rb
+++ b/spec/prog/vnet/cert_nexus_spec.rb
@@ -89,6 +89,17 @@ RSpec.describe Prog::Vnet::CertNexus do
     end
   end
 
+  describe "#before_destroy" do
+    it "replaces the provisioning deadline with a destroy deadline" do
+      refresh_frame(nx, new_values: {"deadline_target" => "wait", "deadline_at" => Time.now.to_s})
+
+      nx.before_destroy
+      expect(nx.strand.stack[0]["deadline_target"]).to be_nil
+      expect(nx.strand.stack[0]["deadline_page"]).to eq "warning"
+      expect(Time.new(nx.strand.stack[0]["deadline_at"])).to be_within(10).of(Time.now + 3 * 60 * 60)
+    end
+  end
+
   describe "#start" do
     it "registers a deadline and starts the certificate creation process" do
       identifiers = [cert.hostname]


### PR DESCRIPTION
**Allow deadline pages to be registered with a severity**
register_deadline's page: argument only supported true (page at error
severity when the deadline expires) or false (only log). Some deadlines
warrant a page that does not need to wake anyone up, for example a
destroy that is stuck on a third party outage and will keep being
retried regardless.

Accept a page severity string for page:. It is stored in the frame's
deadline_page as before, and passed through to Prog::PageNexus.assemble
when the deadline expires. Invalid severities are rejected at
registration time; otherwise the page insert would fail at the start of
every subsequent run of the strand and wedge it.

**Register a destroy specific deadline in Vnet::CertNexus**
The deadline registered in start targets wait, which destroy never
reaches. When destroy gets stuck, for example because the ACME provider
is down and revoke/order lookups keep raising, the deadline registered
during provisioning expires and pages as
"Vnet::CertNexus.destroy did not reach wait on time", which reads as a
provisioning failure. Presigned certs are especially prone to this since
MaintainPresignedCerts gives up and destroys them 5 minutes before their
provisioning deadline.

Replace the provisioning deadline with a 1 hour destroy deadline in
before_destroy. It runs in the strand run that hops to destroy, so it is
committed with the hop and survives the later destroy runs failing.
Registering a new target also resolves any page for the old one.

The destroy deadline pages at warning severity. A stuck destroy is
retried until the provider recovers and nothing is lost while it waits,
so it should be visible without waking anyone up.