### PR TITLE
Lower the first wait_sshable nap to 3 seconds

### DIFF
--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -208,10 +208,10 @@ class Prog::Vm::Metal::Nexus < Prog::Base
       # vm.incr rewrites schedule and strand rerun immediately instead of napping
       Semaphore.incr(vm.id, :update_firewall_rules, wake: false)
       # This is the first time we get into this state and we know that
-      # wait_sshable will take at least 4 seconds on the fastest boot images.
+      # wait_sshable will take at least 3 seconds on the fastest boot images.
       # So, we nap here to reduce the amount of load on the control plane
       # unnecessarily.
-      nap 4
+      nap 3
     end
 
     if (addr = vm.ip4_string)

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -1064,9 +1064,9 @@ RSpec.describe Prog::Vm::Metal::Nexus do
   end
 
   describe "#wait_sshable" do
-    it "naps 4 seconds if it's the first time we execute wait_sshable" do
+    it "naps 3 seconds if it's the first time we execute wait_sshable" do
       schedule = st.schedule
-      expect { nx.wait_sshable }.to nap(4)
+      expect { nx.wait_sshable }.to nap(3)
         .and change { vm.update_firewall_rules_set?(cached: false) }.from(false).to(true)
       expect(st.reload.schedule).to eq(schedule)
     end


### PR DESCRIPTION
c1afcb0b9 lowered the nap from 6 to 4 seconds with a note that it could shrink further if fleet wait_sshable durations settled close to 4 seconds. They did: a good share of wait_sshable runs now finish right at the nap boundary, which means the port was already open when the first probe ran and the nap is the floor. Lower it to 3 seconds; boot images that are not sshable by then only pay an extra probe round through the existing 1 second retry.