### PR TITLE
Improve csi provisioner bookkeeping

### DIFF
--- a/kubernetes/csi/Gemfile.lock
+++ b/kubernetes/csi/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ubi-csi (0.15.0)
+    ubi-csi (0.16.0)
       base64
       grpc (= 1.83.0)
       grpc-tools (= 1.83.0)

--- a/kubernetes/csi/lib/ubi_csi.rb
+++ b/kubernetes/csi/lib/ubi_csi.rb
@@ -5,7 +5,7 @@ require "csi_pb"
 require "csi_services_pb"
 
 module Csi
-  VERSION = "0.15.0"
+  VERSION = "0.16.0"
 end
 
 require_relative "ubi_csi/identity_service"

--- a/kubernetes/csi/lib/ubi_csi/capacity_manager.rb
+++ b/kubernetes/csi/lib/ubi_csi/capacity_manager.rb
@@ -168,7 +168,7 @@ module Csi
       client = kubernetes_client
       hostnames = client.list_csi_nodes_with_driver
       storage_classes = client.list_storage_classes_for_driver
-      existing_objects = client.list_csi_storage_capacities
+      existing_objects = client.list_csi_storage_capacities(owner_uid: @owner_ref["uid"])
       pvs_by_host = client.list_driver_pvs.group_by { |pv| pv[:node] }
 
       existing_by_key = existing_objects.to_h do |obj|
@@ -203,6 +203,7 @@ module Csi
 
       @mutex.synchronize do
         @known.delete_if { |host, _| !hostnames.include?(host) }
+        @known.each_value { |bucket| bucket.delete_if { |sc, _| !storage_classes.include?(sc) } }
         @pending.delete_if { |host, _| !hostnames.include?(host) }
       end
     end

--- a/kubernetes/csi/lib/ubi_csi/capacity_manager.rb
+++ b/kubernetes/csi/lib/ubi_csi/capacity_manager.rb
@@ -194,11 +194,15 @@ module Csi
         end
       end
 
-      existing_by_key.each do |key, obj|
-        next if expected_keys.include?(key)
-        name = obj.dig("metadata", "name")
-        @logger.info("[CapacityManager] Deleting orphaned CSIStorageCapacity #{name}")
-        client.delete_csi_storage_capacity(name:)
+      # An empty host list is a rolling update with the node plugins
+      # re-registering, not a cluster with no nodes.
+      unless hostnames.empty?
+        existing_by_key.each do |key, obj|
+          next if expected_keys.include?(key)
+          name = obj.dig("metadata", "name")
+          @logger.info("[CapacityManager] Deleting orphaned CSIStorageCapacity #{name}")
+          client.delete_csi_storage_capacity(name:)
+        end
       end
 
       @mutex.synchronize do

--- a/kubernetes/csi/lib/ubi_csi/capacity_manager.rb
+++ b/kubernetes/csi/lib/ubi_csi/capacity_manager.rb
@@ -41,6 +41,10 @@ module Csi
     # How often the background thread re-baselines capacity from disk.
     RECONCILE_INTERVAL_SECONDS = 30
 
+    # A node plugin restart drops its CSINode entry for a few seconds,
+    # which must not look like a removed node.
+    ORPHAN_RECONCILES_BEFORE_DELETE = 3
+
     # A single `find` feeds both the uncommitted total and the staged-id
     # list, so the two can never disagree about a file that appears or
     # vanishes between scans.
@@ -99,6 +103,7 @@ module Csi
       @reserve_percent = reserve_percent
       @pending = {}  # hostname => {vol_id => {size:, created_at:}}
       @known = {}    # hostname => {storage_class => {object_name:, base_capacity:, last_published:}}
+      @orphaned = Hash.new(0)  # [hostname, storage_class] => consecutive reconciles seen unexpected
       @mutex = Mutex.new
       @queue = Queue.new
       @shutdown = false
@@ -194,15 +199,15 @@ module Csi
         end
       end
 
-      # An empty host list is a rolling update with the node plugins
-      # re-registering, not a cluster with no nodes.
-      unless hostnames.empty?
-        existing_by_key.each do |key, obj|
-          next if expected_keys.include?(key)
-          name = obj.dig("metadata", "name")
-          @logger.info("[CapacityManager] Deleting orphaned CSIStorageCapacity #{name}")
-          client.delete_csi_storage_capacity(name:)
-        end
+      @orphaned.delete_if { |key, _| expected_keys.include?(key) || !existing_by_key.key?(key) }
+      existing_by_key.each do |key, obj|
+        next if expected_keys.include?(key)
+        count = @orphaned[key] += 1
+        next if count < ORPHAN_RECONCILES_BEFORE_DELETE
+        name = obj.dig("metadata", "name")
+        @logger.info("[CapacityManager] Deleting orphaned CSIStorageCapacity #{name}")
+        client.delete_csi_storage_capacity(name:)
+        @orphaned.delete(key)
       end
 
       @mutex.synchronize do

--- a/kubernetes/csi/lib/ubi_csi/kubernetes_client.rb
+++ b/kubernetes/csi/lib/ubi_csi/kubernetes_client.rb
@@ -185,13 +185,11 @@ module Csi
       end
     end
 
-    # Returns CSIStorageCapacity objects in the controller's namespace
-    # that belong to a StorageClass for our driver.
-    def list_csi_storage_capacities
-      ubi_scs = list_storage_classes_for_driver
-      return [] if ubi_scs.empty?
+    def list_csi_storage_capacities(owner_uid:)
       list = yaml_load_kubectl("-n", CSI_NAMESPACE, "get", "csistoragecapacities")
-      list["items"].select { |obj| ubi_scs.include?(obj["storageClassName"]) }
+      list["items"].select do |obj|
+        obj.dig("metadata", "ownerReferences")&.any? { |ref| ref["uid"] == owner_uid }
+      end
     end
 
     def create_csi_storage_capacity(name:, hostname:, storage_class:, capacity_bytes:, max_volume_size:, owner_ref: nil)

--- a/kubernetes/csi/lib/ubi_csi/node_service.rb
+++ b/kubernetes/csi/lib/ubi_csi/node_service.rb
@@ -121,18 +121,28 @@ module Csi
           client = KubernetesClient.new(req_id:, logger: @logger)
           pvc = fetch_and_migrate_pvc(req_id, client, req)
           perform_node_stage_volume(req_id, pvc, req, _call)
-          roll_back_reclaim_policy(req_id, client, req, pvc)
-          remove_old_pv_annotation_from_pvc(req_id, client, pvc)
+          if pvc
+            roll_back_reclaim_policy(req_id, client, req, pvc)
+            remove_old_pv_annotation_from_pvc(req_id, client, pvc)
+          end
           NodeStageVolumeResponse.new
         rescue => e
           log_and_raise(req_id, e)
         end
       end
 
+      # volume_context names the claim the PV was provisioned for, not the
+      # one it is bound to now, so read the claim from the PV itself.
       def fetch_and_migrate_pvc(req_id, client, req)
-        pvc_namespace = req.volume_context["csi.storage.k8s.io/pvc/namespace"]
-        pvc_name = req.volume_context["csi.storage.k8s.io/pvc/name"]
-        pvc = client.get_pvc(pvc_namespace, pvc_name)
+        claim_ref = client.find_pv_by_volume_id(req.volume_id).dig("spec", "claimRef")
+        return unless claim_ref
+        pvc_namespace, pvc_name = claim_ref.values_at("namespace", "name")
+        begin
+          pvc = client.get_pvc(pvc_namespace, pvc_name)
+        rescue ObjectNotFoundError
+          log_with_id(req_id, "Claim #{pvc_namespace}/#{pvc_name} is gone, nothing to migrate")
+          return
+        end
         if pvc_needs_migration?(pvc)
           migrate_pvc_data(req_id, client, pvc, req)
 

--- a/kubernetes/csi/spec/csi/v1/identity_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/identity_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Csi::V1::IdentityService do
       request = Csi::V1::GetPluginInfoRequest.new
       response = service.get_plugin_info(request, call)
       expect(response.name).to eq("csi.ubicloud.com")
-      expect(response.vendor_version).to eq("0.15.0")
+      expect(response.vendor_version).to eq("0.16.0")
     end
   end
 

--- a/kubernetes/csi/spec/csi/v1/node_service_spec.rb
+++ b/kubernetes/csi/spec/csi/v1/node_service_spec.rb
@@ -182,17 +182,16 @@ RSpec.describe Csi::V1::NodeService do
   end
 
   describe "#fetch_and_migrate_pvc" do
-    let(:req) do
-      Csi::V1::NodeStageVolumeRequest.new(
-        volume_context: {
-          "csi.storage.k8s.io/pvc/namespace" => "default",
-          "csi.storage.k8s.io/pvc/name" => "test-pvc",
-        },
-      )
+    # No claim in volume_context: the PV's claimRef is the only source.
+    let(:req) { Csi::V1::NodeStageVolumeRequest.new(volume_id: "vol-test-123", volume_context: {"size_bytes" => "1073741824"}) }
+    let(:bound_pv) do
+      {"metadata" => {"name" => "pvc-abc", "annotations" => {}},
+       "spec" => {"persistentVolumeReclaimPolicy" => "Delete", "csi" => {"driver" => "csi.ubicloud.com", "volumeHandle" => "vol-test-123"}, "claimRef" => {"namespace" => "default", "name" => "test-pvc"}}}
     end
 
     it "migrates PVC data when migration is needed" do
       pvc_with_migration = {"metadata" => {"annotations" => {"csi.ubicloud.com/old-pv-name" => "old-pv"}}}
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).and_return([YAML.dump({"items" => [bound_pv]}), success_status])
       expect(Open3).to receive(:capture2e).with("kubectl", "-n", "default", "get", "pvc", "test-pvc", "-oyaml", stdin_data: nil).and_return([YAML.dump(pvc_with_migration), success_status])
       expect(service).to receive(:migrate_pvc_data).with(req_id, client, pvc_with_migration, req)
 
@@ -202,27 +201,37 @@ RSpec.describe Csi::V1::NodeService do
 
     it "does not migrate PVC data when not needed and no retained PV exists" do
       pvc_without_migration = {"metadata" => {"annotations" => {}}}
-      pv_list = {"items" => [
-        {"metadata" => {"name" => "pvc-abc", "annotations" => {}},
-         "spec" => {"persistentVolumeReclaimPolicy" => "Delete", "claimRef" => {"namespace" => "default", "name" => "test-pvc"}}},
-      ]}
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).twice.and_return([YAML.dump({"items" => [bound_pv]}), success_status])
       expect(Open3).to receive(:capture2e).with("kubectl", "-n", "default", "get", "pvc", "test-pvc", "-oyaml", stdin_data: nil).and_return([YAML.dump(pvc_without_migration), success_status])
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).and_return([YAML.dump(pv_list), success_status])
       expect(service).not_to receive(:migrate_pvc_data)
 
       result = service.fetch_and_migrate_pvc(req_id, client, req)
       expect(result).to eq(pvc_without_migration)
     end
 
+    it "returns nil without a PVC lookup when the PV is bound to no claim" do
+      bound_pv["spec"].delete("claimRef")
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).and_return([YAML.dump({"items" => [bound_pv]}), success_status])
+
+      expect(service.fetch_and_migrate_pvc(req_id, client, req)).to be_nil
+    end
+
+    it "returns nil when the claim in the PV's claimRef no longer exists" do
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).and_return([YAML.dump({"items" => [bound_pv]}), success_status])
+      expect(Open3).to receive(:capture2e).with("kubectl", "-n", "default", "get", "pvc", "test-pvc", "-oyaml", stdin_data: nil).and_return(['persistentvolumeclaims "test-pvc" not found', failure_status])
+
+      expect(service.fetch_and_migrate_pvc(req_id, client, req)).to be_nil
+    end
+
     it "migrates PVC data via fallback when PVC lacks annotation but retained PV exists" do
       pvc_without_annotation = {"metadata" => {"namespace" => "default", "name" => "test-pvc", "annotations" => {}}}
       retained_pv = {"metadata" => {"name" => "old-pv-123", "annotations" => {"csi.ubicloud.com/old-pvc-object" => "data"}},
                      "spec" => {"persistentVolumeReclaimPolicy" => "Retain", "claimRef" => {"namespace" => "default", "name" => "test-pvc"}}}
-      pv_list = {"items" => [retained_pv]}
+      pv_list = {"items" => [bound_pv, retained_pv]}
       pvc_annotation_patch = {metadata: {annotations: {"csi.ubicloud.com/old-pv-name" => "old-pv-123"}}}.to_json
 
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).twice.and_return([YAML.dump(pv_list), success_status])
       expect(Open3).to receive(:capture2e).with("kubectl", "-n", "default", "get", "pvc", "test-pvc", "-oyaml", stdin_data: nil).and_return([YAML.dump(pvc_without_annotation), success_status])
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).and_return([YAML.dump(pv_list), success_status])
       expect(Open3).to receive(:capture2e).with("kubectl", "-n", "default", "patch", "pvc", "test-pvc", "--type=merge", "-p", pvc_annotation_patch, stdin_data: nil).and_return(["patched", success_status])
       expected_pvc = {"metadata" => {"namespace" => "default", "name" => "test-pvc", "annotations" => {"csi.ubicloud.com/old-pv-name" => "old-pv-123"}}}
       expect(service).to receive(:migrate_pvc_data).with(req_id, client, expected_pvc, req)
@@ -434,6 +443,16 @@ RSpec.describe Csi::V1::NodeService do
 
       result = service.node_stage_volume(req, nil)
       expect(result).to eq(response)
+    end
+
+    it "stages a volume without PVC lookups or patches when the PV is bound to no claim" do
+      unbound_pv = {"metadata" => {"name" => "test-pv"}, "spec" => {"csi" => {"driver" => "csi.ubicloud.com", "volumeHandle" => "vol-test-123"}}}
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).and_return([YAML.dump({"items" => [unbound_pv]}), success_status])
+      expect(service).to receive(:perform_node_stage_volume).with(req_id, nil, req, nil).and_return(response)
+      expect(service).not_to receive(:roll_back_reclaim_policy)
+      expect(service).not_to receive(:remove_old_pv_annotation_from_pvc)
+
+      expect(service.node_stage_volume(req, nil)).to eq(response)
     end
 
     it "re raises error" do

--- a/kubernetes/csi/spec/ubi_csi/capacity_manager_spec.rb
+++ b/kubernetes/csi/spec/ubi_csi/capacity_manager_spec.rb
@@ -423,6 +423,23 @@ RSpec.describe Csi::CapacityManager do
       expect(manager.reserve(hostname: "worker-1", vol_id: "vol-b", size_bytes: 1_000_000_000)).to be true
     end
 
+    it "skips the orphan pass while no node has the driver registered" do
+      existing = [{
+        "metadata" => {"name" => "csisc-worker-1-ubicloud-standard", "ownerReferences" => [{"uid" => "deploy-uid"}]},
+        "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
+        "storageClassName" => "ubicloud-standard",
+        "capacity" => "20Gi",
+        "maximumVolumeSize" => "10Gi",
+      }]
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "csinodes", "-oyaml", stdin_data: nil).and_return([YAML.dump({"items" => []}), success_status])
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "storageclasses", "-oyaml", stdin_data: nil).and_return([storageclasses_yaml, success_status])
+      expect(Open3).to receive(:capture2e).with("kubectl", "-n", "ubicsi", "get", "csistoragecapacities", "-oyaml", stdin_data: nil).and_return([YAML.dump({"items" => existing}), success_status])
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).and_return([pvs_yaml, success_status])
+      expect(manager.kubernetes_client).not_to receive(:delete_csi_storage_capacity)
+
+      manager.reconcile
+    end
+
     it "drops pending entries whose vol_id has been staged" do
       manager.instance_variable_set(:@pending, {"worker-1" => {"vol-a" => {size: 5_000_000, created_at: Time.now}}})
       stub_baseline

--- a/kubernetes/csi/spec/ubi_csi/capacity_manager_spec.rb
+++ b/kubernetes/csi/spec/ubi_csi/capacity_manager_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Csi::CapacityManager do
         "metadata" => {
           "name" => "csisc-worker-1-ubicloud-standard",
           "namespace" => "ubicsi",
-          "ownerReferences" => [{"name" => "ubicsi-provisioner"}],
+          "ownerReferences" => [{"name" => "ubicsi-provisioner", "uid" => "deploy-uid"}],
         },
         "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
         "storageClassName" => "ubicloud-standard",
@@ -260,12 +260,12 @@ RSpec.describe Csi::CapacityManager do
     end
 
     before do
-      manager.instance_variable_set(:@owner_ref, {"name" => "ubicsi-provisioner"})
+      manager.instance_variable_set(:@owner_ref, {"name" => "ubicsi-provisioner", "uid" => "deploy-uid"})
     end
 
     def stub_baseline(existing: [])
       expect(Open3).to receive(:capture2e).with("kubectl", "get", "csinodes", "-oyaml", stdin_data: nil).and_return([csinodes_yaml, success_status])
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "storageclasses", "-oyaml", stdin_data: nil).twice.and_return([storageclasses_yaml, success_status])
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "storageclasses", "-oyaml", stdin_data: nil).and_return([storageclasses_yaml, success_status])
       expect(Open3).to receive(:capture2e).with("kubectl", "-n", "ubicsi", "get", "csistoragecapacities", "-oyaml", stdin_data: nil).and_return([YAML.dump({"items" => existing}), success_status])
       expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).and_return([pvs_yaml, success_status])
     end
@@ -299,7 +299,7 @@ RSpec.describe Csi::CapacityManager do
     it "applies a custom reserve_percent to the capacity math" do
       # 25% reserve: base = 50 - 10 - 25 = 15 GiB = 16_106_127_360 bytes.
       custom = described_class.new(logger:, max_volume_size:, reserve_percent: 25)
-      custom.instance_variable_set(:@owner_ref, {"name" => "ubicsi-provisioner"})
+      custom.instance_variable_set(:@owner_ref, {"name" => "ubicsi-provisioner", "uid" => "deploy-uid"})
       stub_baseline
       stub_node_capacity
       expect(Open3).to receive(:capture2e).with("kubectl", "create", "-f", "-", stdin_data: YAML.dump(create_object.merge("capacity" => "16106127360"))).and_return(["created", success_status])
@@ -311,7 +311,7 @@ RSpec.describe Csi::CapacityManager do
 
     it "patches an existing object when the capacity has changed" do
       existing = [{
-        "metadata" => {"name" => "csisc-existing"},
+        "metadata" => {"name" => "csisc-existing", "ownerReferences" => [{"uid" => "deploy-uid"}]},
         "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
         "storageClassName" => "ubicloud-standard",
         "capacity" => "999",
@@ -334,7 +334,7 @@ RSpec.describe Csi::CapacityManager do
       # parse_quantity has to handle that round-trip or we'd patch every
       # reconcile (or worse, crash on Integer()).
       existing = [{
-        "metadata" => {"name" => "csisc-existing"},
+        "metadata" => {"name" => "csisc-existing", "ownerReferences" => [{"uid" => "deploy-uid"}]},
         "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
         "storageClassName" => "ubicloud-standard",
         "capacity" => "20Gi",
@@ -352,14 +352,14 @@ RSpec.describe Csi::CapacityManager do
     it "deletes orphaned objects whose (host, sc) is no longer expected" do
       existing = [
         {
-          "metadata" => {"name" => "csisc-orphan"},
+          "metadata" => {"name" => "csisc-orphan", "ownerReferences" => [{"uid" => "deploy-uid"}]},
           "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "deleted-host"}},
           "storageClassName" => "ubicloud-standard",
           "capacity" => "42",
           "maximumVolumeSize" => "42",
         },
         {
-          "metadata" => {"name" => "csisc-keep"},
+          "metadata" => {"name" => "csisc-keep", "ownerReferences" => [{"uid" => "deploy-uid"}]},
           "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
           "storageClassName" => "ubicloud-standard",
           "capacity" => "20Gi",
@@ -377,6 +377,50 @@ RSpec.describe Csi::CapacityManager do
       manager.reconcile
 
       expect(manager.instance_variable_get(:@known).keys).to eq(["worker-1"])
+    end
+
+    it "deletes the objects of a StorageClass that has disappeared and drops it from @known" do
+      manager.instance_variable_set(:@known, {
+        "worker-1" => {
+          "ubicloud-standard" => {object_name: "csisc-worker-1-ubicloud-standard", base_capacity: 999, last_published: 999},
+          "e2e-sc-1" => {object_name: "csisc-worker-1-e2e-sc-1", base_capacity: 999, last_published: 999},
+        },
+      })
+      existing = [
+        {
+          "metadata" => {"name" => "csisc-worker-1-ubicloud-standard", "ownerReferences" => [{"uid" => "deploy-uid"}]},
+          "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
+          "storageClassName" => "ubicloud-standard",
+          "capacity" => "20Gi",
+          "maximumVolumeSize" => "10Gi",
+        },
+        {
+          "metadata" => {"name" => "csisc-worker-1-e2e-sc-1", "ownerReferences" => [{"uid" => "deploy-uid"}]},
+          "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
+          "storageClassName" => "e2e-sc-1",
+          "capacity" => "20Gi",
+          "maximumVolumeSize" => "10Gi",
+        },
+      ]
+      stub_baseline(existing:)
+      stub_node_capacity
+      expect(logger).to receive(:info).with("[CapacityManager] Deleting orphaned CSIStorageCapacity csisc-worker-1-e2e-sc-1").and_call_original
+      expect(Open3).to receive(:capture2e).with(
+        "kubectl", "-n", "ubicsi", "delete", "csistoragecapacity", "csisc-worker-1-e2e-sc-1", "--ignore-not-found=true",
+        stdin_data: nil,
+      ).and_return(["deleted", success_status])
+
+      manager.reconcile
+
+      expect(manager.instance_variable_get(:@known)["worker-1"].keys).to eq(["ubicloud-standard"])
+
+      # A reserve afterwards patches only the surviving class.
+      expect(Open3).to receive(:capture2e).with(
+        "kubectl", "-n", "ubicsi", "patch", "csistoragecapacity", "csisc-worker-1-ubicloud-standard",
+        "--type=merge", "-p", '{"capacity":"20474836480","maximumVolumeSize":"10737418240"}',
+        stdin_data: nil,
+      ).and_return(["patched", success_status])
+      expect(manager.reserve(hostname: "worker-1", vol_id: "vol-b", size_bytes: 1_000_000_000)).to be true
     end
 
     it "drops pending entries whose vol_id has been staged" do
@@ -432,7 +476,7 @@ RSpec.describe Csi::CapacityManager do
     it "ignores PVs pinned to another node" do
       pvs = YAML.dump({"items" => [pv_item(volume_handle: "vol-elsewhere", storage: "5Gi", node: "worker-2")]})
       expect(Open3).to receive(:capture2e).with("kubectl", "get", "csinodes", "-oyaml", stdin_data: nil).and_return([csinodes_yaml, success_status])
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "storageclasses", "-oyaml", stdin_data: nil).twice.and_return([storageclasses_yaml, success_status])
+      expect(Open3).to receive(:capture2e).with("kubectl", "get", "storageclasses", "-oyaml", stdin_data: nil).and_return([storageclasses_yaml, success_status])
       expect(Open3).to receive(:capture2e).with("kubectl", "-n", "ubicsi", "get", "csistoragecapacities", "-oyaml", stdin_data: nil).and_return([YAML.dump({"items" => []}), success_status])
       expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).and_return([pvs, success_status])
       stub_node_capacity
@@ -443,7 +487,7 @@ RSpec.describe Csi::CapacityManager do
 
     it "keeps the existing object for a host whose capacity script fails" do
       existing = [{
-        "metadata" => {"name" => "csisc-existing"},
+        "metadata" => {"name" => "csisc-existing", "ownerReferences" => [{"uid" => "deploy-uid"}]},
         "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
         "storageClassName" => "ubicloud-standard",
         "capacity" => "20Gi",

--- a/kubernetes/csi/spec/ubi_csi/capacity_manager_spec.rb
+++ b/kubernetes/csi/spec/ubi_csi/capacity_manager_spec.rb
@@ -350,6 +350,7 @@ RSpec.describe Csi::CapacityManager do
     end
 
     it "deletes orphaned objects whose (host, sc) is no longer expected" do
+      manager.instance_variable_get(:@orphaned)[["deleted-host", "ubicloud-standard"]] = 2
       existing = [
         {
           "metadata" => {"name" => "csisc-orphan", "ownerReferences" => [{"uid" => "deploy-uid"}]},
@@ -380,6 +381,7 @@ RSpec.describe Csi::CapacityManager do
     end
 
     it "deletes the objects of a StorageClass that has disappeared and drops it from @known" do
+      manager.instance_variable_get(:@orphaned)[["worker-1", "e2e-sc-1"]] = 2
       manager.instance_variable_set(:@known, {
         "worker-1" => {
           "ubicloud-standard" => {object_name: "csisc-worker-1-ubicloud-standard", base_capacity: 999, last_published: 999},
@@ -423,21 +425,44 @@ RSpec.describe Csi::CapacityManager do
       expect(manager.reserve(hostname: "worker-1", vol_id: "vol-b", size_bytes: 1_000_000_000)).to be true
     end
 
-    it "skips the orphan pass while no node has the driver registered" do
-      existing = [{
-        "metadata" => {"name" => "csisc-worker-1-ubicloud-standard", "ownerReferences" => [{"uid" => "deploy-uid"}]},
-        "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
-        "storageClassName" => "ubicloud-standard",
-        "capacity" => "20Gi",
-        "maximumVolumeSize" => "10Gi",
-      }]
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "csinodes", "-oyaml", stdin_data: nil).and_return([YAML.dump({"items" => []}), success_status])
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "storageclasses", "-oyaml", stdin_data: nil).and_return([storageclasses_yaml, success_status])
-      expect(Open3).to receive(:capture2e).with("kubectl", "-n", "ubicsi", "get", "csistoragecapacities", "-oyaml", stdin_data: nil).and_return([YAML.dump({"items" => existing}), success_status])
-      expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).and_return([pvs_yaml, success_status])
-      expect(manager.kubernetes_client).not_to receive(:delete_csi_storage_capacity)
+    context "when a node's plugin is unregistered" do
+      let(:existing) do
+        [{
+          "metadata" => {"name" => "csisc-worker-1-ubicloud-standard", "ownerReferences" => [{"uid" => "deploy-uid"}]},
+          "nodeTopology" => {"matchLabels" => {"kubernetes.io/hostname" => "worker-1"}},
+          "storageClassName" => "ubicloud-standard",
+          "capacity" => "20Gi",
+          "maximumVolumeSize" => "10Gi",
+        }]
+      end
+      let(:no_csinodes_yaml) { YAML.dump({"items" => []}) }
 
-      manager.reconcile
+      def stub_baseline_rounds(csinodes_outputs)
+        rounds = csinodes_outputs.size
+        expect(Open3).to receive(:capture2e).with("kubectl", "get", "csinodes", "-oyaml", stdin_data: nil).exactly(rounds).times.and_return(*csinodes_outputs.map { |yaml| [yaml, success_status] })
+        expect(Open3).to receive(:capture2e).with("kubectl", "get", "storageclasses", "-oyaml", stdin_data: nil).exactly(rounds).times.and_return([storageclasses_yaml, success_status])
+        expect(Open3).to receive(:capture2e).with("kubectl", "-n", "ubicsi", "get", "csistoragecapacities", "-oyaml", stdin_data: nil).exactly(rounds).times.and_return([YAML.dump({"items" => existing}), success_status])
+        expect(Open3).to receive(:capture2e).with("kubectl", "get", "pv", "-oyaml", stdin_data: nil).exactly(rounds).times.and_return([pvs_yaml, success_status])
+      end
+
+      it "deletes its object only once it has been unexpected for three consecutive reconciles" do
+        stub_baseline_rounds([no_csinodes_yaml, no_csinodes_yaml, no_csinodes_yaml])
+        expect(logger).to receive(:info).with("[CapacityManager] Deleting orphaned CSIStorageCapacity csisc-worker-1-ubicloud-standard").and_call_original
+        expect(Open3).to receive(:capture2e).with(
+          "kubectl", "-n", "ubicsi", "delete", "csistoragecapacity", "csisc-worker-1-ubicloud-standard", "--ignore-not-found=true",
+          stdin_data: nil,
+        ).and_return(["deleted", success_status])
+
+        3.times { manager.reconcile }
+      end
+
+      it "keeps its object when the plugin registers again in between" do
+        stub_baseline_rounds([no_csinodes_yaml, no_csinodes_yaml, csinodes_yaml, no_csinodes_yaml])
+        stub_node_capacity
+        expect(manager.kubernetes_client).not_to receive(:delete_csi_storage_capacity)
+
+        4.times { manager.reconcile }
+      end
     end
 
     it "drops pending entries whose vol_id has been staged" do

--- a/kubernetes/csi/spec/ubi_csi/kubernetes_client_spec.rb
+++ b/kubernetes/csi/spec/ubi_csi/kubernetes_client_spec.rb
@@ -376,24 +376,15 @@ RSpec.describe Csi::KubernetesClient do
   end
 
   describe "#list_csi_storage_capacities" do
-    let(:sc_list) { {"items" => [{"metadata" => {"name" => "ubicloud-standard"}, "provisioner" => "csi.ubicloud.com"}]} }
-
-    it "filters CSIStorageCapacity objects to those of our StorageClasses" do
-      capacity_list = {"items" => [
-        {"metadata" => {"name" => "csisc-a"}, "storageClassName" => "ubicloud-standard"},
-        {"metadata" => {"name" => "csisc-b"}, "storageClassName" => "other-class"},
-      ]}
-      expect(client).to receive(:run_kubectl).with("get", "storageclasses", "-oyaml").and_return(YAML.dump(sc_list))
+    it "returns the objects owned by the given uid, whether or not their StorageClass still exists" do
+      owned = {"metadata" => {"name" => "csisc-a", "ownerReferences" => [{"uid" => "deploy-uid"}]}, "storageClassName" => "ubicloud-standard"}
+      owned_for_deleted_class = {"metadata" => {"name" => "csisc-b", "ownerReferences" => [{"uid" => "deploy-uid"}]}, "storageClassName" => "deleted-class"}
+      other_owner = {"metadata" => {"name" => "csisc-c", "ownerReferences" => [{"uid" => "other-uid"}]}, "storageClassName" => "ubicloud-standard"}
+      unowned = {"metadata" => {"name" => "csisc-d"}, "storageClassName" => "ubicloud-standard"}
+      capacity_list = {"items" => [owned, owned_for_deleted_class, other_owner, unowned]}
       expect(client).to receive(:run_kubectl).with("-n", "ubicsi", "get", "csistoragecapacities", "-oyaml").and_return(YAML.dump(capacity_list))
 
-      result = client.list_csi_storage_capacities
-      expect(result.map { |obj| obj["metadata"]["name"] }).to eq(["csisc-a"])
-    end
-
-    it "short-circuits to an empty list when no StorageClasses match our driver" do
-      expect(client).to receive(:run_kubectl).with("get", "storageclasses", "-oyaml").and_return(YAML.dump({"items" => []}))
-      expect(client).not_to receive(:run_kubectl)
-      expect(client.list_csi_storage_capacities).to eq([])
+      expect(client.list_csi_storage_capacities(owner_uid: "deploy-uid")).to eq([owned, owned_for_deleted_class])
     end
   end
 

--- a/kubernetes/csi/ubi-csi.gemspec
+++ b/kubernetes/csi/ubi-csi.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "ubi-csi"
-  spec.version = "0.15.0"
+  spec.version = "0.16.0"
   spec.authors = ["Ubicloud"]
   spec.email = ["support@ubicloud.com"]
 

--- a/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/nodeplugin-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:v0.15.0
+          image: ubicloud/ubicsi:v0.16.0
           imagePullPolicy: IfNotPresent
           args: ["node"]
           env:

--- a/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
+++ b/rhizome/kubernetes/manifests/ubicsi/provisioner-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: ubicsi
-          image: ubicloud/ubicsi:v0.15.0
+          image: ubicloud/ubicsi:v0.16.0
           imagePullPolicy: IfNotPresent
           args: ["controller"]
           env:


### PR DESCRIPTION
**Fix per-StorageClass bookkeeping leaks in Ubicsi CapacityManager**
reconcile only pruned @known by host, so every StorageClass the driver had ever seen stayed in @known[hostname] until restart. publish_for_host iterates that whole bucket on every reserve and release, so each CreateVolume and DeleteVolume issued one kubectl patch per class ever seen, serialized. A burst of concurrent CreateVolumes against one host then ran past the external-provisioner's 10s deadline once enough classes had come and gone.

The orphan pass could not clean up either: list_csi_storage_capacities filtered the listing to objects whose StorageClass still exists, which is exactly the set that can never be an orphan, so objects for deleted classes were never removed. Filter by ownerReference to the provisioner Deployment instead, so the existing loop deletes class-orphans within one reconcile, and prune @known[hostname] to the current class list alongside the host prune.

**Keep CSIStorageCapacity objects while Ubicsi node plugins re-register**
During a rolling update the node plugins re-register and list_csi_nodes_with_driver is briefly empty, so expected_keys was empty and reconcile deleted every capacity object as orphaned. With CSIDriver.storageCapacity=true that tells the scheduler no node has room until the next reconcile recreates them. Skip the orphan pass when the host list is empty.

**Bump Ubicsi version**