### PR TITLE
Wait for all test project resources before deleting it

### DIFF
--- a/prog/test/kubernetes_base.rb
+++ b/prog/test/kubernetes_base.rb
@@ -75,7 +75,7 @@ class Prog::Test::KubernetesBase < Prog::Test::Base
   end
 
   def finish
-    nap 5 if kubernetes_cluster
+    nap 5 if kubernetes_test_project.has_resources?
     kubernetes_test_project.destroy
 
     fail_test(fail_message) if fail_message

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Prog::Test::Kubernetes do
     described_class.new(Strand.new(prog: "Test::Kubernetes", label: "start", stack: strand_stack))
   }
 
-  let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id}] }
+  let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "kubernetes_test_project_id" => kubernetes_test_project.id}] }
 
   let(:kubernetes_service_project_id) { Project.generate_uuid }
   let(:kubernetes_test_project) { Project.create(name: "Kubernetes-Test-Project") }
@@ -649,7 +649,7 @@ RSpec.describe Prog::Test::Kubernetes do
   end
 
   describe "#finish" do
-    it "naps if kubernetes cluster is not destroyed yet" do
+    it "naps while the test project still has resources" do
       expect { kubernetes_test.finish }.to nap(5)
     end
 

--- a/spec/prog/test/kubernetes_upgrade_spec.rb
+++ b/spec/prog/test/kubernetes_upgrade_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Prog::Test::KubernetesUpgrade do
     described_class.new(Strand.new(prog: "Test::KubernetesUpgrade", label: "start", stack: strand_stack))
   }
 
-  let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "worker_node_count" => 1}] }
+  let(:strand_stack) { [{"kubernetes_cluster_id" => kubernetes_cluster.id, "kubernetes_test_project_id" => kubernetes_test_project.id, "worker_node_count" => 1}] }
 
   let(:kubernetes_service_project_id) { Project.generate_uuid }
   let(:kubernetes_test_project) { Project.create(name: "Kubernetes-Test-Project") }
@@ -281,7 +281,7 @@ RSpec.describe Prog::Test::KubernetesUpgrade do
   end
 
   describe "#finish" do
-    it "naps if kubernetes cluster is not destroyed yet" do
+    it "naps while the test project still has resources" do
       expect { kubernetes_test.finish }.to nap(5)
     end
 


### PR DESCRIPTION
The e2e report summary listed foreign key violations from load_balancer and private_subnet on every kubernetes run. The cluster row is deleted before its load balancers and private subnet are gone, so finish gated on the wrong thing. Gate on Project#has_resources? instead.