### PR TITLE
Remove the transitional clean_prep label

### DIFF
--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -195,20 +195,6 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     nap 1
   end
 
-  # Only reached by strands from before the cleanup moved into the wait
-  # label. Remove once no strand is left at this label.
-  label def clean_prep
-    host.sshable.cmd("common/bin/daemonizer --clean prep_:vm_name", vm_name:, log: :on_error)
-
-    # The Vm's systemd unit is already written and started by this point, so
-    # this is the earliest point we can learn which hypervisor it ended up
-    # running. It's a fire-and-forget independent Strand rather than a bud,
-    # since nothing here depends on its outcome.
-    Prog::LearnHypervisor.assemble(vm.id)
-
-    hop_wait_sshable
-  end
-
   def write_params_json
     host.sshable.cmd("sudo -u :vm_name tee :params_path > /dev/null", vm_name:, params_path:,
       stdin: vm.params_json(**frame.slice("swap_size_bytes", "hugepages", "hypervisor", "ch_version", "firmware_version").transform_keys!(&:to_sym)), log: :on_error)

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -519,14 +519,6 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     end
   end
 
-  describe "#clean_prep" do
-    it "cleans and hops" do
-      expect(sshable).to receive(:_cmd).with(/common\/bin\/daemonizer --clean prep_/, log: :on_error)
-      expect { nx.clean_prep }.to hop("wait_sshable")
-      expect(Strand.where(prog: "LearnHypervisor").count).to eq(1)
-    end
-  end
-
   describe "#start" do
     let(:storage_volumes) {
       [{


### PR DESCRIPTION
fe524743e moved the prep daemonizer cleanup into the wait label and kept clean_prep only for strands that were parked at it when that deployed. Strands pass through the label in about a second, so none remain, which can be confirmed before merging with:

  Strand.where(prog: "Vm::Metal::Nexus", label: "clean_prep").empty?