### PR TITLE
Increase e2e timeout by 10 minutes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -111,7 +111,7 @@ jobs:
     name: E2E - ${{ matrix.provider }}
     runs-on: ubicloud-standard-4
     environment: E2E-${{ matrix.provider }}
-    timeout-minutes: 75
+    timeout-minutes: 85
     concurrency: ${{ (matrix.provider == 'metal' && 'E2E-metal') || (matrix.provider == 'gcp' && format('E2E-gcp-{0}', github.run_id)) || (needs.setup.outputs.has_github_runner == 'true' && 'E2E-aws') || format('E2E-aws-{0}', github.run_id) }}
     env:
       # Set repo variable E2E_PAUSE_METAL=true to halt metal e2e runs while
@@ -253,7 +253,7 @@ jobs:
         OPERATOR_SSH_PUBLIC_KEYS: ${{ secrets.OPERATOR_SSH_PUBLIC_KEYS }}
       run: |
         set -o pipefail
-        timeout 60m bundle exec foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"
+        timeout 70m bundle exec foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"
 
     - name: Print logs
       if: always() && env.METAL_PAUSED != 'true'


### PR DESCRIPTION
Boot image downloads got slow enough that the metal run hit the 60m timeout with the last 75G runner image still in flight. The resulting e2e failures slow down development, so bump the run timeout to 70m, and the job timeout to 85m to keep the same slack over the failed notification sleep, until we find why downloads are slow.