### PR TITLE
Clean prep daemonizer state after the vm is provisioned

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -51,7 +51,7 @@ class Vm < Sequel::Model
   plugin ResourceMethods, redacted_columns: :public_key
   plugin ProviderDispatcher, __FILE__
   plugin SemaphoreMethods, :destroy, :start_after_host_reboot, :prevent_destroy, :update_firewall_rules,
-    :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started, :restart, :start, :stop, :migrate_to_separate_progs, :admin_stop, :stopping, :prepare_to_move
+    :checkup, :update_spdk_dependency, :waiting_for_capacity, :lb_expiry_started, :restart, :start, :stop, :migrate_to_separate_progs, :admin_stop, :stopping, :prepare_to_move, :clean_prep
   include HealthMonitorMethods
 
   include ObjectTag::Cleanup

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -171,7 +171,16 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     case host.sshable.cmd("common/bin/daemonizer --check prep_:vm_name", vm_name:)
     when "Succeeded"
       vm.nics.each(&:incr_setup_nic)
-      hop_clean_prep
+
+      incr_clean_prep
+
+      # The Vm's systemd unit is already written and started by this point, so
+      # this is the earliest point we can learn which hypervisor it ended up
+      # running. It's a fire-and-forget independent Strand rather than a bud,
+      # since nothing here depends on its outcome.
+      Prog::LearnHypervisor.assemble(vm.id)
+
+      hop_wait_sshable
     when "NotStarted", "Failed"
       secrets_json = JSON.generate({
         storage: vm.storage_secrets,
@@ -186,6 +195,8 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     nap 1
   end
 
+  # Only reached by strands from before the cleanup moved into the wait
+  # label. Remove once no strand is left at this label.
   label def clean_prep
     host.sshable.cmd("common/bin/daemonizer --clean prep_:vm_name", vm_name:, log: :on_error)
 
@@ -327,6 +338,11 @@ class Prog::Vm::Metal::Nexus < Prog::Base
         hop_unavailable
       end
       decr_checkup
+    end
+
+    when_clean_prep_set? do
+      host.sshable.cmd("common/bin/daemonizer --clean prep_:vm_name", vm_name:, log: :on_error)
+      decr_clean_prep
     end
 
     nap 6 * 60 * 60

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -451,9 +451,11 @@ RSpec.describe Prog::Vm::Metal::Nexus do
   end
 
   describe "#prep" do
-    it "hops to clean_prep if prep command succeeds" do
+    it "hops to wait_sshable if prep command succeeds" do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer --check prep_#{nx.vm_name}").and_return("Succeeded")
-      expect { nx.prep }.to hop("clean_prep")
+      expect { nx.prep }.to hop("wait_sshable")
+        .and change { vm.clean_prep_set?(cached: false) }.from(false).to(true)
+      expect(Strand.where(prog: "LearnHypervisor").count).to eq(1)
     end
 
     [
@@ -1240,6 +1242,13 @@ RSpec.describe Prog::Vm::Metal::Nexus do
   describe "#wait" do
     it "naps when nothing to do" do
       expect { nx.wait }.to nap(6 * 60 * 60)
+    end
+
+    it "cleans the prep daemonizer state when requested" do
+      vm.incr_clean_prep
+      expect(sshable).to receive(:_cmd).with(/common\/bin\/daemonizer --clean prep_/, log: :on_error)
+      expect { nx.wait }.to nap(6 * 60 * 60)
+        .and change { vm.clean_prep_set?(cached: false) }.from(true).to(false)
     end
 
     it "hops to start_after_host_reboot when needed" do


### PR DESCRIPTION
Clean prep daemonizer state after the vm is provisioned
clean_prep is a full SSH round trip to the host that sits between prep
succeeding and wait_sshable, adding about a second to every vm's boot
critical path. Nothing reads the daemonizer state after prep succeeds,
so defer the cleanup: prep's success branch sets a clean_prep
semaphore, wait_sshable hops directly to wait, and the wait label
consumes the semaphore and cleans without hopping.

Cleaning inside wait rather than in a label after wait_sshable matters
for waiters: waking the waiting strand implies the vm is at wait, and
most waiters, such as postgres server and resource nexus, check the
label and nap 60 seconds if it does not match. The prog-level
incr_clean_prep goes through SemSnap, which never wakes the strand's
own schedule, and runs in the same transaction as the committed
Succeeded observation, keeping the ordering https://github.com/ubicloud/ubicloud/commit/891e3e9c86ebaaee75bca255e8ae06ef5cd40ddf requires: the
clean side effect only happens after that observation can no longer be
lost. --clean stays idempotent for retries of the wait run.

LearnHypervisor moves to prep's success branch, keeping its earliest
possible timing instead of following the cleanup.

The clean_prep label remains for strands that were parked at it when
this deployed and can be removed once none are left.