### PR TITLE
Fetch minio and mc from their GitHub releases

### DIFF
--- a/rhizome/kubernetes/bin/backup-etcd
+++ b/rhizome/kubernetes/bin/backup-etcd
@@ -10,7 +10,7 @@ require "tempfile"
 input = JSON.parse($stdin.read)
 
 MC_PATH = "/usr/local/bin/mc"
-MC_RELEASE_URL = "https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2025-08-13T08-35-41Z"
+MC_RELEASE_URL = "https://github.com/minio/mc/releases/download/RELEASE.2025-08-13T08-35-41Z/mc.linux-amd64.RELEASE.2025-08-13T08-35-41Z"
 EXPECTED_HASH = "01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891"
 
 unless File.exist?(MC_PATH)

--- a/rhizome/minio/lib/minio_setup.rb
+++ b/rhizome/minio/lib/minio_setup.rb
@@ -3,24 +3,28 @@
 require_relative "../../common/lib/util"
 
 class MinioSetup
-  # Upstream publishes a .sha256sum next to each package; these are the digests
-  # it lists for the linux-amd64 builds.
-  CHECKSUMS = {
-    "minio_20250723155402.0.0_amd64" => "a6ff2d7424206c3d8be43bd5eac159e49ea57780ef1d7fb3afbe47227650a62d",
+  # Upstream publishes a .sha256sum next to each package; these are the release
+  # tags that serve the linux-amd64 builds and the digests it lists for them.
+  RELEASES = {
+    "minio_20250723155402.0.0_amd64" => {
+      tag: "RELEASE.2025-07-23T15-54-02Z",
+      checksum: "a6ff2d7424206c3d8be43bd5eac159e49ea57780ef1d7fb3afbe47227650a62d",
+    },
   }.freeze
 
   def initialize(argv)
     fail "expected a single argument, a minio version like minio_20250723155402.0.0_amd64, got #{argv.length}" unless argv.length == 1
 
     @version = argv[0]
-    fail "no minio checksum for version #{@version.inspect}" unless CHECKSUMS.key?(@version)
+    fail "no minio checksum for version #{@version.inspect}" unless RELEASES.key?(@version)
   end
 
   def run
     package = "#{@version}.deb"
-    url = "https://dl.min.io/server/minio/release/linux-amd64/archive/#{package}"
+    release = RELEASES.fetch(@version)
+    url = "https://github.com/minio/minio/releases/download/#{release.fetch(:tag)}/#{package}"
 
-    fail "Invalid SHA-256 digest" unless curl_file(url, package) == CHECKSUMS.fetch(@version)
+    fail "Invalid SHA-256 digest" unless curl_file(url, package) == release.fetch(:checksum)
 
     r "dpkg", "-i", package
     r "rm", package

--- a/rhizome/minio/spec/minio_setup_spec.rb
+++ b/rhizome/minio/spec/minio_setup_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MinioSetup do
   subject(:setup) { described_class.new(["minio_20250723155402.0.0_amd64"]) }
 
   let(:package) { "minio_20250723155402.0.0_amd64.deb" }
-  let(:url) { "https://dl.min.io/server/minio/release/linux-amd64/archive/#{package}" }
+  let(:url) { "https://github.com/minio/minio/releases/download/RELEASE.2025-07-23T15-54-02Z/#{package}" }
 
   describe "#initialize" do
     it "rejects a missing version" do
@@ -26,7 +26,7 @@ RSpec.describe MinioSetup do
     it "installs the package and enables the service" do
       commands = []
       allow(setup).to receive(:_run_command) { |*command| commands << command.join(" ") }
-      expect(setup).to receive(:curl_file).with(url, package).and_return(described_class::CHECKSUMS.fetch("minio_20250723155402.0.0_amd64"))
+      expect(setup).to receive(:curl_file).with(url, package).and_return(described_class::RELEASES.fetch("minio_20250723155402.0.0_amd64").fetch(:checksum))
 
       setup.run
 


### PR DESCRIPTION
dl.min.io no longer serves anything: every path under it, including the pinned minio .deb and the pinned mc binary, answers 410 Gone. So install_minio fails on every attempt, and Prog::Minio::SetupMinio retries it every 5 seconds without a deadline, so the minio server strand never leaves wait_setup.

That stalls far more than the minio tests. With no S3 endpoint, wal-g gets connection refused on port 9000, and PostgresServer#walg_credentials_ready? polls it with an ssh command that only returns when the 81 second ssh timeout expires. In the last two metal E2E runs those calls burned 6715 and 6964 seconds, 78% of all ssh time in each run, which saturated respirate: queue_size pinned at its maximum of 7, available_workers near 0, and scan_delay median up from 0.5 seconds to over 150. Every nap-based poll then took minutes, so the whole suite ran out of its 70 minute budget. Test::FirewallRules alone went from 45 seconds to over 20 minutes for three of its five subtests.

Upstream still publishes both artifacts as GitHub release assets. The files there are byte-identical to the ones dl.min.io served, so both pinned digests stay as they are. The minio package name does not contain its release tag, unlike the mc binary, so the tag joins the digest in a single RELEASES map rather than living in a second map that could drift out of step with it.