### PR TITLE
Allow disabling migration date validation

### DIFF
--- a/bin/rake-task-runner
+++ b/bin/rake-task-runner
@@ -41,7 +41,10 @@ when "migrate"
   DB.extension :pg_enum
 
   DB.loggers << Logger.new($stdout)
-  opts = {allow_migration_number: 20230117..(Date.today + 5).strftime("%Y%m%d").to_i}
+  opts = {}
+  if Config.validate_migration_dates
+    opts[:allow_migration_number] = 20230117..(Date.today + 5).strftime("%Y%m%d").to_i
+  end
   if version && File.file?(version)
     Sequel::TimestampMigrator.new(DB, "migrate", **opts).run_single(version, :down)
   else

--- a/config.rb
+++ b/config.rb
@@ -97,6 +97,7 @@ module Config
   override :db_pool_web, Config.db_pool, int
   override :db_pool_respirate, Config.db_pool, int
   override :db_pool_monitor, Config.db_pool, int
+  override :validate_migration_dates, true, bool
   override :dispatcher_max_threads, 8, int
   override :dispatcher_min_threads, 1, int
   override :dispatcher_queue_size_ratio, 4, float


### PR DESCRIPTION
In our fork we use 3026*-prefixed migration numbers to keep fork migrations distinguishable from upstream ones, which the new allow_migration_number range rejects.
This adds VALIDATE_MIGRATION_DATES (default true) so the check can be turned off.