### PR TITLE
Add info texts for runner hardware substitutions

### DIFF
--- a/spec/routes/web/project/github_spec.rb
+++ b/spec/routes/web/project/github_spec.rb
@@ -338,6 +338,45 @@ RSpec.describe Clover, "github" do
       expect(page.title).to eq("Ubicloud - GitHub Runner Settings")
     end
 
+    it "shows info about standard runners given premium hardware" do
+      installation.update(allocator_preferences: {})
+
+      vm = create_vm(project_id: project.id, name: "upgraded-vm", family: "premium", location_id: Location::GITHUB_RUNNERS_ID, allocated_at: Time.now)
+      runner = GithubRunner.create(installation_id: installation.id, repository_name: repository.name, label: "ubicloud-standard-4", vm_id: vm.id, location_id: vm.location_id)
+      Strand.create_with_id(runner, prog: "Github::GithubRunnerNexus", label: "wait")
+
+      visit "#{project.path}/github/#{installation.ubid}/runner"
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content "Some of your standard runners were given premium hardware instead, on us."
+      expect(page).to have_no_content "Some of your premium runners were given standard hardware instead"
+
+      runner.update(label: "ubicloud-premium-4")
+      visit "#{project.path}/github/#{installation.ubid}/runner"
+      expect(page).to have_no_content "Some of your standard runners were given premium hardware instead, on us."
+    end
+
+    it "shows info about premium runners given standard hardware" do
+      installation.update(allocator_preferences: {"family_filter" => ["premium", "standard"]})
+
+      vm = create_vm(project_id: project.id, name: "downgraded-vm", family: "standard", location_id: Location::GITHUB_RUNNERS_ID, allocated_at: Time.now)
+      runner = GithubRunner.create(installation_id: installation.id, repository_name: repository.name, label: "ubicloud-standard-4", vm_id: vm.id, location_id: vm.location_id)
+      Strand.create_with_id(runner, prog: "Github::GithubRunnerNexus", label: "wait")
+
+      visit "#{project.path}/github/#{installation.ubid}/runner"
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content "Some of your premium runners were given standard hardware instead"
+      expect(page).to have_no_content "Some of your standard runners were given premium hardware instead, on us."
+
+      vm.update(allocated_at: nil)
+      visit "#{project.path}/github/#{installation.ubid}/runner"
+      expect(page).to have_no_content "Some of your premium runners were given standard hardware instead"
+
+      vm.update(allocated_at: Time.now, arch: "arm64")
+      runner.update(label: "ubicloud-standard-4-arm")
+      visit "#{project.path}/github/#{installation.ubid}/runner"
+      expect(page).to have_no_content "Some of your premium runners were given standard hardware instead"
+    end
+
     it "shows concurrency warning for limited access accounts" do
       installation.project.update(reputation: "limited")
       3.times do |i|

--- a/views/github/runner.erb
+++ b/views/github/runner.erb
@@ -177,3 +177,18 @@
     are only billed when they run a job. Provisioning time and runners that GitHub never assigns a job to are free.
   </div>
 <% end %>
+
+<% if !@installation.premium_runner_enabled? && @runners.any? { it.label_data["family"] == "standard" && it.vm&.family == "premium" } %>
+  <div class="mt-3 flex items-center gap-1.5 text-xs text-gray-500">
+    <%== part("components/icon", name: "hero-information-circle", classes: "h-4 w-4 shrink-0 text-gray-400") %> Some of
+    your standard runners were given premium hardware instead, on us. You're not charged the premium rate for these.
+  </div>
+<% end %>
+
+<% if @installation.premium_runner_enabled? && @runners.any? { it.label_data["arch"] == "x64" && it.vm&.allocated_at && it.vm.family != "premium" } %>
+  <div class="mt-3 flex items-center gap-1.5 text-xs text-gray-500">
+    <%== part("components/icon", name: "hero-information-circle", classes: "h-4 w-4 shrink-0 text-gray-400") %> Some of
+    your premium runners were given standard hardware instead, so they don't wait in the queue for premium capacity.
+    You're only charged the standard rate for these.
+  </div>
+<% end %>


### PR DESCRIPTION
Let customers know when we transparently give them premium hardware for a standard runner request (free, our treat) or standard hardware for a premium request (billed as standard, to avoid a long queue wait), mirroring the existing "not charged while idle" note.