### PR TITLE
Hide page backtraces on the admin homepage

### DIFF
--- a/spec/routes/web/admin/admin_spec.rb
+++ b/spec/routes/web/admin/admin_spec.rb
@@ -972,6 +972,18 @@ RSpec.describe CloverAdmin do
     expect(page.title).to eq "Ubicloud Admin - Vm #{vm.ubid}"
   end
 
+  it "omits the backtrace from the details of active pages on index page" do
+    page1 = Prog::PageNexus.assemble("some problem", %w[a].freeze, nil, resource_id: nil, extra_data: {"exception_class" => "RuntimeError", "backtrace" => ["clover.rb:1"]}).subject
+    visit "/"
+    expect(page_data).to eq [
+      ["", "some problem", "[]", "{\"exception_class\" => \"RuntimeError\"}"],
+    ]
+    expect(page).to have_no_content "clover.rb:1"
+
+    click_link page1.summary
+    expect(page).to have_content "clover.rb:1"
+  end
+
   it "hides snoozed pages on index page and shows a note about them" do
     page1 = Prog::PageNexus.assemble("some problem", %w[a].freeze, nil, resource_id: nil).subject
     page2 = Prog::PageNexus.assemble("another problem", %w[b].freeze, nil, resource_id: nil).subject

--- a/views/admin/index.erb
+++ b/views/admin/index.erb
@@ -18,7 +18,8 @@
       <tbody>
         <% @grouped_pages.sort_by { |k,| k || "z" }.each do |root_resource_id, pages| %>
           <% pages.each_with_index do |page, index| %>
-            <% resources = page.details.delete("related_resources") %>
+            <% details = page.details.except("backtrace") %>
+            <% resources = details.delete("related_resources") %>
 
             <tr>
               <% if index == 0 %>
@@ -33,7 +34,7 @@
               <td><%= page.created_at.strftime("%F %T") %></td>
               <td><a href="/model/Page/<%= page.ubid %>"><%= page.summary %></a></td>
               <td><%== linkify_ubids(resources) %></td>
-              <td><%== linkify_ubids(page.details) %></td>
+              <td><%== linkify_ubids(details) %></td>
             </tr>
           <% end %>
         <% end %>


### PR DESCRIPTION
Pages created for unexpected Clover web request errors carry up to 50 backtrace frames in their details. The admin homepage renders the whole details hash in the Details column, so a single such page pushes every other active page off the screen.

Omit the backtrace when rendering the Details column. The full details, backtrace included, are still on the page's own model view.