### PR TITLE
Ignore nft counters when comparing rules across reboot in the k8s e2e…

### DIFF
--- a/prog/test/kubernetes.rb
+++ b/prog/test/kubernetes.rb
@@ -290,8 +290,8 @@ class Prog::Test::Kubernetes < Prog::Test::KubernetesBase
 
   label def test_reboot_nftables
     node = nodepool.nodes.first
-    nat_rules = node.vm.sshable.cmd("sudo nft list chain ip nat postrouting")
-    pod_access_rules = node.vm.sshable.cmd("sudo nft list chain ip6 pod_access ingress_egress_control")
+    nat_rules = node.vm.sshable.cmd("sudo nft --stateless list chain ip nat postrouting")
+    pod_access_rules = node.vm.sshable.cmd("sudo nft --stateless list chain ip6 pod_access ingress_egress_control")
 
     self.reboot_node_id = node.id
     self.nat_rules_before_reboot = nat_rules
@@ -309,8 +309,8 @@ class Prog::Test::Kubernetes < Prog::Test::KubernetesBase
   label def verify_reboot_nftables
     reboot_node = nodepool.nodes.find { |n| n.id == reboot_node_id }
     nap 5 unless vm_ready?(reboot_node.vm)
-    nat_rules = reboot_node.vm.sshable.cmd("sudo nft list chain ip nat postrouting")
-    pod_access_rules = reboot_node.vm.sshable.cmd("sudo nft list chain ip6 pod_access ingress_egress_control")
+    nat_rules = reboot_node.vm.sshable.cmd("sudo nft --stateless list chain ip nat postrouting")
+    pod_access_rules = reboot_node.vm.sshable.cmd("sudo nft --stateless list chain ip6 pod_access ingress_egress_control")
     if nat_rules != nat_rules_before_reboot
       self.fail_message = "ip nat rules changed after reboot"
       hop_destroy_kubernetes

--- a/spec/prog/test/kubernetes_spec.rb
+++ b/spec/prog/test/kubernetes_spec.rb
@@ -631,16 +631,16 @@ RSpec.describe Prog::Test::Kubernetes do
     let(:sshable) { node.sshable }
 
     it "captures nft rules, reboots the node, and hops to verify_reboot_nftables" do
-      expect(sshable).to receive(:_cmd).with("sudo nft list chain ip nat postrouting").and_return("table ip nat { ... }")
-      expect(sshable).to receive(:_cmd).with("sudo nft list chain ip6 pod_access ingress_egress_control").and_return("table ip6 pod_access { ... }")
+      expect(sshable).to receive(:_cmd).with("sudo nft --stateless list chain ip nat postrouting").and_return("table ip nat { ... }")
+      expect(sshable).to receive(:_cmd).with("sudo nft --stateless list chain ip6 pod_access ingress_egress_control").and_return("table ip6 pod_access { ... }")
       expect(sshable).to receive(:_cmd).with("sudo systemctl reboot")
       expect { kubernetes_test.test_reboot_nftables }.to hop("verify_reboot_nftables")
       expect(kubernetes_test.strand.stack.first).to include("reboot_node_id" => node.id, "nat_rules_before_reboot" => "table ip nat { ... }", "pod_access_rules_before_reboot" => "table ip6 pod_access { ... }")
     end
 
     it "rescues SSH error during reboot and still hops" do
-      expect(sshable).to receive(:_cmd).with("sudo nft list chain ip nat postrouting").and_return("table ip nat { ... }")
-      expect(sshable).to receive(:_cmd).with("sudo nft list chain ip6 pod_access ingress_egress_control").and_return("table ip6 pod_access { ... }")
+      expect(sshable).to receive(:_cmd).with("sudo nft --stateless list chain ip nat postrouting").and_return("table ip nat { ... }")
+      expect(sshable).to receive(:_cmd).with("sudo nft --stateless list chain ip6 pod_access ingress_egress_control").and_return("table ip6 pod_access { ... }")
       expect(sshable).to receive(:_cmd).with("sudo systemctl reboot").and_raise("connection closed")
       expect { kubernetes_test.test_reboot_nftables }.to hop("verify_reboot_nftables")
     end
@@ -669,8 +669,8 @@ RSpec.describe Prog::Test::Kubernetes do
       })
       kubernetes_test.instance_variable_set(:@frame, nil)
       expect(sshable).to receive(:_cmd).with("uptime").and_return("up")
-      expect(sshable).to receive(:_cmd).with("sudo nft list chain ip nat postrouting").and_return("table ip nat { ... }")
-      expect(sshable).to receive(:_cmd).with("sudo nft list chain ip6 pod_access ingress_egress_control").and_return("table ip6 pod_access { ... }")
+      expect(sshable).to receive(:_cmd).with("sudo nft --stateless list chain ip nat postrouting").and_return("table ip nat { ... }")
+      expect(sshable).to receive(:_cmd).with("sudo nft --stateless list chain ip6 pod_access ingress_egress_control").and_return("table ip6 pod_access { ... }")
       expect { kubernetes_test.verify_reboot_nftables }.to hop("destroy_kubernetes")
     end
 
@@ -682,8 +682,8 @@ RSpec.describe Prog::Test::Kubernetes do
       })
       kubernetes_test.instance_variable_set(:@frame, nil)
       expect(sshable).to receive(:_cmd).with("uptime").and_return("up")
-      expect(sshable).to receive(:_cmd).with("sudo nft list chain ip nat postrouting").and_return("different nat rules")
-      expect(sshable).to receive(:_cmd).with("sudo nft list chain ip6 pod_access ingress_egress_control").and_return("table ip6 pod_access { ... }")
+      expect(sshable).to receive(:_cmd).with("sudo nft --stateless list chain ip nat postrouting").and_return("different nat rules")
+      expect(sshable).to receive(:_cmd).with("sudo nft --stateless list chain ip6 pod_access ingress_egress_control").and_return("table ip6 pod_access { ... }")
       expect { kubernetes_test.verify_reboot_nftables }.to hop("destroy_kubernetes")
       expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("ip nat rules changed after reboot")
     end
@@ -696,8 +696,8 @@ RSpec.describe Prog::Test::Kubernetes do
       })
       kubernetes_test.instance_variable_set(:@frame, nil)
       expect(sshable).to receive(:_cmd).with("uptime").and_return("up")
-      expect(sshable).to receive(:_cmd).with("sudo nft list chain ip nat postrouting").and_return("table ip nat { ... }")
-      expect(sshable).to receive(:_cmd).with("sudo nft list chain ip6 pod_access ingress_egress_control").and_return("different pod_access rules")
+      expect(sshable).to receive(:_cmd).with("sudo nft --stateless list chain ip nat postrouting").and_return("table ip nat { ... }")
+      expect(sshable).to receive(:_cmd).with("sudo nft --stateless list chain ip6 pod_access ingress_egress_control").and_return("different pod_access rules")
       expect { kubernetes_test.verify_reboot_nftables }.to hop("destroy_kubernetes")
       expect(kubernetes_test.strand.stack.first["fail_message"]).to eq("ip6 pod_access rules changed after reboot")
     end


### PR DESCRIPTION
Every rule in the pod_access chain carries a counter, and nft list prints the packet and byte totals inline. Counters reset when the ruleset is reloaded at boot, so any pod-subnet traffic before the reboot makes the raw string comparison fail even though the rules themselves persisted. Strip the counter values before comparing.