### PR TITLE
Do Postgres log aggregation setup in an independent strand

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -624,8 +624,7 @@ class PostgresServer < Sequel::Model
     common_headers = {"X-P-Stream" => resource.ubid, "X-P-Log-Source" => "otel-logs"}
     if (override = Config.parseable_endpoint_override)
       {type: "otlp", url: override, options: {"encoding" => "json", "headers" => common_headers}}
-    elsif (pr = ParseableResource.for_project(Config.postgres_service_project_id)) && (ps = pr.servers.first)
-      password = resource.parseable_password
+    elsif (pr = ParseableResource.for_project(Config.postgres_service_project_id)) && (ps = pr.servers.first) && (password = resource.parseable_password)
       headers = {
         "Authorization" => "Basic " + Base64.strict_encode64("#{resource.ubid}:#{password}"),
         **common_headers,

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -235,8 +235,12 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
   end
 
   label def start
-    postgres_resource.setup_log_aggregation
+    Prog::Postgres::SetupLogAggregation.assemble(postgres_resource.id)
 
+    hop_wait_representative_server
+  end
+
+  label def wait_representative_server
     nap 60 unless representative_server.vm.strand.label == "wait"
 
     postgres_resource.incr_initial_provisioning

--- a/prog/postgres/postgres_resource_nexus.rb
+++ b/prog/postgres/postgres_resource_nexus.rb
@@ -479,11 +479,8 @@ class Prog::Postgres::PostgresResourceNexus < Prog::Base
 
       postgres_resource.internal_firewall.destroy
 
-      if postgres_resource.parseable_password &&
-          (client = ParseableResource.client_for_project(Config.postgres_service_project_id))
-        client.delete_stream(stream_name: postgres_resource.ubid)
-        client.delete_user(user_id: postgres_resource.ubid)
-        client.delete_role(role_name: postgres_resource.ubid)
+      if postgres_resource.parseable_password
+        Prog::Postgres::TeardownLogAggregation.assemble(postgres_resource.ubid)
       end
 
       PostgresServer.incr_destroy(server_ids_dataset)

--- a/prog/postgres/postgres_server_nexus.rb
+++ b/prog/postgres/postgres_server_nexus.rb
@@ -418,8 +418,6 @@ TIMER
   end
 
   label def configure_logs
-    nap 5 if ParseableResource.for_project(Config.postgres_service_project_id) && resource.parseable_password.nil?
-
     case vm.sshable.d_check("configure_logs")
     when "Succeeded"
       vm.sshable.d_clean("configure_logs")

--- a/prog/postgres/setup_log_aggregation.rb
+++ b/prog/postgres/setup_log_aggregation.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Prog::Postgres::SetupLogAggregation < Prog::Base
+  subject_is :postgres_resource
+
+  def self.assemble(postgres_resource_id)
+    Strand.create(prog: "Postgres::SetupLogAggregation", label: "start", stack: [{"subject_id" => postgres_resource_id}])
+  end
+
+  # Nothing increments a semaphore on an independent strand to stop it, and
+  # destroying (unlike destroy) stays set for the rest of the destroy flow, so
+  # a late success cannot recreate what #wait_children_destroyed already removed.
+  def before_run
+    pop "postgres resource is gone" if postgres_resource.nil? || postgres_resource.destroying_set?
+  end
+
+  # Registering the deadline in its own label persists it before #setup gets a
+  # chance to fail, as a failing label rolls back its own stack changes.
+  label def start
+    register_deadline(nil, 60 * 60, page: "warning")
+    hop_setup
+  end
+
+  label def setup
+    postgres_resource.setup_log_aggregation
+    postgres_resource.server_incr("configure_logs") if postgres_resource.parseable_password
+
+    pop "log aggregation setup is complete"
+  end
+end

--- a/prog/postgres/teardown_log_aggregation.rb
+++ b/prog/postgres/teardown_log_aggregation.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Prog::Postgres::TeardownLogAggregation < Prog::Base
+  frame_reader :ubid
+
+  def self.assemble(ubid)
+    Strand.create(prog: "Postgres::TeardownLogAggregation", label: "start", stack: [{"ubid" => ubid}])
+  end
+
+  # The PostgresResource is already gone by the time this runs, so the ubid it
+  # named its stream, user and role with is carried in the frame.
+  label def start
+    register_deadline(nil, 60 * 60, page: "warning")
+    hop_teardown
+  end
+
+  label def teardown
+    if (client = ParseableResource.client_for_project(Config.postgres_service_project_id))
+      client.delete_stream(stream_name: ubid)
+      client.delete_user(user_id: ubid)
+      client.delete_role(role_name: ubid)
+    end
+
+    pop "log aggregation teardown is complete"
+  end
+end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -2203,6 +2203,13 @@ RSpec.describe PostgresServer do
         expect(postgres_server.logs_config[:log_destinations]).to eq([])
       end
 
+      it "emits no managed parseable destination when log aggregation setup hasn't completed yet" do
+        ParseableServer.create(parseable_resource_id: parseable_resource.id, vm_id: vm.id)
+        expect(resource.parseable_password).to be_nil
+
+        expect(postgres_server.logs_config[:log_destinations]).to eq([])
+      end
+
       it "emits a managed parseable destination with auth, CA bundle, and JSON encoding when credentials are set" do
         ps = ParseableServer.create(parseable_resource_id: parseable_resource.id, vm_id: vm.id)
         resource.update(parseable_password: "scoped-pw")

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -999,14 +999,25 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
         expect(postgres_resource).not_to exist
       end
 
-      it "cleans up parseable user and role if parseable stream is provisioned" do
+      it "starts an independent strand to tear down log aggregation if a parseable stream is provisioned" do
         postgres_server
+        ubid = postgres_resource.ubid
         postgres_resource.update(parseable_password: "dummy")
-        client = instance_double(Parseable::Client)
-        expect(ParseableResource).to receive(:client_for_project).and_return(client)
-        expect(client).to receive_messages(delete_stream: nil, delete_role: nil, delete_user: nil)
 
         expect { nx.wait_children_destroyed }.to exit({"msg" => "postgres resource is deleted"})
+
+        strand = Strand.first(prog: "Postgres::TeardownLogAggregation")
+        expect(strand.label).to eq("start")
+        expect(strand.parent_id).to be_nil
+        expect(strand.stack[0]["ubid"]).to eq(ubid)
+      end
+
+      it "does not start a teardown strand if log aggregation was never set up" do
+        postgres_server
+
+        expect { nx.wait_children_destroyed }.to exit({"msg" => "postgres resource is deleted"})
+
+        expect(Strand.first(prog: "Postgres::TeardownLogAggregation")).to be_nil
       end
 
       it "resolves resource-keyed pages so they do not orphan after the resource is gone" do

--- a/spec/prog/postgres/postgres_resource_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_resource_nexus_spec.rb
@@ -413,23 +413,26 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
   end
 
   describe "#start" do
+    it "starts an independent strand for log aggregation setup and hops" do
+      postgres_server
+      expect { nx.start }.to hop("wait_representative_server")
+
+      strand = Strand.first(prog: "Postgres::SetupLogAggregation")
+      expect(strand.label).to eq("start")
+      expect(strand.parent_id).to be_nil
+      expect(strand.stack[0]["subject_id"]).to eq(postgres_resource.id)
+    end
+  end
+
+  describe "#wait_representative_server" do
     it "naps if postgres server is not ready" do
       postgres_server
-      expect { nx.start }.to nap(60)
-    end
-
-    it "sets up log aggregation if parseable is available" do
-      client = instance_double(Parseable::Client)
-      expect(ParseableResource).to receive(:client_for_project).and_return(client)
-      expect(client).to receive_messages(create_stream: "test-stream", create_role: "test-role", create_user: "test-parseable-pass")
-      expect(client).to receive(:set_retention).with(stream_name: postgres_resource.ubid, duration_days: ParseableResource::LOG_RETENTION_DAYS)
-      postgres_server
-      expect { nx.start }.to nap(60)
+      expect { nx.wait_representative_server }.to nap(60)
     end
 
     it "hops if postgres server is ready" do
       postgres_server.vm.strand.update(label: "wait")
-      expect { nx.start }.to hop("refresh_dns_record")
+      expect { nx.wait_representative_server }.to hop("refresh_dns_record")
       expect(Semaphore.where(strand_id: st.id, name: "initial_provisioning").first).to exist
     end
 
@@ -438,7 +441,7 @@ RSpec.describe Prog::Postgres::PostgresResourceNexus do
       parent = create_postgres_resource(project:, location_id:)
       create_postgres_server(resource: parent)
       postgres_resource.update(parent:)
-      expect { nx.start }.to hop("refresh_dns_record")
+      expect { nx.wait_representative_server }.to hop("refresh_dns_record")
       expect(st.children.count).to eq(1)
       expect(st.children.first.label).to eq("trigger_pg_current_xact_id_on_parent")
     end

--- a/spec/prog/postgres/postgres_server_nexus_spec.rb
+++ b/spec/prog/postgres/postgres_server_nexus_spec.rb
@@ -902,7 +902,7 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
       allow(nx.postgres_server).to receive(:logs_config).and_return(logs_config)
     end
 
-    it "naps if a parseable resource is available but log aggregation is not setup" do
+    it "runs configure-logs even if a parseable resource is available but log aggregation is not setup yet" do
       ParseableResource.create(
         project_id: Config.postgres_service_project_id,
         location_id: Location::HETZNER_FSN1_ID,
@@ -915,6 +915,8 @@ RSpec.describe Prog::Postgres::PostgresServerNexus do
         target_vm_size: "standard-2",
         target_storage_size_gib: 100,
       )
+      expect(sshable).to receive(:d_check).with("configure_logs").and_return("NotStarted")
+      expect(sshable).to receive(:d_run).with("configure_logs", "/home/ubi/postgres/bin/configure-logs", stdin: logs_config.to_json)
       expect { nx.configure_logs }.to nap(5)
     end
 

--- a/spec/prog/postgres/setup_log_aggregation_spec.rb
+++ b/spec/prog/postgres/setup_log_aggregation_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Prog::Postgres::SetupLogAggregation do
+  subject(:nx) { described_class.new(st) }
+
+  let(:project) { Project.create(name: "test-project") }
+  let(:postgres_project) { Project.create(name: "postgres-service-project") }
+  let(:location_id) { Location::HETZNER_FSN1_ID }
+  let(:postgres_resource) { create_postgres_resource(project:, location_id:) }
+  let(:postgres_server) { create_postgres_server(resource: postgres_resource) }
+  let(:st) { described_class.assemble(postgres_resource.id) }
+
+  before do
+    allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
+  end
+
+  describe ".assemble" do
+    it "creates a strand with no parent" do
+      expect(st.prog).to eq("Postgres::SetupLogAggregation")
+      expect(st.label).to eq("start")
+      expect(st.parent_id).to be_nil
+      expect(st.stack[0]["subject_id"]).to eq(postgres_resource.id)
+    end
+  end
+
+  describe "#before_run" do
+    it "pops if the postgres resource is already gone" do
+      postgres_resource.destroy
+      expect { nx.before_run }.to exit({"msg" => "postgres resource is gone"})
+    end
+
+    it "pops if the postgres resource is being destroyed" do
+      postgres_resource.incr_destroying
+      expect { nx.before_run }.to exit({"msg" => "postgres resource is gone"})
+    end
+
+    it "does nothing while the postgres resource is alive" do
+      expect { nx.before_run }.not_to exit({"msg" => "postgres resource is gone"})
+    end
+  end
+
+  describe "#start" do
+    it "registers a deadline that pages as a warning, then hops" do
+      expect { nx.start }.to hop("setup")
+      expect(nx.strand.stack[0]["deadline_target"]).to be_nil
+      expect(nx.strand.stack[0]["deadline_page"]).to eq("warning")
+      expect(Time.parse(nx.strand.stack[0]["deadline_at"])).to be_within(60).of(Time.now + 60 * 60)
+    end
+  end
+
+  describe "#setup" do
+    it "sets up log aggregation and signals servers to pick up the config" do
+      postgres_server
+
+      client = instance_double(Parseable::Client)
+      expect(ParseableResource).to receive(:client_for_project).and_return(client)
+      expect(client).to receive_messages(create_stream: "test-stream", create_role: "test-role", create_user: "test-parseable-pass")
+      expect(client).to receive(:set_retention).with(stream_name: postgres_resource.ubid, duration_days: ParseableResource::LOG_RETENTION_DAYS)
+
+      expect { nx.setup }.to exit({"msg" => "log aggregation setup is complete"})
+
+      expect(postgres_resource.reload.parseable_password).to eq("test-parseable-pass")
+      expect(Semaphore.where(strand_id: postgres_server.strand.id, name: "configure_logs").count).to eq(1)
+    end
+
+    it "does not signal servers if parseable is not configured in this environment" do
+      postgres_server
+
+      expect { nx.setup }.to exit({"msg" => "log aggregation setup is complete"})
+
+      expect(postgres_resource.reload.parseable_password).to be_nil
+      expect(Semaphore.where(strand_id: postgres_server.strand.id, name: "configure_logs").count).to eq(0)
+    end
+
+    it "does not swallow errors from parseable, so the strand retries" do
+      client = instance_double(Parseable::Client)
+      expect(ParseableResource).to receive(:client_for_project).and_return(client)
+      expect(client).to receive(:create_stream).and_raise(Parseable::Client::Error.new("boom"))
+
+      expect { nx.setup }.to raise_error(Parseable::Client::Error, "boom")
+      expect(postgres_resource.reload.parseable_password).to be_nil
+    end
+  end
+end

--- a/spec/prog/postgres/teardown_log_aggregation_spec.rb
+++ b/spec/prog/postgres/teardown_log_aggregation_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Prog::Postgres::TeardownLogAggregation do
+  subject(:nx) { described_class.new(st) }
+
+  let(:postgres_project) { Project.create(name: "postgres-service-project") }
+  let(:ubid) { "pgvpn8xa4y1jkk8gzgrp5t4h5v" }
+  let(:st) { described_class.assemble(ubid) }
+
+  before do
+    allow(Config).to receive(:postgres_service_project_id).and_return(postgres_project.id)
+  end
+
+  describe ".assemble" do
+    it "creates a strand with no parent, carrying the ubid in its frame" do
+      expect(st.prog).to eq("Postgres::TeardownLogAggregation")
+      expect(st.label).to eq("start")
+      expect(st.parent_id).to be_nil
+      expect(st.stack[0]["ubid"]).to eq(ubid)
+    end
+  end
+
+  describe "#start" do
+    it "registers a deadline that pages as a warning, then hops" do
+      expect { nx.start }.to hop("teardown")
+      expect(nx.strand.stack[0]["deadline_target"]).to be_nil
+      expect(nx.strand.stack[0]["deadline_page"]).to eq("warning")
+      expect(Time.parse(nx.strand.stack[0]["deadline_at"])).to be_within(60).of(Time.now + 60 * 60)
+    end
+  end
+
+  describe "#teardown" do
+    it "deletes the stream, user and role" do
+      client = instance_double(Parseable::Client)
+      expect(ParseableResource).to receive(:client_for_project).and_return(client)
+      expect(client).to receive(:delete_stream).with(stream_name: ubid)
+      expect(client).to receive(:delete_user).with(user_id: ubid)
+      expect(client).to receive(:delete_role).with(role_name: ubid)
+
+      expect { nx.teardown }.to exit({"msg" => "log aggregation teardown is complete"})
+    end
+
+    it "pops if parseable is not configured in this environment" do
+      expect { nx.teardown }.to exit({"msg" => "log aggregation teardown is complete"})
+    end
+
+    it "does not swallow errors from parseable, so the strand retries" do
+      client = instance_double(Parseable::Client)
+      expect(ParseableResource).to receive(:client_for_project).and_return(client)
+      expect(client).to receive(:delete_stream).and_raise(Parseable::Client::Error.new("boom"))
+
+      expect { nx.teardown }.to raise_error(Parseable::Client::Error, "boom")
+    end
+  end
+end


### PR DESCRIPTION
PostgresResourceNexus#start called setup_log_aggregation inline, so a Parseable
outage left the resource strand retrying #start and blocked DNS records,
certificates and billing records behind it. #wait_children_destroyed deleted the
Parseable stream, user and role inline for the same reason, leaving a resource
undeletable while Parseable was down.

Both now run in strands with no parent, so nothing waits on them and they retry
on their own schedule. Each registers a one hour deadline and pages as a warning
if it expires. Servers pick the credentials up through incr_configure_logs once
the setup lands, so configure_logs no longer has to wait for a password that may
never arrive.