### PR TITLE
Wakeup k8s cluster when nodepool hops to wait

### DIFF
--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -134,7 +134,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   end
 
   label def wait_nodes
-    nap 10 unless kubernetes_cluster.nodepools.all? { it.strand.label == "wait" }
+    nap 10 unless Strand.where(id: kubernetes_cluster.nodepools_dataset.select(:id)).exclude(label: "wait").empty?
     hop_wait
   end
 

--- a/prog/kubernetes/kubernetes_cluster_nexus.rb
+++ b/prog/kubernetes/kubernetes_cluster_nexus.rb
@@ -134,7 +134,7 @@ class Prog::Kubernetes::KubernetesClusterNexus < Prog::Base
   end
 
   label def wait_nodes
-    nap 10 unless Strand.where(id: kubernetes_cluster.nodepools_dataset.select(:id)).exclude(label: "wait").empty?
+    nap 60 unless Strand.where(id: kubernetes_cluster.nodepools_dataset.select(:id)).exclude(label: "wait").empty?
     hop_wait
   end
 

--- a/prog/kubernetes/kubernetes_nodepool_nexus.rb
+++ b/prog/kubernetes/kubernetes_nodepool_nexus.rb
@@ -16,7 +16,7 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
 
       kn = KubernetesNodepool.create(name:, node_count:, kubernetes_cluster_id:, target_node_size:, target_node_storage_size_gib:, version: cluster.version)
 
-      strand = Strand.create_with_id(kn, prog: "Kubernetes::KubernetesNodepoolNexus", label: "start", stack: [{"machine_image_version_id" => machine_image_version_id}])
+      strand = Strand.create_with_id(kn, prog: "Kubernetes::KubernetesNodepoolNexus", label: "start", stack: [{"machine_image_version_id" => machine_image_version_id, "waiting_strand_id" => kubernetes_cluster_id}])
       kn.incr_start_bootstrapping if cluster.strand.label == "wait"
       strand
     end
@@ -50,7 +50,7 @@ class Prog::Kubernetes::KubernetesNodepoolNexus < Prog::Base
   label def wait_worker_node
     reap do
       decr_scale_worker_count
-      hop_wait
+      hop_wait_and_wakeup_waiting_strand
     end
   end
 

--- a/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_cluster_nexus_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe Prog::Kubernetes::KubernetesClusterNexus do
   describe "#wait_nodes" do
     it "naps until all nodepools are ready" do
       expect(kubernetes_cluster.nodepools.first.strand.label).not_to eq "wait"
-      expect { nx.wait_nodes }.to nap(10)
+      expect { nx.wait_nodes }.to nap(60)
     end
 
     it "hops to wait when all nodepools are ready" do

--- a/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
+++ b/spec/prog/kubernetes/kubernetes_nodepool_nexus_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
       expect(kn.kubernetes_cluster_id).to eq kc.id
       expect(kn.node_count).to eq 2
       expect(st.label).to eq "start"
+      expect(st.stack[0]["waiting_strand_id"]).to eq kc.id
       expect(kn.target_node_size).to eq "standard-4"
       expect(kn.target_node_storage_size_gib).to eq 37
     end
@@ -138,9 +139,13 @@ RSpec.describe Prog::Kubernetes::KubernetesNodepoolNexus do
   describe "#wait_worker_node" do
     it "decrements scale_worker_count and hops to wait if there are no sub-programs running" do
       kn.strand.update(label: "wait_worker_node")
+      refresh_frame(nx, new_values: {"waiting_strand_id" => kc.id})
+      t = Time.now
+      kc.strand.update(schedule: t + 600)
       nx.incr_scale_worker_count
       expect { nx.wait_worker_node }.to hop("wait")
       expect(kn.scale_worker_count_set?).to be false
+      expect(kc.strand.reload.schedule).to be_within(10).of(t)
     end
 
     it "donates if there are sub-programs running" do


### PR DESCRIPTION
This should cut k8s cluster bootstrapping time by about 5 seconds on average. This uses a similar approach already used for by certs and vms to wakeup related strands, instead of having those strands poll more frequently.

While here, fix an N+1 issue in KubernetesClusterNexus#wait_nodes.