### PR TITLE
Lower the first wait_sshable nap to 4 seconds

### DIFF
--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -191,12 +191,13 @@ class Prog::Vm::Metal::Nexus < Prog::Base
 
   label def wait_sshable
     unless vm.update_firewall_rules_set?
-      # vm.incr rewrites schedule and strand rerun immediately instead of napping 6s
+      # vm.incr rewrites schedule and strand rerun immediately instead of napping
       Semaphore.incr(vm.id, :update_firewall_rules, wake: false)
       # This is the first time we get into this state and we know that
-      # wait_sshable will take definitely more than 6 seconds. So, we nap here
-      # to reduce the amount of load on the control plane unnecessarily.
-      nap 6
+      # wait_sshable will take at least 4 seconds on the fastest boot images.
+      # So, we nap here to reduce the amount of load on the control plane
+      # unnecessarily.
+      nap 4
     end
 
     if (addr = vm.ip4_string)

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -1009,9 +1009,9 @@ RSpec.describe Prog::Vm::Metal::Nexus do
   end
 
   describe "#wait_sshable" do
-    it "naps 6 seconds if it's the first time we execute wait_sshable" do
+    it "naps 4 seconds if it's the first time we execute wait_sshable" do
       schedule = st.schedule
-      expect { nx.wait_sshable }.to nap(6)
+      expect { nx.wait_sshable }.to nap(4)
         .and change { vm.update_firewall_rules_set?(cached: false) }.from(false).to(true)
       expect(st.reload.schedule).to eq(schedule)
     end


### PR DESCRIPTION
The 6 second nap was sized for the previous runner image, which opened port 22 about 7.4 seconds after the kernel started. It also never held until 42e06da4e fixed the self-wake, so the strand accidentally probed at a 1-2 second cadence and detected sshability soon after the port opened.

The current runner image boots to an open port 22 in about 4.8 seconds, roughly 3 seconds after wait_sshable is entered, so an honored 6 second nap now overshoots the port opening and gives back part of the image improvements. Nap 4 seconds instead: on the fastest images the first probe lands just after the port opens, and slower boot images only pay one or two extra probe rounds through the existing 1 second retry. The nap can shrink further if fleet wait_sshable durations settle close to 4 seconds.