### PR TITLE
Poll CRM tag delete LROs instead of fire-and-forget

### DIFF
--- a/lib/gcp_lro.rb
+++ b/lib/gcp_lro.rb
@@ -26,6 +26,36 @@ module GcpLro
     nil
   end
 
+  def poll_crm_delete(pending_key)
+    return unless (pending = send(pending_key))
+    op = credential.crm_client.get_operation(pending)
+    nap 5 unless op.done?
+    send(:"#{pending_key}=", nil)
+    crm_delete_op_failed(pending, op.error) if op.error
+    nil
+  end
+
+  def submit_crm_delete(pending_key)
+    op = yield
+    unless op.done?
+      send(:"#{pending_key}=", op.name)
+      nap 5
+    end
+    crm_delete_op_failed(op.name, op.error) if op.error
+    nil
+  end
+
+  # google.rpc.Code: 5 = NOT_FOUND. A raise here would roll back the
+  # cleared pending op, wedging the strand on re-polling the same failed
+  # operation forever; napping commits the clear so the next run
+  # resubmits the delete.
+  def crm_delete_op_failed(op_name, error)
+    return if error.code == 5
+    Clog.emit("CRM delete failed, will retry",
+      {gcp_crm_delete_retry: {op: op_name, code: error.code, error: error.message}})
+    nap 15
+  end
+
   def save_gcp_op(name, op_name:, scope:, scope_value: nil)
     strand.stack.first[name] = {
       "name" => op_name,

--- a/prog/vnet/gcp/subnet_nexus.rb
+++ b/prog/vnet/gcp/subnet_nexus.rb
@@ -5,7 +5,8 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   include GcpFirewallPolicy
 
   subject_is :private_subnet
-  frame_accessor :tag_key_name, :subnet_tag_value_name, :pending_tag_key_crm_op, :pending_tag_value_crm_op
+  frame_accessor :tag_key_name, :subnet_tag_value_name, :pending_tag_key_crm_op, :pending_tag_value_crm_op,
+    :pending_tag_value_delete_crm_op, :pending_tag_key_delete_crm_op
 
   CrmOperationError = GcpLro::CrmOperationError
 
@@ -308,16 +309,23 @@ class Prog::Vnet::Gcp::SubnetNexus < Prog::Base
   end
 
   def delete_subnet_tag_resources
+    poll_crm_delete(:pending_tag_value_delete_crm_op)
+    poll_crm_delete(:pending_tag_key_delete_crm_op)
+
     tag_key = lookup_tag_key
     return unless tag_key
 
     subnet_tv = credential.crm_client
       .fetch_all(items: :tag_values) { |token, s| s.list_tag_values(parent: tag_key.name, page_token: token) }
       .find { |v| v.short_name == TAG_VALUE }
-    credential.crm_client.delete_tag_value(subnet_tv.name) if subnet_tv
+    # The value must be confirmed deleted before the key delete is
+    # submitted; a key delete with child values fails only in its LRO.
+    if subnet_tv
+      submit_crm_delete(:pending_tag_value_delete_crm_op) { credential.crm_client.delete_tag_value(subnet_tv.name) }
+    end
 
     # Per-subnet tag key. Always delete it when the subnet is destroyed.
-    credential.crm_client.delete_tag_key(tag_key.name)
+    submit_crm_delete(:pending_tag_key_delete_crm_op) { credential.crm_client.delete_tag_key(tag_key.name) }
   rescue Google::Apis::ClientError => e
     case e.status_code
     when 404

--- a/prog/vnet/gcp/vpc_update_firewall_rules.rb
+++ b/prog/vnet/gcp/vpc_update_firewall_rules.rb
@@ -17,7 +17,7 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
 
   subject_is :gcp_vpc
   frame_accessor :fw_tag_data, :pending_tag_key_crm_op, :pending_tag_key_fw_ubid,
-    :pending_tag_value_crm_op, :pending_tag_value_parent
+    :pending_tag_value_crm_op, :pending_tag_value_parent, :pending_orphan_delete_crm_op
 
   def before_run
     # If the VPC is being torn down, exit without touching shared state:
@@ -27,6 +27,8 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
   end
 
   label def update_firewall_rules
+    register_deadline(nil, 5 * 60)
+
     # Enumerate every firewall reachable in this VPC: subnet-attached
     # firewalls from every private_subnet in the VPC, plus direct-VM
     # attachments via the VMs in those subnets' NICs. Dedupe by firewall
@@ -281,6 +283,10 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
   # any subnet or VM associations and deletes the corresponding policy
   # rules, tag value, and tag key.
   def cleanup_orphaned_firewall_rules
+    # Resume an in-flight delete first; the loop below is idempotent, so
+    # after the poll the remaining work is re-derived from live state.
+    poll_crm_delete(:pending_orphan_delete_crm_op)
+
     active_fw_ubids = vpc_firewalls.to_set(&:ubid)
 
     vpc_network_link = gcp_network_self_link_with_id
@@ -330,12 +336,12 @@ class Prog::Vnet::Gcp::VpcUpdateFirewallRules < Prog::Base
           delete_policy_rule(rule.priority)
         end
 
-        # Fire-and-forget: don't wait for CRM LRO. Ghost bindings can
-        # cause 30-second waits that block the respirate thread.
-        credential.crm_client.delete_tag_value(tag_value_name)
+        # The value must be confirmed deleted before the key delete is
+        # submitted; a key delete with child values fails only in its LRO.
+        submit_crm_delete(:pending_orphan_delete_crm_op) { credential.crm_client.delete_tag_value(tag_value_name) }
       end
 
-      credential.crm_client.delete_tag_key(tk.name)
+      submit_crm_delete(:pending_orphan_delete_crm_op) { credential.crm_client.delete_tag_key(tk.name) }
     end
   end
 

--- a/spec/prog/vnet/gcp/subnet_nexus_spec.rb
+++ b/spec/prog/vnet/gcp/subnet_nexus_spec.rb
@@ -526,6 +526,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
 
   describe "#destroy" do
     let(:crm_client) { instance_double(Google::Apis::CloudresourcemanagerV3::CloudResourceManagerService) }
+    let(:crm_delete_done_op) { Google::Apis::CloudresourcemanagerV3::Operation.new(done: true) }
 
     before do
       allow(nx.send(:credential)).to receive(:crm_client).and_return(crm_client)
@@ -574,8 +575,8 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
           Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(tag_values: [subnet_tv]),
         )
 
-      expect(crm_client).to receive(:delete_tag_value).with("tagValues/222")
-      expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111")
+      expect(crm_client).to receive(:delete_tag_value).with("tagValues/222").and_return(crm_delete_done_op)
+      expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111").and_return(crm_delete_done_op)
 
       # delete_gcp_subnet
       expect(subnetworks_client).to receive(:delete).and_raise(Google::Cloud::NotFoundError.new("not found"))
@@ -1023,6 +1024,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
 
   describe "secure tag helpers" do
     let(:crm_client) { instance_double(Google::Apis::CloudresourcemanagerV3::CloudResourceManagerService) }
+    let(:crm_delete_done_op) { Google::Apis::CloudresourcemanagerV3::Operation.new(done: true) }
 
     before do
       allow(nx.send(:credential)).to receive(:crm_client).and_return(crm_client)
@@ -1096,8 +1098,8 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
         expect(crm_client).to receive(:list_tag_values)
           .with(parent: "tagKeys/111", page_token: "del-tok").ordered.and_return(page2)
 
-        expect(crm_client).to receive(:delete_tag_value).with("tagValues/active-on-page-2")
-        expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111")
+        expect(crm_client).to receive(:delete_tag_value).with("tagValues/active-on-page-2").and_return(crm_delete_done_op)
+        expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111").and_return(crm_delete_done_op)
 
         nx.send(:delete_subnet_tag_resources)
       end
@@ -1118,7 +1120,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
             Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(tag_values: [other_tv]),
           )
         expect(crm_client).not_to receive(:delete_tag_value)
-        expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111")
+        expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111").and_return(crm_delete_done_op)
 
         nx.send(:delete_subnet_tag_resources)
       end
@@ -1136,7 +1138,7 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
             Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new,
           )
         expect(crm_client).not_to receive(:delete_tag_value)
-        expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111")
+        expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111").and_return(crm_delete_done_op)
 
         nx.send(:delete_subnet_tag_resources)
       end
@@ -1233,6 +1235,127 @@ RSpec.describe Prog::Vnet::Gcp::SubnetNexus do
 
         expect { nx.send(:delete_subnet_tag_resources) }
           .to raise_error(Google::Apis::ClientError, /forbidden/)
+      end
+
+      it "naps and saves the pending op when the tag value delete LRO is not done" do
+        tag_key = Google::Apis::CloudresourcemanagerV3::TagKey.new(
+          name: "tagKeys/111", short_name: "ubicloud-subnet-#{ps.ubid}",
+        )
+        expect(crm_client).to receive(:list_tag_keys).and_return(
+          Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(tag_keys: [tag_key]),
+        )
+        subnet_tv = Google::Apis::CloudresourcemanagerV3::TagValue.new(
+          name: "tagValues/222", short_name: "active",
+        )
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111", page_token: nil)
+          .and_return(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new(tag_values: [subnet_tv]))
+        expect(crm_client).to receive(:delete_tag_value).with("tagValues/222").and_return(
+          Google::Apis::CloudresourcemanagerV3::Operation.new(name: "operations/tv-del", done: false),
+        )
+        expect(crm_client).not_to receive(:delete_tag_key)
+
+        expect { nx.send(:delete_subnet_tag_resources) }.to nap(5)
+        expect(st.stack.first["pending_tag_value_delete_crm_op"]).to eq("operations/tv-del")
+      end
+
+      it "naps and saves the pending op when the tag key delete LRO is not done" do
+        tag_key = Google::Apis::CloudresourcemanagerV3::TagKey.new(
+          name: "tagKeys/111", short_name: "ubicloud-subnet-#{ps.ubid}",
+        )
+        expect(crm_client).to receive(:list_tag_keys).and_return(
+          Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(tag_keys: [tag_key]),
+        )
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111", page_token: nil)
+          .and_return(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new)
+        expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111").and_return(
+          Google::Apis::CloudresourcemanagerV3::Operation.new(name: "operations/tk-del", done: false),
+        )
+
+        expect { nx.send(:delete_subnet_tag_resources) }.to nap(5)
+        expect(st.stack.first["pending_tag_key_delete_crm_op"]).to eq("operations/tk-del")
+      end
+
+      it "naps while a pending delete op is still running" do
+        refresh_frame(nx, new_values: {"pending_tag_value_delete_crm_op" => "operations/tv-del"})
+        expect(crm_client).to receive(:get_operation).with("operations/tv-del").and_return(
+          Google::Apis::CloudresourcemanagerV3::Operation.new(name: "operations/tv-del", done: false),
+        )
+
+        expect { nx.send(:delete_subnet_tag_resources) }.to nap(5)
+      end
+
+      it "proceeds to the key delete after a pending value delete completes" do
+        refresh_frame(nx, new_values: {"pending_tag_value_delete_crm_op" => "operations/tv-del"})
+        expect(crm_client).to receive(:get_operation).with("operations/tv-del").and_return(
+          Google::Apis::CloudresourcemanagerV3::Operation.new(name: "operations/tv-del", done: true),
+        )
+        tag_key = Google::Apis::CloudresourcemanagerV3::TagKey.new(
+          name: "tagKeys/111", short_name: "ubicloud-subnet-#{ps.ubid}",
+        )
+        expect(crm_client).to receive(:list_tag_keys).and_return(
+          Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(tag_keys: [tag_key]),
+        )
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111", page_token: nil)
+          .and_return(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new)
+        expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111").and_return(crm_delete_done_op)
+
+        nx.send(:delete_subnet_tag_resources)
+        expect(st.stack.first["pending_tag_value_delete_crm_op"]).to be_nil
+      end
+
+      it "treats a NOT_FOUND delete LRO error as already deleted" do
+        refresh_frame(nx, new_values: {"pending_tag_key_delete_crm_op" => "operations/tk-del"})
+        error = Google::Apis::CloudresourcemanagerV3::Status.new(code: 5, message: "tag key not found")
+        expect(crm_client).to receive(:get_operation).with("operations/tk-del").and_return(
+          Google::Apis::CloudresourcemanagerV3::Operation.new(name: "operations/tk-del", done: true, error:),
+        )
+        expect(crm_client).to receive(:list_tag_keys).and_return(
+          Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(tag_keys: []),
+        )
+
+        nx.send(:delete_subnet_tag_resources)
+        expect(st.stack.first["pending_tag_key_delete_crm_op"]).to be_nil
+      end
+
+      it "naps 15 when the value delete LRO fails with FAILED_PRECONDITION (ghost bindings)" do
+        refresh_frame(nx, new_values: {"pending_tag_value_delete_crm_op" => "operations/tv-del"})
+        error = Google::Apis::CloudresourcemanagerV3::Status.new(code: 9, message: "tag value still attached")
+        expect(crm_client).to receive(:get_operation).with("operations/tv-del").and_return(
+          Google::Apis::CloudresourcemanagerV3::Operation.new(name: "operations/tv-del", done: true, error:),
+        )
+        expect(Clog).to receive(:emit).with("CRM delete failed, will retry", anything).and_call_original
+
+        expect { nx.send(:delete_subnet_tag_resources) }.to nap(15)
+        expect(st.stack.first["pending_tag_value_delete_crm_op"]).to be_nil
+      end
+
+      it "naps 15 when an inline-done key delete LRO reports FAILED_PRECONDITION" do
+        tag_key = Google::Apis::CloudresourcemanagerV3::TagKey.new(
+          name: "tagKeys/111", short_name: "ubicloud-subnet-#{ps.ubid}",
+        )
+        expect(crm_client).to receive(:list_tag_keys).and_return(
+          Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse.new(tag_keys: [tag_key]),
+        )
+        expect(crm_client).to receive(:list_tag_values).with(parent: "tagKeys/111", page_token: nil)
+          .and_return(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse.new)
+        error = Google::Apis::CloudresourcemanagerV3::Status.new(code: 9, message: "has child TagValues")
+        expect(crm_client).to receive(:delete_tag_key).with("tagKeys/111").and_return(
+          Google::Apis::CloudresourcemanagerV3::Operation.new(name: "operations/tk-del", done: true, error:),
+        )
+
+        expect { nx.send(:delete_subnet_tag_resources) }.to nap(15)
+      end
+
+      it "naps 15 and clears the pending op for other delete LRO errors so the delete is resubmitted" do
+        refresh_frame(nx, new_values: {"pending_tag_key_delete_crm_op" => "operations/tk-del"})
+        error = Google::Apis::CloudresourcemanagerV3::Status.new(code: 13, message: "server error")
+        expect(crm_client).to receive(:get_operation).with("operations/tk-del").and_return(
+          Google::Apis::CloudresourcemanagerV3::Operation.new(name: "operations/tk-del", done: true, error:),
+        )
+        expect(Clog).to receive(:emit).with("CRM delete failed, will retry", anything).and_call_original
+
+        expect { nx.send(:delete_subnet_tag_resources) }.to nap(15)
+        expect(st.stack.first["pending_tag_key_delete_crm_op"]).to be_nil
       end
     end
 

--- a/spec/prog/vnet/gcp/vpc_update_firewall_rules_spec.rb
+++ b/spec/prog/vnet/gcp/vpc_update_firewall_rules_spec.rb
@@ -141,6 +141,17 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       expect { nx.update_firewall_rules }.to hop("update_firewall_rules", "Vnet::Gcp::VpcNexus")
     end
 
+    it "registers a 5-minute exit deadline" do
+      pending_op = instance_double(Google::Apis::CloudresourcemanagerV3::Operation,
+        done?: false, name: "operations/deadline-test")
+      expect(crm_client).to receive(:create_tag_key).and_return(pending_op)
+
+      expect { nx.update_firewall_rules }.to nap(5)
+      frame = nx.strand.stack.first
+      expect(frame["deadline_target"]).to be_nil
+      expect(Time.new(frame["deadline_at"])).to be_within(10).of(Time.now + 5 * 60)
+    end
+
     it "covers firewalls attached to subnets and VMs in the VPC without duplicates" do
       # direct_fw is reachable via two paths (firewalls_vms and
       # firewalls_private_subnets), so the prog must dedupe to avoid
@@ -816,6 +827,9 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
     let(:orphan_fw_ubid) { Firewall.generate_ubid.to_s }
     let(:orphan_tag_key_name) { "tagKeys/orphan-123" }
     let(:orphan_tag_value_name) { "tagValues/orphan-tv-1" }
+    let(:crm_delete_done_op) {
+      instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, name: "crm-del-op", error: nil)
+    }
 
     it "deletes rules, tag value and tag key for deleted firewalls" do
       orphan_tk = instance_double(Google::Apis::CloudresourcemanagerV3::TagKey,
@@ -835,8 +849,8 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       )
       expect(nfp_client).to receive(:get).and_return(v1::FirewallPolicy.new(rules: [rule]))
       expect(nfp_client).to receive(:remove_rule).with(hash_including(priority: 10005)).and_return(lro_op)
-      expect(crm_client).to receive(:delete_tag_value).with(orphan_tag_value_name)
-      expect(crm_client).to receive(:delete_tag_key).with(orphan_tag_key_name)
+      expect(crm_client).to receive(:delete_tag_value).with(orphan_tag_value_name).and_return(crm_delete_done_op)
+      expect(crm_client).to receive(:delete_tag_key).with(orphan_tag_key_name).and_return(crm_delete_done_op)
 
       nx.send(:cleanup_orphaned_firewall_rules)
     end
@@ -963,7 +977,7 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       )
       expect(nfp_client).not_to receive(:get)
       expect(crm_client).not_to receive(:delete_tag_value)
-      expect(crm_client).to receive(:delete_tag_key).with(orphan_tag_key_name)
+      expect(crm_client).to receive(:delete_tag_key).with(orphan_tag_key_name).and_return(crm_delete_done_op)
 
       nx.send(:cleanup_orphaned_firewall_rules)
     end
@@ -986,8 +1000,8 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       )
       expect(nfp_client).to receive(:get).and_return(v1::FirewallPolicy.new(rules: [deny_rule]))
       expect(nfp_client).not_to receive(:remove_rule)
-      expect(crm_client).to receive(:delete_tag_value).with(orphan_tag_value_name)
-      expect(crm_client).to receive(:delete_tag_key).with(orphan_tag_key_name)
+      expect(crm_client).to receive(:delete_tag_value).with(orphan_tag_value_name).and_return(crm_delete_done_op)
+      expect(crm_client).to receive(:delete_tag_key).with(orphan_tag_key_name).and_return(crm_delete_done_op)
 
       nx.send(:cleanup_orphaned_firewall_rules)
     end
@@ -1010,8 +1024,8 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
       )
       expect(nfp_client).to receive(:get).and_return(v1::FirewallPolicy.new(rules: [unrelated_rule]))
       expect(nfp_client).not_to receive(:remove_rule)
-      expect(crm_client).to receive(:delete_tag_value).with(orphan_tag_value_name)
-      expect(crm_client).to receive(:delete_tag_key).with(orphan_tag_key_name)
+      expect(crm_client).to receive(:delete_tag_value).with(orphan_tag_value_name).and_return(crm_delete_done_op)
+      expect(crm_client).to receive(:delete_tag_key).with(orphan_tag_key_name).and_return(crm_delete_done_op)
 
       nx.send(:cleanup_orphaned_firewall_rules)
     end
@@ -1054,9 +1068,54 @@ RSpec.describe Prog::Vnet::Gcp::VpcUpdateFirewallRules do
         instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: nil, next_page_token: nil),
       )
       # Active tag key (page 1) is NOT deleted; only the orphan from page 2 is.
-      expect(crm_client).to receive(:delete_tag_key).with(orphan_tag_key_name)
+      expect(crm_client).to receive(:delete_tag_key).with(orphan_tag_key_name).and_return(crm_delete_done_op)
 
       nx.send(:cleanup_orphaned_firewall_rules)
+    end
+
+    it "naps and saves the pending op when the orphan tag value delete LRO is not done" do
+      orphan_tk = instance_double(Google::Apis::CloudresourcemanagerV3::TagKey,
+        short_name: "ubicloud-fw-#{orphan_fw_ubid}", name: orphan_tag_key_name,
+        purpose: "GCE_FIREWALL", purpose_data: vpc_purpose_data)
+      expect(crm_client).to receive(:list_tag_keys).and_return(
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [orphan_tk], next_page_token: nil),
+      )
+      orphan_tv = instance_double(Google::Apis::CloudresourcemanagerV3::TagValue,
+        short_name: "active", name: orphan_tag_value_name)
+      expect(crm_client).to receive(:list_tag_values).with(parent: orphan_tag_key_name, page_token: nil).and_return(
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagValuesResponse, tag_values: [orphan_tv], next_page_token: nil),
+      )
+      expect(nfp_client).to receive(:get).and_return(v1::FirewallPolicy.new(rules: []))
+      pending = instance_double(Google::Apis::CloudresourcemanagerV3::Operation,
+        done?: false, name: "operations/orphan-tv-del")
+      expect(crm_client).to receive(:delete_tag_value).with(orphan_tag_value_name).and_return(pending)
+      expect(crm_client).not_to receive(:delete_tag_key)
+
+      expect { nx.send(:cleanup_orphaned_firewall_rules) }.to nap(5)
+      expect(st.stack.first["pending_orphan_delete_crm_op"]).to eq("operations/orphan-tv-del")
+    end
+
+    it "polls a pending orphan delete before recomputing the orphan set" do
+      refresh_frame(nx, new_values: {"pending_orphan_delete_crm_op" => "operations/orphan-del"})
+      expect(crm_client).to receive(:get_operation).with("operations/orphan-del").and_return(
+        instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: true, error: nil),
+      )
+      expect(crm_client).to receive(:list_tag_keys).and_return(
+        instance_double(Google::Apis::CloudresourcemanagerV3::ListTagKeysResponse, tag_keys: [], next_page_token: nil),
+      )
+
+      nx.send(:cleanup_orphaned_firewall_rules)
+      expect(st.stack.first["pending_orphan_delete_crm_op"]).to be_nil
+    end
+
+    it "naps while the pending orphan delete is still running" do
+      refresh_frame(nx, new_values: {"pending_orphan_delete_crm_op" => "operations/orphan-del"})
+      expect(crm_client).to receive(:get_operation).with("operations/orphan-del").and_return(
+        instance_double(Google::Apis::CloudresourcemanagerV3::Operation, done?: false),
+      )
+      expect(crm_client).not_to receive(:list_tag_keys)
+
+      expect { nx.send(:cleanup_orphaned_firewall_rules) }.to nap(5)
     end
   end
 


### PR DESCRIPTION
CRM tag value/key deletes return accepted LROs whose failures (tag value still bound to ghost bindings, tag key still holding child values) surface only in the operation result, never synchronously. The GCP subnet destroy path and the VPC orphaned-firewall cleanup fired both deletes back-to-back without polling, so the key delete always failed asynchronously ("has child TagValues") and every destroyed subnet leaked its tag key. The leak eventually hits GCP's hard 1000-TagKeys-per-parent cap, after which all tag key creation in the project fails with FAILED_PRECONDITION and provisioning wedges.

Add submit_crm_delete/poll_crm_delete to GcpLro: submit a delete LRO and nap-poll it through frame state, treating NOT_FOUND as already deleted and FAILED_PRECONDITION as retriable (nap until GCP garbage-collects the blocking binding or child value). The tag value delete is now confirmed complete before the tag key delete is submitted.