### PR TITLE
Add Prog#hop_wait_and_wakeup_waiting_strand

### DIFF
--- a/prog/base.rb
+++ b/prog/base.rb
@@ -385,8 +385,9 @@ end
     @frame = nil
   end
 
-  def wakeup_waiting_strand
+  def hop_wait_and_wakeup_waiting_strand
     strand.wakeup_waiting_strand
+    hop_wait
   end
 
   # A hop is a kind of jump, as in, like a jump instruction.

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -134,7 +134,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   end
 
   label def wait_nodes
-    nap 10 unless kubernetes_cluster.nodepools.all? { it.strand.label == "wait" }
+    nap 10 unless Strand.where(id: kubernetes_cluster.nodepools_dataset.select(:id)).exclude(label: "wait").empty?
     hop_wait
   end
 

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -134,7 +134,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   end
 
   label def wait_nodes
-    nap 10 unless Strand.where(id: kubernetes_cluster.nodepools_dataset.select(:id)).exclude(label: "wait").empty?
+    nap 60 unless Strand.where(id: kubernetes_cluster.nodepools_dataset.select(:id)).exclude(label: "wait").empty?
     hop_wait
   end
 

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -16,7 +16,7 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
 
       kn = KubernetesNodepool.create(name:, node_count:, kubernetes_cluster_id:, target_node_size:, target_node_storage_size_gib:, version: cluster.version)
 
-      strand = Strand.create_with_id(kn, prog: "Kubernetes::KubernetesNodepoolNexus", label: "start", stack: [{"machine_image_version_id" => machine_image_version_id}])
+      strand = Strand.create_with_id(kn, prog: "Kubernetes::KubernetesNodepoolNexus", label: "start", stack: [{"machine_image_version_id" => machine_image_version_id, "waiting_strand_id" => kubernetes_cluster_id}])
       kn.incr_start_bootstrapping if cluster.strand.label == "wait"
       strand
     end
@@ -50,7 +50,7 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
   label def wait_worker_node
     reap do
       decr_scale_worker_count
-      hop_wait
+      hop_wait_and_wakeup_waiting_strand
     end
   end
 

--- a/prog/vm/aws/nexus.rb
+++ b/prog/vm/aws/nexus.rb
@@ -383,10 +383,8 @@ class Prog::Vm::Aws::Nexus < Prog::Base
 
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, instance_id: vm.aws_instance.instance_id, duration: (Time.now - vm.allocated_at).round(3)}}])
 
-    wakeup_waiting_strand
-
     project = vm.project
-    hop_wait unless project.billable
+    hop_wait_and_wakeup_waiting_strand unless project.billable
 
     BillingRecord.create(
       project_id: project.id,
@@ -396,7 +394,7 @@ class Prog::Vm::Aws::Nexus < Prog::Base
       amount: vm.vcpus,
     )
 
-    hop_wait
+    hop_wait_and_wakeup_waiting_strand
   end
 
   label def wait

--- a/prog/vm/gcp/nexus.rb
+++ b/prog/vm/gcp/nexus.rb
@@ -223,10 +223,8 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
 
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, duration: (time - vm.allocated_at).round(3)}}])
 
-    wakeup_waiting_strand
-
     project = vm.project
-    hop_wait unless project.billable
+    hop_wait_and_wakeup_waiting_strand unless project.billable
 
     BillingRecord.create(
       project_id: project.id,
@@ -236,7 +234,7 @@ class Prog::Vm::Gcp::Nexus < Prog::Base
       amount: vm.vcpus,
     )
 
-    hop_wait
+    hop_wait_and_wakeup_waiting_strand
   end
 
   label def wait

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -225,8 +225,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     vm.update(display_state: "running", provisioned_at: Time.now)
     Clog.emit("vm provisioned", [vm, {provision: {vm_ubid: vm.ubid, vm_host_ubid: host.ubid, duration: (Time.now - vm.allocated_at).round(3)}}])
 
-    wakeup_waiting_strand
-    hop_wait
+    hop_wait_and_wakeup_waiting_strand
   end
 
   label def wait_storage_catchup

--- a/prog/vnet/cert_nexus.rb
+++ b/prog/vnet/cert_nexus.rb
@@ -127,8 +127,7 @@ class Prog::Vnet::CertNexus < Prog::Base
     when "valid"
       cert.update(cert: acme_order.certificate, created_at: Time.now)
       cleanup_dns_challenge_records
-      wakeup_waiting_strand
-      hop_wait
+      hop_wait_and_wakeup_waiting_strand
     else
       Clog.emit("Certificate finalization failed", {order_status:})
       cleanup_dns_challenge_records

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
   describe "#wait_nodes" do
     it "naps until all nodepools are ready" do
       expect(kubernetes_cluster.nodepools.first.strand.label).not_to eq "wait"
-      expect { nx.wait_nodes }.to nap(10)
+      expect { nx.wait_nodes }.to nap(60)
     end
 
     it "hops to wait when all nodepools are ready" do

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       expect(kn.kubernetes_cluster_id).to eq kc.id
       expect(kn.node_count).to eq 2
       expect(st.label).to eq "start"
+      expect(st.stack[0]["waiting_strand_id"]).to eq kc.id
       expect(kn.target_node_size).to eq "standard-4"
       expect(kn.target_node_storage_size_gib).to eq 37
     end
@@ -138,9 +139,13 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
   describe "#wait_worker_node" do
     it "decrements scale_worker_count and hops to wait if there are no sub-programs running" do
       kn.strand.update(label: "wait_worker_node")
+      refresh_frame(nx, new_values: {"waiting_strand_id" => kc.id})
+      t = Time.now
+      kc.strand.update(schedule: t + 600)
       nx.incr_scale_worker_count
       expect { nx.wait_worker_node }.to hop("wait")
       expect(kn.scale_worker_count_set?).to be false
+      expect(kc.strand.reload.schedule).to be_within(10).of(t)
     end
 
     it "donates if there are sub-programs running" do


### PR DESCRIPTION
Remove Prog#wakeup_waiting_strand. We only want to wakeup the waiting strand if we are hopping to wait, since the waiting strands are in general checking to see if the object being waited for is at wait. With the separate #wakeup_waiting_strand, it was possible to misuse the method and call it without hopping to wait, which would result on the waiting strands likely finding the object is not in wait and then delaying strand executions. #hop_wait_and_wakeup_waiting_strand is designed to improve misuse resistance.