### PR TITLE
Heal lost monitoring privileges before paging

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -483,10 +483,19 @@ class PostgresServer < Sequel::Model
         end
       end
 
-      # Paged rather than logged: this freezes last_known_lsn, which blocks the
-      # async-HA failover guard, and it persists until someone re-grants.
-      if access_denied && pulse[:reading_rpt] > 5
-        Prog::PageNexus.assemble("Postgres monitoring lost its database privileges", ["PGMonitoringAccessDenied", id], ubid, severity: primary? ? "error" : "warning")
+      # A lost privilege freezes last_known_lsn, which blocks the async-HA
+      # failover guard. configure re-applies the grant on the writable
+      # primary, so ask for one heal at the detection threshold and page
+      # only when the denial outlasts the heal window: a dropped role or a
+      # read-only primary stays beyond configure's reach. Standbys neither
+      # heal nor page: their denial replicates from the primary, which
+      # detects and reports it itself.
+      if access_denied && pulse[:reading_rpt] > 5 && primary?
+        if pulse[:reading_rpt] == 6
+          incr_configure
+        elsif Time.now - pulse[:reading_chg] > 5 * 60
+          Prog::PageNexus.assemble("Postgres monitoring lost its database privileges", ["PGMonitoringAccessDenied", id], ubid, severity: "error")
+        end
       elsif pulse[:reading] == "up"
         Page.from_tag_parts("PGMonitoringAccessDenied", id)&.incr_resolve
       end

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -967,9 +967,37 @@ RSpec.describe PostgresServer do
     postgres_server.check_pulse(session:, previous_pulse: pulse)
   end
 
-  it "pages when the monitoring role loses its database privileges" do
+  it "asks configure to heal when the denial crosses the detection threshold" do
     session = {ssh_session: Net::SSH::Connection::Session.allocate, db_connection: instance_double(Sequel::Postgres::Database)}
     pulse = {reading: "down", reading_rpt: 5, reading_chg: Time.now}
+    Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
+
+    expect(session[:db_connection]).to receive(:get).and_raise(Sequel::DatabaseConnectionError, 'FATAL:  permission denied for database "ubi_admin"')
+    expect(Prog::PageNexus).not_to receive(:assemble)
+
+    postgres_server.check_pulse(session:, previous_pulse: pulse)
+
+    expect(Semaphore.where(strand_id: postgres_server.id, name: "configure").count).to eq(1)
+  end
+
+  it "neither heals nor pages for a standby, whose denial replicates from the primary" do
+    postgres_server
+    standby = described_class.create(timeline:, resource:, is_representative: false, synchronization_status: "ready", timeline_access: "fetch", version: "16")
+    Strand.create_with_id(standby, prog: "Postgres::PostgresServerNexus", label: "wait")
+    session = {ssh_session: Net::SSH::Connection::Session.allocate, db_connection: instance_double(Sequel::Postgres::Database)}
+    pulse = {reading: "down", reading_rpt: 5, reading_chg: Time.now - 6 * 60}
+
+    expect(session[:db_connection]).to receive(:get).and_raise(Sequel::DatabaseConnectionError, 'FATAL:  permission denied for database "ubi_admin"')
+    expect(Prog::PageNexus).not_to receive(:assemble)
+
+    standby.check_pulse(session:, previous_pulse: pulse)
+
+    expect(Semaphore.where(name: "configure")).to be_empty
+  end
+
+  it "pages when the denial outlasts the heal window" do
+    session = {ssh_session: Net::SSH::Connection::Session.allocate, db_connection: instance_double(Sequel::Postgres::Database)}
+    pulse = {reading: "down", reading_rpt: 6, reading_chg: Time.now - 6 * 60}
 
     expect(session[:db_connection]).to receive(:get).and_raise(Sequel::DatabaseConnectionError, 'FATAL:  permission denied for database "ubi_admin"')
     expect(Prog::PageNexus).to receive(:assemble).with("Postgres monitoring lost its database privileges", ["PGMonitoringAccessDenied", postgres_server.id], postgres_server.ubid, severity: "error")
@@ -977,15 +1005,17 @@ RSpec.describe PostgresServer do
     postgres_server.check_pulse(session:, previous_pulse: pulse)
   end
 
-  it "pages at warning severity when the server is not the primary" do
+  it "waits for the heal window before paging" do
     session = {ssh_session: Net::SSH::Connection::Session.allocate, db_connection: instance_double(Sequel::Postgres::Database)}
-    pulse = {reading: "down", reading_rpt: 5, reading_chg: Time.now}
+    pulse = {reading: "down", reading_rpt: 6, reading_chg: Time.now}
+    Strand.create_with_id(postgres_server, prog: "Postgres::PostgresServerNexus", label: "wait")
 
-    expect(postgres_server).to receive(:primary?).and_return(false)
-    expect(session[:db_connection]).to receive(:get).and_raise(Sequel::DatabaseConnectionError, "FATAL:  role \"ubi_monitoring\" does not exist")
-    expect(Prog::PageNexus).to receive(:assemble).with(anything, anything, anything, severity: "warning")
+    expect(session[:db_connection]).to receive(:get).and_raise(Sequel::DatabaseConnectionError, 'FATAL:  permission denied for database "ubi_admin"')
+    expect(Prog::PageNexus).not_to receive(:assemble)
 
     postgres_server.check_pulse(session:, previous_pulse: pulse)
+
+    expect(Semaphore.where(strand_id: postgres_server.id, name: "configure")).to be_empty
   end
 
   it "does not page when the pulse is down for an ordinary reason" do


### PR DESCRIPTION
Since commit ee8f13bbc the health pulse pages as soon as the monitoring role's denial persists past the detection threshold, although configure already carries the repair for the common case: it re-applies the CONNECT grant on a writable primary and rewrites pg_hba and pg_ident. Nothing triggered that configure, so a transient customer revoke always cost an operator page.

Escalate in two steps instead, on the primary alone. The first pulse past the detection threshold increments configure once; the trigger fires once per denial streak per monitor process, since reading_rpt is monotonic in memory while the reading is unchanged and the trigger matches its exact crossing value. A monitor restart resets the pulse history, which re-arms one more heal and defers a page that has not fired yet by another window, both bounded by the restart rate. The page fires only when the denial outlasts a five-minute window measured from the reading change, which keeps the page for what configure cannot reach: a dropped role and a read-only primary under the disk-full lockout.

Standbys neither heal nor page, per Burak Yucesoy's review suggestion: privileges replicate physically from the primary, so a standby's denial implies the primary's, the grant repair only works where the database is writable, and the primary's page already covers the incident.

A denial that begins mid-streak, after a generic outage held the reading down past the crossing value, gets no heal: the trigger has passed and the window has already run out, so the page fires on the next pulse, which matches the old behavior.