### PR TITLE
Stop retrying the setup command on an ssh auth failure

### DIFF
--- a/prog/github/github_runner_nexus.rb
+++ b/prog/github/github_runner_nexus.rb
@@ -515,13 +515,8 @@ class Prog::Github::GithubRunnerNexus < Prog::Base
       COMMAND
     end
 
-    begin
-      # Remove comments and empty lines before sending them to the machine
-      vm.sshable.cmd("bash", stdin: NetSsh.combine(*command, joiner: "").gsub(/^(\s*# .*)?\n/, ""), log: :on_error)
-    rescue Net::SSH::AuthenticationFailed
-      Clog.emit("ssh authentication failed", {failed_runner_authentication: github_runner})
-      nap 1
-    end
+    # Remove comments and empty lines before sending them to the machine
+    vm.sshable.cmd("bash", stdin: NetSsh.combine(*command, joiner: "").gsub(/^(\s*# .*)?\n/, ""), log: :on_error)
     github_runner.encoded_jit_config ? hop_start_runner : hop_register_runner
   end
 

--- a/spec/prog/github/github_runner_nexus_spec.rb
+++ b/spec/prog/github/github_runner_nexus_spec.rb
@@ -854,14 +854,6 @@ RSpec.describe Prog::Github::GithubRunnerNexus do
 
       expect { nx.setup_environment }.to hop("register_runner")
     end
-
-    it "naps if ssh authentication failed" do
-      expect(vm).to receive(:nics).and_return([instance_double(Nic, private_ipv4: NetAddr::IPv4Net.parse("10.0.0.1/32"), is_management: false)]).at_least(:once)
-      expect(vm.sshable).to receive(:_cmd).and_raise(Net::SSH::AuthenticationFailed.new("Authentication failed for user runneradmin@1.2.3.4"))
-      expect(Clog).to receive(:emit).with("ssh authentication failed", instance_of(Hash)).and_call_original
-
-      expect { nx.setup_environment }.to nap(1)
-    end
   end
 
   describe "#register_runner" do


### PR DESCRIPTION
57f9f037bf75 added this retry for aws runners: they set up runneradmin
in the user_data script, so the vm passed wait_sshable, which only
opened a tcp connection, while cloud-init had not installed the key yet
and no login could succeed.

cb5354a5d3cf now runs a command over ssh in Vm::Aws::Nexus#wait_sshable
before recording provisioned_at, so a runner is handed a vm it can log
into, and the condition this retry waited out is checked where it
happens. Metal delivers the key as cloud-config that is applied before
sshd serves, so it never needed the retry.

No failed_runner_authentication has been logged since 2026-09-07, the
day the aws check reached production.

An auth failure now ends the strand run instead of napping a second.
That is louder and slower to recover, which suits a failure that should
no longer be a race.