### PR TITLE
Use Config.admin_url for admin site Rodauth domain/base_url

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -320,12 +320,11 @@ class CloverAdmin < Roda
 
     uses_instance_variables(:@_webauthn_credential_id)
 
-    if Config.test?
-      admin_uri = URI("http://admin.ubicloud.com")
-      # simplecov:disable
+    admin_uri = if Config.test?
+      URI("http://admin.ubicloud.com")
     else
-      admin_uri = URI(Config.base_url)
-      admin_uri.host = "admin.#{admin_uri.host.delete_prefix("console.")}"
+      # simplecov:disable
+      URI(Config.admin_url)
       # simplecov:enable
     end
     domain admin_uri.host


### PR DESCRIPTION
The admin Rodauth block derived its domain (webauthn rpId) and base_url from Config.base_url via an "admin.#{host.delete_prefix("console.")}" transform. That only holds when the admin host is the console-to-admin rewrite of BASE_URL; when ADMIN_URL is not that rewrite of BASE_URL, the computed rpId and origin do not match the host admins actually visit and webauthn assertion fails. Read domain and base_url from Config.admin_url directly.