### PR TITLE
Clarify runner billing while runners wait for a job

### DIFF
--- a/views/github/runner.erb
+++ b/views/github/runner.erb
@@ -170,3 +170,10 @@
     EMPTY
   ) %>
 </div>
+
+<% if @runners.any? { it.workflow_job.nil? } %>
+  <div class="mt-3 flex items-center gap-1.5 text-xs text-gray-500">
+    <%== part("components/icon", name: "hero-information-circle", classes: "h-4 w-4 shrink-0 text-gray-400") %> Runners
+    are only billed when they run a job. Provisioning time and runners that GitHub never assigns a job to are free.
+  </div>
+<% end %>


### PR DESCRIPTION
Users assumed they were charged for the whole lifetime of a runner, including provisioning and idle runners GitHub never assigns a job to. Say plainly that billing only covers job execution, as a footnote under the runner list, and only while at least one runner is still without a job, which is when the question actually comes up.

| With Note | Without Note |
|:---------:|:------------:|
|   <img width="1400" height="850" alt="with_note" src="https://github.com/user-attachments/assets/84c7b60d-5264-4a4d-bed6-24238ac7b61e" /> |      <img width="1400" height="850" alt="without_note" src="https://github.com/user-attachments/assets/a6a39613-5d54-4686-8ecb-6a11a7dbb8ec" /> |


