### PR TITLE
Create vm host inventory for Hetzner hosts at assembly

### DIFF
--- a/lib/hosting/hetzner_apis.rb
+++ b/lib/hosting/hetzner_apis.rb
@@ -146,6 +146,12 @@ class Hosting::HetznerApis < Hosting::ProviderApis
     json_server.dig("server", "dc")
   end
 
+  # The Robot API reports only the product name for a server.
+  def pull_inventory
+    response = create_connection.get(path: "/server/#{server_id}", expects: 200)
+    {server_model: JSON.parse(response.body).dig("server", "product")}
+  end
+
   def set_server_name(server_name)
     create_connection.post(path: "/server/#{server_id}", body: URI.encode_www_form(server_name:), expects: 200)
   end

--- a/prog/vm/host_nexus.rb
+++ b/prog/vm/host_nexus.rb
@@ -26,7 +26,7 @@ class Prog::Vm::HostNexus < Prog::Base
       if [HostProvider::HETZNER_PROVIDER_NAME, *HostProvider::LEASEWEB_PROVIDER_NAMES].include?(provider_name)
         vmh.create_addresses
         vmh.set_data_center
-        vmh.create_inventory if vmh.leaseweb?
+        vmh.create_inventory
         # Avoid overriding custom server names for development hosts.
         vmh.set_server_name unless Config.development?
       else

--- a/spec/lib/hosting/hetzner_apis_spec.rb
+++ b/spec/lib/hosting/hetzner_apis_spec.rb
@@ -131,6 +131,18 @@ RSpec.describe Hosting::HetznerApis do
     end
   end
 
+  describe "pull_inventory" do
+    it "returns the server's product name" do
+      stub_request(:get, "https://robot-ws.your-server.de/server/123").to_return(status: 200, body: JSON.generate(server: {product: "AX102-3-LTD", dc: "FSN1-DC24"}))
+      expect(hetzner_apis.pull_inventory).to eq(server_model: "AX102-3-LTD")
+    end
+
+    it "raises an error if getting the server info fails" do
+      stub_request(:get, "https://robot-ws.your-server.de/server/123").to_return(status: 400, body: "")
+      expect { hetzner_apis.pull_inventory }.to raise_error Excon::Error::BadRequest
+    end
+  end
+
   describe "hetzner_pull_ips" do
     it "can pull empty data from the API" do
       stub_request(:get, "https://robot-ws.your-server.de/ip").to_return(status: 200, body: JSON.dump([]))

--- a/spec/prog/vm/host_nexus_spec.rb
+++ b/spec/prog/vm/host_nexus_spec.rb
@@ -47,10 +47,12 @@ RSpec.describe Prog::Vm::HostNexus do
       allow(Hosting::ProviderApis).to receive(:for).and_return(api)
       expect(api).to receive(:pull_ips).and_return(hetzner_ips)
       expect(api).to receive(:pull_data_center).and_return("fsn1-dc14")
+      expect(api).to receive(:pull_inventory).and_return(server_model: "AX102")
       expect(api).to receive(:set_server_name).and_return(nil)
       st = described_class.assemble("127.0.0.1", provider_name: HostProvider::HETZNER_PROVIDER_NAME, server_identifier: "1")
       expect(st).to be_a Strand
       expect(st.label).to eq("start")
+      expect(st.subject.inventory.server_model).to eq "AX102"
       expect(st.subject.assigned_subnets.count).to eq(3)
       expect(st.subject.assigned_subnets.map { it.cidr.to_s }.sort).to eq(["127.0.0.1/32", "30.30.30.32/29", "2a01:4f8:10a:128b::/64"].sort)
 
@@ -145,6 +147,7 @@ RSpec.describe Prog::Vm::HostNexus do
       allow(Hosting::ProviderApis).to receive(:for).and_return(api)
       expect(api).to receive(:pull_ips).and_return(hetzner_ips)
       expect(api).to receive(:pull_data_center).and_return("fsn1-dc14")
+      expect(api).to receive(:pull_inventory).and_return(server_model: "AX102")
       expect(api).not_to receive(:set_server_name)
 
       described_class.assemble("127.0.0.1", provider_name: HostProvider::HETZNER_PROVIDER_NAME, server_identifier: "1")
@@ -168,7 +171,7 @@ RSpec.describe Prog::Vm::HostNexus do
   end
 
   def assemble_hetzner_host(**)
-    api = instance_double(Hosting::HetznerApis, pull_ips: nil, pull_data_center: "fsn1-dc14", set_server_name: nil)
+    api = instance_double(Hosting::HetznerApis, pull_ips: nil, pull_data_center: "fsn1-dc14", pull_inventory: {server_model: "AX102"}, set_server_name: nil)
     allow(Hosting::ProviderApis).to receive(:for).and_return(api)
     described_class.assemble("127.0.0.1", provider_name: HostProvider::HETZNER_PROVIDER_NAME, server_identifier: "1", **)
   end

--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -2845,7 +2845,7 @@ RSpec.describe CloverAdmin do
       stub_request(:get, "https://robot-ws.your-server.de/ip").to_return(status: 200, body: JSON.dump([{"ip" => {"ip" => host, "server_ip" => host}}]))
       stub_request(:get, "https://robot-ws.your-server.de/subnet").to_return(status: 200, body: JSON.dump([]))
       stub_request(:get, "https://robot-ws.your-server.de/failover").to_return(status: 200, body: JSON.dump([]))
-      stub_request(:get, "https://robot-ws.your-server.de/server/#{server_identifier}").to_return(status: 200, body: JSON.generate(server: {dc: "fsn1-dc14"}))
+      stub_request(:get, "https://robot-ws.your-server.de/server/#{server_identifier}").to_return(status: 200, body: JSON.generate(server: {dc: "fsn1-dc14", product: "AX102"}))
       stub_request(:post, "https://robot-ws.your-server.de/server/#{server_identifier}").to_return(status: 200, body: "{}")
     end
 
@@ -2893,6 +2893,7 @@ RSpec.describe CloverAdmin do
       expect(vmh.provider_name).to eq "hetzner"
       expect(vmh.provider.server_identifier).to eq "12345"
       expect(vmh.data_center).to eq "fsn1-dc14"
+      expect(vmh.inventory.server_model).to eq "AX102"
 
       frame = st.stack.first
       expect(frame["vhost_block_backend_version"]).to eq Config.vhost_block_backend_version


### PR DESCRIPTION
The Robot API reports only the product name for a server, so the inventory row stores that and leaves the other columns empty.