### PR TITLE
Fix nondeterministic ConvergePostgresResource spec

### DIFF
--- a/spec/prog/postgres/converge_postgres_resource_spec.rb
+++ b/spec/prog/postgres/converge_postgres_resource_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Prog::Postgres::ConvergePostgresResource do
       server.incr_recycle
       allow(Config).to receive(:allow_unspread_servers).and_return(true)
       expect { nx.provision_servers }.to nap
-      expect(PostgresServer.order(:created_at).last.timeline_id).to eq(parent_timeline.id)
+      expect(PostgresServer.order(:created_at, is_representative: false).last.timeline_id).to eq(parent_timeline.id)
     end
 
     it "provisions a new server on AWS even if a server is not assigned to a vm_host" do


### PR DESCRIPTION
created_at is the same for all PostgresServer in the spec, so you need to disambiguate it.

Fixes the following error I hit in CI:

```
  1) Prog::Postgres::ConvergePostgresResource#provision_servers provisions a new server with the correct timeline for a read replica
     Failure/Error: expect(PostgresServer.order(:created_at).last.timeline_id).to eq(parent_timeline.id)

       expected: "f3f1393a-4cfa-82da-9f15-89f207606b67"
            got: "1bbb600d-743c-82da-9cf3-0ab01a0da489"

       (compared using ==)
     # ./spec/prog/postgres/converge_postgres_resource_spec.rb:192:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:73:in 'block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.107.0/lib/sequel/database/transactions.rb:257:in 'Sequel::Database#_transaction'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.107.0/lib/sequel/database/transactions.rb:239:in 'block in Sequel::Database#transaction'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.107.0/lib/sequel/connection_pool/timed_queue.rb:92:in 'Sequel::TimedQueueConnectionPool#hold'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.107.0/lib/sequel/database/connecting.rb:283:in 'Sequel::Database#synchronize'
     # ./vendor/bundle/ruby/4.0.0/gems/sequel-5.107.0/lib/sequel/database/transactions.rb:197:in 'Sequel::Database#transaction'
     # ./spec/spec_helper.rb:72:in 'block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/4.0.0/gems/webmock-3.26.3/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
```