### PR TITLE
Make LoadBalancerNexus#wait_cert_broadcast work if there is no active_cert

### DIFF
--- a/prog/vnet/load_balancer_nexus.rb
+++ b/prog/vnet/load_balancer_nexus.rb
@@ -124,7 +124,7 @@ class Prog::Vnet::LoadBalancerNexus < Prog::Base
     reap(nap: 1) do
       decr_refresh_cert
       self.cert = nil
-      load_balancer.certs_dataset.exclude(id: load_balancer.active_cert.id).all do |cert|
+      load_balancer.certs_dataset.exclude(id: load_balancer.active_cert&.id).all do |cert|
         LoadBalancerCert[cert_id: cert.id].destroy
       end
       hop_wait

--- a/spec/prog/vnet/load_balancer_nexus_spec.rb
+++ b/spec/prog/vnet/load_balancer_nexus_spec.rb
@@ -204,7 +204,12 @@ RSpec.describe Prog::Vnet::LoadBalancerNexus do
       expect { nx.wait_cert_broadcast }.to nap(1)
     end
 
-    it "hops to wait if all children are done and no certs to remove" do
+    it "hops to wait if all children are done and no certs to remove and there is no active cert" do
+      expect(nx).to receive(:reap).and_yield
+      expect { nx.wait_cert_broadcast }.to hop("wait")
+    end
+
+    it "hops to wait if all children are done and no certs to remove and there is an active cert" do
       expect(nx).to receive(:reap).and_yield
       active_cert = Prog::Vnet::CertNexus.assemble("active-cert", dns_zone.id).subject
       expect(nx.load_balancer).to receive(:active_cert).and_return(active_cert)


### PR DESCRIPTION
Previously, this resulted in a NoMethodError. We ran into this problem in staging.