### PR TITLE
Update simplecov to 1.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,7 @@ GEM
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    simplecov (1.0.3)
+    simplecov (1.2.0)
     snaky_hash (2.0.7)
       hashie (>= 0.1.0, < 6)
       version_gem (~> 1.1, >= 1.1.14)

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -8,8 +8,12 @@ elsif (suite = ENV.delete("COVERAGE"))
   require "simplecov"
 
   SimpleCov.start do
-    coverage :line, minimum: 100, minimum_per_file: 100
-    coverage :branch, minimum: 100, minimum_per_file: 100
+    coverage :line, minimum: 100 do
+      minimum 100, per: :file
+    end
+    coverage :branch, minimum: 100 do
+      minimum 100, per: :file
+    end
 
     command_name "#{suite}#{ENV["TEST_ENV_NUMBER"]}"
     parallel_wait_timeout 600

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -24,7 +24,8 @@ elsif (suite = ENV.delete("COVERAGE"))
     else
       skip do |file|
         path = file.filename.delete_prefix(File.dirname(__dir__))
-        path.match?(/\A\/(coverage|rhizome|kubernetes|migrate|ruby_lsp|spec|var|(db|model|loader|\.env)\.rb)/)
+        path.match?(/\A\/(coverage|rhizome|kubernetes|migrate|ruby_lsp|spec|var|(db|model|loader|\.env)\.rb)/) ||
+          (file.relevant_lines.zero? && file.no_branches?)
       end
 
       # Not "**/*.rb": cover parses every matching file on disk before skip


### PR DESCRIPTION
SimpleCov now keeps the "never loaded" flag through a parallel result merge, so it reports 0% branch coverage for files that the suite tracks but never requires. That fails minimum_per_file for four files a simplecov:disable directive turns off in full: both bin scripts, puma_config.rb, and vendor/hidden_class.rb.

Skip files that have no relevant lines and no branches. Such a file carries nothing to measure, so counting it as uncovered says nothing.