### PR TITLE
Honor a manually set spill over semaphore

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -357,6 +357,9 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
   end
 
   label def wait_concurrency_limit
+    # An operator can set the spill over semaphore by hand to override the checks below.
+    hop_allocate_vm if spill_over_set?
+
     if quota_available?
       hop_apply_custom_label_quota if github_runner.custom_label
       hop_allocate_vm

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -386,6 +386,12 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
       end
     end
 
+    it "hops to allocate_vm when the spill over semaphore is set manually" do
+      runner.incr_spill_over
+      expect(project).not_to receive(:quota_available?)
+      expect { nx.wait_concurrency_limit }.to hop("allocate_vm")
+    end
+
     it "hops to allocate_vm when customer concurrency limit frees up" do
       expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(true)
       expect { nx.wait_concurrency_limit }.to hop("allocate_vm")


### PR DESCRIPTION
The spill over semaphore was read only in pick_vm, so setting it by hand moved a runner to AWS only if the runner had already passed wait_concurrency_limit. A runner parked in that label stayed parked, because the label never looked at the semaphore. It waited for its own quota to free up, for utilization to drop, or for the automatic spill conditions to pass on their own, which is exactly the situation an operator sets the semaphore to escape.

Check it at the top of wait_concurrency_limit and hop straight to allocate_vm, bypassing the quota, utilization and spill capacity checks. Setting the semaphore is a deliberate operator action, so treat it as an override rather than a hint.