### PR TITLE
Use a relative date in the audit log action filter spec

### DIFF
--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -3282,7 +3282,7 @@ RSpec.describe CloverAdmin do
     it "can filter by action" do
       insert_audit_log(id: UBID.generate_from_time("a1", Time.now - 10).to_uuid)
       insert_audit_log(action: "destroy", id: UBID.generate_from_time("a1", Time.now).to_uuid)
-      insert_audit_log(ubid_type: "ps", at: "2026-03-08")
+      insert_audit_log(ubid_type: "ps", at: Date.today << 1)
 
       visit "/audit-log"
       expect(audit_log_content).to eq [


### PR DESCRIPTION
The spec inserted its third audit log entry with the hardcoded date 2026-03-08, four days before the spec was written. The admin audit log page shows the last six months by default, so the entry left the default window on 2026-09-08 and the spec started to fail.

Insert the entry one month in the past instead, so that it stays inside the default window on any day.