### PR TITLE
Redesign the GitHub Actions setup page as a guided flow

### DIFF
--- a/spec/routes/web/auth_spec.rb
+++ b/spec/routes/web/auth_spec.rb
@@ -1250,9 +1250,9 @@ RSpec.describe Clover, "auth" do
       mock_provider(:github, name: "foobar")
 
       visit "/?setup=github_actions&source=mysource&source_detail=^"
-      expect(page).to have_content("Step 1: Create Ubicloud Account")
-      expect(page).to have_no_content("Step 2: Add GitHub Repositories")
-      click_button "Create Ubicloud Account Using GitHub"
+      expect(page).to have_content("Step 1 of 4")
+      expect(page).to have_no_content("Step 2 of 4")
+      click_button "Continue with GitHub"
 
       account = Account[email: TEST_USER_EMAIL]
       project = account.default_project
@@ -1263,11 +1263,10 @@ RSpec.describe Clover, "auth" do
       ]
       expect(audit_log_hash).to eq({"create_account" => ip_hash("provider" => "GitHub"), "login" => ip_hash("via" => "GitHub")})
 
-      expect(page).to have_content("Step 1: Create Ubicloud Account")
-      expect(page).to have_content("Step 2: Add GitHub Repositories")
-      expect(page).to have_no_content("Step 3: Add Payment Method")
+      expect(page).to have_content("Step 2 of 4")
+      expect(page).to have_no_content("Step 3 of 4")
 
-      click_link "Add GitHub Repositories"
+      click_link "Install the Ubicloud GitHub app"
       expect(page.status_code).to eq(200)
       expect(page.driver.request.session["login_redirect"]).to eq("/apps/test/installations/new")
 
@@ -1282,10 +1281,8 @@ RSpec.describe Clover, "auth" do
       visit "/set_github_installation_project_id/#{project.ubid}"
       GithubInstallation.create(installation_id: 0, name: "bogus", type: "bogus", project_id: project.id)
       visit "/github/callback?code=123123&installation_id=345"
-      expect(page).to have_content("Step 1: Create Ubicloud Account")
-      expect(page).to have_content("Step 2: Add GitHub Repositories")
-      expect(page).to have_content("Step 3: Add Payment Method")
-      expect(page).to have_no_content("Step 4: Update Workflow .yml Files")
+      expect(page).to have_content("Step 3 of 4")
+      expect(page).to have_no_content("Step 4 of 4")
 
       require "stripe"
       customers_service = instance_double(Stripe::CustomerService)
@@ -1314,14 +1311,11 @@ RSpec.describe Clover, "auth" do
       end
       expect(payment_methods_service).to receive(:retrieve).with("pm_1234567890").and_return(stripe_object("card" => {"brand" => "visa"}, "billing_details" => {}))
 
-      click_button "Add Payment Method"
-      expect(page).to have_content("Step 1: Create Ubicloud Account")
-      expect(page).to have_content("Step 2: Add GitHub Repositories")
-      expect(page).to have_content("Step 3: Add Payment Method")
-      expect(page).to have_content("Step 4: Update Workflow .yml Files")
+      click_button "Add payment method"
+      expect(page).to have_content("Step 4 of 4")
       expect(page).to have_flash_notice(/Payment method added successfully/)
 
-      click_link "Monitor GitHub Runners"
+      click_link "Go to your runners"
       expect(page.title).to eq "Ubicloud - Active Runners"
     end
 
@@ -1335,8 +1329,8 @@ RSpec.describe Clover, "auth" do
       click_button "Log out"
 
       visit "/?setup=github_actions"
-      expect(page).to have_content("Step 1: Create Ubicloud Account")
-      click_button "Create Ubicloud Account Using GitHub"
+      expect(page).to have_content("Step 1 of 4")
+      click_button "Continue with GitHub"
 
       account = Account[email: TEST_USER_EMAIL]
       expect(account.name).to eq "foobar"
@@ -1346,8 +1340,7 @@ RSpec.describe Clover, "auth" do
         "logout" => ip_hash,
       })
 
-      expect(page).to have_content("Step 1: Create Ubicloud Account")
-      expect(page).to have_content("Step 2: Add GitHub Repositories")
+      expect(page).to have_content("Step 2 of 4")
 
       account.default_project.destroy
       visit "/?setup=github_actions"

--- a/views/components/onboarding_note.erb
+++ b/views/components/onboarding_note.erb
@@ -1,0 +1,7 @@
+<%# locals: (text:) %>
+
+<div class="flex items-start gap-2">
+  <%== part("components/icon", name: "hero-information-circle", classes: "mt-0.5 h-4 w-4 shrink-0 text-gray-400") %>
+
+  <p class="text-sm leading-5 text-gray-500"><%= text %></p>
+</div>

--- a/views/components/onboarding_steps.erb
+++ b/views/components/onboarding_steps.erb
@@ -1,0 +1,57 @@
+<%# locals: (steps:, current:) %>
+
+<ol class="flex flex-col sm:flex-row">
+  <% steps.each_with_index do |step, i| %>
+    <% number = i + 1 %>
+    <% last = number == steps.length %>
+
+    <% circle_class = if number < current
+        "bg-orange-600 text-white"
+      elsif number == current
+        "bg-white text-orange-600 border-2 border-orange-600 ring-4 ring-orange-100"
+      else
+        "bg-white text-gray-400 border-2 border-gray-200"
+      end
+
+      label_class = if number < current
+        "text-gray-600 font-medium"
+      elsif number == current
+        "text-gray-900 font-semibold"
+      else
+        "text-gray-400 font-medium"
+      end
+
+      lead_class = if i.zero?
+        "bg-transparent"
+      else
+        (number <= current) ? "bg-orange-600" : "bg-gray-200"
+      end
+
+      trail_class = if last
+        "bg-transparent"
+      else
+        (number < current) ? "bg-orange-600" : "bg-gray-200"
+      end %>
+
+    <li class="flex flex-1 items-stretch gap-3 sm:flex-col sm:items-center sm:gap-2.5 <%= "min-h-11" unless last %>">
+      <div class="flex flex-col items-center sm:w-full sm:flex-row">
+        <div class="w-0.5 flex-1 sm:h-0.5 sm:w-auto <%= lead_class %>"></div>
+
+        <div class="relative z-10 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold sm:h-8 sm:w-8 sm:text-sm <%= circle_class %>">
+          <% if number < current %>
+            <%== part("components/icon", name: "hero-check", classes: "h-4 w-4 stroke-[2.5]") %>
+            <span class="sr-only">Completed:</span>
+          <% else %>
+            <%= number %>
+          <% end %>
+        </div>
+
+        <div class="w-0.5 flex-1 sm:h-0.5 sm:w-auto <%= trail_class %>"></div>
+      </div>
+
+      <div class="text-sm leading-7 sm:px-1 sm:text-center sm:text-xs sm:leading-4 <%= label_class %>">
+        <%= step %>
+      </div>
+    </li>
+  <% end %>
+</ol>

--- a/views/github/actions-setup.erb
+++ b/views/github/actions-setup.erb
@@ -1,47 +1,137 @@
-<% steps = <<END.split("\n")
-Create Ubicloud Account
-Add GitHub Repositories
-Add Payment Method
-Update Workflow .yml Files
-END
-@page_message = "GitHub Actions Setup"
-@use_page_message = true %>
+<% steps = ["Create account", "Connect repositories", "Add payment method", "Update workflows"]
+headings = [
+  "Create your Ubicloud account",
+  "Connect your GitHub repositories",
+  "Add a payment method",
+  "Point your workflows at Ubicloud"
+]
+@page_title = "GitHub Actions Setup"
+@page_message = "Run GitHub Actions on Ubicloud"
+@use_page_message = true
+@wide_page_message = true %>
 
-<div class="mt-4">
-  <div class="mt-4 grid sm:grid-cols-1 gap-4">
-    <span class="bg-white px-6 text-gray-900">This process allows you to easily setup your GitHub repositories to run GitHub Actions on Ubicloud.</span>
+<div class="flex flex-col gap-5">
+  <%== part("components/onboarding_steps", steps:, current: @step) %>
 
-    <hr>
+  <hr class="border-gray-200">
 
-    <% steps[0...@step].each_with_index do |step, i| %>
-      <% i += 1 %>
-      <span class="bg-white px-6 text-gray-900 <%= "line-through" unless i == @step %>">Step <%= i %>: <%= step %></span>
-    <% end %>
+  <div class="flex flex-col gap-3">
+    <div class="flex flex-col gap-1.5">
+      <div class="text-xs font-semibold uppercase tracking-wide text-orange-600">
+        Step <%= @step %> of <%= steps.length %>
+      </div>
 
-    <hr>
+      <h1 class="text-lg font-semibold text-gray-900 sm:text-xl"><%= headings[@step - 1] %></h1>
+    </div>
 
     <% case @step %>
     <% when 1 %>
-      <span class="bg-white px-6 text-gray-900">Ubicloud supports multiple login methods, but since you'll be using GitHub anyway, you probably want to login to Ubicloud via GitHub:</span>
-      <%== part("components/social_button", provider: :github, label: "Create Ubicloud Account Using GitHub") %>
+      <p class="text-sm leading-6 text-gray-600">
+        Sign in with GitHub to create your Ubicloud account. You can use that account to create any Ubicloud resource,
+        not just GitHub Actions runners.
+      </p>
+
+      <div class="mt-1">
+        <%== part("components/social_button", provider: :github, label: "Continue with GitHub") %>
+      </div>
+
+      <%== part("components/onboarding_note", text: "You get 1,250 free runner minutes to test with.") %>
     <% when 2 %>
-      <span class="bg-white px-6 text-gray-900">Your Ubicloud Account has been created! You can now connect your GitHub repositories to Ubicloud:</span>
-      <%== part("components/button", icon: "github", link: "#{@project.path}/github/create", text: "Add GitHub Repositories") %>
+      <p class="text-sm leading-6 text-gray-600">
+        Install the Ubicloud app on the user or organization that owns your repositories. You choose exactly which ones
+        it can see, and you can change that list on GitHub at any time.
+      </p>
+
+      <div class="mt-1 flex">
+        <%== part(
+          "components/button",
+          icon: "github",
+          link: "#{@project.path}/github/create",
+          text: "Install the Ubicloud GitHub app",
+          extra_class: "w-full sm:w-auto min-h-11 sm:min-h-0 gap-1.5 px-4"
+        ) %>
+      </div>
+
+      <%== part("components/onboarding_note", text: "You'll finish on GitHub and land back here automatically.") %>
     <% when 3 %>
-      <span class="bg-white px-6 text-gray-900">Your GitHub repositories have been added! Ubicloud provides inexpensive GitHub Actions runners, but they aren't free, so you need to add a payment method:</span>
-      <span class="bg-white px-6 ml-12 text-gray-900">
-        <% form(action: billing_path, method: :post) do %>
-          <%== part("components/button", text: "Add Payment Method") %>
+      <p class="text-sm leading-6 text-gray-600">
+        Ubicloud runners are pay-as-you-go, so we need a card on file before your first job can run.
+      </p>
+
+      <div class="mt-1 flex">
+        <% form(action: billing_path, method: :post, class: "w-full sm:w-auto") do %>
+          <%== part(
+            "components/button",
+            icon: "hero-banknotes",
+            text: "Add payment method",
+            extra_class: "w-full sm:w-auto min-h-11 sm:min-h-0 px-4"
+          ) %>
         <% end %>
-      </span>
+      </div>
+
+      <%== part(
+        "components/onboarding_note",
+        text: "We place a small temporary authorization to verify the card and cancel it right away. " \
+              "Depending on your bank, it can take up to two weeks to drop off your statement."
+      ) %>
     <% when 4 %>
-      <span class="bg-white px-6 text-gray-900">
-        Your payment method was added! You only needed to change the <code>runs-on</code> entries in your
-        <code>.github/workflows/*.yml</code> files to use <code>ubicloud-standard-2</code> (or
-        <a href="https://www.ubicloud.com/docs/github-actions-integration/runner-types" class="font-medium text-orange-600 hover:text-orange-700">another valid value with <code>ubicloud</code> prefix</a>).
-        Then you can monitor your runners:
-      </span>
-      <%== part("components/button", link: "#{@project.path}/github", text: "Monitor GitHub Runners") %>
+      <p class="text-sm leading-6 text-gray-600">
+        Change <code class="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-700">runs-on</code> to a
+        Ubicloud runner in each workflow file:
+      </p>
+
+      <div class="overflow-hidden rounded-md ring-1 ring-gray-200">
+        <div class="border-b border-gray-200 bg-gray-50 px-3 py-1.5 font-mono text-xs text-gray-500">
+          .github/workflows/*.yml
+        </div>
+
+        <div class="overflow-x-auto py-2 font-mono text-sm leading-5">
+          <div class="flex">
+            <span class="w-7 shrink-0 text-center text-gray-400">&nbsp;</span>
+
+            <span class="whitespace-pre text-gray-700">jobs:</span>
+          </div>
+
+          <div class="flex">
+            <span class="w-7 shrink-0 text-center text-gray-400">&nbsp;</span>
+
+            <span class="whitespace-pre text-gray-700">  build:</span>
+          </div>
+
+          <div class="flex bg-red-50">
+            <span class="w-7 shrink-0 text-center text-red-700">−</span>
+
+            <span class="whitespace-pre text-red-700">  runs-on: ubuntu-latest</span>
+          </div>
+
+          <div class="flex bg-green-50">
+            <span class="w-7 shrink-0 text-center text-green-700">+</span>
+
+            <span class="whitespace-pre text-green-700">  runs-on: </span>
+
+            <%== part("components/copyable_content", content: "ubicloud-standard-2", classes: "text-green-700") %>
+          </div>
+        </div>
+      </div>
+
+      <a
+        href="https://www.ubicloud.com/docs/github-actions-integration/runner-types"
+        class="inline-flex items-center gap-1.5 text-sm font-medium text-orange-600 hover:text-orange-700"
+      >
+        Browse all runner types
+        <%== part("components/icon", name: "hero-arrow-top-right-on-square", classes: "h-4 w-4") %>
+      </a>
+
+      <div class="mt-1 flex">
+        <%== part(
+          "components/button",
+          link: "#{@project.path}/github",
+          text: "Go to your runners",
+          extra_class: "w-full sm:w-auto min-h-11 sm:min-h-0 px-4"
+        ) %>
+      </div>
+
+      <%== part("components/onboarding_note", text: "Push the change and your next workflow run starts on Ubicloud.") %>
     <% end %>
   </div>
 </div>

--- a/views/layouts/app.erb
+++ b/views/layouts/app.erb
@@ -82,43 +82,7 @@
     <% elsif @direct_body_yield %>
       <%== yield %>
     <% else %>
-      <div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
-        <div class="sm:mx-auto sm:w-full sm:max-w-md">
-          <div class="flex shrink-0 items-center px-10 py-4">
-            <img src="/logo-primary.png" alt="Ubicloud">
-          </div>
-
-          <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900"><%= @page_message %></h2>
-        </div>
-
-        <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-          <div class="bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10">
-            <div class="pt-4 empty:hidden"><%== render("components/flash_message") %></div>
-            <%== yield %>
-          </div>
-        </div>
-
-        <div class="mt-10 flex justify-center space-x-5">
-          <a href="https://github.com/ubicloud/ubicloud" target="_blank" class="text-gray-400 hover:text-gray-500">
-            <span class="sr-only">GitHub</span>
-            <%== part("components/icon", name: "github") %>
-          </a>
-
-          <a href="mailto:support@ubicloud.com" class="text-gray-400 hover:text-gray-500">
-            <span class="sr-only">Support</span>
-            <%== part("components/icon", name: "hero-envelope") %>
-          </a>
-        </div>
-
-        <% if Config.managed_service %>
-          <div class="text-sm text-gray-500 text-center mt-10 w-full">
-            By using Ubicloud console you agree to our
-            <a href="https://www.ubicloud.com/docs/about/terms-of-service" class="font-medium text-orange-500 hover:text-orange-600" target="_blank"> terms of service </a>
-            and
-            <a href="https://www.ubicloud.com/docs/about/privacy-policy" class="font-medium text-orange-500 hover:text-orange-600" target="_blank"> privacy policy </a>
-          </div>
-        <% end %>
-      </div>
+      <%== part(@wide_page_message ? "layouts/content_wide" : "layouts/content", content_html: yield) %>
     <% end %>
 
     <%== assets(:js) %>

--- a/views/layouts/content.erb
+++ b/views/layouts/content.erb
@@ -1,0 +1,20 @@
+<%# locals: (content_html:) %>
+
+<div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-md">
+    <div class="flex shrink-0 items-center px-10 py-4">
+      <img src="/logo-primary.png" alt="Ubicloud">
+    </div>
+
+    <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900"><%= @page_message %></h2>
+  </div>
+
+  <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+    <div class="bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10">
+      <div class="pt-4 empty:hidden"><%== render("components/flash_message") %></div>
+      <%== content_html %>
+    </div>
+  </div>
+
+  <%== part("layouts/page_footer", offset: "mt-10") %>
+</div>

--- a/views/layouts/content_wide.erb
+++ b/views/layouts/content_wide.erb
@@ -1,0 +1,20 @@
+<%# locals: (content_html:) %>
+
+<div class="flex min-h-full flex-col justify-center py-8 sm:px-6 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-2xl">
+    <div class="flex shrink-0 items-center justify-center px-10 py-3">
+      <img src="/logo-primary.png" alt="Ubicloud" class="max-h-9 w-auto">
+    </div>
+
+    <h2 class="mt-4 text-center text-2xl font-bold tracking-tight text-gray-900"><%= @page_message %></h2>
+  </div>
+
+  <div class="mt-6 sm:mx-auto sm:w-full sm:max-w-2xl">
+    <div class="bg-white px-4 py-6 shadow sm:rounded-lg sm:px-10">
+      <div class="pt-4 empty:hidden"><%== render("components/flash_message") %></div>
+      <%== content_html %>
+    </div>
+  </div>
+
+  <%== part("layouts/page_footer", offset: "mt-6") %>
+</div>

--- a/views/layouts/page_footer.erb
+++ b/views/layouts/page_footer.erb
@@ -1,0 +1,22 @@
+<%# locals: (offset:) %>
+
+<div class="<%= offset %> flex justify-center space-x-5">
+  <a href="https://github.com/ubicloud/ubicloud" target="_blank" class="text-gray-400 hover:text-gray-500">
+    <span class="sr-only">GitHub</span>
+    <%== part("components/icon", name: "github") %>
+  </a>
+
+  <a href="mailto:support@ubicloud.com" class="text-gray-400 hover:text-gray-500">
+    <span class="sr-only">Support</span>
+    <%== part("components/icon", name: "hero-envelope") %>
+  </a>
+</div>
+
+<% if Config.managed_service %>
+  <div class="text-sm text-gray-500 text-center <%= offset %> w-full">
+    By using Ubicloud console you agree to our
+    <a href="https://www.ubicloud.com/docs/about/terms-of-service" class="font-medium text-orange-500 hover:text-orange-600" target="_blank"> terms of service </a>
+    and
+    <a href="https://www.ubicloud.com/docs/about/privacy-policy" class="font-medium text-orange-500 hover:text-orange-600" target="_blank"> privacy policy </a>
+  </div>
+<% end %>


### PR DESCRIPTION
    The page rendered only the steps completed so far, so a user could not
    see what remained, and it struck through finished steps, which reads as
    cancelled rather than done. Show all four steps throughout, give each
    one a single action, and correct step one, which claimed signing in with
    GitHub was what let Ubicloud see your repositories; installing the
    GitHub App in step two does that.

    The stepper needs more width than the page-message layout allowed, so
    split that layout into layouts/content and layouts/content_wide, chosen
    by @wide_page_message, rather than adding conditionals to a layout also
    used by login and signup.


| Before | After |
|--------|-------|
| <img width="2024" height="1638" alt="CleanShot 2026-09-08 at 13 14 36@2x" src="https://github.com/user-attachments/assets/9512b82b-a918-4c95-a6ff-79b1727f5047" /> |       <img width="2244" height="1492" alt="CleanShot 2026-09-08 at 15 01 40@2x" src="https://github.com/user-attachments/assets/3d585eca-9a2d-433d-84f0-264d18d7d37a" /> |
| <img width="1818" height="1626" alt="CleanShot 2026-09-08 at 13 18 19@2x" src="https://github.com/user-attachments/assets/2981d630-b069-42ba-ae0d-e5110c3b37e2" /> | <img width="2002" height="1488" alt="CleanShot 2026-09-08 at 15 01 46@2x" src="https://github.com/user-attachments/assets/e7d53fd8-d4a4-4384-bcb6-8e828bdd9c3c" /> |
| <img width="1940" height="1658" alt="CleanShot 2026-09-08 at 13 18 28@2x" src="https://github.com/user-attachments/assets/efa80cf7-44ef-45bf-8403-0cc4b747776f" /> | <img width="2176" height="1346" alt="CleanShot 2026-09-08 at 15 01 55@2x" src="https://github.com/user-attachments/assets/b7c39c0e-f116-4a84-aed8-7594ec365f19" /> |
| <img width="1930" height="1674" alt="CleanShot 2026-09-08 at 13 18 39@2x" src="https://github.com/user-attachments/assets/8134c620-9979-4e87-ac14-31e480ecc311" /> | <img width="1818" height="1584" alt="CleanShot 2026-09-08 at 15 02 07@2x" src="https://github.com/user-attachments/assets/67f540f4-b6d6-4069-8da5-b4237f22295f" /> |