### PR TITLE
Accept numeric values in the Postgres config response schema

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -3225,13 +3225,17 @@ components:
           example:
             max_connections: '100'
           additionalProperties:
-            type: string
+            anyOf:
+              - type: string
+              - type: number
         pgbouncer_config:
           type: object
           example:
             max_client_conn: '100'
           additionalProperties:
-            type: string
+            anyOf:
+              - type: string
+              - type: number
         default_pg_config:
           description: System-computed configuration values based on instance size. User overrides in pg_config take precedence.
           type: object

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -1441,6 +1441,17 @@ RSpec.describe Clover, "postgres" do
         expect(response_body["default_pg_config"]).to include("shared_buffers", "work_mem", "max_connections", "effective_cache_size")
       end
 
+      it "serializes numeric config values without failing response validation" do
+        pg.update(user_config: {"max_connections" => 100}, pgbouncer_user_config: {"max_client_conn" => 100})
+
+        get "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/config"
+
+        expect(last_response.status).to eq(200)
+        response_body = JSON.parse(last_response.body)
+        expect(response_body["pg_config"]).to eq({"max_connections" => 100})
+        expect(response_body["pgbouncer_config"]).to eq({"max_client_conn" => 100})
+      end
+
       it "full update" do
         pg.update(user_config: {"max_connections" => "100"}, pgbouncer_user_config: {"max_client_conn" => "100"})
         post "/project/#{project.ubid}/location/#{pg.display_location}/postgres/#{pg.name}/config", {


### PR DESCRIPTION
The config endpoints return user_config verbatim, and user_config is a JSONB column. A client that sends a JSON number (for example {"pg_config": {"max_connections": 8}}) stores an integer there, since typecast_params.Hash does not coerce value types. The PostgresConfig schema only allowed string values, so Committee rejected the response with "expected string, but received Integer".

Values are normalized to strings on the disk-write path already (PostgresConfig.quote_value calls to_s), so the stored type is harmless everywhere except this response check. Widen additionalProperties to accept string or number. number covers integers and floats, so float-typed parameters like random_page_cost do not trip the same error.