### PR TITLE
Suppress unused association message

### DIFF
--- a/model/hypervisor.rb
+++ b/model/hypervisor.rb
@@ -3,7 +3,7 @@
 require_relative "../model"
 
 class Hypervisor < Sequel::Model
-  one_to_many :vms, read_only: true
+  one_to_many :vms, read_only: true, is_used: true
 
   plugin ResourceMethods, etc_type: true
 


### PR DESCRIPTION
The `one_to_many` Hypervisor to VM association is only used on admin pages, where it creates pages listing the VMs that use a specific hypervisor.

Because it is only used on admin pages, `rake unused_associations_check` flags it as unused, but because the admin pages are helpful, we suppress the flag using `is_used: true`.