### PR TITLE
Fix a couple minor information disclosure vulnerabilities related to ubid resolution

### DIFF
--- a/routes/project/cli.rb
+++ b/routes/project/cli.rb
@@ -65,7 +65,9 @@ class Clover
             end
             UBID.resolve_map(ubids) do |ds|
               # All UBIDs matching UbiCli::OBJECT_INFO_REGEXP need location to construct the path
-              ds.eager(:location)
+              # Only resolve ubids that are in the current project (all resolved models have a
+              # project_id column).
+              ds.eager(:location).where(project_id: @project.id)
             end
             h(body).gsub(UbiCli::OBJECT_INFO_REGEXP) do
               if (obj = ubids[UBID.to_uuid(it)]) && obj.respond_to?(:path)

--- a/routes/project/user.rb
+++ b/routes/project/user.rb
@@ -335,6 +335,10 @@ class Clover
               # entries and that will not introduce loops
               DB.transaction do
                 num_removed = @tag.remove_members(to_remove)
+                if num_removed != to_remove.length
+                  raise Sequel::ValidationFailed, "Attempt to remove a member not in the tag"
+                end
+
                 audit_log(@tag, "remove_member", to_remove)
 
                 if @tag_type == "subject" && @tag.name == "Admin" && !@tag.member_ids.find { UBID.uuid_class_match?(it, Account) }

--- a/spec/routes/web/access_control_spec.rb
+++ b/spec/routes/web/access_control_spec.rb
@@ -869,6 +869,18 @@ RSpec.describe Clover, "access control" do
       ]
     end
 
+    it "fails when removing members not in project" do
+      st = SubjectTag.create(project_id: project.id, name: "stt")
+      sst = SubjectTag.create(project_id: project.id, name: "sst")
+      st.add_member(sst.id)
+      visit "#{project.path}/user/access-control/tag/subject/#{st.ubid}"
+      st.remove_members([sst.id])
+      check "remove[]"
+      click_button "Remove Members"
+      expect(page).to have_flash_error "Attempt to remove a member not in the tag"
+      expect(page.title).to eq "Ubicloud - Default - stt"
+    end
+
     it "cannot remove all accounts from Admin subject tag" do
       admin = SubjectTag[project_id: project.id, name: "Admin"]
       visit "#{project.path}/user/access-control/tag/subject/#{admin.ubid}"

--- a/spec/routes/web/cli_spec.rb
+++ b/spec/routes/web/cli_spec.rb
@@ -59,6 +59,14 @@ RSpec.describe Clover, "web shell" do
     expect(page.html).to include ">#{ps.ubid}</a>"
   end
 
+  it "does not link ubids in other projects" do
+    fw = Firewall.create(name: "fw", location_id: Location::HETZNER_FSN1_ID, project_id: Project.create(name: "other").id)
+    fill_in "cli", with: fw.ubid
+    click_button "Run"
+    expect(page.html).to include fw.ubid
+    expect(page.html).not_to include ">#{fw.ubid}</a>"
+  end
+
   it "handles ubid-like output that are not valid ubids" do
     fill_in "cli", with: "ps eu-central-h1/vm78zgv9w9et4mg6pba1frsz8m create"
     click_button "Run"


### PR DESCRIPTION
`UBID.resolve_map` doesn't do any check that the resolved objects are the member of the same project.  In the web shell, this could be abused to find the name of an object in another project if you had the object's uuid or ubid.

This can also be an issue in the audit log page, but only if there is a separate vulnerability that allowed arbitrary ubids to be placed into the audit log. There was one such vulnerability in the code to remove members from tags, which didn't check that the number of removed members matched the number of requested members. Add that check.

Note that this still leaves the audit log resolution vulnerable if there is another vulnerability that allows arbitrary ubids to be placed into the audit log. However, the audit log resolves many more types of objects than the web shell, and I'm not sure whether all resolved objects have a `project_id` column that could be used for scoping. We can address this later.

Thank you to @GrayOM for reporting both issues.