### PR TITLE
Handle missing tax_id parameter in billing info update

### DIFF
--- a/routes/project/billing.rb
+++ b/routes/project/billing.rb
@@ -22,7 +22,7 @@ class Clover
           handle_validation_failure("project/billing")
           current_tax_id = billing_info.stripe_data["tax_id"].to_s
           tp = typecast_params
-          new_tax_id = tp.str("tax_id").gsub(/[^a-zA-Z0-9]/, "")
+          new_tax_id = tp.str!("tax_id").gsub(/[^a-zA-Z0-9]/, "")
           begin
             StripeClient.customers.update(billing_info.stripe_id, {
               name: tp.str!("name"),


### PR DESCRIPTION
This caused unexpected web request page.

typecast_params.str returns nil when the parameter is absent, so a POST to the billing page without a tax_id field raised NoMethodError on gsub and produced a Clover500 page. Treat a missing tax_id the same as an empty one.