### PR TITLE
Cap the number of spilled runners

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -1923,7 +1923,7 @@ class CloverAdmin < Roda
         .select_append { round(sum(:used_hugepages_1g) * 100.0 / sum(:total_hugepages_1g), 2).cast(:float).as(:hugepage_util) }
         .to_hash(:family, [:vcpu_util, :hugepage_util])
 
-      @spilled_vcpus = Vm.where(arch: @arch, boot_image: Prog::Github::GithubRunnerNexus::AWS_AMI_VERSIONS).sum(:vcpus) || 0
+      @spilled_vcpus, @spilled_runners = GithubRunner.aws_vm_usage(arch: @arch)
 
       view("github_runner_usage")
     end

--- a/config.rb
+++ b/config.rb
@@ -144,6 +144,7 @@ module Config
   optional :github_runner_aws_spot_instance_max_price_per_vcpu, float
   override :github_runner_aws_spill_threshold_seconds, 30, int
   override :github_runner_aws_spill_vcpu_capacity, 100, int
+  override :github_runner_aws_spill_runner_capacity, 50, int
 
   # GitHub Cache
   optional :github_cache_blob_storage_endpoint, string

--- a/model/github/github_runner.rb
+++ b/model/github/github_runner.rb
@@ -15,6 +15,15 @@ class GithubRunner < Sequel::Model
 
   NOT_VM_ALLOCATED_RUNNER_LABELS = %w[start wait_concurrency_limit apply_custom_label_quota].freeze
 
+  AWS_AMI_VERSIONS = [
+    Config.github_ubuntu_2204_x64_aws_ami_version,
+    Config.github_ubuntu_2404_x64_aws_ami_version,
+    Config.github_ubuntu_2604_x64_aws_ami_version,
+    Config.github_ubuntu_2204_arm64_aws_ami_version,
+    Config.github_ubuntu_2404_arm64_aws_ami_version,
+    Config.github_ubuntu_2604_arm64_aws_ami_version,
+  ].freeze
+
   dataset_module do
     def total_active_runner_vcpus
       left_join(:strand, id: Sequel[:github_runner][:id])
@@ -36,6 +45,15 @@ class GithubRunner < Sequel::Model
       where(location_id: aws_location_id)
         .total_active_runner_vcpus
     end
+  end
+
+  def self.aws_vm_usage(arch: nil)
+    ds = Vm.where(boot_image: AWS_AMI_VERSIONS)
+    ds = ds.where(arch:) if arch
+    ds.get([
+      Sequel.function(:coalesce, Sequel.function(:sum, :vcpus), 0).as(:vcpus),
+      Sequel.function(:count).*.as(:runners),
+    ])
   end
 
   def label_data

--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -11,15 +11,6 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
   def_delegators :github_runner, :installation, :vm, :label_data
   def_delegators :installation, :project
 
-  AWS_AMI_VERSIONS = [
-    Config.github_ubuntu_2204_x64_aws_ami_version,
-    Config.github_ubuntu_2404_x64_aws_ami_version,
-    Config.github_ubuntu_2604_x64_aws_ami_version,
-    Config.github_ubuntu_2204_arm64_aws_ami_version,
-    Config.github_ubuntu_2404_arm64_aws_ami_version,
-    Config.github_ubuntu_2604_arm64_aws_ami_version,
-  ].freeze
-
   SHOW_RUNNER_SCRIPT_SUBSTATE = "systemctl show -p SubState --value runner-script"
   RUNNER_SCRIPT_SUBSTATE_COMMAND = "sudo #{SHOW_RUNNER_SCRIPT_SUBSTATE} 2>/dev/null || #{SHOW_RUNNER_SCRIPT_SUBSTATE}".freeze
 
@@ -396,9 +387,9 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
         aws_quota_available?
 
       if should_spill_over
-        spilled_vcpus = Vm.where(boot_image: AWS_AMI_VERSIONS).sum(:vcpus) || 0
-        if spilled_vcpus >= Config.github_runner_aws_spill_vcpu_capacity
-          Clog.emit("not allowed because of high utilization and spill capacity exceeded", {exceeded_spill_capacity: {family_utilization:, spilled_vcpus:, label: github_runner.label, arch:, repository_name: github_runner.repository_name}})
+        spilled_vcpus, spilled_runners = GithubRunner.aws_vm_usage
+        if spilled_vcpus >= Config.github_runner_aws_spill_vcpu_capacity || spilled_runners >= Config.github_runner_aws_spill_runner_capacity
+          Clog.emit("not allowed because of high utilization and spill capacity exceeded", {exceeded_spill_capacity: {family_utilization:, spilled_vcpus:, spilled_runners:, label: github_runner.label, arch:, repository_name: github_runner.repository_name}})
           nap rand(5..15)
         end
 

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -432,6 +432,18 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
         expect(runner.spill_over_set?).to be(false)
       end
 
+      it "waits if utilization is high, spill over enabled, and waited enough but spill runner limit exceeded" do
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
+        expect(project).to receive(:quota_available?).with("GithubRunnerVCpuAws", 0).and_return(true)
+        project.set_ff_spill_to_alien_runners(true)
+        runner.update(created_at: now - 40)
+        expect(Config).to receive(:github_runner_aws_spill_runner_capacity).and_return(1)
+        create_vm(vcpus: 2, boot_image: Config.github_ubuntu_2204_x64_aws_ami_version)
+
+        expect { nx.wait_concurrency_limit }.to nap
+        expect(runner.spill_over_set?).to be(false)
+      end
+
       it "waits if utilization is high, spill over enabled, and waited enough but customer's own alien quota is exceeded" do
         expect(project).to receive(:quota_available?).with("GithubRunnerVCpu", 0).and_return(false)
         expect(project).to receive(:quota_available?).with("GithubRunnerVCpuAws", 0).and_return(false)

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2962,7 +2962,7 @@ RSpec.describe CloverAdmin do
     click_link "GitHub Runner VM Usage"
     expect(page.title).to eq "Ubicloud Admin - GitHub Runner x64 VM Usage"
     expect(page).to have_link "Show arm64"
-    expect(page).to have_css("p", exact_text: "standard: vcpu 25.0%, hugepage 4.27%, spilled vcpus 12 - premium: vcpu 50.0%, hugepage 4.27%")
+    expect(page).to have_css("p", exact_text: "standard: vcpu 25.0%, hugepage 4.27%, spilled vcpus 12, spilled runners 2 - premium: vcpu 50.0%, hugepage 4.27%")
     expect(page.all("#content td").map(&:text)).to eq [
       "TOTAL", "", "400", "100",
       "2", "1", "1", "0", "1", "0",
@@ -2997,7 +2997,7 @@ RSpec.describe CloverAdmin do
 
     expect(page.title).to eq "Ubicloud Admin - GitHub Runner arm64 VM Usage"
     expect(page).to have_link "Show x64"
-    expect(page).to have_css("p", exact_text: "standard: vcpu 25.0%, hugepage 4.27%, spilled vcpus 8")
+    expect(page).to have_css("p", exact_text: "standard: vcpu 25.0%, hugepage 4.27%, spilled vcpus 8, spilled runners 1")
     expect(page.all("#content td").map(&:text)).to eq [
       "TOTAL", "", "100", "0",
       "1", "0", "0", "0", "0", "0",

--- a/views/admin/github_runner_usage.erb
+++ b/views/admin/github_runner_usage.erb
@@ -22,7 +22,7 @@ end
 
 <p>
   <strong>standard:</strong>
-  <%= "vcpu #{@family_utilization.dig("standard", 0) || 0}%, hugepage #{@family_utilization.dig("standard", 1) || 0}%, spilled vcpus #{@spilled_vcpus}" %>
+  <%= "vcpu #{@family_utilization.dig("standard", 0) || 0}%, hugepage #{@family_utilization.dig("standard", 1) || 0}%, spilled vcpus #{@spilled_vcpus}, spilled runners #{@spilled_runners}" %>
 
   <% if @arch == "x64" %>
     - <strong>premium:</strong>


### PR DESCRIPTION
Spilling was bounded only by total vCPUs, which is the wrong unit for
the constraint that actually binds first. Each spilled runner gets its
own private subnet, and each AWS subnet gets its own VPC, so the
number of spilled runners is the number of VPCs we hold in the region.
The VPC limit is per region and is not proportional to instance size,
so a burst of small runners exhausts it long before the vCPU capacity
is reached, and the subnet creation then fails outside the spill
check where nothing backs off.

Add github_runner_aws_spill_runner_capacity and check it alongside
github_runner_aws_spill_vcpu_capacity, in the same query. Default it
to 50, which is what 100 vCPUs of the smallest runner already allows,
so the new limit does not change current behavior on its own.

Move AWS_AMI_VERSIONS onto GithubRunner and read both numbers through
GithubRunner.aws_vm_usage, so the admin panel no longer reaches into
a prog constant to rebuild the same query. It sits next to
aws_active_runner_vcpus, which answers a related question about AWS
runners, though by location and label vCPUs rather than by image and
instance vCPUs.

Also show the spilled runner count next to the spilled vCPUs in the
admin runner usage view, so the new limit is observable.