### PR TITLE
Pin the uplink to its permanent MAC in a host's netplan

### DIFF
--- a/lib/hosting/leaseweb_netplan.rb
+++ b/lib/hosting/leaseweb_netplan.rb
@@ -3,7 +3,7 @@
 require "yaml"
 
 # Builds the desired-state /etc/netplan/01-netcfg.yaml for a Leaseweb host
-# from its ip records, NIC names, and the resolvers its environment provided.
+# from its ip records, NIC MACs, and the resolvers its environment provided.
 class Hosting::LeasewebNetplan
   ROUTE_METRIC = 100
   INTERNAL_MTU = 9000
@@ -13,9 +13,9 @@ class Hosting::LeasewebNetplan
   CONNECTIVITY_HOST_OFFSET = 2
   ROUTED_HOST_OFFSET = 1
 
-  def initialize(public_interface:, internal_interface:, internal_ip:, ip_infos:, nameservers:, search_domains:)
-    @public_interface = public_interface
-    @internal_interface = internal_interface
+  def initialize(public_mac:, internal_mac:, internal_ip:, ip_infos:, nameservers:, search_domains:)
+    @public_mac = public_mac
+    @internal_mac = internal_mac
     @internal_ip = internal_ip
     @ip_infos = ip_infos
     @nameservers = nameservers
@@ -29,18 +29,19 @@ class Hosting::LeasewebNetplan
   end
 
   def to_h
-    ethernets = {@public_interface => public_ethernet}
-    ethernets[@internal_interface] = internal_ethernet if @internal_interface
+    ethernets = {"public" => public_ethernet}
+    ethernets["internal"] = internal_ethernet if @internal_mac
 
     {"network" => {"version" => 2, "renderer" => "networkd", "ethernets" => ethernets}}
   end
 
-  # Desired addresses keyed by the interface each belongs to, so verify can check
-  # placement, not mere presence.
-  def interface_addresses
-    interfaces = {@public_interface => public_addresses}
-    interfaces[@internal_interface] = internal_addresses if @internal_interface
-    interfaces
+  # Desired addresses keyed by the MAC each belongs to, so verify can check
+  # placement, not mere presence, without depending on a name the firmware
+  # is free to reassign.
+  def addresses_by_mac
+    macs = {@public_mac => public_addresses}
+    macs[@internal_mac] = internal_addresses if @internal_mac
+    macs
   end
 
   # One default route per family; a segment gateway resolves to the same router.
@@ -62,13 +63,14 @@ class Hosting::LeasewebNetplan
   # Declare the reserved VLAN address (a DHCP-disabled VLAN still gets addressed).
   # optional keeps a dead private port from stalling network-online.target.
   def internal_ethernet
-    {"addresses" => internal_addresses, "mtu" => INTERNAL_MTU, "optional" => true}
+    {"match" => {"macaddress" => @internal_mac}, "addresses" => internal_addresses, "mtu" => INTERNAL_MTU, "optional" => true}
   end
 
   # accept-ra false: dhcp6 off still accepts router advertisements, which would
   # add a competing default route / SLAAC address; this file is the whole state.
   def public_ethernet
     {
+      "match" => {"macaddress" => @public_mac},
       "dhcp4" => false,
       "dhcp6" => false,
       "accept-ra" => false,

--- a/prog/leaseweb/setup_networking.rb
+++ b/prog/leaseweb/setup_networking.rb
@@ -3,9 +3,9 @@
 class Prog::Leaseweb::SetupNetworking < Prog::Base
   subject_is :sshable, :vm_host
 
-  # start passes verify the desired addresses, gateways, and internal ifname
+  # start passes verify the desired addresses, gateways, and internal mac
   # through the frame, so verify needs no second API pull.
-  frame_accessor :expected_addresses, :expected_gateways, :expected_internal_interface
+  frame_accessor :expected_addresses, :expected_gateways, :expected_internal_mac
 
   # Leaseweb hands a fresh server only its main IP over DHCP, so we configure
   # every other routed address as the whole desired-state netplan.
@@ -14,14 +14,8 @@ class Prog::Leaseweb::SetupNetworking < Prog::Base
     nics = api.pull_network_interfaces
     links = sshable.cmd_json("/usr/sbin/ip -j link")
 
-    public_interface = interface_for(links, nics.public_mac)
-    fail "no interface with leaseweb public mac #{nics.public_mac}" unless public_interface
-
-    internal_interface = nil
-    if nics.internal_mac
-      internal_interface = interface_for(links, nics.internal_mac)
-      fail "no interface with leaseweb internal mac #{nics.internal_mac}" unless internal_interface
-    end
+    fail "no interface with leaseweb public mac #{nics.public_mac}" unless interface_for(links, nics.public_mac)
+    fail "no interface with leaseweb internal mac #{nics.internal_mac}" if nics.internal_mac && !interface_for(links, nics.internal_mac)
 
     # /etc/resolv.conf names only the local stub; this file holds the real
     # upstreams the environment handed the host, frozen in since dhcp4 goes off.
@@ -35,12 +29,12 @@ class Prog::Leaseweb::SetupNetworking < Prog::Base
     ip_infos = api.pull_ips
     vm_host.create_addresses(ip_records: ip_infos)
 
-    netplan = Hosting::LeasewebNetplan.new(public_interface:, internal_interface:, internal_ip: nics.internal_ip, ip_infos:, nameservers:, search_domains:)
+    netplan = Hosting::LeasewebNetplan.new(public_mac: nics.public_mac, internal_mac: nics.internal_mac, internal_ip: nics.internal_ip, ip_infos:, nameservers:, search_domains:)
     sshable.cmd("sudo host/bin/setup-leaseweb-networking :netplan", netplan: netplan.to_yaml)
 
-    self.expected_addresses = netplan.interface_addresses
+    self.expected_addresses = netplan.addresses_by_mac
     self.expected_gateways = netplan.gateways
-    self.expected_internal_interface = internal_interface
+    self.expected_internal_mac = nics.internal_mac
     hop_verify
   end
 
@@ -56,7 +50,7 @@ class Prog::Leaseweb::SetupNetworking < Prog::Base
     # Check per interface, not the union: an address on the wrong NIC would pass a
     # global check. Exclude the optional internal NIC so a dead port never pages.
     configured = configured_addresses(links)
-    nap 1 unless expected_addresses.except(expected_internal_interface).all? { |ifname, addresses| (addresses - configured.fetch(ifname, [])).empty? }
+    nap 1 unless expected_addresses.except(expected_internal_mac).all? { |mac, addresses| (addresses - configured.fetch(mac, [])).empty? }
 
     # netplan apply exits zero even if a gateway is unreachable, so ping each.
     expected_gateways.each do |gateway|
@@ -69,7 +63,7 @@ class Prog::Leaseweb::SetupNetworking < Prog::Base
 
     # A green public path says nothing about the private port; record its state
     # for diagnostics, never page.
-    emit_internal_port_state(links) if expected_internal_interface
+    emit_internal_port_state(links) if expected_internal_mac
 
     hop_refresh_nftables
   end
@@ -82,17 +76,17 @@ class Prog::Leaseweb::SetupNetworking < Prog::Base
     push Prog::SetupNftables
   end
 
-  # Addresses each interface holds, keyed by ifname, so verify checks placement.
+  # Addresses each interface holds, keyed by mac, so verify checks placement.
   def configured_addresses(links)
     links.to_h do |link|
-      [link["ifname"], link.fetch("addr_info", []).map { "#{it["local"]}/#{it["prefixlen"]}" }]
+      [link["address"], link.fetch("addr_info", []).map { "#{it["local"]}/#{it["prefixlen"]}" }]
     end
   end
 
   # Internal port operstate + carrier for diagnostics; absent when it never got
   # carrier to install a link.
   def emit_internal_port_state(links)
-    link = links.find { it["ifname"] == expected_internal_interface } || {}
-    Clog.emit("leaseweb internal port state", {leaseweb_internal_port: {ifname: expected_internal_interface, operstate: link["operstate"], carrier: link.fetch("flags", []).include?("LOWER_UP")}})
+    link = links.find { it["address"] == expected_internal_mac } || {}
+    Clog.emit("leaseweb internal port state", {leaseweb_internal_port: {mac: expected_internal_mac, ifname: link["ifname"], operstate: link["operstate"], carrier: link.fetch("flags", []).include?("LOWER_UP")}})
   end
 end

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -6,6 +6,7 @@ require_relative "../lib/cloud_hypervisor"
 require_relative "../lib/crypt_swap_setup"
 require_relative "../lib/htcat_setup"
 require_relative "../lib/spdk_setup"
+require_relative "../lib/uplink_mac_pin"
 require "fileutils"
 require "socket"
 
@@ -107,7 +108,9 @@ r "apt-get -y install qemu-utils mtools acl"
 r "apt-get -y install nvme-cli systemd-coredump" if is_prod_env
 
 # We need smartmontools, nvme-cli and jq in order to probe the disk status of VmHosts
-r "apt-get -y install smartmontools nvme-cli jq"
+r "apt-get -y install smartmontools nvme-cli jq ethtool"
+
+puts UplinkMacPin.new.run
 
 HtcatSetup.new.run
 

--- a/rhizome/host/lib/uplink_mac_pin.rb
+++ b/rhizome/host/lib/uplink_mac_pin.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "fileutils"
+require "json"
+require "yaml"
+
+class UplinkMacPin
+  def run
+    ifname = uplink_interface
+    path, id = name_keyed_entry(ifname)
+    return "netplan does not select #{ifname} by name, nothing to pin" unless path
+
+    fail "netplan already has an ethernet named uplink" if ethernet_ids.include?("uplink")
+
+    mac = permanent_mac(ifname)
+    document = pin(load_netplan(path), id, mac)
+    verify(path, document)
+    archive(path)
+    safe_write_to_file(path, YAML.dump(document), perm: 0o600)
+    "pinned #{ifname} to #{mac} in #{path}"
+  end
+
+  private
+
+  def uplink_interface
+    dev = JSON.parse(r("ip", "-j", "route", "show", "default")).filter_map { |route| route["dev"] }.first
+    fail "no default route to identify the uplink interface" unless dev
+    dev
+  end
+
+  def permanent_mac(ifname)
+    mac = r("ethtool", "-P", ifname)[/(?:[0-9a-f]{2}:){5}[0-9a-f]{2}/]
+    mac = File.read(File.join("/sys/class/net", ifname, "address"))[/(?:[0-9a-f]{2}:){5}[0-9a-f]{2}/] if mac.nil? || mac == "00:00:00:00:00:00"
+    fail "no permanent mac for #{ifname}" unless mac
+    mac
+  end
+
+  def netplan_paths
+    Dir.glob("/etc/netplan/*.yaml").sort
+  end
+
+  def load_netplan(path)
+    YAML.safe_load_file(path, permitted_classes: [Symbol], aliases: true)
+  end
+
+  def name_keyed_entry(ifname)
+    netplan_paths.each do |path|
+      conf = load_netplan(path).to_h.dig("network", "ethernets").to_h[ifname]
+      return [path, ifname] if conf.is_a?(Hash) && !conf.key?("match")
+    end
+    nil
+  end
+
+  def ethernet_ids
+    netplan_paths.flat_map { |path| load_netplan(path).to_h.dig("network", "ethernets").to_h.keys }
+  end
+
+  def pin(document, id, mac)
+    ethernets = document.dig("network", "ethernets")
+    ethernets["uplink"] = {"match" => {"macaddress" => mac}}.merge(ethernets.delete(id))
+    document
+  end
+
+  def verify(path, document)
+    before = stage("before")
+    after = stage("after")
+    File.write(File.join(after, "etc/netplan", File.basename(path)), YAML.dump(document), perm: 0o600)
+    r "netplan", "generate", "--root-dir", before
+    r "netplan", "generate", "--root-dir", after
+
+    fail "pinning #{path} would change the generated network configuration" unless generated(before) == generated(after)
+  ensure
+    FileUtils.rm_rf("/var/tmp/uplink-mac-pin")
+  end
+
+  def stage(name)
+    root = File.join("/var/tmp/uplink-mac-pin", name)
+    netplan = File.join(root, "etc/netplan")
+    FileUtils.mkdir_p(netplan, mode: 0o700)
+    netplan_paths.each { |path| FileUtils.cp(path, netplan, preserve: true) }
+    root
+  end
+
+  def generated(root)
+    Dir.glob(File.join(root, "run/systemd/network/*.network")).map { |unit| without_match(File.read(unit)) }.sort
+  end
+
+  def without_match(unit)
+    unit.split(/^(?=\[)/).reject { |section| section.start_with?("[Match]") }.join
+  end
+
+  def archive(path)
+    target = path + ".ubicloud-orig"
+    return if File.exist?(target)
+
+    tmp = "#{target}.tmp"
+    FileUtils.cp(path, tmp, preserve: true)
+    File.rename(tmp, target)
+  end
+end

--- a/rhizome/host/spec/uplink_mac_pin_spec.rb
+++ b/rhizome/host/spec/uplink_mac_pin_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require_relative "../lib/uplink_mac_pin"
+require "tmpdir"
+
+RSpec.describe UplinkMacPin do
+  subject(:pin) { described_class.new }
+
+  let(:netplan_dir) { Dir.mktmpdir }
+  let(:staging_dir) { "/var/tmp/uplink-mac-pin" }
+  let(:path) { File.join(netplan_dir, "01-netcfg.yaml") }
+
+  let(:named_netplan) do
+    <<~YAML
+      network:
+        version: 2
+        renderer: networkd
+        ethernets:
+          enp2s0:
+            addresses:
+              - 157.90.0.37/32
+              - 2a01:4f8:2b02:699::2/64
+            routes:
+              - on-link: true
+                to: 0.0.0.0/0
+                via: 157.90.0.1
+              - to: default
+                via: fe80::1
+    YAML
+  end
+
+  before do
+    allow(Dir).to receive(:glob).and_call_original
+    allow(Dir).to receive(:glob).with("/etc/netplan/*.yaml") { Dir.children(netplan_dir).filter_map { |name| File.join(netplan_dir, name) if name.end_with?(".yaml") } }
+    File.write(path, named_netplan)
+  end
+
+  after do
+    FileUtils.rm_rf(netplan_dir)
+    FileUtils.rm_rf(staging_dir)
+  end
+
+  # Stands in for netplan generate: renders each ethernet's addresses under a
+  # [Match] keyed on however that ethernet is selected, which is exactly the
+  # part verify is required to ignore.
+  def stub_netplan_generate(divergent: nil)
+    allow(pin).to receive(:_run_command).with("netplan", "generate", "--root-dir", anything) do |*args|
+      root = args.last
+      out = File.join(root, "run/systemd/network")
+      FileUtils.mkdir_p(out)
+      doc = YAML.safe_load_file(File.join(root, "etc/netplan/01-netcfg.yaml"), permitted_classes: [Symbol])
+      doc.dig("network", "ethernets").each do |id, conf|
+        addresses = conf["addresses"].to_a
+        addresses += [divergent] if divergent && File.basename(root) == "after"
+        File.write(File.join(out, "10-netplan-#{id}.network"),
+          "[Match]\nName=#{id}\n\n[Network]\n" + addresses.map { |address| "Address=#{address}\n" }.join)
+      end
+      ""
+    end
+  end
+
+  def stub_uplink(dev: "enp2s0", mac: "98:b7:85:00:99:9a")
+    allow(pin).to receive(:_run_command).with("ip", "-j", "route", "show", "default")
+      .and_return(JSON.generate([{dst: "default", gateway: "157.90.0.1", dev: dev}]))
+    allow(pin).to receive(:_run_command).with("ethtool", "-P", dev)
+      .and_return("Permanent address: #{mac}\n")
+  end
+
+  describe "#run" do
+    it "rewrites the named ethernet to select the uplink by its permanent mac" do
+      stub_uplink
+      stub_netplan_generate
+
+      expect(pin.run).to eq "pinned enp2s0 to 98:b7:85:00:99:9a in #{path}"
+
+      ethernets = YAML.safe_load_file(path, permitted_classes: [Symbol]).dig("network", "ethernets")
+      expect(ethernets.keys).to eq ["uplink"]
+      expect(ethernets["uplink"]["match"]).to eq("macaddress" => "98:b7:85:00:99:9a")
+    end
+
+    it "keeps every address and route the entry carried" do
+      stub_uplink
+      stub_netplan_generate
+      before = YAML.safe_load_file(path, permitted_classes: [Symbol]).dig("network", "ethernets", "enp2s0")
+
+      pin.run
+
+      after = YAML.safe_load_file(path, permitted_classes: [Symbol]).dig("network", "ethernets", "uplink")
+      expect(after.except("match")).to eq before
+    end
+
+    it "writes an unquoted ipv6 default route back unchanged" do
+      stub_uplink
+      stub_netplan_generate
+
+      pin.run
+
+      expect(File.read(path)).to include("via: fe80::1")
+    end
+
+    it "keeps the displaced config alongside the rewritten one" do
+      stub_uplink
+      stub_netplan_generate
+
+      pin.run
+
+      expect(File.read(path + ".ubicloud-orig")).to eq named_netplan
+    end
+
+    it "leaves an entry that already matches on something alone" do
+      File.write(path, named_netplan.sub("    enp2s0:\n", "    enp2s0:\n      match:\n        macaddress: 98:b7:85:00:99:9a\n"))
+      stub_uplink
+
+      expect(pin.run).to eq "netplan does not select enp2s0 by name, nothing to pin"
+      expect(File).not_to exist(path + ".ubicloud-orig")
+    end
+
+    it "ignores files that configure no ethernets, and entries that are not mappings" do
+      File.write(File.join(netplan_dir, "00-empty.yaml"), "network:\n  version: 2\n")
+      File.write(File.join(netplan_dir, "00-blank-entry.yaml"), "network:\n  version: 2\n  ethernets:\n    enp2s0:\n")
+      stub_uplink
+      stub_netplan_generate
+
+      expect(pin.run).to eq "pinned enp2s0 to 98:b7:85:00:99:9a in #{path}"
+    end
+
+    it "refuses to write a rewrite that would change what netplan generates" do
+      stub_uplink
+      stub_netplan_generate(divergent: "10.0.0.1/32")
+
+      expect { pin.run }.to raise_error RuntimeError, "pinning #{path} would change the generated network configuration"
+      expect(YAML.safe_load_file(path, permitted_classes: [Symbol]).dig("network", "ethernets").keys).to eq ["enp2s0"]
+    end
+
+    it "clears the staging root even when verification fails" do
+      stub_uplink
+      stub_netplan_generate(divergent: "10.0.0.1/32")
+
+      expect { pin.run }.to raise_error RuntimeError
+      expect(File).not_to exist(staging_dir)
+    end
+
+    it "fails when the host has no default route" do
+      allow(pin).to receive(:_run_command).with("ip", "-j", "route", "show", "default").and_return("[]")
+
+      expect { pin.run }.to raise_error RuntimeError, "no default route to identify the uplink interface"
+    end
+
+    it "fails when netplan already has an ethernet named uplink" do
+      File.write(File.join(netplan_dir, "02-extra.yaml"), "network:\n  version: 2\n  ethernets:\n    uplink:\n      dhcp4: false\n")
+      stub_uplink
+
+      expect { pin.run }.to raise_error RuntimeError, "netplan already has an ethernet named uplink"
+    end
+  end
+
+  describe "#permanent_mac" do
+    before { stub_uplink }
+
+    it "falls back to the sysfs address when ethtool reports none" do
+      allow(pin).to receive(:_run_command).with("ethtool", "-P", "enp2s0").and_return("Permanent address: not set\n")
+      allow(File).to receive(:read).with("/sys/class/net/enp2s0/address").and_return("98:b7:85:00:99:9a\n")
+
+      expect(pin.send(:permanent_mac, "enp2s0")).to eq "98:b7:85:00:99:9a"
+    end
+
+    it "falls back to the sysfs address when ethtool reports all zeroes" do
+      allow(pin).to receive(:_run_command).with("ethtool", "-P", "enp2s0").and_return("Permanent address: 00:00:00:00:00:00\n")
+      allow(File).to receive(:read).with("/sys/class/net/enp2s0/address").and_return("98:b7:85:00:99:9a\n")
+
+      expect(pin.send(:permanent_mac, "enp2s0")).to eq "98:b7:85:00:99:9a"
+    end
+
+    it "fails when neither source yields a mac" do
+      allow(pin).to receive(:_run_command).with("ethtool", "-P", "enp2s0").and_return("")
+      allow(File).to receive(:read).with("/sys/class/net/enp2s0/address").and_return("\n")
+
+      expect { pin.send(:permanent_mac, "enp2s0") }.to raise_error RuntimeError, "no permanent mac for enp2s0"
+    end
+  end
+
+  describe "#archive" do
+    it "keeps the first config it displaces and leaves it there on a rerun" do
+      pin.send(:archive, path)
+      File.write(path, "changed")
+      pin.send(:archive, path)
+
+      expect(File.read(path + ".ubicloud-orig")).to eq named_netplan
+    end
+  end
+end

--- a/spec/lib/hosting/leaseweb_netplan_spec.rb
+++ b/spec/lib/hosting/leaseweb_netplan_spec.rb
@@ -5,11 +5,8 @@ RSpec.describe Hosting::LeasewebNetplan do
     Hosting::LeasewebApis::IpInfo.new(ip_address:, source_host_ip:, gateway:)
   end
 
-  # The prog learns these from the host's resolved state and passes them in.
-  def netplan_for(**kwargs)
-    described_class.new(nameservers: ["23.19.53.53", "23.19.52.52"], search_domains: ["dedi.leaseweb.net"], **kwargs)
-  end
-
+  let(:public_mac) { "8c:84:74:54:ea:d0" }
+  let(:internal_mac) { "8c:84:74:54:ea:d1" }
   # What pull_ips returns for server 12493302, the hand-configured reference.
   let(:reference_ip_infos) do
     [
@@ -19,7 +16,6 @@ RSpec.describe Hosting::LeasewebNetplan do
       ip_info("216.22.15.64/26"),
     ]
   end
-
   # /etc/netplan/01-netcfg.yaml as hand-written on 12493302, less its second
   # default route via the host's own address, and less its ens3f1np1 stanza: the
   # hand-written file configures dhcp4 on an internal port with no private
@@ -34,7 +30,9 @@ RSpec.describe Hosting::LeasewebNetplan do
           version: 2
           renderer: networkd
           ethernets:
-              ens3f0np0:
+              public:
+                  match:
+                      macaddress: '8c:84:74:54:ea:d0'
                   dhcp4: no
                   dhcp6: no
                   accept-ra: no
@@ -60,11 +58,16 @@ RSpec.describe Hosting::LeasewebNetplan do
   # 12493302 reports no private network, so pull_network_interfaces gives it no
   # internal interface even though it reports an internal MAC.
   let(:netplan) do
-    netplan_for(public_interface: "ens3f0np0", internal_interface: nil, internal_ip: nil, ip_infos: reference_ip_infos)
+    netplan_for(public_mac:, internal_mac: nil, internal_ip: nil, ip_infos: reference_ip_infos)
+  end
+
+  # The prog learns these from the host's resolved state and passes them in.
+  def netplan_for(**kwargs)
+    described_class.new(nameservers: ["23.19.53.53", "23.19.52.52"], search_domains: ["dedi.leaseweb.net"], **kwargs)
   end
 
   it "keeps standalone routed addresses off the NIC" do
-    netplan = netplan_for(public_interface: "eno1", internal_interface: nil, internal_ip: nil,
+    netplan = netplan_for(public_mac:, internal_mac: nil, internal_ip: nil,
       ip_infos: [
         ip_info("216.22.50.197/32", "216.22.50.254"),
         ip_info("5.6.7.8/32"),
@@ -72,7 +75,7 @@ RSpec.describe Hosting::LeasewebNetplan do
       ])
     # The /32 and /31 belong to VMs whole; only claimed and anchored
     # addresses appear on the interface.
-    expect(netplan.interface_addresses).to eq("eno1" => ["216.22.50.197/32"])
+    expect(netplan.addresses_by_mac).to eq(public_mac => ["216.22.50.197/32"])
   end
 
   it "reproduces the hand-written netplan of server 12493302, less its internal stanza" do
@@ -80,8 +83,8 @@ RSpec.describe Hosting::LeasewebNetplan do
   end
 
   it "claims ::2 out of a connectivity prefix and ::1 out of a routed prefix" do
-    expect(netplan.interface_addresses).to eq(
-      "ens3f0np0" => [
+    expect(netplan.addresses_by_mac).to eq(
+      public_mac => [
         "216.22.50.197/32",
         "216.22.15.64/26",
         "2604:9a00:2100:a020:4::2/112",
@@ -95,7 +98,7 @@ RSpec.describe Hosting::LeasewebNetplan do
   end
 
   it "omits the internal ethernet when the server has no private network" do
-    expect(netplan.to_h.dig("network", "ethernets").keys).to eq ["ens3f0np0"]
+    expect(netplan.to_h.dig("network", "ethernets").keys).to eq ["public"]
   end
 
   # Server 91478's shape. The internal NIC takes its reserved VLAN address
@@ -104,29 +107,29 @@ RSpec.describe Hosting::LeasewebNetplan do
   # list netplan generates for systemd-networkd-wait-online, so a private port
   # whose link never comes up cannot stall boot.
   it "addresses the internal ethernet statically when the server has a private network" do
-    netplan = netplan_for(public_interface: "eno0", internal_interface: "eno1", internal_ip: "10.31.2.19/27", ip_infos: reference_ip_infos)
-    expect(netplan.to_h.dig("network", "ethernets", "eno1")).to eq(
-      "addresses" => ["10.31.2.19/27"], "mtu" => 9000, "optional" => true,
+    netplan = netplan_for(public_mac:, internal_mac:, internal_ip: "10.31.2.19/27", ip_infos: reference_ip_infos)
+    expect(netplan.to_h.dig("network", "ethernets", "internal")).to eq(
+      "match" => {"macaddress" => internal_mac}, "addresses" => ["10.31.2.19/27"], "mtu" => 9000, "optional" => true,
     )
   end
 
   it "never marks the public ethernet optional" do
-    netplan = netplan_for(public_interface: "eno0", internal_interface: "eno1", internal_ip: "10.31.2.19/27", ip_infos: reference_ip_infos)
-    expect(netplan.to_h.dig("network", "ethernets", "eno0")).not_to include "optional"
+    netplan = netplan_for(public_mac:, internal_mac:, internal_ip: "10.31.2.19/27", ip_infos: reference_ip_infos)
+    expect(netplan.to_h.dig("network", "ethernets", "public")).not_to include "optional"
   end
 
   # The internal VLAN address joins the desired state the prog verifies the host
   # converged on, keyed to the internal NIC, never the public one.
-  it "keys the internal address to the internal interface, never the public one" do
-    netplan = netplan_for(public_interface: "eno0", internal_interface: "eno1", internal_ip: "10.31.2.19/27", ip_infos: reference_ip_infos)
-    expect(netplan.interface_addresses).to eq(
-      "eno0" => [
+  it "keys the internal address to the internal mac, never the public one" do
+    netplan = netplan_for(public_mac:, internal_mac:, internal_ip: "10.31.2.19/27", ip_infos: reference_ip_infos)
+    expect(netplan.addresses_by_mac).to eq(
+      public_mac => [
         "216.22.50.197/32",
         "216.22.15.64/26",
         "2604:9a00:2100:a020:4::2/112",
         "2607:f5b7:3:104::1/64",
       ],
-      "eno1" => ["10.31.2.19/27"],
+      internal_mac => ["10.31.2.19/27"],
     )
   end
 
@@ -134,7 +137,7 @@ RSpec.describe Hosting::LeasewebNetplan do
   # advertisements even though dhcp6 is off, so the host would take a default
   # route from the segment's router if ours ever went missing.
   it "refuses router advertisements on the public ethernet" do
-    expect(netplan.to_h.dig("network", "ethernets", "ens3f0np0", "accept-ra")).to be false
+    expect(netplan.to_h.dig("network", "ethernets", "public", "accept-ra")).to be false
   end
 
   # Server 91478's extra IPv4s sit on a switched /29 behind their own gateway.
@@ -142,7 +145,7 @@ RSpec.describe Hosting::LeasewebNetplan do
   # route. Its gateway resolves to the same router as the main one, so it must
   # not add a second default route.
   it "claims gatewayed non-main ipv4s as /32 without routing through their gateway" do
-    netplan = netplan_for(public_interface: "eno1", internal_interface: nil, internal_ip: nil, ip_infos: [
+    netplan = netplan_for(public_mac:, internal_mac: nil, internal_ip: nil, ip_infos: [
       ip_info("23.105.171.112/32", "23.105.171.126", source_host_ip: "23.105.171.112"),
       ip_info("23.105.176.3/32", "23.105.176.6", source_host_ip: "23.105.171.112"),
       ip_info("23.105.176.1/32", "23.105.176.6", source_host_ip: "23.105.171.112"),
@@ -150,8 +153,8 @@ RSpec.describe Hosting::LeasewebNetplan do
       ip_info("2607:f5b7:1:30:9::/112", "2607:f5b7:1:30::1", source_host_ip: "23.105.171.112"),
     ])
 
-    expect(netplan.interface_addresses).to eq(
-      "eno1" => [
+    expect(netplan.addresses_by_mac).to eq(
+      public_mac => [
         "23.105.171.112/32",
         "23.105.176.1/32",
         "23.105.176.2/32",
@@ -163,18 +166,18 @@ RSpec.describe Hosting::LeasewebNetplan do
   end
 
   it "sorts multiple routed ipv4 blocks by network address" do
-    netplan = netplan_for(public_interface: "eno1", internal_interface: nil, internal_ip: nil, ip_infos: [
+    netplan = netplan_for(public_mac:, internal_mac: nil, internal_ip: nil, ip_infos: [
       ip_info("216.22.50.197/32", "216.22.50.254"),
       ip_info("216.22.60.0/26"),
       ip_info("216.22.15.64/26"),
     ])
 
-    expect(netplan.interface_addresses).to eq("eno1" => ["216.22.50.197/32", "216.22.15.64/26", "216.22.60.0/26"])
+    expect(netplan.addresses_by_mac).to eq(public_mac => ["216.22.50.197/32", "216.22.15.64/26", "216.22.60.0/26"])
   end
 
   it "fails when no address matches the source host ip" do
     expect {
-      netplan_for(public_interface: "eno1", internal_interface: nil, internal_ip: nil, ip_infos: [ip_info("216.22.15.64/26")])
+      netplan_for(public_mac:, internal_mac: nil, internal_ip: nil, ip_infos: [ip_info("216.22.15.64/26")])
     }.to raise_error RuntimeError, "no main IPv4 address among leaseweb ip infos"
   end
 end

--- a/spec/model/vm_host_spec.rb
+++ b/spec/model/vm_host_spec.rb
@@ -384,11 +384,11 @@ RSpec.describe VmHost do
 
       ip_records = vm_host.provider.api.pull_ips
       vm_host.create_addresses(ip_records:)
-      netplan = Hosting::LeasewebNetplan.new(public_interface: "eno0", internal_interface: nil, internal_ip: nil, ip_infos: ip_records,
+      netplan = Hosting::LeasewebNetplan.new(public_mac: "8c:84:74:54:ea:d0", internal_mac: nil, internal_ip: nil, ip_infos: ip_records,
         nameservers: ["23.19.53.53", "23.19.52.52"], search_domains: ["dedi.leaseweb.net"])
 
-      expect(netplan.interface_addresses).to eq(
-        "eno0" => [
+      expect(netplan.addresses_by_mac).to eq(
+        "8c:84:74:54:ea:d0" => [
           "23.105.171.112/32",
           "23.105.176.1/32",
           "23.105.176.2/32",

--- a/spec/prog/leaseweb/setup_networking_spec.rb
+++ b/spec/prog/leaseweb/setup_networking_spec.rb
@@ -25,9 +25,13 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
     ])
   end
 
+  let(:public_mac) { "8c:84:74:54:ea:d0" }
+  let(:internal_mac) { "8c:84:74:54:ea:d1" }
+
   let(:addr_output) do
     JSON.generate([{
       ifname: "ens3f0np0",
+      address: "8c:84:74:54:ea:d0",
       addr_info: [
         {local: "216.22.50.197", prefixlen: 32},
         {local: "216.22.15.64", prefixlen: 26},
@@ -40,7 +44,7 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
   # What the kernel holds in the beat between `netplan apply` returning and the
   # rest of the addresses landing.
   let(:unsettled_addr_output) do
-    JSON.generate([{ifname: "ens3f0np0", addr_info: [{local: "216.22.50.197", prefixlen: 32}]}])
+    JSON.generate([{ifname: "ens3f0np0", address: "8c:84:74:54:ea:d0", addr_info: [{local: "216.22.50.197", prefixlen: 32}]}])
   end
 
   # The addresses and gateways setup hands verify through the frame: netplan
@@ -95,9 +99,9 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
         ["216.22.15.64/26", "216.22.50.197/32", "2607:f5b7:3:104::/64"],
       )
 
-      expect(ln.expected_addresses).to eq("ens3f0np0" => expected_addresses)
+      expect(ln.expected_addresses).to eq(public_mac => expected_addresses)
       expect(ln.expected_gateways).to eq expected_gateways
-      expect(ln.expected_internal_interface).to be_nil
+      expect(ln.expected_internal_mac).to be_nil
     end
 
     it "skips the addresses assemble already recorded from the same snapshot" do
@@ -117,9 +121,10 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
       expect(ln.sshable).to receive(:_cmd).with("cat /run/systemd/resolve/resolv.conf").and_return(resolv_conf_output)
       expect(ln.sshable).to receive(:_cmd).with(a_string_starting_with("sudo host/bin/setup-leaseweb-networking")) do |command|
         netplan = YAML.safe_load(Shellwords.split(command).last)
-        expect(netplan.dig("network", "ethernets", "ens3f0np0", "addresses")).to eq expected_addresses
-        expect(netplan.dig("network", "ethernets", "ens3f0np0", "nameservers")).to eq("search" => ["dedi.leaseweb.net"], "addresses" => ["23.19.53.53", "23.19.52.52"])
-        expect(netplan.dig("network", "ethernets")).not_to include "ens3f1np1"
+        expect(netplan.dig("network", "ethernets", "public", "match")).to eq("macaddress" => public_mac)
+        expect(netplan.dig("network", "ethernets", "public", "addresses")).to eq expected_addresses
+        expect(netplan.dig("network", "ethernets", "public", "nameservers")).to eq("search" => ["dedi.leaseweb.net"], "addresses" => ["23.19.53.53", "23.19.52.52"])
+        expect(netplan.dig("network", "ethernets")).not_to include "internal"
         ""
       end
 
@@ -138,15 +143,15 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
         expect(ln.sshable).to receive(:_cmd).with("cat /run/systemd/resolve/resolv.conf").and_return(resolv_conf_output)
         expect(ln.sshable).to receive(:_cmd).with(a_string_starting_with("sudo host/bin/setup-leaseweb-networking")) do |command|
           netplan = YAML.safe_load(Shellwords.split(command).last)
-          expect(netplan.dig("network", "ethernets", "ens3f1np1")).to eq(
-            "addresses" => ["10.31.2.19/27"], "mtu" => 9000, "optional" => true,
+          expect(netplan.dig("network", "ethernets", "internal")).to eq(
+            "match" => {"macaddress" => internal_mac}, "addresses" => ["10.31.2.19/27"], "mtu" => 9000, "optional" => true,
           )
           ""
         end
 
         expect { ln.start }.to hop("verify")
-        expect(ln.expected_addresses).to eq("ens3f0np0" => expected_addresses, "ens3f1np1" => ["10.31.2.19/27"])
-        expect(ln.expected_internal_interface).to eq("ens3f1np1")
+        expect(ln.expected_addresses).to eq(public_mac => expected_addresses, internal_mac => ["10.31.2.19/27"])
+        expect(ln.expected_internal_mac).to eq(internal_mac)
       end
 
       it "fails when no interface carries the internal mac" do
@@ -177,7 +182,7 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
     let(:ln) do
       described_class.new(Strand.new(stack: [{
         "subject_id" => vm_host.id,
-        "expected_addresses" => {"ens3f0np0" => expected_addresses},
+        "expected_addresses" => {"8c:84:74:54:ea:d0" => expected_addresses},
         "expected_gateways" => expected_gateways,
       }]))
     end
@@ -203,18 +208,19 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
       # address is present somewhere.
       ln = described_class.new(Strand.new(stack: [{
         "subject_id" => vm_host.id,
-        "expected_addresses" => {"ens3f0np0" => expected_addresses, "ens3f1np1" => ["10.31.2.19/27"]},
+        "expected_addresses" => {"8c:84:74:54:ea:d0" => expected_addresses, "8c:84:74:54:ea:d1" => ["10.31.2.19/27"]},
         "expected_gateways" => expected_gateways,
-        "expected_internal_interface" => "ens3f1np1",
+        "expected_internal_mac" => "8c:84:74:54:ea:d1",
       }]))
       misplaced = JSON.generate([{
         ifname: "ens3f0np0",
+        address: "8c:84:74:54:ea:d0",
         addr_info: [
           {local: "216.22.50.197", prefixlen: 32},
           {local: "2604:9a00:2100:a020:4::2", prefixlen: 112},
           {local: "2607:f5b7:3:104::1", prefixlen: 64},
         ],
-      }, {ifname: "ens3f1np1", addr_info: [
+      }, {ifname: "ens3f1np1", address: "8c:84:74:54:ea:d1", addr_info: [
         {local: "216.22.15.64", prefixlen: 26},
         {local: "10.31.2.19", prefixlen: 27},
       ]}])
@@ -227,14 +233,14 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
       let(:ln) do
         described_class.new(Strand.new(stack: [{
           "subject_id" => vm_host.id,
-          "expected_addresses" => {"ens3f0np0" => expected_addresses, "ens3f1np1" => ["10.31.2.19/27"]},
+          "expected_addresses" => {"8c:84:74:54:ea:d0" => expected_addresses, "8c:84:74:54:ea:d1" => ["10.31.2.19/27"]},
           "expected_gateways" => expected_gateways,
-          "expected_internal_interface" => "ens3f1np1",
+          "expected_internal_mac" => "8c:84:74:54:ea:d1",
         }]))
       end
 
       let(:public_link) do
-        {ifname: "ens3f0np0", addr_info: [
+        {ifname: "ens3f0np0", address: "8c:84:74:54:ea:d0", addr_info: [
           {local: "216.22.50.197", prefixlen: 32},
           {local: "216.22.15.64", prefixlen: 26},
           {local: "2604:9a00:2100:a020:4::2", prefixlen: 112},
@@ -251,11 +257,11 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
 
       it "records the internal port up when it has carrier" do
         addr = JSON.generate([public_link,
-          {ifname: "ens3f1np1", operstate: "UP", flags: ["BROADCAST", "MULTICAST", "UP", "LOWER_UP"],
+          {ifname: "ens3f1np1", address: "8c:84:74:54:ea:d1", operstate: "UP", flags: ["BROADCAST", "MULTICAST", "UP", "LOWER_UP"],
            addr_info: [{local: "10.31.2.19", prefixlen: 27}]}])
         expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j addr").and_return(addr)
         expect(Clog).to receive(:emit).with("leaseweb internal port state",
-          {leaseweb_internal_port: {ifname: "ens3f1np1", operstate: "UP", carrier: true}}).and_call_original
+          {leaseweb_internal_port: {mac: "8c:84:74:54:ea:d1", ifname: "ens3f1np1", operstate: "UP", carrier: true}}).and_call_original
 
         expect { ln.verify }.to hop("refresh_nftables")
       end
@@ -264,11 +270,11 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
         # The static /27 survives carrier loss, so presence alone would read a
         # dead port green. Record the drop, hop anyway; the port is optional.
         addr = JSON.generate([public_link,
-          {ifname: "ens3f1np1", operstate: "DOWN", flags: ["BROADCAST", "MULTICAST"],
+          {ifname: "ens3f1np1", address: "8c:84:74:54:ea:d1", operstate: "DOWN", flags: ["BROADCAST", "MULTICAST"],
            addr_info: [{local: "10.31.2.19", prefixlen: 27}]}])
         expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j addr").and_return(addr)
         expect(Clog).to receive(:emit).with("leaseweb internal port state",
-          {leaseweb_internal_port: {ifname: "ens3f1np1", operstate: "DOWN", carrier: false}}).and_call_original
+          {leaseweb_internal_port: {mac: "8c:84:74:54:ea:d1", ifname: "ens3f1np1", operstate: "DOWN", carrier: false}}).and_call_original
 
         expect { ln.verify }.to hop("refresh_nftables")
       end
@@ -279,7 +285,7 @@ RSpec.describe Prog::Leaseweb::SetupNetworking do
         addr = JSON.generate([public_link])
         expect(ln.sshable).to receive(:_cmd).with("/usr/sbin/ip -j addr").and_return(addr)
         expect(Clog).to receive(:emit).with("leaseweb internal port state",
-          {leaseweb_internal_port: {ifname: "ens3f1np1", operstate: nil, carrier: false}}).and_call_original
+          {leaseweb_internal_port: {mac: "8c:84:74:54:ea:d1", ifname: nil, operstate: nil, carrier: false}}).and_call_original
 
         expect { ln.verify }.to hop("refresh_nftables")
       end


### PR DESCRIPTION
Interface names are not stable across reboots. `enpXsY` and friends
encode the device's position in the PCIe tree, not its identity, and the
firmware is free to hand out a different position on the next boot.

Observed on a Hetzner host, where the root complex exposed the NIC's
root port as 00:01.1 on one boot and 00:01.3 on another. Root ports are
walked in device:function order, so that moved the NIC from before to
after the NVMe's port, the two swapped bus numbers, and enp2s0 became
enp1s0. Nothing was added, removed or faulted: the same 42 devices and
13 bridges enumerated on every boot. A host whose netplan names the
interface loses all networking when this happens and needs a rescue-mode
visit to recover.

This uses permanent MACs for pinning the uplink. If NIC device itself change
the MAC would change as well, but NIC device change is already a destructive
operation where on-call needs to intervene.