### PR TITLE
Fix sync internal dns in kubernetes

### DIFF
--- a/model/kubernetes/kubernetes_cluster.rb
+++ b/model/kubernetes/kubernetes_cluster.rb
@@ -198,12 +198,12 @@ class KubernetesCluster < Sequel::Model
     nodes.map(&:install_rhizome)
   end
 
-  def all_nodes
-    nodes + nodepools(eager: :nodes).flat_map(&:nodes)
+  def all_nodes(eager: nil)
+    nodes(eager:) + nodepools(eager: {nodes: eager}).flat_map(&:nodes)
   end
 
-  def all_functional_nodes
-    functional_nodes + nodepools(eager: :functional_nodes).flat_map(&:functional_nodes)
+  def all_functional_nodes(eager: nil)
+    functional_nodes(eager:) + nodepools(eager: {functional_nodes: eager}).flat_map(&:functional_nodes)
   end
 
   def all_functional_nodes_ready?

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -402,7 +402,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   label def sync_internal_dns_config
     decr_sync_internal_dns_config
 
-    dns_records = kubernetes_cluster.all_functional_nodes.flat_map { |n| ["#{n.vm.private_ipv4} #{n.name}", "#{n.vm.private_ipv6} #{n.name}"] }
+    dns_records = kubernetes_cluster.all_functional_nodes(eager: {vm: :nics}).flat_map { |n| ["#{n.vm.private_ipv4} #{n.name}", "#{n.vm.private_ipv6} #{n.name}"] }
 
     client = kubernetes_cluster.client
     coredns_configmap = YAML.load(client.kubectl("-n kube-system get cm coredns -oyaml"))

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -402,7 +402,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   label def sync_internal_dns_config
     decr_sync_internal_dns_config
 
-    dns_records = kubernetes_cluster.all_functional_nodes.flat_map { |n| ["#{n.vm.ip4} #{n.name}", "#{n.vm.ip6} #{n.name}"] }
+    dns_records = kubernetes_cluster.all_functional_nodes.flat_map { |n| ["#{n.vm.private_ipv4} #{n.name}", "#{n.vm.private_ipv6} #{n.name}"] }
 
     client = kubernetes_cluster.client
     coredns_configmap = YAML.load(client.kubectl("-n kube-system get cm coredns -oyaml"))
@@ -416,8 +416,8 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
     # Example matched block (with ~8-space indent for contents):
     #     hosts {
     #         # Ubicloud Hosts
-    #         178.63.152.192 kcg0zevswgsp6hqepg9de83wwq-nz1df
-    #         178.63.152.197 knbvkn6c55gt1mfhab6znfv4j5-ukgtf
+    #         10.39.0.5 kcg0zevswgsp6hqepg9de83wwq-nz1df
+    #         10.39.0.9 knbvkn6c55gt1mfhab6znfv4j5-ukgtf
     #         # End Ubicloud Hosts
     #         fallthrough
     #     }

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -79,7 +79,7 @@ class Prog::Test::Kubernetes < Prog::Test::KubernetesBase
 
   label def test_node_dns
     client = kubernetes_cluster.client
-    kubernetes_cluster.all_nodes.each do |node|
+    kubernetes_cluster.all_nodes(eager: {vm: :nics}).each do |node|
       {"ahostsv4" => node.vm.private_ipv4_string, "ahostsv6" => node.vm.private_ipv6_string}.each do |database, expected_ip|
         command = NetSsh.command("getent :database :name | awk '{print $1; exit}'", database:, name: node.name)
         resolved_ip = client.kubectl("exec -t ubuntu-statefulset-0 -- sh -c :command", command:).strip

--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -74,6 +74,29 @@ class Prog::Test::Kubernetes < Prog::Test::KubernetesBase
   label def wait_for_statefulset
     pod_status = kubernetes_cluster.client.kubectl("get pods ubuntu-statefulset-0 -ojsonpath={.status.phase}").strip
     nap 5 unless pod_status == "Running"
+    hop_test_node_dns
+  end
+
+  label def test_node_dns
+    client = kubernetes_cluster.client
+    kubernetes_cluster.all_nodes.each do |node|
+      {"ahostsv4" => node.vm.private_ipv4_string, "ahostsv6" => node.vm.private_ipv6_string}.each do |database, expected_ip|
+        command = NetSsh.command("getent :database :name | awk '{print $1; exit}'", database:, name: node.name)
+        resolved_ip = client.kubectl("exec -t ubuntu-statefulset-0 -- sh -c :command", command:).strip
+        if resolved_ip != expected_ip
+          self.fail_message = "#{node.name} resolved to #{resolved_ip.inspect} from a pod, expected #{expected_ip}"
+          hop_destroy_kubernetes
+        end
+
+        connect = NetSsh.command("exec 3<>/dev/tcp/:ip/10250", ip: expected_ip)
+        begin
+          client.kubectl("exec -t ubuntu-statefulset-0 -- timeout 5 bash -c :connect", connect:)
+        rescue RuntimeError
+          self.fail_message = "#{node.name} (#{expected_ip}) is not reachable on port 10250 from a pod"
+          hop_destroy_kubernetes
+        end
+      end
+    end
     hop_test_lsblk
   end
 

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -914,7 +914,9 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
       expect { nx.sync_internal_dns_config }.to hop("wait")
     end
 
-    it "adds the ubicloud block and replaces the configmap" do
+    it "adds the ubicloud block for functional nodes and replaces the configmap" do
+      KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kubernetes_cluster.id, state: "draining")
+      KubernetesNode.create(vm_id: create_vm.id, kubernetes_cluster_id: kubernetes_cluster.id, kubernetes_nodepool_id: kubernetes_cluster.nodepools.first.id, state: "draining")
       nodes = kubernetes_cluster.functional_nodes
       nodes.first.vm.user_nic.update(private_ipv4: "10.39.0.5/32", private_ipv6: "fd8c:1234::/79")
       nodes.last.vm.user_nic.update(private_ipv4: "10.39.0.9/32", private_ipv6: "fd8c:5678::/79")

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -916,14 +916,8 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
 
     it "adds the ubicloud block and replaces the configmap" do
       nodes = kubernetes_cluster.functional_nodes
-      expect(nodes.first.vm).to receive_messages(
-        ip4: NetAddr.parse_ip("1.2.3.4"),
-        ip6: NetAddr.parse_ip("2001:db8::1234"),
-      )
-      expect(nodes.last.vm).to receive_messages(
-        ip4: NetAddr.parse_ip("5.6.7.8"),
-        ip6: NetAddr.parse_ip("2001:db8::5678"),
-      )
+      nodes.first.vm.user_nic.update(private_ipv4: "10.39.0.5/32", private_ipv6: "fd8c:1234::/79")
+      nodes.last.vm.user_nic.update(private_ipv4: "10.39.0.9/32", private_ipv6: "fd8c:5678::/79")
       get_cm = <<~YAML
     apiVersion: v1
     data:
@@ -975,10 +969,10 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
             }
             hosts {
                 # Ubicloud Hosts
-                1.2.3.4 #{nodes.first.name}
-                2001:db8::1234 #{nodes.first.name}
-                5.6.7.8 #{nodes.last.name}
-                2001:db8::5678 #{nodes.last.name}
+                10.39.0.5 #{nodes.first.name}
+                fd8c:1234::2 #{nodes.first.name}
+                10.39.0.9 #{nodes.last.name}
+                fd8c:5678::2 #{nodes.last.name}
                 # End of Ubicloud Hosts
                 fallthrough
             }

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -165,13 +165,56 @@ RSpec.describe Prog::Test::Kubernetes do
     it "waits for the stateful pod to become running" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("Running", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.status.phase}").and_return(response)
-      expect { kubernetes_test.wait_for_statefulset }.to hop("test_lsblk")
+      expect { kubernetes_test.wait_for_statefulset }.to hop("test_node_dns")
     end
 
     it "naps if pod is not running yet" do
       response = Net::SSH::Connection::Session::StringWithExitstatus.new("ContainerCreating", 0)
       expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s get pods ubuntu-statefulset-0 -ojsonpath={.status.phase}").and_return(response)
       expect { kubernetes_test.wait_for_statefulset }.to nap(5)
+    end
+  end
+
+  describe "#test_node_dns" do
+    let(:node_addresses) { {"cp-node" => ["10.39.0.5", "fd8c:1::2"], "w1-node" => ["10.39.0.9", "fd8c:2::2"], "w2-node" => ["10.39.0.13", "fd8c:3::2"]} }
+
+    before do
+      Vm[name: "cp-node"].user_nic.update(private_ipv4: "10.39.0.5/32", private_ipv6: "fd8c:1::/79")
+      Vm[name: "w1-node"].user_nic.update(private_ipv4: "10.39.0.9/32", private_ipv6: "fd8c:2::/79")
+      Vm[name: "w2-node"].user_nic.update(private_ipv4: "10.39.0.13/32", private_ipv6: "fd8c:3::/79")
+    end
+
+    def expect_resolve(database, name, ip)
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("#{ip}\n", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- sh -c getent\\ #{database}\\ #{name}\\ \\|\\ awk\\ \\'\\{print\\ \\$1\\;\\ exit\\}\\'").and_return(response)
+    end
+
+    def expect_connect(ip, exitstatus)
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("", exitstatus)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=30s exec -t ubuntu-statefulset-0 -- timeout 5 bash -c exec\\ 3\\<\\>/dev/tcp/#{ip}/10250").and_return(response)
+    end
+
+    it "resolves every node name to its private addresses, connects to kubelet on both and hops to test_lsblk" do
+      node_addresses.each do |name, (ipv4, ipv6)|
+        expect_resolve("ahostsv4", name, ipv4)
+        expect_connect(ipv4, 0)
+        expect_resolve("ahostsv6", name, ipv6)
+        expect_connect(ipv6, 0)
+      end
+      expect { kubernetes_test.test_node_dns }.to hop("test_lsblk")
+    end
+
+    it "fails when a node name resolves to a different address" do
+      expect_resolve("ahostsv4", "cp-node", "178.63.152.196")
+      expect { kubernetes_test.test_node_dns }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq "cp-node resolved to \"178.63.152.196\" from a pod, expected 10.39.0.5"
+    end
+
+    it "fails when the resolved address does not accept connections on 10250" do
+      expect_resolve("ahostsv4", "cp-node", "10.39.0.5")
+      expect_connect("10.39.0.5", 124)
+      expect { kubernetes_test.test_node_dns }.to hop("destroy_kubernetes")
+      expect(kubernetes_test.strand.stack.first["fail_message"]).to eq "cp-node (10.39.0.5) is not reachable on port 10250 from a pod"
     end
   end
 


### PR DESCRIPTION
**Publish private node addresses in the CoreDNS hosts block**
sync_internal_dns_config mapped node names to vm.ip4 and vm.ip6, the node's public addresses. Pod traffic to a public destination leaves with a public source (IPv4 is masqueraded to the route-selected node address, IPv6 is not NATed), and the cluster firewall only opens all ports to subnet.net4 and subnet.net6. So the published addresses were exactly the ones pods could not reach on 10250 or any port but 22.

Publish vm.private_ipv4 (already kubelet's --node-ip) and vm.private_ipv6 (the ::2 of the NIC's ULA /79) instead. The block is rewritten whole on every run, so existing clusters pick up the new addresses the next time the semaphore is incremented.

**Verify node names resolve to reachable addresses in the Kubernetes e2e test**
After the statefulset pod is running, resolve each node name from inside the pod for both families with getent and check the answer is the node's private IPv4 and ULA IPv6. Then open a TCP connection to kubelet's port 10250 on that address with bash's /dev/tcp, so the test fails if the CoreDNS hosts block ever publishes an address the cluster firewall drops.

**Eager load node VMs and NICs when building the CoreDNS hosts block**
all_nodes and all_functional_nodes take an eager option that is passed through to both the control plane and nodepool node associations. The CoreDNS sync and the e2e DNS check use it so VMs and NICs load in one query each per node group instead of two queries per node.

The sync spec now includes a draining control plane node and a draining nodepool node so the functional-node filter is load-bearing.