### PR TITLE
Handle MS_UNAVAILABLE result when trying to validate vat

### DIFF
--- a/model/billing_info.rb
+++ b/model/billing_info.rb
@@ -63,6 +63,8 @@ class BillingInfo < Sequel::Model
       true
     when "INVALID", "INVALID_INPUT"
       false
+    when "MS_UNAVAILABLE"
+      nil
     else
       fail "Unexpected response from VAT service: #{status}"
     end

--- a/prog/validate_vat.rb
+++ b/prog/validate_vat.rb
@@ -6,7 +6,9 @@ class Prog::ValidateVat < Prog::Base
   subject_is :billing_info
 
   label def start
-    billing_info.update(valid_vat: billing_info.validate_vat)
+    valid_vat = billing_info.validate_vat
+    nap(60 * 60) if valid_vat.nil?
+    billing_info.update(valid_vat:)
 
     if !billing_info.valid_vat && (email = billing_info.email || billing_info.project.accounts.first&.email || Config.invalid_vat_notification_email)
       Util.send_email(email, "Your VAT number could not be verified",

--- a/spec/model/billing_info_spec.rb
+++ b/spec/model/billing_info_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe BillingInfo do
       expect(billing_info.validate_vat).to be false
     end
 
+    it "returns nil if VAT number cannot be determined" do
+      stub_request(:get, "https://ec.europa.eu/taxation_customs/vies/rest-api/ms/NL/vat/123123").to_return(status: 200, body: {userError: "MS_UNAVAILABLE"}.to_json)
+      expect(billing_info).to receive(:stripe_data).and_return({"country" => "NL", "tax_id" => 123123}).at_least(:once)
+      expect(billing_info.validate_vat).to be_nil
+    end
+
     it "converts country code to VAT code for Greece" do
       stub_request(:get, "https://ec.europa.eu/taxation_customs/vies/rest-api/ms/EL/vat/123123").to_return(status: 200, body: {userError: "VALID"}.to_json)
       expect(billing_info).to receive(:stripe_data).and_return({"country" => "GR", "tax_id" => 123123}).at_least(:once)

--- a/spec/prog/validate_vat_spec.rb
+++ b/spec/prog/validate_vat_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe Prog::ValidateVat do
   end
 
   describe "#start" do
+    it "naps if VAT cannot be determined" do
+      expect(billing_info).to receive(:validate_vat).and_return(nil)
+      expect { vv.start }.to nap(60 * 60)
+    end
+
     it "pops after validating VAT" do
       expect(billing_info).to receive(:validate_vat).and_return(true)
       expect {


### PR DESCRIPTION
Instead of having BillingInfo#validate_vat raise in this case, have it return nil, and have the prog recognize a nil value and nap for an hour.