### PR TITLE
Add labels to nodepool nodes

### DIFF
--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -246,6 +246,7 @@ class Prog::Kubernetes::ProvisionKubernetesNode < Prog::Base
         discovery_token_ca_cert_hash: cp_sshable.cmd("sudo kubeadm token create --print-join-command", log: false)[/discovery-token-ca-cert-hash (\S+)/, 1],
         node_ipv4: vm.private_ipv4,
         node_ipv6: vm.ip6,
+        node_labels: {"ubicloud.com/nodepool" => kubernetes_nodepool.ubid},
       }
       vm.sshable.d_run("join_worker", "kubernetes/bin/join-node", stdin: JSON.generate(params), log: false)
       nap 15

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -52,6 +52,17 @@ class Prog::Test::Kubernetes < Prog::Test::KubernetesBase
       self.fail_message = "node #{missing_nodes.join(", ")} not found in cluster"
       hop_destroy_kubernetes
     end
+    hop_test_nodepool_label
+  end
+
+  label def test_nodepool_label
+    nodepool_ubid = nodepool.ubid
+    labeled_nodes = kubernetes_cluster.client.kubectl("get nodes -l ubicloud.com/nodepool=:nodepool_ubid -o name", nodepool_ubid:).split.map! { it.delete_prefix("node/") }.sort!
+    expected_nodes = nodepool.nodes.map(&:name).sort!
+    if labeled_nodes != expected_nodes
+      self.fail_message = "nodes labeled with nodepool #{nodepool_ubid} are #{labeled_nodes.join(", ")}, expected #{expected_nodes.join(", ")}"
+      hop_destroy_kubernetes
+    end
     hop_test_csi
   end
 

--- a/rhizome/kubernetes/bin/join-node
+++ b/rhizome/kubernetes/bin/join-node
@@ -17,6 +17,8 @@ begin
   node_ipv6 = params.fetch("node_ipv6")
   if is_control_plane
     certificate_key = params.fetch("certificate_key")
+  else
+    node_labels = params.fetch("node_labels")
   end
 rescue KeyError => e
   puts "Needed #{e.key} in parameters"
@@ -51,6 +53,11 @@ if is_control_plane
       "advertiseAddress" => node_ipv4,
       "bindPort" => 6443,
     },
+  }
+else
+  config["nodeRegistration"]["kubeletExtraArgs"] << {
+    "name" => "node-labels",
+    "value" => node_labels.map { |k, v| "#{k}=#{v}" }.join(","),
   }
 end
 

--- a/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
+++ b/spec/prog/kubernetes/provision_kubernetes_node_spec.rb
@@ -444,6 +444,7 @@ RSpec.describe Prog::Kubernetes::ProvisionKubernetesNode do
           discovery_token_ca_cert_hash: "dtcch",
           node_ipv4: "172.19.145.65",
           node_ipv6: "2001:db8:85a3:73f2:1c4a::2",
+          node_labels: {"ubicloud.com/nodepool" => kubernetes_nodepool.ubid},
         }),
         log: false,
       )

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -112,11 +112,11 @@ RSpec.describe Prog::Test::Kubernetes do
   end
 
   describe "#test_nodes" do
-    it "succeeds and hops to test_csi" do
+    it "succeeds and hops to test_nodepool_label" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("NAME      STATUS   ROLES           AGE     VERSION\ncp-node   Ready    control-plane   7m47s   v1.34.0\nw1-node   Ready    control-plane   7m47s   v1.34.0\nw2-node   Ready    control-plane   7m47s   v1.34.0\n", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes").and_return(response)
 
-      expect { kubernetes_test.test_nodes }.to hop("test_csi")
+      expect { kubernetes_test.test_nodes }.to hop("test_nodepool_label")
     end
 
     it "fails and hops to destroy_kubernetes with fail message" do
@@ -132,6 +132,25 @@ RSpec.describe Prog::Test::Kubernetes do
 
       expect { kubernetes_test.test_nodes }.to hop("destroy_kubernetes")
       expect(kubernetes_test.strand.stack[0]["fail_message"]).to eq "node w1-node not found in cluster"
+    end
+  end
+
+  describe "#test_nodepool_label" do
+    let(:nodepool) { kubernetes_test.nodepool }
+
+    it "hops to test_csi when every nodepool node carries the nodepool label" do
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("node/w1-node\nnode/w2-node\n", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -l ubicloud.com/nodepool=#{nodepool.ubid} -o name").and_return(response)
+
+      expect { kubernetes_test.test_nodepool_label }.to hop("test_csi")
+    end
+
+    it "fails and hops to destroy_kubernetes when a nodepool node is missing the label" do
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("node/w1-node\n", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get nodes -l ubicloud.com/nodepool=#{nodepool.ubid} -o name").and_return(response)
+
+      expect { kubernetes_test.test_nodepool_label }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack[0]["fail_message"]).to eq "nodes labeled with nodepool #{nodepool.ubid} are w1-node, expected w1-node, w2-node"
     end
   end
 


### PR DESCRIPTION
**Label nodepool worker nodes with the nodepool ubid**
Workers joining via join-node now pass node_labels, which becomes the kubelet --node-labels argument, so each node carries ubicloud.com/nodepool=<nodepool ubid> from registration. Customers can use it as a nodeSelector to pin workloads to a nodepool.

Only nodes joined after this change get the label; existing nodes are left untouched.

**Verify nodepool label on worker nodes in the kubernetes e2e test**
After checking all nodes joined, list nodes selected by ubicloud.com/nodepool=<nodepool ubid> and require the set to match the nodepool's nodes exactly.