### PR TITLE
Keep the Postgres root filesystem within its budget

### DIFF
--- a/model/postgres/postgres_server.rb
+++ b/model/postgres/postgres_server.rb
@@ -187,6 +187,7 @@ class PostgresServer < Sequel::Model
       metrics_config:,
       disk_throughput_baseline_mbps:,
       strict_overcommit: !resource.skip_strict_memory_overcommit_set?,
+      aws: vm.location.aws?,
     }
   end
 

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -230,3 +230,7 @@ end
 max_connections = configure_hash["user_config"]["max_connections"] || configure_hash["configs"]["max_connections"]
 pgbouncer_setup = PgBouncerSetup.new(v, max_connections, configure_hash["pgbouncer_instances"], configure_hash["pgbouncer_user_config"])
 pgbouncer_setup.setup
+
+# Last, so a failure reclaiming the root disk never leaves the Postgres
+# configuration above unapplied.
+pgsetup.configure_root_disk(aws: configure_hash["aws"])

--- a/rhizome/postgres/lib/io_throttle.rb
+++ b/rhizome/postgres/lib/io_throttle.rb
@@ -37,12 +37,15 @@ class IoThrottle
     archival_throttle_mbps = calculate_archival_throttle(backlog)
     disk_usage_throttle_mbps = calculate_disk_usage_throttle
     throttle_mbps = [archival_throttle_mbps, disk_usage_throttle_mbps].compact.min
+    # The timer runs this every 15 seconds; log only when the limit changes.
+    return unless apply(throttle_mbps)
+
     @logger.info("Archival backlog: #{backlog} files (#{archival_throttle_mbps || "none"}), " \
       "disk usage throttle: #{disk_usage_throttle_mbps || "none"}, " \
       "effective: #{throttle_mbps ? "#{throttle_mbps} MB/s" : "none"}")
-    apply(throttle_mbps)
   end
 
+  # Returns whether io.max changed.
   def apply(throttle_mbps, data_mount_path = "/dat")
     fail "Service cgroup not found: #{@service_cgroup}" unless File.directory?(@service_cgroup)
 
@@ -55,19 +58,23 @@ class IoThrottle
     end
   end
 
+  # io.max lists only devices with a limit set, so an unthrottled cgroup reads
+  # as empty and a throttled one as "8:0 rbps=max wbps=52428800 ...".
   def remove_throttle
     io_max_file = "#{@throttled_cgroup}/io.max"
+    return false unless File.read(io_max_file).match?(/wbps=\d/)
+
     File.write(io_max_file, "#{@dev_id} wbps=max")
-    @logger.info("Removed I/O throttle")
+    true
   rescue Errno::ENOENT
-    @logger.info("No throttle to remove")
+    false
   end
 
   def apply_throttle(throttle_mbps)
-    return unless enable_io_controller
-    set_io_limit(throttle_mbps)
-    immune_pids = classify_processes
-    @logger.info("Applied I/O throttle: #{throttle_mbps} MB/s (immune pids: #{immune_pids.join(", ")})")
+    return false unless enable_io_controller
+    changed = set_io_limit(throttle_mbps)
+    classify_processes
+    changed
   end
 
   def find_postmaster_pid
@@ -154,8 +161,12 @@ class IoThrottle
   end
 
   def set_io_limit(throttle_mbps)
+    io_max_file = "#{@throttled_cgroup}/io.max"
     throttle_bytes = throttle_mbps * 1024 * 1024
-    File.write("#{@throttled_cgroup}/io.max", "#{@dev_id} wbps=#{throttle_bytes}")
+    return false if File.read(io_max_file).match?(/wbps=#{throttle_bytes}\b/)
+
+    File.write(io_max_file, "#{@dev_id} wbps=#{throttle_bytes}")
+    true
   end
 
   def classify_processes

--- a/rhizome/postgres/lib/postgres_setup.rb
+++ b/rhizome/postgres/lib/postgres_setup.rb
@@ -50,10 +50,21 @@ class PostgresSetup
 
   JOURNALD_CONF_PATH = "/etc/systemd/journald.conf.d/50-persistent.conf"
 
+  # The root filesystem is 16 GiB (Config.postgres_boot_disk_size_gib) and the
+  # control plane pages at 90% of it. What sits there besides this journal:
+  # about 6 G of image, a 4 G swapfile on the hobby sizes, and up to 1 G of
+  # Prometheus TSDB (--storage.tsdb.retention.size). A 4G cap here pushed every
+  # hobby server over the page line as its journal filled. 1G holds roughly a
+  # month of entries once configure_root_disk has quieted the writers below,
+  # and 64M files let vacuuming reclaim in small steps. SplitMode=none keeps
+  # journald from carrying one 8 MB-minimum file per UID that ever logged.
   JOURNALD_CONF = <<~JOURNALD
     [Journal]
     Storage=persistent
-    SystemMaxUse=4G
+    SystemMaxUse=1G
+    SystemMaxFileSize=64M
+    MaxRetentionSec=1month
+    SplitMode=none
     Compress=yes
     ForwardToSyslog=no
   JOURNALD
@@ -71,6 +82,10 @@ class PostgresSetup
       r "mkdir", "-p", File.dirname(JOURNALD_CONF_PATH)
       safe_write_to_file(JOURNALD_CONF_PATH, JOURNALD_CONF)
       r "systemctl", "restart", "systemd-journald"
+      # A lowered cap only bites at the next rotation; rotate and vacuum now so
+      # the space comes back with the configure that lowered it.
+      r "journalctl", "--rotate"
+      r "journalctl", "--vacuum-size=1G"
     end
 
     return unless File.exist?("/usr/sbin/rsyslogd")
@@ -80,6 +95,147 @@ class PostgresSetup
     r "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "purge", "-y", "rsyslog"
 
     FileUtils.rm_f(Dir.glob(RSYSLOG_LOGS_GLOB))
+  end
+
+  # Everything below keeps the root filesystem within its budget: the journal
+  # writers that fill it and the dead weight the image left on it. Applied from
+  # bin/configure, like configure_journald, so it reaches every server.
+  def configure_root_disk(aws:)
+    quiet_periodic_units
+    # nil means the control plane predates the flag; leave the agent alone
+    # rather than guess where the server runs.
+    disable_guardduty if aws == false
+    purge_snapd
+    purge_stale_kernels
+    clean_package_caches
+  end
+
+  # Units a timer runs every 15-20 seconds. For each run systemd logs three
+  # info lines of its own (Starting, Finished, Deactivated successfully) on top
+  # of whatever the unit prints: about 60K journal entries a day per server.
+  # LogLevelMax filters PID 1's messages about the unit as well as the unit's
+  # own output, so the output is raised to notice first, which keeps it and
+  # drops only the per-run chatter.
+  PERIODIC_UNITS = %w[postgres-metrics.service io-throttle@.service disk-full-check@.service].freeze
+
+  PERIODIC_UNIT_DROPIN = <<~DROPIN
+    [Service]
+    SyslogLevel=notice
+    LogLevelMax=notice
+  DROPIN
+
+  def quiet_periodic_units
+    changed = false
+    PERIODIC_UNITS.each do |unit|
+      path = "/etc/systemd/system/#{unit}.d/50-quiet-journal.conf"
+      next if File.exist?(path) && File.read(path) == PERIODIC_UNIT_DROPIN
+      r "mkdir", "-p", File.dirname(path)
+      safe_write_to_file(path, PERIODIC_UNIT_DROPIN)
+      changed = true
+    end
+    r "systemctl", "daemon-reload" if changed
+  end
+
+  GUARDDUTY_UNIT = "amazon-guardduty-agent.service"
+
+  # The image carries the GuardDuty agent for AWS runtime monitoring. Anywhere
+  # else it cannot reach its endpoint, exits, and systemd restarts it every few
+  # seconds: five journal lines per attempt, about 100K a day. Masking keeps a
+  # package upgrade from enabling it again.
+  def disable_guardduty
+    return if r("systemctl", "show", "-p", "FragmentPath", "--value", GUARDDUTY_UNIT).strip.empty?
+    return if r("systemctl", "is-enabled", GUARDDUTY_UNIT, expect: [0, 1]).strip == "masked"
+    r "systemctl", "disable", "--now", GUARDDUTY_UNIT
+    r "systemctl", "mask", GUARDDUTY_UNIT
+  end
+
+  APT = %w[env DEBIAN_FRONTEND=noninteractive apt-get -y -o DPkg::Lock::Timeout=600].freeze
+
+  SNAPD_PIN_PATH = "/etc/apt/preferences.d/nosnap.pref"
+  SNAPD_PIN = <<~PIN
+    Package: snapd
+    Pin: release a=*
+    Pin-Priority: -10
+  PIN
+
+  # jammy's cloud image ships snapd with the lxd, core20 and core22 snaps:
+  # 0.7-0.8 G of squashfs on the root disk, refreshed in the background, with
+  # the previous revision of each kept after a refresh. Nothing on a Postgres
+  # server uses them. --purge skips the snapshot snapd otherwise takes of a
+  # removed snap, which would land in /var/lib/snapd/snapshots. Apps depend on
+  # bases and bases on the snapd snap, so they go in that order.
+  def purge_snapd
+    if File.exist?("/usr/bin/snap")
+      snaps = r("snap", "list").lines.drop(1).map { |line| line.split.values_at(0, 5) }
+      snaps.sort_by { |name, notes| [snap_removal_rank(name, notes), name] }.each do |name, _|
+        r "snap", "remove", "--purge", name
+      end
+      r(*APT, "purge", "snapd")
+    end
+    FileUtils.rm_rf(["/var/lib/snapd", "/snap", "/root/snap"])
+    return if File.exist?(SNAPD_PIN_PATH) && File.read(SNAPD_PIN_PATH) == SNAPD_PIN
+    safe_write_to_file(SNAPD_PIN_PATH, SNAPD_PIN)
+  end
+
+  def snap_removal_rank(name, notes)
+    if name == "snapd"
+      2
+    elsif notes.to_s.include?("base")
+      1
+    else
+      0
+    end
+  end
+
+  KERNEL_VERSION_RE = /\d+\.\d+\.\d+-\d+/
+
+  # The unversioned flavour metapackages: linux-virtual, linux-image-virtual,
+  # linux-headers-generic, linux-azure-6.5 and so on. Named flavours only, so
+  # linux-base, linux-firmware, linux-libc-dev and linux-tools-common stay.
+  KERNEL_META_RE = /\Alinux-(?:image-|headers-|tools-|cloud-tools-|modules-extra-)?(?:generic|virtual|aws|azure|gcp|gke|oracle|kvm|lowlatency)/
+
+  # The image installs its kernel next to the stock one, and unattended-upgrades
+  # keeps the stock one current through the linux-image-virtual metapackage, so
+  # 0.5-0.9 G of modules, headers, tools and initrds sit on the root disk for
+  # kernels that have never booted here. Only the running kernel's packages
+  # stay. The metapackages go by name: asked to remove only the versioned
+  # packages, apt keeps a metapackage by upgrading it when a newer one is
+  # known, which installs another kernel instead of removing one. The dry run
+  # is the guard against that: nothing may be installed.
+  def purge_stale_kernels
+    running = r("uname", "-r").strip[KERNEL_VERSION_RE]
+    return unless running
+
+    installed = r("dpkg-query", "-W", "-f=${Package} ${Status}\n", "linux-*").lines.filter_map do |line|
+      package, status = line.split(" ", 2)
+      package if status&.strip == "install ok installed"
+    end
+    return unless installed.any? { |package| package.start_with?("linux-image-") && package.include?(running) }
+
+    stale = installed.select do |package|
+      if (version = package[KERNEL_VERSION_RE])
+        version != running
+      else
+        package.match?(KERNEL_META_RE)
+      end
+    end
+    return if stale.empty?
+
+    planned = r(*APT, "-s", "purge", *stale)
+    if (install = planned.lines.grep(/\AInst /)).any?
+      fail "apt would install #{install.map { |line| line.split[1] }.join(", ")} while purging stale kernels; refusing"
+    end
+
+    r(*APT, "purge", *stale)
+    r(*APT, "autoremove", "--purge")
+  end
+
+  # The image build leaves the apt archive cache populated, and the ParadeDB
+  # package cache outlived the extensions (postgres-vm-images a42c000); nothing
+  # in the rhizome reads it.
+  def clean_package_caches
+    r "apt-get", "clean"
+    FileUtils.rm_rf("/var/cache/paradedb")
   end
 
   def configure_service_slice

--- a/rhizome/postgres/spec/io_throttle_spec.rb
+++ b/rhizome/postgres/spec/io_throttle_spec.rb
@@ -87,23 +87,31 @@ RSpec.describe IoThrottle do
   describe "#remove_throttle" do
     before { throttle.instance_variable_set(:@dev_id, "8:0") }
 
-    it "resets io.max to max" do
+    it "resets io.max to max when a limit is set" do
+      expect(File).to receive(:read).with("#{throttled_cgroup}/io.max").and_return("8:0 rbps=max wbps=52428800 riops=max wiops=max\n")
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=max")
-      throttle.remove_throttle
+      expect(throttle.remove_throttle).to be(true)
+    end
+
+    it "leaves io.max alone when no limit is set" do
+      expect(File).to receive(:read).with("#{throttled_cgroup}/io.max").and_return("")
+      expect(File).not_to receive(:write)
+      expect(throttle.remove_throttle).to be(false)
     end
 
     it "does nothing if throttled cgroup doesn't exist" do
-      expect(File).to receive(:write).and_raise(Errno::ENOENT)
-      expect { throttle.remove_throttle }.not_to raise_error
+      expect(File).to receive(:read).and_raise(Errno::ENOENT)
+      expect(throttle.remove_throttle).to be(false)
     end
   end
 
   describe "#apply" do
     it "removes throttle when throttle_mbps is nil" do
       expect(File).to receive(:directory?).with(service_cgroup).and_return(true)
+      expect(File).to receive(:read).with("#{throttled_cgroup}/io.max").and_return("8:0 rbps=max wbps=52428800 riops=max wiops=max\n")
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=max")
       expect(throttle).to receive(:find_device_id).and_return("8:0")
-      throttle.apply(nil)
+      expect(throttle.apply(nil)).to be(true)
     end
 
     it "fails if service cgroup doesn't exist" do
@@ -126,7 +134,16 @@ RSpec.describe IoThrottle do
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=104857600")
       expect(File).to receive(:write).with("/sys/fs/cgroup/system.slice/system-postgresql.slice/postgresql@17-main.service/immune/cgroup.procs", "1000")
 
-      throttle.apply_throttle(100)
+      expect(throttle.apply_throttle(100)).to be(true)
+    end
+
+    it "skips the write when io.max already holds the limit" do
+      allow(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
+      allow(File).to receive(:read).with("#{throttled_cgroup}/io.max").and_return("8:0 rbps=max wbps=104857600 riops=max wiops=max\n")
+      expect(throttle).to receive_messages(find_immune_pids: [], get_cgroup_pids: [])
+      expect(File).not_to receive(:write)
+
+      expect(throttle.apply_throttle(100)).to be(false)
     end
 
     it "returns early without throttling when enable_io_controller is false" do
@@ -277,7 +294,23 @@ RSpec.describe IoThrottle do
       expect(File).to receive(:directory?).with(service_cgroup).and_return(true)
       expect(throttle).to receive_messages(find_device_id: "8:0", calculate_disk_usage_throttle: nil)
       expect(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return([])
+      expect(File).to receive(:read).with("#{throttled_cgroup}/io.max").and_return("8:0 rbps=max wbps=52428800 riops=max wiops=max\n")
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=max")
+      expect(logger).to receive(:info).with("Archival backlog: 0 files (none), disk usage throttle: none, effective: none")
+
+      throttle.run
+    end
+
+    it "stays quiet when the limit is unchanged" do
+      expect(File).to receive(:directory?).with(service_cgroup).and_return(true)
+      expect(throttle).to receive_messages(find_device_id: "8:0", calculate_disk_usage_throttle: nil)
+      ready_files = Array.new(150) { |i| "#{data_dir}/pg_wal/archive_status/#{i.to_s.rjust(8, "0")}.ready" }
+      expect(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return(ready_files)
+      expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
+      expect(File).to receive(:read).with("#{throttled_cgroup}/io.max").and_return("8:0 rbps=max wbps=#{80 * 1024 * 1024} riops=max wiops=max\n")
+      expect(throttle).to receive_messages(find_immune_pids: [], get_cgroup_pids: [])
+      expect(File).not_to receive(:write)
+      expect(logger).not_to receive(:info)
 
       throttle.run
     end
@@ -288,10 +321,12 @@ RSpec.describe IoThrottle do
       ready_files = Array.new(150) { |i| "#{data_dir}/pg_wal/archive_status/#{i.to_s.rjust(8, "0")}.ready" }
       expect(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return(ready_files)
       expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
+      expect(File).to receive(:read).with("#{throttled_cgroup}/io.max").and_return("")
       expect(throttle).to receive_messages(find_immune_pids: [], get_cgroup_pids: [])
 
       # 150 files hits moderate tier (100+): 80% of baseline 100 MB/s = 80 MB/s
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=#{80 * 1024 * 1024}")
+      expect(logger).to receive(:info).with("Archival backlog: 150 files (80), disk usage throttle: none, effective: 80 MB/s")
 
       throttle.run
     end
@@ -304,6 +339,7 @@ RSpec.describe IoThrottle do
       ready_files = Array.new(150) { |i| "#{data_dir}/pg_wal/archive_status/#{i.to_s.rjust(8, "0")}.ready" }
       expect(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return(ready_files)
       expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
+      expect(File).to receive(:read).with("#{throttled_cgroup}/io.max").and_return("")
       expect(throttle_leaseweb).to receive_messages(find_immune_pids: [], get_cgroup_pids: [])
 
       # 150 files hits moderate tier (100+): 80% of baseline 35 MB/s = 28 MB/s
@@ -318,10 +354,12 @@ RSpec.describe IoThrottle do
       expect(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return([])
       expect(throttle).to receive(:calculate_disk_usage_throttle).and_return(55)
       expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
+      expect(File).to receive(:read).with("#{throttled_cgroup}/io.max").and_return("")
       expect(throttle).to receive(:find_immune_pids).and_return([])
       expect(throttle).to receive(:get_cgroup_pids).and_return([]).at_least(:once)
 
       expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=#{55 * 1024 * 1024}")
+      expect(logger).to receive(:info).with("Archival backlog: 0 files (none), disk usage throttle: 55, effective: 55 MB/s")
 
       throttle.run
     end
@@ -334,6 +372,7 @@ RSpec.describe IoThrottle do
       # Archival: 80 MB/s, disk usage: 55 MB/s -> pick 55
       expect(throttle).to receive(:calculate_disk_usage_throttle).and_return(55)
       expect(File).to receive(:read).with("#{service_cgroup}/cgroup.subtree_control").and_return("io")
+      expect(File).to receive(:read).with("#{throttled_cgroup}/io.max").and_return("")
       expect(throttle).to receive(:find_immune_pids).and_return([])
       expect(throttle).to receive(:get_cgroup_pids).and_return([]).at_least(:once)
 

--- a/rhizome/postgres/spec/postgres_setup_spec.rb
+++ b/rhizome/postgres/spec/postgres_setup_spec.rb
@@ -120,11 +120,16 @@ RSpec.describe PostgresSetup do
       expect(pg_setup).to receive(:safe_write_to_file).with(PostgresSetup::JOURNALD_CONF_PATH, <<~JOURNALD)
         [Journal]
         Storage=persistent
-        SystemMaxUse=4G
+        SystemMaxUse=1G
+        SystemMaxFileSize=64M
+        MaxRetentionSec=1month
+        SplitMode=none
         Compress=yes
         ForwardToSyslog=no
       JOURNALD
       expect(pg_setup).to receive(:_run_command).with("systemctl", "restart", "systemd-journald")
+      expect(pg_setup).to receive(:_run_command).with("journalctl", "--rotate")
+      expect(pg_setup).to receive(:_run_command).with("journalctl", "--vacuum-size=1G")
       expect(File).to receive(:exist?).with("/usr/sbin/rsyslogd").and_return(true)
       expect(pg_setup).to receive(:_run_command).with("env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "purge", "-y", "rsyslog")
       expect(Dir).to receive(:glob).with(PostgresSetup::RSYSLOG_LOGS_GLOB).and_return(["/var/log/syslog", "/var/log/syslog.1", "/var/log/auth.log.2.gz"])
@@ -148,6 +153,8 @@ RSpec.describe PostgresSetup do
       expect(pg_setup).to receive(:_run_command).with("mkdir", "-p", "/etc/systemd/journald.conf.d")
       expect(pg_setup).to receive(:safe_write_to_file).with(PostgresSetup::JOURNALD_CONF_PATH, PostgresSetup::JOURNALD_CONF)
       expect(pg_setup).to receive(:_run_command).with("systemctl", "restart", "systemd-journald")
+      expect(pg_setup).to receive(:_run_command).with("journalctl", "--rotate")
+      expect(pg_setup).to receive(:_run_command).with("journalctl", "--vacuum-size=1G")
       expect(File).to receive(:exist?).with("/usr/sbin/rsyslogd").and_return(false)
 
       pg_setup.configure_journald
@@ -180,6 +187,268 @@ RSpec.describe PostgresSetup do
       ["/var/log/postgresql.log", "/var/log/journal", "/var/log/wtmp", "/var/log/dpkg.log"].each do |path|
         expect(File.fnmatch?(PostgresSetup::RSYSLOG_LOGS_GLOB, path, File::FNM_EXTGLOB)).to be(false), "#{path} matched"
       end
+    end
+  end
+
+  describe "#configure_root_disk" do
+    it "runs every step, disabling GuardDuty off AWS" do
+      expect(pg_setup).to receive(:quiet_periodic_units).ordered
+      expect(pg_setup).to receive(:disable_guardduty).ordered
+      expect(pg_setup).to receive(:purge_snapd).ordered
+      expect(pg_setup).to receive(:purge_stale_kernels).ordered
+      expect(pg_setup).to receive(:clean_package_caches).ordered
+      pg_setup.configure_root_disk(aws: false)
+    end
+
+    it "leaves GuardDuty alone on AWS" do
+      expect(pg_setup).to receive_messages(quiet_periodic_units: nil, purge_snapd: nil, purge_stale_kernels: nil, clean_package_caches: nil)
+      expect(pg_setup).not_to receive(:disable_guardduty)
+      pg_setup.configure_root_disk(aws: true)
+    end
+
+    it "leaves GuardDuty alone when the control plane did not say where the server runs" do
+      expect(pg_setup).to receive_messages(quiet_periodic_units: nil, purge_snapd: nil, purge_stale_kernels: nil, clean_package_caches: nil)
+      expect(pg_setup).not_to receive(:disable_guardduty)
+      pg_setup.configure_root_disk(aws: nil)
+    end
+  end
+
+  describe "#quiet_periodic_units" do
+    let(:dropin) { PostgresSetup::PERIODIC_UNIT_DROPIN }
+    let(:units) { PostgresSetup::PERIODIC_UNITS }
+
+    def dropin_path(unit) = "/etc/systemd/system/#{unit}.d/50-quiet-journal.conf"
+
+    it "raises the unit's own output to notice so LogLevelMax keeps it and drops only systemd's" do
+      expect(dropin).to eq("[Service]\nSyslogLevel=notice\nLogLevelMax=notice\n")
+      expect(units).to contain_exactly("postgres-metrics.service", "io-throttle@.service", "disk-full-check@.service")
+    end
+
+    it "writes a drop-in per unit and reloads systemd" do
+      units.each do |unit|
+        expect(File).to receive(:exist?).with(dropin_path(unit)).and_return(false)
+        expect(pg_setup).to receive(:_run_command).with("mkdir", "-p", "/etc/systemd/system/#{unit}.d")
+        expect(pg_setup).to receive(:safe_write_to_file).with(dropin_path(unit), dropin)
+      end
+      expect(pg_setup).to receive(:_run_command).with("systemctl", "daemon-reload")
+
+      pg_setup.quiet_periodic_units
+    end
+
+    it "skips the reload when every drop-in already matches" do
+      units.each do |unit|
+        expect(File).to receive(:exist?).with(dropin_path(unit)).and_return(true)
+        expect(File).to receive(:read).with(dropin_path(unit)).and_return(dropin)
+      end
+      expect(pg_setup).not_to receive(:safe_write_to_file)
+      expect(pg_setup).not_to receive(:_run_command)
+
+      pg_setup.quiet_periodic_units
+    end
+
+    it "rewrites a drop-in whose content differs" do
+      units.each do |unit|
+        expect(File).to receive(:exist?).with(dropin_path(unit)).and_return(true)
+        expect(File).to receive(:read).with(dropin_path(unit)).and_return((unit == units.first) ? "[Service]\nLogLevelMax=info\n" : dropin)
+      end
+      expect(pg_setup).to receive(:_run_command).with("mkdir", "-p", "/etc/systemd/system/#{units.first}.d")
+      expect(pg_setup).to receive(:safe_write_to_file).with(dropin_path(units.first), dropin)
+      expect(pg_setup).to receive(:_run_command).with("systemctl", "daemon-reload")
+
+      pg_setup.quiet_periodic_units
+    end
+  end
+
+  describe "#disable_guardduty" do
+    let(:unit) { PostgresSetup::GUARDDUTY_UNIT }
+    let(:show) { ["systemctl", "show", "-p", "FragmentPath", "--value", unit] }
+
+    it "stops, disables and masks the agent" do
+      expect(pg_setup).to receive(:_run_command).with(*show).and_return("/lib/systemd/system/amazon-guardduty-agent.service\n")
+      expect(pg_setup).to receive(:_run_command).with("systemctl", "is-enabled", unit, expect: [0, 1]).and_return("enabled\n")
+      expect(pg_setup).to receive(:_run_command).with("systemctl", "disable", "--now", unit).ordered
+      expect(pg_setup).to receive(:_run_command).with("systemctl", "mask", unit).ordered
+
+      pg_setup.disable_guardduty
+    end
+
+    it "does nothing on an image without the agent" do
+      expect(pg_setup).to receive(:_run_command).with(*show).and_return("\n")
+
+      pg_setup.disable_guardduty
+    end
+
+    it "does nothing once masked" do
+      expect(pg_setup).to receive(:_run_command).with(*show).and_return("/dev/null\n")
+      expect(pg_setup).to receive(:_run_command).with("systemctl", "is-enabled", unit, expect: [0, 1]).and_return("masked\n")
+
+      pg_setup.disable_guardduty
+    end
+  end
+
+  describe "#purge_snapd" do
+    let(:leftovers) { ["/var/lib/snapd", "/snap", "/root/snap"] }
+    let(:snap_list) do
+      <<~SNAPS
+        Name    Version        Rev    Tracking       Publisher    Notes
+        core22  20260410       2437   latest/stable  canonical**  base
+        lxd     5.0.9-ea18dad  40575  5.0/stable/…   canonical**  -
+        snapd   2.76.2         27710  latest/stable  canonical**  snapd
+        core20  20260410       2866   latest/stable  canonical**  base
+      SNAPS
+    end
+
+    it "removes apps, then bases, then snapd itself, purges the package, sweeps and pins it out" do
+      expect(File).to receive(:exist?).with("/usr/bin/snap").and_return(true)
+      expect(pg_setup).to receive(:_run_command).with("snap", "list").and_return(snap_list)
+      %w[lxd core20 core22 snapd].each do |name|
+        expect(pg_setup).to receive(:_run_command).with("snap", "remove", "--purge", name).ordered
+      end
+      expect(pg_setup).to receive(:_run_command).with(*PostgresSetup::APT, "purge", "snapd").ordered
+      expect(FileUtils).to receive(:rm_rf).with(leftovers)
+      expect(File).to receive(:exist?).with(PostgresSetup::SNAPD_PIN_PATH).and_return(false)
+      expect(pg_setup).to receive(:safe_write_to_file).with(PostgresSetup::SNAPD_PIN_PATH, PostgresSetup::SNAPD_PIN)
+
+      pg_setup.purge_snapd
+    end
+
+    it "purges the package even when no snaps are installed" do
+      expect(File).to receive(:exist?).with("/usr/bin/snap").and_return(true)
+      expect(pg_setup).to receive(:_run_command).with("snap", "list").and_return("")
+      expect(pg_setup).to receive(:_run_command).with(*PostgresSetup::APT, "purge", "snapd")
+      expect(FileUtils).to receive(:rm_rf).with(leftovers)
+      expect(File).to receive(:exist?).with(PostgresSetup::SNAPD_PIN_PATH).and_return(false)
+      expect(pg_setup).to receive(:safe_write_to_file).with(PostgresSetup::SNAPD_PIN_PATH, PostgresSetup::SNAPD_PIN)
+
+      pg_setup.purge_snapd
+    end
+
+    it "only sweeps when snapd is already gone and the pin is in place" do
+      expect(File).to receive(:exist?).with("/usr/bin/snap").and_return(false)
+      expect(FileUtils).to receive(:rm_rf).with(leftovers)
+      expect(File).to receive(:exist?).with(PostgresSetup::SNAPD_PIN_PATH).and_return(true)
+      expect(File).to receive(:read).with(PostgresSetup::SNAPD_PIN_PATH).and_return(PostgresSetup::SNAPD_PIN)
+      expect(pg_setup).not_to receive(:safe_write_to_file)
+
+      pg_setup.purge_snapd
+    end
+
+    it "rewrites a pin whose content differs" do
+      expect(File).to receive(:exist?).with("/usr/bin/snap").and_return(false)
+      expect(FileUtils).to receive(:rm_rf).with(leftovers)
+      expect(File).to receive(:exist?).with(PostgresSetup::SNAPD_PIN_PATH).and_return(true)
+      expect(File).to receive(:read).with(PostgresSetup::SNAPD_PIN_PATH).and_return("Package: snapd\nPin-Priority: 100\n")
+      expect(pg_setup).to receive(:safe_write_to_file).with(PostgresSetup::SNAPD_PIN_PATH, PostgresSetup::SNAPD_PIN)
+
+      pg_setup.purge_snapd
+    end
+
+    it "pins snapd below anything apt would install" do
+      expect(PostgresSetup::SNAPD_PIN).to eq("Package: snapd\nPin: release a=*\nPin-Priority: -10\n")
+    end
+  end
+
+  describe "#purge_stale_kernels" do
+    let(:dpkg_query) { ["dpkg-query", "-W", "-f=${Package} ${Status}\n", "linux-*"] }
+
+    let(:dpkg_output) do
+      <<~DPKG
+        linux-azure-6.5 install ok installed
+        linux-base install ok installed
+        linux-base-sgx install ok installed
+        linux-cloud-tools-common install ok installed
+        linux-firmware install ok installed
+        linux-headers-5.15.0-190 install ok installed
+        linux-headers-5.15.0-190-generic install ok installed
+        linux-headers-6.8.0-90-generic install ok installed
+        linux-headers-generic install ok installed
+        linux-headers-virtual install ok installed
+        linux-hwe-6.8-headers-6.8.0-90 install ok installed
+        linux-hwe-6.8-tools-6.8.0-90 install ok installed
+        linux-image-5.15.0-190-generic install ok installed
+        linux-image-6.5.0-1011-azure install ok installed
+        linux-image-6.8.0-90-generic install ok installed
+        linux-image-unsigned-5.15.0-187-generic unknown ok not-installed
+        linux-image-virtual install ok installed
+        linux-libc-dev install ok installed
+        linux-modules-5.15.0-190-generic install ok installed
+        linux-modules-extra-6.8.0-90-generic install ok installed
+        linux-tools-6.8.0-90-generic install ok installed
+        linux-tools-common install ok installed
+        linux-virtual install ok installed
+
+      DPKG
+    end
+    let(:stale) do
+      %w[
+        linux-azure-6.5 linux-headers-5.15.0-190 linux-headers-5.15.0-190-generic linux-headers-generic
+        linux-headers-virtual linux-image-5.15.0-190-generic linux-image-6.5.0-1011-azure linux-image-virtual
+        linux-modules-5.15.0-190-generic linux-virtual
+      ]
+    end
+
+    it "purges other kernels' versioned packages and the flavour metapackages, then autoremoves" do
+      expect(pg_setup).to receive(:_run_command).with("uname", "-r").and_return("6.8.0-90-generic\n")
+      expect(pg_setup).to receive(:_run_command).with(*dpkg_query).and_return(dpkg_output)
+      expect(pg_setup).to receive(:_run_command).with(*PostgresSetup::APT, "-s", "purge", *stale).and_return(<<~PLAN).ordered
+        Remv linux-virtual [5.15.0.190.169]
+        Remv linux-image-5.15.0-190-generic [5.15.0-190.200]
+        Purg linux-image-5.15.0-190-generic
+      PLAN
+      expect(pg_setup).to receive(:_run_command).with(*PostgresSetup::APT, "purge", *stale).ordered
+      expect(pg_setup).to receive(:_run_command).with(*PostgresSetup::APT, "autoremove", "--purge").ordered
+
+      pg_setup.purge_stale_kernels
+    end
+
+    it "refuses when apt would keep a metapackage by installing a newer kernel" do
+      expect(pg_setup).to receive(:_run_command).with("uname", "-r").and_return("6.8.0-90-generic\n")
+      expect(pg_setup).to receive(:_run_command).with(*dpkg_query).and_return(dpkg_output)
+      expect(pg_setup).to receive(:_run_command).with(*PostgresSetup::APT, "-s", "purge", *stale).and_return(<<~PLAN)
+        Inst linux-modules-5.15.0-164-generic (5.15.0-164.174 Ubuntu:22.04/jammy-updates [amd64])
+        Inst linux-image-5.15.0-164-generic (5.15.0-164.174 Ubuntu:22.04/jammy-updates [amd64])
+        Remv linux-image-5.15.0-190-generic [5.15.0-190.200]
+      PLAN
+      expect(pg_setup).not_to receive(:_run_command).with(*PostgresSetup::APT, "purge", any_args)
+
+      expect { pg_setup.purge_stale_kernels }.to raise_error(RuntimeError, /would install linux-modules-5.15.0-164-generic, linux-image-5.15.0-164-generic/)
+    end
+
+    it "does nothing when only the running kernel is installed" do
+      expect(pg_setup).to receive(:_run_command).with("uname", "-r").and_return("6.8.0-90-generic\n")
+      expect(pg_setup).to receive(:_run_command).with(*dpkg_query).and_return(<<~DPKG)
+        linux-base install ok installed
+        linux-image-6.8.0-90-generic install ok installed
+        linux-modules-6.8.0-90-generic install ok installed
+        linux-tools-common install ok installed
+      DPKG
+
+      pg_setup.purge_stale_kernels
+    end
+
+    it "does nothing when the running kernel's image package is not installed" do
+      expect(pg_setup).to receive(:_run_command).with("uname", "-r").and_return("6.8.0-90-generic\n")
+      expect(pg_setup).to receive(:_run_command).with(*dpkg_query).and_return(<<~DPKG)
+        linux-image-5.15.0-190-generic install ok installed
+        linux-modules-5.15.0-190-generic install ok installed
+      DPKG
+
+      pg_setup.purge_stale_kernels
+    end
+
+    it "does nothing when the running kernel version cannot be parsed" do
+      expect(pg_setup).to receive(:_run_command).with("uname", "-r").and_return("custom\n")
+
+      pg_setup.purge_stale_kernels
+    end
+  end
+
+  describe "#clean_package_caches" do
+    it "empties the apt archive cache and removes the orphaned ParadeDB cache" do
+      expect(pg_setup).to receive(:_run_command).with("apt-get", "clean")
+      expect(FileUtils).to receive(:rm_rf).with("/var/cache/paradedb")
+
+      pg_setup.clean_package_caches
     end
   end
 

--- a/spec/model/postgres/postgres_server_spec.rb
+++ b/spec/model/postgres/postgres_server_spec.rb
@@ -153,6 +153,16 @@ RSpec.describe PostgresServer do
       expect(postgres_server.configure_hash[:configs]).to include(:log_connections, :log_disconnections)
     end
 
+    it "tells the rhizome the server does not run on AWS" do
+      expect(postgres_server.configure_hash[:aws]).to be(false)
+    end
+
+    it "tells the rhizome the server runs on AWS" do
+      location.update(provider: "aws")
+      postgres_server.timeline_access = "push"
+      expect(postgres_server.configure_hash[:aws]).to be(true)
+    end
+
     it "sets allow_alter_system to off for version >= 17" do
       postgres_server.update(version: "17")
       expect(postgres_server.configure_hash[:configs]).to include("allow_alter_system" => "off")


### PR DESCRIPTION
Every hobby-sized Postgres server was heading for the 90% root disk page, and four had reached it. Nothing leaks; the pieces we put on the 16 GiB root simply add up past the line: about 6 G of image, the 4 G swapfile the hobby sizes get, up to 1 G of Prometheus TSDB, and a journal that 55af274aa allowed to grow to 4 G. Standard sizes have no swapfile and sit around 65% with the same journal.

The journal fills from entry count, not text: 130-250K entries a day at roughly 0.8 KB each on disk. Measured writers on the paged servers:

  * the GuardDuty agent, shipped in the image for AWS, crash-looping every 4 seconds anywhere else: five systemd lines per attempt, about 100K a day;
  * the postgres-metrics, io-throttle@ and disk-full-check@ timers at 15-20 seconds, three systemd lines per run plus their own output, about 57K a day;
  * sshd at LogLevel VERBOSE logging every channel our long-lived monitoring sessions open, about 50K a day. That level is deliberate (prog/bootstrap_rhizome.rb) and is left alone here.

configure_root_disk, run last from bin/configure so it reaches every server the way configure_journald does, applies the end state:

  * journal capped at 1G with 64M files, SplitMode=none so journald stops keeping an 8 MB-minimum file per UID, rotated and vacuumed when the cap changes;
  * SyslogLevel=notice with LogLevelMax=notice on the three timer units, which drops PID 1's per-run lines and keeps the units' own output;
  * GuardDuty disabled and masked when the control plane says the server is not on AWS (configure_hash gains "aws"; nil leaves it alone);
  * snapd and the lxd/core20/core22 snaps removed and snapd pinned out, 0.7-0.8 G of squashfs nothing on a Postgres server uses;
  * every kernel package but the running kernel's purged, including the flavour metapackages by name: left installed, apt keeps a metapackage by upgrading it, which installs another kernel instead of removing one. An apt dry run guards against any install before the purge;
  * apt cache cleaned and the ParadeDB package cache, orphaned since the extensions left the image, removed.

apply-io-throttle now logs only when io.max changes rather than every 15 seconds.

Measured on the four paged servers: 90-93% down to 67%, journal 3.1-3.6 G down to 1 G, one kernel left.