### PR TITLE
Split OidcProvider.register into itself and discovery_attributes

### DIFF
--- a/model/oidc_provider.rb
+++ b/model/oidc_provider.rb
@@ -23,29 +23,31 @@ class OidcProvider < Sequel::Model
   # information, you'll need to be provided all OIDC information and
   # create the instance manually using OidcProvider.create.
   def self.register(display_name, url, client_id:, client_secret:, group_prefix: nil)
+    create(**discovery_attributes(display_name, url, client_id:, client_secret:, group_prefix:))
+  end
+
+  # Fetch the provider's OIDC discovery document and return the column values
+  # for a new or existing OidcProvider row, without creating or updating
+  # anything itself. Used by register (create) below, and by any caller
+  # that wants to update an existing provider in place instead.
+  def self.discovery_attributes(display_name, url, client_id:, client_secret:, group_prefix: nil)
     uri = URI(url)
     unless url.end_with?("/.well-known/openid-configuration")
       uri.path += "/.well-known/openid-configuration"
     end
     response = Excon.get(uri.to_s, headers: {"Accept" => "application/json"}, expects: 200)
     config_info = JSON.parse(response.body)
-    url = config_info.fetch("issuer")
-    authorization_endpoint = URI(config_info.fetch("authorization_endpoint")).path
-    token_endpoint = URI(config_info.fetch("token_endpoint")).path
-    userinfo_endpoint = URI(config_info.fetch("userinfo_endpoint")).path
-    jwks_uri = config_info.fetch("jwks_uri")
-
-    create(
+    {
       display_name:,
-      url:,
+      url: config_info.fetch("issuer"),
       client_id:,
       client_secret:,
-      authorization_endpoint:,
-      token_endpoint:,
-      userinfo_endpoint:,
-      jwks_uri:,
+      authorization_endpoint: URI(config_info.fetch("authorization_endpoint")).path,
+      token_endpoint: URI(config_info.fetch("token_endpoint")).path,
+      userinfo_endpoint: URI(config_info.fetch("userinfo_endpoint")).path,
+      jwks_uri: config_info.fetch("jwks_uri"),
       group_prefix:,
-    )
+    }
   end
 
   plugin ResourceMethods, encrypted_columns: [:client_secret, :registration_access_token]

--- a/model/oidc_provider.rb
+++ b/model/oidc_provider.rb
@@ -22,14 +22,10 @@ class OidcProvider < Sequel::Model
   # a new client. If the OIDC provider does not provide OIDC discovery
   # information, you'll need to be provided all OIDC information and
   # create the instance manually using OidcProvider.create.
-  def self.register(display_name, url, client_id:, client_secret:, group_prefix: nil)
-    create(**discovery_attributes(display_name, url, client_id:, client_secret:, group_prefix:))
+  def self.register(...)
+    create(discovery_attributes(...))
   end
 
-  # Fetch the provider's OIDC discovery document and return the column values
-  # for a new or existing OidcProvider row, without creating or updating
-  # anything itself. Used by register (create) below, and by any caller
-  # that wants to update an existing provider in place instead.
   def self.discovery_attributes(display_name, url, client_id:, client_secret:, group_prefix: nil)
     uri = URI(url)
     unless url.end_with?("/.well-known/openid-configuration")

--- a/spec/model/oidc_provider_spec.rb
+++ b/spec/model/oidc_provider_spec.rb
@@ -44,4 +44,21 @@ RSpec.describe OidcProvider do
     end
     expect(described_class.count).to eq 2
   end
+
+  it ".discovery_attributes returns the column values without creating a row" do
+    stub_request(:get, "https://example.com/.well-known/openid-configuration").to_return(status: 200, body: registration_body)
+    attrs = described_class.discovery_attributes("Test", "https://example.com", client_id: "123", client_secret: "456")
+    expect(attrs).to eq(
+      display_name: "Test",
+      url: "https://host/issuer",
+      client_id: "123",
+      client_secret: "456",
+      authorization_endpoint: "/auth",
+      token_endpoint: "/tok",
+      userinfo_endpoint: "/ui",
+      jwks_uri: "https://host/jw",
+      group_prefix: nil,
+    )
+    expect(described_class.count).to eq 0
+  end
 end


### PR DESCRIPTION
### Why
`register` is currently the only way to set an `OidcProvider`'s discovery-derived columns, and it always creates a new row.

This has a few issues:

* `allowed_oidc_provider_domain` uses `ON DELETE CASCADE`, so destroying a provider can silently delete associated data.
* `locked_domain` has no `ON DELETE` behavior, so destroying a provider raises an FK violation.
* As a result, providers using domain locking or allowed domains have no safe way to refresh their configuration today.

### What

This change extracts the discovery-fetch logic from `register` into `discovery_attributes`.

`discovery_attributes` fetches the provider's discovery configuration and returns the corresponding column values without modifying the database.

`register` remains unchanged, and the existing spec passes as-is.