### PR TITLE
Reserve free space on storage devices during allocation

### DIFF
--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -708,6 +708,10 @@ module Scheduling::Allocator
   end
 
   class StorageAllocation
+    # Space kept free on every storage device, so that a device always has
+    # room for a new boot image or for an emergency.
+    RESERVED_STORAGE_GIB = 100
+
     attr_reader :is_valid, :total, :used, :requested, :volume_to_device_map
     def initialize(candidate_host, request)
       @candidate_host = candidate_host
@@ -784,11 +788,24 @@ module Scheduling::Allocator
 
       @volume_to_device_map = {}
       @request.storage_volumes.each do |vol_id, vol|
-        dev = @storage_device_allocations.detect { |dev| dev.available_storage_gib >= vol["size_gib"] && !(@request.distinct_storage_devices && dev.allocated_storage_gib > 0) }
+        size_gib = vol["size_gib"]
+
+        # Devices are ordered by available space, so the smallest device that
+        # fits wins. Prefer the smallest device that also keeps the reserve
+        # free, and fall back to the smallest device that fits only when no
+        # device can keep the reserve.
+        smallest_fit = nil
+        dev = @storage_device_allocations.detect { |dev|
+          next if @request.distinct_storage_devices && dev.allocated_storage_gib > 0
+          next if dev.available_storage_gib < size_gib
+
+          smallest_fit ||= dev
+          dev.available_storage_gib - size_gib >= RESERVED_STORAGE_GIB
+        } || smallest_fit
         return false if dev.nil?
 
         @volume_to_device_map[vol_id] = dev.id
-        dev.allocate(vol["size_gib"])
+        dev.allocate(size_gib)
       end
       true
     end

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -769,6 +769,39 @@ RSpec.describe Scheduling::Allocator do
       expect(storage_allocation.is_valid).to be_falsey
     end
 
+    it "skips a device that would be left with less than the reserved space" do
+      reserved = Al::StorageAllocation::RESERVED_STORAGE_GIB
+      vmhds[:storage_devices] = [{"available_storage_gib" => reserved + 100, "id" => "sd1id", "total_storage_gib" => reserved + 100},
+        {"available_storage_gib" => reserved + 500, "id" => "sd2id", "total_storage_gib" => reserved + 500}]
+      vmhds[:available_storage_gib] = 2 * reserved + 600
+      vmhds[:total_storage_gib] = 2 * reserved + 600
+      req.storage_gib = 150
+      req.storage_volumes = [[0, {"size_gib" => 150}]]
+      storage_allocation = Al::StorageAllocation.new(vmhds, req)
+      expect(storage_allocation.is_valid).to be_truthy
+      expect(storage_allocation.volume_to_device_map).to eq({0 => "sd2id"})
+    end
+
+    it "uses the smallest device that keeps the reserved space" do
+      reserved = Al::StorageAllocation::RESERVED_STORAGE_GIB
+      vmhds[:storage_devices] = [{"available_storage_gib" => reserved + 100, "id" => "sd1id", "total_storage_gib" => reserved + 100},
+        {"available_storage_gib" => reserved + 500, "id" => "sd2id", "total_storage_gib" => reserved + 500}]
+      vmhds[:available_storage_gib] = 2 * reserved + 600
+      vmhds[:total_storage_gib] = 2 * reserved + 600
+      req.storage_gib = 50
+      req.storage_volumes = [[0, {"size_gib" => 50}]]
+      storage_allocation = Al::StorageAllocation.new(vmhds, req)
+      expect(storage_allocation.volume_to_device_map).to eq({0 => "sd1id"})
+    end
+
+    it "uses the reserved space if no device can hold the volume without it" do
+      req.storage_gib = 50
+      req.storage_volumes = [[0, {"size_gib" => 50}]]
+      storage_allocation = Al::StorageAllocation.new(vmhds, req)
+      expect(storage_allocation.is_valid).to be_truthy
+      expect(storage_allocation.volume_to_device_map).to eq({0 => "sd2id"})
+    end
+
     it "reduces_large_device_multiples? is false when volumes were never mapped to devices" do
       req.storage_gib = 10000
       storage_allocation = Al::StorageAllocation.new(vmhds, req)


### PR DESCRIPTION
The allocator places a volume on the storage device with the least free space that still fits it. The DEFAULT device is usually the first pick, because it also holds the boot images and therefore has less free space than the other devices. Over time that fills DEFAULT completely, and then there is no room to download a new boot image, which only goes to DEFAULT.

Keep a reserve of 100 GiB free on every device: a volume goes to the smallest device that fits it and still keeps the reserve free. When no device can hold the volume without the reserve, fall back to the previous behavior, so the capacity is not lost when a host is nearly full.

The devices come from the query sorted by ascending free space, so a single pass gives both candidates: it stops at the first device that keeps the reserve, and on the way it remembers the first device that fits without it, which is the fallback.