### PR TITLE
Log customer-initiated Postgres operations

### DIFF
--- a/helpers/postgres.rb
+++ b/helpers/postgres.rb
@@ -66,6 +66,21 @@ class Clover
     end
   end
 
+  POSTGRES_ACTION_LOG_MESSAGES = {
+    postgres_scale: "Postgres database scale requested",
+    postgres_ha_change: "Postgres database high availability change requested",
+    postgres_upgrade: "Postgres database upgrade requested",
+  }.freeze
+
+  def postgres_action_log(pg, event, **details)
+    Clog.emit(POSTGRES_ACTION_LOG_MESSAGES.fetch(event), {event => {
+      resource_ubid: pg.ubid,
+      project_ubid: @project.ubid,
+      account_ubid: current_account.ubid,
+      location: @location.display_name,
+    }.merge(details)})
+  end
+
   def postgres_list(tags_param: nil)
     dataset = dataset_authorize(@project.postgres_resources_dataset.eager(:project, :timeline, representative_server: [:semaphores, :strand, vm: :vm_storage_volumes]), "Postgres:view").eager(:semaphores, :location, strand: :children)
 

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -93,6 +93,11 @@ class Clover
 
         Validation.validate_vcpu_quota(@project, "PostgresVCpu", requested_postgres_vcpu_count - current_postgres_vcpu_count)
 
+        current_vm_size = pg.target_vm_size
+        current_storage_size_gib = pg.target_storage_size_gib
+        current_ha_type = pg.ha_type
+        current_standby_count = pg.target_standby_count
+
         DB.transaction do
           pg.update_target_sizes_with_replicas(target_vm_size: requested_parsed_size.name, target_storage_size_gib:, ha_type:, tags:)
 
@@ -112,6 +117,20 @@ class Clover
             end
           end
           audit_log(pg, "update")
+        end
+
+        if current_vm_size != pg.target_vm_size || current_storage_size_gib != pg.target_storage_size_gib
+          postgres_action_log(pg, :postgres_scale,
+            current_vm_size:, target_vm_size: pg.target_vm_size,
+            current_storage_size_gib:, target_storage_size_gib: pg.target_storage_size_gib,
+            current_vcpu_count: current_postgres_vcpu_count, target_vcpu_count: requested_postgres_vcpu_count)
+        end
+
+        if current_ha_type != pg.ha_type
+          postgres_action_log(pg, :postgres_ha_change,
+            current_ha_type:, target_ha_type: pg.ha_type,
+            current_standby_count:, target_standby_count: pg.target_standby_count,
+            vcpu_count: requested_parsed_size.vcpu_count, storage_size_gib: pg.target_storage_size_gib)
         end
 
         if api?
@@ -943,11 +962,15 @@ class Clover
 
           Validation.validate_postgres_upgrade(pg)
 
-          DB.transaction do
+          read_replica_count = DB.transaction do
             pg.update(target_version: pg.version.to_i + 1)
-            pg.read_replicas_dataset.update(target_version: pg.target_version)
             audit_log(pg, "upgrade")
+
+            pg.read_replicas_dataset.update(target_version: pg.target_version)
           end
+
+          postgres_action_log(pg, :postgres_upgrade,
+            current_version: pg.version, target_version: pg.target_version, read_replica_count:)
 
           if api?
             Serializers::PostgresUpgrade.serialize(pg)

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -257,6 +257,76 @@ RSpec.describe Clover, "postgres" do
         expect(last_response.status).to eq(200)
       end
 
+      it "logs scale and high availability changes" do
+        expect(Clog).to receive(:emit).with("Postgres database scale requested", {postgres_scale: {
+          resource_ubid: pg.ubid,
+          project_ubid: project.ubid,
+          account_ubid: user.ubid,
+          location: pg.display_location,
+          current_vm_size: "standard-2",
+          target_vm_size: "standard-8",
+          current_storage_size_gib: 128,
+          target_storage_size_gib: 256,
+          current_vcpu_count: 2,
+          target_vcpu_count: 16,
+        }}).and_call_original
+        expect(Clog).to receive(:emit).with("Postgres database high availability change requested", {postgres_ha_change: {
+          resource_ubid: pg.ubid,
+          project_ubid: project.ubid,
+          account_ubid: user.ubid,
+          location: pg.display_location,
+          current_ha_type: "none",
+          target_ha_type: "async",
+          current_standby_count: 0,
+          target_standby_count: 1,
+          vcpu_count: 8,
+          storage_size_gib: 256,
+        }}).and_call_original
+
+        patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}", {
+          size: "standard-8",
+          storage_size: 256,
+          ha_type: "async",
+        }.to_json
+
+        expect(last_response.status).to eq(200)
+      end
+
+      it "logs vcpu and storage sizes when only high availability changes" do
+        allow(Clog).to receive(:emit).and_call_original
+        expect(Clog).not_to receive(:emit).with("Postgres database scale requested", anything)
+        expect(Clog).to receive(:emit).with("Postgres database high availability change requested", {postgres_ha_change: {
+          resource_ubid: pg.ubid,
+          project_ubid: project.ubid,
+          account_ubid: user.ubid,
+          location: pg.display_location,
+          current_ha_type: "none",
+          target_ha_type: "sync",
+          current_standby_count: 0,
+          target_standby_count: 2,
+          vcpu_count: 2,
+          storage_size_gib: 128,
+        }}).and_call_original
+
+        patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}", {
+          ha_type: "sync",
+        }.to_json
+
+        expect(last_response.status).to eq(200)
+      end
+
+      it "does not log scale or high availability changes if the configuration is unchanged" do
+        allow(Clog).to receive(:emit).and_call_original
+        expect(Clog).not_to receive(:emit).with("Postgres database scale requested", anything)
+        expect(Clog).not_to receive(:emit).with("Postgres database high availability change requested", anything)
+
+        patch "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}", {
+          tags: [{key: "env", value: "prod"}],
+        }.to_json
+
+        expect(last_response.status).to eq(200)
+      end
+
       it "clears storage auto-scale semaphores on update" do
         pg.incr_storage_auto_scale_action_performed_80
         pg.incr_storage_auto_scale_action_performed_85
@@ -1492,6 +1562,22 @@ RSpec.describe Clover, "postgres" do
         expect(response["current_version"]).to eq(pg.version)
         expect(response["target_version"]).to eq(pg.reload.target_version)
         expect(pg.reload.target_version.to_i).to eq(old_pg_version + 1)
+      end
+
+      it "logs the upgrade request" do
+        expect(Clog).to receive(:emit).with("Postgres database upgrade requested", {postgres_upgrade: {
+          resource_ubid: pg.ubid,
+          project_ubid: project.ubid,
+          account_ubid: user.ubid,
+          location: pg.display_location,
+          current_version: "16",
+          target_version: "17",
+          read_replica_count: 0,
+        }}).and_call_original
+
+        post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/upgrade"
+
+        expect(last_response.status).to eq(200)
       end
 
       it "failed post" do


### PR DESCRIPTION
Emit a log line at the point the request is accepted to gather data. The
endpoints are the natural place for this: they see both the old and the
new configuration, they know which account asked, and there is exactly
one line per customer action rather than one per convergence attempt.
The resize endpoint serves both scaling and HA changes and can carry a
request that touches neither, so it emits up to two lines, only for the
fields that actually changed.