### PR TITLE
Chain the portmap CNI plugin after ubicni

### DIFF
--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -268,15 +268,23 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
 {
   "cniVersion": "1.0.0",
   "name": "ubicni-network",
-  "type": "ubicni",
-  "ranges":{
-      "subnet_ipv6": "#{NetAddr::IPv6Net.new(vm.ephemeral_net6.network, NetAddr::Mask128.new(vm.ephemeral_net6.netmask.prefix_len + 1))}",
-      "subnet_ula_ipv6": "#{vm.user_nic.private_ipv6}",
-      "subnet_ipv4": "#{vm.user_nic.private_ipv4}"
-  }
+  "plugins": [
+    {
+      "type": "ubicni",
+      "ranges":{
+          "subnet_ipv6": "#{NetAddr::IPv6Net.new(vm.ephemeral_net6.network, NetAddr::Mask128.new(vm.ephemeral_net6.netmask.prefix_len + 1))}",
+          "subnet_ula_ipv6": "#{vm.user_nic.private_ipv6}",
+          "subnet_ipv4": "#{vm.user_nic.private_ipv4}"
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    }
+  ]
 }
 CONFIG
-    vm.sshable.cmd("sudo tee /etc/cni/net.d/ubicni-config.json", stdin: cni_config)
+    vm.sshable.cmd("sudo tee /etc/cni/net.d/ubicni-config.conflist", stdin: cni_config)
     hop_approve_new_csr
   end
 

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -480,20 +480,28 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
   end
 
   describe "#install_cni" do
-    it "configures ubicni with the VM's ephemeral prefix" do
+    it "chains portmap after ubicni and configures it with the VM's ephemeral prefix" do
       expected_config = <<~CONFIG
         {
           "cniVersion": "1.0.0",
           "name": "ubicni-network",
-          "type": "ubicni",
-          "ranges":{
-              "subnet_ipv6": "2001:db8:85a3:73f2:1c4a::/80",
-              "subnet_ula_ipv6": "fd40:1a0a:8d48:182a::/79",
-              "subnet_ipv4": "172.19.145.64/26"
-          }
+          "plugins": [
+            {
+              "type": "ubicni",
+              "ranges":{
+                  "subnet_ipv6": "2001:db8:85a3:73f2:1c4a::/80",
+                  "subnet_ula_ipv6": "fd40:1a0a:8d48:182a::/79",
+                  "subnet_ipv4": "172.19.145.64/26"
+              }
+            },
+            {
+              "type": "portmap",
+              "capabilities": {"portMappings": true}
+            }
+          ]
         }
       CONFIG
-      expect(prog.vm.sshable).to receive(:_cmd).with("sudo tee /etc/cni/net.d/ubicni-config.json", stdin: expected_config)
+      expect(prog.vm.sshable).to receive(:_cmd).with("sudo tee /etc/cni/net.d/ubicni-config.conflist", stdin: expected_config)
       expect { prog.install_cni }.to hop("approve_new_csr")
     end
 
@@ -503,15 +511,23 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
         {
           "cniVersion": "1.0.0",
           "name": "ubicni-network",
-          "type": "ubicni",
-          "ranges":{
-              "subnet_ipv6": "2607:f5b7:9:1a:0:355c:0:0/96",
-              "subnet_ula_ipv6": "fd40:1a0a:8d48:182a::/79",
-              "subnet_ipv4": "172.19.145.64/26"
-          }
+          "plugins": [
+            {
+              "type": "ubicni",
+              "ranges":{
+                  "subnet_ipv6": "2607:f5b7:9:1a:0:355c:0:0/96",
+                  "subnet_ula_ipv6": "fd40:1a0a:8d48:182a::/79",
+                  "subnet_ipv4": "172.19.145.64/26"
+              }
+            },
+            {
+              "type": "portmap",
+              "capabilities": {"portMappings": true}
+            }
+          ]
         }
       CONFIG
-      expect(prog.vm.sshable).to receive(:_cmd).with("sudo tee /etc/cni/net.d/ubicni-config.json", stdin: expected_config)
+      expect(prog.vm.sshable).to receive(:_cmd).with("sudo tee /etc/cni/net.d/ubicni-config.conflist", stdin: expected_config)
       expect { prog.install_cni }.to hop("approve_new_csr")
     end
   end


### PR DESCRIPTION
containerd offers pod port mappings to the CNI as the portMappings capability. Our net.d config was a single ubicni plugin, so nothing consumed them and hostPort was a silent no-op.

Write a plugin list instead, with portmap second and portMappings declared as a capability. The file is renamed to .conflist because go-cni parses anything else as a single plugin config and rejects it for having no top-level type. The portmap binary ships with the kubernetes-cni deb that kubeadm depends on, so it is already present at /opt/cni/bin/portmap.