### PR TITLE
List timeline objects from a cursor

### DIFF
--- a/lib/minio/client.rb
+++ b/lib/minio/client.rb
@@ -119,42 +119,37 @@ class Minio::Client
     response.status == 200
   end
 
-  def list_objects(bucket_name, folder_path, max_keys: 1000, delimiter: "")
-    objects = []
-    query = URI.encode_www_form({
+  # Returns [objects, next_token], where a nil token means the listing is
+  # complete. Callers that must bound their own work stop between pages.
+  def list_objects_page(bucket_name, folder_path, max_keys: 1000, delimiter: "", start_after: nil, token: nil)
+    params = {
       "delimiter" => delimiter,
       "encoding-type" => "url",
       "list-type" => 2,
       "prefix" => folder_path,
       "max-keys" => max_keys,
-    })
-    response = send_request("GET", s3_uri("#{bucket_name}?#{query}"))
-    if response.status == 404
-      return objects
+    }
+    if token
+      params["continuation-token"] = token
+    elsif start_after
+      params["start-after"] = start_after
     end
 
-    parsed_objects = parse_list_objects(response.data[:body])
-    objects.concat(parsed_objects[0])
+    response = send_request("GET", s3_uri("#{bucket_name}?#{URI.encode_www_form(params)}"))
+    return [[].freeze, nil] if response.status == 404
 
-    is_truncated = parsed_objects[1]
-    continuation_token = parsed_objects[2]
-    while is_truncated
-      query = URI.encode_www_form({
-        "continuation-token" => continuation_token,
-        "delimiter" => delimiter,
-        "encoding-type" => "url",
-        "list-type" => 2,
-        "prefix" => folder_path,
-        "max-keys" => max_keys,
-        "start-after" => continuation_token,
-      })
-      response = send_request("GET", s3_uri("#{bucket_name}?#{query}"))
-      parsed_objects = parse_list_objects(response.data[:body])
-      objects.concat(parsed_objects[0])
-      is_truncated = parsed_objects[1]
-      continuation_token = parsed_objects[2]
+    objects, is_truncated, continuation_token = parse_list_objects(response.data[:body])
+    [objects, is_truncated ? continuation_token : nil]
+  end
+
+  def list_objects(bucket_name, folder_path, max_keys: 1000, delimiter: "", start_after: nil)
+    objects = []
+    token = nil
+    loop do
+      page, token = list_objects_page(bucket_name, folder_path, max_keys:, delimiter:, start_after:, token:)
+      objects.concat(page)
+      break unless token
     end
-
     objects
   end
 

--- a/model/location_credential_gcp.rb
+++ b/model/location_credential_gcp.rb
@@ -5,6 +5,7 @@ require "google/cloud/compute/v1"
 require "google/cloud/storage"
 require "google/apis/cloudresourcemanager_v3"
 require "google/apis/iam_v1"
+require "google/apis/storage_v1"
 require "googleauth"
 
 class LocationCredentialGcp < Sequel::Model
@@ -72,6 +73,15 @@ class LocationCredentialGcp < Sequel::Model
       project_id:,
       credentials: auth_credentials,
     )
+  end
+
+  # Bucket#files cannot list from an offset; startOffset needs this client.
+  def storage_api_client
+    @storage_api_client ||= begin
+      client = Google::Apis::StorageV1::StorageService.new
+      client.authorization = auth_credentials
+      client
+    end
   end
 
   def iam_client

--- a/model/postgres/aws/postgres_timeline.rb
+++ b/model/postgres/aws/postgres_timeline.rb
@@ -67,12 +67,25 @@ PGDATA=/dat/#{version}/data
       )
     end
 
-    def aws_list_objects(prefix, delimiter: "")
-      response = blob_storage_client.list_objects_v2(bucket: ubid, prefix:, delimiter:)
-      objects = response.contents
-      while response.is_truncated
-        response = blob_storage_client.list_objects_v2(bucket: ubid, prefix:, delimiter:, continuation_token: response.next_continuation_token)
-        objects.concat(response.contents)
+    def aws_list_objects_page(prefix, delimiter: "", start_after: nil, token: nil)
+      params = {bucket: ubid, prefix:, delimiter:}
+      # continuation_token supersedes start_after.
+      if token
+        params[:continuation_token] = token
+      elsif start_after
+        params[:start_after] = start_after
+      end
+      response = blob_storage_client.list_objects_v2(**params)
+      [response.contents, response.is_truncated ? response.next_continuation_token : nil]
+    end
+
+    def aws_list_objects(prefix, delimiter: "", start_after: nil)
+      objects = []
+      token = nil
+      loop do
+        page, token = aws_list_objects_page(prefix, delimiter:, start_after:, token:)
+        objects.concat(page)
+        break unless token
       end
       objects
     end

--- a/model/postgres/gcp/postgres_timeline.rb
+++ b/model/postgres/gcp/postgres_timeline.rb
@@ -2,7 +2,7 @@
 
 class PostgresTimeline < Sequel::Model
   GcsBlobStorage = Data.define(:url)
-  GcsFileWrapper = Data.define(:key, :last_modified)
+  GcsFileWrapper = Data.define(:key, :last_modified, :size)
 
   module Gcp
     private
@@ -40,19 +40,33 @@ PGDATA=/dat/#{version}/data
       @blob_storage_client ||= location.location_credential_gcp.storage_client
     end
 
-    def gcp_list_objects(prefix, delimiter: "")
-      bucket = blob_storage_client.bucket(ubid)
-      return [] unless bucket
-
+    def gcp_list_objects_page(prefix, delimiter: "", start_after: nil, token: nil)
+      api = location.location_credential_gcp.storage_api_client
       delimiter = nil if delimiter.empty?
-      files = bucket.files(prefix:, delimiter:)
-      all_files = files.to_a
-      while (token = files.token)
-        files = bucket.files(prefix:, delimiter:, token:)
-        all_files.concat(files.to_a)
-      end
 
-      all_files.map! { |f| GcsFileWrapper.new(f.name, f.updated_at.to_time) }
+      # A page token already encodes its position, and the other providers only
+      # accept a cursor on the first request.
+      response = api.list_objects(ubid, prefix:, delimiter:, start_offset: (start_after if token.nil?),
+        page_token: token, max_results: 1000)
+      objects = response.items || [].freeze
+      # startOffset is inclusive, start_after is not.
+      objects = objects.drop(1) if token.nil? && start_after && objects.first&.name == start_after
+
+      [objects.map { GcsFileWrapper.new(it.name, it.updated.to_time, it.size) }, response.next_page_token]
+    rescue Google::Apis::ClientError => ex
+      raise unless ex.status_code == 404
+      [[].freeze, nil]
+    end
+
+    def gcp_list_objects(prefix, delimiter: "", start_after: nil)
+      objects = []
+      token = nil
+      loop do
+        page, token = gcp_list_objects_page(prefix, delimiter:, start_after:, token:)
+        objects.concat(page)
+        break unless token
+      end
+      objects
     end
 
     def gcp_create_bucket

--- a/model/postgres/metal/postgres_timeline.rb
+++ b/model/postgres/metal/postgres_timeline.rb
@@ -46,8 +46,12 @@ PGDATA=/dat/#{version}/data
       )
     end
 
-    def metal_list_objects(prefix, delimiter: "")
-      blob_storage_client.list_objects(ubid, prefix, delimiter:)
+    def metal_list_objects_page(prefix, delimiter: "", start_after: nil, token: nil)
+      blob_storage_client.list_objects_page(ubid, prefix, delimiter:, start_after:, token:)
+    end
+
+    def metal_list_objects(prefix, delimiter: "", start_after: nil)
+      blob_storage_client.list_objects(ubid, prefix, delimiter:, start_after:)
     end
 
     def metal_create_bucket

--- a/spec/lib/minio/client_spec.rb
+++ b/spec/lib/minio/client_spec.rb
@@ -194,13 +194,49 @@ RSpec.describe Minio::Client do
 
     it "properly lists objects with or without continuation-token" do
       stub_request(:get, "#{endpoint}/test?delimiter=&encoding-type=url&list-type=2&prefix=folder_path&max-keys=1").to_return(status: 200, body: xml_with_continuation_token)
-      stub_request(:get, "#{endpoint}/test?continuation-token=ct&delimiter=&encoding-type=url&list-type=2&prefix=folder_path&max-keys=1&start-after=ct").to_return(status: 200, body: xml_without_continuation_token)
+      stub_request(:get, "#{endpoint}/test?delimiter=&encoding-type=url&list-type=2&prefix=folder_path&max-keys=1&continuation-token=ct").to_return(status: 200, body: xml_without_continuation_token)
       expect(minio_client.list_objects("test", "folder_path", max_keys: 1).map(&:key)).to eq(["name1", "name2"])
+    end
+
+    it "returns a page and its continuation token" do
+      stub_request(:get, "#{endpoint}/test?delimiter=&encoding-type=url&list-type=2&prefix=folder_path&max-keys=1").to_return(status: 200, body: xml_with_continuation_token)
+      objects, token = minio_client.list_objects_page("test", "folder_path", max_keys: 1)
+      expect(objects.map(&:key)).to eq(["name1"])
+      expect(token).to eq("ct")
+    end
+
+    it "returns a nil token on the last page" do
+      stub_request(:get, "#{endpoint}/test?delimiter=&encoding-type=url&list-type=2&prefix=folder_path&max-keys=1").to_return(status: 200, body: xml_without_continuation_token)
+      objects, token = minio_client.list_objects_page("test", "folder_path", max_keys: 1)
+      expect(objects.map(&:key)).to eq(["name2"])
+      expect(token).to be_nil
+    end
+
+    it "sends continuation-token instead of start-after once paging" do
+      stub_request(:get, "#{endpoint}/test?delimiter=&encoding-type=url&list-type=2&prefix=folder_path&max-keys=1&continuation-token=ct").to_return(status: 200, body: xml_without_continuation_token)
+      objects, token = minio_client.list_objects_page("test", "folder_path", max_keys: 1, start_after: "name1", token: "ct")
+      expect(objects.map(&:key)).to eq(["name2"])
+      expect(token).to be_nil
+    end
+
+    it "returns an empty page for a non existent bucket" do
+      stub_request(:get, "#{endpoint}/test?delimiter=&encoding-type=url&list-type=2&prefix=folder_path&max-keys=1").to_return(status: 404)
+      expect(minio_client.list_objects_page("test", "folder_path", max_keys: 1)).to eq([[], nil])
     end
 
     it "returns empty list for non existent bucket" do
       stub_request(:get, "#{endpoint}/test?delimiter=&encoding-type=url&list-type=2&prefix=folder_path&max-keys=1").to_return(status: 404)
       expect(minio_client.list_objects("test", "folder_path", max_keys: 1)).to eq([])
+    end
+
+    it "passes start-after when given" do
+      stub_request(:get, "#{endpoint}/test?delimiter=&encoding-type=url&list-type=2&prefix=folder_path&max-keys=1&start-after=name1").to_return(status: 200, body: xml_without_continuation_token)
+      expect(minio_client.list_objects("test", "folder_path", max_keys: 1, start_after: "name1").map(&:key)).to eq(["name2"])
+    end
+
+    it "omits start-after when not given" do
+      stub_request(:get, "#{endpoint}/test?delimiter=&encoding-type=url&list-type=2&prefix=folder_path&max-keys=1").to_return(status: 200, body: xml_without_continuation_token)
+      expect(minio_client.list_objects("test", "folder_path", max_keys: 1).map(&:key)).to eq(["name2"])
     end
   end
 

--- a/spec/model/postgres/gcp/postgres_timeline_spec.rb
+++ b/spec/model/postgres/gcp/postgres_timeline_spec.rb
@@ -103,70 +103,125 @@ PGDATA=/dat/17/data
     end
 
     describe "#list_objects" do
-      it "returns wrapped GCS file objects with key and last_modified converted to Time" do
-        bucket = instance_double(Google::Cloud::Storage::Bucket)
-        storage_client = instance_double(Google::Cloud::Storage::Project)
-        expect(postgres_timeline).to receive(:blob_storage_client).and_return(storage_client)
+      let(:storage_api) { instance_double(Google::Apis::StorageV1::StorageService) }
 
-        updated_datetime = Time.now
-        file1 = instance_double(Google::Cloud::Storage::File, name: "basebackups_005/0001_backup_stop_sentinel.json", updated_at: updated_datetime)
-        file2 = instance_double(Google::Cloud::Storage::File, name: "basebackups_005/0002_data.tar", updated_at: updated_datetime)
-        file_list = instance_double(Google::Cloud::Storage::File::List, to_a: [file1, file2], token: nil)
-
-        expect(storage_client).to receive(:bucket).with(postgres_timeline.ubid).and_return(bucket)
-        expect(bucket).to receive(:files).with(prefix: "basebackups_005/", delimiter: nil).and_return(file_list)
-
-        objects = postgres_timeline.list_objects("basebackups_005/")
-        expect(objects.length).to eq(2)
-        expect(objects.first.key).to eq("basebackups_005/0001_backup_stop_sentinel.json")
-        expect(objects.first.last_modified).to be_a(Time)
-        expect(objects.first.last_modified).to eq(updated_datetime.to_time)
+      before do
+        allow(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(nil)
+        allow(Google::Apis::StorageV1::StorageService).to receive(:new).and_return(storage_api)
+        allow(storage_api).to receive(:authorization=)
       end
 
-      it "returns empty array when bucket does not exist" do
-        storage_client = instance_double(Google::Cloud::Storage::Project)
-        expect(postgres_timeline).to receive(:blob_storage_client).and_return(storage_client)
-        expect(storage_client).to receive(:bucket).with(postgres_timeline.ubid).and_return(nil)
+      def gcs_object(name, size: 100, updated: Time.now)
+        instance_double(Google::Apis::StorageV1::Object, name:, size:, updated:)
+      end
+
+      def gcs_page(items, next_page_token: nil)
+        instance_double(Google::Apis::StorageV1::Objects, items:, next_page_token:)
+      end
+
+      it "returns wrapped objects with key, last_modified and size" do
+        updated = Time.now
+        expect(storage_api).to receive(:list_objects).with(postgres_timeline.ubid, prefix: "basebackups_005/",
+          delimiter: nil, start_offset: nil, page_token: nil, max_results: 1000)
+          .and_return(gcs_page([gcs_object("basebackups_005/0001_backup_stop_sentinel.json", size: 42, updated:)]))
+
+        objects = postgres_timeline.list_objects("basebackups_005/")
+        expect(objects.length).to eq(1)
+        expect(objects.first.key).to eq("basebackups_005/0001_backup_stop_sentinel.json")
+        expect(objects.first.size).to eq(42)
+        expect(objects.first.last_modified).to eq(updated.to_time)
+      end
+
+      it "returns empty array when the bucket does not exist" do
+        expect(storage_api).to receive(:list_objects).once
+          .and_raise(Google::Apis::ClientError.new("notFound", status_code: 404))
 
         expect(postgres_timeline.list_objects("prefix/")).to eq([])
       end
 
-      it "handles pagination with delimiter" do
-        bucket = instance_double(Google::Cloud::Storage::Bucket)
-        storage_client = instance_double(Google::Cloud::Storage::Project)
-        expect(postgres_timeline).to receive(:blob_storage_client).and_return(storage_client)
+      it "re-raises client errors other than a missing bucket" do
+        expect(storage_api).to receive(:list_objects).once
+          .and_raise(Google::Apis::ClientError.new("forbidden", status_code: 403))
 
-        file1 = instance_double(Google::Cloud::Storage::File, name: "file1", updated_at: Time.now)
-        file2 = instance_double(Google::Cloud::Storage::File, name: "file2", updated_at: Time.now)
-        page1 = instance_double(Google::Cloud::Storage::File::List, to_a: [file1], token: "next-page")
-        page2 = instance_double(Google::Cloud::Storage::File::List, to_a: [file2], token: nil)
-
-        expect(storage_client).to receive(:bucket).with(postgres_timeline.ubid).and_return(bucket)
-        expect(bucket).to receive(:files).with(prefix: "prefix/", delimiter: "/").and_return(page1)
-        expect(bucket).to receive(:files).with(prefix: "prefix/", delimiter: "/", token: "next-page").and_return(page2)
-
-        objects = postgres_timeline.list_objects("prefix/", delimiter: "/")
-        expect(objects.length).to eq(2)
-        expect(objects.map(&:key)).to eq(["file1", "file2"])
+        expect { postgres_timeline.list_objects("prefix/") }.to raise_error(Google::Apis::ClientError)
       end
 
-      it "handles pagination without delimiter" do
-        bucket = instance_double(Google::Cloud::Storage::Bucket)
-        storage_client = instance_double(Google::Cloud::Storage::Project)
-        expect(postgres_timeline).to receive(:blob_storage_client).and_return(storage_client)
+      it "follows pagination and passes the delimiter through" do
+        expect(storage_api).to receive(:list_objects).with(postgres_timeline.ubid, prefix: "prefix/", delimiter: "/",
+          start_offset: nil, page_token: nil, max_results: 1000)
+          .and_return(gcs_page([gcs_object("file1")], next_page_token: "next-page"))
+        expect(storage_api).to receive(:list_objects).with(postgres_timeline.ubid, prefix: "prefix/", delimiter: "/",
+          start_offset: nil, page_token: "next-page", max_results: 1000)
+          .and_return(gcs_page([gcs_object("file2")]))
 
-        file1 = instance_double(Google::Cloud::Storage::File, name: "file1", updated_at: Time.now)
-        file2 = instance_double(Google::Cloud::Storage::File, name: "file2", updated_at: Time.now)
-        page1 = instance_double(Google::Cloud::Storage::File::List, to_a: [file1], token: "next-page")
-        page2 = instance_double(Google::Cloud::Storage::File::List, to_a: [file2], token: nil)
+        expect(postgres_timeline.list_objects("prefix/", delimiter: "/").map(&:key)).to eq(["file1", "file2"])
+      end
 
-        expect(storage_client).to receive(:bucket).with(postgres_timeline.ubid).and_return(bucket)
-        expect(bucket).to receive(:files).with(prefix: "prefix/", delimiter: nil).and_return(page1)
-        expect(bucket).to receive(:files).with(prefix: "prefix/", delimiter: nil, token: "next-page").and_return(page2)
+      it "drops the cursor object, because startOffset is inclusive" do
+        expect(storage_api).to receive(:list_objects).with(postgres_timeline.ubid, prefix: "wal_005/", delimiter: nil,
+          start_offset: "wal_005/a", page_token: nil, max_results: 1000)
+          .and_return(gcs_page([gcs_object("wal_005/a"), gcs_object("wal_005/b")]))
 
-        objects = postgres_timeline.list_objects("prefix/")
-        expect(objects.length).to eq(2)
-        expect(objects.map(&:key)).to eq(["file1", "file2"])
+        expect(postgres_timeline.list_objects("wal_005/", start_after: "wal_005/a").map(&:key)).to eq(["wal_005/b"])
+      end
+
+      it "keeps the first object when it is past the cursor" do
+        expect(storage_api).to receive(:list_objects).with(postgres_timeline.ubid, prefix: "wal_005/", delimiter: nil,
+          start_offset: "wal_005/a", page_token: nil, max_results: 1000)
+          .and_return(gcs_page([gcs_object("wal_005/b"), gcs_object("wal_005/c")]))
+
+        expect(postgres_timeline.list_objects("wal_005/", start_after: "wal_005/a").map(&:key)).to eq(["wal_005/b", "wal_005/c"])
+      end
+
+      it "tolerates a bucket with no objects" do
+        expect(storage_api).to receive(:list_objects).once.and_return(gcs_page(nil))
+
+        expect(postgres_timeline.list_objects("wal_005/", start_after: "wal_005/a")).to eq([])
+      end
+    end
+
+    describe "#list_objects_page" do
+      let(:storage_api) { instance_double(Google::Apis::StorageV1::StorageService) }
+
+      before do
+        allow(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(nil)
+        allow(Google::Apis::StorageV1::StorageService).to receive(:new).and_return(storage_api)
+        allow(storage_api).to receive(:authorization=)
+      end
+
+      def gcs_object(name, size: 100, updated: Time.now)
+        instance_double(Google::Apis::StorageV1::Object, name:, size:, updated:)
+      end
+
+      def gcs_page(items, next_page_token: nil)
+        instance_double(Google::Apis::StorageV1::Objects, items:, next_page_token:)
+      end
+
+      it "returns one page and its token without following it" do
+        expect(storage_api).to receive(:list_objects).once.with(postgres_timeline.ubid, prefix: "wal_005/",
+          delimiter: nil, start_offset: nil, page_token: nil, max_results: 1000)
+          .and_return(gcs_page([gcs_object("wal_005/a")], next_page_token: "next-page"))
+
+        objects, token = postgres_timeline.list_objects_page("wal_005/")
+        expect(objects.map(&:key)).to eq(["wal_005/a"])
+        expect(token).to eq("next-page")
+      end
+
+      it "keeps the cursor object on a continuation page, and sends no offset with a token" do
+        expect(storage_api).to receive(:list_objects).with(postgres_timeline.ubid, prefix: "wal_005/",
+          delimiter: nil, start_offset: nil, page_token: "next-page", max_results: 1000)
+          .and_return(gcs_page([gcs_object("wal_005/a"), gcs_object("wal_005/b")]))
+
+        objects, token = postgres_timeline.list_objects_page("wal_005/", start_after: "wal_005/a", token: "next-page")
+        expect(objects.map(&:key)).to eq(["wal_005/a", "wal_005/b"])
+        expect(token).to be_nil
+      end
+
+      it "returns an empty page when the bucket does not exist" do
+        expect(storage_api).to receive(:list_objects).once
+          .and_raise(Google::Apis::ClientError.new("notFound", status_code: 404))
+
+        expect(postgres_timeline.list_objects_page("wal_005/")).to eq([[], nil])
       end
     end
 

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -317,7 +317,7 @@ PGDATA=/dat/17/data
     expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs")).at_least(:once)
 
     minio_client = Minio::Client.new(endpoint: "https://blob-endpoint", access_key: "access_key", secret_key: "secret_key", ssl_ca_data: "data")
-    expect(minio_client).to receive(:list_objects).with(postgres_timeline.ubid, "basebackups_005/", delimiter: "/").and_return([instance_double(Minio::Client::Blob, key: "backup_stop_sentinel.json"), instance_double(Minio::Client::Blob, key: "unrelated_file.txt")])
+    expect(minio_client).to receive(:list_objects).with(postgres_timeline.ubid, "basebackups_005/", delimiter: "/", start_after: nil).and_return([instance_double(Minio::Client::Blob, key: "backup_stop_sentinel.json"), instance_double(Minio::Client::Blob, key: "unrelated_file.txt")])
     expect(Minio::Client).to receive(:new).and_return(minio_client)
 
     expect(postgres_timeline.backups.map(&:key)).to eq(["backup_stop_sentinel.json"])
@@ -342,6 +342,42 @@ PGDATA=/dat/17/data
     expect(s3_client).to receive(:list_objects_v2).with(bucket: postgres_timeline.ubid, prefix: "basebackups_005/", delimiter: "/", continuation_token: "token").and_call_original
     expect(Aws::S3::Client).to receive(:new).and_return(s3_client)
     expect(postgres_timeline.backups.map(&:key)).to eq(["backup_stop_sentinel.json", "backup_stop_sentinel.json"])
+  end
+
+  it "returns a single page and its continuation token" do
+    expect(postgres_timeline).to receive(:blob_storage).and_return(instance_double(MinioCluster, url: "https://blob-endpoint", root_certs: "certs")).at_least(:once)
+
+    minio_client = Minio::Client.new(endpoint: "https://blob-endpoint", access_key: "access_key", secret_key: "secret_key", ssl_ca_data: "data")
+    expect(minio_client).to receive(:list_objects_page).with(postgres_timeline.ubid, "wal_005/", delimiter: "", start_after: "wal_005/a", token: nil).and_return([[], "token"])
+    expect(Minio::Client).to receive(:new).and_return(minio_client)
+
+    expect(postgres_timeline.list_objects_page("wal_005/", start_after: "wal_005/a")).to eq([[], "token"])
+  end
+
+  it "returns a single page and its continuation token for AWS regions" do
+    postgres_timeline.update(location_id: create_aws_location.id)
+
+    s3_client = Aws::S3::Client.new(stub_responses: true)
+    s3_client.stub_responses(:list_objects_v2, {contents: [{key: "wal_005/b"}], is_truncated: true, next_continuation_token: "token"})
+    expect(s3_client).to receive(:list_objects_v2).with(bucket: postgres_timeline.ubid, prefix: "wal_005/", delimiter: "", continuation_token: "prev").and_call_original
+    expect(Aws::S3::Client).to receive(:new).and_return(s3_client)
+
+    objects, token = postgres_timeline.list_objects_page("wal_005/", token: "prev")
+    expect(objects.map(&:key)).to eq(["wal_005/b"])
+    expect(token).to eq("token")
+  end
+
+  it "sends the cursor as start_after when there is no continuation token for AWS regions" do
+    postgres_timeline.update(location_id: create_aws_location.id)
+
+    s3_client = Aws::S3::Client.new(stub_responses: true)
+    s3_client.stub_responses(:list_objects_v2, {contents: [{key: "wal_005/b"}], is_truncated: false})
+    expect(s3_client).to receive(:list_objects_v2).with(bucket: postgres_timeline.ubid, prefix: "wal_005/", delimiter: "", start_after: "wal_005/a").and_call_original
+    expect(Aws::S3::Client).to receive(:new).and_return(s3_client)
+
+    objects, token = postgres_timeline.list_objects_page("wal_005/", start_after: "wal_005/a")
+    expect(objects.map(&:key)).to eq(["wal_005/b"])
+    expect(token).to be_nil
   end
 
   it "returns blob storage endpoint" do


### PR DESCRIPTION
## Summary

Lets a timeline's object storage be listed from a cursor, a page at a time, across all three storage providers. Also fills in an object size that the Google Cloud Storage wrapper had been discarding.

## Why

Working out how much storage a timeline holds means listing its bucket. Write-ahead log objects are append-only and their names sort chronologically, so a sweep only needs whatever arrived after the last object it saw. Re-walking the bucket from the start every time is wasted work.

Handing back a single page plus a marker for where to resume also lets a caller with a limited time slice stop partway through and continue later, instead of being committed to draining an entire bucket in one call. The existing whole-bucket listing becomes a loop over that, so nothing using it today behaves differently.

The providers disagree in ways better absorbed here than in every caller: Google's convenience library cannot start from an offset at all, and where Amazon's cursor excludes the object you name, Google's includes it. Both are normalised so callers see one behaviour everywhere.

Nothing lists by page yet; #6390 is the first caller.
