### PR TITLE
Measure and tune deleted_record archive slices

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -234,6 +234,7 @@ module Config
   optional :deleted_record_archive_bucket, string
   optional :deleted_record_archive_access_key, string, clear: true
   optional :deleted_record_archive_secret_key, string, clear: true
+  override :deleted_record_archive_window_seconds, 60 * 60, int
 
   # Ubicloud Images (R2)
   optional :ubicloud_images_r2_bucket_name, string

--- a/prog/deleted_record_archiver.rb
+++ b/prog/deleted_record_archiver.rb
@@ -164,6 +164,7 @@ class Prog::DeletedRecordArchiver < Prog::Base
       gz = Zlib::GzipWriter.new(file, Zlib::BEST_SPEED)
 
       buffer = "".b
+      copy_started = Time.now
       DB.copy_table(ds, format: :csv) do |chunk|
         rows += 1
         buffer << chunk
@@ -172,6 +173,7 @@ class Prog::DeletedRecordArchiver < Prog::Base
           buffer.clear
         end
       end
+      copy_duration = Time.now - copy_started
       gz.write(buffer) unless buffer.empty?
 
       gz.finish
@@ -179,6 +181,7 @@ class Prog::DeletedRecordArchiver < Prog::Base
       bytes = file.size
       file.rewind
 
+      upload_started = Time.now
       etag = blob_storage_client.put_object(
         bucket: Config.deleted_record_archive_bucket,
         key:,
@@ -187,11 +190,15 @@ class Prog::DeletedRecordArchiver < Prog::Base
         content_type: "application/gzip",
         checksum_algorithm: "CRC32",
       ).etag
+      upload_duration = Time.now - upload_started
 
       period = Sequel.pg_range(window_from...window_to, :tstzrange)
       DB[:deleted_record_archive_slice].insert(day:, period:, object_key: key, row_count: rows, bytes:, etag:)
 
-      Clog.emit("archived deleted_record slice", {deleted_record_slice_archived: {day:, key:, rows:, bytes:}})
+      Clog.emit("archived deleted_record slice", {deleted_record_slice_archived: {
+        day:, key:, rows:, bytes:,
+        copy_duration: copy_duration.round(3), upload_duration: upload_duration.round(3),
+      }})
     end
   end
 

--- a/prog/deleted_record_archiver.rb
+++ b/prog/deleted_record_archiver.rb
@@ -7,7 +7,6 @@ require "zlib"
 class Prog::DeletedRecordArchiver < Prog::Base
   COLUMNS = [:deleted_at, :model_name, :record_id, :model_values].freeze
   COPY_TIMEOUT = "30s"
-  WINDOW_SECONDS = 60 * 60
   WRITE_BUFFER_BYTES = 64 * 1024
   STALL_DEADLINE = 3 * 60 * 60
   MANIFEST_RETENTION_DAYS = 365
@@ -147,8 +146,9 @@ class Prog::DeletedRecordArchiver < Prog::Base
     day = day_row[:day]
     window_from = archived_through(day)
 
-    next_hour = window_from + WINDOW_SECONDS - (window_from.to_i % WINDOW_SECONDS)
-    window_to = [next_hour, day_end(day)].min
+    seconds = Config.deleted_record_archive_window_seconds
+    next_boundary = window_from + seconds - (window_from.to_i % seconds)
+    window_to = [next_boundary, day_end(day)].min
     key = object_key(day, window_from, window_to)
 
     DB.run("SET LOCAL TimeZone = 'UTC'")

--- a/spec/prog/deleted_record_archiver_spec.rb
+++ b/spec/prog/deleted_record_archiver_spec.rb
@@ -214,6 +214,30 @@ RSpec.describe Prog::DeletedRecordArchiver do
       expect(slices.first[:row_count]).to eq 3
     end
 
+    it "cuts the hour down when a shorter window is configured" do
+      allow(Config).to receive(:deleted_record_archive_window_seconds).and_return(15 * 60)
+
+      expect { prog.archive }.to nap(1)
+      expect { prog.archive }.to nap(1)
+
+      expect(uploads.map { it[:key] }).to eq [
+        "date=#{day}/0000-0015.csv.gz",
+        "date=#{day}/0015-0030.csv.gz",
+      ]
+      expect(prog.archived_through(day)).to eq day_start + (30 * 60)
+    end
+
+    it "picks up a window length that changed partway through a day" do
+      expect { prog.archive }.to nap(1)
+      allow(Config).to receive(:deleted_record_archive_window_seconds).and_return(15 * 60)
+      expect { prog.archive }.to nap(1)
+
+      expect(uploads.map { it[:key] }).to eq [
+        "date=#{day}/0000-0100.csv.gz",
+        "date=#{day}/0100-0115.csv.gz",
+      ]
+    end
+
     it "leaves no trace when the copy fails partway through" do
       expect(DB).to receive(:copy_table).and_raise(Zlib::BufError)
 


### PR DESCRIPTION
- **Log copy and upload durations per slice**
  The deleted_record archiver now splits a slice's time, so a slow COPY
  and a slow upload are distinguishable.
  

- **Make the deleted_record archive window configurable**
  Shortening a window is the lever when one no longer fits in a strand
  run. Mixing lengths within a day is supported.
  