### PR TITLE
Improve csi capability validation

### DIFF
--- a/kubernetes/csi/Gemfile.lock
+++ b/kubernetes/csi/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ubi-csi (0.13.0)
+    ubi-csi (0.14.0)
       base64
       grpc (= 1.83.0)
       grpc-tools (= 1.83.0)

--- a/kubernetes/csi/lib/ubi_csi.rb
+++ b/kubernetes/csi/lib/ubi_csi.rb
@@ -5,7 +5,7 @@ require "csi_pb"
 require "csi_services_pb"
 
 module Csi
-  VERSION = "0.13.0"
+  VERSION = "0.14.0"
 end
 
 require_relative "ubi_csi/identity_service"

--- a/kubernetes/csi/lib/ubi_csi/controller_service.rb
+++ b/kubernetes/csi/lib/ubi_csi/controller_service.rb
@@ -13,6 +13,8 @@ module Csi
 
       OneGB = 1024 * 1024 * 1024
 
+      UNSUPPORTED_CAPABILITY_MESSAGE = "Only mount volumes with the SINGLE_NODE_WRITER access mode are supported"
+
       def max_volume_size
         @max_volume_size ||= begin
           limit_gb_str = ENV.fetch("DISK_LIMIT_GB", "10")
@@ -88,6 +90,12 @@ module Csi
         selected
       end
 
+      def supported_volume_capabilities?(capabilities)
+        capabilities.all? do |capability|
+          capability.access_type == :mount && capability.access_mode&.mode == :SINGLE_NODE_WRITER
+        end
+      end
+
       def validate_create_volume_request(req)
         if req.name.nil? || req.name.empty?
           raise GRPC::InvalidArgument.new("Volume name is required")
@@ -112,6 +120,10 @@ module Csi
 
         if req.volume_capabilities.nil? || req.volume_capabilities.empty?
           raise GRPC::InvalidArgument.new("Volume capabilities are required")
+        end
+
+        unless supported_volume_capabilities?(req.volume_capabilities)
+          raise GRPC::InvalidArgument.new(UNSUPPORTED_CAPABILITY_MESSAGE)
         end
 
         if req.accessibility_requirements.nil? || req.accessibility_requirements.requisite.empty?
@@ -221,6 +233,25 @@ module Csi
         rescue => e
           log_with_id(req_id, "Internal error in delete_volume: #{e.class} - #{e.message}\n#{e.backtrace.join("\n")}")
           raise GRPC::Internal, "DeleteVolume error: #{e.message}"
+        end
+      end
+
+      def validate_volume_capabilities(req, _call)
+        log_request_response(req, "validate_volume_capabilities") do |req_id|
+          raise GRPC::InvalidArgument.new("Volume ID is required") if req.volume_id.empty?
+          raise GRPC::InvalidArgument.new("Volume capabilities are required") if req.volume_capabilities.empty?
+
+          if supported_volume_capabilities?(req.volume_capabilities)
+            ValidateVolumeCapabilitiesResponse.new(
+              confirmed: ValidateVolumeCapabilitiesResponse::Confirmed.new(
+                volume_context: req.volume_context.to_h,
+                volume_capabilities: req.volume_capabilities.to_a,
+                parameters: req.parameters.to_h,
+              ),
+            )
+          else
+            ValidateVolumeCapabilitiesResponse.new(message: UNSUPPORTED_CAPABILITY_MESSAGE)
+          end
         end
       end
     end

--- a/kubernetes/csi/spec/csi/v1/controller_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/controller_service_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Csi::V1::ControllerService do
       end
 
       it "raises FailedPrecondition for different capabilities" do
-        base_request_args[:volume_capabilities] = [{block: {}, access_mode: {mode: :MULTI_NODE_READER_ONLY}}]
+        base_request_args[:volume_capabilities] = [{mount: {fs_type: "xfs", mount_flags: []}, access_mode: {mode: :SINGLE_NODE_WRITER}}]
         request = Csi::V1::CreateVolumeRequest.new(base_request_args)
         expect { service.create_volume(request, call) }.to raise_error(GRPC::FailedPrecondition, "9:Volume with same name but different capabilities exists")
       end
@@ -292,6 +292,30 @@ RSpec.describe Csi::V1::ControllerService do
         expect { service.create_volume(request, call) }.to raise_error(GRPC::InvalidArgument, "3:Volume capabilities are required")
       end
 
+      it "raises InvalidArgument when a capability requests block access" do
+        base_request_args[:volume_capabilities] = [{block: {}, access_mode: {mode: :SINGLE_NODE_WRITER}}]
+        request = Csi::V1::CreateVolumeRequest.new(base_request_args)
+        expect { service.create_volume(request, call) }.to raise_error(GRPC::InvalidArgument, "3:Only mount volumes with the SINGLE_NODE_WRITER access mode are supported")
+      end
+
+      it "raises InvalidArgument when a capability requests a multi node access mode" do
+        base_request_args[:volume_capabilities] = [{mount: {fs_type: "ext4", mount_flags: []}, access_mode: {mode: :MULTI_NODE_MULTI_WRITER}}]
+        request = Csi::V1::CreateVolumeRequest.new(base_request_args)
+        expect { service.create_volume(request, call) }.to raise_error(GRPC::InvalidArgument, "3:Only mount volumes with the SINGLE_NODE_WRITER access mode are supported")
+      end
+
+      it "raises InvalidArgument when a capability has no access mode" do
+        base_request_args[:volume_capabilities] = [{mount: {fs_type: "ext4", mount_flags: []}}]
+        request = Csi::V1::CreateVolumeRequest.new(base_request_args)
+        expect { service.create_volume(request, call) }.to raise_error(GRPC::InvalidArgument, "3:Only mount volumes with the SINGLE_NODE_WRITER access mode are supported")
+      end
+
+      it "raises InvalidArgument when one of several capabilities is unsupported" do
+        base_request_args[:volume_capabilities] = [volume_capability, {block: {}, access_mode: {mode: :SINGLE_NODE_WRITER}}]
+        request = Csi::V1::CreateVolumeRequest.new(base_request_args)
+        expect { service.create_volume(request, call) }.to raise_error(GRPC::InvalidArgument, "3:Only mount volumes with the SINGLE_NODE_WRITER access mode are supported")
+      end
+
       it "raises InvalidArgument when accessibility_requirements is nil" do
         request = Csi::V1::CreateVolumeRequest.new(
           name: "test",
@@ -311,6 +335,57 @@ RSpec.describe Csi::V1::ControllerService do
         )
         expect { service.create_volume(request, call) }.to raise_error(GRPC::InvalidArgument, "3:Topology requirement is required")
       end
+    end
+  end
+
+  describe "#validate_volume_capabilities" do
+    let(:call) { instance_double(GRPC::ActiveCall) }
+    let(:mount_capability) { {mount: {fs_type: "ext4", mount_flags: []}, access_mode: {mode: :SINGLE_NODE_WRITER}} }
+
+    it "confirms mount capabilities with the single node writer access mode" do
+      request = Csi::V1::ValidateVolumeCapabilitiesRequest.new(
+        volume_id: "vol-123",
+        volume_capabilities: [mount_capability],
+        volume_context: {"size_bytes" => "1073741824"},
+        parameters: {"type" => "ssd"},
+      )
+      expect(service.validate_volume_capabilities(request, call)).to eq(Csi::V1::ValidateVolumeCapabilitiesResponse.new(
+        confirmed: {
+          volume_context: {"size_bytes" => "1073741824"},
+          volume_capabilities: [mount_capability],
+          parameters: {"type" => "ssd"},
+        },
+      ))
+    end
+
+    it "does not confirm block capabilities" do
+      request = Csi::V1::ValidateVolumeCapabilitiesRequest.new(
+        volume_id: "vol-123",
+        volume_capabilities: [{block: {}, access_mode: {mode: :SINGLE_NODE_WRITER}}],
+      )
+      expect(service.validate_volume_capabilities(request, call)).to eq(Csi::V1::ValidateVolumeCapabilitiesResponse.new(
+        message: "Only mount volumes with the SINGLE_NODE_WRITER access mode are supported",
+      ))
+    end
+
+    it "does not confirm multi node access modes" do
+      request = Csi::V1::ValidateVolumeCapabilitiesRequest.new(
+        volume_id: "vol-123",
+        volume_capabilities: [mount_capability, {mount: {fs_type: "ext4", mount_flags: []}, access_mode: {mode: :MULTI_NODE_MULTI_WRITER}}],
+      )
+      expect(service.validate_volume_capabilities(request, call)).to eq(Csi::V1::ValidateVolumeCapabilitiesResponse.new(
+        message: "Only mount volumes with the SINGLE_NODE_WRITER access mode are supported",
+      ))
+    end
+
+    it "raises InvalidArgument when volume_id is empty" do
+      request = Csi::V1::ValidateVolumeCapabilitiesRequest.new(volume_capabilities: [mount_capability])
+      expect { service.validate_volume_capabilities(request, call) }.to raise_error(GRPC::InvalidArgument, "3:Volume ID is required")
+    end
+
+    it "raises InvalidArgument when volume_capabilities is empty" do
+      request = Csi::V1::ValidateVolumeCapabilitiesRequest.new(volume_id: "vol-123")
+      expect { service.validate_volume_capabilities(request, call) }.to raise_error(GRPC::InvalidArgument, "3:Volume capabilities are required")
     end
   end
 

--- a/kubernetes/csi/spec/csi/v1/identity_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/identity_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Csi::V1::IdentityService do
       request = Csi::V1::GetPluginInfoRequest.new
       response = service.get_plugin_info(request, call)
       expect(response.name).to eq("csi.ubicloud.com")
-      expect(response.vendor_version).to eq("0.13.0")
+      expect(response.vendor_version).to eq("0.14.0")
     end
   end
 

--- a/kubernetes/csi/ubi-csi.gemspec
+++ b/kubernetes/csi/ubi-csi.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "ubi-csi"
-  spec.version = "0.13.0"
+  spec.version = "0.14.0"
   spec.authors = ["Ubicloud"]
   spec.email = ["support@ubicloud.com"]
 

--- a/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:v0.13.0
+          image: ubicloud/ubicsi:v0.14.0
           imagePullPolicy: IfNotPresent
           args: ["node"]
           env:

--- a/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:v0.13.0
+          image: ubicloud/ubicsi:v0.14.0
           imagePullPolicy: IfNotPresent
           args: ["controller"]
           env:


### PR DESCRIPTION
**Reject unsupported volume capabilities in Ubicsi**
CreateVolume only checked that volume_capabilities was non-empty, so a PVC with volumeMode Block or a ReadWriteMany access mode was provisioned and bound. The node then skipped mkfs for a block capability and tried to mount an unformatted loop device, turning a claim that should have been refused up front into a mount error at NodeStageVolume.

Reject capabilities whose access type is not mount or whose access mode is not SINGLE_NODE_WRITER with INVALID_ARGUMENT, and implement ValidateVolumeCapabilities against the same rule.

**Bump Ubicsi version**