### PR TITLE
Csi improvements

### DIFF
--- a/kubernetes/csi/Gemfile.lock
+++ b/kubernetes/csi/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ubi-csi (0.14.0)
+    ubi-csi (0.15.0)
       base64
       grpc (= 1.83.0)
       grpc-tools (= 1.83.0)

--- a/kubernetes/csi/lib/ubi_csi.rb
+++ b/kubernetes/csi/lib/ubi_csi.rb
@@ -5,7 +5,7 @@ require "csi_pb"
 require "csi_services_pb"
 
 module Csi
-  VERSION = "0.14.0"
+  VERSION = "0.15.0"
 end
 
 require_relative "ubi_csi/identity_service"

--- a/kubernetes/csi/lib/ubi_csi/controller_service.rb
+++ b/kubernetes/csi/lib/ubi_csi/controller_service.rb
@@ -76,12 +76,12 @@ module Csi
       # This function will be used in CreateVolume method,
       # Telling the kubernetes cluster first to not select control-plane nodes,
       # then selecting any of the nodes which might can host the PV.
-      def select_worker_topology(req)
-        preferred = req.accessibility_requirements.preferred
-        requisite = req.accessibility_requirements.requisite
+      def select_worker_topology(req, req_id)
+        control_plane_nodes = KubernetesClient.new(req_id:, logger: @logger).list_control_plane_nodes
+        requirements = req.accessibility_requirements
 
-        selected = preferred.find { |topo| !topo.segments["kubernetes.io/hostname"].start_with?("kc") }
-        selected ||= requisite.find { |topo| !topo.segments["kubernetes.io/hostname"].start_with?("kc") }
+        # Scanning preferred before requisite keeps the scheduler's preference.
+        selected = (requirements.preferred + requirements.requisite).find { |topo| !control_plane_nodes.include?(topo.segments["kubernetes.io/hostname"]) }
 
         if selected.nil?
           raise GRPC::FailedPrecondition.new("No suitable worker node topology found")
@@ -141,7 +141,7 @@ module Csi
 
           @mutex.synchronize do
             unless (existing = @volume_store[req.name])
-              selected_topology = select_worker_topology(req)
+              selected_topology = select_worker_topology(req, req_id)
               new_volume_id = "vol-#{SecureRandom.uuid}"
               @volume_store[req.name] = {
                 volume_id: new_volume_id,

--- a/kubernetes/csi/lib/ubi_csi/kubernetes_client.rb
+++ b/kubernetes/csi/lib/ubi_csi/kubernetes_client.rb
@@ -105,6 +105,11 @@ module Csi
       !get_node(name).dig("spec", "unschedulable")
     end
 
+    def list_control_plane_nodes
+      list = yaml_load_kubectl("get", "nodes", "-l", "node-role.kubernetes.io/control-plane")
+      list["items"].map { |node| node.dig("metadata", "name") }
+    end
+
     def find_pv_by_volume_id(volume_id)
       pv_list = yaml_load_kubectl("get", "pv")
       pv = pv_list["items"].find { |pv| pv.dig("spec", "csi", "volumeHandle") == volume_id }

--- a/kubernetes/csi/lib/ubi_csi/node_service.rb
+++ b/kubernetes/csi/lib/ubi_csi/node_service.rb
@@ -247,7 +247,9 @@ module Csi
             client.patch_resource("pv", old_pv_name, MIGRATION_RETRY_COUNT_ANNOTATION_KEY, nil)
           end
         when "NotStarted"
-          copy_command = ["rsync", "-az", "--inplace", "--compress-level=9", "--partial", "--whole-file", "-e", "ssh -T -c aes128-gcm@openssh.com -o Compression=no -x -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/ubi/.ssh/id_ed25519", "ubi@#{old_node_ip}:#{old_data_path}", current_data_path]
+          # --sparse keeps the holes in the backing file. All production nodes run an
+          # rsync that supports combining it with --inplace.
+          copy_command = ["rsync", "-az", "--sparse", "--inplace", "--compress-level=9", "--partial", "--whole-file", "-e", "ssh -T -c aes128-gcm@openssh.com -o Compression=no -x -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/ubi/.ssh/id_ed25519", "ubi@#{old_node_ip}:#{old_data_path}", current_data_path]
           run_cmd_output("nsenter", "-t", "1", "-a", "/home/ubi/common/bin/daemonizer2", "run", daemonizer_unit_name, *copy_command, req_id:)
           raise CopyNotFinishedError, "Old PV data is not copied yet"
         when "InProgress"

--- a/kubernetes/csi/lib/ubi_csi/node_service.rb
+++ b/kubernetes/csi/lib/ubi_csi/node_service.rb
@@ -69,12 +69,12 @@ module Csi
 
       def is_mounted?(path, req_id:)
         _, status = run_cmd("mountpoint", "-q", path, req_id:)
-        status == 0
+        status.success?
       end
 
       def find_loop_device(backing_file, req_id:)
-        output, ok = run_cmd("losetup", "-j", backing_file, req_id:)
-        if ok && !output.empty?
+        output, status = run_cmd("losetup", "-j", backing_file, req_id:)
+        if status.success? && !output.empty?
           loop_device = output.split(":", 2)[0].strip
           return loop_device if loop_device.start_with?("/dev/loop")
         end
@@ -85,8 +85,8 @@ module Csi
         loop_device = find_loop_device(backing_file, req_id:)
         return unless loop_device
 
-        output, ok = run_cmd("losetup", "-d", loop_device, req_id:)
-        unless ok
+        output, status = run_cmd("losetup", "-d", loop_device, req_id:)
+        unless status.success?
           raise "Could not remove loop device: #{output}"
         end
       end
@@ -101,12 +101,17 @@ module Csi
       end
 
       def find_file_system(loop_device, req_id:)
-        output, ok = run_cmd("blkid", "-o", "value", "-s", "TYPE", loop_device, req_id:)
-        unless ok
+        output, status = run_cmd("blkid", "-o", "value", "-s", "TYPE", loop_device, req_id:)
+        case status.exitstatus
+        when 0
+          output.strip
+        when 2
+          # blkid exits 2 with no output when the device carries no filesystem, the
+          # normal state of a backing file that has not been formatted yet.
+          ""
+        else
           raise "Failed to get the loop device filesystem status: #{output}"
         end
-
-        output.strip
       end
 
       def node_stage_volume(req, _call)
@@ -150,13 +155,13 @@ module Csi
         backing_file = NodeService.backing_file_path(volume_id)
 
         unless File.exist?(backing_file)
-          output, ok = run_cmd("fallocate", "-l", size_bytes.to_s, backing_file, req_id:)
-          unless ok
+          output, status = run_cmd("fallocate", "-l", size_bytes.to_s, backing_file, req_id:)
+          unless status.success?
             raise GRPC::ResourceExhausted.new("Failed to allocate backing file: #{output}")
           end
 
-          output, ok = run_cmd("fallocate", "--punch-hole", "--keep-size", "-o", "0", "-l", size_bytes.to_s, backing_file, req_id:)
-          unless ok
+          output, status = run_cmd("fallocate", "--punch-hole", "--keep-size", "-o", "0", "-l", size_bytes.to_s, backing_file, req_id:)
+          unless status.success?
             raise GRPC::ResourceExhausted.new("Failed to punch hole in backing file: #{output}")
           end
         end
@@ -165,9 +170,9 @@ module Csi
         is_new_loop_device = loop_device.nil?
         if is_new_loop_device
           log_with_id(req_id, "Setting up new loop device for: #{backing_file}")
-          output, ok = run_cmd("losetup", "--find", "--show", backing_file, req_id:)
+          output, status = run_cmd("losetup", "--find", "--show", backing_file, req_id:)
           loop_device = output.strip
-          unless ok && !loop_device.empty?
+          unless status.success? && !loop_device.empty?
             raise "Failed to setup loop device: #{output}"
           end
         else
@@ -184,16 +189,16 @@ module Csi
           if current_fs_type != "" && current_fs_type != desired_fs_type
             raise "Unexpected filesystem on volume. desired: #{desired_fs_type}, current: #{current_fs_type}"
           elsif current_fs_type == ""
-            output, ok = run_cmd("mkfs.#{desired_fs_type}", loop_device, req_id:)
-            unless ok
+            output, status = run_cmd("mkfs.#{desired_fs_type}", loop_device, req_id:)
+            unless status.success?
               raise "Failed to format device #{loop_device} with #{desired_fs_type}: #{output}"
             end
           end
         end
         unless is_mounted?(staging_path, req_id:)
           FileUtils.mkdir_p(staging_path)
-          output, ok = run_cmd("mount", loop_device, staging_path, req_id:)
-          unless ok
+          output, status = run_cmd("mount", loop_device, staging_path, req_id:)
+          unless status.success?
             raise "Failed to mount #{loop_device} to #{staging_path}: #{output}"
           end
         end
@@ -272,8 +277,8 @@ module Csi
           remove_loop_device(backing_file, req_id:)
           staging_path = req.staging_target_path
           if is_mounted?(staging_path, req_id:)
-            output, ok = run_cmd("umount", "-q", staging_path, req_id:)
-            unless ok
+            output, status = run_cmd("umount", "-q", staging_path, req_id:)
+            unless status.success?
               raise "Failed to unmount #{staging_path}: #{output}"
             end
           end
@@ -353,8 +358,8 @@ module Csi
 
           unless is_mounted?(target_path, req_id:)
             FileUtils.mkdir_p(target_path)
-            output, ok = run_cmd("mount", "--bind", staging_path, target_path, req_id:)
-            unless ok
+            output, status = run_cmd("mount", "--bind", staging_path, target_path, req_id:)
+            unless status.success?
               raise "Failed to bind mount #{staging_path} to #{target_path}: #{output}"
             end
           end
@@ -370,8 +375,8 @@ module Csi
           target_path = req.target_path
 
           if is_mounted?(target_path, req_id:)
-            output, ok = run_cmd("umount", "-q", target_path, req_id:)
-            unless ok
+            output, status = run_cmd("umount", "-q", target_path, req_id:)
+            unless status.success?
               raise "Failed to unmount #{target_path}: #{output}"
             end
           else

--- a/kubernetes/csi/lib/ubi_csi/node_service.rb
+++ b/kubernetes/csi/lib/ubi_csi/node_service.rb
@@ -63,7 +63,9 @@ module Csi
       end
 
       def run_cmd_output(*cmd, req_id:)
-        output, _ = run_cmd(*cmd, req_id:)
+        output, status = run_cmd(*cmd, req_id:)
+        raise output unless status.success?
+
         output
       end
 

--- a/kubernetes/csi/spec/csi/v1/controller_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/controller_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Csi::V1::ControllerService do
   let(:stuck_volume_detector) { instance_double(Csi::StuckVolumeDetector, start: nil, shutdown!: nil) }
   let(:capacity_manager) { Csi::CapacityManager.new(logger:, max_volume_size: 10 * 1024 * 1024 * 1024) }
   let(:service) { described_class.new(logger:) }
+  let(:control_plane_nodes_yaml) { YAML.dump({"items" => [{"metadata" => {"name" => "kc4jz1-control-plane-1"}}]}) }
 
   before do
     allow(Csi::StuckVolumeDetector).to receive(:new).and_return(stuck_volume_detector)
@@ -73,38 +74,53 @@ RSpec.describe Csi::V1::ControllerService do
   end
 
   describe "#select_worker_topology" do
-    let(:kc) { Csi::V1::Topology.new(segments: {"kubernetes.io/hostname" => "kc-worker-1"}) }
-    let(:worker1) { Csi::V1::Topology.new(segments: {"kubernetes.io/hostname" => "worker-1"}) }
-    let(:worker2) { Csi::V1::Topology.new(segments: {"kubernetes.io/hostname" => "worker-2"}) }
+    let(:control_plane) { Csi::V1::Topology.new(segments: {"kubernetes.io/hostname" => "kc4jz1-control-plane-1"}) }
+    let(:worker1) { Csi::V1::Topology.new(segments: {"kubernetes.io/hostname" => "kn2ab9-worker-1"}) }
+    let(:worker2) { Csi::V1::Topology.new(segments: {"kubernetes.io/hostname" => "kn2ab9-worker-2"}) }
+
+    before do
+      allow(Open3).to receive(:capture2e).with("kubectl", "get", "nodes", "-l", "node-role.kubernetes.io/control-plane", "-oyaml", stdin_data: nil).and_return([control_plane_nodes_yaml, instance_double(Process::Status, success?: true)])
+    end
 
     it "selects from preferred topology when suitable worker exists" do
       request = Csi::V1::CreateVolumeRequest.new(
         accessibility_requirements: {
-          preferred: [worker1, kc],
-          requisite: [kc],
+          preferred: [worker1, control_plane],
+          requisite: [control_plane],
         },
       )
-      expect(service.select_worker_topology(request).segments["kubernetes.io/hostname"]).to eq("worker-1")
+      expect(service.select_worker_topology(request, "test-req-id").segments["kubernetes.io/hostname"]).to eq("kn2ab9-worker-1")
     end
 
     it "selects from requisite topology when preferred has no suitable worker" do
       request = Csi::V1::CreateVolumeRequest.new(
         accessibility_requirements: {
-          preferred: [kc],
-          requisite: [worker2, kc],
+          preferred: [control_plane],
+          requisite: [worker2, control_plane],
         },
       )
-      expect(service.select_worker_topology(request).segments["kubernetes.io/hostname"]).to eq("worker-2")
+      expect(service.select_worker_topology(request, "test-req-id").segments["kubernetes.io/hostname"]).to eq("kn2ab9-worker-2")
+    end
+
+    it "selects a node that is absent from the control-plane list" do
+      unlabeled = Csi::V1::Topology.new(segments: {"kubernetes.io/hostname" => "kc4jz1-control-plane-2"})
+      request = Csi::V1::CreateVolumeRequest.new(
+        accessibility_requirements: {
+          preferred: [unlabeled],
+          requisite: [unlabeled],
+        },
+      )
+      expect(service.select_worker_topology(request, "test-req-id").segments["kubernetes.io/hostname"]).to eq("kc4jz1-control-plane-2")
     end
 
     it "raises FailedPrecondition when no suitable worker found" do
       request = Csi::V1::CreateVolumeRequest.new(
         accessibility_requirements: {
-          preferred: [kc],
-          requisite: [kc],
+          preferred: [control_plane],
+          requisite: [control_plane],
         },
       )
-      expect { service.select_worker_topology(request) }.to raise_error(GRPC::FailedPrecondition, /No suitable worker node topology found/)
+      expect { service.select_worker_topology(request, "test-req-id") }.to raise_error(GRPC::FailedPrecondition, "9:No suitable worker node topology found")
     end
   end
 
@@ -140,6 +156,7 @@ RSpec.describe Csi::V1::ControllerService do
 
     before do
       allow(SecureRandom).to receive(:uuid).and_return(*uuids)
+      allow(Open3).to receive(:capture2e).with("kubectl", "get", "nodes", "-l", "node-role.kubernetes.io/control-plane", "-oyaml", stdin_data: nil).and_return([control_plane_nodes_yaml, instance_double(Process::Status, success?: true)])
     end
 
     context "with valid request" do

--- a/kubernetes/csi/spec/csi/v1/identity_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/identity_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Csi::V1::IdentityService do
       request = Csi::V1::GetPluginInfoRequest.new
       response = service.get_plugin_info(request, call)
       expect(response.name).to eq("csi.ubicloud.com")
-      expect(response.vendor_version).to eq("0.14.0")
+      expect(response.vendor_version).to eq("0.15.0")
     end
   end
 

--- a/kubernetes/csi/spec/csi/v1/node_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/node_service_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe Csi::V1::NodeService do
         result = service.run_cmd_output("echo", "test", req_id: "req-id")
         expect(result).to eq("extracted_output")
       end
+
+      it "raises when the command fails" do
+        expect(service).to receive(:run_cmd).with("echo", "test", req_id: "req-id").and_return(["some error", failure_status])
+
+        expect { service.run_cmd_output("echo", "test", req_id: "req-id") }.to raise_error("some error")
+      end
     end
 
     describe "#is_mounted?" do

--- a/kubernetes/csi/spec/csi/v1/node_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/node_service_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Csi::V1::NodeService do
   let(:client) { Csi::KubernetesClient.new(logger:, req_id:) }
   let(:service) { described_class.new(logger:, node_id: "test-node") }
   let(:mesh_checker) { instance_double(Csi::MeshConnectivityChecker, start: nil, shutdown!: nil) }
+  let(:success_status) { instance_double(Process::Status, success?: true, exitstatus: 0) }
+  let(:failure_status) { instance_double(Process::Status, success?: false, exitstatus: 1) }
+  let(:no_filesystem_status) { instance_double(Process::Status, success?: false, exitstatus: 2) }
 
   before do
     allow(SecureRandom).to receive(:uuid).and_return("test-req-id")
@@ -58,17 +61,17 @@ RSpec.describe Csi::V1::NodeService do
 
     describe "#run_cmd" do
       it "executes command and returns output and status" do
-        expect(Open3).to receive(:capture2e).with("echo", "test").and_return(["output", 0])
+        expect(Open3).to receive(:capture2e).with("echo", "test").and_return(["output", success_status])
 
         output, status = service.run_cmd("echo", "test", req_id: "req-id")
         expect(output).to eq("output")
-        expect(status).to eq(0)
+        expect(status).to eq(success_status)
       end
     end
 
     describe "#run_cmd_output" do
       it "extracts output from run_cmd result" do
-        expect(service).to receive(:run_cmd).with("echo", "test", req_id: "req-id").and_return(["extracted_output", 0])
+        expect(service).to receive(:run_cmd).with("echo", "test", req_id: "req-id").and_return(["extracted_output", success_status])
 
         result = service.run_cmd_output("echo", "test", req_id: "req-id")
         expect(result).to eq("extracted_output")
@@ -77,34 +80,34 @@ RSpec.describe Csi::V1::NodeService do
 
     describe "#is_mounted?" do
       it "returns true when path is mounted" do
-        expect(service).to receive(:run_cmd).with("mountpoint", "-q", "/mnt/test", req_id: "req-id").and_return(["", 0])
+        expect(service).to receive(:run_cmd).with("mountpoint", "-q", "/mnt/test", req_id: "req-id").and_return(["", success_status])
         expect(service.is_mounted?("/mnt/test", req_id: "req-id")).to be true
       end
 
       it "returns false when path is not mounted" do
-        expect(service).to receive(:run_cmd).with("mountpoint", "-q", "/mnt/test", req_id: "req-id").and_return(["", 1])
+        expect(service).to receive(:run_cmd).with("mountpoint", "-q", "/mnt/test", req_id: "req-id").and_return(["", failure_status])
         expect(service.is_mounted?("/mnt/test", req_id: "req-id")).to be false
       end
     end
 
     describe "#find_loop_device" do
       it "returns loop device when found" do
-        expect(service).to receive(:run_cmd).with("losetup", "-j", "/path/to/file", req_id: "req-id").and_return(["/dev/loop0: [2049]:123456 (/path/to/file)", true])
+        expect(service).to receive(:run_cmd).with("losetup", "-j", "/path/to/file", req_id: "req-id").and_return(["/dev/loop0: [2049]:123456 (/path/to/file)", success_status])
         expect(service.find_loop_device("/path/to/file", req_id: "req-id")).to eq("/dev/loop0")
       end
 
       it "returns nil when not found in a list" do
-        expect(service).to receive(:run_cmd).with("losetup", "-j", "/path/to/file", req_id: "req-id").and_return(["/dev/nbd0: [2049]:123456 (/path/to/file)", true])
+        expect(service).to receive(:run_cmd).with("losetup", "-j", "/path/to/file", req_id: "req-id").and_return(["/dev/nbd0: [2049]:123456 (/path/to/file)", success_status])
         expect(service.find_loop_device("/path/to/file", req_id: "req-id")).to be_nil
       end
 
       it "returns nil when not found" do
-        expect(service).to receive(:run_cmd).with("losetup", "-j", "/path/to/file", req_id: "req-id").and_return(["", true])
+        expect(service).to receive(:run_cmd).with("losetup", "-j", "/path/to/file", req_id: "req-id").and_return(["", success_status])
         expect(service.find_loop_device("/path/to/file", req_id: "req-id")).to be_nil
       end
 
       it "returns nil when command fails" do
-        expect(service).to receive(:run_cmd).with("losetup", "-j", "/path/to/file", req_id: "req-id").and_return(["some output", false])
+        expect(service).to receive(:run_cmd).with("losetup", "-j", "/path/to/file", req_id: "req-id").and_return(["some output", failure_status])
         expect(service.find_loop_device("/path/to/file", req_id: "req-id")).to be_nil
       end
     end
@@ -120,13 +123,13 @@ RSpec.describe Csi::V1::NodeService do
 
       it "tries to remove the loop device but gets an error" do
         expect(service).to receive(:find_loop_device).and_return("/dev/loop4")
-        expect(service).to receive(:run_cmd).with("losetup", "-d", "/dev/loop4", req_id:).and_return(["some output", false])
+        expect(service).to receive(:run_cmd).with("losetup", "-d", "/dev/loop4", req_id:).and_return(["some output", failure_status])
         expect { service.remove_loop_device(backing_file, req_id:) }.to raise_error("Could not remove loop device: some output")
       end
 
       it "successfully removes the loop device" do
         expect(service).to receive(:find_loop_device).and_return("/dev/loop4")
-        expect(service).to receive(:run_cmd).with("losetup", "-d", "/dev/loop4", req_id:).and_return(["some output", true])
+        expect(service).to receive(:run_cmd).with("losetup", "-d", "/dev/loop4", req_id:).and_return(["some output", success_status])
         expect { service.remove_loop_device(backing_file, req_id:) }.not_to raise_error
       end
     end
@@ -157,17 +160,17 @@ RSpec.describe Csi::V1::NodeService do
 
   describe "#find_file_system" do
     it "raises an error if blkid command is not successful" do
-      expect(service).to receive(:run_cmd).with("blkid", "-o", "value", "-s", "TYPE", "/dev/loop4", req_id:).and_return(["some error", false])
+      expect(service).to receive(:run_cmd).with("blkid", "-o", "value", "-s", "TYPE", "/dev/loop4", req_id:).and_return(["some error", failure_status])
       expect { service.find_file_system("/dev/loop4", req_id:) }.to raise_error("Failed to get the loop device filesystem status: some error")
     end
 
     it "strips the output and returns the filesystem" do
-      expect(service).to receive(:run_cmd).with("blkid", "-o", "value", "-s", "TYPE", "/dev/loop4", req_id:).and_return(["ext4\n", true])
+      expect(service).to receive(:run_cmd).with("blkid", "-o", "value", "-s", "TYPE", "/dev/loop4", req_id:).and_return(["ext4\n", success_status])
       expect(service.find_file_system("/dev/loop4", req_id:)).to eq("ext4")
     end
 
     it "returns empty string when no filesystem is installed on the device" do
-      expect(service).to receive(:run_cmd).with("blkid", "-o", "value", "-s", "TYPE", "/dev/loop4", req_id:).and_return(["", true])
+      expect(service).to receive(:run_cmd).with("blkid", "-o", "value", "-s", "TYPE", "/dev/loop4", req_id:).and_return(["", no_filesystem_status])
       expect(service.find_file_system("/dev/loop4", req_id:)).to eq("")
     end
   end
@@ -181,7 +184,6 @@ RSpec.describe Csi::V1::NodeService do
         },
       )
     end
-    let(:success_status) { instance_double(Process::Status, success?: true) }
 
     it "migrates PVC data when migration is needed" do
       pvc_with_migration = {"metadata" => {"annotations" => {"csi.ubicloud.com/old-pv-name" => "old-pv"}}}
@@ -248,10 +250,10 @@ RSpec.describe Csi::V1::NodeService do
         is_mounted?: false,
         find_loop_device: nil,
       )
-      allow(service).to receive(:run_cmd).with("losetup", "--find", "--show", backing_file, req_id:).and_return(["/dev/loop0", true])
-      allow(service).to receive(:run_cmd).with("mkfs.ext4", "/dev/loop0", req_id:).and_return(["", true])
+      allow(service).to receive(:run_cmd).with("losetup", "--find", "--show", backing_file, req_id:).and_return(["/dev/loop0", success_status])
+      allow(service).to receive(:run_cmd).with("mkfs.ext4", "/dev/loop0", req_id:).and_return(["", success_status])
       allow(Dir).to receive(:exist?).with(staging_path).and_return(false)
-      allow(service).to receive(:run_cmd).with("mount", "/dev/loop0", staging_path, req_id:).and_return(["", true])
+      allow(service).to receive(:run_cmd).with("mount", "/dev/loop0", staging_path, req_id:).and_return(["", success_status])
       allow(service).to receive(:find_file_system).and_return("")
     end
 
@@ -267,23 +269,23 @@ RSpec.describe Csi::V1::NodeService do
       it "creates file when it doesn't exist - success path" do
         expect(FileUtils).to receive(:mkdir_p).with(staging_path)
         expect(File).to receive(:exist?).with(backing_file).and_return(false)
-        expect(service).to receive(:run_cmd).with("fallocate", "-l", size_bytes.to_s, backing_file, req_id:).and_return(["", true])
-        expect(service).to receive(:run_cmd).with("fallocate", "--punch-hole", "--keep-size", "-o", "0", "-l", size_bytes.to_s, backing_file, req_id:).and_return(["", true])
+        expect(service).to receive(:run_cmd).with("fallocate", "-l", size_bytes.to_s, backing_file, req_id:).and_return(["", success_status])
+        expect(service).to receive(:run_cmd).with("fallocate", "--punch-hole", "--keep-size", "-o", "0", "-l", size_bytes.to_s, backing_file, req_id:).and_return(["", success_status])
 
         service.perform_node_stage_volume(req_id, pvc, req, nil)
       end
 
       it "handles fallocate failure" do
         expect(File).to receive(:exist?).with(backing_file).and_return(false)
-        expect(service).to receive(:run_cmd).with("fallocate", "-l", size_bytes.to_s, backing_file, req_id:).and_return(["Error message", false])
+        expect(service).to receive(:run_cmd).with("fallocate", "-l", size_bytes.to_s, backing_file, req_id:).and_return(["Error message", failure_status])
 
         expect { service.perform_node_stage_volume(req_id, pvc, req, nil) }.to raise_error(GRPC::ResourceExhausted, /Failed to allocate backing file/)
       end
 
       it "handles punch hole failure" do
         expect(File).to receive(:exist?).with(backing_file).and_return(false)
-        expect(service).to receive(:run_cmd).with("fallocate", "-l", size_bytes.to_s, backing_file, req_id:).and_return(["", true])
-        expect(service).to receive(:run_cmd).with("fallocate", "--punch-hole", "--keep-size", "-o", "0", "-l", size_bytes.to_s, backing_file, req_id:).and_return(["Punch hole error", false])
+        expect(service).to receive(:run_cmd).with("fallocate", "-l", size_bytes.to_s, backing_file, req_id:).and_return(["", success_status])
+        expect(service).to receive(:run_cmd).with("fallocate", "--punch-hole", "--keep-size", "-o", "0", "-l", size_bytes.to_s, backing_file, req_id:).and_return(["Punch hole error", failure_status])
 
         expect { service.perform_node_stage_volume(req_id, pvc, req, nil) }.to raise_error(GRPC::ResourceExhausted, /Failed to punch hole/)
       end
@@ -296,14 +298,14 @@ RSpec.describe Csi::V1::NodeService do
 
       it "handles loop device setup failure" do
         expect(service).to receive(:find_loop_device).and_return(nil)
-        expect(service).to receive(:run_cmd).with("losetup", "--find", "--show", backing_file, req_id:).and_return(["Error setting up loop device", false])
+        expect(service).to receive(:run_cmd).with("losetup", "--find", "--show", backing_file, req_id:).and_return(["Error setting up loop device", failure_status])
 
         expect { service.perform_node_stage_volume(req_id, pvc, req, nil) }.to raise_error("Failed to setup loop device: Error setting up loop device")
       end
 
       it "handles empty loop device output" do
         expect(service).to receive(:find_loop_device).and_return(nil)
-        expect(service).to receive(:run_cmd).with("losetup", "--find", "--show", backing_file, req_id:).and_return(["", true])
+        expect(service).to receive(:run_cmd).with("losetup", "--find", "--show", backing_file, req_id:).and_return(["", success_status])
 
         expect { service.perform_node_stage_volume(req_id, pvc, req, nil) }.to raise_error("Failed to setup loop device: ")
       end
@@ -312,7 +314,7 @@ RSpec.describe Csi::V1::NodeService do
         expect(FileUtils).to receive(:mkdir_p).with(staging_path)
         expect(service).to receive(:find_loop_device).and_return("/dev/loop1")
         expect(service).to receive(:find_file_system).with("/dev/loop1", req_id: "test-req-id").and_return("ext4")
-        expect(service).to receive(:run_cmd).with("mount", "/dev/loop1", staging_path, req_id:).and_return(["", true])
+        expect(service).to receive(:run_cmd).with("mount", "/dev/loop1", staging_path, req_id:).and_return(["", success_status])
 
         service.perform_node_stage_volume(req_id, pvc, req, nil)
       end
@@ -330,6 +332,15 @@ RSpec.describe Csi::V1::NodeService do
 
         req.volume_capability.mount = nil
         expect(service).not_to receive(:find_file_system)
+        service.perform_node_stage_volume(req_id, pvc, req, nil)
+      end
+
+      it "formats a device that blkid reports as carrying no filesystem" do
+        expect(FileUtils).to receive(:mkdir_p).with(staging_path)
+        expect(service).to receive(:find_file_system).with("/dev/loop0", req_id:).and_call_original
+        expect(service).to receive(:run_cmd).with("blkid", "-o", "value", "-s", "TYPE", "/dev/loop0", req_id:).and_return(["", no_filesystem_status])
+        expect(service).to receive(:run_cmd).with("mkfs.ext4", "/dev/loop0", req_id:).and_return(["", success_status])
+
         service.perform_node_stage_volume(req_id, pvc, req, nil)
       end
 
@@ -372,8 +383,8 @@ RSpec.describe Csi::V1::NodeService do
           find_loop_device: nil,  # New loop device
           find_file_system: "",
         )
-        expect(service).to receive(:run_cmd).with("losetup", "--find", "--show", backing_file, req_id:).and_return(["/dev/loop0", true])
-        expect(service).to receive(:run_cmd).with("mkfs.ext4", "/dev/loop0", req_id:).and_return(["mkfs error", false])
+        expect(service).to receive(:run_cmd).with("losetup", "--find", "--show", backing_file, req_id:).and_return(["/dev/loop0", success_status])
+        expect(service).to receive(:run_cmd).with("mkfs.ext4", "/dev/loop0", req_id:).and_return(["mkfs error", failure_status])
 
         expect { service.perform_node_stage_volume(req_id, pvc, req, nil) }.to raise_error("Failed to format device /dev/loop0 with ext4: mkfs error")
       end
@@ -385,7 +396,7 @@ RSpec.describe Csi::V1::NodeService do
           is_mounted?: false,
         )
         expect(FileUtils).to receive(:mkdir_p).with(staging_path)
-        expect(service).to receive(:run_cmd).with("mount", "/dev/loop0", staging_path, req_id:).and_return(["mount error", false])
+        expect(service).to receive(:run_cmd).with("mount", "/dev/loop0", staging_path, req_id:).and_return(["mount error", failure_status])
 
         expect { service.perform_node_stage_volume(req_id, pvc, req, nil) }.to raise_error("Failed to mount /dev/loop0 to /var/lib/kubelet/plugins/kubernetes.io/csi/pv/test-pv/globalmount: mount error")
       end
@@ -511,8 +522,6 @@ RSpec.describe Csi::V1::NodeService do
         "metadata" => {"annotations" => {"csi.ubicloud.com/old-pvc-object" => "base64-blob"}},
         "spec" => {"persistentVolumeReclaimPolicy" => "Delete"},
       }
-      success_status = instance_double(Process::Status, success?: true)
-
       expect(Open3).to receive(:capture2e).with(
         "kubectl", "get", "pv", "old-pv-123", "-oyaml", stdin_data: nil,
       ).and_return([YAML.dump(pv), success_status])
@@ -667,6 +676,7 @@ RSpec.describe Csi::V1::NodeService do
       expect(client).to receive(:node_schedulable?).with(service.node_id).and_return(true)
       expect(service).to receive(:remove_loop_device)
       expect(service).to receive(:is_mounted?).with(req.staging_target_path, req_id: "test-req-id").and_return(true)
+      expect(service).to receive(:run_cmd).with("umount", "-q", req.staging_target_path, req_id:).and_return(["", success_status])
 
       result = service.node_unstage_volume(req, nil)
       expect(result).to eq(response)
@@ -677,6 +687,7 @@ RSpec.describe Csi::V1::NodeService do
       expect(service).to receive(:prepare_data_migration).with(client, "test-req-id", "vol-test-123")
       expect(service).to receive(:remove_loop_device)
       expect(service).to receive(:is_mounted?).with(req.staging_target_path, req_id:).and_return(true)
+      expect(service).to receive(:run_cmd).with("umount", "-q", req.staging_target_path, req_id:).and_return(["", success_status])
 
       result = service.node_unstage_volume(req, nil)
       expect(result).to eq(response)
@@ -692,7 +703,7 @@ RSpec.describe Csi::V1::NodeService do
       expect(client).to receive(:node_schedulable?).with(service.node_id).and_return(true)
       expect(service).to receive(:remove_loop_device)
       expect(service).to receive(:is_mounted?).with("/var/lib/kubelet/plugins/kubernetes.io/csi/pv/vol-test-123/globalmount", req_id:).and_return(true)
-      expect(service).to receive(:run_cmd).with("umount", "-q", "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/vol-test-123/globalmount", req_id:).and_return(["umount: device is busy", false])
+      expect(service).to receive(:run_cmd).with("umount", "-q", "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/vol-test-123/globalmount", req_id:).and_return(["umount: device is busy", failure_status])
 
       expect { service.node_unstage_volume(req, nil) }.to raise_error(GRPC::Internal, "13:Failed to unmount /var/lib/kubelet/plugins/kubernetes.io/csi/pv/vol-test-123/globalmount: umount: device is busy")
     end
@@ -763,7 +774,7 @@ RSpec.describe Csi::V1::NodeService do
 
     it "unpublishes a mounted volume successfully" do
       expect(service).to receive(:is_mounted?).with(target_path, req_id:).and_return(true)
-      expect(service).to receive(:run_cmd).with("umount", "-q", target_path, req_id:).and_return(["", true])
+      expect(service).to receive(:run_cmd).with("umount", "-q", target_path, req_id:).and_return(["", success_status])
 
       result = service.node_unpublish_volume(req, nil)
 
@@ -780,7 +791,7 @@ RSpec.describe Csi::V1::NodeService do
 
     it "handles umount failure" do
       expect(service).to receive(:is_mounted?).with(target_path, req_id:).and_return(true)
-      expect(service).to receive(:run_cmd).with("umount", "-q", target_path, req_id:).and_return(["umount error", false])
+      expect(service).to receive(:run_cmd).with("umount", "-q", target_path, req_id:).and_return(["umount error", failure_status])
 
       expect { service.node_unpublish_volume(req, nil) }.to raise_error(GRPC::Internal, "13:Failed to unmount /var/lib/kubelet/pods/pod-123/volumes/kubernetes.io~csi/vol-test-123/mount: umount error")
     end
@@ -809,7 +820,7 @@ RSpec.describe Csi::V1::NodeService do
     it "publishes a volume successfully" do
       expect(service).to receive(:is_mounted?).with(target_path, req_id:).and_return(false)
       expect(FileUtils).to receive(:mkdir_p).with(target_path)
-      expect(service).to receive(:run_cmd).with("mount", "--bind", staging_path, target_path, req_id: "test-req-id").and_return(["", true])
+      expect(service).to receive(:run_cmd).with("mount", "--bind", staging_path, target_path, req_id: "test-req-id").and_return(["", success_status])
 
       result = service.node_publish_volume(req, nil)
 
@@ -819,7 +830,7 @@ RSpec.describe Csi::V1::NodeService do
     it "handles bind mount failure" do
       expect(service).to receive(:is_mounted?).with(target_path, req_id:).and_return(false)
       expect(FileUtils).to receive(:mkdir_p).with(target_path)
-      expect(service).to receive(:run_cmd).with("mount", "--bind", staging_path, target_path, req_id: "test-req-id").and_return(["mount error", false])
+      expect(service).to receive(:run_cmd).with("mount", "--bind", staging_path, target_path, req_id: "test-req-id").and_return(["mount error", failure_status])
 
       expect { service.node_publish_volume(req, nil) }.to raise_error(GRPC::Internal, "13:Failed to bind mount /var/lib/kubelet/plugins/kubernetes.io/csi/pv/vol-test-123/globalmount to /var/lib/kubelet/pods/pod-123/volumes/kubernetes.io~csi/vol-test-123/mount: mount error")
     end

--- a/kubernetes/csi/spec/csi/v1/node_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/node_service_spec.rb
@@ -602,7 +602,10 @@ RSpec.describe Csi::V1::NodeService do
 
       # First call is the check, second call is the run
       expect(service).to receive(:run_cmd_output).with("nsenter", "-t", "1", "-a", "/home/ubi/common/bin/daemonizer2", "check", "copy_old-pv-123", req_id:).and_return("NotStarted")
-      expect(service).to receive(:run_cmd_output).with("nsenter", "-t", "1", "-a", "/home/ubi/common/bin/daemonizer2", "run", any_args, req_id:)
+      expect(service).to receive(:run_cmd_output).with("nsenter", "-t", "1", "-a", "/home/ubi/common/bin/daemonizer2", "run", "copy_old-pv-123",
+        "rsync", "-az", "--sparse", "--inplace", "--compress-level=9", "--partial", "--whole-file",
+        "-e", "ssh -T -c aes128-gcm@openssh.com -o Compression=no -x -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/ubi/.ssh/id_ed25519",
+        "ubi@10.0.0.1:/var/lib/ubicsi/vol-old-123.img", "/var/lib/ubicsi/vol-new-123.img", req_id:)
 
       expect { service.migrate_pvc_data(req_id, client, pvc, req) }.to raise_error(CopyNotFinishedError, "Old PV data is not copied yet")
     end

--- a/kubernetes/csi/ubi-csi.gemspec
+++ b/kubernetes/csi/ubi-csi.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "ubi-csi"
-  spec.version = "0.14.0"
+  spec.version = "0.15.0"
   spec.authors = ["Ubicloud"]
   spec.email = ["support@ubicloud.com"]
 

--- a/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:v0.14.0
+          image: ubicloud/ubicsi:v0.15.0
           imagePullPolicy: IfNotPresent
           args: ["node"]
           env:

--- a/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:v0.14.0
+          image: ubicloud/ubicsi:v0.15.0
           imagePullPolicy: IfNotPresent
           args: ["controller"]
           env:


### PR DESCRIPTION
**Check command exit status in Ubicsi node service**
run_cmd returns [output, Process::Status], but node_service bound the status as
`ok` and tested `unless ok`. Process::Status is truthy on failure too, so every one of those checks was dead: a failing mkfs, mount, fallocate or losetup left NodeStageVolume returning success with nothing mounted. Use status.success? throughout, as the other services already do.

blkid is the one command here whose non-zero exit is routine: it exits 2 with no output when the device carries no filesystem, which is how find_file_system detects a backing file that still needs mkfs. Treat that code as "no filesystem" and raise only for the rest.

The specs stubbed run_cmd with bare true/false, which is falsy on failure and so passed either way; they return instance_double(Process::Status) now. The unformatted-device example also stubbed blkid as succeeding, so nothing covered the fresh-volume path through run_cmd.

**Improve control-plane node detection in select_worker_topology**
Select control-plane nodes with the node-role.kubernetes.io/control-plane label selector instead of matching the "kc" name prefix.

**Preserve sparseness when copying backing files during migration**
rsync writes every zero region without --sparse, so a migrated backing file lands fully allocated on the destination: a 10GiB volume holding 32MB consumes the full 10GiB and costs 10GiB of write I/O to get there. It stays that way, because fetch_and_migrate_pvc runs before perform_node_stage_volume, whose fallocate and punch-hole are skipped once rsync has created the file.

The transfer itself was never the problem; -z --compress-level=9 already sends only the literal data.

All production nodes were checked to run an rsync that supports combining
--sparse with --inplace.

**Bump Ubicsi version**