### PR TITLE
Allow 30 vCPU runners to spill over

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1862,7 +1862,7 @@ class CloverAdmin < Roda
       count_f = ->(cond) { Sequel.function(:count).*.filter(cond) }
       standard_sizes = [2, 4, 8, 16, 30, 60]
       premium_sizes = [2, 4, 8, 16, 30]
-      alien_sizes = [2, 4, 8, 16]
+      alien_sizes = [2, 4, 8, 16, 32]
 
       quota_default = ProjectQuota.default_quotas[(@arch == "arm64") ? "GithubRunnerVCpuArm" : "GithubRunnerVCpu"]
       quota_expr = Sequel.function(

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -321,7 +321,7 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
   end
 
   def support_alien?
-    label_data["vcpus"] <= 16
+    label_data["vcpus"] <= 30
   end
 
   def before_destroy

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
     end
 
     it "does not use alien vms for large vcpu runners" do
-      runner.update(label: "ubicloud-standard-30")
+      runner.update(label: "ubicloud-standard-60")
       project.set_ff_aws_alien_runners_ratio(1.0)
       picked_vm = nx.pick_vm
       expect(picked_vm.family).to eq("standard")
@@ -450,6 +450,25 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
         expect { nx.wait_concurrency_limit }.to hop("allocate_vm")
         expect(runner.spill_over_set?).to be(true)
+      end
+
+      it "spills over 30 vCPU runners" do
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpuAws", 0).and_return(true)
+        project.set_ff_spill_to_alien_runners(true)
+        runner.update(label: "ubicloud-standard-30", created_at: now - 40)
+
+        expect { nx.wait_concurrency_limit }.to hop("allocate_vm")
+        expect(runner.spill_over_set?).to be(true)
+      end
+
+      it "does not spill over 60 vCPU runners" do
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
+        project.set_ff_spill_to_alien_runners(true)
+        runner.update(label: "ubicloud-standard-60", created_at: now - 40)
+
+        expect { nx.wait_concurrency_limit }.to nap
+        expect(runner.spill_over_set?).to be(false)
       end
 
       it "allocates if standard utilization is low" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2951,7 +2951,8 @@ RSpec.describe CloverAdmin do
     GithubRunner.create(installation_id:, repository_name:, label: "ubicloud-standard-4", allocated_at: Time.now, vm_id: vm4.id, location_id: vm4.location_id)
     vm8 = create_vm(vcpus: 8, family: "m7a")
     GithubRunner.create(installation_id:, repository_name:, label: "ubicloud-standard-8", allocated_at: Time.now, vm_id: vm8.id, location_id: vm8.location_id)
-    GithubRunner.create(installation_id:, repository_name:, label: "ubicloud-standard-30")
+    vm30 = create_vm(vcpus: 32, family: "m7a", allocated_at: Time.now)
+    GithubRunner.create(installation_id:, repository_name:, label: "ubicloud-standard-30", allocated_at: Time.now, vm_id: vm30.id, location_id: vm30.location_id)
     create_vm_host(location_id: Location::GITHUB_RUNNERS_ID, family: "standard", used_cores: 12, total_cores: 48)
     create_vm_host(location_id: Location::HETZNER_FSN1_ID, family: "premium", used_cores: 12, total_cores: 24)
     create_vm(boot_image: Config.github_ubuntu_2204_x64_aws_ami_version, vcpus: 4)
@@ -2965,16 +2966,16 @@ RSpec.describe CloverAdmin do
     expect(page.all("#content td").map(&:text)).to eq [
       "TOTAL", "", "400", "100",
       "2", "1", "1", "0", "1", "0",
-      "16 / 46", "2 / 14",
+      "46 / 46", "34 / 46",
       "1", "0", "0", "0", "0", "0",
       "0", "1", "0", "0", "0",
-      "0", "0", "1", "0",
+      "0", "0", "1", "0", "1",
       "test-installation", "true", "400", "100",
       "2", "1", "1", "0", "1", "0",
-      "16 / 46", "2 / 14",
+      "46 / 46", "34 / 46",
       "1", "0", "0", "0", "0", "0",
       "0", "1", "0", "0", "0",
-      "0", "0", "1", "0",
+      "0", "0", "1", "0", "1",
     ]
 
     click_link "test-installation"
@@ -3003,13 +3004,13 @@ RSpec.describe CloverAdmin do
       "0 / 2", "0 / 0",
       "0", "0", "0", "0", "0", "0",
       "0", "0", "0", "0", "0",
-      "0", "0", "0", "0",
+      "0", "0", "0", "0", "0",
       "test-installation", "true", "100", "",
       "1", "0", "0", "0", "0", "0",
       "0 / 2", "0 / 0",
       "0", "0", "0", "0", "0", "0",
       "0", "0", "0", "0", "0",
-      "0", "0", "0", "0",
+      "0", "0", "0", "0", "0",
     ]
   end
 


### PR DESCRIPTION
- **Allow 30 vCPU runners to spill over**

Alien runner support was limited to labels with 16 vCPUs or fewer, so
30 vCPU runners had to wait for capacity on our own hosts even when
the project had AWS spill quota available. These are the labels that
wait the longest during high utilization, because few hosts have 30
free cores at once.

The rest of the path already handled them: pick_vm maps a 30 vCPU
label to a 32 vCPU instance, since AWS has no 30 vCPU size, and
update_billing_record still bills the customer for 30 vCPUs.

- **Add a32 column to the runner usage table**

Now that 30 vCPU runners spill over to AWS, the admin runner usage
table needs a column for them, or these runners disappear from the
alien counts. AWS has no 30 vCPU instance size, so they run on 32
vCPU instances, and the alien columns count instance vCPUs.
