### PR TITLE
Add backtrace to unexpected web request pages and reduce severity

### DIFF
--- a/clover.rb
+++ b/clover.rb
@@ -301,6 +301,7 @@ class Clover < Roda
           ["Clover500", exception_class],
           [],
           resource_id: nil,
+          severity: "warning",
           extra_data: {exception_class:, request_method: request.request_method, request_path: request.path, backtrace: e.backtrace[0...50]},
         )
       rescue => page_exception

--- a/clover.rb
+++ b/clover.rb
@@ -301,7 +301,7 @@ class Clover < Roda
           ["Clover500", exception_class],
           [],
           resource_id: nil,
-          extra_data: {exception_class:, request_method: request.request_method, request_path: request.path},
+          extra_data: {exception_class:, request_method: request.request_method, request_path: request.path, backtrace: e.backtrace[0...50]},
         )
       rescue => page_exception
         Clog.emit("failed to page for unexpected error", Util.exception_to_hash(page_exception, into: {unexpected_error_page_failure: {original_exception: exception_class, request_path: request.path}}))

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -132,6 +132,8 @@ RSpec.describe Clover do
     expect(pg.details["request_method"]).to eq("GET")
     expect(pg.details["request_path"]).to eq("/webhook/test-error")
     expect(pg.resource_id).to be_nil
+    expect(pg.details["backtrace"]).to be_a(Array)
+    expect(pg.details["backtrace"].first).to include("clover.rb")
 
     visit "/webhook/test-error"
     expect(Page.active.where(tag: "Clover500-RuntimeError").count).to eq 1
@@ -147,6 +149,7 @@ RSpec.describe Clover do
         exception_class: "RuntimeError",
         request_method: "GET",
         request_path: "/webhook/test-error",
+        backtrace: instance_of(Array),
       },
     ).and_raise(RuntimeError.new("paging failure"))
     allow(Clog).to receive(:emit).and_call_original

--- a/spec/routes/web/clover_web_spec.rb
+++ b/spec/routes/web/clover_web_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Clover do
     expect(page.title).to eq("Ubicloud - UnexpectedError")
 
     pg = Page.active.first!(tag: "Clover500-RuntimeError")
-    expect(pg.severity).to eq("error")
+    expect(pg.severity).to eq("warning")
     expect(pg.details).not_to have_key("exception_message")
     expect(pg.details["exception_class"]).to eq("RuntimeError")
     expect(pg.details["request_method"]).to eq("GET")
@@ -145,6 +145,7 @@ RSpec.describe Clover do
       ["Clover500", "RuntimeError"],
       [],
       resource_id: nil,
+      severity: "warning",
       extra_data: {
         exception_class: "RuntimeError",
         request_method: "GET",


### PR DESCRIPTION
**Include the backtrace in Clover500 page details**
Unexpected web request exceptions page with only the exception class,
request method, and path. That is often not enough to locate the
failure without cross-referencing the logs, so include the backtrace
in the page's extra data as well. It is truncated to 50 frames, the
same limit Util.exception_to_hash applies when logging.

**Page Clover500 errors with warning severity**
Unexpected web request exceptions currently page with the default
error severity. Individual request failures rarely require an
immediate response, so downgrade them to warning.