### PR TITLE
Group machine image archive log metadata under a named key

### DIFF
--- a/prog/machine_image/version_metal_nexus.rb
+++ b/prog/machine_image/version_metal_nexus.rb
@@ -85,9 +85,11 @@ class Prog::MachineImage::VersionMetalNexus < Prog::Base
     when "Failed"
       self.archive_failures = (archive_failures || 0) + 1
       Clog.emit("Machine image archive failed", {
-        machine_image_version_metal: machine_image_version_metal.ubid,
-        archive_failures:,
-        logs: sshable.d_logs(archive_unit, lines: 50),
+        machine_image_archive_failure: {
+          machine_image_version_metal: machine_image_version_metal.ubid,
+          archive_failures:,
+          logs: sshable.d_logs(archive_unit, lines: 50),
+        },
       })
       if archive_failures >= MAX_ARCHIVE_FAILURES
         machine_image_version_metal.update(status: "failed", pinned_source_vm_id: nil)
@@ -219,10 +221,12 @@ class Prog::MachineImage::VersionMetalNexus < Prog::Base
     unless response.errors.empty?
       miv = machine_image_version_metal.machine_image_version
       Clog.emit("Failed to delete some machine image archive objects", {
-        machine_image: miv.machine_image.ubid,
-        version: miv.version,
-        count: response.errors.size,
-        first_error: response.errors.first.to_h,
+        machine_image_archive_delete_failure: {
+          machine_image: miv.machine_image.ubid,
+          version: miv.version,
+          count: response.errors.size,
+          first_error: response.errors.first.to_h,
+        },
       })
 
       # nap longer to space out retries

--- a/spec/prog/machine_image/version_metal_nexus_spec.rb
+++ b/spec/prog/machine_image/version_metal_nexus_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Prog::MachineImage::VersionMetalNexus do
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 check #{daemon}").and_return("Failed")
       expect(sshable).to receive(:_cmd).with("sudo journalctl -u #{daemon} -n 50 --no-pager").and_return("archive logs")
       expect(sshable).to receive(:_cmd).with("common/bin/daemonizer2 clean #{daemon}")
-      expect(Clog).to receive(:emit).with("Machine image archive failed", {machine_image_version_metal: metal.ubid, archive_failures: 1, logs: "archive logs"}).and_call_original
+      expect(Clog).to receive(:emit).with("Machine image archive failed", {machine_image_archive_failure: {machine_image_version_metal: metal.ubid, archive_failures: 1, logs: "archive logs"}}).and_call_original
       expect { prog.archive }.to nap(60)
       expect(strand.stack.first["archive_failures"]).to eq(1)
       expect(metal.reload.status).to eq("creating")


### PR DESCRIPTION
Per the Clog convention introduced in f2b128f97, we prefer to use a single hash for metadata, with a unique-ish name, so the fields are selectable by concern in log queries.

Wrap the archive-failure and delete-failure metadata this way, matching the delete-error emit already in this file.