### PR TITLE
Cut wal-g download-file retries on backup-fetch

### DIFF
--- a/lib/walg_config.rb
+++ b/lib/walg_config.rb
@@ -34,6 +34,8 @@ module WalgConfig
       "WALG_UPLOAD_QUEUE=#{UPLOAD_QUEUE}",
       "WALG_S3_MAX_PART_SIZE=#{max_part_size_mib * 1024 * 1024}",
       "WALG_DOWNLOAD_CONCURRENCY=#{restore_download_concurrency}",
+      # Trims wal-g's retry rounds on an unrecoverable fetch. See commit for why =0 is not immediate.
+      "WALG_DOWNLOAD_FILE_RETRIES=0",
     ]
     if direct_io
       # RAID0 arrays attempt to evenly distribute the data blocks across the block devices.

--- a/spec/lib/walg_config_spec.rb
+++ b/spec/lib/walg_config_spec.rb
@@ -46,6 +46,11 @@ RSpec.describe WalgConfig do
       expect(env(vcpu_count: 192, memory_mib: 1536 * 1024)["WALG_DOWNLOAD_CONCURRENCY"]).to eq("128") # cap
     end
 
+    it "trims the per-file download retry budget on every size" do
+      expect(env(vcpu_count: 2, memory_mib: 8 * 1024)["WALG_DOWNLOAD_FILE_RETRIES"]).to eq("0")
+      expect(env(vcpu_count: 48, memory_mib: 384 * 1024, direct_io: true)["WALG_DOWNLOAD_FILE_RETRIES"]).to eq("0")
+    end
+
     it "scales DISK_CONCURRENCY by disk parallelism: 1/2 vCPU generic, vCPU for dense NVMe or <=2 vCPU" do
       # O_DIRECT, generic NVMe, >2 vCPU -> 1/2 vCPU (a single stream saturates the faster device)
       expect(env(vcpu_count: 48, memory_mib: 384 * 1024, direct_io: true)["WALG_UPLOAD_DISK_CONCURRENCY"]).to eq("24")


### PR DESCRIPTION
WALG_DOWNLOAD_FILE_RETRIES defaults to 15, so an unrecoverable
backup-fetch retries for a long time before it surfaces to the strand.
Setting it to 0 does not exit immediately. wal-g only gives up once it
has halved WALG_DOWNLOAD_CONCURRENCY (pinned to vcpu_count.clamp(10,
128)) down to 1, and only when every remaining file fails in the same
round. That drops the worst case from ~67min to ~7min at concurrency 10,
and to ~27min at 128. A single file blipping still retries as before.