### PR TITLE
Show the real SSH user in the admin object page

### DIFF
--- a/model/vm.rb
+++ b/model/vm.rb
@@ -81,6 +81,10 @@ class Vm < Sequel::Model
     "/location/#{display_location}/vm/#{name}"
   end
 
+  def admin_ssh_user
+    sshable.unix_user
+  end
+
   def ip4
     ephemeral_net4&.nth(0)
   end

--- a/model/vm_host.rb
+++ b/model/vm_host.rb
@@ -44,6 +44,10 @@ class VmHost < Sequel::Model
     sshable.host
   end
 
+  def admin_ssh_user
+    "root"
+  end
+
   # Compute the IPv6 Subnet that can be used to address the host
   # itself, and should not be delegated to any VMs.
   #

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -914,6 +914,15 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - VmHost #{vm_host.ubid}"
     expect(page).to have_content "SSH Command: ssh root@1.2.3.4"
 
+    project = Project.create(name: "Default")
+    vm = Prog::Vm::Nexus.assemble_with_sshable(project.id, sshable_unix_user: "ubi", name: "sshable-vm").subject
+    vm.sshable.update(host: "5.6.7.8")
+    visit "/"
+    fill_in "UBID, UUID, or prefix:term", with: vm.ubid
+    click_button "Show Object"
+    expect(page.title).to eq "Ubicloud Admin - Vm #{vm.ubid}"
+    expect(page).to have_content "SSH Command: ssh ubi@5.6.7.8"
+
     visit "/"
     fill_in "UBID, UUID, or prefix:term", with: vm_pool.ubid
     click_button "Show Object"

--- a/views/admin/object.erb
+++ b/views/admin/object.erb
@@ -1,7 +1,7 @@
 <% @page_title = "#{@klass.name} #{@obj.ubid}" %>
 
 <% if @klass.associations.include?(:sshable) && (sshable = @obj.sshable) %>
-  <p>SSH Command: <code>ssh root@<%= sshable.host %></code></p>
+  <p>SSH Command: <code>ssh <%= @obj.admin_ssh_user %>@<%= sshable.host %></code></p>
 <% end %>
 
 <div id="strand-info">


### PR DESCRIPTION
The SSH command on the admin object page hardcoded root. Only VmHost and Vm carry a :sshable association, and root is the account operators use on hosts, so every VM shown on that page offered a command that cannot connect: the guest has no root login, and the account the control plane uses is recorded on the sshable itself.

Read the user from the object instead. VmHost keeps root, because the sshable there says rhizome, which is the control plane's own account and not what an operator logs in with. Vm returns its sshable's unix_user, which is ubi for everything except GitHub runner and pool VMs, where it is runneradmin.