### PR TITLE
Add a couple indexes to strand to improve respirate performance

### DIFF
--- a/migrate/20260907_strand_schedule_index.rb
+++ b/migrate/20260907_strand_schedule_index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  no_transaction
+
+  change do
+    add_index :strand, [:schedule, :id, :lease], where: {exitval: nil}, name: :strand_schedule_id_lease_idx, concurrently: true
+  end
+end

--- a/migrate/20260908_strand_parent_id_index.rb
+++ b/migrate/20260908_strand_parent_id_index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  no_transaction
+
+  change do
+    add_index :strand, :parent_id, where: Sequel.~(parent_id: nil), name: :strand_parent_id_idx, concurrently: true
+  end
+end

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -389,7 +389,8 @@ end
 #  retval    | jsonb                    |
 #  try       | integer                  | NOT NULL DEFAULT 0
 # Indexes:
-#  strand_pkey | PRIMARY KEY btree (id)
+#  strand_pkey                  | PRIMARY KEY btree (id)
+#  strand_schedule_id_lease_idx | btree (schedule, id, lease) WHERE exitval IS NULL
 # Foreign key constraints:
 #  strand_parent_id_fkey | (parent_id) REFERENCES strand(id)
 # Referenced By:

--- a/model/strand.rb
+++ b/model/strand.rb
@@ -390,6 +390,7 @@ end
 #  try       | integer                  | NOT NULL DEFAULT 0
 # Indexes:
 #  strand_pkey                  | PRIMARY KEY btree (id)
+#  strand_parent_id_idx         | btree (parent_id) WHERE parent_id IS NOT NULL
 #  strand_schedule_id_lease_idx | btree (schedule, id, lease) WHERE exitval IS NULL
 # Foreign key constraints:
 #  strand_parent_id_fkey | (parent_id) REFERENCES strand(id)


### PR DESCRIPTION
The first one improves performance of the scan query. The second one improves sibling strand lookup and reap queries. All 3 queries likely resulted in a sequential scan previously (the partitioning in respirate may result in a primary key index scan being used for the respirate scan query, but I'm not sure). Both indexes are partial indexes to exclude rows not needed by the queries.