### PR TITLE
Add admin pages to group accounts by IP address

### DIFF
--- a/clover_admin.rb
+++ b/clover_admin.rb
@@ -2150,6 +2150,72 @@ class CloverAdmin < Roda
       view("customer_usage")
     end
 
+    r.on "accounts-by-ip" do
+      @days = (typecast_params.pos_int("days") || 30).clamp(1, 365)
+      audit_logs = DB[:account_authentication_audit_log].where(at: (Time.now - @days * 24 * 60 * 60)..)
+
+      r.get true do
+        @min_accounts = (typecast_params.pos_int("min_accounts") || 2).clamp(2, 100)
+
+        ip = Sequel.pg_jsonb_op(:metadata).get_text("ip")
+        account_ips = audit_logs
+          .exclude(ip => nil)
+          .distinct
+          .select(ip.as(:ip), :account_id)
+
+        count = Sequel.function(:count).*
+        last_created_at = Sequel.function(:max, Sequel[:accounts][:created_at])
+
+        @data = DB[account_ips.as(:ai)]
+          .join(:accounts, id: Sequel[:ai][:account_id])
+          .group(Sequel[:ai][:ip])
+          .having(count >= @min_accounts)
+          .select(
+            Sequel[:ai][:ip],
+            count.as(:account_count),
+            count.filter(Sequel.~(Sequel[:accounts][:suspended_at] => nil)).as(:suspended_account_count),
+            Sequel.function(:min, Sequel[:accounts][:created_at]).as(:first_created_at),
+            last_created_at.as(:last_created_at),
+          )
+          .reverse(last_created_at)
+          .map do |row|
+            {
+              "IP" => table_link(row[:ip], "/accounts-by-ip/#{row[:ip]}?#{to_query_string("days" => @days)}"),
+              "Accounts" => row[:account_count],
+              "Suspended Accounts" => row[:suspended_account_count],
+              "First Account Created At" => row[:first_created_at],
+              "Last Account Created At" => row[:last_created_at],
+            }
+          end
+
+        view("accounts_by_ip")
+      end
+
+      r.get String do |ip|
+        @ip = ip
+        account_ids = audit_logs
+          .where(Sequel.pg_jsonb_op(:metadata).contains(Sequel.pg_jsonb("ip" => ip)))
+          .select(:account_id)
+
+        @data = DB[:accounts]
+          .where(id: account_ids)
+          .reverse(:created_at)
+          .select(:id, :name, :email, :created_at, :suspended_at)
+          .map do |row|
+            ubid = UBID.to_ubid(row[:id])
+            {
+              "Account" => table_link(ubid, "/model/Account/#{ubid}"),
+              "Name" => row[:name],
+              "Email" => row[:email],
+              "Created At" => row[:created_at],
+              "Suspended At" => row[:suspended_at],
+            }
+          end
+
+        view("accounts_for_ip")
+      end
+    end
+
     r.post "close-admin-account" do
       login = typecast_params.nonempty_str!("login")
 

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -3932,6 +3932,85 @@ RSpec.describe CloverAdmin do
     expect(page).to have_no_content("internal-service")
   end
 
+  it "shows accounts grouped by IP address, ordered by last account creation" do
+    fraud1 = create_account("fraud1@ibi.com", with_project: false)
+    fraud2 = create_account("fraud2@ibi.com", with_project: false)
+    fraud3 = create_account("fraud3@ibi.com", with_project: false)
+    other = create_account("other@ibi.com", with_project: false)
+    alone = create_account("alone@ibi.com", with_project: false)
+
+    fraud1.update(created_at: Time.now - 300, suspended_at: Time.now)
+    fraud2.update(created_at: Time.now - 200)
+    fraud3.update(created_at: Time.now - 100, suspended_at: Time.now)
+    other.update(created_at: Time.now - 400)
+
+    add_ip = ->(account, ip, message = "login", at: Sequel::CURRENT_TIMESTAMP) do
+      DB[:account_authentication_audit_log].insert(account_id: account.id, message:, metadata: Sequel.pg_jsonb({"ip" => ip}), at:)
+    end
+
+    [fraud1, fraud2, fraud3].each { add_ip.call(it, "1.2.3.4", "create_account") }
+    add_ip.call(fraud1, "1.2.3.4") # duplicate IP for same account is counted once
+    add_ip.call(fraud1, "5.6.7.8")
+    add_ip.call(other, "5.6.7.8")
+    add_ip.call(alone, "9.9.9.9") # single account IPs are not shown
+    add_ip.call(other, "1.2.3.4", "login", at: Time.now - 40 * 24 * 60 * 60) # older than the default 30 day window
+    DB[:account_authentication_audit_log].insert(account_id: alone.id, message: "login", metadata: Sequel.pg_jsonb({}))
+
+    rows = -> { page.all(".accounts-by-ip-table tbody tr").map { it.all("td").map(&:text) } }
+    time = ->(account) { account.reload.created_at.strftime("%F %T") }
+
+    click_link "Accounts by IP Address"
+    expect(page.title).to eq "Ubicloud Admin - Accounts by IP Address"
+    expect(page.all(".accounts-by-ip-table thead th").map(&:text)).to eq(
+      ["IP", "Accounts", "Suspended Accounts", "First Account Created At", "Last Account Created At"],
+    )
+    expect(rows.call).to eq([
+      ["1.2.3.4", "3", "2", time.call(fraud1), time.call(fraud3)],
+      ["5.6.7.8", "2", "1", time.call(other), time.call(fraud1)],
+    ])
+
+    click_link "1.2.3.4"
+    expect(page).to have_current_path("/accounts-by-ip/1.2.3.4?days=30")
+    expect(page.title).to eq "Ubicloud Admin - Accounts for 1.2.3.4"
+    expect(page.all(".accounts-for-ip-table thead th").map(&:text)).to eq(
+      ["Account", "Name", "Email", "Created At", "Suspended At"],
+    )
+    expect(page.all(".accounts-for-ip-table tbody tr").map { it.all("td").map(&:text) }).to eq([
+      [fraud3.ubid, "", fraud3.email, time.call(fraud3), fraud3.suspended_at.strftime("%F %T")],
+      [fraud2.ubid, "", fraud2.email, time.call(fraud2), ""],
+      [fraud1.ubid, "", fraud1.email, time.call(fraud1), fraud1.suspended_at.strftime("%F %T")],
+    ])
+
+    # The older log line of the other account is only in the wider day window.
+    click_link "Back to Accounts by IP Address"
+    fill_in "Days", with: "60"
+    click_button "Show Accounts"
+    click_link "1.2.3.4"
+    expect(page.all(".accounts-for-ip-table tbody td:nth-child(3)").map(&:text)).to include(other.email)
+
+    click_link "Authentication Audit Logs for this IP"
+    expect(page.title).to eq "Ubicloud Admin - Authentication Audit Log"
+    expect(page.all("#audit-log-search-results tbody td:nth-child(3)").map(&:text).uniq.sort).to eq([fraud1, fraud2, fraud3, other].map(&:ubid).sort)
+
+    visit "/accounts-by-ip"
+    fill_in "Days", with: "60"
+    click_button "Show Accounts"
+    expect(rows.call).to eq([
+      ["1.2.3.4", "4", "2", time.call(other), time.call(fraud3)],
+      ["5.6.7.8", "2", "1", time.call(other), time.call(fraud1)],
+    ])
+
+    visit "/accounts-by-ip"
+    fill_in "Minimum Accounts", with: "3"
+    click_button "Show Accounts"
+    expect(rows.call).to eq([["1.2.3.4", "3", "2", time.call(fraud1), time.call(fraud3)]])
+
+    DB[:account_authentication_audit_log].delete
+    visit "/accounts-by-ip"
+    expect(page).to have_no_css(".accounts-by-ip-table")
+    expect(page).to have_content("No data available")
+  end
+
   it "shows customer resources hosted on a VM host, resolving managed services to the customer" do
     vm_host = create_vm_host
     other_vm_host = create_vm_host

--- a/views/admin/accounts_by_ip.erb
+++ b/views/admin/accounts_by_ip.erb
@@ -1,0 +1,16 @@
+<% @page_title = "Accounts by IP Address" %>
+
+<p>
+  Accounts grouped by the IP addresses in their authentication audit logs. Fraudulent accounts often sign up and sign in
+  from the same address, so addresses with many accounts are worth a review. Only the authentication audit logs of the
+  given number of days are used, thus a group that was quiet for a longer time needs a larger day value. Larger day
+  values increase the query duration.
+</p>
+
+<% form(id: "accounts_by_ip_form", class: "form-vertical") do |f| %>
+  <%== f.input(:number, key: "days", label: "Days", value: @days, min: 1, max: 365) %>
+  <%== f.input(:number, key: "min_accounts", label: "Minimum Accounts", value: @min_accounts, min: 2, max: 100) %>
+  <%== f.button("Show Accounts") %>
+<% end %>
+
+<%== part("components/table", title: nil, table_class: "accounts-by-ip-table", data: @data, use_admin_label: false) %>

--- a/views/admin/accounts_for_ip.erb
+++ b/views/admin/accounts_for_ip.erb
@@ -1,0 +1,12 @@
+<% @page_title = "Accounts for #{@ip}" %>
+
+<p>
+  Accounts that used <strong><%= @ip %></strong> in their authentication audit logs in the last <%= @days %> days.
+</p>
+
+<p>
+  <a href="/accounts-by-ip?<%= to_query_string("days" => @days) %>">Back to Accounts by IP Address</a> |
+  <a href="/authentication-audit-log?<%= to_query_string("metadata" => "ip=#{@ip}") %>">Authentication Audit Logs for this IP</a>
+</p>
+
+<%== part("components/table", title: nil, table_class: "accounts-for-ip-table", data: @data, use_admin_label: false) %>

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -69,6 +69,7 @@
     <li><a href="/cogs">VM Host COGS</a></li>
     <li><a href="/setup-vm-host">Setup VM Host</a></li>
     <li><a href="/customer-usage">Customer Usage</a></li>
+    <li><a href="/accounts-by-ip">Accounts by IP Address</a></li>
 
     <li>
       <a href="/audit-log">View Audit Logs</a> | <a href="/authentication-audit-log">View Authentication Audit Logs</a>


### PR DESCRIPTION
Fraudulent accounts often sign up and sign in from a single IP address, but nothing in the admin panel made that visible. Finding a ring meant searching the authentication audit log by IP by hand, one address at a time.

Add two pages driven by the ip key that Rodauth writes into every authentication audit log entry:

- /accounts-by-ip lists the addresses with more than one account, showing the account count, the suspended account count, and the first and last account creation dates, ordered by the last creation date. A day window (30 by default) bounds the query, which also lets Postgres prune the monthly log partitions.

- /accounts-by-ip?ip=... names the accounts behind one address, with name, email, creation date, and suspension date. It carries the day window over, so the listed accounts match the count that was clicked, and it uses jsonb containment, which the GIN index on the metadata column serves.

A distinct (ip, account_id) pair feeds the grouping, so repeated logins from one account count as one account.