### PR TITLE
Raise the default AWS spill quotas to 500 vCPUs

### DIFF
--- a/config/default_quotas.yml
+++ b/config/default_quotas.yml
@@ -1,8 +1,8 @@
 - { id: c088f732-0a30-454b-aa6b-542ce1d67bfb, resource_type: VmVCpu,                   limited_value: 16,  new_value: 32,   verified_value: 256 }
 - { id: 14fa6820-bf63-41d2-b35e-4a4dcefd1b15, resource_type: GithubRunnerVCpu,         limited_value: 128, new_value: 300,  verified_value: 300 }
 - { id: 452f14c5-4858-457e-9fb8-d5e81452c804, resource_type: GithubRunnerVCpuArm,      limited_value: 50,  new_value: 100,  verified_value: 100 }
-- { id: c4c06b31-a416-4cac-8721-6f15ea3b21d7, resource_type: GithubRunnerVCpuAws,      limited_value: 0,   new_value: 100,  verified_value: 100 }
-- { id: c8d83548-c804-40f5-b7d9-3de142325df9, resource_type: GithubRunnerVCpuArmAws,   limited_value: 0,   new_value: 50,   verified_value: 50  }
+- { id: c4c06b31-a416-4cac-8721-6f15ea3b21d7, resource_type: GithubRunnerVCpuAws,      limited_value: 0,   new_value: 500,  verified_value: 500 }
+- { id: c8d83548-c804-40f5-b7d9-3de142325df9, resource_type: GithubRunnerVCpuArmAws,   limited_value: 0,   new_value: 500,  verified_value: 500 }
 - { id: 0ac764de-48c5-4432-876d-389878da0885, resource_type: GithubRunnerCacheStorage, limited_value: 30,  new_value: 30,   verified_value: 30  }
 - { id: 91d616ea-a15b-4d54-90b7-aaa1e1bd2f19, resource_type: PostgresVCpu,             limited_value: 16,  new_value: 128,  verified_value: 256 }
 - { id: 3acfffdb-37d6-42ff-8d1f-78a1915c7912, resource_type: KubernetesVCpu,           limited_value: 16,  new_value: 32,   verified_value: 256 }

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -287,8 +287,8 @@ RSpec.describe Project do
     expect(project.effective_quota_value("PostgresVCpu")).to eq 16
 
     project.reputation = "verified"
-    expect(project.effective_quota_value("GithubRunnerVCpuAws")).to eq 100
-    expect(project.effective_quota_value("GithubRunnerVCpuArmAws")).to eq 50
+    expect(project.effective_quota_value("GithubRunnerVCpuAws")).to eq 500
+    expect(project.effective_quota_value("GithubRunnerVCpuArmAws")).to eq 500
   end
 
   it "checks if quota is available" do

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -796,8 +796,8 @@ RSpec.describe CloverAdmin do
       ["VmVCpu", "32", "16"],
       ["GithubRunnerVCpu", "400", "0"],
       ["GithubRunnerVCpuArm", "100", "0"],
-      ["GithubRunnerVCpuAws", "100", "0"],
-      ["GithubRunnerVCpuArmAws", "50", "0"],
+      ["GithubRunnerVCpuAws", "500", "0"],
+      ["GithubRunnerVCpuArmAws", "500", "0"],
       ["PostgresVCpu", "128", "0"],
       ["KubernetesVCpu", "32", "0"],
       ["MachineImageVersion", "16", "0"],
@@ -2964,13 +2964,13 @@ RSpec.describe CloverAdmin do
     expect(page).to have_link "Show arm64"
     expect(page).to have_css("p", exact_text: "standard: vcpu 25.0%, hugepage 4.27%, spilled vcpus 12 - premium: vcpu 50.0%, hugepage 4.27%")
     expect(page.all("#content td").map(&:text)).to eq [
-      "TOTAL", "", "400", "100",
+      "TOTAL", "", "400", "500",
       "2", "1", "1", "0", "1", "0",
       "46 / 46", "34 / 46",
       "1", "0", "0", "0", "0", "0",
       "0", "1", "0", "0", "0",
       "0", "0", "1", "0", "1",
-      "test-installation", "true", "400", "100",
+      "test-installation", "true", "400", "500",
       "2", "1", "1", "0", "1", "0",
       "46 / 46", "34 / 46",
       "1", "0", "0", "0", "0", "0",


### PR DESCRIPTION
The AWS spill quotas were set conservatively when spilling was first introduced, at 100 vCPUs for x64 and 50 for arm64. They now cut off spilling well before the global spill capacity is reached, so busy projects stop spilling and go back to waiting for our own hosts even though AWS capacity is still available.

Raise both to 500 vCPUs. The global limit set by
github_runner_aws_spill_vcpu_capacity, along with the high utilization trigger, remains the effective brake on total AWS spend. The per-project quota is there to stop a single project from consuming all of it, and 500 vCPUs still serves that purpose.

Leave the limited value at 0, so projects with limited reputation still cannot spill.