### PR TITLE
Add internal support for almalinux-10 VMs

### DIFF
--- a/prog/download_boot_image.rb
+++ b/prog/download_boot_image.rb
@@ -83,9 +83,10 @@ class Prog::DownloadBootImage < Prog::Base
       arch = render_arch(arch, arm64: "arm64", x64: "amd64")
       deb_version = image_name.split("-").last
       "https://cloud.debian.org/images/cloud/#{DEBIAN_VERSION_NICKNAME_MAP.fetch(deb_version)}/#{version}/debian-#{deb_version}-genericcloud-#{arch}-#{version}.raw"
-    when "almalinux-9"
+    when "almalinux-10", "almalinux-9"
       arch = render_arch(arch, arm64: "aarch64", x64: "x86_64")
-      "https://repo.almalinux.org/almalinux/9/cloud/#{arch}/images/AlmaLinux-9-GenericCloud-#{version}.#{arch}.qcow2"
+      major_version = image_name.split("-").last
+      "https://repo.almalinux.org/almalinux/#{major_version}/cloud/#{arch}/images/AlmaLinux-#{major_version}-GenericCloud-#{version}.#{arch}.qcow2"
     else
       fail "Unknown image name: #{image_name}"
     end
@@ -147,11 +148,21 @@ class Prog::DownloadBootImage < Prog::Base
         "9.5-20241120" => "abddf01589d46c841f718cec239392924a03b34c4fe84929af5d543c50e37e37",
         "9.6-20250522" => "b08cd5db79bf32860412f5837e8c7b8df9447e032376e3c622840b31aaf26bc6",
         "9.7-20251118" => "5ff9c048859046f41db4a33b1f1a96675711288078aac66b47d0be023af270d1",
+        "9.8-20260526" => "c397eed7023e92c841155831b1f47e26300e5bef0f0256c129322307c897a251",
       },
       "arm64" => {
         "9.5-20241120" => "5ede4affaad0a997a2b642f1628b6268bd8eba775f281346b75be3ed20ec369e",
         "9.6-20250522" => "47e6801d066c311c44a5ce8100bed16b5976bde610e599dd384d1dca73b31ac5",
         "9.7-20251118" => "c6c09af3b5be62e0ca82ccfafe0b1de9be90890fa8fddbd6118fa8b76b36de2d",
+        "9.8-20260526" => "b5d883c5f84c68a9828fbd3aac863f9a723b43f8965a32ff7a1c198301f42a29",
+      },
+    },
+    "almalinux-10" => {
+      "x64" => {
+        "10.2-20260526.0" => "47f2218668dd4776be140dd92fa3bea700be1766e2c7d88bdfd6a4b50f477b4d",
+      },
+      "arm64" => {
+        "10.2-20260526.0" => "336c6861fe0ba9115af00f557ed1b09385a3525612dd0cb9cce7e0486f8e74a4",
       },
     },
     "github-ubuntu-2604" => {

--- a/rhizome/host/bin/setup-vm
+++ b/rhizome/host/bin/setup-vm
@@ -112,7 +112,7 @@ when "recreate-unpersisted"
 when "reinstall-systemd-units"
   vm_setup.install_systemd_unit(
     max_vcpus, cpu_topology, mem_gib, storage_volumes, nics,
-    pci_devices, slice_name, cpu_percent_limit, cpu_burst_percent_limit,
+    pci_devices, slice_name, cpu_percent_limit, boot_image,
   )
 when "reassign-ip6"
   secrets = JSON.parse($stdin.read)

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -797,7 +797,9 @@ DNSMASQ_SERVICE
         disk_params.map { |x| "--disk #{x}" }.join(" ")
       end
 
-    net_params = nics.map { "--net mac=#{_1.mac},tap=#{_1.tap},ip=,mask=,num_queues=#{max_vcpus * 2 + 1}" }
+    # AlmaLinux 10 VMs drop DHCPv6 replies if virtio checksum offload is enabled
+    net_offload_params = ",offload_tso=off,offload_ufo=off,offload_csum=off" if boot_image == "almalinux-10"
+    net_params = nics.map { "--net mac=#{_1.mac},tap=#{_1.tap},ip=,mask=,num_queues=#{max_vcpus * 2 + 1}#{net_offload_params}" }
     pci_device_params =
       if pci_devices.empty?
         nil

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -53,7 +53,7 @@ class VmSetup
     [network_thread, storage_thread].each(&:join)
     hugepages(mem_gib)
     prepare_gpus(pci_devices, gpu_partition_id)
-    install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices, slice_name, cpu_percent_limit)
+    install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices, slice_name, cpu_percent_limit, boot_image)
     start_systemd_unit
     update_via_routes(nics)
 
@@ -86,7 +86,7 @@ class VmSetup
     setup_networking(false, gua, ip4, local_ip4, nics, ndp_needed, dns_ipv4, multiqueue: max_vcpus > 1)
     hugepages(mem_gib)
     storage(storage_params, storage_secrets, false)
-    install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices, slice_name, cpu_percent_limit)
+    install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices, slice_name, cpu_percent_limit, boot_image)
     start_systemd_unit
     update_via_routes(nics)
     enable_bursting(slice_name, cpu_burst_percent_limit) unless cpu_burst_percent_limit == 0
@@ -669,7 +669,7 @@ DNSMASQ_CONF
     gpus.each { |_, iommu_group| chown_vfio(iommu_group) }
   end
 
-  def install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices, slice_name, cpu_percent_limit)
+  def install_systemd_unit(max_vcpus, cpu_topology, mem_gib, storage_params, nics, pci_devices, slice_name, cpu_percent_limit, boot_image)
     fail "BUG" if /["'\s]/.match?(cpu_topology)
 
     tapnames = nics.map { "-i #{_1.tap}" }.join(" ")
@@ -754,6 +754,7 @@ DNSMASQ_SERVICE
       storage_params: storage_params,
       nics: nics,
       pci_devices: pci_devices,
+      boot_image: boot_image,
     )
 
     vp.write_systemd_service(vm_service)
@@ -779,7 +780,7 @@ DNSMASQ_SERVICE
     r "systemctl", "restart", @vm_name
   end
 
-  def build_ch_service(header:, footer:, slice_name:, mem_gib:, max_vcpus:, cpu_topology:, storage_volumes:, storage_params:, nics:, pci_devices:)
+  def build_ch_service(header:, footer:, slice_name:, mem_gib:, max_vcpus:, cpu_topology:, storage_volumes:, storage_params:, nics:, pci_devices:, boot_image:)
     disk_params = storage_volumes.map { |volume|
       if volume.read_only
         "path=#{volume.image_path},readonly=on"
@@ -831,7 +832,7 @@ DNSMASQ_SERVICE
     SERVICE
   end
 
-  def build_qemu_service(header:, footer:, slice_name:, mem_gib:, max_vcpus:, cpu_topology:, storage_volumes:, storage_params:, nics:, pci_devices:)
+  def build_qemu_service(header:, footer:, slice_name:, mem_gib:, max_vcpus:, cpu_topology:, storage_volumes:, storage_params:, nics:, pci_devices:, boot_image:)
     disk_parts = storage_volumes.each_with_index.flat_map do |vol, i|
       if vol.read_only
         [

--- a/rhizome/host/lib/vm_setup.rb
+++ b/rhizome/host/lib/vm_setup.rb
@@ -598,6 +598,9 @@ DNSMASQ_CONF
     runcmd.concat(install_commands(boot_image))
     runcmd << init_script if init_script
 
+    bootcmd = nft_bootcmd
+    bootcmd = bootcmd.map { "command -v nft > /dev/null && #{_1}" } if installs_nftables?(boot_image)
+
     config = {
       "users" => [{
         "name" => unix_user,
@@ -609,7 +612,7 @@ DNSMASQ_CONF
       "ssh_genkeytypes" => ["ed25519"],
       "ssh_quiet_keygen" => true,
       "runcmd" => runcmd,
-      "bootcmd" => nft_bootcmd,
+      "bootcmd" => bootcmd,
     }
 
     if swap_size_bytes
@@ -620,11 +623,15 @@ DNSMASQ_CONF
     vp.write_yaml_user_data(config, prefix: "#cloud-config")
   end
 
+  private def installs_nftables?(boot_image)
+    boot_image.include?("almalinux") || boot_image.include?("debian")
+  end
+
   private def install_commands(boot_image)
     if boot_image.include?("almalinux")
-      [%w[dnf install -y nftables].freeze.shelljoin]
+      [%w[dnf install -y nftables].freeze.shelljoin] + nft_bootcmd
     elsif boot_image.include?("debian")
-      [%w[apt-get update].freeze.shelljoin, %w[apt-get install -y nftables].freeze.shelljoin]
+      [%w[apt-get update].freeze.shelljoin, %w[apt-get install -y nftables].freeze.shelljoin] + nft_bootcmd
     else
       []
     end

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -444,6 +444,26 @@ RSpec.describe VmSetup do
       }
     end
 
+    it "disables net offload for almalinux-10, which drops DHCPv6 replies otherwise" do
+      vps = instance_spy(VmPath,
+        ch_api_sock: "/tmp/ch.sock",
+        serial_log: "/vm/test/serial.log",
+        cloudinit_img: "/vm/test/cloudinit.img")
+      expect(vs).to receive(:vp).and_return(vps).at_least(:once)
+
+      vs.instance_variable_set(:@ch_version,
+        CloudHypervisor::Version.new("35.1", "sha256_ch_bin", "sha256_ch_remote"))
+      vs.instance_variable_set(:@firmware_version,
+        CloudHypervisor::Firmware.new("202311", "sha256"))
+
+      expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
+      vs.send(:install_systemd_unit, *args[...-1], "almalinux-10")
+
+      expect(vps).to have_received(:write_systemd_service) { |content|
+        expect(content).to include("--net mac=02:aa:bb:cc:dd:01,tap=tap0,ip=,mask=,num_queues=5,offload_tso=off,offload_ufo=off,offload_csum=off")
+      }
+    end
+
     it "can write a QEMU systemd unit" do
       vs.instance_variable_set(:@hypervisor, "qemu")
 

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -90,23 +90,43 @@ RSpec.describe VmSetup do
       }.to raise_error RuntimeError, "BUG: swap_size_bytes must be an integer"
     end
 
-    it "includes install commands for debian boot images" do
+    it "includes install commands and nft setup in runcmd for debian boot images" do
       vs.write_user_data("user", ["key"], nil, "debian-12")
       config = parse_user_data
       expect(config["runcmd"]).to include("apt-get update")
       expect(config["runcmd"]).to include("apt-get install -y nftables")
+      expect(config["runcmd"]).to include("nft add table ip6 filter")
     end
 
-    it "includes install commands for almalinux boot images" do
+    it "includes install commands and nft setup in runcmd for almalinux boot images" do
       vs.write_user_data("user", ["key"], nil, "almalinux-9")
       config = parse_user_data
       expect(config["runcmd"]).to include("dnf install -y nftables")
+      expect(config["runcmd"]).to include("nft add table ip6 filter")
     end
 
     it "includes no install commands for ubuntu boot images" do
       vs.write_user_data("user", ["key"], nil, "ubuntu-noble")
       config = parse_user_data
       expect(config["runcmd"]).to eq(["systemctl daemon-reload"])
+    end
+
+    it "guards bootcmd's nft rules so they're skipped, not errored, before nftables is installed on almalinux" do
+      vs.write_user_data("user", ["key"], nil, "almalinux-9")
+      config = parse_user_data
+      expect(config["bootcmd"].first).to eq("command -v nft > /dev/null && nft add table ip6 filter")
+    end
+
+    it "guards bootcmd's nft rules so they're skipped, not errored, before nftables is installed on debian" do
+      vs.write_user_data("user", ["key"], nil, "debian-12")
+      config = parse_user_data
+      expect(config["bootcmd"].first).to eq("command -v nft > /dev/null && nft add table ip6 filter")
+    end
+
+    it "does not guard bootcmd's nft rules on ubuntu, which ships nftables by default" do
+      vs.write_user_data("user", ["key"], nil, "ubuntu-noble")
+      config = parse_user_data
+      expect(config["bootcmd"].first).to eq("nft add table ip6 filter")
     end
 
     it "includes init_script as a string in runcmd" do

--- a/rhizome/host/spec/vm_setup_spec.rb
+++ b/rhizome/host/spec/vm_setup_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe VmSetup do
         {"disk_index" => 2, "device_id" => "vol_2", "encrypted" => true, "read_only" => false, "vhost_block_backend_version" => "v0.4.0"},
       ]
     }
-    let(:args) { [2, "1:1:1:2", 2, storage_params, [VmSetup::Nic.new("fd00::/64", "10.0.0.1/32", "tap0", "02:aa:bb:cc:dd:01", "10.0.0.254/32")], [], "system.slice", 0] }
+    let(:args) { [2, "1:1:1:2", 2, storage_params, [VmSetup::Nic.new("fd00::/64", "10.0.0.1/32", "tap0", "02:aa:bb:cc:dd:01", "10.0.0.254/32")], [], "system.slice", 0, "ubuntu-noble"] }
 
     it "uses cloud-hypervisor by default" do
       vps = instance_spy(VmPath)
@@ -493,7 +493,7 @@ RSpec.describe VmSetup do
     end
 
     it "raises BUG when cpu_topology contains special characters" do
-      expect { vs.send(:install_systemd_unit, 2, '"1:1:1:2"', 2, [], [], [], "system.slice", 0) }.to raise_error("BUG")
+      expect { vs.send(:install_systemd_unit, 2, '"1:1:1:2"', 2, [], [], [], "system.slice", 0, "ubuntu-noble") }.to raise_error("BUG")
     end
 
     it "adds topoext when CPU vendor is AMD" do
@@ -1355,7 +1355,7 @@ NFTABLES_CONF
       vs.instance_variable_set(:@hypervisor, "kvm")
       vps = instance_spy(VmPath)
       expect(vs).to receive(:vp).and_return(vps)
-      expect { vs.send(:install_systemd_unit, 2, "1:1:1:2", 2, [], [], [], "system.slice", 0) }.to raise_error(/unsupported hypervisor kvm/)
+      expect { vs.send(:install_systemd_unit, 2, "1:1:1:2", 2, [], [], [], "system.slice", 0, "ubuntu-noble") }.to raise_error(/unsupported hypervisor kvm/)
     end
   end
 
@@ -1373,7 +1373,7 @@ NFTABLES_CONF
         CloudHypervisor::Firmware.new("202311", "sha256"))
 
       storage_params = []
-      args = [2, "1:1:1:2", 2, storage_params, [], [["00:01.0", "1"], ["00:02.0", "2"]], "system.slice", 0]
+      args = [2, "1:1:1:2", 2, storage_params, [], [["00:01.0", "1"], ["00:02.0", "2"]], "system.slice", 0, "ubuntu-noble"]
 
       expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       vs.send(:install_systemd_unit, *args)
@@ -1401,7 +1401,7 @@ NFTABLES_CONF
       storage_params = [
         {"disk_index" => 0, "device_id" => "vol_0", "encrypted" => true, "vhost_block_backend_version" => "v0.4.0"},
       ]
-      args = [2, "1:1:1:2", 2, storage_params, [VmSetup::Nic.new("fd00::/64", "10.0.0.1/32", "tap0", "02:aa:bb:cc:dd:01", "10.0.0.254/32")], [["00:01.0", "1"]], "system.slice", 0]
+      args = [2, "1:1:1:2", 2, storage_params, [VmSetup::Nic.new("fd00::/64", "10.0.0.1/32", "tap0", "02:aa:bb:cc:dd:01", "10.0.0.254/32")], [["00:01.0", "1"]], "system.slice", 0, "ubuntu-noble"]
 
       expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
       vs.send(:install_systemd_unit, *args)
@@ -1430,7 +1430,7 @@ NFTABLES_CONF
         CloudHypervisor::Firmware.new("202311", "sha256"))
 
       expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
-      vs.send(:install_systemd_unit, 2, "1:1:1:2", 2, [], [], [], "system.slice", 0)
+      vs.send(:install_systemd_unit, 2, "1:1:1:2", 2, [], [], [], "system.slice", 0, "ubuntu-noble")
 
       expect(vps).to have_received(:write_systemd_service) { |content|
         expect(content).to include("shared=on")
@@ -1453,7 +1453,7 @@ NFTABLES_CONF
         CloudHypervisor::Firmware.new("202311", "sha256"))
 
       expect(vs).to receive(:_run_command).with("systemctl daemon-reload")
-      vs.send(:install_systemd_unit, 2, "1:1:1:2", 2, [], [], [], "system.slice", 50)
+      vs.send(:install_systemd_unit, 2, "1:1:1:2", 2, [], [], [], "system.slice", 50, "ubuntu-noble")
 
       expect(vps).to have_received(:write_systemd_service) { |content|
         expect(content).to include("CPUQuota=50%")
@@ -1477,7 +1477,7 @@ NFTABLES_CONF
       expect(vs).to receive(:cpu_vendor).and_return("GenuineIntel")
 
       storage_params = []
-      args = [2, "1:1:1:2", 2, storage_params, [], [], "system.slice", 0]
+      args = [2, "1:1:1:2", 2, storage_params, [], [], "system.slice", 0, "ubuntu-noble"]
       vs.send(:install_systemd_unit, *args)
 
       expect(vps).to have_received(:write_systemd_service) { |content|
@@ -1503,7 +1503,7 @@ NFTABLES_CONF
 
       storage_params = []
       pci_devices = [["00:01.0", "1"], ["00:02.0", "2"]]
-      args = [2, "1:1:1:2", 2, storage_params, [], pci_devices, "system.slice", 0]
+      args = [2, "1:1:1:2", 2, storage_params, [], pci_devices, "system.slice", 0, "ubuntu-noble"]
       vs.send(:install_systemd_unit, *args)
 
       expect(vps).to have_received(:write_systemd_service) { |content|

--- a/spec/prog/download_boot_image_spec.rb
+++ b/spec/prog/download_boot_image_spec.rb
@@ -149,6 +149,18 @@ RSpec.describe Prog::DownloadBootImage do
       expect(dbi.url).to eq("https://repo.almalinux.org/almalinux/9/cloud/aarch64/images/AlmaLinux-9-GenericCloud-9.5-20241120.aarch64.qcow2")
     end
 
+    it "returns URL for x64 almalinux-10 image" do
+      refresh_frame(dbi, new_values: {"image_name" => "almalinux-10", "version" => "10.2-20260526.0", "custom_url" => nil})
+      expect(dbi.url).to eq("https://repo.almalinux.org/almalinux/10/cloud/x86_64/images/AlmaLinux-10-GenericCloud-10.2-20260526.0.x86_64.qcow2")
+    end
+
+    it "returns URL for arm64 almalinux-10 image" do
+      refresh_frame(dbi, new_values: {"image_name" => "almalinux-10", "version" => "10.2-20260526.0", "custom_url" => nil})
+      vm_host.update(arch: "arm64")
+
+      expect(dbi.url).to eq("https://repo.almalinux.org/almalinux/10/cloud/aarch64/images/AlmaLinux-10-GenericCloud-10.2-20260526.0.aarch64.qcow2")
+    end
+
     it "returns URL for ai model image" do
       refresh_frame(dbi, new_values: {"image_name" => "ai-model-test-model", "version" => "20240924.1.0", "custom_url" => nil})
 


### PR DESCRIPTION
The biggest change needed is to disable checksum offloading, as that prevents almalinux 10 networking from work.

I also found an issue with both debian and almalinux trying to use `nft` before is was installed, so include a fix for that.

Also add support for boot image downloads.

I also found rhizome setup-vm reinstall-systemd-units command was broken about 21 months ago. Not sure if we still need it, but this fixes it.