### PR TITLE
Increase WAL-G Concurrency

### DIFF
--- a/lib/walg_config.rb
+++ b/lib/walg_config.rb
@@ -4,7 +4,7 @@
 # The config maximizes Backup/Restore throughput, applying limits on RAM used.
 module WalgConfig
   UPLOAD_QUEUE = 2
-  UPLOAD_CONCURRENCY = 4
+  UPLOAD_CONCURRENCY = 8
   S3_MAX_PART_SIZE_UPPER_LIMIT = 64
   DIRECT_IO_BLOCKS_PER_DRIVE = 256
 

--- a/rhizome/postgres/bin/configure
+++ b/rhizome/postgres/bin/configure
@@ -157,7 +157,8 @@ safe_write_to_file("/etc/systemd/system/postgresql@.service.d/override.conf", po
 
 # Install systemd timer to enforce I/O throttling every 15 seconds.
 # The timer runs apply-io-throttle which reads the archival backlog locally
-# and adjusts cgroup I/O limits without any control plane interaction.
+# and adjusts the cgroup I/O limits and the wal-g daemon's upload concurrency
+# without any control plane interaction.
 safe_write_to_file("/etc/systemd/system/io-throttle@.service", <<~SERVICE)
   [Unit]
   Description=PostgreSQL I/O Throttle Enforcement for %i

--- a/rhizome/postgres/lib/io_throttle.rb
+++ b/rhizome/postgres/lib/io_throttle.rb
@@ -107,11 +107,13 @@ class IoThrottle
 
   private
 
+  def tier_for(tiers, backlog_count)
+    tiers.find { |threshold, _| backlog_count >= threshold }&.last
+  end
+
   def calculate_archival_throttle(backlog_count)
-    IO_THROTTLE_RATIOS.each do |threshold, ratio|
-      return (@disk_throughput_baseline_mbps * ratio).round if backlog_count >= threshold
-    end
-    nil
+    ratio = tier_for(IO_THROTTLE_RATIOS, backlog_count)
+    (@disk_throughput_baseline_mbps * ratio).round if ratio
   end
 
   # descend to 1% of baseline, starting at 91% disk usage

--- a/rhizome/postgres/lib/io_throttle.rb
+++ b/rhizome/postgres/lib/io_throttle.rb
@@ -20,6 +20,15 @@ class IoThrottle
     [100, 0.80],    # Moderate: 100-499 files -> 80% of baseline
   ].freeze
 
+  # IO_THROTTLE_RATIOS thresholds halved, so that wal-g reaches its next
+  # concurrency level before the backlog hits the matching I/O throttle tier.
+  WALG_CONCURRENCY_TIERS = IO_THROTTLE_RATIOS.map { |threshold, _| threshold / 2 }.zip([32, 24, 16]).freeze
+  WALG_BASELINE_CONCURRENCY = 8
+
+  WALG_CONCURRENCY_ENV_PATH = "/etc/postgresql/wal-g-upload-concurrency.env"
+  WALG_CONCURRENCY_DROP_IN_PATH = "/etc/systemd/system/wal-g.service.d/upload-concurrency.conf"
+  WALG_CONCURRENCY_DROP_IN_CONTENTS = "[Service]\nEnvironmentFile=#{WALG_CONCURRENCY_ENV_PATH}\n"
+
   def initialize(instance, logger, disk_throughput_baseline_mbps)
     @instance = instance
     @logger = logger
@@ -34,6 +43,7 @@ class IoThrottle
   # and disk usage, calculates appropriate throttle, and applies it.
   def run
     backlog = Dir.glob("#{@data_dir}/pg_wal/archive_status/*.ready").length
+    apply_walg_upload_concurrency(backlog)
     archival_throttle_mbps = calculate_archival_throttle(backlog)
     disk_usage_throttle_mbps = calculate_disk_usage_throttle
     throttle_mbps = [archival_throttle_mbps, disk_usage_throttle_mbps].compact.min
@@ -68,6 +78,29 @@ class IoThrottle
     set_io_limit(throttle_mbps)
     immune_pids = classify_processes
     @logger.info("Applied I/O throttle: #{throttle_mbps} MB/s (immune pids: #{immune_pids.join(", ")})")
+  end
+
+  def apply_walg_upload_concurrency(backlog_count)
+    current_env = File.exist?(WALG_CONCURRENCY_ENV_PATH) ? File.read(WALG_CONCURRENCY_ENV_PATH) : ""
+    current_concurrency = current_env[/^WALG_UPLOAD_CONCURRENCY=(\d+)$/, 1].to_i
+    target_concurrency = walg_upload_concurrency(backlog_count)
+    return if target_concurrency == current_concurrency
+
+    # A restart loses the segments the daemon had in flight, which grows the
+    # very backlog a descent follows, so climb at once but only release once
+    # the backlog is clear of half the lowest tier.
+    return if target_concurrency < current_concurrency && backlog_count > WALG_CONCURRENCY_TIERS.last.first / 2
+
+    safe_write_to_file(WALG_CONCURRENCY_ENV_PATH, "WALG_UPLOAD_CONCURRENCY=#{target_concurrency}\n")
+    FileUtils.mkdir_p(File.dirname(WALG_CONCURRENCY_DROP_IN_PATH))
+    safe_write_to_file(WALG_CONCURRENCY_DROP_IN_PATH, WALG_CONCURRENCY_DROP_IN_CONTENTS)
+    r "systemctl daemon-reload"
+    r "systemctl", "try-restart", "wal-g.service"
+    @logger.info("Set wal-g upload concurrency to #{target_concurrency} (archival backlog: #{backlog_count} files)")
+  end
+
+  def walg_upload_concurrency(backlog_count)
+    tier_for(WALG_CONCURRENCY_TIERS, backlog_count) || WALG_BASELINE_CONCURRENCY
   end
 
   def find_postmaster_pid

--- a/rhizome/postgres/spec/io_throttle_spec.rb
+++ b/rhizome/postgres/spec/io_throttle_spec.rb
@@ -270,8 +270,99 @@ RSpec.describe IoThrottle do
     end
   end
 
+  describe "#walg_upload_concurrency" do
+    it "climbs a tier at a time as the backlog grows" do
+      expect(throttle.walg_upload_concurrency(0)).to eq(8)
+      expect(throttle.walg_upload_concurrency(49)).to eq(8)
+      expect(throttle.walg_upload_concurrency(50)).to eq(16)
+      expect(throttle.walg_upload_concurrency(249)).to eq(16)
+      expect(throttle.walg_upload_concurrency(250)).to eq(24)
+      expect(throttle.walg_upload_concurrency(499)).to eq(24)
+      expect(throttle.walg_upload_concurrency(500)).to eq(32)
+      expect(throttle.walg_upload_concurrency(10_000)).to eq(32)
+    end
+
+    it "starts climbing a tier before the I/O throttle takes bandwidth away" do
+      described_class::IO_THROTTLE_RATIOS.each do |threshold, _|
+        expect(throttle.walg_upload_concurrency(threshold)).to be > described_class::WALG_BASELINE_CONCURRENCY
+      end
+    end
+  end
+
+  describe "#apply_walg_upload_concurrency" do
+    let(:env_path) { described_class::WALG_CONCURRENCY_ENV_PATH }
+
+    def env_for(concurrency)
+      "WALG_UPLOAD_CONCURRENCY=#{concurrency}\n"
+    end
+
+    def expect_written(concurrency)
+      expect(throttle).to receive(:safe_write_to_file).with(env_path, env_for(concurrency))
+      expect(FileUtils).to receive(:mkdir_p).with(File.dirname(described_class::WALG_CONCURRENCY_DROP_IN_PATH))
+      expect(throttle).to receive(:safe_write_to_file).with(described_class::WALG_CONCURRENCY_DROP_IN_PATH, described_class::WALG_CONCURRENCY_DROP_IN_CONTENTS)
+      expect(throttle).to receive(:_run_command).with("systemctl daemon-reload")
+      expect(throttle).to receive(:_run_command).with("systemctl", "try-restart", "wal-g.service")
+    end
+
+    it "writes the baseline and restarts the daemon when there is no override" do
+      expect(File).to receive(:exist?).with(env_path).and_return(false)
+      expect_written(8)
+      expect(logger).to receive(:info).with("Set wal-g upload concurrency to 8 (archival backlog: 0 files)")
+
+      throttle.apply_walg_upload_concurrency(0)
+    end
+
+    it "climbs to the tier the backlog calls for" do
+      expect(File).to receive(:exist?).with(env_path).and_return(true)
+      expect(File).to receive(:read).with(env_path).and_return(env_for(24))
+      expect_written(32)
+
+      throttle.apply_walg_upload_concurrency(500)
+    end
+
+    it "does nothing while the tier is unchanged" do
+      expect(File).to receive(:exist?).with(env_path).and_return(true)
+      expect(File).to receive(:read).with(env_path).and_return(env_for(16))
+      expect(throttle).not_to receive(:safe_write_to_file)
+      expect(logger).not_to receive(:info)
+
+      throttle.apply_walg_upload_concurrency(100)
+    end
+
+    it "holds a climbed tier until the backlog is clear, so an upload in flight survives" do
+      expect(File).to receive(:exist?).with(env_path).twice.and_return(true)
+      expect(File).to receive(:read).with(env_path).twice.and_return(env_for(32))
+      expect(throttle).not_to receive(:safe_write_to_file)
+
+      # A backlog resting on the lowest threshold, and one still draining from a
+      # higher tier, both leave the daemon where it is.
+      throttle.apply_walg_upload_concurrency(49)
+      throttle.apply_walg_upload_concurrency(249)
+    end
+
+    it "returns a climbed tier to the baseline once the backlog is clear" do
+      expect(File).to receive(:exist?).with(env_path).and_return(true)
+      expect(File).to receive(:read).with(env_path).and_return(env_for(32))
+      expect_written(8)
+
+      throttle.apply_walg_upload_concurrency(25)
+    end
+  end
+
   describe "#run" do
     let(:data_dir) { "/dat/17/data" }
+
+    before { allow(throttle).to receive(:apply_walg_upload_concurrency) }
+
+    it "hands the backlog to the wal-g upload concurrency too" do
+      expect(File).to receive(:directory?).with(service_cgroup).and_return(true)
+      expect(throttle).to receive_messages(find_device_id: "8:0", calculate_disk_usage_throttle: nil)
+      expect(Dir).to receive(:glob).with("#{data_dir}/pg_wal/archive_status/*.ready").and_return(["a.ready", "b.ready"])
+      expect(File).to receive(:write).with("#{throttled_cgroup}/io.max", "8:0 wbps=max")
+      expect(throttle).to receive(:apply_walg_upload_concurrency).with(2)
+
+      throttle.run
+    end
 
     it "applies no throttle when backlog is below threshold and no disk usage throttle" do
       expect(File).to receive(:directory?).with(service_cgroup).and_return(true)
@@ -298,6 +389,7 @@ RSpec.describe IoThrottle do
 
     it "scales throttle values with the disk throughput baseline" do
       throttle_leaseweb = described_class.new("17-main", logger, 35)
+      allow(throttle_leaseweb).to receive(:apply_walg_upload_concurrency)
       expect(File).to receive(:directory?).with(service_cgroup).and_return(true)
       expect(throttle_leaseweb).to receive_messages(find_device_id: "8:0", calculate_disk_usage_throttle: nil)
 

--- a/spec/lib/walg_config_spec.rb
+++ b/spec/lib/walg_config_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe WalgConfig do
       h = env(vcpu_count: 48, memory_mib: 384 * 1024, direct_io: true, dense_nvme: true)
       expect(h["WALG_COMPRESSION_METHOD"]).to eq("lz4")
       expect(h["WALG_UPLOAD_DISK_CONCURRENCY"]).to eq("48")   # dense NVMe -> full vCPU under O_DIRECT
-      expect(h["WALG_UPLOAD_CONCURRENCY"]).to eq("4")
+      expect(h["WALG_UPLOAD_CONCURRENCY"]).to eq("8")
       expect(h["WALG_UPLOAD_QUEUE"]).to eq("2")
-      expect(h["WALG_S3_MAX_PART_SIZE"]).to eq((64 * 1024 * 1024).to_s)
+      expect(h["WALG_S3_MAX_PART_SIZE"]).to eq((43 * 1024 * 1024).to_s) # floor(5%*384GiB / ((48+2)*(8+1)))
       expect(h["WALG_DOWNLOAD_CONCURRENCY"]).to eq("48")      # vCPU, clamped [10,128]
       expect(h["WALG_DIRECT_IO"]).to eq("true")
       expect(h["WALG_DIRECT_IO_BLOCK_COUNT"]).to eq("1024")   # 4 drives * 256
@@ -22,8 +22,8 @@ RSpec.describe WalgConfig do
     it "sizes the m8gd.large (2 vCPU / 8 GiB) row: buffered, 5%-RAM cap binds the part size" do
       h = env(vcpu_count: 2, memory_mib: 8 * 1024)
       expect(h["WALG_UPLOAD_DISK_CONCURRENCY"]).to eq("1")    # 1/2 vCPU (buffered) = 2/2 = 1
-      expect(h["WALG_UPLOAD_CONCURRENCY"]).to eq("4")
-      expect(h["WALG_S3_MAX_PART_SIZE"]).to eq((27 * 1024 * 1024).to_s) # floor(5%*8GiB / ((1+2)*(4+1)))
+      expect(h["WALG_UPLOAD_CONCURRENCY"]).to eq("8")
+      expect(h["WALG_S3_MAX_PART_SIZE"]).to eq((15 * 1024 * 1024).to_s) # floor(5%*8GiB / ((1+2)*(8+1)))
       expect(h["WALG_DOWNLOAD_CONCURRENCY"]).to eq("10")      # floor
       expect(h).not_to have_key("WALG_DIRECT_IO")             # off by default
     end

--- a/spec/model/postgres/postgres_timeline_spec.rb
+++ b/spec/model/postgres/postgres_timeline_spec.rb
@@ -113,7 +113,8 @@ PGDATA=/dat/17/data
 
     config = postgres_timeline.generate_walg_config(17, server)
     expect(config).to include("WALG_UPLOAD_DISK_CONCURRENCY=48")   # i8ge dense NVMe -> vCPU under O_DIRECT
-    expect(config).to include("WALG_S3_MAX_PART_SIZE=#{64 * 1024 * 1024}")
+    expect(config).to include("WALG_UPLOAD_CONCURRENCY=8")
+    expect(config).to include("WALG_S3_MAX_PART_SIZE=#{43 * 1024 * 1024}")
     expect(config).to include("WALG_DOWNLOAD_CONCURRENCY=48")
     expect(config).to include("WALG_DIRECT_IO=true")
     expect(config).to include("WALG_DIRECT_IO_BLOCK_COUNT=#{3 * 256}")   # drive count = RAID0 members (storage_device_paths)


### PR DESCRIPTION
WALG_UPLOAD_CONCURRENCY is how many ready WAL segments the wal-g daemon
ships in parallel, and it is the dominant term in archiving throughput.
Three repetitions per configuration, median of the archiving rate:

    configuration            3 reps                 median
    shipped (concurrency 4)  94.6 / 131.9 / 110.4   110 MB/s
    concurrency 32           680.5 / 652.4 / 526.7  652 MB/s