### PR TITLE
Keep subsecond precision in hop duration measurements

### DIFF
--- a/model/strand.rb
+++ b/model/strand.rb
@@ -312,7 +312,7 @@ SQL
         hp = prog_action
         last_changed_at = Time.new(top_frame["last_label_changed_at"])
         Clog.emit("hopped", {strand_hopped: {strand: ubid, duration: Time.now - last_changed_at, from: prog_label, to: "#{hp.new_prog}.#{hp.new_label}"}})
-        top_frame["last_label_changed_at"] = Time.now.to_s
+        top_frame["last_label_changed_at"] = time_string(Time.now)
         modified!(:stack)
 
         update(**hp.strand_update_args, try: 0)

--- a/spec/model/strand_spec.rb
+++ b/spec/model/strand_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe Strand do
     }.to change(st, :label).from("hop_entry").to("hop_exit")
   end
 
+  it "records the label transition time with subsecond precision on hop" do
+    st.save_changes
+    st.label = "hop_entry"
+    expect(st).to receive(:load).and_return Prog::Test.new(st)
+    st.unsynchronized_run
+    expect(st.stack[0]["last_label_changed_at"]).to match(/\.\d{6} /)
+  end
+
   it "rejects prog names that are not in the right module" do
     expect {
       described_class.prog_verify(Object)


### PR DESCRIPTION
The strand_hopped and strand_exited durations are measured against last_label_changed_at, which the initial run records with microsecond precision via time_string, but every hop rewrites with Time#to_s, which truncates to whole seconds. Every duration after a strand's first hop is therefore inflated by a uniform zero-to-one second of lost fraction, about half a second on average.

The fleet numbers show the artifact exactly: create_billing_record for runner vms, whose service project is not billable so the label runs a handful of queries, measures 15ms at minimum but 0.501s on average, 0.75s at p75 and 0.93s at p95, the signature of uniform noise on a fast label. Use time_string on hop as well.